### PR TITLE
fix(brain): add missing TurnOutcome fields to two test fixtures

### DIFF
--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -4194,11 +4194,16 @@ description = "Runs Acme."
             reply: "checkpoint".to_string(),
             steps: Vec::new(),
             hit_iteration_cap: true,
+            // Test fixture, not the ACP fold (PR #1880 review).
+            abnormal_stop: None,
             halted_for_spend: Some(crate::harness::SpendHalt {
                 agent: "ceo".to_string(),
                 spent_usd: 1.25,
                 cap_usd: 1.0,
             }),
+            // This fixture scripts a SPEND halt; a budget pause is the separate
+            // signal added in issue #1846 and is not what it exercises.
+            budget_paused: None,
         };
         let brain = brain_with_queue_and_events(dir.path(), Default::default(), log.clone())
             .with_default_engine(Some(Arc::new(FixedOutcomeTurn {
@@ -4256,7 +4261,10 @@ description = "Runs Acme."
                     reply: "checkpoint".to_string(),
                     steps: Vec::new(),
                     hit_iteration_cap: false,
+                    // Test fixture, not the ACP fold (PR #1880 review).
+                    abnormal_stop: None,
                     halted_for_spend: None,
+                    budget_paused: None,
                 },
                 approval_requests: Some(requests.clone()),
             })));


### PR DESCRIPTION
## Summary

`Rust (openhuman, tinymemory)` is red on `main` and has been for at least the
last five runs. It is not flaky and it is not infrastructure:

```
error[E0063]: missing fields `abnormal_stop` and `budget_paused`
              in initializer of `built_in::TurnOutcome`
error: could not compile `opencompany` (lib test) due to 2 previous errors
```

`TurnOutcome` gained `abnormal_stop` (PR #1880) and `budget_paused`
(issue #1846). Both sweeps updated the production constructors and the fixture
at `brain.rs:10816`, but missed two others in the same file — so the struct
literals are incomplete and `--all-targets` cannot compile the lib test.

Both now carry the two fields, matching the pattern the third fixture in this
file already uses.

## Why this is its own PR

It blocks every open PR in the repository, and it is unrelated to whatever each
of those PRs is changing. I hit it while babysitting #1892, whose diff is
entirely `.github/workflows/**` and `scripts/release/**` — no Rust at all — and
which fails this lane with byte-identical output to `main`'s.

## Choice of values

`None` for both, on both fixtures:

- `abnormal_stop` is only ever set by the ACP fold. Neither fixture goes near
  it, which is the same reason the existing fixture below them says
  `abnormal_stop: None` with the comment "Test fixture, not the ACP fold".
- `budget_paused` is a distinct signal from `halted_for_spend`. The first
  fixture deliberately scripts a **spend halt** and asserts on that; giving it a
  budget pause as well would change what the test exercises.

So this restores compilation without altering the behaviour either test asserts.

## Testing

- `cargo fmt -- --check` passes.
- I could not run `cargo build --locked --features openhuman --all-targets`
  locally — the nested `vendor/openhuman/vendor/tinymemory` submodule would not
  fetch in my checkout, so the build cannot resolve `tinymemory-api`. The
  gated CI lane on this PR is the check that matters here, since it is the exact
  job that is currently failing; it going green is the verification.

The change is two struct literals gaining two `None` fields each, matching a
sibling fixture twenty lines away, so the risk of it being wrong in a way CI
cannot see is low.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated scheduled-cycle test scenarios to reflect new turn outcome statuses, including abnormal stops and paused budgets.

* **Chores**
  * Updated the bundled OpenHuman component to a newer upstream revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->