### PR TITLE
Show Chargebee's mark on the Invoicing connection panel

### DIFF
--- a/docs/design-system/color.md
+++ b/docs/design-system/color.md
@@ -353,5 +353,10 @@ so it is named: `--brand-discord`, `--brand-discord-hover`,
 `--brand-discord-on-dark`. The token name is what stops a future cleanup
 "fixing" it into the palette.
 
+`--brand-chargebee` (`#ff3300`) joins it for the same reason — the provider
+mark on Finance → Invoicing. One token where Discord needs three: as a mark
+rather than a label it only has to clear 3:1, which it does on both grounds
+(5.36:1 dark, 3.67:1 light), so neither theme needs its own step.
+
 Anything drawn on top of a provider colour must not assume a light or dark
 ground — they span `#0F0F0F` to `#EA4335`.

--- a/frontend/src/components/chargebee-icon.tsx
+++ b/frontend/src/components/chargebee-icon.tsx
@@ -1,0 +1,21 @@
+/**
+ * Chargebee's symbol mark (lucide-react in this build ships no brand icons).
+ *
+ * The symbol, not the wordmark: it sits beside a label that already reads
+ * "Chargebee", and the primary logo is a 730×110 lockup that would say the name
+ * twice at seven times the width.
+ *
+ * `currentColor`, so the one place that names the colour is the call site's
+ * `--brand-chargebee` token rather than five `fill` attributes here.
+ */
+export function ChargebeeIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 100 100" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M33.7401 50.0067L99.7959 34.2536V0H65.5424L33.7401 50.0067Z" />
+      <path d="M1 49.4036C1 53.5014 1.49951 57.479 2.44303 61.2901L33.7365 50.0048L2.18403 38.6178C1.41626 42.0866 1 45.6942 1 49.3943V49.4036Z" />
+      <path d="M12.6361 17.5588L33.7266 50.0086L43.4486 0.492188C31.1365 2.22198 20.286 8.49363 12.6361 17.5588V17.5588Z" />
+      <path d="M33.7401 50.0022L99.7959 65.7461V99.9996H65.5424L33.7401 50.0022Z" />
+      <path d="M12.6397 82.4438L33.7302 49.994L43.443 99.5012C31.1309 97.7714 20.2804 91.4998 12.6305 82.4345L12.6397 82.4438Z" />
+    </svg>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -401,6 +401,13 @@
        a 14px label needs. This is still Discord's palette, which is the
        constraint that matters; it is only a different step of it. */
     --brand-discord-on-light: #4752c4;
+
+    /* Chargebee's orange, from their media kit's symbol mark. One value, not a
+       per-theme pair like the blurple above: as a graphic it measures 5.36:1 on
+       the dark canvas and 3.67:1 on the light one, both clear of the 3:1 a
+       non-text mark needs, so neither theme has to bend it. Their navy (#012A38)
+       and white variants each vanish into one of the two. */
+    --brand-chargebee: #ff3300;
 }
 
 .dark {

--- a/frontend/src/views/finance/ConnectionPanel.tsx
+++ b/frontend/src/views/finance/ConnectionPanel.tsx
@@ -23,6 +23,16 @@ interface Props {
   /** Test-id prefix, e.g. `chargebee`. */
   testId: string;
   /**
+   * The provider's own mark, sized by the caller, shown before the title.
+   *
+   * A prop rather than a lookup keyed off `title`: this panel is shared, and
+   * the two providers' marks are their trade dress, not our palette — each page
+   * names its own and colours it from the `--brand-*` token that says so.
+   * Optional, so a provider we have no licensed mark for is a bare title rather
+   * than a gap.
+   */
+  logo?: ReactNode;
+  /**
    * Grants `health.grantNamespace`, when a missing grant is what is wrong
    * (issue #1796). Omitted by a caller that has no client to grant with.
    *
@@ -71,6 +81,7 @@ export function ConnectionPanel({
   onExpandedChange,
   onTest,
   testId,
+  logo,
   onGrant,
   canManage = false,
   granting = false,
@@ -118,6 +129,7 @@ export function ConnectionPanel({
             data-testid={`${testId}-toggle`}
           >
             <Chevron className="size-4 shrink-0 text-muted-foreground" />
+            {logo ? <span className="shrink-0">{logo}</span> : null}
             <span className="text-sm font-medium">{title}</span>
             <span
               className="truncate text-xs text-muted-foreground"

--- a/frontend/src/views/finance/InvoicingView.tsx
+++ b/frontend/src/views/finance/InvoicingView.tsx
@@ -5,6 +5,7 @@ import { getBilling, type BillingStatus } from "@/api/billing";
 import type { OpenCompanyClient } from "@/api/client";
 import { listInvoices, testChargebee, type Invoice } from "@/api/finance";
 import { ApiError } from "@/api/types";
+import { ChargebeeIcon } from "@/components/chargebee-icon";
 import { PageHeader } from "@/components/page-header";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -187,6 +188,7 @@ export function InvoicingView({ client, company }: Props) {
         <ConnectionPanel
           title="Chargebee"
           testId="chargebee"
+          logo={<ChargebeeIcon className="size-4 text-(--brand-chargebee)" />}
           health={health}
           expanded={expanded}
           onExpandedChange={setExpanded}


### PR DESCRIPTION
## Summary

The connection panel at the top of Finance → Invoicing identified the provider by its name alone. It now carries Chargebee's own symbol mark.

`ConnectionPanel` is shared by both providers, so the mark arrives as an optional `logo?: ReactNode` prop rather than a lookup keyed off `title` — PayPal's mark lands in the same slot on Wallet later without touching this file again.

## Which asset, and why

From Chargebee's media kit:

- **Symbol, not the primary lockup.** The row already reads "Chargebee"; the wordmark is a 730×110 lockup that would say the name twice at 7:1 aspect in a 16px row.
- **Orange, not the navy or white variants.** `#012A38` sinks into the dark canvas and white vanishes on the light one. `#ff3300` clears both.
- **One token, where Discord needs three.** As a *mark* it has to clear 3:1, not the 4.5:1 a label does, and it measures 5.36:1 on `--surface-dark-1` and 3.67:1 on `--surface-light-1`. So neither theme needs its own step. If someone later sets the word "Chargebee" in this orange that stops holding and it will need the pair.

The colour lives in the "Third-party brand colours" block in `index.css` — whose own comment already anticipated this: *"so a future provider row has somewhere to live"* — and the glyph uses `currentColor`, so the one place naming the colour is the call site's token rather than five `fill` attributes.

## Files

| | |
|---|---|
| `frontend/src/components/chargebee-icon.tsx` | new; follows the `discord-icon.tsx` precedent |
| `frontend/src/index.css` | `--brand-chargebee: #ff3300` |
| `frontend/src/views/finance/ConnectionPanel.tsx` | optional `logo` prop, rendered before the title |
| `frontend/src/views/finance/InvoicingView.tsx` | passes the mark |
| `docs/design-system/color.md` | the third-party section already enumerates the Discord tokens; names this one too |

## Commands run locally

- `npm run typecheck`, `npm run typecheck:e2e`, `npm run typecheck:unit` — clean
- `npx vitest run` — 3553 passed (373 files)
- `scripts/ci/assert-design-tokens.sh` — passes

Rendered the header row at 16px against the real surface primitives (`#FFFFFF` / `#0C0D0F`) in both themes to confirm the mark holds at that size before committing to it.

## Behaviour changes

Visual only, and additive: `logo` is optional, so the Wallet panel renders exactly as before. No finance visual snapshot exists under `test/e2e`, so there is nothing to regenerate.