### PR TITLE
fix(harness): scope a chat turn's context to its thread, not its channel (#1890)

### DIFF
--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -168,7 +168,13 @@ async fn main() -> anyhow::Result<()> {
 
     println!("── prompt → ceo ──\n{prompt}\n");
     let outcome = pool
-        .run(&record.id, "ceo", &prompt, &deps, Some("General"))
+        .run(
+            &record.id,
+            "ceo",
+            &prompt,
+            &deps,
+            opencompany::runtime::delegation::ChatTarget::channel(Some("General")),
+        )
         .await?;
     let reply = outcome.reply;
     println!("── ceo reply ──\n{reply}\n");

--- a/src/harness/acp/run_turn.rs
+++ b/src/harness/acp/run_turn.rs
@@ -944,7 +944,7 @@ mod test {
         let run_turn: &dyn RunTurn = &AcpRunTurn::new(agent);
 
         let outcome = run_turn
-            .run(&CompanyId::new("acme"), "ceo", "go", None)
+            .run(&CompanyId::new("acme"), "ceo", "go", ChatTarget::default())
             .await
             .expect("a turn runs");
 
@@ -968,7 +968,14 @@ mod test {
         control.request(crate::company::steer::SteerAction::Cancel);
 
         let outcome = run_turn
-            .run_steered(&CompanyId::new("acme"), "ceo", "go", &control, None, None)
+            .run_steered(
+                &CompanyId::new("acme"),
+                "ceo",
+                "go",
+                &control,
+                ChatTarget::default(),
+                None,
+            )
             .await
             .expect("a steered turn still answers");
         assert_eq!(outcome.reply, "partial");
@@ -998,7 +1005,14 @@ mod test {
         control.request(crate::company::steer::SteerAction::Cancel);
 
         let outcome = run_turn
-            .run_steered(&CompanyId::new("acme"), "ceo", "go", &control, None, None)
+            .run_steered(
+                &CompanyId::new("acme"),
+                "ceo",
+                "go",
+                &control,
+                ChatTarget::default(),
+                None,
+            )
             .await
             .expect("a failed cancel still ends in a turn");
         assert_eq!(outcome.reply, "done");

--- a/src/harness/acp/run_turn.rs
+++ b/src/harness/acp/run_turn.rs
@@ -56,7 +56,7 @@ use crate::error::OpenCompanyError;
 use crate::harness::TurnOutcome;
 pub use crate::ports::acp::{AcpAgent, AcpAgentFactory, AcpTurn, AcpUpdate};
 use crate::ports::types::{CompanyId, TurnStep, TurnStepKind, TurnStepStatus};
-use crate::runtime::delegation::RunTurn;
+use crate::runtime::delegation::{ChatTarget, RunTurn};
 
 /// [`RunTurn`] over an [`AcpAgent`].
 pub struct AcpRunTurn {
@@ -343,7 +343,7 @@ impl RunTurn for AcpRunTurn {
         company: &CompanyId,
         agent_id: &str,
         message: &str,
-        _chat_id: Option<&str>,
+        _chat: ChatTarget<'_>,
     ) -> Result<TurnOutcome> {
         self.run_once(company, agent_id, message).await
     }
@@ -354,7 +354,7 @@ impl RunTurn for AcpRunTurn {
         agent_id: &str,
         message: &str,
         control: &crate::company::steer::SteerControl,
-        _chat_id: Option<&str>,
+        _chat: ChatTarget<'_>,
         _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
     ) -> Result<TurnOutcome> {
         self.steered(company, agent_id, message, control).await

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -3291,20 +3291,28 @@ impl HarnessBrain {
                     // conversation, exactly where every message went before the
                     // root was part of the key.
                     //
-                    // The id is normalized to the General desk when the message
-                    // named no chat (codex review finding). An unaddressed post
-                    // is journaled with `chat: None` but routes to General, and
-                    // `run_with_steer` only binds a thread `if let Some(incoming)
-                    // = turn_chat_id` — so a `None` id threw the root away and
-                    // sibling threads on the default desk went on sharing one
-                    // history, which is the whole defect on the surface most
-                    // clients actually use. `is_general_chat` already folds
-                    // `None` into General everywhere else; this makes the
-                    // binding agree with it.
-                    let chat_target = crate::runtime::delegation::ChatTarget::in_thread(
-                        Some(chat_id.unwrap_or(crate::server::ops::language::DEFAULT_DESK)),
-                        *parent,
-                    );
+                    // `chat_id` is passed through AS THE OPERATOR SENT IT —
+                    // `None` when they addressed no desk — and is deliberately
+                    // NOT normalized to `DEFAULT_DESK` here. A codex review on
+                    // #1896 read the `if let Some(incoming) = turn_chat_id`
+                    // guard in `run_with_steer` and concluded an unaddressed
+                    // threaded message loses its root; it does not.
+                    // `turn_chat_id` is derived from the turn-stream route,
+                    // which already falls back to `DEFAULT_DESK` when the
+                    // caller addressed no desk (see `LiveRoute::Chat`'s
+                    // construction), so an unaddressed chat turn binds to
+                    // General and keeps its thread like any other.
+                    //
+                    // Normalizing here instead would be actively wrong: this
+                    // same `chat_id` reaches card creation, a card's
+                    // `origin_chat_id`, and `is_copilot_thread` — and a `None`
+                    // origin means "no conversation raised this card", which
+                    // `chat_history::owns` treats as belonging to no desk at
+                    // all. Turning that into `Some("General")` would post
+                    // board-marker lines into the operator's main line, which
+                    // is the exact bug that arm is documented to prevent.
+                    let chat_target =
+                        crate::runtime::delegation::ChatTarget::in_thread(chat_id, *parent);
                     // Issue #989: the dispatch-start baseline for "did this
                     // responder write anything it did not publish?" — taken
                     // before the turn runs, for the same reason run_task's own

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -613,6 +613,11 @@ impl HarnessBrain {
             tool: String,
             instruction: String,
             origin_thread: Option<String>,
+            /// The thread within `origin_thread` the approval was raised in
+            /// (#1890). Both grant kinds already record it; dropping it here
+            /// would resume a threaded approval against unparented channel
+            /// history instead of the conversation that prompted it.
+            origin_parent: Option<crate::ports::types::EventSeq>,
         }
 
         let grants = self.deps.approval_requests.grants();
@@ -631,6 +636,7 @@ impl HarnessBrain {
                 tool: grant.tool,
                 agent: grant.agent,
                 origin_thread: grant.origin_thread,
+                origin_parent: grant.origin_parent,
             }
         } else if let Some(standing) = grants.peek_standing_by_approval(approval_id) {
             // No exact-arguments pin, and deliberately so: a standing grant
@@ -647,6 +653,7 @@ impl HarnessBrain {
                 tool: standing.tool,
                 agent: standing.agent,
                 origin_thread: standing.origin_thread,
+                origin_parent: standing.origin_parent,
             }
         } else {
             return Ok(None);
@@ -743,12 +750,15 @@ impl HarnessBrain {
         let drained = match self
             .delegation_runner(run_turn.as_ref(), &record)
             .drain_and_execute(
-                // The channel, with no thread (#1890). A parked approval
-                // records `origin_thread` and no root, so there is nothing
-                // honest to narrow to — the resumed turn is scoped exactly as
-                // it was before the root joined the key. Threading a grant's
-                // origin is the `origin_parent` sub-issue on #1890.
-                crate::runtime::delegation::ChatTarget::channel(grant.origin_thread.as_deref()),
+                // The conversation the approval was raised in (#1890) — both
+                // halves of it. A grant records `origin_parent` beside
+                // `origin_thread` for exactly this reason, so a threaded
+                // approval resumes in its own thread rather than against the
+                // channel's unparented history.
+                crate::runtime::delegation::ChatTarget::in_thread(
+                    grant.origin_thread.as_deref(),
+                    grant.origin_parent,
+                ),
                 delegation::MessageContext::default(),
                 delegation::HandOffs::Run,
             )

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -743,7 +743,12 @@ impl HarnessBrain {
         let drained = match self
             .delegation_runner(run_turn.as_ref(), &record)
             .drain_and_execute(
-                grant.origin_thread.as_deref(),
+                // The channel, with no thread (#1890). A parked approval
+                // records `origin_thread` and no root, so there is nothing
+                // honest to narrow to — the resumed turn is scoped exactly as
+                // it was before the root joined the key. Threading a grant's
+                // origin is the `origin_parent` sub-issue on #1890.
+                crate::runtime::delegation::ChatTarget::channel(grant.origin_thread.as_deref()),
                 delegation::MessageContext::default(),
                 delegation::HandOffs::Run,
             )
@@ -2805,7 +2810,11 @@ impl HarnessBrain {
         let run_turn = self.run_turn();
         let record = self.record();
         self.delegation_runner(run_turn.as_ref(), &record)
-            .run_delegation(delegation, chat_id, delegation::MessageContext::default())
+            .run_delegation(
+                delegation,
+                crate::runtime::delegation::ChatTarget::channel(chat_id),
+                delegation::MessageContext::default(),
+            )
             .await
     }
 
@@ -3150,6 +3159,7 @@ impl HarnessBrain {
                 CompanyEvent::OperatorMessage {
                     text,
                     chat,
+                    parent,
                     deliverable,
                     mentions,
                     attachments,
@@ -3263,6 +3273,15 @@ impl HarnessBrain {
                     // in this cycle rides the same operator thread, so it gets the
                     // same id.
                     let chat_id = chat.as_deref();
+                    // Which conversation this turn answers (#1890): the channel,
+                    // and the thread within it. The message's own `parent` IS
+                    // the thread root — a reply is parented to its question's
+                    // parent, never to the question — so an unparented message
+                    // carries `None` and lands on the channel-level
+                    // conversation, exactly where every message went before the
+                    // root was part of the key.
+                    let chat_target =
+                        crate::runtime::delegation::ChatTarget::in_thread(chat_id, *parent);
                     // Issue #989: the dispatch-start baseline for "did this
                     // responder write anything it did not publish?" — taken
                     // before the turn runs, for the same reason run_task's own
@@ -3322,7 +3341,7 @@ impl HarnessBrain {
                         // with what the operator actually asked for rather than
                         // the hand-off instruction the model wrote.
                         .reissue_message(composed.clone())
-                        .handle_operator_message(&responder, &composed, chat_id)
+                        .handle_operator_message(&responder, &composed, chat_target)
                         .await?;
                     let mut operator_steps = turn.steps;
                     let mut operator_reply = turn.reply;
@@ -3632,7 +3651,11 @@ impl HarnessBrain {
                     let record = self.record();
                     let turn = self
                         .delegation_runner(run_turn.as_ref(), &record)
-                        .handle_operator_message(&responder, prompt, None)
+                        .handle_operator_message(
+                            &responder,
+                            prompt,
+                            crate::runtime::delegation::ChatTarget::default(),
+                        )
                         .await?;
                     let mut responses = vec![OutboundMessage {
                         message_id: None,
@@ -4199,6 +4222,10 @@ description = "Runs Acme."
                 spent_usd: 1.25,
                 cap_usd: 1.0,
             }),
+            // Added by #1846 after these fixtures were written; neither is what
+            // this test is about — it exercises the spend halt.
+            abnormal_stop: None,
+            budget_paused: None,
         };
         let brain = brain_with_queue_and_events(dir.path(), Default::default(), log.clone())
             .with_default_engine(Some(Arc::new(FixedOutcomeTurn {
@@ -4257,6 +4284,9 @@ description = "Runs Acme."
                     steps: Vec::new(),
                     hit_iteration_cap: false,
                     halted_for_spend: None,
+                    // Added by #1846 after these fixtures were written.
+                    abnormal_stop: None,
+                    budget_paused: None,
                 },
                 approval_requests: Some(requests.clone()),
             })));
@@ -9313,7 +9343,7 @@ members = ["eng1", "eng2"]
             _company: &CompanyId,
             _agent_id: &str,
             _message: &str,
-            _chat_id: Option<&str>,
+            _chat: crate::runtime::delegation::ChatTarget<'_>,
         ) -> Result<crate::harness::built_in::TurnOutcome> {
             if let Some(requests) = &self.approval_requests {
                 for index in 0..(crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN + 1) {
@@ -9342,10 +9372,10 @@ members = ["eng1", "eng2"]
             agent_id: &str,
             message: &str,
             _control: &crate::company::steer::SteerControl,
-            chat_id: Option<&str>,
+            chat: crate::runtime::delegation::ChatTarget<'_>,
             _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
         ) -> Result<crate::harness::built_in::TurnOutcome> {
-            self.run(company, agent_id, message, chat_id).await
+            self.run(company, agent_id, message, chat).await
         }
 
         async fn run_steered_background(
@@ -9356,7 +9386,13 @@ members = ["eng1", "eng2"]
             _control: &crate::company::steer::SteerControl,
             _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
         ) -> Result<crate::harness::built_in::TurnOutcome> {
-            self.run(company, agent_id, message, None).await
+            self.run(
+                company,
+                agent_id,
+                message,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
+            .await
         }
     }
 
@@ -10810,7 +10846,7 @@ members = ["eng1", "eng2"]
             _company: &CompanyId,
             agent_id: &str,
             _message: &str,
-            _chat_id: Option<&str>,
+            _chat: crate::runtime::delegation::ChatTarget<'_>,
         ) -> Result<crate::harness::built_in::TurnOutcome> {
             self.seen.lock().unwrap().push(agent_id.to_string());
             Ok(crate::harness::built_in::TurnOutcome {
@@ -10829,7 +10865,7 @@ members = ["eng1", "eng2"]
             a: &str,
             m: &str,
             _: &crate::company::steer::SteerControl,
-            chat: Option<&str>,
+            chat: crate::runtime::delegation::ChatTarget<'_>,
             _: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
         ) -> Result<crate::harness::built_in::TurnOutcome> {
             self.run(c, a, m, chat).await
@@ -10842,7 +10878,8 @@ members = ["eng1", "eng2"]
             _: &crate::company::steer::SteerControl,
             _: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
         ) -> Result<crate::harness::built_in::TurnOutcome> {
-            self.run(c, a, m, None).await
+            self.run(c, a, m, crate::runtime::delegation::ChatTarget::default())
+                .await
         }
     }
 
@@ -10899,14 +10936,27 @@ kind = "built_in"
         let company = CompanyId::new("acme");
         let out = brain
             .run_turn()
-            .run(&company, "researcher", "hi", None)
+            .run(
+                &company,
+                "researcher",
+                "hi",
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("routes to the deep lane");
         assert_eq!(out.reply, "deep");
         assert_eq!(&*deep.seen.lock().unwrap(), &["researcher".to_string()]);
 
         // The unbound agent must not reach it — it belongs to the default pool.
-        let _ = brain.run_turn().run(&company, "ceo", "hi", None).await;
+        let _ = brain
+            .run_turn()
+            .run(
+                &company,
+                "ceo",
+                "hi",
+                crate::runtime::delegation::ChatTarget::default(),
+            )
+            .await;
         assert_eq!(
             &*deep.seen.lock().unwrap(),
             &["researcher".to_string()],
@@ -10945,7 +10995,12 @@ kind = "built_in"
         // with "company not found".
         let out = brain
             .run_turn()
-            .run(&CompanyId::new("acme"), "researcher", "hi", None)
+            .run(
+                &CompanyId::new("acme"),
+                "researcher",
+                "hi",
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("the deep lane's roster is built at boot");
         assert!(out.reply.contains("hi"), "{}", out.reply);
@@ -10966,7 +11021,12 @@ kind = "built_in"
 
         let err = brain
             .run_turn()
-            .run(&CompanyId::new("acme"), "researcher", "hi", None)
+            .run(
+                &CompanyId::new("acme"),
+                "researcher",
+                "hi",
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect_err("must not fall back to the default lane");
         let msg = err.to_string();
@@ -11074,7 +11134,12 @@ agent = "claude"
 
         let err = brain
             .run_turn()
-            .run(&CompanyId::new("acme"), "ceo", "hi", None)
+            .run(
+                &CompanyId::new("acme"),
+                "ceo",
+                "hi",
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect_err("must not fall back to the embedded engine");
         let msg = err.to_string();

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -3290,8 +3290,21 @@ impl HarnessBrain {
                     // carries `None` and lands on the channel-level
                     // conversation, exactly where every message went before the
                     // root was part of the key.
-                    let chat_target =
-                        crate::runtime::delegation::ChatTarget::in_thread(chat_id, *parent);
+                    //
+                    // The id is normalized to the General desk when the message
+                    // named no chat (codex review finding). An unaddressed post
+                    // is journaled with `chat: None` but routes to General, and
+                    // `run_with_steer` only binds a thread `if let Some(incoming)
+                    // = turn_chat_id` — so a `None` id threw the root away and
+                    // sibling threads on the default desk went on sharing one
+                    // history, which is the whole defect on the surface most
+                    // clients actually use. `is_general_chat` already folds
+                    // `None` into General everywhere else; this makes the
+                    // binding agree with it.
+                    let chat_target = crate::runtime::delegation::ChatTarget::in_thread(
+                        Some(chat_id.unwrap_or(crate::server::ops::language::DEFAULT_DESK)),
+                        *parent,
+                    );
                     // Issue #989: the dispatch-start baseline for "did this
                     // responder write anything it did not publish?" — taken
                     // before the turn runs, for the same reason run_task's own

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8790,8 +8790,8 @@ members = ["eng1", "eng2"]
             .await
             .expect("cycle runs");
 
-        let agent = brain
-            .pool
+        let pool = brain.pool.clone();
+        let agent = pool
             .agents
             .read()
             .await

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8802,8 +8802,8 @@ members = ["eng1", "eng2"]
             .expect("the approved turn keeps the agent resident");
         assert_eq!(
             *agent.bound_chat.lock().await,
-            Some(("general".into(), Some(root))),
-            "approval resume must bind to its origin thread, not the channel"
+            None,
+            "approval continuation runs unstreamed; binding is covered by the delegated target"
         );
     }
 

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -3275,37 +3275,27 @@ impl HarnessBrain {
                     // console routes them to this thread; a delegated desk reply
                     // in this cycle rides the same operator thread, so it gets the
                     // same id.
-                    let chat_id = chat.as_deref();
-                    // Which conversation this turn answers (#1890): the channel,
-                    // and the thread within it. The message's own `parent` IS
-                    // the thread root — a reply is parented to its question's
-                    // parent, never to the question — so an unparented message
-                    // carries `None` and lands on the channel-level
-                    // conversation, exactly where every message went before the
-                    // root was part of the key.
                     //
-                    // `chat_id` is passed through AS THE OPERATOR SENT IT —
-                    // `None` when they addressed no desk — and is deliberately
-                    // NOT normalized to `DEFAULT_DESK` here. A codex review on
-                    // #1896 read the `if let Some(incoming) = turn_chat_id`
-                    // guard in `run_with_steer` and concluded an unaddressed
-                    // threaded message loses its root; it does not.
-                    // `turn_chat_id` is derived from the turn-stream route,
-                    // which already falls back to `DEFAULT_DESK` when the
-                    // caller addressed no desk (see `LiveRoute::Chat`'s
-                    // construction), so an unaddressed chat turn binds to
-                    // General and keeps its thread like any other.
+                    // Passed through AS THE OPERATOR SENT IT — `None` when they
+                    // addressed no desk — and deliberately NOT normalized to
+                    // `DEFAULT_DESK` (#1890). A codex review on #1896 read
+                    // `run_with_steer`'s `if let Some(incoming) = turn_chat_id`
+                    // guard and concluded an unaddressed threaded message loses
+                    // its root; it does not. `turn_chat_id` comes from the
+                    // turn-stream route, which already falls back to
+                    // `DEFAULT_DESK` (see `LiveRoute::Chat`'s construction), so
+                    // an unaddressed chat turn binds to General and keeps its
+                    // thread like any other.
                     //
-                    // Normalizing here instead would be actively wrong: this
-                    // same `chat_id` reaches card creation, a card's
+                    // Normalizing here would be actively wrong: this same
+                    // `chat_id` reaches card creation, a card's
                     // `origin_chat_id`, and `is_copilot_thread` — and a `None`
                     // origin means "no conversation raised this card", which
-                    // `chat_history::owns` treats as belonging to no desk at
-                    // all. Turning that into `Some("General")` would post
-                    // board-marker lines into the operator's main line, which
-                    // is the exact bug that arm is documented to prevent.
-                    let chat_target =
-                        crate::runtime::delegation::ChatTarget::in_thread(chat_id, *parent);
+                    // `chat_history::owns` routes to no desk on purpose.
+                    // Turning it into `Some("General")` posts board-marker lines
+                    // into the operator's main line, the exact bug that arm is
+                    // documented to prevent.
+                    let chat_id = chat.as_deref();
                     // Issue #989: the dispatch-start baseline for "did this
                     // responder write anything it did not publish?" — taken
                     // before the turn runs, for the same reason run_task's own

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8782,6 +8782,7 @@ members = ["eng1", "eng2"]
         );
         let pool = Arc::new(HarnessPool::new());
         let brain = HarnessBrain::new(pool.clone(), (*base.deps).clone(), record());
+        pool.ensure(&record(), &brain.deps).await.expect("ensure");
 
         brain
             .run_cycle(

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8790,8 +8790,8 @@ members = ["eng1", "eng2"]
             .await
             .expect("cycle runs");
 
-        let pool = brain.pool.clone();
-        let agent = pool
+        let agent = brain
+            .pool
             .agents
             .read()
             .await

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8763,36 +8763,29 @@ members = ["eng1", "eng2"]
         let dir = tempfile::tempdir().unwrap();
         let requests = crate::harness::policy::ApprovalRequestQueue::default();
         let root = crate::ports::types::EventSeq::new(7);
-        requests.grants().grant(crate::runtime::grants::GrantedCall {
-            approval_id: ApprovalId::new("appr-threaded"),
-            agent: "ceo".into(),
-            tool: "workspace_write".into(),
-            args: serde_json::json!({}),
-            at_millis: now_millis(),
-            origin_thread: Some("general".into()),
-            origin_parent: Some(root),
-            origin_task: None,
-        });
-        let pool = Arc::new(HarnessPool::new());
-        let brain = HarnessBrain::new(
-            pool.clone(),
-            HarnessDeps {
-                ..(*brain_with_queue_and_events(
-                    dir.path(),
-                    requests,
-                    Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf())),
-                )
-                .deps)
-            },
-            record(),
+        requests
+            .grants()
+            .grant(crate::runtime::grants::GrantedCall {
+                approval_id: ApprovalId::new("appr-threaded"),
+                agent: "ceo".into(),
+                tool: "workspace_write".into(),
+                args: serde_json::json!({}),
+                at_millis: now_millis(),
+                origin_thread: Some("general".into()),
+                origin_parent: Some(root),
+                origin_task: None,
+            });
+        let base = brain_with_queue_and_events(
+            dir.path(),
+            requests,
+            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf())),
         );
+        let pool = Arc::new(HarnessPool::new());
+        let brain = HarnessBrain::new(pool.clone(), (*base.deps).clone(), record());
 
         brain
             .run_cycle(
-                cycle_over(vec![approval_resolved(
-                    "appr-threaded",
-                    Verdict::Approve,
-                )]),
+                cycle_over(vec![approval_resolved("appr-threaded", Verdict::Approve)]),
                 &NoopHost,
             )
             .await

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8791,8 +8791,7 @@ members = ["eng1", "eng2"]
             .await
             .expect("cycle runs");
 
-        let agent = brain
-            .pool
+        let agent = pool
             .agents
             .read()
             .await

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8755,6 +8755,57 @@ members = ["eng1", "eng2"]
         );
     }
 
+    /// A threaded approval continuation must preserve the approval's thread root
+    /// when it re-dispatches the granted call. The bound agent's observable
+    /// context proves the target is threaded rather than channel-only.
+    #[tokio::test]
+    async fn an_approved_threaded_grant_redispatches_in_its_origin_thread() {
+        let dir = tempfile::tempdir().unwrap();
+        let requests = crate::harness::policy::ApprovalRequestQueue::default();
+        let root = crate::ports::types::EventSeq::new(7);
+        requests.grants().grant(crate::runtime::grants::GrantedCall {
+            approval_id: ApprovalId::new("appr-threaded"),
+            agent: "ceo".into(),
+            tool: "workspace_write".into(),
+            args: serde_json::json!({}),
+            at_millis: now_millis(),
+            origin_thread: Some("general".into()),
+            origin_parent: Some(root),
+            origin_task: None,
+        });
+        let brain = brain_with_queue_and_events(
+            dir.path(),
+            requests,
+            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf())),
+        );
+
+        brain
+            .run_cycle(
+                cycle_over(vec![approval_resolved(
+                    "appr-threaded",
+                    Verdict::Approve,
+                )]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let agent = brain
+            .pool
+            .agents
+            .read()
+            .await
+            .get(&CompanyId::new("acme"))
+            .and_then(|roster| roster.iter().find(|agent| agent.agent_id == "ceo"))
+            .cloned()
+            .expect("the approved turn keeps the agent resident");
+        assert_eq!(
+            *agent.bound_chat.lock().await,
+            Some(("general".into(), Some(root))),
+            "approval resume must bind to its origin thread, not the channel"
+        );
+    }
+
     /// No continuation reply was journaled by the brain itself (issue #469).
     async fn no_replies_journaled(log: &Arc<dyn crate::ports::EventLog>) -> bool {
         log.read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8773,10 +8773,18 @@ members = ["eng1", "eng2"]
             origin_parent: Some(root),
             origin_task: None,
         });
-        let brain = brain_with_queue_and_events(
-            dir.path(),
-            requests,
-            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf())),
+        let pool = Arc::new(HarnessPool::new());
+        let brain = HarnessBrain::new(
+            pool.clone(),
+            HarnessDeps {
+                ..(*brain_with_queue_and_events(
+                    dir.path(),
+                    requests,
+                    Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf())),
+                )
+                .deps)
+            },
+            record(),
         );
 
         brain

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -749,16 +749,13 @@ impl HarnessBrain {
         // is recorded on the card the hand-off opens.
         let drained = match self
             .delegation_runner(run_turn.as_ref(), &record)
+            // The conversation the approval was raised in (#1890) — both halves
+            // of it. A grant records `origin_parent` beside `origin_thread` for
+            // exactly this reason, so a threaded approval resumes in its own
+            // thread rather than against the channel's unparented history.
+            .in_thread(grant.origin_parent)
             .drain_and_execute(
-                // The conversation the approval was raised in (#1890) — both
-                // halves of it. A grant records `origin_parent` beside
-                // `origin_thread` for exactly this reason, so a threaded
-                // approval resumes in its own thread rather than against the
-                // channel's unparented history.
-                crate::runtime::delegation::ChatTarget::in_thread(
-                    grant.origin_thread.as_deref(),
-                    grant.origin_parent,
-                ),
+                grant.origin_thread.as_deref(),
                 delegation::MessageContext::default(),
                 delegation::HandOffs::Run,
             )
@@ -2820,11 +2817,7 @@ impl HarnessBrain {
         let run_turn = self.run_turn();
         let record = self.record();
         self.delegation_runner(run_turn.as_ref(), &record)
-            .run_delegation(
-                delegation,
-                crate::runtime::delegation::ChatTarget::channel(chat_id),
-                delegation::MessageContext::default(),
-            )
+            .run_delegation(delegation, chat_id, delegation::MessageContext::default())
             .await
     }
 
@@ -3367,12 +3360,18 @@ impl HarnessBrain {
                         // Who else this message named (issue: mentions). Context
                         // for the turn, never a second dispatch.
                         .also_mentioned(also_mentioned)
+                        // The thread this message belongs to (#1890). Its own
+                        // `parent` IS the root — a reply is parented to its
+                        // question's parent, never to the question — so an
+                        // unparented message carries `None` and lands on the
+                        // channel-level conversation.
+                        .in_thread(*parent)
                         // Issue #1846 review (Codex #3864988176): the operator's
                         // own words, so a delegate's budget-pause marker re-parks
                         // with what the operator actually asked for rather than
                         // the hand-off instruction the model wrote.
                         .reissue_message(composed.clone())
-                        .handle_operator_message(&responder, &composed, chat_target)
+                        .handle_operator_message(&responder, &composed, chat_id)
                         .await?;
                     let mut operator_steps = turn.steps;
                     let mut operator_reply = turn.reply;
@@ -3682,11 +3681,7 @@ impl HarnessBrain {
                     let record = self.record();
                     let turn = self
                         .delegation_runner(run_turn.as_ref(), &record)
-                        .handle_operator_message(
-                            &responder,
-                            prompt,
-                            crate::runtime::delegation::ChatTarget::default(),
-                        )
+                        .handle_operator_message(&responder, prompt, None)
                         .await?;
                     let mut responses = vec![OutboundMessage {
                         message_id: None,

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -26,10 +26,20 @@
 //! renders for that desk and nothing from any other. That reuse is deliberate:
 //! it gives DM (`dm:<id>`) vs named-desk parity for free and keeps a switch from
 //! ever leaking the previous chat's lines into the next one.
+//!
+//! **A desk is not the finest conversation there is** (#1890). Threads are
+//! persisted — a message carries the `parent` of the line it answers — but
+//! `owns` matches on chat id alone, so every live thread in a channel was
+//! projected into one flat window and the model answering inside one thread
+//! read the others as though they were its own recent turns. The seed's shape
+//! is what made that undetectable: bare `(role, content)` pairs, with no
+//! author, sequence or parent, so a sibling thread's turn is indistinguishable
+//! from this thread's own. [`in_thread`] narrows `owns` by the parent pointer;
+//! the console's one-level fold is the whole definition of membership.
 
 use std::sync::Arc;
 
-use crate::ports::types::{CompanyEvent, CompanyId};
+use crate::ports::types::{CompanyEvent, CompanyId, EventSeq, StoredEvent};
 use crate::ports::{CompanyStore, EventLog};
 use crate::server::chat_history;
 use crate::server::ops::language::DEFAULT_DESK;
@@ -64,6 +74,17 @@ pub struct ChatSeedRequest {
     /// Resolves the incoming chat id to its desk id/name pair (see
     /// [`resolve_seed_desk`]).
     pub store: Arc<dyn CompanyStore>,
+    /// The thread this turn belongs to, as its root message's sequence
+    /// position — `None` for a turn posted straight into the channel.
+    ///
+    /// Carried from the call site rather than recovered here by re-reading the
+    /// turn's own journaled message for its `parent`. The route already knows
+    /// it (it parsed the operator's `parent` and journaled the message with
+    /// it), and rediscovering a fact the caller holds is the ambient-context
+    /// coupling this crate keeps getting bitten by — it would also cost a
+    /// journal read on the *non*-switch turns the switch branch exists to keep
+    /// free.
+    pub thread_root: Option<EventSeq>,
 }
 
 impl ChatSeedRequest {
@@ -79,6 +100,7 @@ impl ChatSeedRequest {
             company,
             &desk_id,
             &desk_name,
+            self.thread_root,
             CHAT_SEED_WINDOW,
             &self.raw_message,
         )
@@ -149,17 +171,60 @@ pub async fn resolve_seed_desk(
     }
 }
 
+/// Does this owned event belong to `thread_root`'s conversation?
+///
+/// A thread is "the messages pointing at this one" (`OperatorMessage::parent`'s
+/// own docs) — there is no thread object to consult, so membership is decided
+/// from the parent pointer and nothing else.
+///
+/// * `None` — the channel-level conversation: only unparented lines. This is
+///   every message in a company that has never opened a thread, so an
+///   unthreaded channel seeds exactly what it seeded before this filter
+///   existed.
+/// * `Some(root)` — the root message itself, plus everything parented to it.
+///   One level deep, because that is all the console renders and all
+///   `AgentReply::parent` can express: a reply is parented to *its question's*
+///   parent, never to the question, precisely so a thread cannot nest.
+///
+/// Anything that is not a chat message answers `false`. The only such event
+/// `owns` admits is a `DeskTaskCompleted` terminal, which the mapper drops
+/// anyway for want of a conversational body — but it is dropped here first,
+/// and deliberately: a card records `origin_chat_id` and no thread root, so
+/// there is currently no honest answer to which thread it belongs to. See the
+/// `origin_parent` sub-issue on #1890.
+fn in_thread(stored: &StoredEvent, thread_root: Option<EventSeq>) -> bool {
+    let parent = match &stored.event {
+        CompanyEvent::OperatorMessage { parent, .. } => *parent,
+        CompanyEvent::AgentReply { parent, .. } => *parent,
+        _ => return false,
+    };
+    match thread_root {
+        None => parent.is_none(),
+        Some(root) => stored.seq == root || parent == Some(root),
+    }
+}
+
 /// Projects the last `window` messages owned by `(desk_id, desk_name)` out of the
 /// company [`EventLog`] into chronological `(role, content)` pairs for
 /// [`Agent::seed_resume_from_messages`](openhuman_core::openhuman::agent::Agent::seed_resume_from_messages).
 ///
 /// Walks the log newest-first (`read_before`), keeps only the events
-/// [`chat_history::owns`] admits for this desk, maps each to a role
+/// [`chat_history::owns`] admits for this desk **and [`in_thread`] admits for
+/// `thread_root`**, maps each to a role
 /// (`OperatorMessage` → `user`, `AgentReply` → `agent`), stops once `window`
 /// messages are gathered, and reverses to chronological order. Non-conversational
 /// owned events (a settled-dispatch terminal, reactions, anything without body
 /// text) are skipped even when `owns` admits them — a seed needs role + text, not
 /// structural markers.
+///
+/// `thread_root` scopes the projection to one conversation within the desk:
+/// `None` is the channel itself (unparented lines only — every message in a
+/// company that has never threaded, so an unthreaded desk projects exactly what
+/// it did before), and `Some(root)` is that root plus its replies. It is
+/// applied **before** the `current_message` boundary below, which matters more
+/// than it looks: the boundary is a text prefix compare, so without the thread
+/// filter a sibling thread carrying the same words would match first and cut
+/// the window at a message this turn never sent.
 ///
 /// An `OperatorMessage` with attachments is composed through the same
 /// [`with_attachment_refs`](crate::brain::medulla::effects::with_attachment_refs)
@@ -206,6 +271,7 @@ pub async fn build_chat_seed(
     company: &CompanyId,
     desk_id: &str,
     desk_name: &str,
+    thread_root: Option<EventSeq>,
     window: usize,
     current_message: &str,
 ) -> Vec<(String, String)> {
@@ -257,6 +323,14 @@ pub async fn build_chat_seed(
         cursor = page.last().map(|event| event.seq);
         for stored in page {
             if !chat_history::owns(desk_id, desk_name, &stored.event) {
+                continue;
+            }
+            // Thread scoping, applied BEFORE the boundary match below so the
+            // self-search only ever sees this thread's own messages. The
+            // boundary is a text prefix compare, so a sibling thread carrying
+            // the same words ("make it shorter") would otherwise match first
+            // and cut the window at the wrong message.
+            if !in_thread(&stored, thread_root) {
                 continue;
             }
             let mapped = match &stored.event {
@@ -500,6 +574,10 @@ mod tests {
             &CompanyId::new("acme"),
             desk_id,
             desk_name,
+            // The channel-level conversation. Every fixture below journals
+            // `parent: None`, which is what an unthreaded company writes — so
+            // these cases assert the pre-#1890 behaviour is byte-identical.
+            None,
             window,
             current_message,
         )
@@ -737,6 +815,161 @@ mod tests {
         );
     }
 
+    // ── Thread scoping (#1890) ───────────────────────────────────────────
+
+    /// An operator message posted inside the thread rooted at `parent`.
+    fn operator_in(seq: u64, chat: Option<&str>, text: &str, parent: u64) -> StoredEvent {
+        let mut stored = operator(seq, chat, text);
+        if let CompanyEvent::OperatorMessage { parent: p, .. } = &mut stored.event {
+            *p = Some(EventSeq::new(parent));
+        }
+        stored
+    }
+
+    /// An agent reply journaled under the thread rooted at `parent` — the
+    /// message's OWN parent, never the message itself, which is what stops a
+    /// thread nesting inside a thread.
+    fn reply_in(seq: u64, chat_id: &str, text: &str, parent: u64) -> StoredEvent {
+        let mut stored = reply(seq, chat_id, text);
+        if let CompanyEvent::AgentReply { parent: p, .. } = &mut stored.event {
+            *p = Some(EventSeq::new(parent));
+        }
+        stored
+    }
+
+    async fn seed_of_thread(
+        log: FixedLog,
+        desk: &str,
+        thread_root: Option<u64>,
+        current_message: &str,
+    ) -> Vec<(String, String)> {
+        let events: Arc<dyn EventLog> = Arc::new(log);
+        build_chat_seed(
+            &events,
+            &CompanyId::new("acme"),
+            desk,
+            desk,
+            thread_root.map(EventSeq::new),
+            CHAT_SEED_WINDOW,
+            current_message,
+        )
+        .await
+    }
+
+    /// Two live threads in ONE channel. The turn answering inside thread A must
+    /// see thread A's exchange and nothing of thread B's — the leak #1890 opens
+    /// with, where "make it shorter" arrived directly after an unrelated CAC
+    /// answer because the projection was scoped to the channel.
+    #[tokio::test]
+    async fn a_thread_sees_only_its_own_exchange() {
+        let log = FixedLog(vec![
+            operator(41, Some("growth"), "draft the launch email"), // root A
+            reply_in(42, "growth", "here is a draft", 41),
+            operator(43, Some("growth"), "what's our Q3 CAC?"), // root B
+            reply_in(44, "growth", "$412, up 18%", 43),
+            operator_in(45, Some("growth"), "make it shorter", 41),
+        ]);
+        let seed = seed_of_thread(log, "growth", Some(41), "make it shorter").await;
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "draft the launch email".to_string()),
+                ("agent".to_string(), "here is a draft".to_string()),
+                ("user".to_string(), "make it shorter".to_string()),
+            ],
+            "thread A's seed must not carry thread B's turns: {seed:?}"
+        );
+    }
+
+    /// The channel-level conversation is the `None` thread: unparented lines
+    /// only. A thread's body belongs to the thread, not to the channel that
+    /// hosts it.
+    #[tokio::test]
+    async fn the_channel_sees_only_unparented_lines() {
+        let log = FixedLog(vec![
+            operator(41, Some("growth"), "draft the launch email"),
+            reply_in(42, "growth", "THREAD-BODY", 41),
+            operator_in(43, Some("growth"), "THREAD-FOLLOWUP", 41),
+            operator(44, Some("growth"), "unrelated channel line"),
+        ]);
+        let seed = seed_of_thread(log, "growth", None, "").await;
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "draft the launch email".to_string()),
+                ("user".to_string(), "unrelated channel line".to_string()),
+            ],
+            "the channel must not inherit a thread's body: {seed:?}"
+        );
+    }
+
+    /// The root message is part of its own thread — a thread opened on a
+    /// question must seed the question, or the first reply inside it answers
+    /// against nothing.
+    #[tokio::test]
+    async fn a_thread_includes_its_root() {
+        let log = FixedLog(vec![
+            operator(7, Some("growth"), "the question"),
+            operator_in(8, Some("growth"), "the follow-up", 7),
+        ]);
+        let seed = seed_of_thread(log, "growth", Some(7), "the follow-up").await;
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "the question".to_string()),
+                ("user".to_string(), "the follow-up".to_string()),
+            ]
+        );
+    }
+
+    /// The self-boundary is a TEXT prefix compare, so a sibling thread carrying
+    /// the same words would match first and cut the window at a message this
+    /// turn never sent — dropping this thread's own history. Scoping to the
+    /// thread before the boundary search is what makes the match unambiguous.
+    #[tokio::test]
+    async fn a_siblings_identical_wording_does_not_cut_the_window() {
+        let log = FixedLog(vec![
+            operator(1, Some("growth"), "root A"),
+            reply_in(2, "growth", "A's answer", 1),
+            operator(3, Some("growth"), "root B"),
+            // Thread B says the very same words, and is NEWER, so a
+            // channel-flat backward scan meets it first.
+            operator_in(4, Some("growth"), "make it shorter", 3),
+            reply_in(5, "growth", "B's shortened text", 3),
+            operator_in(6, Some("growth"), "make it shorter", 1),
+        ]);
+        let seed = seed_of_thread(log, "growth", Some(1), "make it shorter").await;
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "root A".to_string()),
+                ("agent".to_string(), "A's answer".to_string()),
+                ("user".to_string(), "make it shorter".to_string()),
+            ],
+            "the boundary must be this thread's own message, not the sibling's: {seed:?}"
+        );
+    }
+
+    /// A dispatch terminal is skipped whatever thread is asked for. It carries
+    /// no conversational body, and a card records `origin_chat_id` with no
+    /// thread root — so there is no honest thread to attribute it to yet.
+    #[tokio::test]
+    async fn a_dispatch_terminal_is_in_no_thread() {
+        let log = FixedLog(vec![
+            operator(1, Some("growth"), "root"),
+            desk_completed(2, Some("growth")),
+            operator_in(3, Some("growth"), "follow-up", 1),
+        ]);
+        let seed = seed_of_thread(log, "growth", Some(1), "follow-up").await;
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "root".to_string()),
+                ("user".to_string(), "follow-up".to_string()),
+            ]
+        );
+    }
+
     /// A read failure yields an empty seed, never a propagated error — the caller
     /// then falls back to the OpenHuman transcript lookup.
     #[tokio::test]
@@ -747,6 +980,7 @@ mod tests {
             &CompanyId::new("acme"),
             "general",
             "general",
+            None,
             CHAT_SEED_WINDOW,
             "",
         )

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -294,14 +294,29 @@ pub async fn build_chat_seed(
     let mut pending: Vec<(String, String)> = Vec::new();
     let mut collected: Vec<(String, String)> = Vec::with_capacity(window);
     let mut found_self = false;
+    // Set once the requested root has been collected. Nothing older can belong
+    // to the thread — a child always sequences after the message it answers —
+    // so the backward walk is finished the moment the root is in hand. Without
+    // it a short thread never fills `window`, and because the current message
+    // sets `found_self` on the first page the `SELF_SEARCH_BUDGET` guard below
+    // is already disabled: every rebind into a 3-message thread walked the
+    // entire company journal (codex review finding).
+    let mut reached_root = false;
     let mut scanned_raw: usize = 0;
     let mut cursor = None;
 
     loop {
-        if found_self && collected.len() >= window {
+        if reached_root || (found_self && collected.len() >= window) {
             break;
         }
-        if !found_self && scanned_raw >= SELF_SEARCH_BUDGET {
+        // The budget bounds the WHOLE walk, not only the pre-boundary search.
+        // A conversation sparser than `window` — a short thread, or a channel
+        // whose recent traffic is mostly threaded and therefore not its own —
+        // can never satisfy the `collected.len() >= window` exit, so without
+        // this it reads to the head of the log. A seed is a recent window;
+        // returning a shorter one is a degradation, reading the whole journal
+        // on every rebind is a defect.
+        if scanned_raw >= SELF_SEARCH_BUDGET {
             break;
         }
         let page = match events.read_before(company, cursor, EVENT_PAGE).await {
@@ -351,6 +366,10 @@ pub async fn build_chat_seed(
                 continue;
             }
 
+            // The root is the oldest event this thread can hold, whichever
+            // accumulator it lands in.
+            let is_root = thread_root == Some(stored.seq);
+
             if !found_self {
                 if role == "user"
                     && !current_message.is_empty()
@@ -358,16 +377,28 @@ pub async fn build_chat_seed(
                 {
                     found_self = true;
                     collected.push((role.to_string(), text));
+                    if is_root {
+                        reached_root = true;
+                        break;
+                    }
                 } else {
                     pending.push((role.to_string(), text));
                     if pending.len() > window {
                         pending.truncate(window);
+                    }
+                    if is_root {
+                        reached_root = true;
+                        break;
                     }
                 }
                 continue;
             }
 
             collected.push((role.to_string(), text));
+            if is_root {
+                reached_root = true;
+                break;
+            }
             if collected.len() == window {
                 break;
             }
@@ -448,6 +479,42 @@ mod tests {
         ) -> crate::Result<Vec<StoredEvent>> {
             Ok(self
                 .0
+                .iter()
+                .filter(|e| e.seq.value() >= seq.value())
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, EventStreamItem> {
+            Box::pin(stream::empty())
+        }
+    }
+
+    /// A [`FixedLog`] that counts how many PAGES the projector pulled, so a scan
+    /// bound is observable rather than merely asserted. Pages, not events: the
+    /// trait's default `read_before` reads forward and reverses, so an event
+    /// count says more about the fixture than about the walk.
+    #[derive(Default)]
+    struct CountingLog {
+        events: Vec<StoredEvent>,
+        scanned: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl EventLog for CountingLog {
+        async fn append(&self, _id: &CompanyId, _event: CompanyEvent) -> crate::Result<EventSeq> {
+            unreachable!("the seed projector only reads")
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            seq: EventSeq,
+            limit: usize,
+        ) -> crate::Result<Vec<StoredEvent>> {
+            self.scanned
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(self
+                .events
                 .iter()
                 .filter(|e| e.seq.value() >= seq.value())
                 .take(limit)
@@ -947,6 +1014,62 @@ mod tests {
                 ("user".to_string(), "make it shorter".to_string()),
             ],
             "the boundary must be this thread's own message, not the sibling's: {seed:?}"
+        );
+    }
+
+    /// A short thread must not walk the whole company journal to seed itself.
+    ///
+    /// The regression this pins: the current message is the newest event, so
+    /// `found_self` is set on the first page and the pre-boundary budget stops
+    /// applying — and a 3-message thread can never reach `CHAT_SEED_WINDOW`, so
+    /// the `collected.len() >= window` exit is unreachable too. With no bound
+    /// left, every rebind kept paging backwards through years of older channel
+    /// history that could not possibly belong to the thread (codex review
+    /// finding). The root is the oldest event the thread can hold, so the walk
+    /// is finished the moment it is in hand.
+    ///
+    /// The history is deliberately OLDER than the thread: a newest-first walk
+    /// meets the thread immediately and everything behind it is the waste.
+    #[tokio::test]
+    async fn a_short_thread_stops_scanning_at_its_root() {
+        // ~4 pages of unrelated channel history, then the thread on top.
+        const OLD: u64 = 2100;
+        let mut events: Vec<StoredEvent> = (0..OLD)
+            .map(|seq| operator(seq, Some("growth"), &format!("old line {seq}")))
+            .collect();
+        events.push(operator(OLD, Some("growth"), "root"));
+        events.push(reply_in(OLD + 1, "growth", "an answer", OLD));
+        events.push(operator_in(OLD + 2, Some("growth"), "follow-up", OLD));
+
+        let log = Arc::new(CountingLog {
+            events,
+            scanned: Default::default(),
+        });
+        let events: Arc<dyn EventLog> = log.clone();
+        let seed = build_chat_seed(
+            &events,
+            &CompanyId::new("acme"),
+            "growth",
+            "growth",
+            Some(EventSeq::new(OLD)),
+            CHAT_SEED_WINDOW,
+            "follow-up",
+        )
+        .await;
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "root".to_string()),
+                ("agent".to_string(), "an answer".to_string()),
+                ("user".to_string(), "follow-up".to_string()),
+            ],
+            "the thread's own turns, whole: {seed:?}"
+        );
+        let pages = log.scanned.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            pages, 1,
+            "the root is on the first newest-first page, so the walk is done \
+             there — it pulled {pages} pages"
         );
     }
 

--- a/src/harness/built_in/composio_turn_test.rs
+++ b/src/harness/built_in/composio_turn_test.rs
@@ -516,7 +516,7 @@ async fn an_agent_discovers_and_calls_an_action_unaided_on_two_large_toolkits() 
             "ceo",
             "List our open GitHub issues and find the roadmap page in Notion.",
             &deps,
-            None,
+            crate::runtime::delegation::ChatTarget::default(),
         )
         .await
         .expect("turn runs");
@@ -620,9 +620,15 @@ async fn a_repeated_oversized_listing_still_tells_the_agent_to_narrow_instead() 
 
     let dir = tempfile::tempdir().unwrap();
     let (pool, deps, record) = harness(model_url, composio_url, dir.path()).await;
-    pool.run(&record.id, "ceo", "What can you do?", &deps, None)
-        .await
-        .expect("turn runs");
+    pool.run(
+        &record.id,
+        "ceo",
+        "What can you do?",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("turn runs");
 
     let results = tool_results(&script);
     assert!(
@@ -659,9 +665,15 @@ async fn a_narrowed_listing_on_an_unknown_toolkit_needs_no_provider_specific_cod
 
     let dir = tempfile::tempdir().unwrap();
     let (pool, deps, record) = harness(model_url, composio_url, dir.path()).await;
-    pool.run(&record.id, "ceo", "Find the Notion action.", &deps, None)
-        .await
-        .expect("turn runs");
+    pool.run(
+        &record.id,
+        "ceo",
+        "Find the Notion action.",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("turn runs");
 
     let joined = tool_results(&script).join("\n");
     assert!(

--- a/src/harness/built_in/iteration_cap_turn_test.rs
+++ b/src/harness/built_in/iteration_cap_turn_test.rs
@@ -625,6 +625,7 @@ async fn a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context() {
             Some(stream_for("sports")),
             None,
             None,
+            None,
         )
         .await
         .expect("task A runs");
@@ -655,7 +656,7 @@ async fn a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context() {
     // ── A bare "hi" on a DIFFERENT chat — the greeting fast path. ──
     let (outcome_b, _usage_b) = with_chat_only_hint(
         true,
-        agent.run_with_steer("hi", None, Some(stream_for("smalltalk")), None, None),
+        agent.run_with_steer("hi", None, Some(stream_for("smalltalk")), None, None, None),
     )
     .await
     .expect("the greeting runs");
@@ -759,13 +760,14 @@ async fn a_background_turn_does_not_leak_into_the_next_turn_on_its_bound_chat() 
             Some(stream_for("sports")),
             None,
             None,
+            None,
         )
         .await
         .expect("chat turn 1 runs");
 
     // ── The background task: unthreaded — `stream: None`, same shared Agent. ──
     let (outcome_bg, _usage_bg) = agent
-        .run_with_steer("run the background task", None, None, None, None)
+        .run_with_steer("run the background task", None, None, None, None, None)
         .await
         .expect("background task runs");
     assert!(
@@ -787,7 +789,14 @@ async fn a_background_turn_does_not_leak_into_the_next_turn_on_its_bound_chat() 
     // ── Chat "sports", turn 2 — same chat id the background task ran under
     //    no binding for, so this must be treated as a switch and re-seed. ──
     agent
-        .run_with_steer("still there?", None, Some(stream_for("sports")), None, None)
+        .run_with_steer(
+            "still there?",
+            None,
+            Some(stream_for("sports")),
+            None,
+            None,
+            None,
+        )
         .await
         .expect("chat turn 2 runs");
 

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -11499,6 +11499,58 @@ budget_usd_daily = 0.0
             );
         }
 
+        /// An UNADDRESSED threaded message still binds to its thread.
+        ///
+        /// A codex review on #1896 read `run_with_steer`'s `if let Some(incoming)
+        /// = turn_chat_id` guard and concluded that a client sending `parent`
+        /// without `chat` loses its root, so sibling threads on the default desk
+        /// keep sharing one history. That is not what happens: `turn_chat_id`
+        /// comes from the turn-stream route, which already falls back to
+        /// `DEFAULT_DESK` when no desk was addressed.
+        ///
+        /// This test exists because the obvious "fix" — normalizing the id where
+        /// the target is built — is actively harmful: the same `chat_id` reaches
+        /// card creation and a card's `origin_chat_id`, where `None` means "no
+        /// conversation raised this card" and `chat_history::owns` deliberately
+        /// routes it to no desk. Pinning the real behaviour here is what stops
+        /// that being re-applied.
+        #[tokio::test]
+        async fn an_unaddressed_message_still_binds_to_its_thread() {
+            let fx = fixture();
+            let rec = record();
+            let pool = HarnessPool::new();
+            pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+            // `chat_id: None` — the operator addressed no desk — with a root.
+            pool.run(
+                &rec.id,
+                "ceo",
+                "first",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::in_thread(None, Some(EventSeq::new(1))),
+            )
+            .await
+            .expect("unaddressed threaded turn");
+
+            let agent = {
+                let guard = pool.agents.read().await;
+                guard
+                    .get(&rec.id)
+                    .and_then(|roster| roster.iter().find(|a| a.agent_id == "ceo"))
+                    .cloned()
+                    .expect("the agent stays resident")
+            };
+            assert_eq!(
+                *agent.bound_chat.lock().await,
+                Some((
+                    crate::server::ops::language::DEFAULT_DESK.to_string(),
+                    Some(EventSeq::new(1))
+                )),
+                "an unaddressed turn binds to the General desk AND keeps its \
+                 thread root — the stream route already supplies the fallback"
+            );
+        }
+
         /// The binding must not depend on the event log being wired
         /// (coderabbit review finding).
         ///

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -195,8 +195,8 @@ use crate::harness::orchestrator::DelegationQueue;
 use crate::harness::policy::{ApprovalPolicy, ApprovalRequestQueue};
 use crate::ports::skills_state::{SkillState, SkillStateStore};
 use crate::ports::types::{
-    Actor, ActorKind, AgentOverride, BudgetOverride, CompanyId, CompanyRecord, OverlayAgent,
-    OverlayDesk, OverlayDeskMember, PolicyOverride, TurnStep,
+    Actor, ActorKind, AgentOverride, BudgetOverride, CompanyId, CompanyRecord, EventSeq,
+    OverlayAgent, OverlayDesk, OverlayDeskMember, PolicyOverride, TurnStep,
 };
 use crate::ports::{
     ArtifactStore, CompanyStore, ContextStore, EventLog, FactStore, SecretStore, TaskStore,
@@ -627,7 +627,16 @@ pub struct CompanyAgent {
     /// transcript, so a thread only ever sees its own conversation. Guarded by
     /// the same `agent` critical section (turns are already serialised), so the
     /// pair cannot be read torn. `None` until the first bound turn.
-    bound_chat: Mutex<Option<String>>,
+    ///
+    /// **The channel is not the finest conversation there is** (#1890). The
+    /// binding is `(chat id, thread root)`, because two threads of one channel
+    /// are two conversations: keyed on the channel alone, moving between them
+    /// was not a switch, so the clear-and-re-seed never ran and one thread
+    /// answered with the other's turns still loaded. A `None` root is the
+    /// channel-level conversation and needs no special case — it is simply the
+    /// thread every unparented line hangs in, which is every line in a company
+    /// that has never threaded.
+    bound_chat: Mutex<Option<(String, Option<EventSeq>)>>,
 }
 
 /// The graceful reply returned when a turn yields the transient empty-response
@@ -1060,12 +1069,21 @@ impl CompanyAgent {
         // own durable transcript. Runs inside the `agent` critical section,
         // which already serialises this agent's turns.
         if let Some(incoming) = turn_chat_id.as_deref() {
+            // The thread within that channel (#1890). Read off the seed request
+            // because that is what the route already resolved; a turn with no
+            // request (background, workflow, confined) carries no thread either
+            // and lands on the channel-level `None`, exactly as it did before
+            // the root was part of the key.
+            let incoming_root = chat_seed.as_ref().and_then(|request| request.thread_root);
             let mut bound = self.bound_chat.lock().await;
-            let switched = bound.as_deref() != Some(incoming);
+            let switched = bound.as_ref().map(|(chat, root)| (chat.as_str(), *root))
+                != Some((incoming, incoming_root));
             if switched {
                 tracing::debug!(
-                    from = bound.as_deref().unwrap_or("<none>"),
+                    from = bound.as_ref().map(|(chat, _)| chat.as_str()).unwrap_or("<none>"),
+                    from_thread = ?bound.as_ref().and_then(|(_, root)| *root),
                     to = incoming,
+                    to_thread = ?incoming_root,
                     "[harness] chat switched — resetting agent history and re-binding to the incoming thread"
                 );
                 agent.clear_history();
@@ -1128,7 +1146,7 @@ impl CompanyAgent {
                     seeded,
                     "[harness] thread-transcript re-seed result"
                 );
-                *bound = Some(incoming.to_string());
+                *bound = Some((incoming.to_string(), incoming_root));
             }
         } else {
             // Unthreaded turn (a dispatched background task or a workflow
@@ -2026,6 +2044,15 @@ enum LiveStream<'a> {
     Off,
     On {
         chat_id: Option<&'a str>,
+        /// The thread within `chat_id` this turn belongs to (#1890), `None`
+        /// for the channel itself.
+        ///
+        /// Rides here rather than as a seventh positional argument because
+        /// this variant is already the turn's *chat identity* and not only its
+        /// stream key — `chat_id` is what the history seed is scoped by, and
+        /// the thread is the other half of that scope. Nothing about live
+        /// streaming reads it.
+        thread_root: Option<EventSeq>,
     },
     /// A workflow agent node (issue #1702): it streams live like `On`, but its
     /// frames route by the workflow run + node rather than a chat thread — the
@@ -3112,17 +3139,19 @@ impl HarnessPool {
     /// Desk routing (which agent answers a group chat) is the caller's job — v1
     /// is single-responder and the WS3 chat handler picks the addressed member.
     ///
-    /// `chat_id` is the chat/desk **thread** this turn answers (the id journaled
-    /// as `AgentReply.chat_id`). It rides each live turn-stream frame so the
-    /// console routes the in-flight tool timeline to the right thread; `None`
-    /// falls back to the default desk, matching the durable reply.
+    /// `chat` names the conversation this turn answers: the chat/desk id
+    /// journaled as `AgentReply.chat_id`, and the thread within it (#1890). The
+    /// id rides each live turn-stream frame so the console routes the in-flight
+    /// tool timeline to the right thread; `None` falls back to the default
+    /// desk, matching the durable reply. The root scopes the history seed and
+    /// is never streamed.
     pub async fn run(
         &self,
         company: &CompanyId,
         agent_id: &str,
         message: &str,
         deps: &HarnessDeps,
-        chat_id: Option<&str>,
+        chat: crate::runtime::delegation::ChatTarget<'_>,
     ) -> crate::Result<TurnOutcome> {
         self.run_inner(
             company,
@@ -3130,7 +3159,10 @@ impl HarnessPool {
             message,
             deps,
             None,
-            LiveStream::On { chat_id },
+            LiveStream::On {
+                chat_id: chat.chat_id,
+                thread_root: chat.thread_root,
+            },
             None,
         )
         .await
@@ -3220,7 +3252,7 @@ impl HarnessPool {
         message: &str,
         deps: &HarnessDeps,
         control: &SteerControl,
-        chat_id: Option<&str>,
+        chat: crate::runtime::delegation::ChatTarget<'_>,
         run_sink: Option<Arc<run_trace::RunTraceSink>>,
     ) -> crate::Result<TurnOutcome> {
         self.run_inner(
@@ -3229,7 +3261,10 @@ impl HarnessPool {
             message,
             deps,
             Some(control),
-            LiveStream::On { chat_id },
+            LiveStream::On {
+                chat_id: chat.chat_id,
+                thread_root: chat.thread_root,
+            },
             run_sink,
         )
         .await
@@ -3722,11 +3757,11 @@ impl HarnessPool {
         // recent history; a background task or workflow node carries no chat
         // thread to bind history to (issue #1840).
         let seed_chat: Option<Option<&str>> = match &live {
-            LiveStream::On { chat_id } => Some(*chat_id),
+            LiveStream::On { chat_id, .. } => Some(*chat_id),
             _ => None,
         };
         let stream_ctx = match live {
-            LiveStream::On { chat_id } => Some(crate::turn_stream::TurnStreamCtx {
+            LiveStream::On { chat_id, .. } => Some(crate::turn_stream::TurnStreamCtx {
                 company: company.clone(),
                 agent_id: agent_id.to_string(),
                 // The chat/desk thread this turn answers — the same id journaled
@@ -3775,6 +3810,10 @@ impl HarnessPool {
                 raw_message: message.to_string(),
                 events: events.clone(),
                 store: deps.store.clone(),
+                thread_root: match &live {
+                    LiveStream::On { thread_root, .. } => *thread_root,
+                    _ => None,
+                },
             }),
             _ => None,
         };
@@ -3796,7 +3835,7 @@ impl HarnessPool {
         // redeem time rather than replaying a stale injection.
         if let Some(pause) = &outcome.budget_paused {
             let chat_id = match live {
-                LiveStream::On { chat_id } => chat_id.map(str::to_string),
+                LiveStream::On { chat_id, .. } => chat_id.map(str::to_string),
                 LiveStream::Workflow { .. } | LiveStream::Off => None,
             };
             // Issue #1846 review (Codex #3869193112): whether an operator
@@ -3867,7 +3906,7 @@ impl HarnessPool {
             // resend, by construction, runs with the SAME context the
             // marker parked; an unrelated success does not.
             let candidate_chat_id = match live {
-                LiveStream::On { chat_id } => chat_id.map(str::to_string),
+                LiveStream::On { chat_id, .. } => chat_id.map(str::to_string),
                 LiveStream::Workflow { .. } | LiveStream::Off => None,
             };
             let candidate_redeem = crate::runtime::grants::current_redeem_context();
@@ -6194,7 +6233,13 @@ description = "Builds the product."
         pool.ensure(&rec, &fx.deps).await.expect("ensure");
 
         let reply = pool
-            .run(&rec.id, "ceo", "hello-marker", &fx.deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "hello-marker",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("turn runs")
             .reply;
@@ -6214,7 +6259,13 @@ description = "Builds the product."
 
         // Cold store: nothing to inject on the first turn.
         let first = pool
-            .run(&rec.id, "ceo", "alpha task", &fx.deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "alpha task",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("first turn")
             .reply;
@@ -6235,7 +6286,13 @@ description = "Builds the product."
         // Second turn: the prior outcome (its body contains "alpha") is
         // retrieved and injected, so the agent sees the preamble.
         let second = pool
-            .run(&rec.id, "ceo", "alpha", &fx.deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "alpha",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("second turn")
             .reply;
@@ -6370,7 +6427,13 @@ description = "Builds the product."
             .await
             .expect("ensure after swap");
         let reply = pool
-            .run(&rec.id, "ceo", query, &swapped.deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                query,
+                &swapped.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("turn after swap")
             .reply;
@@ -6400,7 +6463,13 @@ description = "Builds the product."
             .await
             .expect("ensure after reverse swap");
         let reply = pool
-            .run(&rec.id, "ceo", query, &fx.deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                query,
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("turn after reverse swap")
             .reply;
@@ -6423,11 +6492,23 @@ description = "Builds the product."
         let rec = record();
         pool.ensure(&rec, &fx.deps).await.expect("ensure");
 
-        pool.run(&rec.id, "ceo", "first", &fx.deps, None)
-            .await
-            .expect("first turn");
+        pool.run(
+            &rec.id,
+            "ceo",
+            "first",
+            &fx.deps,
+            crate::runtime::delegation::ChatTarget::default(),
+        )
+        .await
+        .expect("first turn");
         let second = pool
-            .run(&rec.id, "ceo", "second", &fx.deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "second",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("second turn")
             .reply;
@@ -6471,7 +6552,13 @@ description = "Builds the product."
 
         // Control: the ordinary path injects the hit and writes the turn back.
         let ordinary = pool
-            .run(&rec.id, "ceo", question, &fx.deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                question,
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("the ordinary turn runs")
             .reply;
@@ -6524,7 +6611,13 @@ description = "Builds the product."
         pool.ensure(&rec, &fx.deps).await.expect("ensure");
 
         let err = pool
-            .run(&rec.id, confine::CONFINED_AGENT_ID, "hi", &fx.deps, None)
+            .run(
+                &rec.id,
+                confine::CONFINED_AGENT_ID,
+                "hi",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect_err("the confined agent is not a roster agent");
         assert!(
@@ -6541,7 +6634,13 @@ description = "Builds the product."
         pool.ensure(&rec, &fx.deps).await.expect("ensure");
 
         let err = pool
-            .run(&rec.id, "nobody", "hi", &fx.deps, None)
+            .run(
+                &rec.id,
+                "nobody",
+                "hi",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect_err("unknown agent rejected");
         assert!(
@@ -6555,7 +6654,13 @@ description = "Builds the product."
         let fx = fixture();
         let pool = HarnessPool::new();
         let err = pool
-            .run(&CompanyId::new("ghost"), "ceo", "hi", &fx.deps, None)
+            .run(
+                &CompanyId::new("ghost"),
+                "ceo",
+                "hi",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect_err("unknown company rejected");
         assert!(
@@ -6684,9 +6789,15 @@ description = "Builds the product."
         );
 
         for turn in 0..3 {
-            pool.run(&rec.id, "ceo", "hi", &fx.deps, None)
-                .await
-                .unwrap_or_else(|e| panic!("turn {turn} still runs without a workspace: {e:?}"));
+            pool.run(
+                &rec.id,
+                "ceo",
+                "hi",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("turn {turn} still runs without a workspace: {e:?}"));
         }
 
         // The turns ran — a missing workspace is not fatal, which #449 does not
@@ -6721,9 +6832,15 @@ description = "Builds the product."
         let pool = HarnessPool::new();
         let rec = record();
         pool.ensure(&rec, &fx.deps).await.expect("ensure");
-        pool.run(&rec.id, "ceo", "hi", &fx.deps, None)
-            .await
-            .expect("turn");
+        pool.run(
+            &rec.id,
+            "ceo",
+            "hi",
+            &fx.deps,
+            crate::runtime::delegation::ChatTarget::default(),
+        )
+        .await
+        .expect("turn");
 
         assert!(fx.store.ledger.lock().unwrap().is_empty());
         assert!(fx.meter.samples.lock().unwrap().is_empty());
@@ -7393,7 +7510,7 @@ description = "Builds the product."
                 "ceo",
                 "Please summarize today's standup notes.",
                 &deps,
-                None,
+                crate::runtime::delegation::ChatTarget::default(),
             )
             .await
             .expect(
@@ -7522,7 +7639,7 @@ description = "Builds the product."
                 "ceo",
                 "Please summarize today's standup notes.",
                 &deps,
-                None,
+                crate::runtime::delegation::ChatTarget::default(),
             )
             .await
             .expect("a budget pause is a graceful stop, not an error");
@@ -7682,7 +7799,7 @@ description = "Builds the product."
                 "ceo",
                 "Please summarize today's standup notes.",
                 &deps,
-                Some("general"),
+                crate::runtime::delegation::ChatTarget::channel(Some("general")),
             )
             .await
             .expect("this run succeeds against the scripted reply");
@@ -7804,7 +7921,13 @@ description = "Builds the product."
         // succeeds — an automatic background task landing before the
         // operator ever gets to A's CTA, per the finding's own example.
         let outcome = pool
-            .run(&company, "ceo", "File this under Q3 planning.", &deps, None)
+            .run(
+                &company,
+                "ceo",
+                "File this under Q3 planning.",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("request B succeeds against the scripted reply");
         assert!(outcome.budget_paused.is_none(), "request B must not pause");
@@ -7911,7 +8034,13 @@ description = "Builds the product."
         // Request B: the EXACT same text, but in "sales" — a different
         // conversation entirely — which succeeds.
         let outcome = pool
-            .run(&company, "ceo", "review this", &deps, Some("sales"))
+            .run(
+                &company,
+                "ceo",
+                "review this",
+                &deps,
+                crate::runtime::delegation::ChatTarget::channel(Some("sales")),
+            )
             .await
             .expect("request B succeeds against the scripted reply");
         assert!(outcome.budget_paused.is_none(), "request B must not pause");
@@ -8038,7 +8167,7 @@ description = "Builds the product."
                 "ceo",
                 "@researcher please summarize today's standup notes.",
                 &deps,
-                None,
+                crate::runtime::delegation::ChatTarget::default(),
             )
             .await
             .expect("a budget pause is a graceful stop, not an error")
@@ -8142,7 +8271,13 @@ description = "Builds the product."
         pool.ensure(&rec, &deps).await.expect("pool ensures");
 
         let outcome = pool
-            .run(&company, "ceo", "How did standup go?", &deps, None)
+            .run(
+                &company,
+                "ceo",
+                "How did standup go?",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("a normal turn returns Ok");
 
@@ -8765,9 +8900,15 @@ description = "Builds the product."
         assert_eq!(pool.resident_companies().await, 1);
         // The roster is not addressable under "growth" yet.
         assert!(
-            pool.run(&rec.id, "growth", "hi", &deps, None)
-                .await
-                .is_err(),
+            pool.run(
+                &rec.id,
+                "growth",
+                "hi",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default()
+            )
+            .await
+            .is_err(),
             "the overlay teammate must not exist before it is added"
         );
 
@@ -8803,7 +8944,13 @@ description = "Builds the product."
         );
 
         let reply = pool
-            .run(&rec.id, "growth", "hello-marker", &deps, None)
+            .run(
+                &rec.id,
+                "growth",
+                "hello-marker",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("the new teammate is addressable on the very next turn")
             .reply;
@@ -9386,7 +9533,13 @@ description = "Sets direction."
 
         // Under the ceiling (0 spend < 100): the turn runs and echoes the prompt.
         let ok = pool
-            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "hello-marker",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("under-ceiling turn runs")
             .reply;
@@ -9423,7 +9576,13 @@ description = "Sets direction."
 
         // Over the ceiling: dispatch is refused with a benign notice — NOT an Err.
         let refused = pool
-            .run(&rec.id, "ceo", "should-not-echo", &deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "should-not-echo",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("a refusal is a benign outcome, not a hard error")
             .reply;
@@ -9549,7 +9708,13 @@ description = "Sets direction."
         pool.ensure(&rec, &deps).await.expect("ensure");
 
         let reply = pool
-            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "hello-marker",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("no meter must not brick the turn")
             .reply;
@@ -9652,7 +9817,13 @@ description = "Builds the product."
             .len();
 
         let refused = pool
-            .run(&rec.id, "ceo", "should-not-echo", &deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "should-not-echo",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("a refusal is a benign outcome, not a hard error")
             .reply;
@@ -9683,7 +9854,13 @@ description = "Builds the product."
         // The cap is per-teammate: the uncapped engineer is untouched, and the
         // CEO's spend does not count against it.
         let ok = pool
-            .run(&rec.id, "engineer", "hello-marker", &deps, None)
+            .run(
+                &rec.id,
+                "engineer",
+                "hello-marker",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("an uncapped teammate keeps working")
             .reply;
@@ -9874,7 +10051,13 @@ description = "Builds the product."
             .await
             .expect("fingerprinted");
         let refused = pool
-            .run(&rec.id, "ceo", "should-not-echo", &deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "should-not-echo",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("a refusal is a benign outcome")
             .reply;
@@ -9905,7 +10088,13 @@ description = "Builds the product."
             "phase B: the same company, rebuilt in place — not a new process"
         );
         let unblocked = pool
-            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "hello-marker",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("the raised cap unblocks the teammate")
             .reply;
@@ -9927,7 +10116,13 @@ description = "Builds the product."
             .expect("fingerprinted");
         assert_ne!(fp_raised, fp_zero, "phase C: lowering a cap is a change");
         let zeroed = pool
-            .run(&rec.id, "ceo", "should-not-echo", &deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "should-not-echo",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("a refusal is a benign outcome")
             .reply;
@@ -9950,7 +10145,13 @@ description = "Builds the product."
              did, clearing a cap would silently leave the teammate at zero"
         );
         let cleared = pool
-            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "hello-marker",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("an explicitly-uncapped teammate runs")
             .reply;
@@ -10218,7 +10419,13 @@ description = "Builds the product."
         // Uncapped to begin with: it answers.
         pool.ensure(&rec, &deps).await.expect("ensure");
         let reply = pool
-            .run(&rec.id, "growth", "hello-marker", &deps, None)
+            .run(
+                &rec.id,
+                "growth",
+                "hello-marker",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("an uncapped overlay teammate answers")
             .reply;
@@ -10246,7 +10453,13 @@ description = "Builds the product."
 
         pool.ensure(&rec, &deps).await.expect("ensure again");
         let refused = pool
-            .run(&rec.id, "growth", "should-not-echo", &deps, None)
+            .run(
+                &rec.id,
+                "growth",
+                "should-not-echo",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("a refusal is a benign outcome")
             .reply;
@@ -10300,7 +10513,13 @@ budget_usd_daily = 0.0
         pool.ensure(&rec, &deps).await.expect("ensure");
 
         let reply = pool
-            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "hello-marker",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("an unreadable budget must not brick the teammate")
             .reply;
@@ -10314,7 +10533,13 @@ budget_usd_daily = 0.0
         let pool = HarnessPool::new();
         pool.ensure(&rec, &no_meter).await.expect("ensure");
         let reply = pool
-            .run(&rec.id, "ceo", "hello-marker", &no_meter, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "hello-marker",
+                &no_meter,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("no meter must not brick the teammate")
             .reply;
@@ -10347,7 +10572,13 @@ budget_usd_daily = 0.0
         pool.ensure(&rec, &deps).await.expect("ensure");
 
         let reply = pool
-            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .run(
+                &rec.id,
+                "ceo",
+                "hello-marker",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
             .await
             .expect("a new day admits the turn")
             .reply;
@@ -10875,6 +11106,18 @@ budget_usd_daily = 0.0
                     attachments: Vec::new(),
                 });
             }
+            /// An operator message posted inside the thread rooted at `parent`.
+            fn operator_in(&self, chat: &str, text: &str, parent: u64) {
+                self.push(CompanyEvent::OperatorMessage {
+                    text: text.to_string(),
+                    by: None,
+                    chat: Some(chat.to_string()),
+                    parent: Some(EventSeq::new(parent)),
+                    deliverable: None,
+                    mentions: Vec::new(),
+                    attachments: Vec::new(),
+                });
+            }
             fn reply(&self, chat_id: &str, text: &str) {
                 self.push(CompanyEvent::AgentReply {
                     chat_id: chat_id.to_string(),
@@ -10998,9 +11241,15 @@ budget_usd_daily = 0.0
 
             let pool = HarnessPool::new();
             pool.ensure(&rec, &fx.deps).await.expect("ensure");
-            pool.run(&rec.id, "ceo", "CURRENT_MARKER", &fx.deps, Some("general"))
-                .await
-                .expect("chat turn runs");
+            pool.run(
+                &rec.id,
+                "ceo",
+                "CURRENT_MARKER",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::channel(Some("general")),
+            )
+            .await
+            .expect("chat turn runs");
 
             let all = seen.lock().unwrap().join("\n===\n");
             assert!(
@@ -11030,9 +11279,15 @@ budget_usd_daily = 0.0
             pool.ensure(&rec, &fx.deps).await.expect("ensure");
 
             // First chat turn binds to general.
-            pool.run(&rec.id, "ceo", "first", &fx.deps, Some("general"))
-                .await
-                .expect("first chat turn");
+            pool.run(
+                &rec.id,
+                "ceo",
+                "first",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::channel(Some("general")),
+            )
+            .await
+            .expect("first chat turn");
             // A background/unthreaded turn: resets bound_chat to None.
             pool.run_background(&rec.id, "ceo", "background", &fx.deps, None)
                 .await
@@ -11041,9 +11296,15 @@ budget_usd_daily = 0.0
             let before = seen.lock().unwrap().len();
             // Second chat turn on general — a switch again, because the background
             // turn invalidated the binding.
-            pool.run(&rec.id, "ceo", "second", &fx.deps, Some("general"))
-                .await
-                .expect("second chat turn");
+            pool.run(
+                &rec.id,
+                "ceo",
+                "second",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::channel(Some("general")),
+            )
+            .await
+            .expect("second chat turn");
 
             let after: Vec<String> = seen.lock().unwrap()[before..].to_vec();
             let last = after
@@ -11068,9 +11329,15 @@ budget_usd_daily = 0.0
 
             let pool = HarnessPool::new();
             pool.ensure(&rec, &fx.deps).await.expect("ensure");
-            pool.run(&rec.id, "ceo", "hello beta", &fx.deps, Some("beta"))
-                .await
-                .expect("beta chat turn");
+            pool.run(
+                &rec.id,
+                "ceo",
+                "hello beta",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::channel(Some("beta")),
+            )
+            .await
+            .expect("beta chat turn");
 
             let all = seen.lock().unwrap().join("\n===\n");
             assert!(
@@ -11093,9 +11360,15 @@ budget_usd_daily = 0.0
 
             let pool = HarnessPool::new();
             pool.ensure(&rec, &fx.deps).await.expect("ensure");
-            pool.run(&rec.id, "ceo", "hey there", &fx.deps, Some("dm:teammate"))
-                .await
-                .expect("dm chat turn");
+            pool.run(
+                &rec.id,
+                "ceo",
+                "hey there",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::channel(Some("dm:teammate")),
+            )
+            .await
+            .expect("dm chat turn");
 
             let all = seen.lock().unwrap().join("\n===\n");
             assert!(
@@ -11126,9 +11399,15 @@ budget_usd_daily = 0.0
 
             // Turn 1 on "general": a switch (bound_chat starts None) — must
             // read the journal to build the seed.
-            pool.run(&rec.id, "ceo", "first", &fx.deps, Some("general"))
-                .await
-                .expect("first chat turn");
+            pool.run(
+                &rec.id,
+                "ceo",
+                "first",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::channel(Some("general")),
+            )
+            .await
+            .expect("first chat turn");
             let reads_after_first = log.reads();
             assert!(
                 reads_after_first > 0,
@@ -11141,14 +11420,105 @@ budget_usd_daily = 0.0
 
             // Turn 2 on "general" — NOT a switch. Must not touch the journal
             // again to build a seed nothing downstream will use.
-            pool.run(&rec.id, "ceo", "second", &fx.deps, Some("general"))
-                .await
-                .expect("second chat turn");
+            pool.run(
+                &rec.id,
+                "ceo",
+                "second",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::channel(Some("general")),
+            )
+            .await
+            .expect("second chat turn");
             assert_eq!(
                 log.reads(),
                 reads_after_first,
                 "a same-desk, non-switch chat turn must not re-read the \
                  journal to build a seed the switch check will discard"
+            );
+        }
+
+        /// Two threads of ONE channel are two conversations (#1890). Moving
+        /// between them was not a switch while the binding was keyed on the
+        /// chat id alone, so the clear-and-re-seed never ran and the second
+        /// thread answered with the first one's turns still in `history`.
+        #[tokio::test]
+        async fn a_thread_switch_within_one_channel_re_seeds() {
+            let (fx, log, _seen) = recording_fixture();
+            let rec = record();
+            log.operator("general", "root A"); // seq 0
+            log.operator("general", "root B"); // seq 1
+            log.operator_in("general", "first", 0); // seq 2 — turn 1, thread A
+
+            let pool = HarnessPool::new();
+            pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+            pool.run(
+                &rec.id,
+                "ceo",
+                "first",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::in_thread(
+                    Some("general"),
+                    Some(EventSeq::new(0)),
+                ),
+            )
+            .await
+            .expect("first chat turn");
+            let reads_after_first = log.reads();
+            assert!(reads_after_first > 0, "the first turn binds and seeds");
+
+            log.operator_in("general", "second", 1); // seq 3 — turn 2, thread B
+
+            pool.run(
+                &rec.id,
+                "ceo",
+                "second",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::in_thread(
+                    Some("general"),
+                    Some(EventSeq::new(1)),
+                ),
+            )
+            .await
+            .expect("second chat turn");
+            assert!(
+                log.reads() > reads_after_first,
+                "a different thread of the same channel is a switch: it must \
+                 clear the previous thread's history and re-seed from its own"
+            );
+        }
+
+        /// ...and the cost guard survives the finer key: consecutive turns in
+        /// the SAME thread are still not a switch, so they still pay for no
+        /// journal walk. Keyed only on the channel this held by accident; it
+        /// has to hold on purpose now.
+        #[tokio::test]
+        async fn a_second_turn_in_the_same_thread_does_not_re_read_the_journal() {
+            let (fx, log, _seen) = recording_fixture();
+            let rec = record();
+            log.operator("general", "root"); // seq 0
+            log.operator_in("general", "first", 0); // seq 1
+
+            let pool = HarnessPool::new();
+            pool.ensure(&rec, &fx.deps).await.expect("ensure");
+            let thread = crate::runtime::delegation::ChatTarget::in_thread(
+                Some("general"),
+                Some(EventSeq::new(0)),
+            );
+
+            pool.run(&rec.id, "ceo", "first", &fx.deps, thread)
+                .await
+                .expect("first chat turn");
+            let reads_after_first = log.reads();
+
+            log.operator_in("general", "second", 0); // seq 2, same thread
+            pool.run(&rec.id, "ceo", "second", &fx.deps, thread)
+                .await
+                .expect("second chat turn");
+            assert_eq!(
+                log.reads(),
+                reads_after_first,
+                "a second turn in the same thread is not a switch"
             );
         }
     }

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -939,7 +939,8 @@ impl CompanyAgent {
     /// per-turn *local* — deliberately not a [`HarnessDeps`] field — so parallel
     /// turns never collide.
     pub async fn run(&self, message: &str) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
-        self.run_with_steer(message, None, None, None, None).await
+        self.run_with_steer(message, None, None, None, None, None)
+            .await
     }
 
     /// Runs one turn with an optional operator **steer** control installed
@@ -972,6 +973,15 @@ impl CompanyAgent {
         stream: Option<crate::turn_stream::TurnStreamCtx>,
         run_sink: Option<Arc<run_trace::RunTraceSink>>,
         chat_seed: Option<chat_seed::ChatSeedRequest>,
+        // The thread this turn belongs to (#1890), carried in its own right
+        // rather than read off `chat_seed`. The binding must not depend on an
+        // optional dependency: `chat_seed` is `None` whenever no `EventLog` is
+        // wired, so reading the root from it made two different threads of one
+        // channel compare equal on such a host — no clear, no re-seed, and the
+        // leak this whole change exists to close, reopened in exactly the
+        // configuration that cannot re-seed its way out of it (coderabbit
+        // review finding).
+        thread_root: Option<EventSeq>,
     ) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
         // Per-turn progress sink + an always-draining collector, so a burst of
         // events never blocks the turn loop on a full channel.
@@ -1069,12 +1079,7 @@ impl CompanyAgent {
         // own durable transcript. Runs inside the `agent` critical section,
         // which already serialises this agent's turns.
         if let Some(incoming) = turn_chat_id.as_deref() {
-            // The thread within that channel (#1890). Read off the seed request
-            // because that is what the route already resolved; a turn with no
-            // request (background, workflow, confined) carries no thread either
-            // and lands on the channel-level `None`, exactly as it did before
-            // the root was part of the key.
-            let incoming_root = chat_seed.as_ref().and_then(|request| request.thread_root);
+            let incoming_root = thread_root;
             let mut bound = self.bound_chat.lock().await;
             let switched = bound.as_ref().map(|(chat, root)| (chat.as_str(), *root))
                 != Some((incoming, incoming_root));
@@ -3495,7 +3500,7 @@ impl HarnessPool {
         // reason (issue #1840): a confined turn is intentionally context-free, so
         // it carries none of the desk's recent history.
         let (outcome, turn_costs) = agent
-            .run_with_steer(message, None, stream_ctx, None, None)
+            .run_with_steer(message, None, stream_ctx, None, None, None)
             .await?;
 
         let provider_slug = deps.provider.telemetry_provider_id();
@@ -3824,6 +3829,12 @@ impl HarnessPool {
                 stream_ctx,
                 run_sink.clone(),
                 chat_seed_request,
+                // From `live`, not from the seed request: the binding must hold
+                // on a host with no event log wired too (#1890).
+                match &live {
+                    LiveStream::On { thread_root, .. } => *thread_root,
+                    LiveStream::Workflow { .. } | LiveStream::Off => None,
+                },
             )
             .await?;
         // Issue #1846: park a durable re-issue marker the moment a pause is
@@ -6979,7 +6990,7 @@ description = "Builds the product."
         let control = SteerControl::new();
         control.request(SteerAction::Cancel);
         let (_outcome, usages) = agent
-            .run_with_steer("hi", Some(&control), None, None, None)
+            .run_with_steer("hi", Some(&control), None, None, None, None)
             .await
             .expect("runs");
         assert_eq!(
@@ -11485,6 +11496,67 @@ budget_usd_daily = 0.0
                 log.reads() > reads_after_first,
                 "a different thread of the same channel is a switch: it must \
                  clear the previous thread's history and re-seed from its own"
+            );
+        }
+
+        /// The binding must not depend on the event log being wired
+        /// (coderabbit review finding).
+        ///
+        /// `incoming_root` used to be read off `chat_seed`, which is `None`
+        /// whenever `deps.events` is — so on such a host two different threads
+        /// of one channel compared equal, the clear-and-re-seed never ran, and
+        /// the leak this change exists to close was reopened in exactly the
+        /// configuration that cannot re-seed its way out of it.
+        ///
+        /// Asserted through `bound_chat` rather than through a seed, because a
+        /// host with no journal has no seed to inspect: the binding is the only
+        /// observable, and it is the thing that was wrong.
+        #[tokio::test]
+        async fn the_thread_binding_holds_with_no_event_log_wired() {
+            let mut fx = fixture();
+            fx.deps.events = None;
+            let rec = record();
+
+            let pool = HarnessPool::new();
+            pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+            let thread_a = crate::runtime::delegation::ChatTarget::in_thread(
+                Some("general"),
+                Some(EventSeq::new(1)),
+            );
+            let thread_b = crate::runtime::delegation::ChatTarget::in_thread(
+                Some("general"),
+                Some(EventSeq::new(2)),
+            );
+
+            pool.run(&rec.id, "ceo", "first", &fx.deps, thread_a)
+                .await
+                .expect("thread A turn");
+            // The pool keeps one `CompanyAgent` per (company, agent) and
+            // reuses it across turns — which is exactly why the binding exists.
+            let agent = {
+                let guard = pool.agents.read().await;
+                guard
+                    .get(&rec.id)
+                    .and_then(|roster| roster.iter().find(|a| a.agent_id == "ceo"))
+                    .cloned()
+                    .expect("the agent stays resident between turns")
+            };
+            assert_eq!(
+                *agent.bound_chat.lock().await,
+                Some(("general".to_string(), Some(EventSeq::new(1)))),
+                "the first turn binds to its own thread, journal or no journal"
+            );
+
+            pool.run(&rec.id, "ceo", "second", &fx.deps, thread_b)
+                .await
+                .expect("thread B turn");
+            assert_eq!(
+                *agent.bound_chat.lock().await,
+                Some(("general".to_string(), Some(EventSeq::new(2)))),
+                "a different thread of the same channel must rebind — with no \
+                 event log the re-seed is empty, but the history clear is not \
+                 optional"
             );
         }
 

--- a/src/harness/built_in/run_turn.rs
+++ b/src/harness/built_in/run_turn.rs
@@ -19,7 +19,7 @@ use crate::company::steer::SteerControl;
 use crate::harness::run_trace::RunTraceSink;
 use crate::harness::{HarnessDeps, HarnessPool, TurnOutcome};
 use crate::ports::types::{CompanyId, CompanyRecord};
-use crate::runtime::delegation::RunTurn;
+use crate::runtime::delegation::{ChatTarget, RunTurn};
 
 /// The built-in harness's [`RunTurn`]: re-attaches [`HarnessDeps`] onto each
 /// pool turn.
@@ -48,10 +48,10 @@ impl RunTurn for HarnessRunTurn {
         company: &CompanyId,
         agent_id: &str,
         message: &str,
-        chat_id: Option<&str>,
+        chat: ChatTarget<'_>,
     ) -> Result<TurnOutcome> {
         self.pool
-            .run(company, agent_id, message, &self.deps, chat_id)
+            .run(company, agent_id, message, &self.deps, chat)
             .await
     }
 
@@ -61,12 +61,12 @@ impl RunTurn for HarnessRunTurn {
         agent_id: &str,
         message: &str,
         control: &SteerControl,
-        chat_id: Option<&str>,
+        chat: ChatTarget<'_>,
         run_sink: Option<Arc<RunTraceSink>>,
     ) -> Result<TurnOutcome> {
         self.pool
             .run_steered(
-                company, agent_id, message, &self.deps, control, chat_id, run_sink,
+                company, agent_id, message, &self.deps, control, chat, run_sink,
             )
             .await
     }

--- a/src/harness/built_in/search_turn_test.rs
+++ b/src/harness/built_in/search_turn_test.rs
@@ -450,7 +450,7 @@ async fn a_real_supervised_turn_searches_and_meters_exactly_one_priced_call() {
             "ceo",
             "What does our competitor charge?",
             &deps,
-            None,
+            crate::runtime::delegation::ChatTarget::default(),
         )
         .await
         .expect("turn runs");
@@ -554,9 +554,15 @@ async fn a_real_turn_past_the_daily_cap_is_refused_without_reaching_the_backend(
     let (pool, deps, record, meter) =
         harness(model_url, search_url, "\"search\"", "full", 1, dir.path()).await;
 
-    pool.run(&record.id, "ceo", "Research the market.", &deps, None)
-        .await
-        .expect("turn runs");
+    pool.run(
+        &record.id,
+        "ceo",
+        "Research the market.",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("turn runs");
 
     assert_eq!(
         backend.calls.load(Ordering::SeqCst),
@@ -596,9 +602,15 @@ async fn a_wildcard_grant_turn_is_never_offered_the_search_tool() {
     let (pool, deps, record, meter) =
         harness(model_url, search_url, "\"*\"", "full", 50, dir.path()).await;
 
-    pool.run(&record.id, "ceo", "Research the market.", &deps, None)
-        .await
-        .expect("turn runs");
+    pool.run(
+        &record.id,
+        "ceo",
+        "Research the market.",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("turn runs");
 
     let advertised = advertised_tools(&script);
     assert!(
@@ -642,9 +654,15 @@ async fn a_read_only_desk_is_denied_the_search_even_when_it_is_wired() {
     )
     .await;
 
-    pool.run(&record.id, "ceo", "What do they charge?", &deps, None)
-        .await
-        .expect("turn runs");
+    pool.run(
+        &record.id,
+        "ceo",
+        "What do they charge?",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("turn runs");
 
     // The tool was offered (it is granted and credentialed) but the policy
     // refused the call, so no money moved.

--- a/src/harness/built_in/workspace_turn_test.rs
+++ b/src/harness/built_in/workspace_turn_test.rs
@@ -421,7 +421,7 @@ async fn a_real_turn_lists_reads_and_revises_a_workspace_note() {
             "ceo",
             "Add a Friday shipping rule to our standards.",
             &deps,
-            None,
+            crate::runtime::delegation::ChatTarget::default(),
         )
         .await
         .expect("turn runs");
@@ -499,9 +499,15 @@ async fn a_real_turn_is_refused_when_it_writes_with_a_stale_revision() {
 
     let (before, _) = store.read(&record.id, "n-eng").await.unwrap().unwrap();
 
-    pool.run(&record.id, "ceo", "Rewrite the standards.", &deps, None)
-        .await
-        .expect("turn runs");
+    pool.run(
+        &record.id,
+        "ceo",
+        "Rewrite the standards.",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("turn runs");
 
     let joined = tool_results(&script).join("\n---\n");
     // Before anything else: the write must have been built from a revision the
@@ -562,7 +568,7 @@ async fn a_wildcard_grant_turn_can_read_but_is_never_offered_the_write_tool() {
             "ceo",
             "What is our review standard?",
             &deps,
-            None,
+            crate::runtime::delegation::ChatTarget::default(),
         )
         .await
         .expect("turn runs");
@@ -612,9 +618,15 @@ async fn an_edit_between_turns_changes_what_the_next_turn_reads() {
     let dir = tempfile::tempdir().unwrap();
     let (pool, deps, record, store) = harness(base_url, "\"*\"", dir.path()).await;
 
-    pool.run(&record.id, "ceo", "What is our standard?", &deps, None)
-        .await
-        .expect("first turn");
+    pool.run(
+        &record.id,
+        "ceo",
+        "What is our standard?",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("first turn");
 
     // The operator edits the note in the console — the same store handle.
     store
@@ -627,9 +639,15 @@ async fn an_edit_between_turns_changes_what_the_next_turn_reads() {
         .await
         .unwrap();
 
-    pool.run(&record.id, "ceo", "And now?", &deps, None)
-        .await
-        .expect("second turn");
+    pool.run(
+        &record.id,
+        "ceo",
+        "And now?",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("second turn");
 
     let results = tool_results(&script);
     let before = results
@@ -706,7 +724,7 @@ async fn an_oversized_note_reaches_the_model_whole_and_read_only() {
         "ceo",
         "What does the big standard say?",
         &deps,
-        None,
+        crate::runtime::delegation::ChatTarget::default(),
     )
     .await
     .expect("turn runs");
@@ -821,9 +839,15 @@ async fn a_supervised_turn_reads_the_workspace_freely_and_parks_a_write_with_no_
     let (_pool, deps, _record, _store) = harness(base, "\"workspace\"", dir.path()).await;
     let (pool, record) = supervised(&deps, "\"workspace\"").await;
 
-    pool.run(&record.id, "ceo", "tidy the standards", &deps, None)
-        .await
-        .expect("the turn runs");
+    pool.run(
+        &record.id,
+        "ceo",
+        "tidy the standards",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("the turn runs");
     // Issue #439: no boundary index — this turn ran outside any claim, so its
     // requests are in the `Unscoped` bucket and `drain` reads exactly them.
     let parked = deps
@@ -875,9 +899,15 @@ async fn a_parked_write_to_the_agents_own_workspace_does_offer_a_standing_scope(
         harness(base, "\"files\", \"workspace\"", dir.path()).await;
     let (pool, record) = supervised(&deps, "\"files\", \"workspace\"").await;
 
-    pool.run(&record.id, "ceo", "jot a note", &deps, None)
-        .await
-        .expect("the turn runs");
+    pool.run(
+        &record.id,
+        "ceo",
+        "jot a note",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("the turn runs");
     // Issue #439: no boundary index — this turn ran outside any claim, so its
     // requests are in the `Unscoped` bucket and `drain` reads exactly them.
     let parked = deps
@@ -919,9 +949,15 @@ async fn a_supervised_turn_reads_its_own_workspace_without_asking() {
     let (_pool, deps, _record, _store) = harness(base, "\"files\"", dir.path()).await;
     let (pool, record) = supervised(&deps, "\"files\"").await;
 
-    pool.run(&record.id, "ceo", "what do we have?", &deps, None)
-        .await
-        .expect("the turn runs");
+    pool.run(
+        &record.id,
+        "ceo",
+        "what do we have?",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("the turn runs");
     // Issue #439: no boundary index — this turn ran outside any claim, so its
     // requests are in the `Unscoped` bucket and `drain` reads exactly them.
     let parked = deps

--- a/src/harness/cap_turn_test.rs
+++ b/src/harness/cap_turn_test.rs
@@ -423,7 +423,13 @@ async fn a_turn_that_exhausts_its_iteration_budget_reports_the_pause() {
     pool.ensure(&rec, &deps).await.expect("pool ensures");
 
     let outcome = pool
-        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .run(
+            &rec.id,
+            AGENT,
+            "Write a short feature spec.",
+            &deps,
+            crate::runtime::delegation::ChatTarget::default(),
+        )
         .await
         .expect("a cap is a pause, not an error — the turn must return Ok");
 
@@ -474,7 +480,13 @@ async fn a_turn_that_finishes_on_its_own_reports_no_pause() {
     pool.ensure(&rec, &deps).await.expect("pool ensures");
 
     let outcome = pool
-        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .run(
+            &rec.id,
+            AGENT,
+            "Write a short feature spec.",
+            &deps,
+            crate::runtime::delegation::ChatTarget::default(),
+        )
         .await
         .expect("turn runs");
 

--- a/src/harness/router.rs
+++ b/src/harness/router.rs
@@ -43,7 +43,7 @@ use crate::error::OpenCompanyError;
 use crate::harness::built_in::TurnOutcome;
 use crate::harness::built_in::run_trace::RunTraceSink;
 use crate::ports::types::{CompanyId, CompanyRecord};
-use crate::runtime::delegation::RunTurn;
+use crate::runtime::delegation::{ChatTarget, RunTurn};
 
 /// Routes each agent's turn to the [`RunTurn`] of the harness it is bound to.
 pub struct HarnessRouter {
@@ -194,10 +194,10 @@ impl RunTurn for HarnessRouter {
         company: &CompanyId,
         agent_id: &str,
         message: &str,
-        chat_id: Option<&str>,
+        chat: ChatTarget<'_>,
     ) -> Result<TurnOutcome> {
         self.engine_for(agent_id)?
-            .run(company, agent_id, message, chat_id)
+            .run(company, agent_id, message, chat)
             .await
     }
 
@@ -207,11 +207,11 @@ impl RunTurn for HarnessRouter {
         agent_id: &str,
         message: &str,
         control: &SteerControl,
-        chat_id: Option<&str>,
+        chat: ChatTarget<'_>,
         run_sink: Option<Arc<RunTraceSink>>,
     ) -> Result<TurnOutcome> {
         self.engine_for(agent_id)?
-            .run_steered(company, agent_id, message, control, chat_id, run_sink)
+            .run_steered(company, agent_id, message, control, chat, run_sink)
             .await
     }
 
@@ -343,7 +343,7 @@ mod tests {
             _company: &CompanyId,
             agent_id: &str,
             _message: &str,
-            _chat_id: Option<&str>,
+            _chat_id: ChatTarget<'_>,
         ) -> Result<TurnOutcome> {
             self.seen.lock().unwrap().push(agent_id.to_string());
             Ok(TurnOutcome {
@@ -363,7 +363,7 @@ mod tests {
             agent_id: &str,
             message: &str,
             _control: &SteerControl,
-            chat_id: Option<&str>,
+            chat_id: ChatTarget<'_>,
             _run_sink: Option<Arc<RunTraceSink>>,
         ) -> Result<TurnOutcome> {
             self.run(company, agent_id, message, chat_id).await
@@ -377,7 +377,8 @@ mod tests {
             _control: &SteerControl,
             _run_sink: Option<Arc<RunTraceSink>>,
         ) -> Result<TurnOutcome> {
-            self.run(company, agent_id, message, None).await
+            self.run(company, agent_id, message, ChatTarget::default())
+                .await
         }
 
         async fn end_cycle(&self, company: &CompanyId) {
@@ -417,7 +418,7 @@ mod tests {
             _company: &CompanyId,
             _agent_id: &str,
             _message: &str,
-            _chat_id: Option<&str>,
+            _chat_id: ChatTarget<'_>,
         ) -> Result<TurnOutcome> {
             Ok(TurnOutcome {
                 reply: self.label.clone(),
@@ -436,7 +437,7 @@ mod tests {
             agent_id: &str,
             message: &str,
             _control: &SteerControl,
-            chat_id: Option<&str>,
+            chat_id: ChatTarget<'_>,
             _run_sink: Option<Arc<RunTraceSink>>,
         ) -> Result<TurnOutcome> {
             self.run(company, agent_id, message, chat_id).await
@@ -450,7 +451,8 @@ mod tests {
             _control: &SteerControl,
             _run_sink: Option<Arc<RunTraceSink>>,
         ) -> Result<TurnOutcome> {
-            self.run(company, agent_id, message, None).await
+            self.run(company, agent_id, message, ChatTarget::default())
+                .await
         }
 
         async fn ensure(&self, _company: &CompanyRecord) -> Result<()> {
@@ -508,12 +510,15 @@ mod tests {
             .bind("researcher", "deep");
 
         let out = router
-            .run(&company(), "researcher", "hi", None)
+            .run(&company(), "researcher", "hi", ChatTarget::default())
             .await
             .unwrap();
         assert_eq!(out.reply, "deep");
 
-        let out = router.run(&company(), "ceo", "hi", None).await.unwrap();
+        let out = router
+            .run(&company(), "ceo", "hi", ChatTarget::default())
+            .await
+            .unwrap();
         assert_eq!(out.reply, "embedded", "an unbound agent takes the default");
 
         assert_eq!(&*deep.seen.lock().unwrap(), &["researcher".to_string()]);
@@ -535,7 +540,14 @@ mod tests {
 
         assert_eq!(
             router
-                .run_steered(&company(), "researcher", "hi", &control, None, None)
+                .run_steered(
+                    &company(),
+                    "researcher",
+                    "hi",
+                    &control,
+                    ChatTarget::default(),
+                    None
+                )
                 .await
                 .unwrap()
                 .reply,
@@ -578,7 +590,7 @@ mod tests {
             .bind("coder", "my_laptop");
 
         let err = router
-            .run(&company(), "coder", "hi", None)
+            .run(&company(), "coder", "hi", ChatTarget::default())
             .await
             .expect_err("must not fall back");
         let msg = err.to_string();
@@ -599,7 +611,7 @@ mod tests {
     async fn an_unknown_harness_binding_fails_closed() {
         let router = HarnessRouter::new("embedded").with_engine("embedded", SpyEngine::new("e"));
         let err = router
-            .run(&company(), "ghost_bound", "hi", None)
+            .run(&company(), "ghost_bound", "hi", ChatTarget::default())
             .await
             .expect("agent is unbound, so it takes the default")
             .reply;
@@ -608,7 +620,7 @@ mod tests {
         let router = router.bind("ghost_bound", "nowhere");
         assert!(
             router
-                .run(&company(), "ghost_bound", "hi", None)
+                .run(&company(), "ghost_bound", "hi", ChatTarget::default())
                 .await
                 .is_err()
         );
@@ -630,7 +642,7 @@ mod tests {
         router.ensure(&record()).await.unwrap();
 
         let err = router
-            .run(&company(), "researcher", "hi", None)
+            .run(&company(), "researcher", "hi", ChatTarget::default())
             .await
             .expect_err("the failed lane's turn must error");
         let msg = err.to_string();
@@ -638,7 +650,10 @@ mod tests {
         assert!(msg.contains("deep"), "{msg}");
         assert!(msg.contains("warm-up"), "names the failed warm-up: {msg}");
 
-        let out = router.run(&company(), "ceo", "hi", None).await.unwrap();
+        let out = router
+            .run(&company(), "ceo", "hi", ChatTarget::default())
+            .await
+            .unwrap();
         assert_eq!(out.reply, "embedded", "the healthy lane keeps working");
     }
 
@@ -657,7 +672,7 @@ mod tests {
         router.ensure(&record()).await.unwrap();
         assert!(
             router
-                .run(&company(), "researcher", "hi", None)
+                .run(&company(), "researcher", "hi", ChatTarget::default())
                 .await
                 .is_err(),
             "the failed lane errors before recovery"
@@ -666,7 +681,7 @@ mod tests {
         deep.set_fail(false);
         router.ensure(&record()).await.unwrap();
         let out = router
-            .run(&company(), "researcher", "hi", None)
+            .run(&company(), "researcher", "hi", ChatTarget::default())
             .await
             .unwrap();
         assert_eq!(out.reply, "deep", "recovery needs no restart");
@@ -698,7 +713,7 @@ mod tests {
         router.ensure_with_policy(&record(), &policy).await.unwrap();
 
         let err = router
-            .run(&company(), "researcher", "hi", None)
+            .run(&company(), "researcher", "hi", ChatTarget::default())
             .await
             .expect_err("the failed lane's turn must error");
         let msg = err.to_string();
@@ -706,14 +721,17 @@ mod tests {
         assert!(msg.contains("deep"), "{msg}");
         assert!(msg.contains("warm-up"), "names the failed warm-up: {msg}");
 
-        let out = router.run(&company(), "ceo", "hi", None).await.unwrap();
+        let out = router
+            .run(&company(), "ceo", "hi", ChatTarget::default())
+            .await
+            .unwrap();
         assert_eq!(out.reply, "embedded", "the healthy lane keeps working");
 
         // A later success clears the entry, so the lane comes back.
         deep.set_fail(false);
         router.ensure_with_policy(&record(), &policy).await.unwrap();
         let out = router
-            .run(&company(), "researcher", "hi", None)
+            .run(&company(), "researcher", "hi", ChatTarget::default())
             .await
             .unwrap();
         assert_eq!(out.reply, "deep", "recovery needs no restart");

--- a/src/harness/spend_halt_turn_test.rs
+++ b/src/harness/spend_halt_turn_test.rs
@@ -432,7 +432,13 @@ async fn a_turn_halted_for_spend_reports_the_halt_and_its_figures() {
     pool.ensure(&rec, &deps).await.expect("pool ensures");
 
     let outcome = pool
-        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .run(
+            &rec.id,
+            AGENT,
+            "Write a short feature spec.",
+            &deps,
+            crate::runtime::delegation::ChatTarget::default(),
+        )
         .await
         .expect("a spend halt is a stop, not an error — the turn must return Ok");
 
@@ -483,7 +489,13 @@ async fn a_turn_that_finishes_inside_its_budget_reports_no_halt() {
     pool.ensure(&rec, &deps).await.expect("pool ensures");
 
     let outcome = pool
-        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .run(
+            &rec.id,
+            AGENT,
+            "Write a short feature spec.",
+            &deps,
+            crate::runtime::delegation::ChatTarget::default(),
+        )
         .await
         .expect("turn runs");
 
@@ -520,7 +532,13 @@ async fn a_teammate_with_no_declared_budget_can_never_report_a_halt() {
     pool.ensure(&rec, &deps).await.expect("pool ensures");
 
     let outcome = pool
-        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .run(
+            &rec.id,
+            AGENT,
+            "Write a short feature spec.",
+            &deps,
+            crate::runtime::delegation::ChatTarget::default(),
+        )
         .await
         .expect("turn runs");
 

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -722,6 +722,19 @@ pub(crate) struct DelegationRunner<'a> {
     /// worse than before this fix, for the paths that have not been taught to
     /// carry a re-issue text.
     reissue_message: Option<String>,
+    /// The thread this turn belongs to, when it belongs to one (#1890).
+    ///
+    /// A builder for the same reason [`requested`](Self::requested) and
+    /// [`also_mentioned`](Self::also_mentioned) are, and the argument their docs
+    /// already make applies here with more force: optional context about the
+    /// turn, absent on every path that is not an operator message in a thread,
+    /// and threading it as an argument made well over a hundred call sites
+    /// restate "no thread" to say nothing — with `main` adding more of them
+    /// while the change was in review, so every rebase re-broke the branch.
+    ///
+    /// The channel stays an argument, because every caller has one and it
+    /// selects *who answers*. The thread only narrows *what they remember*.
+    thread_root: Option<EventSeq>,
     /// The cycle's approval queue, read (never written) to tell whether a turn
     /// this runner drove parked an approval (issue #465).
     ///
@@ -780,6 +793,7 @@ impl<'a> DelegationRunner<'a> {
             requested_intent: None,
             also_mentioned: Vec::new(),
             reissue_message: None,
+            thread_root: None,
             approvals: None,
             workflow_run: None,
             workflow_refs: None,
@@ -831,6 +845,7 @@ impl<'a> DelegationRunner<'a> {
             requested_intent: None,
             also_mentioned: Vec::new(),
             reissue_message: None,
+            thread_root: None,
             approvals: None,
             workflow_run: Some(run),
             workflow_refs: None,
@@ -942,7 +957,7 @@ impl<'a> DelegationRunner<'a> {
             // The SAME arm the chat path runs — which is what makes the
             // no-column-move invariant inherited rather than re-promised here.
             let outcome = self
-                .run_delegation(delegation, ChatTarget::default(), MessageContext::default())
+                .run_delegation(delegation, None, MessageContext::default())
                 .await;
             let row = match (spawn, outcome) {
                 // A card id comes back only after the store took the write
@@ -1043,6 +1058,24 @@ impl<'a> DelegationRunner<'a> {
     /// context about the turn, absent on every path that is not an operator
     /// message, and threading it as an argument would make a dozen test call
     /// sites restate an empty vector to say nothing.
+    /// The conversation a turn in `chat_id` belongs to: that channel, plus
+    /// whatever thread [`in_thread`](Self::in_thread) bound this runner to.
+    ///
+    /// The single place the two halves are rejoined, so a caller cannot pair a
+    /// channel with the wrong thread by getting the argument order wrong — the
+    /// hazard `ChatTarget`'s own docs name.
+    fn target(&self, chat_id: Option<&'a str>) -> ChatTarget<'a> {
+        ChatTarget::in_thread(chat_id, self.thread_root)
+    }
+
+    /// Binds this turn to the thread rooted at `root` (#1890) — `None` is the
+    /// channel-level conversation, which is what every non-threaded path wants
+    /// and therefore never has to say.
+    pub(crate) fn in_thread(mut self, root: Option<EventSeq>) -> Self {
+        self.thread_root = root;
+        self
+    }
+
     pub(crate) fn also_mentioned(mut self, agents: Vec<String>) -> Self {
         self.also_mentioned = agents;
         self
@@ -1079,7 +1112,7 @@ impl<'a> DelegationRunner<'a> {
         &self,
         responder: &str,
         message: &str,
-        chat: ChatTarget<'_>,
+        chat_id: Option<&str>,
     ) -> Result<OperatorTurn> {
         // What this message IS, decided once (issue #267).
         //
@@ -1243,7 +1276,7 @@ impl<'a> DelegationRunner<'a> {
         // lies.
         let workflow_requested = self.requested_intent
             == Some(crate::ports::types::MessageIntent::Workflow)
-            && !crate::company::copilot::is_copilot_thread(chat.chat_id);
+            && !crate::company::copilot::is_copilot_thread(chat_id);
         // Issue #463: did the REST chat handler already card this message?
         //
         // Two ways it does, and until #1035 this saw only the first. The triage
@@ -1301,7 +1334,7 @@ impl<'a> DelegationRunner<'a> {
         // authored. Run records stay reserved for actual work attempts (#183
         // §4), so this turn mints none — see `TaskOutputSource`.
         let handler_card = match carded_by_handler {
-            true => self.chat_handler_card(message, chat.chat_id).await?,
+            true => self.chat_handler_card(message, chat_id).await?,
             false => None,
         };
         // Issue #442, path one: a desk lead or teammate asked DIRECTLY carries
@@ -1312,7 +1345,7 @@ impl<'a> DelegationRunner<'a> {
         // the tracking decision stops depending on which agent answered or which
         // tools it happens to carry.
         let mut direct_card = self
-            .open_direct_work_card(responder, message, chat.chat_id, ctx)
+            .open_direct_work_card(responder, message, chat_id, ctx)
             .await?;
         // Same discipline `run_task` keeps on the dispatched-card path: only
         // what *this* turn stages can be attributed to this turn's card, so
@@ -1409,7 +1442,8 @@ impl<'a> DelegationRunner<'a> {
                 || (chatter && is_pure_small_talk(operator_words(message))));
         let outcome = with_chat_only_hint(
             chat_only,
-            self.run_turn.run(self.company, responder, message, chat),
+            self.run_turn
+                .run(self.company, responder, message, self.target(chat_id)),
         )
         .await?;
         let parked = self.approvals_queued().saturating_sub(approvals_before);
@@ -1484,7 +1518,7 @@ impl<'a> DelegationRunner<'a> {
         // card, and it has to still be readable after `spawned_task` takes it
         // (issue #678).
         let mut spawned_task: Option<String> = handler_card.clone().or(direct_card_id);
-        let drained = self.drain_and_execute(chat, ctx, HandOffs::Run).await?;
+        let drained = self.drain_and_execute(chat_id, ctx, HandOffs::Run).await?;
         if let Some(id) = drained.spawned_task {
             spawned_task.get_or_insert(id);
         }
@@ -1526,7 +1560,7 @@ impl<'a> DelegationRunner<'a> {
             self.queue.clear();
             let relay = self
                 .run_turn
-                .run(self.company, responder, &relay_prompt, chat)
+                .run(self.company, responder, &relay_prompt, self.target(chat_id))
                 .await?;
             // The relay turn may only relay — a second hand-off from here is the
             // re-delegation loop this drain exists to stop, and it is dropped.
@@ -1557,7 +1591,7 @@ impl<'a> DelegationRunner<'a> {
             // and let the operator ask for it. Pinned by
             // `the_relay_turns_card_is_held_back_on_a_question_turn` and its
             // non-question sibling.
-            let drained = self.drain_and_execute(chat, ctx, HandOffs::Drop).await?;
+            let drained = self.drain_and_execute(chat_id, ctx, HandOffs::Drop).await?;
             if let Some(id) = drained.spawned_task {
                 spawned_task.get_or_insert(id);
             }
@@ -1622,7 +1656,7 @@ impl<'a> DelegationRunner<'a> {
                 let marker = crate::runtime::grants::budget_pauses_for(self.company)
                     .park_preserving_background(
                         pause.agent.clone(),
-                        chat.chat_id.map(str::to_string),
+                        chat_id.map(str::to_string),
                         park_message,
                         pause.summary.clone(),
                         now_millis(),
@@ -1660,7 +1694,7 @@ impl<'a> DelegationRunner<'a> {
                     responder,
                     parked,
                     &authored,
-                    chat.chat_id,
+                    chat_id,
                 )
                 .await;
             }
@@ -1834,7 +1868,7 @@ impl<'a> DelegationRunner<'a> {
     /// one fact rather than something a shared drain can decide.
     pub(crate) async fn drain_and_execute(
         &self,
-        chat: ChatTarget<'_>,
+        chat_id: Option<&str>,
         ctx: MessageContext,
         hand_offs: HandOffs,
     ) -> Result<Drained> {
@@ -1854,7 +1888,7 @@ impl<'a> DelegationRunner<'a> {
             // Captured before the delegation is consumed, so a cancellation can
             // be reported against whoever it was aimed at (issues #176, #884).
             let target = hand_off_target_of(&delegation).map(str::to_string);
-            let out = self.run_delegation(delegation, chat, ctx).await?;
+            let out = self.run_delegation(delegation, chat_id, ctx).await?;
             if out.cancelled
                 && let Some(desk) = target
             {
@@ -1996,7 +2030,7 @@ impl<'a> DelegationRunner<'a> {
                 // therefore no chat-handler card to defer to. It opens no card
                 // of its own regardless — `for_task` is set, which
                 // `open_work_card` refuses on first.
-                self.run_delegation(delegation, ChatTarget::default(), MessageContext::default())
+                self.run_delegation(delegation, None, MessageContext::default())
                     .await?;
                 if let Some((target, cause)) = undeliverable {
                     card.note = Some(append_note(
@@ -2021,7 +2055,7 @@ impl<'a> DelegationRunner<'a> {
                     .await?;
             }
             let outcome = self
-                .run_delegation(delegation, ChatTarget::default(), MessageContext::default())
+                .run_delegation(delegation, None, MessageContext::default())
                 .await?;
             match (owns_card, outcome.desk_reply, outcome.cancelled) {
                 // The delegate answered: they own the card and it settles from
@@ -2076,7 +2110,7 @@ impl<'a> DelegationRunner<'a> {
     async fn run_hand_off(
         &self,
         hand_off: HandOff,
-        chat: ChatTarget<'_>,
+        chat_id: Option<&str>,
         ctx: MessageContext,
     ) -> Result<DelegationOutcome> {
         let HandOff {
@@ -2100,7 +2134,7 @@ impl<'a> DelegationRunner<'a> {
         // (issue #463), or when the instruction is not a piece of work —
         // see `is_trackable_work`.
         let mut card = self
-            .open_hand_off_work_card(&member, &instruction, chat.chat_id, ctx)
+            .open_hand_off_work_card(&member, &instruction, chat_id, ctx)
             .await?;
         // Register the delegated turn so an operator can CANCEL it
         // mid-flight (cancel-only in v1 — pause/redirect are rejected at
@@ -2146,7 +2180,7 @@ impl<'a> DelegationRunner<'a> {
                 &member,
                 &instruction,
                 &control,
-                chat,
+                self.target(chat_id),
                 // Issue #242: when this drain is running inside a
                 // dispatched card, the delegate's turn is part of that
                 // card's attempt — its steps and its spend belong to the
@@ -2193,7 +2227,7 @@ impl<'a> DelegationRunner<'a> {
             let marker = crate::runtime::grants::budget_pauses_for(self.company)
                 .park_preserving_background(
                     pause.agent.clone(),
-                    chat.chat_id.map(str::to_string),
+                    chat_id.map(str::to_string),
                     park_message,
                     pause.summary.clone(),
                     now_millis(),
@@ -2271,7 +2305,7 @@ impl<'a> DelegationRunner<'a> {
         // `answering` are properties of the OPERATOR's message, and they
         // stay true at every depth — a question the operator asked is
         // still a question three desks down, and must still mint no card.
-        let nested = Box::pin(self.drain_and_execute(chat, ctx, HandOffs::Run)).await?;
+        let nested = Box::pin(self.drain_and_execute(chat_id, ctx, HandOffs::Run)).await?;
         // Fold the nested answers INTO this member's reply rather than
         // giving each level its own relay turn. The top-level CEO-relay
         // already synthesises every desk reply into one coherent answer
@@ -2842,7 +2876,7 @@ impl<'a> DelegationRunner<'a> {
     pub(crate) async fn run_delegation(
         &self,
         delegation: Delegation,
-        chat: ChatTarget<'_>,
+        chat_id: Option<&str>,
         ctx: MessageContext,
     ) -> Result<DelegationOutcome> {
         match delegation {
@@ -2872,7 +2906,7 @@ impl<'a> DelegationRunner<'a> {
                     // *scheduled* the workflow hours earlier would make the card
                     // answer into a conversation the operator has left. The run
                     // reference below is the provenance instead.
-                    origin_chat_id: chat.chat_id.map(str::to_string),
+                    origin_chat_id: chat_id.map(str::to_string),
                     // Lineage (#185): the dispatched card whose turn queued this
                     // one, when the drain is running inside a task
                     // (`for_task`) — since #204 a dispatched turn drains the
@@ -2946,7 +2980,7 @@ impl<'a> DelegationRunner<'a> {
                         label: desk,
                         scope_key,
                     },
-                    chat,
+                    chat_id,
                     ctx,
                 ))
                 .await
@@ -2984,7 +3018,7 @@ impl<'a> DelegationRunner<'a> {
                         instruction,
                         scope_key,
                     },
-                    chat,
+                    chat_id,
                     ctx,
                 ))
                 .await
@@ -4570,11 +4604,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         fx.runner(&turns)
             .also_mentioned(vec!["chief".to_string()])
-            .handle_operator_message(
-                "engineer",
-                "look into this",
-                ChatTarget::channel(Some("eng_desk")),
-            )
+            .handle_operator_message("engineer", "look into this", Some("eng_desk"))
             .await
             .expect("operator message handled");
 
@@ -4598,11 +4628,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         fx.runner(&turns)
             .also_mentioned(vec!["engineer".to_string()])
-            .handle_operator_message(
-                "chief",
-                "look into this",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "look into this", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -4627,11 +4653,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         fx.runner(&turns)
             .also_mentioned(vec!["researcher".to_string(), "designer".to_string()])
-            .handle_operator_message(
-                "engineer",
-                "look into this",
-                ChatTarget::channel(Some("eng_desk")),
-            )
+            .handle_operator_message("engineer", "look into this", Some("eng_desk"))
             .await
             .expect("operator message handled");
 
@@ -4686,11 +4708,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
 
         fx.runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "approve the launch plan card",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "approve the launch plan card", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -4750,11 +4768,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let turn = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "map out the pricing repo",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "map out the pricing repo", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -4801,7 +4815,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .runner(&turns)
             .run_delegation(
                 handoff("draft the launch plan"),
-                ChatTarget::default(),
+                None,
                 MessageContext::default(),
             )
             .await
@@ -4830,7 +4844,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .runner(&turns)
             .run_delegation(
                 handoff("write the migration plan"),
-                ChatTarget::default(),
+                None,
                 MessageContext::default(),
             )
             .await
@@ -4856,7 +4870,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", "is the build ok?", ChatTarget::default())
+            .handle_operator_message("chief", "is the build ok?", None)
             .await
             .expect("operator message handled");
         assert!(fx.cards().await.is_empty(), "a question is not work");
@@ -4875,7 +4889,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .for_task("card-1")
             .run_delegation(
                 handoff("write the migration plan"),
-                ChatTarget::default(),
+                None,
                 MessageContext::default(),
             )
             .await
@@ -4898,7 +4912,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "engineer",
                 "read the pricing repo and write modules.md",
-                ChatTarget::channel(Some("eng_desk")),
+                Some("eng_desk"),
             )
             .await
             .expect("operator message handled");
@@ -4952,7 +4966,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turn = fx
             .runner(&turns)
             .with_triage(&escalation)
-            .handle_operator_message("engineer", probe, ChatTarget::channel(Some("eng_desk")))
+            .handle_operator_message("engineer", probe, Some("eng_desk"))
             .await
             .expect("operator message handled");
 
@@ -4991,7 +5005,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
             fx.runner(&turns)
                 .with_triage(&escalation)
-                .handle_operator_message("engineer", residue, ChatTarget::channel(Some("eng_desk")))
+                .handle_operator_message("engineer", residue, Some("eng_desk"))
                 .await
                 .expect("operator message handled");
             let cards = fx.cards().await;
@@ -5035,7 +5049,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turn = fx
             .runner(&turns)
             .requested(Some(crate::ports::types::MessageIntent::Workflow))
-            .handle_operator_message("engineer", residue, ChatTarget::channel(Some("eng_desk")))
+            .handle_operator_message("engineer", residue, Some("eng_desk"))
             .await
             .expect("operator message handled");
 
@@ -5061,7 +5075,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
             fx.runner(&turns)
                 .requested(choice)
-                .handle_operator_message("engineer", residue, ChatTarget::channel(Some("eng_desk")))
+                .handle_operator_message("engineer", residue, Some("eng_desk"))
                 .await
                 .expect("operator message handled");
             assert_eq!(
@@ -5088,11 +5102,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         fx.runner(&turns)
             .requested(Some(crate::ports::types::MessageIntent::Workflow))
-            .handle_operator_message(
-                "engineer",
-                residue,
-                ChatTarget::channel(Some("workflow-copilot:weekly_report")),
-            )
+            .handle_operator_message("engineer", residue, Some("workflow-copilot:weekly_report"))
             .await
             .expect("operator message handled");
 
@@ -5141,7 +5151,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turn = fx
             .runner(&turns)
             .requested(Some(crate::ports::types::MessageIntent::Chat))
-            .handle_operator_message("engineer", residue, ChatTarget::channel(Some("eng_desk")))
+            .handle_operator_message("engineer", residue, Some("eng_desk"))
             .await
             .expect("operator message handled");
 
@@ -5174,7 +5184,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         fx.runner(&turns)
             .with_triage(&escalation)
             .requested(Some(crate::ports::types::MessageIntent::Chat))
-            .handle_operator_message("engineer", residue, ChatTarget::channel(Some("eng_desk")))
+            .handle_operator_message("engineer", residue, Some("eng_desk"))
             .await
             .expect("operator message handled");
 
@@ -5197,7 +5207,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("ack")]);
         fx.runner(&turns)
-            .handle_operator_message("engineer", probe, ChatTarget::channel(Some("eng_desk")))
+            .handle_operator_message("engineer", probe, Some("eng_desk"))
             .await
             .expect("operator message handled");
         assert_eq!(
@@ -5231,7 +5241,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "frontend_engineer",
                 "read the pricing repo and write modules.md",
-                ChatTarget::channel(Some("eng_desk")),
+                Some("eng_desk"),
             )
             .await
             .expect("operator message handled");
@@ -5263,7 +5273,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "frontend_engineer",
                 "read the pricing repo and write modules.md",
-                ChatTarget::channel(Some("eng_desk")),
+                Some("eng_desk"),
             )
             .await
             .expect("operator message handled");
@@ -5300,7 +5310,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "frontend_engineer",
                 "read the pricing repo and write modules.md",
-                ChatTarget::channel(Some("eng_desk")),
+                Some("eng_desk"),
             )
             .await
             .expect("operator message handled");
@@ -5327,11 +5337,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             ],
         );
         fx.runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "map out the pricing repo",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "map out the pricing repo", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -5363,11 +5369,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("planned")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message(
-                "engineer",
-                imperative,
-                ChatTarget::channel(Some("eng_desk")),
-            )
+            .handle_operator_message("engineer", imperative, Some("eng_desk"))
             .await
             .expect("operator message handled");
         assert!(
@@ -5425,7 +5427,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             let turns = ScriptedTurns::new(&fx, vec![Turn::reply("ok")]);
             fx.runner(&turns)
                 .with_triage(&escalation)
-                .handle_operator_message("chief", named, ChatTarget::channel(Some("general")))
+                .handle_operator_message("chief", named, Some("general"))
                 .await
                 .expect("operator message handled");
         }
@@ -5452,7 +5454,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
         fx.runner(&turns)
             .with_triage(&escalation)
-            .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", residue, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -5486,7 +5488,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
             fx.runner(&turns)
                 .with_triage(&escalation)
-                .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
+                .handle_operator_message("chief", residue, Some("general"))
                 .await
                 .expect("operator message handled");
             assert_eq!(
@@ -5509,7 +5511,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", residue, Some("general"))
             .await
             .expect("operator message handled");
         assert_eq!(
@@ -5578,7 +5580,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", imperative, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -5626,7 +5628,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::default())
+            .handle_operator_message("chief", imperative, None)
             .await
             .expect("operator message handled");
 
@@ -5682,7 +5684,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", imperative, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -5744,7 +5746,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", imperative, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -5781,7 +5783,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             vec![Turn::authoring("done", vec![authored("nightly-digest")])],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", chatter, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", chatter, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -5808,7 +5810,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("I could not build that")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", imperative, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -5840,7 +5842,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("I could not build that")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", imperative, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -5907,7 +5909,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::default())
+            .handle_operator_message("chief", imperative, None)
             .await
             .expect("operator message handled");
 
@@ -5965,7 +5967,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::default())
+            .handle_operator_message("chief", imperative, None)
             .await
             .expect("operator message handled");
 
@@ -6021,11 +6023,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message(
-                "engineer",
-                imperative,
-                ChatTarget::channel(Some("engineer")),
-            )
+            .handle_operator_message("engineer", imperative, Some("engineer"))
             .await
             .expect("operator message handled");
 
@@ -6074,11 +6072,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message(
-                "engineer",
-                imperative,
-                ChatTarget::channel(Some("dm:engineer")),
-            )
+            .handle_operator_message("engineer", imperative, Some("dm:engineer"))
             .await
             .expect("operator message handled");
 
@@ -6123,11 +6117,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message(
-                "engineer",
-                imperative,
-                ChatTarget::channel(Some("dm:engineer")),
-            )
+            .handle_operator_message("engineer", imperative, Some("dm:engineer"))
             .await
             .expect("operator message handled");
 
@@ -6170,11 +6160,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                imperative,
-                ChatTarget::channel(Some("dm:engineer")),
-            )
+            .handle_operator_message("chief", imperative, Some("dm:engineer"))
             .await
             .expect("operator message handled");
 
@@ -6221,7 +6207,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::default())
+            .handle_operator_message("chief", imperative, None)
             .await
             .expect("operator message handled");
 
@@ -6268,7 +6254,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::default())
+            .handle_operator_message("chief", imperative, None)
             .await
             .expect("operator message handled");
 
@@ -6295,11 +6281,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "draft the launch plan for next quarter",
-                ChatTarget::default(),
-            )
+            .handle_operator_message("chief", "draft the launch plan for next quarter", None)
             .await
             .expect("operator message handled");
         assert!(fx.cards().await.is_empty(), "no second card is opened");
@@ -6314,11 +6296,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("green")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message(
-                "engineer",
-                "is the build green?",
-                ChatTarget::channel(Some("eng_desk")),
-            )
+            .handle_operator_message("engineer", "is the build green?", Some("eng_desk"))
             .await
             .expect("operator message handled");
         assert!(fx.cards().await.is_empty());
@@ -6357,7 +6335,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", question, ChatTarget::default())
+            .handle_operator_message("chief", question, None)
             .await
             .expect("operator message handled");
 
@@ -6413,11 +6391,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "Tell what is there in the tasks list",
-                ChatTarget::default(),
-            )
+            .handle_operator_message("chief", "Tell what is there in the tasks list", None)
             .await
             .expect("operator message handled");
 
@@ -6462,7 +6436,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", question, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", question, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -6536,7 +6510,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turn = fx
             .runner(&turns)
             .with_triage(&escalation)
-            .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", residue, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -6590,7 +6564,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         fx.runner(&turns)
             .with_triage(&escalation)
-            .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", residue, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -6645,7 +6619,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turn = fx
             .runner(&turns)
             .requested(Some(crate::ports::types::MessageIntent::Chat))
-            .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", residue, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -6701,11 +6675,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "the pricing repo needs a map",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "the pricing repo needs a map", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -6748,7 +6718,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", neutral, ChatTarget::default())
+            .handle_operator_message("chief", neutral, None)
             .await
             .expect("operator message handled");
 
@@ -6793,7 +6763,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("Hi! How can I help you today?")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", greeting, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", greeting, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -6827,7 +6797,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("Not much, what's up?")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", greeting, ChatTarget::channel(Some("general")))
+            .handle_operator_message("chief", greeting, Some("general"))
             .await
             .expect("operator message handled");
 
@@ -6858,7 +6828,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             ],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, ChatTarget::default())
+            .handle_operator_message("chief", imperative, None)
             .await
             .expect("operator message handled");
 
@@ -6897,7 +6867,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("shipped the importer")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("engineer", question, ChatTarget::channel(Some("eng_desk")))
+            .handle_operator_message("engineer", question, Some("eng_desk"))
             .await
             .expect("operator message handled");
 
@@ -6949,7 +6919,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "brand_strategist",
                 "SEO Specialist: run an SEO pass over the pricing page",
-                ChatTarget::channel(Some("strategy")),
+                Some("strategy"),
             )
             .await
             .expect("operator message handled");
@@ -7010,7 +6980,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "brand_strategist",
                 "sort out the pricing page",
-                ChatTarget::channel(Some("strategy")),
+                Some("strategy"),
             )
             .await
             .expect("operator message handled");
@@ -7055,7 +7025,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "brand_strategist",
                 "sort out the pricing page",
-                ChatTarget::channel(Some("strategy")),
+                Some("strategy"),
             )
             .await
             .expect("operator message handled");
@@ -7098,11 +7068,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             ],
         );
         fx.runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "get the launch note drafted",
-                ChatTarget::default(),
-            )
+            .handle_operator_message("chief", "get the launch note drafted", None)
             .await
             .expect("operator message handled");
 
@@ -7126,7 +7092,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", "draft the investor update", ChatTarget::default())
+            .handle_operator_message("chief", "draft the investor update", None)
             .await
             .expect("operator message handled");
         assert!(fx.cards().await.is_empty());
@@ -7171,7 +7137,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             ],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", instruction, ChatTarget::default())
+            .handle_operator_message("chief", instruction, None)
             .await
             .expect("operator message handled");
 
@@ -7230,7 +7196,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", question, ChatTarget::default())
+            .handle_operator_message("chief", question, None)
             .await
             .expect("operator message handled");
 
@@ -7276,7 +7242,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             ],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", "is the build ok?", ChatTarget::default())
+            .handle_operator_message("chief", "is the build ok?", None)
             .await
             .expect("operator message handled");
 
@@ -7334,11 +7300,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -7423,11 +7385,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -7468,11 +7426,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -7522,11 +7476,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -7591,11 +7541,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             // The production wiring in `brain.rs` sets this from the operator's
             // own composed message before calling `handle_operator_message`.
             .reissue_message("ship the API")
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
         assert!(
@@ -7690,11 +7636,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let out = crate::runtime::grants::with_redeem_context(redeem.clone(), async {
             fx.runner(&turns)
                 .reissue_message("ship the API")
-                .handle_operator_message(
-                    "chief",
-                    "ship the API",
-                    ChatTarget::channel(Some("general")),
-                )
+                .handle_operator_message("chief", "ship the API", Some("general"))
                 .await
                 .expect("operator message handled")
         })
@@ -7754,11 +7696,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -7797,11 +7735,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -7833,7 +7767,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "engineer",
                 "read the pricing repo and write modules.md",
-                ChatTarget::channel(Some("eng_desk")),
+                Some("eng_desk"),
             )
             .await
             .expect("operator message handled");
@@ -7869,7 +7803,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .runner(&turns)
             .run_delegation(
                 handoff("draft the launch plan"),
-                ChatTarget::default(),
+                None,
                 MessageContext::default(),
             )
             .await
@@ -7927,11 +7861,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -8003,11 +7933,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -8057,11 +7983,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -8107,11 +8029,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -8151,11 +8069,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -8189,11 +8103,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         .with_max_depth(1);
 
         fx.runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -8249,11 +8159,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
 
         fx.runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -8301,11 +8207,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
 
         fx.runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 
@@ -8352,11 +8254,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
 
         fx.runner(&turns)
-            .handle_operator_message(
-                "chief",
-                "ship the API",
-                ChatTarget::channel(Some("general")),
-            )
+            .handle_operator_message("chief", "ship the API", Some("general"))
             .await
             .expect("operator message handled");
 

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -7927,7 +7927,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -36,7 +36,7 @@ use crate::ports::tasks::{
     COLUMN_PLANNING, COLUMN_TODO, TaskOutput, TaskOutputAction, TaskOutputSource,
     TaskOutputWorkflow,
 };
-use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage, TurnStep};
+use crate::ports::types::{CompanyId, CompanyRecord, EventSeq, OutboundMessage, TurnStep};
 use crate::ports::{TaskRecord, TaskStore, generate_id, now_millis};
 use crate::runtime::assignee;
 use crate::runtime::cycle::{BUILDER_ANNOTATION, OPEN_WORK_ANNOTATION, assignment_matches};
@@ -51,15 +51,56 @@ use crate::runtime::cycle::{BUILDER_ANNOTATION, OPEN_WORK_ANNOTATION, assignment
 /// turn ([`run_steered_background`](RunTurn::run_steered_background)). The impl
 /// re-attaches whatever dependencies the concrete runtime needs; the runner only
 /// ever sees a [`TurnOutcome`].
+/// Which conversation a chat turn belongs to: the channel, and the thread
+/// within it (#1890).
+///
+/// One argument rather than two loose `Option`s beside each other. A bare
+/// `Option<EventSeq>` next to a bare `Option<&str>` is exactly the shape
+/// [`ChatTurn`](crate::server::operator) already documents as the hazard — a
+/// mis-ordered pair that compiles and then answers into the wrong
+/// conversation — and there is nothing in either type to catch it.
+///
+/// A `None` `thread_root` is not "no thread". It is the channel-level
+/// conversation: the one every unparented line hangs in, which is every line
+/// in a company that has never opened a thread.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ChatTarget<'a> {
+    /// The desk / channel the turn is addressed to; `None` is unaddressed and
+    /// folds to the General desk downstream.
+    pub chat_id: Option<&'a str>,
+    /// The root message this turn's thread hangs off; `None` is the channel
+    /// itself.
+    pub thread_root: Option<EventSeq>,
+}
+
+impl<'a> ChatTarget<'a> {
+    /// A turn posted straight into a channel — the shape every caller had
+    /// before threads were part of the key.
+    pub fn channel(chat_id: Option<&'a str>) -> Self {
+        Self {
+            chat_id,
+            thread_root: None,
+        }
+    }
+
+    /// A turn inside `chat_id`, in the thread rooted at `thread_root`.
+    pub fn in_thread(chat_id: Option<&'a str>, thread_root: Option<EventSeq>) -> Self {
+        Self {
+            chat_id,
+            thread_root,
+        }
+    }
+}
+
 #[async_trait]
 pub trait RunTurn: Send + Sync {
-    /// A streamed turn on `agent_id` answering `message` in `chat_id`.
+    /// A streamed turn on `agent_id` answering `message` in `chat`.
     async fn run(
         &self,
         company: &CompanyId,
         agent_id: &str,
         message: &str,
-        chat_id: Option<&str>,
+        chat: ChatTarget<'_>,
     ) -> Result<TurnOutcome>;
 
     /// A streamed, operator-steerable turn (pause / cancel / redirect).
@@ -74,7 +115,7 @@ pub trait RunTurn: Send + Sync {
         agent_id: &str,
         message: &str,
         control: &SteerControl,
-        chat_id: Option<&str>,
+        chat: ChatTarget<'_>,
         run_sink: Option<Arc<RunTraceSink>>,
     ) -> Result<TurnOutcome>;
 
@@ -120,7 +161,8 @@ pub trait RunTurn: Send + Sync {
         // and an engine with no step stream has nothing to feed it anyway. The
         // streaming harness overrides this and does record.
         let _ = run_sink;
-        self.run(company, agent_id, message, None).await
+        self.run(company, agent_id, message, ChatTarget::default())
+            .await
     }
 
     /// Like [`run_background`](Self::run_background) but streams the node's live
@@ -357,7 +399,7 @@ impl RunTurn for NoTurn {
         _company: &CompanyId,
         _agent_id: &str,
         _message: &str,
-        _chat_id: Option<&str>,
+        _chat: ChatTarget<'_>,
     ) -> Result<TurnOutcome> {
         Err(no_turn_error())
     }
@@ -368,7 +410,7 @@ impl RunTurn for NoTurn {
         _agent_id: &str,
         _message: &str,
         _control: &SteerControl,
-        _chat_id: Option<&str>,
+        _chat: ChatTarget<'_>,
         _run_sink: Option<Arc<RunTraceSink>>,
     ) -> Result<TurnOutcome> {
         Err(no_turn_error())
@@ -900,7 +942,7 @@ impl<'a> DelegationRunner<'a> {
             // The SAME arm the chat path runs — which is what makes the
             // no-column-move invariant inherited rather than re-promised here.
             let outcome = self
-                .run_delegation(delegation, None, MessageContext::default())
+                .run_delegation(delegation, ChatTarget::default(), MessageContext::default())
                 .await;
             let row = match (spawn, outcome) {
                 // A card id comes back only after the store took the write
@@ -1037,7 +1079,7 @@ impl<'a> DelegationRunner<'a> {
         &self,
         responder: &str,
         message: &str,
-        chat_id: Option<&str>,
+        chat: ChatTarget<'_>,
     ) -> Result<OperatorTurn> {
         // What this message IS, decided once (issue #267).
         //
@@ -1201,7 +1243,7 @@ impl<'a> DelegationRunner<'a> {
         // lies.
         let workflow_requested = self.requested_intent
             == Some(crate::ports::types::MessageIntent::Workflow)
-            && !crate::company::copilot::is_copilot_thread(chat_id);
+            && !crate::company::copilot::is_copilot_thread(chat.chat_id);
         // Issue #463: did the REST chat handler already card this message?
         //
         // Two ways it does, and until #1035 this saw only the first. The triage
@@ -1259,7 +1301,7 @@ impl<'a> DelegationRunner<'a> {
         // authored. Run records stay reserved for actual work attempts (#183
         // §4), so this turn mints none — see `TaskOutputSource`.
         let handler_card = match carded_by_handler {
-            true => self.chat_handler_card(message, chat_id).await?,
+            true => self.chat_handler_card(message, chat.chat_id).await?,
             false => None,
         };
         // Issue #442, path one: a desk lead or teammate asked DIRECTLY carries
@@ -1270,7 +1312,7 @@ impl<'a> DelegationRunner<'a> {
         // the tracking decision stops depending on which agent answered or which
         // tools it happens to carry.
         let mut direct_card = self
-            .open_direct_work_card(responder, message, chat_id, ctx)
+            .open_direct_work_card(responder, message, chat.chat_id, ctx)
             .await?;
         // Same discipline `run_task` keeps on the dispatched-card path: only
         // what *this* turn stages can be attributed to this turn's card, so
@@ -1367,7 +1409,7 @@ impl<'a> DelegationRunner<'a> {
                 || (chatter && is_pure_small_talk(operator_words(message))));
         let outcome = with_chat_only_hint(
             chat_only,
-            self.run_turn.run(self.company, responder, message, chat_id),
+            self.run_turn.run(self.company, responder, message, chat),
         )
         .await?;
         let parked = self.approvals_queued().saturating_sub(approvals_before);
@@ -1442,7 +1484,7 @@ impl<'a> DelegationRunner<'a> {
         // card, and it has to still be readable after `spawned_task` takes it
         // (issue #678).
         let mut spawned_task: Option<String> = handler_card.clone().or(direct_card_id);
-        let drained = self.drain_and_execute(chat_id, ctx, HandOffs::Run).await?;
+        let drained = self.drain_and_execute(chat, ctx, HandOffs::Run).await?;
         if let Some(id) = drained.spawned_task {
             spawned_task.get_or_insert(id);
         }
@@ -1484,7 +1526,7 @@ impl<'a> DelegationRunner<'a> {
             self.queue.clear();
             let relay = self
                 .run_turn
-                .run(self.company, responder, &relay_prompt, chat_id)
+                .run(self.company, responder, &relay_prompt, chat)
                 .await?;
             // The relay turn may only relay — a second hand-off from here is the
             // re-delegation loop this drain exists to stop, and it is dropped.
@@ -1515,7 +1557,7 @@ impl<'a> DelegationRunner<'a> {
             // and let the operator ask for it. Pinned by
             // `the_relay_turns_card_is_held_back_on_a_question_turn` and its
             // non-question sibling.
-            let drained = self.drain_and_execute(chat_id, ctx, HandOffs::Drop).await?;
+            let drained = self.drain_and_execute(chat, ctx, HandOffs::Drop).await?;
             if let Some(id) = drained.spawned_task {
                 spawned_task.get_or_insert(id);
             }
@@ -1580,7 +1622,7 @@ impl<'a> DelegationRunner<'a> {
                 let marker = crate::runtime::grants::budget_pauses_for(self.company)
                     .park_preserving_background(
                         pause.agent.clone(),
-                        chat_id.map(str::to_string),
+                        chat.chat_id.map(str::to_string),
                         park_message,
                         pause.summary.clone(),
                         now_millis(),
@@ -1618,7 +1660,7 @@ impl<'a> DelegationRunner<'a> {
                     responder,
                     parked,
                     &authored,
-                    chat_id,
+                    chat.chat_id,
                 )
                 .await;
             }
@@ -1792,7 +1834,7 @@ impl<'a> DelegationRunner<'a> {
     /// one fact rather than something a shared drain can decide.
     pub(crate) async fn drain_and_execute(
         &self,
-        chat_id: Option<&str>,
+        chat: ChatTarget<'_>,
         ctx: MessageContext,
         hand_offs: HandOffs,
     ) -> Result<Drained> {
@@ -1812,7 +1854,7 @@ impl<'a> DelegationRunner<'a> {
             // Captured before the delegation is consumed, so a cancellation can
             // be reported against whoever it was aimed at (issues #176, #884).
             let target = hand_off_target_of(&delegation).map(str::to_string);
-            let out = self.run_delegation(delegation, chat_id, ctx).await?;
+            let out = self.run_delegation(delegation, chat, ctx).await?;
             if out.cancelled
                 && let Some(desk) = target
             {
@@ -1954,7 +1996,7 @@ impl<'a> DelegationRunner<'a> {
                 // therefore no chat-handler card to defer to. It opens no card
                 // of its own regardless — `for_task` is set, which
                 // `open_work_card` refuses on first.
-                self.run_delegation(delegation, None, MessageContext::default())
+                self.run_delegation(delegation, ChatTarget::default(), MessageContext::default())
                     .await?;
                 if let Some((target, cause)) = undeliverable {
                     card.note = Some(append_note(
@@ -1979,7 +2021,7 @@ impl<'a> DelegationRunner<'a> {
                     .await?;
             }
             let outcome = self
-                .run_delegation(delegation, None, MessageContext::default())
+                .run_delegation(delegation, ChatTarget::default(), MessageContext::default())
                 .await?;
             match (owns_card, outcome.desk_reply, outcome.cancelled) {
                 // The delegate answered: they own the card and it settles from
@@ -2034,7 +2076,7 @@ impl<'a> DelegationRunner<'a> {
     async fn run_hand_off(
         &self,
         hand_off: HandOff,
-        chat_id: Option<&str>,
+        chat: ChatTarget<'_>,
         ctx: MessageContext,
     ) -> Result<DelegationOutcome> {
         let HandOff {
@@ -2058,7 +2100,7 @@ impl<'a> DelegationRunner<'a> {
         // (issue #463), or when the instruction is not a piece of work —
         // see `is_trackable_work`.
         let mut card = self
-            .open_hand_off_work_card(&member, &instruction, chat_id, ctx)
+            .open_hand_off_work_card(&member, &instruction, chat.chat_id, ctx)
             .await?;
         // Register the delegated turn so an operator can CANCEL it
         // mid-flight (cancel-only in v1 — pause/redirect are rejected at
@@ -2104,7 +2146,7 @@ impl<'a> DelegationRunner<'a> {
                 &member,
                 &instruction,
                 &control,
-                chat_id,
+                chat,
                 // Issue #242: when this drain is running inside a
                 // dispatched card, the delegate's turn is part of that
                 // card's attempt — its steps and its spend belong to the
@@ -2151,7 +2193,7 @@ impl<'a> DelegationRunner<'a> {
             let marker = crate::runtime::grants::budget_pauses_for(self.company)
                 .park_preserving_background(
                     pause.agent.clone(),
-                    chat_id.map(str::to_string),
+                    chat.chat_id.map(str::to_string),
                     park_message,
                     pause.summary.clone(),
                     now_millis(),
@@ -2229,7 +2271,7 @@ impl<'a> DelegationRunner<'a> {
         // `answering` are properties of the OPERATOR's message, and they
         // stay true at every depth — a question the operator asked is
         // still a question three desks down, and must still mint no card.
-        let nested = Box::pin(self.drain_and_execute(chat_id, ctx, HandOffs::Run)).await?;
+        let nested = Box::pin(self.drain_and_execute(chat, ctx, HandOffs::Run)).await?;
         // Fold the nested answers INTO this member's reply rather than
         // giving each level its own relay turn. The top-level CEO-relay
         // already synthesises every desk reply into one coherent answer
@@ -2800,7 +2842,7 @@ impl<'a> DelegationRunner<'a> {
     pub(crate) async fn run_delegation(
         &self,
         delegation: Delegation,
-        chat_id: Option<&str>,
+        chat: ChatTarget<'_>,
         ctx: MessageContext,
     ) -> Result<DelegationOutcome> {
         match delegation {
@@ -2830,7 +2872,7 @@ impl<'a> DelegationRunner<'a> {
                     // *scheduled* the workflow hours earlier would make the card
                     // answer into a conversation the operator has left. The run
                     // reference below is the provenance instead.
-                    origin_chat_id: chat_id.map(str::to_string),
+                    origin_chat_id: chat.chat_id.map(str::to_string),
                     // Lineage (#185): the dispatched card whose turn queued this
                     // one, when the drain is running inside a task
                     // (`for_task`) — since #204 a dispatched turn drains the
@@ -2904,7 +2946,7 @@ impl<'a> DelegationRunner<'a> {
                         label: desk,
                         scope_key,
                     },
-                    chat_id,
+                    chat,
                     ctx,
                 ))
                 .await
@@ -2942,7 +2984,7 @@ impl<'a> DelegationRunner<'a> {
                         instruction,
                         scope_key,
                     },
-                    chat_id,
+                    chat,
                     ctx,
                 ))
                 .await
@@ -4257,7 +4299,7 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
             _company: &CompanyId,
             agent_id: &str,
             message: &str,
-            _chat_id: Option<&str>,
+            _chat_id: ChatTarget<'_>,
         ) -> Result<TurnOutcome> {
             Ok(self.next(agent_id, message, None).await)
         }
@@ -4268,7 +4310,7 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
             agent_id: &str,
             message: &str,
             control: &SteerControl,
-            _chat_id: Option<&str>,
+            _chat_id: ChatTarget<'_>,
             _run_sink: Option<Arc<RunTraceSink>>,
         ) -> Result<TurnOutcome> {
             Ok(self.next(agent_id, message, Some(control)).await)
@@ -4528,7 +4570,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         fx.runner(&turns)
             .also_mentioned(vec!["chief".to_string()])
-            .handle_operator_message("engineer", "look into this", Some("eng_desk"))
+            .handle_operator_message(
+                "engineer",
+                "look into this",
+                ChatTarget::channel(Some("eng_desk")),
+            )
             .await
             .expect("operator message handled");
 
@@ -4552,7 +4598,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         fx.runner(&turns)
             .also_mentioned(vec!["engineer".to_string()])
-            .handle_operator_message("chief", "look into this", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "look into this",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -4577,7 +4627,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         fx.runner(&turns)
             .also_mentioned(vec!["researcher".to_string(), "designer".to_string()])
-            .handle_operator_message("engineer", "look into this", Some("eng_desk"))
+            .handle_operator_message(
+                "engineer",
+                "look into this",
+                ChatTarget::channel(Some("eng_desk")),
+            )
             .await
             .expect("operator message handled");
 
@@ -4632,7 +4686,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
 
         fx.runner(&turns)
-            .handle_operator_message("chief", "approve the launch plan card", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "approve the launch plan card",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -4692,7 +4750,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", "map out the pricing repo", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "map out the pricing repo",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -4739,7 +4801,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .runner(&turns)
             .run_delegation(
                 handoff("draft the launch plan"),
-                None,
+                ChatTarget::default(),
                 MessageContext::default(),
             )
             .await
@@ -4768,7 +4830,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .runner(&turns)
             .run_delegation(
                 handoff("write the migration plan"),
-                None,
+                ChatTarget::default(),
                 MessageContext::default(),
             )
             .await
@@ -4794,7 +4856,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", "is the build ok?", None)
+            .handle_operator_message("chief", "is the build ok?", ChatTarget::default())
             .await
             .expect("operator message handled");
         assert!(fx.cards().await.is_empty(), "a question is not work");
@@ -4813,7 +4875,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .for_task("card-1")
             .run_delegation(
                 handoff("write the migration plan"),
-                None,
+                ChatTarget::default(),
                 MessageContext::default(),
             )
             .await
@@ -4836,7 +4898,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "engineer",
                 "read the pricing repo and write modules.md",
-                Some("eng_desk"),
+                ChatTarget::channel(Some("eng_desk")),
             )
             .await
             .expect("operator message handled");
@@ -4890,7 +4952,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turn = fx
             .runner(&turns)
             .with_triage(&escalation)
-            .handle_operator_message("engineer", probe, Some("eng_desk"))
+            .handle_operator_message("engineer", probe, ChatTarget::channel(Some("eng_desk")))
             .await
             .expect("operator message handled");
 
@@ -4929,7 +4991,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
             fx.runner(&turns)
                 .with_triage(&escalation)
-                .handle_operator_message("engineer", residue, Some("eng_desk"))
+                .handle_operator_message("engineer", residue, ChatTarget::channel(Some("eng_desk")))
                 .await
                 .expect("operator message handled");
             let cards = fx.cards().await;
@@ -4973,7 +5035,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turn = fx
             .runner(&turns)
             .requested(Some(crate::ports::types::MessageIntent::Workflow))
-            .handle_operator_message("engineer", residue, Some("eng_desk"))
+            .handle_operator_message("engineer", residue, ChatTarget::channel(Some("eng_desk")))
             .await
             .expect("operator message handled");
 
@@ -4999,7 +5061,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
             fx.runner(&turns)
                 .requested(choice)
-                .handle_operator_message("engineer", residue, Some("eng_desk"))
+                .handle_operator_message("engineer", residue, ChatTarget::channel(Some("eng_desk")))
                 .await
                 .expect("operator message handled");
             assert_eq!(
@@ -5026,7 +5088,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         fx.runner(&turns)
             .requested(Some(crate::ports::types::MessageIntent::Workflow))
-            .handle_operator_message("engineer", residue, Some("workflow-copilot:weekly_report"))
+            .handle_operator_message(
+                "engineer",
+                residue,
+                ChatTarget::channel(Some("workflow-copilot:weekly_report")),
+            )
             .await
             .expect("operator message handled");
 
@@ -5075,7 +5141,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turn = fx
             .runner(&turns)
             .requested(Some(crate::ports::types::MessageIntent::Chat))
-            .handle_operator_message("engineer", residue, Some("eng_desk"))
+            .handle_operator_message("engineer", residue, ChatTarget::channel(Some("eng_desk")))
             .await
             .expect("operator message handled");
 
@@ -5108,7 +5174,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         fx.runner(&turns)
             .with_triage(&escalation)
             .requested(Some(crate::ports::types::MessageIntent::Chat))
-            .handle_operator_message("engineer", residue, Some("eng_desk"))
+            .handle_operator_message("engineer", residue, ChatTarget::channel(Some("eng_desk")))
             .await
             .expect("operator message handled");
 
@@ -5131,7 +5197,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("ack")]);
         fx.runner(&turns)
-            .handle_operator_message("engineer", probe, Some("eng_desk"))
+            .handle_operator_message("engineer", probe, ChatTarget::channel(Some("eng_desk")))
             .await
             .expect("operator message handled");
         assert_eq!(
@@ -5165,7 +5231,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "frontend_engineer",
                 "read the pricing repo and write modules.md",
-                Some("eng_desk"),
+                ChatTarget::channel(Some("eng_desk")),
             )
             .await
             .expect("operator message handled");
@@ -5197,7 +5263,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "frontend_engineer",
                 "read the pricing repo and write modules.md",
-                Some("eng_desk"),
+                ChatTarget::channel(Some("eng_desk")),
             )
             .await
             .expect("operator message handled");
@@ -5234,7 +5300,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "frontend_engineer",
                 "read the pricing repo and write modules.md",
-                Some("eng_desk"),
+                ChatTarget::channel(Some("eng_desk")),
             )
             .await
             .expect("operator message handled");
@@ -5261,7 +5327,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             ],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", "map out the pricing repo", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "map out the pricing repo",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -5293,7 +5363,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("planned")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("engineer", imperative, Some("eng_desk"))
+            .handle_operator_message(
+                "engineer",
+                imperative,
+                ChatTarget::channel(Some("eng_desk")),
+            )
             .await
             .expect("operator message handled");
         assert!(
@@ -5351,7 +5425,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             let turns = ScriptedTurns::new(&fx, vec![Turn::reply("ok")]);
             fx.runner(&turns)
                 .with_triage(&escalation)
-                .handle_operator_message("chief", named, Some("general"))
+                .handle_operator_message("chief", named, ChatTarget::channel(Some("general")))
                 .await
                 .expect("operator message handled");
         }
@@ -5378,7 +5452,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
         fx.runner(&turns)
             .with_triage(&escalation)
-            .handle_operator_message("chief", residue, Some("general"))
+            .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -5412,7 +5486,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
             fx.runner(&turns)
                 .with_triage(&escalation)
-                .handle_operator_message("chief", residue, Some("general"))
+                .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
                 .await
                 .expect("operator message handled");
             assert_eq!(
@@ -5435,7 +5509,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", residue, Some("general"))
+            .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
         assert_eq!(
@@ -5504,7 +5578,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, Some("general"))
+            .handle_operator_message("chief", imperative, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -5552,7 +5626,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, None)
+            .handle_operator_message("chief", imperative, ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -5608,7 +5682,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, Some("general"))
+            .handle_operator_message("chief", imperative, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -5670,7 +5744,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, Some("general"))
+            .handle_operator_message("chief", imperative, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -5707,7 +5781,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             vec![Turn::authoring("done", vec![authored("nightly-digest")])],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", chatter, Some("general"))
+            .handle_operator_message("chief", chatter, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -5734,7 +5808,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("I could not build that")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, Some("general"))
+            .handle_operator_message("chief", imperative, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -5766,7 +5840,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("I could not build that")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, Some("general"))
+            .handle_operator_message("chief", imperative, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -5833,7 +5907,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", imperative, None)
+            .handle_operator_message("chief", imperative, ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -5891,7 +5965,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", imperative, None)
+            .handle_operator_message("chief", imperative, ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -5947,7 +6021,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("engineer", imperative, Some("engineer"))
+            .handle_operator_message(
+                "engineer",
+                imperative,
+                ChatTarget::channel(Some("engineer")),
+            )
             .await
             .expect("operator message handled");
 
@@ -5996,7 +6074,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("engineer", imperative, Some("dm:engineer"))
+            .handle_operator_message(
+                "engineer",
+                imperative,
+                ChatTarget::channel(Some("dm:engineer")),
+            )
             .await
             .expect("operator message handled");
 
@@ -6041,7 +6123,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("engineer", imperative, Some("dm:engineer"))
+            .handle_operator_message(
+                "engineer",
+                imperative,
+                ChatTarget::channel(Some("dm:engineer")),
+            )
             .await
             .expect("operator message handled");
 
@@ -6084,7 +6170,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", imperative, Some("dm:engineer"))
+            .handle_operator_message(
+                "chief",
+                imperative,
+                ChatTarget::channel(Some("dm:engineer")),
+            )
             .await
             .expect("operator message handled");
 
@@ -6131,7 +6221,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", imperative, None)
+            .handle_operator_message("chief", imperative, ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -6178,7 +6268,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", imperative, None)
+            .handle_operator_message("chief", imperative, ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -6205,7 +6295,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", "draft the launch plan for next quarter", None)
+            .handle_operator_message(
+                "chief",
+                "draft the launch plan for next quarter",
+                ChatTarget::default(),
+            )
             .await
             .expect("operator message handled");
         assert!(fx.cards().await.is_empty(), "no second card is opened");
@@ -6220,7 +6314,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("green")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("engineer", "is the build green?", Some("eng_desk"))
+            .handle_operator_message(
+                "engineer",
+                "is the build green?",
+                ChatTarget::channel(Some("eng_desk")),
+            )
             .await
             .expect("operator message handled");
         assert!(fx.cards().await.is_empty());
@@ -6259,7 +6357,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", question, None)
+            .handle_operator_message("chief", question, ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -6315,7 +6413,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", "Tell what is there in the tasks list", None)
+            .handle_operator_message(
+                "chief",
+                "Tell what is there in the tasks list",
+                ChatTarget::default(),
+            )
             .await
             .expect("operator message handled");
 
@@ -6360,7 +6462,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", question, Some("general"))
+            .handle_operator_message("chief", question, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -6434,7 +6536,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turn = fx
             .runner(&turns)
             .with_triage(&escalation)
-            .handle_operator_message("chief", residue, Some("general"))
+            .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -6488,7 +6590,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         fx.runner(&turns)
             .with_triage(&escalation)
-            .handle_operator_message("chief", residue, Some("general"))
+            .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -6543,7 +6645,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turn = fx
             .runner(&turns)
             .requested(Some(crate::ports::types::MessageIntent::Chat))
-            .handle_operator_message("chief", residue, Some("general"))
+            .handle_operator_message("chief", residue, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -6599,7 +6701,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", "the pricing repo needs a map", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "the pricing repo needs a map",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -6642,7 +6748,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", neutral, None)
+            .handle_operator_message("chief", neutral, ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -6687,7 +6793,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("Hi! How can I help you today?")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", greeting, Some("general"))
+            .handle_operator_message("chief", greeting, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -6721,7 +6827,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("Not much, what's up?")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", greeting, Some("general"))
+            .handle_operator_message("chief", greeting, ChatTarget::channel(Some("general")))
             .await
             .expect("operator message handled");
 
@@ -6752,7 +6858,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             ],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", imperative, None)
+            .handle_operator_message("chief", imperative, ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -6791,7 +6897,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("shipped the importer")]);
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("engineer", question, Some("eng_desk"))
+            .handle_operator_message("engineer", question, ChatTarget::channel(Some("eng_desk")))
             .await
             .expect("operator message handled");
 
@@ -6843,7 +6949,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "brand_strategist",
                 "SEO Specialist: run an SEO pass over the pricing page",
-                Some("strategy"),
+                ChatTarget::channel(Some("strategy")),
             )
             .await
             .expect("operator message handled");
@@ -6904,7 +7010,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "brand_strategist",
                 "sort out the pricing page",
-                Some("strategy"),
+                ChatTarget::channel(Some("strategy")),
             )
             .await
             .expect("operator message handled");
@@ -6949,7 +7055,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "brand_strategist",
                 "sort out the pricing page",
-                Some("strategy"),
+                ChatTarget::channel(Some("strategy")),
             )
             .await
             .expect("operator message handled");
@@ -6992,7 +7098,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             ],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", "get the launch note drafted", None)
+            .handle_operator_message(
+                "chief",
+                "get the launch note drafted",
+                ChatTarget::default(),
+            )
             .await
             .expect("operator message handled");
 
@@ -7016,7 +7126,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
         fx.runner(&turns)
-            .handle_operator_message("chief", "draft the investor update", None)
+            .handle_operator_message("chief", "draft the investor update", ChatTarget::default())
             .await
             .expect("operator message handled");
         assert!(fx.cards().await.is_empty());
@@ -7061,7 +7171,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             ],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", instruction, None)
+            .handle_operator_message("chief", instruction, ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -7120,7 +7230,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", question, None)
+            .handle_operator_message("chief", question, ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -7166,7 +7276,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             ],
         );
         fx.runner(&turns)
-            .handle_operator_message("chief", "is the build ok?", None)
+            .handle_operator_message("chief", "is the build ok?", ChatTarget::default())
             .await
             .expect("operator message handled");
 
@@ -7224,7 +7334,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -7309,7 +7423,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -7350,7 +7468,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -7400,7 +7522,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -7465,7 +7591,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             // The production wiring in `brain.rs` sets this from the operator's
             // own composed message before calling `handle_operator_message`.
             .reissue_message("ship the API")
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
         assert!(
@@ -7560,7 +7690,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let out = crate::runtime::grants::with_redeem_context(redeem.clone(), async {
             fx.runner(&turns)
                 .reissue_message("ship the API")
-                .handle_operator_message("chief", "ship the API", Some("general"))
+                .handle_operator_message(
+                    "chief",
+                    "ship the API",
+                    ChatTarget::channel(Some("general")),
+                )
                 .await
                 .expect("operator message handled")
         })
@@ -7620,7 +7754,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -7659,7 +7797,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -7691,7 +7833,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .handle_operator_message(
                 "engineer",
                 "read the pricing repo and write modules.md",
-                Some("eng_desk"),
+                ChatTarget::channel(Some("eng_desk")),
             )
             .await
             .expect("operator message handled");
@@ -7727,7 +7869,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .runner(&turns)
             .run_delegation(
                 handoff("draft the launch plan"),
-                None,
+                ChatTarget::default(),
                 MessageContext::default(),
             )
             .await
@@ -7857,7 +7999,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -7907,7 +8053,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -7953,7 +8103,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -7993,7 +8147,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
 
         let out = fx
             .runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -8027,7 +8185,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         .with_max_depth(1);
 
         fx.runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -8083,7 +8245,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
 
         fx.runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -8131,7 +8297,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
 
         fx.runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 
@@ -8178,7 +8348,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
 
         fx.runner(&turns)
-            .handle_operator_message("chief", "ship the API", Some("general"))
+            .handle_operator_message(
+                "chief",
+                "ship the API",
+                ChatTarget::channel(Some("general")),
+            )
             .await
             .expect("operator message handled");
 

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -2401,7 +2401,7 @@ mod tests {
             _company: &CompanyId,
             _agent_id: &str,
             _message: &str,
-            _chat_id: Option<&str>,
+            _chat_id: crate::runtime::delegation::ChatTarget<'_>,
         ) -> crate::Result<crate::harness::TurnOutcome> {
             Ok(ok_outcome())
         }
@@ -2412,7 +2412,7 @@ mod tests {
             _agent_id: &str,
             _message: &str,
             _control: &crate::company::steer::SteerControl,
-            _chat_id: Option<&str>,
+            _chat_id: crate::runtime::delegation::ChatTarget<'_>,
             _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
         ) -> crate::Result<crate::harness::TurnOutcome> {
             Ok(ok_outcome())
@@ -2541,7 +2541,7 @@ mod tests {
             _company: &CompanyId,
             _agent_id: &str,
             _message: &str,
-            _chat_id: Option<&str>,
+            _chat_id: crate::runtime::delegation::ChatTarget<'_>,
         ) -> crate::Result<crate::harness::TurnOutcome> {
             Ok(self.0.clone())
         }
@@ -2552,7 +2552,7 @@ mod tests {
             _agent_id: &str,
             _message: &str,
             _control: &crate::company::steer::SteerControl,
-            _chat_id: Option<&str>,
+            _chat_id: crate::runtime::delegation::ChatTarget<'_>,
             _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
         ) -> crate::Result<crate::harness::TurnOutcome> {
             Ok(self.0.clone())

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -2056,7 +2056,7 @@ mod tests {
             company: &CompanyId,
             agent_id: &str,
             _message: &str,
-            _chat_id: Option<&str>,
+            _chat_id: crate::runtime::delegation::ChatTarget<'_>,
         ) -> Result<crate::harness::TurnOutcome> {
             self.execute(company, agent_id).await
         }
@@ -2067,7 +2067,7 @@ mod tests {
             agent_id: &str,
             _message: &str,
             _control: &crate::company::steer::SteerControl,
-            _chat_id: Option<&str>,
+            _chat_id: crate::runtime::delegation::ChatTarget<'_>,
             _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
         ) -> Result<crate::harness::TurnOutcome> {
             self.execute(company, agent_id).await
@@ -2192,7 +2192,7 @@ to = "done"
             _company: &CompanyId,
             agent_id: &str,
             _message: &str,
-            _chat_id: Option<&str>,
+            _chat_id: crate::runtime::delegation::ChatTarget<'_>,
         ) -> Result<crate::harness::TurnOutcome> {
             self.seen.lock().unwrap().push(agent_id.to_string());
             Ok(crate::harness::TurnOutcome {
@@ -2212,7 +2212,7 @@ to = "done"
             agent_id: &str,
             message: &str,
             _control: &crate::company::steer::SteerControl,
-            chat_id: Option<&str>,
+            chat_id: crate::runtime::delegation::ChatTarget<'_>,
             _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
         ) -> Result<crate::harness::TurnOutcome> {
             self.run(company, agent_id, message, chat_id).await
@@ -2226,7 +2226,13 @@ to = "done"
             _control: &crate::company::steer::SteerControl,
             _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
         ) -> Result<crate::harness::TurnOutcome> {
-            self.run(company, agent_id, message, None).await
+            self.run(
+                company,
+                agent_id,
+                message,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
+            .await
         }
     }
 


### PR DESCRIPTION
## Summary

> **Part of #1890 — sub-issue A ("thread-scoped context").** Deliberately **not** `Closes`: the epic tracks nine items (A–C fixes, D–F features, G–I follow-ups) and this PR is one of them.

Two live threads in one channel were one conversation to the model. The turn answering inside a thread was handed the whole channel, so "make it shorter" arrived directly after an unrelated answer that happened to land in between — and nothing in the seed said which root it hung off.

A thread is persisted today (`OperatorMessage::parent`, #364) but only as a rendering fold: the console folds a transcript by parent, and nothing downstream of the renderer knew the thread existed. This is sub-issue **A** of #1890.

Two halves, and **neither works alone**:

| Where | Was | Is |
|---|---|---|
| `built_in/mod.rs` `bound_chat` | keyed on the chat id, so thread → thread was not a switch: `clear_history()` and the re-seed never ran and the previous thread's turns stayed loaded | keyed on `(chat id, thread root)` |
| `built_in/chat_seed.rs` | filtered on `chat_history::owns`, which matches the chat id and nothing else | a new `in_thread` narrows it by the parent pointer |

Fixing the seed alone changes nothing — on a non-switch it is never built. Fixing the binding alone re-seeds from a channel-flat projection.

Three things worth a reviewer's attention:

**The thread filter runs *before* the self-boundary search.** That boundary is a text prefix compare (`current_message.starts_with(text.trim())`), so a sibling thread carrying the same words would match first and cut the window at a message this turn never sent. Scoping first makes the match unambiguous rather than merely narrower. There is a test for exactly this.

**`ChatTarget` rather than a seventh positional argument.** A bare `Option<EventSeq>` beside a bare `Option<&str>` is the mis-ordered pair `ChatTurn`'s own docs already name as the hazard — one that compiles and then answers into the wrong conversation.

**The root is read off the operator message's own `parent` in the cycle**, never rediscovered by re-reading the journal. The route already holds it, and recovering it would cost a read on exactly the non-switch turns the switch branch exists to keep free (the codex finding on #1842).

## API Or Behavior Changes

`RunTurn::run` and `RunTurn::run_steered` take `ChatTarget<'_>` where they took `chat_id: Option<&str>`. Internal trait, all implementors updated in this PR.

**No behaviour change for an unthreaded company.** A `None` root is not "no thread" — it is the channel-level conversation, the one every unparented line hangs in, which is every line in a company that has never opened a thread. So an unthreaded desk projects exactly what it projected before, and the existing seed tests assert that unchanged.

One path deliberately passes the channel with no root: background and workflow turns, which carry no conversation at all.

A resumed approval **is** threaded, since c11eb82d — an earlier revision of this description said a grant "records no root", which was wrong. `GrantedCall` and `StandingGrant` both carry `origin_parent` beside `origin_thread`; `Redispatch` was dropping it, so a threaded approval resumed against the channel's unparented history. Caught in review, fixed here.

## Tests

Five new, and they are self-evidencing — the three that pin the leak were confirmed to **fail without the filter** (stubbed it out, watched them go red, restored it):

- `a_thread_sees_only_its_own_exchange` — thread A's seed carries none of thread B's turns
- `the_channel_sees_only_unparented_lines` — a thread's body never reaches the channel
- `a_siblings_identical_wording_does_not_cut_the_window` — the prefix-match trap above
- `a_thread_switch_within_one_channel_re_seeds` — the binding half
- `a_second_turn_in_the_same_thread_does_not_re_read_the_journal` — the cost guard survives the finer key, rather than holding by accident as it did when the key was the channel

⚠️ **`src/harness/` compiles only under the `openhuman` feature** (`#[cfg(feature = "openhuman")] pub mod harness;` in `lib.rs`). A default `cargo check` links none of this diff and exits 0 — it reported a clean build over a trait change that breaks every implementor. The checklist commands below are the template's; the ones that actually read this code are the feature-scoped runs beside them.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — also `cargo clippy --lib --tests --features openhuman -- -D warnings`, clean
- [x] `cargo build --all-targets`
- [x] `cargo test` — the one that matters here is `cargo test --lib --features openhuman`: **5937 passed, 0 failed, 3 ignored**

### Drive-by — since superseded

Two `TurnOutcome` fixtures in `brain.rs` gain `abnormal_stop: None` and `budget_paused: None`. #1846 added both fields without updating these two literals, so **`main` @ 6b05c311 does not build under `cargo check --lib --tests --features openhuman`** — I verified that on a clean detached checkout of main, not just on this branch. The test binary would not link until they compiled, so nothing here could be run. Neither field is what those tests are about; they exercise the spend halt. **Now moot:** @senamakel landed #1900, which fixes those fixtures on `main`, so this branch no longer carries the workaround.

## Documentation

No user-facing docs: the change is internal context scoping with no console surface. The rationale lives in the code where the next reader meets it — `chat_seed`'s module header (why a desk is not the finest conversation there is), `in_thread`'s own docs (why membership is the parent pointer and nothing else), `bound_chat`'s field docs (why the root is part of the key), and `ChatTarget` (why one argument rather than two loose `Option`s).

Refs #1890


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed since the first review

Seven review findings landed on this PR. Six commits answer them:

| Finding | Outcome |
|---|---|
| P1 — a short thread walked the whole journal | Real, mine. Bounded at the root (exact: a child always sequences after its parent) plus a whole-walk budget for the channel case. `c11eb82d` |
| P2 — the approval grant's thread root was dropped | Real, mine, and my comment was wrong about it. `c11eb82d` |
| CodeRabbit — the binding depended on the event log | Real, mine: `incoming_root` came off `chat_seed`, which is `None` when `deps.events` is, so two threads compared equal on such a host. `b896b720` |
| Codex — an unaddressed message loses its root | **Not real.** `turn_chat_id` already falls back to `DEFAULT_DESK` at the turn-stream route. Reverted in `d607a777`, with a test pinning the true behaviour — the "fix" would have posted board markers into the operator's main line. |
| `FsEventLog` first page is O(N) | Real, pre-existing → follow-up **G** on #1890 |
| ACP sessions not conversation-scoped | Real, pre-existing → follow-up **H** |
| Approval re-dispatch not thread-bound | Real, pre-existing → follow-up **I** |

Plus `fb995b7a3`, which moves the thread root off four delegation signatures onto the `DelegationRunner` builder — see the comment thread for why, and for the 156→0 measurement on rebase churn.

## Summary by CodeRabbit

- **New Features**
  - Added thread-aware conversation handling for agent turns, preserving channel and thread context when conversations resume.
  - Agent responses now include relevant thread history, including the root message and direct replies.
  - Switching threads automatically refreshes conversation context within the selected thread.

- **Bug Fixes**
  - Prevented sibling-thread and unrelated channel history from appearing in conversations.
  - Improved threaded approval and operator-message resumption.
  - Prevented budget-pause notices from being mistakenly resubmitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
