### PR TITLE
fix(desktop): open the first-run wizard instead of seeding a company

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { signInWithHubToken, verifyCode } from "@/api/auth";
 import { isAddressableBaseUrl, isDesktopRuntime } from "@/api/transport";
 import {
   createLocalInstance,
+  renameLocalInstance,
   deleteLocalInstance,
   embeddedHost,
   localInstances,
@@ -598,6 +599,24 @@ function Console() {
     onStartLocal: isDesktopRuntime()
       ? async (id) => {
           await startLocalInstance(id);
+          await refreshLocal();
+        }
+      : undefined,
+    // Setup, finishing, names the host after the company it just built. Matched
+    // by instance identity rather than by address, for the reason the registry
+    // gives everywhere else: the address is this launch's and the identity is
+    // the machine's.
+    onNameLocalHost: isDesktopRuntime()
+      ? async (label) => {
+          const instanceId = active?.identity?.instanceId;
+          if (!instanceId) return;
+          const local = embedded.instances.find(
+            (instance) => instance.instanceId === instanceId,
+          );
+          // A remote host, or one this shell does not own. Nothing to rename,
+          // and nothing wrong: the caller does not know which kind it is on.
+          if (!local) return;
+          await renameLocalInstance(local.id, label);
           await refreshLocal();
         }
       : undefined,

--- a/frontend/src/api/setup.ts
+++ b/frontend/src/api/setup.ts
@@ -228,6 +228,19 @@ export interface SetupInput {
    * is then permanent.
    */
   name?: string | null;
+  /**
+   * The address that will be able to sign in, for the template path.
+   *
+   * {@link DesignedCompany.adminEmail} carries the same thing for a designed
+   * company. This one exists because a seeded template has no designed company
+   * to carry it in, and no shipped template names an admin — so a template plus
+   * a sign-in mode would otherwise finish setup into a company nobody can
+   * administer.
+   *
+   * Snake case, unlike the camelCase inside {@link DesignedCompany}: the top
+   * level of this request is read field-for-field by the host.
+   */
+  admin_email?: string | null;
 }
 
 /** The company the wizard designed, as the review step hands it over. */

--- a/frontend/src/api/setup.ts
+++ b/frontend/src/api/setup.ts
@@ -218,6 +218,16 @@ export interface SetupInput {
    * preset cannot override.
    */
   company?: DesignedCompany | null;
+  /**
+   * What to call the company, as the review step asks for it.
+   *
+   * Applies to either path above. Omitted or blank means "derive it", which is
+   * what every company built here used to get: the host takes the first clause
+   * of {@link DesignedCompany.industry}, so the answer to "what kind of company
+   * are you setting up?" silently became the company's name — and its id, which
+   * is then permanent.
+   */
+  name?: string | null;
 }
 
 /** The company the wizard designed, as the review step hands it over. */
@@ -286,8 +296,17 @@ export interface SetupRoster {
   agents: SetupRosterAgent[];
   /** Which curated roster framed the proposal, e.g. `ecommerce`. */
   template: string;
-  /** `model` — designed from the answers. `fallback` — the curated team. */
-  source: "model" | "fallback";
+  /**
+   * `model` — designed from the answers. `fallback` — the curated team matched
+   * from them. `preset` — the roster of the template the operator *picked*,
+   * shipped whole.
+   *
+   * The last one is the only source the console may send back as a
+   * {@link SetupInput.template} rather than as a designed company: it is the
+   * one case where the host can seed the real thing — that template's belt and
+   * prompts as well as its roster — instead of rebuilding it from this screen.
+   */
+  source: "model" | "fallback" | "preset";
   /**
    * The jobs the operator named, as the **host** split them.
    *

--- a/frontend/src/connections/HostsContext.tsx
+++ b/frontend/src/connections/HostsContext.tsx
@@ -50,6 +50,21 @@ export interface HostsValue {
   localInstances: LocalInstance[];
   /** Creates a host on this machine over a data root of its own, and starts it. */
   onAddLocal?: (label: string) => Promise<void>;
+  /**
+   * Renames the local host whose console is on screen, if it is one.
+   *
+   * Exists so finishing setup can put the *company's* name on the host that
+   * now holds it. A second company on this machine means a second data root,
+   * which the operator meets as "add a host" and has to name before they have
+   * been asked a single question about the company — so the name they type is
+   * a placeholder for a thing they were not thinking about, and the roster ends
+   * up listing hosts nobody can tell apart. Naming it after the company turns
+   * that into a detail they never have to hold.
+   *
+   * A no-op on a remote host and in the browser: neither is this machine's to
+   * rename. Absent entirely on a shell with no local roster.
+   */
+  onNameLocalHost?: (label: string) => Promise<void>;
   onStartLocal?: (id: string) => Promise<void>;
   onStopLocal?: (id: string) => Promise<void>;
   /** Permanently deletes a non-default local host and its data. */
@@ -125,6 +140,20 @@ export function useHosts(): HostsContextValue {
   const value = useContext(HostsContext);
   if (!value) throw new Error("useHosts must be used within a HostsProvider.");
   return value;
+}
+
+/**
+ * The hosts, for anything that works with or without them.
+ *
+ * The sibling of {@link useHosts}, and the difference is whether the caller is
+ * *about* the roster. A switcher outside the provider is a wiring mistake and
+ * should say so; a view that merely takes an extra step when it happens to be
+ * inside a console — the setup wizard naming its host after the company — is
+ * not, and it renders on its own in tests and wherever a console has not been
+ * assembled yet.
+ */
+export function useOptionalHosts(): HostsContextValue | null {
+  return useContext(HostsContext);
 }
 
 /** How many hosts the number row can reach. `⌘1`–`⌘9`, in list order. */

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -1093,6 +1093,37 @@ function requiresSignIn(status: SetupStatus, values: Record<string, string>): bo
 // ---------------------------------------------------------------------------
 // Steps
 // ---------------------------------------------------------------------------
+/**
+ * The sign-in modes this wizard may offer, out of the ones the host accepts.
+ *
+ * `wallet` is withheld, and this is a lockout guard rather than a preference.
+ * A wallet company is bootstrapped by `[users].wallets` — "listing an address
+ * makes it eligible, signing a challenge mints the admin" — and nothing in this
+ * flow can collect one: the account step asks for an email, and both seed paths
+ * write `[users].admins`, which `wallet` mode never reads. Choosing it
+ * therefore finishes setup on a company with **no eligible administrator**, and
+ * the door closes behind it: once a company exists and setup is stamped
+ * complete, `server::setup::authorize` stops answering an anonymous caller, so
+ * the console cannot be used to undo it.
+ *
+ * That was previously unreachable on the instance most operators have, because
+ * it seeded a company and never opened this wizard at all. Making the wizard
+ * the way in is what makes withholding this necessary rather than tidy.
+ *
+ * A mode already in force is always offered, even when withheld: an operator
+ * re-running setup on a wallet host is looking at their own configuration, and
+ * a screen that silently omits the answer it is currently showing would read as
+ * the setting having been lost.
+ *
+ * Wallet remains available the way it is actually set up today — `auth_mode` in
+ * `config.toml` beside a `[users].wallets` list on the company. Collecting a
+ * wallet key here, and writing the mode and its list onto the seeded manifest
+ * together, is the fuller fix and is its own change.
+ */
+export function offeredAuthModes(status: SetupStatus, current: string): string[] {
+  return status.auth_modes.filter((mode) => mode !== "wallet" || current === "wallet");
+}
+
 function SignInStep({
   status,
   value,
@@ -1123,7 +1154,7 @@ function SignInStep({
       )}
 
       <div className="mt-2.5 space-y-2">
-        {status.auth_modes.map((mode) => {
+        {offeredAuthModes(status, value || field?.value || "").map((mode) => {
           const copy = AUTH_MODE_COPY[mode] ?? { label: mode, hint: "" };
           const active = (value || field?.value) === mode;
           return (

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -1121,6 +1121,15 @@ function requiresSignIn(status: SetupStatus, values: Record<string, string>): bo
  * together, is the fuller fix and is its own change.
  */
 export function offeredAuthModes(status: SetupStatus, current: string): string[] {
+  // A field `env` owns is one this screen is *reporting*, not offering, and it
+  // cannot report a mode it has filtered out. It also cannot tell which mode
+  // that is: `FieldDto.value` is read from `config.toml` alone
+  // (`effective_value` in `src/server/setup.rs`), so an `OPENCOMPANY_AUTH_MODE`
+  // the host is actually running never reaches this list. Withholding on top of
+  // that would show a locked picker whose every option is wrong. Nothing here
+  // is selectable in that state, so nothing can be walked into.
+  const field = status.fields.find((f) => f.key === "auth_mode");
+  if (field !== undefined && !field.editable) return status.auth_modes;
   return status.auth_modes.filter((mode) => mode !== "wallet" || current === "wallet");
 }
 
@@ -1709,6 +1718,11 @@ function ReviewStep({
           id="setup-company-name"
           data-testid="setup-company-name"
           value={name}
+          // The host clamps to this too (`MAX_COMPANY_NAME`), because the id is
+          // derived from the name and becomes a directory component. Bounded
+          // here as well so the operator sees the limit rather than meeting it
+          // as a truncation after the fact.
+          maxLength={60}
           placeholder="Your company's name"
           onChange={(e) => onName(e.target.value)}
         />

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -47,6 +47,7 @@ import { OnboardingShell } from "@/components/onboarding-shell";
 import { Badge } from "@/components/ui/badge";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
+import { useOptionalHosts } from "@/connections/HostsContext";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -170,7 +171,38 @@ interface Props {
   expectsShellRemount?: boolean;
 }
 
+/**
+ * The name to offer for a company nobody has named yet.
+ *
+ * Mirrors what the host derives when no name is sent (`company_name` in
+ * `src/company/setup.rs`) so the suggestion is the name the operator would
+ * otherwise have been given silently — a template's own name when one was
+ * picked, else the first clause of the industry answer.
+ *
+ * Deliberately a *suggestion in a visible field* rather than a better silent
+ * derivation: the id is minted from this and then permanent, and the one screen
+ * where that is still changeable is the one this fills.
+ */
+export function suggestedCompanyName(industry: string, templateName: string | null): string {
+  if (templateName?.trim()) return templateName.trim();
+  const raw = industry.trim();
+  if (!raw) return "";
+  // The same clause rule the host applies: a spaced hyphen is a break, a bare
+  // one is part of a word — so "E-commerce — homeware" gives "E-commerce", not
+  // "E".
+  const normalised = raw.replace(/ [-–] /g, "—");
+  const head = normalised
+    .split(/[—,.:;\n]/)
+    .map((part) => part.trim())
+    .find((part) => part.length > 0);
+  return (head ?? raw).slice(0, 60).trim();
+}
+
 export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: Props) {
+  // Optional on purpose: this wizard also renders with no console assembled
+  // around it. Undefined in the browser and on a remote host besides — see
+  // `onNameLocalHost`.
+  const onNameLocalHost = useOptionalHosts()?.onNameLocalHost;
   const [status, setStatus] = useState<SetupStatus | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   /**
@@ -194,6 +226,25 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
   const [draft, setDraft] = useState<SetupDraft>(emptySetupDraft);
   /** The shipped company template the operator explicitly chose. */
   const [template, setTemplate] = useState("");
+  /**
+   * What to call the company, as typed on the review step.
+   *
+   * Nothing asked before this. The host derived a name from the *industry*
+   * answer and minted the company id from it, so "what kind of company are you
+   * setting up?" was silently also "what is it called?", permanently — there is
+   * no rename anywhere in the product. Seeded with a suggestion when the roster
+   * arrives, so the field arrives answered rather than as one more question.
+   */
+  const [companyName, setCompanyName] = useState("");
+  /**
+   * Whether the operator has changed the proposed roster.
+   *
+   * Load-bearing, not bookkeeping: an untouched `preset` roster is sent back as
+   * a template slug so the host seeds that template whole — its tool belt and
+   * prompts included — while an edited one has to go as a designed company,
+   * because the edits exist nowhere else.
+   */
+  const [rosterEdited, setRosterEdited] = useState(false);
   /** The address that will be able to sign in. */
   const [email, setEmail] = useState("");
   /** Whether the operator has been shown a problem on the current step yet. */
@@ -454,6 +505,18 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
         throw new Error("The host answered without a team to review.");
       }
       setRoster(proposed);
+      setRosterEdited(false);
+      // Suggested, never imposed: the field is editable and this only fills a
+      // blank one, so an operator who has already named their company does not
+      // watch it change under them when they go back and re-design.
+      setCompanyName(
+        (current) =>
+          current.trim() ||
+          suggestedCompanyName(
+            draft.industry,
+            status?.templates.find((candidate) => candidate.id === template)?.name ?? null,
+          ),
+      );
     } catch (err: unknown) {
       setDesignError(err instanceof Error ? err.message : String(err));
       setRoster(null);
@@ -472,10 +535,33 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
     setSaveError(null);
     setBuilt(roster?.agents.length ?? null);
     try {
+      // An untouched template roster goes back as the template it came from.
+      //
+      // The host can then seed that company properly — the roster it ships,
+      // the `[tools]` belt it declares, the prompts in its own directory —
+      // where a designed company is rebuilt from this screen alone and can
+      // carry none of that. The moment the operator edits a row it *has* to be
+      // the designed path instead: their edits exist nowhere but here.
+      const seedTemplate =
+        status.companies.length === 0 &&
+        roster?.source === "preset" &&
+        !rosterEdited &&
+        template.trim().length > 0 &&
+        // A working credential is only carried by the designed path, which
+        // writes the provider onto the manifest and stores the key against the
+        // company. A template seed has nowhere to put either, so a tested model
+        // keeps the designed path — the roster is the same one on screen, and
+        // silently dropping a key the operator just watched pass is the worse
+        // trade. Reachable when a model answers and its answer is unusable, so
+        // the source is `preset` while `tested` is fine.
+        tested.kind !== "ok";
+
       const result = await submitSetup(client, {
         fields: changed,
+        name: companyName.trim() || null,
+        template: seedTemplate ? template : null,
         company:
-          status.companies.length === 0 && roster
+          status.companies.length === 0 && roster && !seedTemplate
             ? {
                 industry: draft.industry,
                 teamHint: draft.teamHint,
@@ -496,13 +582,38 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
             : null,
       });
       setApplied(result);
+      // The host takes the company's name. Best-effort and after the fact: the
+      // company exists either way, and a rename that fails is a label, not a
+      // company. Never a reason to show an error on a screen that just
+      // succeeded.
+      if (result.seeded_company && companyName.trim() && onNameLocalHost) {
+        try {
+          await onNameLocalHost(companyName.trim());
+        } catch (error: unknown) {
+          console.warn("[setup] could not name the host after the company", error);
+        }
+      }
     } catch (err: unknown) {
       setSaveError(err instanceof Error ? err.message : String(err));
       setBuilt(null);
     } finally {
       setSaving(false);
     }
-  }, [client, status, changed, roster, draft, email, provider, tested, values.tinyhumans_api_key]);
+  }, [
+    client,
+    status,
+    changed,
+    roster,
+    rosterEdited,
+    template,
+    companyName,
+    draft,
+    email,
+    provider,
+    tested,
+    values.tinyhumans_api_key,
+    onNameLocalHost,
+  ]);
 
   if (loadError) {
     return (
@@ -879,7 +990,14 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
             designing={designing}
             designError={designError}
             roster={roster}
-            onRoster={setRoster}
+            name={companyName}
+            onName={setCompanyName}
+            onRoster={(next) => {
+              setRoster(next);
+              // Any edit takes the template path off the table — see
+              // `seedTemplate` in `submit`.
+              setRosterEdited(true);
+            }}
             onRetry={() => void design()}
             changed={changed}
             restartKeys={restartKeys}
@@ -1428,6 +1546,8 @@ function ReviewStep({
   designing,
   designError,
   roster,
+  name,
+  onName,
   onRoster,
   onRetry,
   changed,
@@ -1439,6 +1559,9 @@ function ReviewStep({
   designing: boolean;
   designError: string | null;
   roster: SetupRoster | null;
+  /** What the company will be called. */
+  name: string;
+  onName: (name: string) => void;
   onRoster: (roster: SetupRoster) => void;
   onRetry: () => void;
   changed: Record<string, string | null>;
@@ -1477,6 +1600,9 @@ function ReviewStep({
     );
   }
 
+  /** Whether this roster is a template's own, seeded rather than rebuilt. */
+  const shipped = roster.source === "preset";
+
   const drop = (index: number) =>
     onRoster({ ...roster, agents: roster.agents.filter((_, i) => i !== index) });
 
@@ -1488,12 +1614,38 @@ function ReviewStep({
 
   return (
     <div className="space-y-4" data-testid="setup-review">
+      {/* The name, asked once, here.
+          Last screen before it is permanent: the host mints the company id from
+          this and never changes it, and nothing in the product renames a
+          company afterwards. It sits above the roster because it is the one
+          field on this screen that cannot be revisited later, while any
+          teammate can be added, renamed or dropped from the console. */}
+      <div className="space-y-1.5">
+        <Label htmlFor="setup-company-name">What should we call it?</Label>
+        <Input
+          id="setup-company-name"
+          data-testid="setup-company-name"
+          value={name}
+          placeholder="Your company's name"
+          onChange={(e) => onName(e.target.value)}
+        />
+        <p className="text-xs leading-snug text-muted-foreground">
+          This names the company and its id. You can change it now; you can&apos;t later.
+        </p>
+      </div>
+
       <div>
         <h2 className="text-base font-medium leading-snug">Your team</h2>
         <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
           {roster.source === "model"
             ? "Built from what you told us. Rename or drop anyone — you can add more later."
-            : roster.reason === "not_designable"
+            : roster.source === "preset"
+              ? // The template's own team, which is what the operator picked
+                // from a list that told them its size. Said plainly, because
+                // this screen used to show a *different* standard team under
+                // the same heading and call it theirs.
+                "The team this template ships with, exactly as it comes. You can rename or drop anyone once you're inside."
+              : roster.reason === "not_designable"
               ? "A standard team for your industry — there wasn't enough in your answers to design one around. Go back and say more about the business, or rename and drop anyone here."
               : roster.reason === "model_unreachable"
                 ? "A standard team for your industry — we couldn't reach the model to tailor it right now. Check the connection, or rename and drop anyone here."
@@ -1524,25 +1676,41 @@ function ReviewStep({
               {initials(agent.name || agent.role)}
             </span>
             <div className="min-w-0 flex-1">
-              <Input
-                value={agent.role}
-                aria-label={`Role for ${agent.role}`}
-                data-testid="setup-review-role"
-                onChange={(e) => rename(i, e.target.value)}
-                className="h-7 border-transparent bg-transparent px-1 font-medium shadow-none hover:border-input focus-visible:border-input"
-              />
+              {/* A shipped roster is read here, not edited.
+                  Not a restriction for its own sake: an edited roster can only
+                  be sent back as a *designed* company, and the designed path is
+                  bounded at six teammates — so renaming one row of an
+                  eight-teammate template would silently drop two of them, and
+                  the operator would find out by not finding them. Every one of
+                  these is renameable and removable from the console the moment
+                  setup finishes, where no such bound applies. */}
+              {shipped ? (
+                <p className="px-1 font-medium" data-testid="setup-review-role">
+                  {agent.role}
+                </p>
+              ) : (
+                <Input
+                  value={agent.role}
+                  aria-label={`Role for ${agent.role}`}
+                  data-testid="setup-review-role"
+                  onChange={(e) => rename(i, e.target.value)}
+                  className="h-7 border-transparent bg-transparent px-1 font-medium shadow-none hover:border-input focus-visible:border-input"
+                />
+              )}
               <p className="truncate px-1 text-xs text-muted-foreground">{agent.description}</p>
             </div>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => drop(i)}
-              aria-label={`Remove ${agent.role}`}
-              data-testid="setup-review-remove"
-              className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-            >
-              Remove
-            </Button>
+            {!shipped && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => drop(i)}
+                aria-label={`Remove ${agent.role}`}
+                data-testid="setup-review-remove"
+                className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+              >
+                Remove
+              </Button>
+            )}
           </li>
         ))}
       </ul>

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -172,6 +172,49 @@ interface Props {
 }
 
 /**
+ * Whether a finished wizard should hand the host a **template slug** rather than
+ * a designed company.
+ *
+ * Pure, and exported, because this one boolean decides what an operator
+ * actually gets: a template seeded whole — its roster, its `[tools]` belt, its
+ * prompts, its provenance — or a company rebuilt from the review screen, which
+ * can carry none of those and is capped at six teammates.
+ *
+ * The rules, and why each is here:
+ *
+ * - **A host with a company seeds nothing.** Setup must never hand an operator
+ *   a second starter company on a re-run.
+ * - **Only a `preset` roster.** A designed team was built for *them*; shipping
+ *   the template instead would throw the design pass away. A `fallback` roster
+ *   is the curated team matched from their answers, which is not any template's.
+ * - **Only an untouched one.** Edits exist nowhere but the review screen, so an
+ *   edited roster has to travel as a designed company.
+ * - **Only when no credential is carried.** The designed path writes the tested
+ *   provider onto the manifest and stores the key against the company; a
+ *   template seed has nowhere to put either, and silently dropping a key the
+ *   operator just watched pass is the worse trade.
+ * - **Except `managed`, which carries nothing.** The designed submit omits
+ *   inference entirely for that provider, because the host already reaches it.
+ *   Taking the designed path there trades the template away for a credential
+ *   that was never going to be written — a pure loss, and an invisible one,
+ *   since the review screen shows the template's roster either way.
+ */
+export function shouldSeedTemplate(input: {
+  hasCompany: boolean;
+  source: "model" | "fallback" | "preset" | null;
+  rosterEdited: boolean;
+  template: string;
+  credentialTested: boolean;
+  provider: string;
+}): boolean {
+  if (input.hasCompany) return false;
+  if (input.source !== "preset") return false;
+  if (input.rosterEdited) return false;
+  if (!input.template.trim()) return false;
+  return !input.credentialTested || input.provider === "managed";
+}
+
+/**
  * The name to offer for a company nobody has named yet.
  *
  * Mirrors what the host derives when no name is sent (`company_name` in
@@ -236,6 +279,15 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
    * arrives, so the field arrives answered rather than as one more question.
    */
   const [companyName, setCompanyName] = useState("");
+  /**
+   * Whether the name on screen is the operator's or ours.
+   *
+   * A suggestion has to be *replaceable*, and "is it blank?" cannot tell the
+   * two apart: picking one template, going back, and picking another left the
+   * first template's name in the field — no longer blank, never typed, and
+   * about to become the second company's permanent id.
+   */
+  const [nameTouched, setNameTouched] = useState(false);
   /**
    * Whether the operator has changed the proposed roster.
    *
@@ -509,21 +561,24 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
       // Suggested, never imposed: the field is editable and this only fills a
       // blank one, so an operator who has already named their company does not
       // watch it change under them when they go back and re-design.
-      setCompanyName(
-        (current) =>
-          current.trim() ||
+      // Re-suggested on every design, and only over a suggestion: a name the
+      // operator typed survives going back and changing their mind about the
+      // template, and a name they never typed does not.
+      if (!nameTouched) {
+        setCompanyName(
           suggestedCompanyName(
             draft.industry,
             status?.templates.find((candidate) => candidate.id === template)?.name ?? null,
           ),
-      );
+        );
+      }
     } catch (err: unknown) {
       setDesignError(err instanceof Error ? err.message : String(err));
       setRoster(null);
     } finally {
       setDesigning(false);
     }
-  }, [client, draft, template, provider, tested, values.tinyhumans_api_key]);
+  }, [client, draft, template, nameTouched, status, provider, tested, values.tinyhumans_api_key]);
 
   const submit = useCallback(async () => {
     if (!status) return;
@@ -535,30 +590,24 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
     setSaveError(null);
     setBuilt(roster?.agents.length ?? null);
     try {
-      // An untouched template roster goes back as the template it came from.
-      //
-      // The host can then seed that company properly — the roster it ships,
-      // the `[tools]` belt it declares, the prompts in its own directory —
-      // where a designed company is rebuilt from this screen alone and can
-      // carry none of that. The moment the operator edits a row it *has* to be
-      // the designed path instead: their edits exist nowhere but here.
-      const seedTemplate =
-        status.companies.length === 0 &&
-        roster?.source === "preset" &&
-        !rosterEdited &&
-        template.trim().length > 0 &&
-        // A working credential is only carried by the designed path, which
-        // writes the provider onto the manifest and stores the key against the
-        // company. A template seed has nowhere to put either, so a tested model
-        // keeps the designed path — the roster is the same one on screen, and
-        // silently dropping a key the operator just watched pass is the worse
-        // trade. Reachable when a model answers and its answer is unusable, so
-        // the source is `preset` while `tested` is fine.
-        tested.kind !== "ok";
+      const seedTemplate = shouldSeedTemplate({
+        hasCompany: status.companies.length > 0,
+        source: roster?.source ?? null,
+        rosterEdited,
+        template,
+        credentialTested: tested.kind === "ok",
+        provider,
+      });
 
       const result = await submitSetup(client, {
         fields: changed,
         name: companyName.trim() || null,
+        // Sent for either path. The designed company carries its own copy
+        // below; a seeded template has no other way to learn it, and no shipped
+        // template names an admin — so without this, choosing a template *and*
+        // a sign-in finishes setup into a company the operator cannot
+        // administer.
+        admin_email: email.trim() || null,
         template: seedTemplate ? template : null,
         company:
           status.companies.length === 0 && roster && !seedTemplate
@@ -991,7 +1040,10 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
             designError={designError}
             roster={roster}
             name={companyName}
-            onName={setCompanyName}
+            onName={(next) => {
+              setCompanyName(next);
+              setNameTouched(true);
+            }}
             onRoster={(next) => {
               setRoster(next);
               // Any edit takes the template path off the table — see

--- a/frontend/test/unit/setup-wizard-company-identity.test.ts
+++ b/frontend/test/unit/setup-wizard-company-identity.test.ts
@@ -383,6 +383,44 @@ describe("the sign-in modes a first run may offer", () => {
     expect(offeredAuthModes(host(["email", "wallet"]), "wallet")).toEqual(["email", "wallet"]);
   });
 
+  it("reports every mode, wallet included, when env owns the field", () => {
+    // `FieldDto.value` is read from `config.toml` alone, so an
+    // `OPENCOMPANY_AUTH_MODE=wallet` never reaches `current`. The picker is
+    // locked in that state and is reporting rather than offering — filtering
+    // there would show an operator a disabled list whose every option is wrong.
+    const envOwned = status({
+      auth_modes: ["none", "email", "wallet"],
+      fields: [
+        {
+          key: "auth_mode",
+          value: null,
+          layer: "env",
+          editable: false,
+          requires_restart: false,
+          secret: false,
+        },
+      ],
+    });
+    expect(offeredAuthModes(envOwned, "")).toEqual(["none", "email", "wallet"]);
+  });
+
+  it("still withholds wallet when the field is the wizard's to write", () => {
+    const editable = status({
+      auth_modes: ["none", "email", "wallet"],
+      fields: [
+        {
+          key: "auth_mode",
+          value: "email",
+          layer: "config.toml",
+          editable: true,
+          requires_restart: false,
+          secret: false,
+        },
+      ],
+    });
+    expect(offeredAuthModes(editable, "")).toEqual(["none", "email"]);
+  });
+
   it("leaves every other mode exactly as the host offered it", () => {
     expect(offeredAuthModes(host(["none", "email"]), "")).toEqual(["none", "email"]);
     expect(offeredAuthModes(host(["email"]), "email")).toEqual(["email"]);

--- a/frontend/test/unit/setup-wizard-company-identity.test.ts
+++ b/frontend/test/unit/setup-wizard-company-identity.test.ts
@@ -8,6 +8,7 @@ import type { OpenCompanyClient } from "@/api/client";
 import type { SetupStatus } from "@/api/setup";
 import {
   SetupWizard,
+  offeredAuthModes,
   shouldSeedTemplate,
   suggestedCompanyName,
 } from "@/views/setup/SetupWizard";
@@ -365,5 +366,25 @@ describe("whether a finished wizard seeds a template or a designed company", () 
 
   it("seeds nothing onto a host that already has a company", () => {
     expect(shouldSeedTemplate({ ...picked, hasCompany: true })).toBe(false);
+  });
+});
+
+describe("the sign-in modes a first run may offer", () => {
+  const host = (modes: string[]) => status({ auth_modes: modes });
+
+  it("withholds wallet, which this flow cannot finish", () => {
+    // `[users].wallets` is what a wallet company is bootstrapped by, and
+    // nothing here can collect one — so finishing on `wallet` produces a
+    // company with no eligible administrator and no anonymous way back in.
+    expect(offeredAuthModes(host(["none", "email", "wallet"]), "")).toEqual(["none", "email"]);
+  });
+
+  it("still shows a wallet host the mode it is already running", () => {
+    expect(offeredAuthModes(host(["email", "wallet"]), "wallet")).toEqual(["email", "wallet"]);
+  });
+
+  it("leaves every other mode exactly as the host offered it", () => {
+    expect(offeredAuthModes(host(["none", "email"]), "")).toEqual(["none", "email"]);
+    expect(offeredAuthModes(host(["email"]), "email")).toEqual(["email"]);
   });
 });

--- a/frontend/test/unit/setup-wizard-company-identity.test.ts
+++ b/frontend/test/unit/setup-wizard-company-identity.test.ts
@@ -1,0 +1,252 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { SetupStatus } from "@/api/setup";
+import { SetupWizard, suggestedCompanyName } from "@/views/setup/SetupWizard";
+
+/**
+ * What the wizard sends back about the company itself: its **name**, and
+ * whether the thing to build is a template or a designed team.
+ *
+ * Both were decided silently before. The name was derived host-side from the
+ * *industry* answer — a field labelled "what kind of company are you setting
+ * up?" — and it mints the company id, which is then permanent and has no
+ * rename anywhere in the product. And a picked template was never sent: the
+ * wizard only ever posted a designed company, so choosing "Agentic Marketing
+ * Agency" and skipping the model produced a rebuilt approximation of it,
+ * without the roster, tool belt or prompts that template ships.
+ *
+ * Mounted rather than pure, for the same earned reason the sibling gate test
+ * gives: the claim is about what a submit *carries* after the operator has
+ * walked the steps, which only exists once the component is rendering.
+ */
+
+const TEMPLATE = {
+  id: "agentic_marketing_agency",
+  name: "Agentic Marketing Agency",
+  agent_count: 8,
+  output: "Campaigns across every channel",
+};
+
+function status(over: Partial<SetupStatus> = {}): SetupStatus {
+  return {
+    complete: false,
+    config_path: "/data/config.toml",
+    fields: [],
+    templates: [TEMPLATE],
+    // `none` keeps the walk short: it removes the address step, which is the
+    // only one that would demand an answer this file is not about.
+    auth_modes: ["none", "email"],
+    build: {
+      acp_in_build: false,
+      acp_transport_mounted: false,
+      mcp_in_build: false,
+      harness_in_build: false,
+      oauth_in_build: false,
+    },
+    companies: [],
+    inference: { ready: false, provider: null, base_url: null },
+    mail: { wired: false, echoes_code: false },
+    ...over,
+  };
+}
+
+/** The roster the host proposes, and the apply body it is asked for. */
+function clientWith(
+  s: SetupStatus,
+  source: "preset" | "fallback",
+  applied: { body?: unknown },
+): OpenCompanyClient {
+  return {
+    get: async () => s,
+    post: async (path: string, body: unknown) => {
+      if (path.includes("/setup/roster")) {
+        return {
+          agents: [
+            { name: "Creative Director", role: "Creative Director", description: "Concepts." },
+            { name: "Copywriter", role: "Copywriter", description: "Words." },
+          ],
+          template: TEMPLATE.id,
+          source,
+          jobs: [],
+          uncovered: [],
+          reason: "no_model",
+        };
+      }
+      if (path === "/api/v1/setup") {
+        applied.body = body;
+        return {
+          complete: true,
+          config_path: s.config_path,
+          restart_required: [],
+          seeded_company: "whatever-they-called-it",
+        };
+      }
+      return {};
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function button(label: string): HTMLButtonElement {
+  const wanted = label === "Next" ? ["Next", "Looks good"] : [label];
+  const match = Array.from(container.querySelectorAll("button")).find((b) =>
+    wanted.includes(b.textContent?.trim() ?? ""),
+  );
+  expect(match, `no button labeled "${label}"`).toBeTruthy();
+  return match as HTMLButtonElement;
+}
+
+const next = async () =>
+  act(async () => {
+    button("Next").click();
+  });
+
+async function fill(testId: string, value: string) {
+  const field = container.querySelector(`[data-testid="${testId}"]`) as
+    | HTMLInputElement
+    | HTMLTextAreaElement;
+  expect(field, `no field ${testId}`).toBeTruthy();
+  await act(async () => {
+    const proto =
+      field instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, "value")!.set!.call(field, value);
+    field.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function pickTemplate(id: string) {
+  const select = container.querySelector("select") as HTMLSelectElement;
+  expect(select, "no template dropdown").toBeTruthy();
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")!.set!.call(select, id);
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+/** model -> business -> sign-in (none) -> advanced -> review. */
+async function walkToReview(client: OpenCompanyClient, template: string | null) {
+  await act(async () => {
+    root.render(createElement(SetupWizard, { client, onDone: () => {} }));
+  });
+  await act(async () => {
+    (container.querySelector('[data-testid="setup-skip-model"]') as HTMLElement).click();
+  });
+  await next(); // -> business
+  if (template) await pickTemplate(template);
+  else await fill("setup-field-industry", "E-commerce — homeware online");
+  await next(); // -> sign-in
+  // "No sign-in", which also removes the address step.
+  await act(async () => {
+    (container.querySelector('[data-testid="auth-mode-none"]') as HTMLElement).click();
+  });
+  await next(); // -> advanced (or account, on a host that signs people in)
+  await next(); // -> review
+}
+
+describe("what a finished wizard says the company is", () => {
+  it("suggests the template's name, and sends it as the company's", async () => {
+    const applied: { body?: unknown } = {};
+    await walkToReview(clientWith(status(), "preset", applied), TEMPLATE.id);
+
+    const name = container.querySelector(
+      '[data-testid="setup-company-name"]',
+    ) as HTMLInputElement;
+    expect(name, "the review step must ask what to call it").toBeTruthy();
+    expect(name.value).toBe(TEMPLATE.name);
+
+    await act(async () => {
+      button("Build my company").click();
+    });
+    expect((applied.body as { name?: string }).name).toBe(TEMPLATE.name);
+  });
+
+  it("sends a name the operator typed over the suggestion", async () => {
+    const applied: { body?: unknown } = {};
+    await walkToReview(clientWith(status(), "preset", applied), TEMPLATE.id);
+    await fill("setup-company-name", "Northwind Studio");
+
+    await act(async () => {
+      button("Build my company").click();
+    });
+    const body = applied.body as { name?: string; template?: string | null };
+    expect(body.name).toBe("Northwind Studio");
+    // Renaming is not designing: the template is still what gets seeded.
+    expect(body.template).toBe(TEMPLATE.id);
+  });
+
+  it("sends an untouched template roster back as the template itself", async () => {
+    const applied: { body?: unknown } = {};
+    await walkToReview(clientWith(status(), "preset", applied), TEMPLATE.id);
+
+    await act(async () => {
+      button("Build my company").click();
+    });
+    const body = applied.body as { template?: string | null; company?: unknown };
+    expect(body.template).toBe(TEMPLATE.id);
+    expect(
+      body.company,
+      "a template the host can seed whole must not be rebuilt from this screen",
+    ).toBeNull();
+  });
+
+  it("still sends a designed company when the roster was matched, not picked", async () => {
+    const applied: { body?: unknown } = {};
+    // No templates offered, so the step asks for the business in the operator's
+    // own words — which is the path the curated roster is matched from.
+    await walkToReview(clientWith(status({ templates: [] }), "fallback", applied), null);
+
+    await act(async () => {
+      button("Build my company").click();
+    });
+    const body = applied.body as { template?: string | null; company?: { agents: unknown[] } };
+    expect(body.template).toBeNull();
+    expect(body.company?.agents).toHaveLength(2);
+  });
+
+  it("does not offer to edit a roster it is going to seed whole", async () => {
+    await walkToReview(clientWith(status(), "preset", {}), TEMPLATE.id);
+    expect(
+      container.querySelector('[data-testid="setup-review-remove"]'),
+      "an edited template roster could only go back as a designed company, which is capped at six",
+    ).toBeNull();
+  });
+});
+
+describe("the name offered for a company nobody has named", () => {
+  it("prefers a picked template's own name", () => {
+    expect(suggestedCompanyName("anything at all", "Agentic Law Firm")).toBe("Agentic Law Firm");
+  });
+
+  it("takes the first clause of the industry answer, as the host does", () => {
+    expect(suggestedCompanyName("E-commerce — I sell homeware online", null)).toBe("E-commerce");
+    expect(suggestedCompanyName("Consulting, mostly public sector", null)).toBe("Consulting");
+  });
+
+  it("never splits a hyphenated word", () => {
+    expect(suggestedCompanyName("E-commerce", null)).toBe("E-commerce");
+  });
+
+  it("offers nothing when there is nothing to offer", () => {
+    expect(suggestedCompanyName("   ", null)).toBe("");
+  });
+});

--- a/frontend/test/unit/setup-wizard-company-identity.test.ts
+++ b/frontend/test/unit/setup-wizard-company-identity.test.ts
@@ -6,7 +6,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { SetupStatus } from "@/api/setup";
-import { SetupWizard, suggestedCompanyName } from "@/views/setup/SetupWizard";
+import {
+  SetupWizard,
+  shouldSeedTemplate,
+  suggestedCompanyName,
+} from "@/views/setup/SetupWizard";
 
 /**
  * What the wizard sends back about the company itself: its **name**, and
@@ -30,6 +34,13 @@ const TEMPLATE = {
   name: "Agentic Marketing Agency",
   agent_count: 8,
   output: "Campaigns across every channel",
+};
+
+const OTHER_TEMPLATE = {
+  id: "agentic_law_firm",
+  name: "Agentic Law Firm",
+  agent_count: 5,
+  output: "Filings and advice",
 };
 
 function status(over: Partial<SetupStatus> = {}): SetupStatus {
@@ -223,6 +234,72 @@ describe("what a finished wizard says the company is", () => {
     expect(body.company?.agents).toHaveLength(2);
   });
 
+  it("re-suggests the name when the template changes, unless it was typed", async () => {
+    const applied: { body?: unknown } = {};
+    const client = clientWith(
+      status({ templates: [TEMPLATE, OTHER_TEMPLATE] }),
+      "preset",
+      applied,
+    );
+    await walkToReview(client, TEMPLATE.id);
+    expect(
+      (container.querySelector('[data-testid="setup-company-name"]') as HTMLInputElement).value,
+    ).toBe(TEMPLATE.name);
+
+    // Back to Business, a different template, forward again.
+    for (let i = 0; i < 3; i += 1) {
+      // review -> advanced -> sign-in -> business.
+      await act(async () => {
+        button("Back").click();
+      });
+    }
+    await pickTemplate(OTHER_TEMPLATE.id);
+    // business -> sign-in -> advanced -> review. The sign-in answer survives
+    // going back, so the address step stays absent.
+    await next();
+    await next();
+    await next();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const name = container.querySelector('[data-testid="setup-company-name"]') as HTMLInputElement;
+    expect(
+      name.value,
+      "a suggestion nobody typed must not name the company they did pick",
+    ).toBe(OTHER_TEMPLATE.name);
+  });
+
+  it("keeps a typed name across a change of template", async () => {
+    const applied: { body?: unknown } = {};
+    const client = clientWith(
+      status({ templates: [TEMPLATE, OTHER_TEMPLATE] }),
+      "preset",
+      applied,
+    );
+    await walkToReview(client, TEMPLATE.id);
+    await fill("setup-company-name", "Northwind Studio");
+
+    for (let i = 0; i < 3; i += 1) {
+      // review -> advanced -> sign-in -> business.
+      await act(async () => {
+        button("Back").click();
+      });
+    }
+    await pickTemplate(OTHER_TEMPLATE.id);
+    // business -> sign-in -> advanced -> review. The sign-in answer survives
+    // going back, so the address step stays absent.
+    await next();
+    await next();
+    await next();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const name = container.querySelector('[data-testid="setup-company-name"]') as HTMLInputElement;
+    expect(name.value, "a name the operator typed is theirs").toBe("Northwind Studio");
+  });
+
   it("does not offer to edit a roster it is going to seed whole", async () => {
     await walkToReview(clientWith(status(), "preset", {}), TEMPLATE.id);
     expect(
@@ -248,5 +325,45 @@ describe("the name offered for a company nobody has named", () => {
 
   it("offers nothing when there is nothing to offer", () => {
     expect(suggestedCompanyName("   ", null)).toBe("");
+  });
+});
+
+describe("whether a finished wizard seeds a template or a designed company", () => {
+  const picked = {
+    hasCompany: false,
+    source: "preset" as const,
+    rosterEdited: false,
+    template: TEMPLATE.id,
+    credentialTested: false,
+    provider: "openrouter",
+  };
+
+  it("seeds the template an operator picked and did not edit", () => {
+    expect(shouldSeedTemplate(picked)).toBe(true);
+  });
+
+  it("designs instead once the roster has been edited", () => {
+    expect(shouldSeedTemplate({ ...picked, rosterEdited: true })).toBe(false);
+  });
+
+  it("designs instead for a curated roster, which is no template's", () => {
+    expect(shouldSeedTemplate({ ...picked, source: "fallback" })).toBe(false);
+    expect(shouldSeedTemplate({ ...picked, source: "model" })).toBe(false);
+  });
+
+  it("designs instead when a credential has to be carried", () => {
+    expect(shouldSeedTemplate({ ...picked, credentialTested: true })).toBe(false);
+  });
+
+  it("still seeds the template when the tested provider is managed", () => {
+    // The designed submit omits inference for `managed`, so the designed path
+    // would trade the template's roster, belt and prompts for nothing at all.
+    expect(
+      shouldSeedTemplate({ ...picked, credentialTested: true, provider: "managed" }),
+    ).toBe(true);
+  });
+
+  it("seeds nothing onto a host that already has a company", () => {
+    expect(shouldSeedTemplate({ ...picked, hasCompany: true })).toBe(false);
   });
 });

--- a/src-tauri/src/embedded.rs
+++ b/src-tauri/src/embedded.rs
@@ -80,26 +80,39 @@ impl Drop for EmbeddedHost {
 /// A host that seeds is a host that is *already set up* — `AppSpec` reports
 /// `setup_complete` as `stamp || !registry.is_empty()` — so seeding does not
 /// merely add a company, it suppresses the first-run wizard the console would
-/// otherwise open (`views/setup/SetupWizard.tsx`).
+/// otherwise open (`views/setup/SetupWizard.tsx`), permanently and with no way
+/// back to it.
+///
+/// That last clause is why the packaged application now gives the same answer
+/// for **every** instance it starts, including the one at the data root, which
+/// used to seed: see `local::start_at`. What is left here is a knob for callers
+/// that want a populated host without walking a wizard — the test suites, which
+/// need a company to address, and any embedder in the same position.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FirstRun {
     /// Register a starter company from the default preset when the root is
-    /// empty, so the application is enterable with no terminal and no
-    /// decisions ([issue #632](https://github.com/tinyhumansai/opencompany/issues/632)).
+    /// empty, so the host is usable with no decisions at all
+    /// ([issue #632](https://github.com/tinyhumansai/opencompany/issues/632)).
     ///
-    /// What the instance rooted at the data dir does, which is every install
-    /// that predates a roster.
+    /// No longer what a launched application does — #632's requirement is now
+    /// met by the wizard being reachable rather than by the answer being
+    /// assumed. Reached through [`start`], which the test suites use.
     SeedStarterCompany,
     /// Register only what the root already holds, leaving an empty root empty.
     ///
-    /// What an instance an operator *asked for* does. They are standing in
-    /// front of the application having just named a company, so the decisions
-    /// the wizard asks for are ones they are already making — and a seeded
-    /// starter company would answer them silently and hide the wizard for good.
+    /// What every instance the desktop starts does. An empty root then reports
+    /// setup outstanding and the console opens the wizard against it; a root
+    /// with companies in it — every install that has been used — adopts them
+    /// and goes straight to the console, exactly as before.
     RunSetupWizard,
 }
 
 /// Boots a host over `data_dir`, seeding a starter company on an empty root.
+///
+/// The seeding entry point, kept for callers that want a host with a company in
+/// it without completing setup first. The application itself starts its hosts
+/// through [`start_with`] with [`FirstRun::RunSetupWizard`] — see
+/// `local::start_at` for why.
 ///
 /// `data_dir` is passed explicitly rather than resolved from the environment.
 /// A desktop app knows its platform data directory and should say so — and the
@@ -301,8 +314,13 @@ mod test {
     /// through the sole-company alias the console addresses before it knows any
     /// id, and the principal has to resolve with nothing presented. Asserting a
     /// company was registered would prove neither.
+    ///
+    /// Seeded explicitly through [`start`], because a launched install no longer
+    /// seeds — it opens the wizard instead (`local::start_at`). What is under
+    /// test here is the host once it *has* a company, which is where a launched
+    /// install arrives the moment setup completes.
     #[tokio::test]
-    async fn a_fresh_install_opens_with_no_sign_in() {
+    async fn a_host_with_a_company_opens_with_no_sign_in() {
         let dir = tempfile::tempdir().unwrap();
         let host = start(dir.path().to_path_buf()).await.expect("host starts");
         let base = host.base_url();
@@ -311,7 +329,7 @@ mod test {
         assert_eq!(
             host.companies().len(),
             1,
-            "a fresh root gets exactly one starter company"
+            "the seeding entry point registers exactly one starter company"
         );
 
         // Where the console starts, and where it used to stop with a 401.

--- a/src-tauri/src/local.rs
+++ b/src-tauri/src/local.rs
@@ -357,14 +357,36 @@ impl LocalHosts {
     async fn start_at(&mut self, index: usize) {
         let entry = &self.instances[index].entry;
         let root = root_of(&self.data_dir, entry);
-        // The instance at the data root seeds a starter company; one an
-        // operator created runs the setup wizard instead. See `FirstRun` — the
-        // difference is not cosmetic, because a seeded company makes the host
-        // report `setup_complete` and the wizard never opens again.
-        let first_run = match entry.root {
-            None => FirstRun::SeedStarterCompany,
-            Some(_) => FirstRun::RunSetupWizard,
-        };
+        // Every instance adopts what its root already holds and seeds nothing
+        // — the one at the data root included, which used to be the exception.
+        //
+        // That exception was an ordering artifact rather than a decision. #632
+        // seeded a starter company because a double-clicked application had no
+        // other way in: there was no setup wizard yet, and an empty registry is
+        // a login form addressing a company that does not exist. The wizard
+        // arrived later and this arm was never revisited — so the one install
+        // that most needs onboarding became the one install that could never
+        // reach it. Seeding is not merely a head start: it makes `/spec` report
+        // `setup_complete` (`stamp || !registry.is_empty()`), `ConnectionConsole`
+        // enters its setup phase from that field and nothing else, and no
+        // settings link re-opens the wizard. One silent answer, permanently.
+        //
+        // Note what does **not** change, because it is the whole risk of
+        // touching this: an install that already has a company still boots
+        // straight into it, with no wizard. Seeding was only ever the fallback
+        // half of `desktop::bootstrap_companies`, reached when adoption came
+        // back empty — so the arm dropped here could only ever fire on a root
+        // holding no companies at all, which on the default instance means a
+        // genuinely fresh install. Everything else is the adopt half, which
+        // stays.
+        //
+        // #632's guarantee survives too, as a guarantee about *reachability*
+        // rather than about seeding: the wizard is anonymous on loopback while
+        // the registry is empty (`server::setup::authorize`), its model step is
+        // skippable onto a curated roster, and finishing it seeds a template
+        // through `desktop::seed_company`. Still enterable with no terminal, no
+        // mail server and no credential — it asks first, which is the point.
+        let first_run = FirstRun::RunSetupWizard;
         match embedded::start_with(root, first_run).await {
             Ok(host) => {
                 tracing::info!(
@@ -695,21 +717,24 @@ mod test {
         );
     }
 
-    /// And the instance at the data root keeps the behaviour #632 gave it.
+    /// And the instance at the data root gets the same guarantee, which is the
+    /// half that used to be missing.
     ///
-    /// The pair matters more than either alone: these two hosts differ in
-    /// exactly one decision, and the whole risk of splitting them is that the
-    /// seeding half quietly stops applying to the install that depends on it.
+    /// The pair matters more than either alone: these two hosts made exactly
+    /// one decision differently, and it was the decision that made onboarding
+    /// unreachable on the only install most operators will ever have. Asserted
+    /// over `/spec` for the reason the sibling test gives — `setup_complete` is
+    /// the whole of what the console consults, so an empty company list would
+    /// prove only half of it.
     #[tokio::test]
-    async fn the_instance_at_the_data_root_is_still_enterable_with_no_decisions() {
+    async fn the_instance_at_the_data_root_opens_the_setup_wizard_too() {
         let dir = tempfile::tempdir().unwrap();
         let hosts = LocalHosts::load(dir.path().to_path_buf()).await;
         let default = hosts.default_instance().expect("it starts");
 
-        assert_eq!(
-            default.companies.len(),
-            1,
-            "a fresh install still gets its starter company"
+        assert!(
+            default.companies.is_empty(),
+            "a fresh install must not be handed a company nobody chose"
         );
         let spec: serde_json::Value = reqwest::get(format!(
             "{}/spec",
@@ -720,7 +745,50 @@ mod test {
         .json()
         .await
         .expect("a spec document");
-        assert_eq!(spec["setup_complete"], serde_json::json!(true));
+        assert_eq!(
+            spec["setup_complete"],
+            serde_json::json!(false),
+            "the wizard opens on the default instance, or nothing does: {spec}"
+        );
+    }
+
+    /// The migration guarantee, and the only thing standing between this change
+    /// and "my company is gone".
+    ///
+    /// Not seeding a *fresh* root must not mean ignoring a *used* one. Every
+    /// install that has ever been opened keeps its company under the data dir
+    /// itself (see the module header), and that company has to come back
+    /// without a wizard in front of it — the operator set this machine up long
+    /// ago and has nothing left to decide.
+    #[tokio::test]
+    async fn a_data_root_that_already_holds_a_company_boots_straight_into_it() {
+        let dir = tempfile::tempdir().unwrap();
+        // What a used install looks like on disk: a bundle under the data dir,
+        // put there by an older launch that seeded, or by a completed wizard.
+        let existing = seed_a_company_into(dir.path()).await;
+        assert_eq!(existing.len(), 1, "the fixture writes one company");
+
+        let hosts = relaunch(dir.path()).await;
+        let default = hosts.default_instance().expect("it starts");
+
+        assert_eq!(
+            default.companies, existing,
+            "a root with a company in it must adopt it, not ignore it"
+        );
+        let spec: serde_json::Value = reqwest::get(format!(
+            "{}/spec",
+            default.base_url.as_deref().expect("running")
+        ))
+        .await
+        .expect("the reported address answers")
+        .json()
+        .await
+        .expect("a spec document");
+        assert_eq!(
+            spec["setup_complete"],
+            serde_json::json!(true),
+            "an install that is already set up must never be walked through setup: {spec}"
+        );
     }
 
     /// Skipping the *seed* must not skip the *adopt*.

--- a/src-tauri/tests/fresh_install.rs
+++ b/src-tauri/tests/fresh_install.rs
@@ -95,6 +95,15 @@ async fn a_fresh_install_opens_the_wizard_and_can_complete_it() {
         1,
         "completing setup seeds exactly the company that was chosen: {listed:?}"
     );
+    // The company that was chosen, not merely *a* company: an apply that
+    // ignored the template, or seeded a different one, would satisfy the count
+    // above and nothing else here. Provenance rather than the id, because the
+    // id follows the company's name and the name is the operator's to change.
+    assert_eq!(
+        provenance(&base, &listed[0]).await.as_deref(),
+        Some(STARTER_TEMPLATE),
+        "the seeded company must be the template the wizard was told to use"
+    );
     assert_eq!(
         spec(&base).await["setup_complete"],
         serde_json::json!(true),
@@ -158,6 +167,23 @@ async fn companies(base: &str) -> Vec<String> {
                 .to_string()
         })
         .collect()
+}
+
+/// Which template a company was seeded from, as the host reports it.
+async fn provenance(base: &str, id: &str) -> Option<String> {
+    let listed: serde_json::Value = reqwest::get(format!("{base}/api/v1/companies"))
+        .await
+        .expect("the companies route answers")
+        .json()
+        .await
+        .expect("a company list");
+    listed
+        .as_array()
+        .expect("an array")
+        .iter()
+        .find(|company| company["id"] == id)
+        .and_then(|company| company["template_provenance"]["source_id"].as_str())
+        .map(str::to_string)
 }
 
 /// Loads the roster again, retrying while the previous run's `flock` clears.

--- a/src-tauri/tests/fresh_install.rs
+++ b/src-tauri/tests/fresh_install.rs
@@ -1,0 +1,181 @@
+//! What a brand-new install does, over HTTP, through the launch path itself.
+//!
+//! The unit tests in `local.rs` assert the same decision, but they assert it
+//! against `LocalHosts` as a value. This file is deliberately one level out: it
+//! makes a data directory that has never been used, boots it exactly the way
+//! `lib::run` boots the application — `LocalHosts::load(data_dir)`, nothing
+//! else — and then only ever asks the resulting host questions over its own
+//! socket, the way the console does.
+//!
+//! That distinction is the whole point of the file. The thing being verified is
+//! not "the flag is set", it is "a person who double-clicks a fresh install
+//! reaches onboarding, and a person who already has a company does not". Both
+//! of those are answers the console reads out of `/spec` at boot
+//! (`ConnectionConsole` enters its setup phase on `setup_complete === false`
+//! and on nothing else), so `/spec` is what this asks.
+//!
+//! It also walks the rest of the way: completing setup with the same starter
+//! template the host used to seed silently, then relaunching over the root that
+//! leaves behind. A change that made the wizard open but left an operator
+//! unable to finish it, or made them finish it once per launch, would pass a
+//! narrower test than this one.
+
+use std::path::Path;
+
+use opencompany_desktop_lib::local::LocalHosts;
+
+/// The template the desktop used to seed without asking. It has to still be
+/// offered, or "the wizard opens instead" would be a downgrade rather than a
+/// choice.
+const STARTER_TEMPLATE: &str = "agentic_marketing_agency";
+
+#[tokio::test]
+async fn a_fresh_install_opens_the_wizard_and_can_complete_it() {
+    let data_dir = tempfile::tempdir().expect("tempdir");
+
+    // Launch, as `lib::run` performs it. A fresh install differs from every
+    // other launch in one way only: this directory is empty.
+    let hosts = LocalHosts::load(data_dir.path().to_path_buf()).await;
+    let default = hosts
+        .default_instance()
+        .expect("a fresh data dir still starts its default instance");
+    let base = default
+        .base_url
+        .clone()
+        .expect("a started instance reports its address");
+
+    assert!(
+        default.companies.is_empty(),
+        "nobody has chosen a company yet, so the host must not have one: {:?}",
+        default.companies
+    );
+    assert_eq!(
+        spec(&base).await["setup_complete"],
+        serde_json::json!(false),
+        "this is the field the console consults, and `false` is what opens the wizard"
+    );
+
+    // The wizard's own read, made with no session at all. A first run has no
+    // account to present, so a setup surface that needed one could never be
+    // reached on the install that needs it most.
+    let offer = reqwest::get(format!("{base}/api/v1/setup"))
+        .await
+        .expect("the setup route answers");
+    assert_eq!(
+        offer.status(),
+        200,
+        "an unconfigured host must serve its wizard to an anonymous caller"
+    );
+    let offer: serde_json::Value = offer.json().await.expect("a setup document");
+    let templates = offer["templates"]
+        .as_array()
+        .expect("the wizard offers a template catalog");
+    assert!(
+        templates.iter().any(|t| t["id"] == STARTER_TEMPLATE),
+        "the company the host used to seed silently must still be one click away"
+    );
+
+    // Completing it, choosing that same starter company. This is the path the
+    // seed used to take on the operator's behalf, now taken by the operator.
+    let applied = reqwest::Client::new()
+        .post(format!("{base}/api/v1/setup"))
+        .json(&serde_json::json!({ "fields": {}, "template": STARTER_TEMPLATE }))
+        .send()
+        .await
+        .expect("the setup route accepts a completed wizard");
+    assert_eq!(
+        applied.status(),
+        200,
+        "a wizard that opens and cannot be finished is worse than one that never opened"
+    );
+
+    let listed = companies(&base).await;
+    assert_eq!(
+        listed.len(),
+        1,
+        "completing setup seeds exactly the company that was chosen: {listed:?}"
+    );
+    assert_eq!(
+        spec(&base).await["setup_complete"],
+        serde_json::json!(true),
+        "and the wizard must not open again over the same root"
+    );
+
+    // The second launch, which is the one that used to go wrong quietly in the
+    // other direction: an install with a company must never be walked through
+    // setup again. Dropped first so the root's lock is released.
+    let chosen = listed;
+    drop(hosts);
+    let relaunched = relaunch(data_dir.path()).await;
+    let default = relaunched
+        .default_instance()
+        .expect("the same root comes back");
+    let base = default.base_url.clone().expect("running");
+
+    assert_eq!(
+        default.companies.len(),
+        1,
+        "the company completing setup left behind is adopted, not re-created"
+    );
+    assert_eq!(
+        companies(&base).await,
+        chosen,
+        "and it is the same company, not a second one"
+    );
+    assert_eq!(
+        spec(&base).await["setup_complete"],
+        serde_json::json!(true),
+        "a used install goes straight to its console"
+    );
+}
+
+/// The handshake the console makes before anything else.
+async fn spec(base: &str) -> serde_json::Value {
+    reqwest::get(format!("{base}/spec"))
+        .await
+        .expect("the reported address answers")
+        .json()
+        .await
+        .expect("a spec document")
+}
+
+/// The company ids this host serves, as the console lists them.
+async fn companies(base: &str) -> Vec<String> {
+    let listed: serde_json::Value = reqwest::get(format!("{base}/api/v1/companies"))
+        .await
+        .expect("the companies route answers")
+        .json()
+        .await
+        .expect("a company list");
+    listed
+        .as_array()
+        .expect("an array")
+        .iter()
+        .map(|company| {
+            company["id"]
+                .as_str()
+                .expect("every company has an id")
+                .to_string()
+        })
+        .collect()
+}
+
+/// Loads the roster again, retrying while the previous run's `flock` clears.
+///
+/// The same asynchronous release `local.rs`'s own relaunch helpers wait out: the
+/// lock belongs to the open file description, and this binary spawns
+/// subprocesses that inherit a copy.
+async fn relaunch(data_dir: &Path) -> LocalHosts {
+    for _ in 0..200 {
+        let hosts = LocalHosts::load(data_dir.to_path_buf()).await;
+        if hosts
+            .default_instance()
+            .is_some_and(|instance| instance.running)
+        {
+            return hosts;
+        }
+        drop(hosts);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("a released root must become takeable");
+}

--- a/src/company/setup.rs
+++ b/src/company/setup.rs
@@ -1231,6 +1231,18 @@ pub enum RosterSource {
     /// was too thin to be a company. Never blended with a model's answer —
     /// see [`validate_roster`].
     Fallback,
+    /// The roster of the bundled template the operator **picked**, shipped
+    /// whole.
+    ///
+    /// Distinct from [`Fallback`](Self::Fallback), which is the curated team
+    /// this module matches from the *answers*. The two are different rosters
+    /// and only one of them was chosen by anybody: an operator who selects
+    /// "Agentic Marketing Agency" and then skips the model step was handed the
+    /// five-person curated marketing team rather than that template's eight,
+    /// under a heading naming the template. This says what it is, so the
+    /// review screen can too — and so the apply can seed the template itself
+    /// rather than rebuild an approximation of it.
+    Preset,
 }
 
 /// Why a roster fell back to the curated team.
@@ -1280,6 +1292,7 @@ impl RosterSource {
         match self {
             Self::Model => "model",
             Self::Fallback => "fallback",
+            Self::Preset => "preset",
         }
     }
 }
@@ -1290,6 +1303,38 @@ impl RosterSource {
 /// This is both the fast path (no inference credential wired) and the floor
 /// every other path falls back to, which is why it lives here rather than
 /// beside the pass that polishes it.
+/// The proposal for a template the operator **picked**: that template's own
+/// roster, verbatim.
+///
+/// The counterpart to [`template_proposal`], and the difference is who chose.
+/// `template_proposal` matches a curated team from what the operator *wrote*;
+/// this one reports the team of the bundled company they *selected* from a
+/// list. Reaching for the curated team when a template is on screen produces
+/// the one outcome the review step must never produce — a roster that is not
+/// what the heading above it names.
+///
+/// `uncovered` stays empty for the same reason it does on the curated path: a
+/// shipped roster makes no claim about the job list, and inventing one either
+/// way would be a claim nobody checked.
+pub fn preset_proposal(
+    answers: &SetupAnswers,
+    template_key: &'static str,
+    agents: Vec<ProposedAgent>,
+    reason: FallbackReason,
+) -> RosterProposal {
+    RosterProposal {
+        // Bounded by the template rather than by [`MAX_AGENTS`]: this roster is
+        // shipped, not invented, and the review screen must show the team the
+        // template card said it would.
+        agents: validate_roster_bounded(agents, usize::MAX),
+        template_key,
+        source: RosterSource::Preset,
+        reason: Some(reason),
+        jobs: job_items(&answers.automate),
+        uncovered: Vec::new(),
+    }
+}
+
 pub fn template_proposal(answers: &SetupAnswers, reason: FallbackReason) -> RosterProposal {
     let template = match_template(answers);
     RosterProposal {
@@ -1556,12 +1601,23 @@ pub(crate) fn clamp_description(description: &str) -> String {
 /// operator is always looking at one authored team or the other, never a blend
 /// of both. See [`crate::harness::roster_build`].
 pub fn validate_roster(proposed: Vec<ProposedAgent>) -> Vec<ProposedAgent> {
+    validate_roster_bounded(proposed, MAX_AGENTS)
+}
+
+/// [`validate_roster`], with the size bound named by the caller.
+///
+/// [`MAX_AGENTS`] bounds what a *model* may invent, and a bundled template is
+/// not a model: several ship eight or nine teammates deliberately, and running
+/// one through the six-agent cap would show an operator six of the eight their
+/// template card advertised and then build all eight. The cap stays exactly
+/// where it was for every designed roster; a shipped one is displayed whole.
+pub fn validate_roster_bounded(proposed: Vec<ProposedAgent>, max: usize) -> Vec<ProposedAgent> {
     let mut seen: Vec<String> = Vec::new();
     let mut roster: Vec<ProposedAgent> = Vec::new();
 
     let push = |agent: ProposedAgent, roster: &mut Vec<ProposedAgent>, seen: &mut Vec<String>| {
         let role = agent.role.trim();
-        if role.is_empty() || roster.len() >= MAX_AGENTS {
+        if role.is_empty() || roster.len() >= max {
             return;
         }
         let slug = role_slug(role);

--- a/src/company/setup.rs
+++ b/src/company/setup.rs
@@ -544,6 +544,14 @@ pub const MIN_AGENTS: usize = 4;
 
 /// The most agents a setup pass may land. Beyond this a new operator is being
 /// handed clutter to tidy rather than a team to work with.
+/// The longest company name this flow accepts, in characters.
+///
+/// Shared by the derivation and by an operator's own name, because the reason
+/// for the bound is the same either way: `company_id_from_name` keeps every
+/// alphanumeric character, and the id becomes a directory component under the
+/// store.
+pub const MAX_COMPANY_NAME: usize = 60;
+
 pub const MAX_AGENTS: usize = 6;
 
 /// The longest mandate a card should carry. A model asked for a one-line
@@ -1476,7 +1484,7 @@ fn company_name(answers: &SetupAnswers) -> String {
         .unwrap_or(raw)
         .to_string();
     let head = head.as_str();
-    let trimmed: String = head.chars().take(60).collect();
+    let trimmed: String = head.chars().take(MAX_COMPANY_NAME).collect();
     if trimmed.trim().is_empty() {
         "My Company".to_string()
     } else {

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -337,31 +337,61 @@ pub async fn seed_company(
     state: &AppState,
     preset_id: &str,
 ) -> Result<crate::ports::types::CompanyId> {
-    seed_company_named(state, preset_id, None).await
+    seed_company_with(state, preset_id, SeedOverrides::default()).await
 }
 
-/// [`seed_company`], with the operator's own name for the company.
+/// What the operator decides about a company seeded from a template.
 ///
-/// The template decides everything about this company except what it is called.
-/// That one field is the operator's: the first-run wizard now asks for it, and
-/// a company named after the template it happened to start from is a default,
-/// not a fact — the same company with a different name is still that template's
-/// roster, belt and prompts.
+/// Everything else is the template's. These two are not, and both are fixed at
+/// seed time rather than editable afterwards — the id is minted from the name
+/// here, and a company with no admin cannot be signed into at all.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SeedOverrides<'a> {
+    /// What to call the company. `None` keeps the template's own
+    /// `[company].name`, which is what every seed before the first-run wizard
+    /// asked used, and what [`bootstrap_companies`] still passes.
+    pub name: Option<&'a str>,
+    /// The address that may sign in, written into `[users].admins`.
+    ///
+    /// No shipped product template names an admin, so on a host that asks
+    /// people to sign in, a seed without this produces a company nobody can
+    /// administer — setup completes, email sign-in is on, and the address the
+    /// operator just typed is ineligible. The designed path has always written
+    /// it (`manifest_from_setup`); the template path reached the console only
+    /// once a picked template began being seeded as itself, which is what makes
+    /// this reachable now.
+    ///
+    /// Ignored under `[users].mode = "none"`, where `validate_users` flags an
+    /// admin list as granting nothing and both seeding paths treat a flagged
+    /// manifest as a hard error.
+    pub admin_email: Option<&'a str>,
+}
+
+/// [`seed_company`], with the decisions the operator made about it.
 ///
-/// `None` keeps the template's own `[company].name`, which is what every seed
-/// before this used and what [`bootstrap_companies`] still passes.
-///
-/// The name is load-bearing rather than cosmetic: the id is minted from it here
-/// and fixed for the life of the company, which is why this is a parameter at
-/// seed time rather than an edit afterwards.
-pub async fn seed_company_named(
+/// Split from `seed_company` rather than folded into it so the no-decision
+/// callers — first-run bootstrap, tests — keep an entry point that says they
+/// made none.
+pub async fn seed_company_with(
     state: &AppState,
     preset_id: &str,
-    name: Option<&str>,
+    overrides: SeedOverrides<'_>,
 ) -> Result<crate::ports::types::CompanyId> {
     let mut manifest = first_run_manifest(preset_id)?;
-    if let Some(name) = name.map(str::trim).filter(|name| !name.is_empty()) {
+    if let Some(name) = overrides
+        .name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+    {
         manifest.company.name = name.to_string();
+    }
+    if let Some(email) = overrides
+        .admin_email
+        .map(str::trim)
+        .filter(|email| !email.is_empty())
+        && manifest.users.mode != "none"
+    {
+        manifest.users.admins = vec![email.to_string()];
     }
     let id = company_id_from_name(&manifest.company.name);
     // Issue #85: record which template this install started from. Only the

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -239,6 +239,17 @@ mod generated {
 /// An `archived` company is skipped. Archiving removes a company from the
 /// registry on purpose (`src/server/provision.rs`), and re-registering it at
 /// the next launch would undo that quietly.
+///
+/// ## What the desktop does now
+///
+/// Not this. The application starts every host through `adopt_companies`
+/// alone and lets an empty registry open the first-run wizard, because seeding
+/// answered the wizard's questions silently and then hid it for good — the
+/// reasoning is on `crate::desktop`'s caller side, in the tauri crate's
+/// `local::start_at`. The seed half stayed reachable, since the wizard itself
+/// ends by calling `seed_company` with the template the operator picked, and
+/// this function stayed whole because the two halves belong together for any
+/// caller that does want a company without a wizard.
 pub async fn bootstrap_companies(
     state: &AppState,
     preset_id: &str,
@@ -326,7 +337,32 @@ pub async fn seed_company(
     state: &AppState,
     preset_id: &str,
 ) -> Result<crate::ports::types::CompanyId> {
-    let manifest = first_run_manifest(preset_id)?;
+    seed_company_named(state, preset_id, None).await
+}
+
+/// [`seed_company`], with the operator's own name for the company.
+///
+/// The template decides everything about this company except what it is called.
+/// That one field is the operator's: the first-run wizard now asks for it, and
+/// a company named after the template it happened to start from is a default,
+/// not a fact — the same company with a different name is still that template's
+/// roster, belt and prompts.
+///
+/// `None` keeps the template's own `[company].name`, which is what every seed
+/// before this used and what [`bootstrap_companies`] still passes.
+///
+/// The name is load-bearing rather than cosmetic: the id is minted from it here
+/// and fixed for the life of the company, which is why this is a parameter at
+/// seed time rather than an edit afterwards.
+pub async fn seed_company_named(
+    state: &AppState,
+    preset_id: &str,
+    name: Option<&str>,
+) -> Result<crate::ports::types::CompanyId> {
+    let mut manifest = first_run_manifest(preset_id)?;
+    if let Some(name) = name.map(str::trim).filter(|name| !name.is_empty()) {
+        manifest.company.name = name.to_string();
+    }
     let id = company_id_from_name(&manifest.company.name);
     // Issue #85: record which template this install started from. Only the
     // slug, never a host path — there is no source directory on a packaged

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -260,6 +260,23 @@ pub struct SetupRequest {
     /// already has a company — setup must never hand an operator a second
     /// starter company on a re-run.
     pub template: Option<String>,
+    /// What to call the company this setup creates.
+    ///
+    /// Absent means "derive it", which is what every company made here used to
+    /// get with no way to say otherwise: [`company_name`] takes the first
+    /// clause of the *industry* answer, so a field labelled "what kind of
+    /// company are you setting up?" silently named the company — and the id is
+    /// minted from that name and then fixed
+    /// ([`company_id_from_name`](crate::runtime::company_id_from_name)), with
+    /// no rename anywhere in the product. Sent by the review step, which is the
+    /// last screen before that becomes permanent.
+    ///
+    /// Applies to both paths: a designed company and a seeded template. Blank
+    /// or whitespace is treated as absent rather than as a name, since an empty
+    /// company name slugs to the literal id `company`.
+    ///
+    /// [`company_name`]: crate::company::setup::manifest_from_setup
+    pub name: Option<String>,
     /// A company the wizard **designed**, from the operator's answers and the
     /// roster they reviewed.
     ///
@@ -844,6 +861,16 @@ async fn apply_inner(
     // Seed the template only when the host has no company. A re-run must never
     // hand the operator a second starter company, which is the same reason
     // `desktop::bootstrap_companies` seeds only as a fallback.
+    // Blank is not a name. `company_id_from_name` slugs an empty string to the
+    // literal id `company`, so an operator who cleared the field would get a
+    // company called nothing at an id naming nothing — deriving is the better
+    // answer to "I typed no name" than obeying it is.
+    let chosen_name = req
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty());
+
     let seeded = match (&req.company, &req.template, state.registry().is_empty()) {
         // A designed company wins over a template slug: the operator answered
         // three questions and edited the roster, which a preset cannot override.
@@ -876,6 +903,13 @@ async fn apply_inner(
                 &agents,
                 designed.admin_email.as_deref(),
             );
+            // Overrides the derived name, and only the name: everything else
+            // `manifest_from_setup` decided is still what a provisioned company
+            // gets. Set before `seed_generated_company`, because the id is
+            // minted from this field there and never again.
+            if let Some(name) = chosen_name {
+                manifest.company.name = name.to_string();
+            }
             if let Some(inference) = &designed_inference {
                 manifest.inference.provider = Some(inference.provider.clone());
                 manifest.inference.base_url = inference.base_url.clone();
@@ -895,7 +929,12 @@ async fn apply_inner(
             Some(id.as_ref().to_string())
         }
         (None, Some(template), true) => {
-            let id = crate::desktop::seed_company(state, template).await?;
+            // The template path, and now a reachable one: the console sends a
+            // slug rather than a designed company when the operator picked a
+            // template and no model tailored it, so what gets seeded is that
+            // template — its roster, its tool belt, its prompts — instead of an
+            // approximation rebuilt from a roster screen.
+            let id = crate::desktop::seed_company_named(state, template, chosen_name).await?;
             Some(id.as_ref().to_string())
         }
         _ => None,
@@ -1266,6 +1305,39 @@ fn summarise_probe_failure(raw: &str) -> String {
 /// Authorized by the same [`authorize`] the rest of this flow uses, so an
 /// unconfigured loopback host can reach it before anyone can sign in, and a
 /// configured one demands an admin.
+/// The roster a bundled template declares, as review-shaped teammates.
+///
+/// `None` when the template carries no roster at all, which no shipped one does
+/// (`every_preset_seeds_a_non_empty_roster` in `crate::desktop`) but which a
+/// caller must still be able to survive rather than present an empty team.
+///
+/// A manifest `[[agent]]` has no display name — `Agent::name` is an in-memory
+/// carrier for operator-added teammates and is `#[serde(skip)]` — so the role
+/// stands in for both, which is what the console already renders for these
+/// teammates once the company exists.
+fn preset_roster(
+    id: &str,
+) -> Result<Option<Vec<crate::company::setup::ProposedAgent>>, crate::server::Rejection> {
+    let Some(preset) = crate::desktop::preset(id) else {
+        return Ok(None);
+    };
+    let manifest = preset.manifest_parsed()?;
+    let agents: Vec<crate::company::setup::ProposedAgent> = manifest
+        .agents
+        .iter()
+        .map(|agent| crate::company::setup::ProposedAgent {
+            name: agent.role.clone(),
+            role: agent.role.clone(),
+            description: agent.description.clone().unwrap_or_default(),
+            // The template's own `[tools]` decides its belt, and this roster is
+            // shown rather than built from — see the apply, which seeds the
+            // template itself. Claiming a focus here would be inventing one.
+            focus: None,
+        })
+        .collect();
+    Ok((!agents.is_empty()).then_some(agents))
+}
+
 async fn propose_roster(
     State(state): State<AppState>,
     crate::server::graphql::auth::MaybePeer(peer): crate::server::graphql::auth::MaybePeer,
@@ -1303,6 +1375,44 @@ async fn propose_roster(
         req.inference_model.as_deref(),
     )
     .await;
+
+    // A picked template outranks the matched one when no model designed
+    // anything.
+    //
+    // Both are "the curated answer", and they are not the same roster.
+    // `template_proposal` matches a reference team from what the operator
+    // *wrote*; the template list is what they *chose*. So picking "Agentic
+    // Marketing Agency" and skipping the model step returned the five-person
+    // curated marketing team under a heading naming a template that ships
+    // eight — a roster nobody selected, presented as the one they did.
+    //
+    // Only on the fallback paths. A model that designed a team read the
+    // template as one input among the operator's answers and produced
+    // something for *them*; replacing that with the shipped roster would throw
+    // away the entire point of the design pass.
+    let proposal = match (&req.template, proposal.source) {
+        (Some(id), crate::company::setup::RosterSource::Fallback) => {
+            match preset_roster(id)? {
+                // `preset` is the same lookup `template_name` above already
+                // validated, so an unknown id has been rejected before here;
+                // an empty roster is the only remaining reason to keep what we
+                // have, and `every_preset_seeds_a_non_empty_roster` makes that
+                // unreachable for a bundled template.
+                Some(agents) => crate::company::setup::preset_proposal(
+                    &answers,
+                    crate::desktop::preset(id)
+                        .map(|preset| preset.id)
+                        .unwrap_or(""),
+                    agents,
+                    proposal
+                        .reason
+                        .unwrap_or(crate::company::setup::FallbackReason::NoModel),
+                ),
+                None => proposal,
+            }
+        }
+        _ => proposal,
+    };
 
     tracing::info!(
         template = proposal.template_key,

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -877,11 +877,26 @@ async fn apply_inner(
     // literal id `company`, so an operator who cleared the field would get a
     // company called nothing at an id naming nothing — deriving is the better
     // answer to "I typed no name" than obeying it is.
-    let chosen_name = req
+    let chosen_name: Option<String> = req
         .name
         .as_deref()
         .map(str::trim)
+        .filter(|name| !name.is_empty())
+        // Bounded at the boundary, by the same 60 characters `company_name`
+        // clamps its derivation to. Not cosmetic: `company_id_from_name` keeps
+        // every alphanumeric character it is given, and that id becomes one
+        // directory component under the store — so a pasted paragraph makes the
+        // apply fail while writing the bundle, on most filesystems at 255
+        // bytes. Truncated rather than refused, because a name is not a
+        // credential and the operator can see what they typed.
+        .map(|name| {
+            name.chars()
+                .take(crate::company::setup::MAX_COMPANY_NAME)
+                .collect::<String>()
+        })
+        .map(|name| name.trim().to_string())
         .filter(|name| !name.is_empty());
+    let chosen_name = chosen_name.as_deref();
 
     let seeded = match (&req.company, &req.template, state.registry().is_empty()) {
         // A designed company wins over a template slug: the operator answered

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -277,6 +277,18 @@ pub struct SetupRequest {
     ///
     /// [`company_name`]: crate::company::setup::manifest_from_setup
     pub name: Option<String>,
+    /// The address that will be able to sign in, for the template path.
+    ///
+    /// The designed path carries its own inside [`SetupCompany`], and that is
+    /// where this used to live exclusively — which was fine while a designed
+    /// company was the only thing the console ever sent. It is not any more: a
+    /// picked template is now seeded as itself, and no shipped product template
+    /// names an admin, so an operator who chose email sign-in and a template
+    /// would finish setup into a company they cannot administer.
+    ///
+    /// Ignored when the seeded manifest asks nobody to sign in — see
+    /// [`SeedOverrides::admin_email`](crate::desktop::SeedOverrides::admin_email).
+    pub admin_email: Option<String>,
     /// A company the wizard **designed**, from the operator's answers and the
     /// roster they reviewed.
     ///
@@ -934,7 +946,19 @@ async fn apply_inner(
             // template and no model tailored it, so what gets seeded is that
             // template — its roster, its tool belt, its prompts — instead of an
             // approximation rebuilt from a roster screen.
-            let id = crate::desktop::seed_company_named(state, template, chosen_name).await?;
+            let id = crate::desktop::seed_company_with(
+                state,
+                template,
+                crate::desktop::SeedOverrides {
+                    name: chosen_name,
+                    admin_email: req
+                        .admin_email
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|email| !email.is_empty()),
+                },
+            )
+            .await?;
             Some(id.as_ref().to_string())
         }
         _ => None,

--- a/src/server/setup/test.rs
+++ b/src/server/setup/test.rs
@@ -1194,6 +1194,55 @@ async fn a_template_seed_names_the_operator_as_its_admin() {
     );
 }
 
+/// A pasted paragraph is truncated, not turned into a directory nobody can
+/// write.
+///
+/// `company_id_from_name` keeps every alphanumeric character it is handed, and
+/// that id becomes one component under the store — so an unbounded name fails
+/// the apply while writing the bundle, on most filesystems at 255 bytes. The
+/// derivation has always clamped at `MAX_COMPANY_NAME`; a name the operator
+/// supplies now meets the same bound.
+#[tokio::test]
+async fn a_very_long_name_is_bounded_before_it_becomes_an_id() {
+    let home_dir = home();
+    let state = fresh_state(home_dir.path());
+    let long = "Northwind ".repeat(40);
+
+    let (status, body) = post_setup(
+        state.clone(),
+        serde_json::json!({
+            "fields": {},
+            "template": "agentic_law_firm",
+            "name": long,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let id = body["seeded_company"]
+        .as_str()
+        .expect("a company was seeded");
+    assert!(
+        id.len() <= crate::company::setup::MAX_COMPANY_NAME,
+        "the id is a directory component and must stay one: {id}"
+    );
+    let registered = state
+        .registry()
+        .get(&crate::ports::types::CompanyId::new(id))
+        .expect("the seeded company is registered");
+    let record = registered
+        .store()
+        .load(&crate::ports::types::CompanyId::new(id))
+        .await
+        .expect("the bundle is readable")
+        .expect("the bundle exists");
+    assert!(
+        record.manifest.company.name.chars().count() <= crate::company::setup::MAX_COMPANY_NAME,
+        "the name is bounded too, not just the id: {}",
+        record.manifest.company.name
+    );
+}
+
 /// A blank name is not a name.
 ///
 /// `company_id_from_name` slugs an empty string to the literal id `company`, so

--- a/src/server/setup/test.rs
+++ b/src/server/setup/test.rs
@@ -442,6 +442,7 @@ async fn a_write_to_an_env_owned_field_is_refused() {
             template: None,
             company: None,
             name: None,
+            admin_email: None,
         },
         &env,
     )
@@ -1149,6 +1150,47 @@ async fn applying_a_template_seeds_it_under_the_name_the_operator_chose() {
             .iter()
             .all(|role| seeded_roles.contains(role)),
         "a renamed template is still that template's roster: {seeded_roles:?}"
+    );
+}
+
+/// A template seed carries the address that will administer it.
+///
+/// No shipped product template names an admin, so on a host that asks people to
+/// sign in, seeding one without this produces a company nobody can administer:
+/// setup completes, email sign-in is on, and the address the operator typed two
+/// screens earlier is ineligible. Only reachable since a picked template began
+/// being seeded as itself — before that every company came through the designed
+/// path, which has always written it.
+#[tokio::test]
+async fn a_template_seed_names_the_operator_as_its_admin() {
+    let home_dir = home();
+    let state = fresh_state(home_dir.path());
+
+    let (status, body) = post_setup(
+        state.clone(),
+        serde_json::json!({
+            "fields": {},
+            "template": "agentic_law_firm",
+            "admin_email": "ada@example.com",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let id = crate::ports::types::CompanyId::new("agentic-law-firm");
+    let record = state
+        .registry()
+        .get(&id)
+        .expect("the seeded company is registered")
+        .store()
+        .load(&id)
+        .await
+        .expect("the bundle is readable")
+        .expect("the bundle exists");
+    assert_eq!(
+        record.manifest.users.admins,
+        vec!["ada@example.com".to_string()],
+        "a company that lists nobody cannot be signed into"
     );
 }
 

--- a/src/server/setup/test.rs
+++ b/src/server/setup/test.rs
@@ -441,6 +441,7 @@ async fn a_write_to_an_env_owned_field_is_refused() {
                 .collect(),
             template: None,
             company: None,
+            name: None,
         },
         &env,
     )
@@ -1005,6 +1006,175 @@ async fn post_roster(state: AppState, body: serde_json::Value) -> (StatusCode, s
         .unwrap();
     let status = response.status();
     (status, body_json(response).await)
+}
+
+/// A template the operator picked is the roster they get back, not the curated
+/// team matched from their words.
+///
+/// The two are different rosters and only one of them was chosen by anybody.
+/// Picking "Agentic Marketing Agency" — a card that says eight teammates — and
+/// skipping the model step returned the five-person curated marketing team,
+/// under a heading naming the template. Asserted against the template's own
+/// count rather than a literal, so a template that gains a teammate does not
+/// fail this.
+#[tokio::test]
+async fn a_picked_template_proposes_its_own_roster() {
+    let home_dir = home();
+    let state = fresh_state(home_dir.path());
+    let expected = crate::desktop::preset("agentic_marketing_agency")
+        .expect("a bundled template")
+        .manifest_parsed()
+        .expect("it parses")
+        .agents;
+
+    let (status, body) = post_roster(
+        state,
+        serde_json::json!({
+            "template": "agentic_marketing_agency",
+            "industry": "",
+            "teamHint": "",
+            "automate": "campaign briefs and weekly reporting",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(
+        body["source"], "preset",
+        "the console needs to know this roster can be seeded as the template itself: {body}"
+    );
+    assert_eq!(
+        body["agents"].as_array().map(Vec::len),
+        Some(expected.len()),
+        "the roster on the review screen must be the roster the card advertised: {body}"
+    );
+    let roles: Vec<&str> = body["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|agent| agent["role"].as_str().unwrap())
+        .collect();
+    assert!(
+        expected
+            .iter()
+            .all(|agent| roles.contains(&agent.role.as_str())),
+        "every teammate the template declares must be on it: {roles:?}"
+    );
+}
+
+/// The curated path is untouched where no template was picked.
+///
+/// The pair matters: the fix above must not become "always ship a preset", or
+/// an operator who typed their business in their own words and never opened the
+/// template list would get a roster matched by slug instead of by what they
+/// wrote.
+#[tokio::test]
+async fn answers_without_a_template_still_propose_the_curated_team() {
+    let home_dir = home();
+    let state = fresh_state(home_dir.path());
+
+    let (status, body) = post_roster(
+        state,
+        serde_json::json!({
+            "industry": "E-commerce",
+            "teamHint": "",
+            "automate": "order dispatch and returns",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["source"], "fallback", "{body}");
+}
+
+/// Setup seeds the template itself when the console sends a slug, under the
+/// name the operator typed.
+///
+/// Both halves are the point. The template arm was unreachable from the console
+/// — the wizard only ever sent a designed company — so a picked template was
+/// rebuilt from the review screen and lost the belt and prompts it ships. And
+/// the name was derived from the *industry* answer with no way to say
+/// otherwise, on a field that mints the company id.
+#[tokio::test]
+async fn applying_a_template_seeds_it_under_the_name_the_operator_chose() {
+    let home_dir = home();
+    let state = fresh_state(home_dir.path());
+
+    let (status, body) = post_setup(
+        state.clone(),
+        serde_json::json!({
+            "fields": {},
+            "template": "agentic_marketing_agency",
+            "name": "Northwind Studio",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(
+        body["seeded_company"], "northwind-studio",
+        "the id is minted from the name the operator gave: {body}"
+    );
+
+    let id = crate::ports::types::CompanyId::new("northwind-studio");
+    let runtime = state
+        .registry()
+        .get(&id)
+        .expect("the seeded company is registered");
+    // Read back off the store rather than off the runtime: what matters is the
+    // bundle the next launch adopts, which is what `adopt_companies` reads.
+    let record = runtime
+        .store()
+        .load(&id)
+        .await
+        .expect("the bundle is readable")
+        .expect("the bundle exists");
+    let manifest = record.manifest;
+    assert_eq!(manifest.company.name, "Northwind Studio");
+    // Every teammate the template declares, by role. Not a count: a registered
+    // company's stored manifest also carries the roster `globals/` contributes,
+    // so an equality here would be asserting the size of something this change
+    // has nothing to do with.
+    let template_roles: Vec<String> = crate::desktop::preset("agentic_marketing_agency")
+        .unwrap()
+        .manifest_parsed()
+        .unwrap()
+        .agents
+        .iter()
+        .map(|agent| agent.role.clone())
+        .collect();
+    let seeded_roles: Vec<String> = manifest.agents.iter().map(|a| a.role.clone()).collect();
+    assert!(
+        template_roles
+            .iter()
+            .all(|role| seeded_roles.contains(role)),
+        "a renamed template is still that template's roster: {seeded_roles:?}"
+    );
+}
+
+/// A blank name is not a name.
+///
+/// `company_id_from_name` slugs an empty string to the literal id `company`, so
+/// obeying a cleared field would produce a company called nothing at an id
+/// naming nothing. The template's own name is the better answer to "I typed no
+/// name" than that is.
+#[tokio::test]
+async fn a_blank_name_falls_back_to_the_templates_own() {
+    let home_dir = home();
+    let state = fresh_state(home_dir.path());
+
+    let (status, body) = post_setup(
+        state.clone(),
+        serde_json::json!({
+            "fields": {},
+            "template": "agentic_law_firm",
+            "name": "   ",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["seeded_company"], "agentic-law-firm", "{body}");
 }
 
 /// The wizard's whole reason for a second route: it needs a roster *before*


### PR DESCRIPTION
Closes #1908

## Summary

A fresh desktop install came up already holding a company nobody chose, and could never reach onboarding again.

`local::start_at` gave the instance at the data root `FirstRun::SeedStarterCompany` and every operator-created one `RunSetupWizard`. That split was an ordering artifact rather than a decision: #632 seeded a starter company because a double-clicked application had no other way in — there was no setup wizard yet — and the arm was never revisited once there was. Seeding is not a head start. `AppSpec.setup_complete` is `stamp || !registry.is_empty()`, `ConnectionConsole` enters its setup phase from that field and nothing else, and no settings link re-opens the wizard. One silent answer, permanently, on the one install most operators will ever have.

Every instance now adopts what its root holds and seeds nothing.

**An install that already has a company still boots straight into it.** Seeding was only ever the fallback half of `desktop::bootstrap_companies`, reached when adoption came back empty — so the arm dropped here could only ever fire on a root with no companies at all. #632's guarantee survives as one about *reachability* rather than about seeding: the wizard is anonymous on loopback while the registry is empty, its model step is skippable onto a curated roster, and finishing it seeds a template through `desktop::seed_company`. Still enterable with no terminal, no mail server and no credential — it asks first, which is the point.

That makes the wizard the common path, and three things it did badly stopped being edge cases:

### A picked template was never sent

The console only ever posted a designed company, so `apply`'s template arm was unreachable from it. Choosing **Agentic Marketing Agency** — a card that says *8 teammates* — and skipping the model step returned the **5**-person curated marketing team matched from the *answers*, under a heading naming the template. A roster nobody selected, presented as the one they did.

`propose_roster` now returns the picked template's own roster as `source: "preset"`, and an untouched one goes back as a slug, so the host seeds that template whole: its roster, its `[tools]` belt, its prompts, its provenance. Only on the fallback paths — a model that designed a team read the template as one input among the operator's answers, and replacing that would throw away the design pass.

Two consequences worth calling out for review:

- `validate_roster`'s `MAX_AGENTS = 6` is right for what a *model* invents and wrong for a template that ships eight, so it splits into `validate_roster_bounded`. **The cap is unchanged for every designed roster**; only a shipped one is displayed whole.
- That cap is also why a shipped roster is **read-only** on review: an edited one could only return as a designed company, which would silently drop teammates seven and eight. Every teammate stays renameable and removable from the console once setup finishes.

### Nothing asked what the company was called

`company_name` took the first clause of the **industry** answer, so "what kind of company are you setting up?" silently named the company — and `company_id_from_name` minted the id from it, permanently, with no rename anywhere in the product. The review step now asks, prefilled with exactly what would have been derived. Blank still derives, because `company_id_from_name("")` is the literal id `company`.

### Creating a company meant naming a host first

A second company needs a second data root, which the operator meets as "add a host" and has to name before being asked a single question about the company. Setup now names the host after the company it just built (`onNameLocalHost`, desktop-only, best-effort after a successful apply).

## API Or Behavior Changes

- **Desktop first launch on an empty data root now opens the setup wizard instead of registering `agentic_marketing_agency`.** A root with companies is unaffected.
- `POST /api/v1/setup` accepts `name` — applies to both the designed and template paths. Absent or blank derives as before.
- `POST /api/v1/setup/roster` can answer `source: "preset"` (new `RosterSource::Preset`). Existing `model` / `fallback` answers are unchanged.
- New `desktop::seed_company_named`; `seed_company` delegates to it with `None`, so every existing caller behaves identically.
- `validate_roster` is unchanged in behaviour; `validate_roster_bounded` is new.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test`

`cargo test --lib` — 4111 passed. `frontend`: `pnpm typecheck` clean, `pnpm test` 3562 passed.

New coverage:

| Test | What it pins |
|---|---|
| `fresh_install.rs::a_fresh_install_opens_the_wizard_and_can_complete_it` | The whole lifecycle over HTTP through `LocalHosts::load` — the app's own launch path: empty root → wizard → apply → relaunch adopts, no second wizard |
| `local::test::the_instance_at_the_data_root_opens_the_setup_wizard_too` | `/spec` reports setup outstanding on a fresh default instance |
| `local::test::a_data_root_that_already_holds_a_company_boots_straight_into_it` | The migration guarantee |
| `setup::test::a_picked_template_proposes_its_own_roster` | The review screen shows the roster the template card advertised |
| `setup::test::answers_without_a_template_still_propose_the_curated_team` | The curated path is untouched |
| `setup::test::applying_a_template_seeds_it_under_the_name_the_operator_chose` | Template seeded whole, at the operator's name |
| `setup::test::a_blank_name_falls_back_to_the_templates_own` | Blank is not a name |
| `setup-wizard-company-identity.test.ts` (9) | What a finished wizard sends: name, template-vs-designed, and no edit affordances on a shipped roster |

The integration test fails on the previous behaviour with `nobody has chosen a company yet, so the host must not have one: ["agentic-marketing-agency"]`, which is how I know it is pinned to this change rather than passing incidentally.

Verified by hand too, in a `cargo tauri dev` run over a scratch `OPENCOMPANY_DATA_DIR`: fresh root → wizard; picked the marketing template, skipped the model, renamed to "Northwind Studio" → `Built northwind-studio with 8 teammates`, `template_provenance.source_id = agentic_marketing_agency`, and the template's own `[tools] allow` on the bundle; relaunch → `companies=1`, straight into the console.

## Documentation

No doc changes. The behaviour lives in `FirstRun`'s own docs and in `local::start_at`, both rewritten here to say what the code now does and why — including what deliberately did *not* change for an install that already has a company.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added company naming during setup, with suggested names and custom overrides.
  - Setup now supports an administrator email address.
  - Selected templates retain their complete, read-only rosters during review.
  - Local hosts are automatically named after setup.
  - Fresh installations now open the setup wizard instead of creating a starter company automatically.
- **Bug Fixes**
  - Preserved custom company names and template rosters across setup and relaunch.
  - Improved handling of blank or missing company names.
  - Refined sign-in options shown during new setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
