### PR TITLE
fix(harness): convert the last composio turn call to ChatTarget

### DIFF
--- a/src/harness/built_in/composio_turn_test.rs
+++ b/src/harness/built_in/composio_turn_test.rs
@@ -726,9 +726,15 @@ async fn the_composio_routing_brief_reaches_the_model_system_prompt() {
 
     let dir = tempfile::tempdir().unwrap();
     let (pool, deps, record) = harness(model_url, composio_url, dir.path()).await;
-    pool.run(&record.id, "ceo", "What can you do on GitHub?", &deps, None)
-        .await
-        .expect("turn runs");
+    pool.run(
+        &record.id,
+        "ceo",
+        "What can you do on GitHub?",
+        &deps,
+        crate::runtime::delegation::ChatTarget::default(),
+    )
+    .await
+    .expect("turn runs");
 
     let system = system_prompts(&script).join("\n");
     // The routing rule reached the model.


### PR DESCRIPTION
## Summary

`main` does not compile under `--features openhuman,chargebee,paypal,composio`:

```
error[E0308]: mismatched types
  --> src/harness/built_in/composio_turn_test.rs:729:70
      pool.run(&record.id, "ceo", "What can you do on GitHub?", &deps, None)
                                                                ^^^^ expected `ChatTarget<'_>`, found `Option<_>`
```

`AgentPool::run` took `chat: ChatTarget<'_>` in 4a4b9a574, under the #1890 epic. The two sibling calls in this same file were converted with it; this one was not — and it is the only one written on a single line, which is presumably what the conversion pattern matched on.

It is the third miss of that shape: d28774b49 is titled *"convert the call site main added while this branch was open"*.

It passes `ChatTarget::default()` now, exactly as its two siblings and every caller in `mod.rs` do.

## API Or Behavior Changes

None. Test-only, and nothing about the test's subject changes: it asserts that the composio routing brief reaches the model's system prompt, while the argument decides which thread a turn's context is scoped to — and `default()` is what the other composio turn tests in this file already run under.

## Why it reached `main`

`src/harness/` compiles **only** under `--features openhuman`, so a default `cargo check` walks past this file entirely. The lane that does build it — `Rust (openhuman, tinymemory)` — takes ~35 minutes, and had been red on `main` for two consecutive runs before this PR:

| Run | Branch | `Rust (openhuman, tinymemory)` |
|---|---|---|
| [33180938003](https://github.com/tinyhumansai/opencompany/actions/runs/33180938003) | `main` | failure |
| [33180915777](https://github.com/tinyhumansai/opencompany/actions/runs/33180915777) | `main` | failure |

I also swept `src/harness/` for other callers still passing `None` into a converted signature. The remaining hits are unrelated functions (`peek`, `run_background`, `policy`), so this is the last one.

## Tests

Verified with the failing lane's own feature set rather than a default build, since a default build is exactly what missed it:

- [x] `cargo check --features openhuman,chargebee,paypal,composio --lib --tests` — clean
- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings` — not run under this feature set locally (~35m tree); CI covers it
- [x] `cargo test --features openhuman,chargebee,paypal,composio --lib composio_turn_test` — **4 passed**, including `the_composio_routing_brief_reaches_the_model_system_prompt`, the test this converts

## Documentation

None needed — a test call site converted to a signature that changed under #1890.

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>
