### PR TITLE
build: copy only what cargo reads into the builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,21 @@ RUN apt-get update \
 # The whole workspace is copied (examples/*/Cargo.toml load the workspace;
 # vendor/openhuman/vendor/tinyagents backs the [patch.crates-io] entry).
 # vendor/openhuman, target/, and node_modules are trimmed via .dockerignore.
-COPY . .
+#
+# `COPY . .` is correct but expensive: it puts the console, the docs, the
+# skills and the whole git history into the build context. The builder only
+# reads what cargo resolves, so copy exactly that:
+#   * Cargo.toml / Cargo.lock / rust-toolchain.toml — resolution and toolchain.
+#   * src/, benches/, tests/, examples/ — auto-discovered workspace targets.
+#   * vendor/ — backs the [patch.crates-io] table.
+#   * companies/ — the default companies baked into the image.
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY src ./src
+COPY benches ./benches
+COPY tests ./tests
+COPY examples ./examples
+COPY vendor ./vendor
+COPY companies ./companies
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/build/target \


### PR DESCRIPTION
Editing a file the compiler never opens rebuilds the whole binary. Change one
line of the console, a doc page, or a script, and `docker build` goes back
through cargo. Measured on this tree: over ten minutes for a change that touches
no Rust at all.


The builder stage copies the entire context in one layer:

```dockerfile
COPY . .
```

Docker invalidates a layer when any file in it changes, and every later layer
with it — including the `cargo build` layer. So `frontend/`, `docs/`,
`gitbooks/`, `skills/`, `scripts/`, `deploy/`, `docker/` and `src-tauri/` all sit
inside the compiler's cache key. On this checkout that is **516 files across 8
directories that cargo never reads**, against 340 that it does.

`.dockerignore` does not help: it excludes build artefacts (`target/`,
`node_modules/`, docs *contents*), not source that is simply irrelevant to the
compiler.


Copy the cargo inputs explicitly:

```dockerfile
COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
COPY src ./src
COPY benches ./benches
COPY tests ./tests
COPY examples ./examples
COPY vendor ./vendor
COPY companies ./companies
```

The comment in the Dockerfile explains why each entry has to stay. `benches/`,
`tests/` and `examples/` are auto-discovered targets that cargo reads during
resolution even for `--bin opencompany`; `vendor/` backs the `[patch.crates-io]`
table.

`companies/` is the surprising one and it is load-bearing: `src/desktop.rs` bakes
every shipped preset manifest into the binary with

```rust
manifest: include_str!(concat!("../companies/", $id, "/company.toml")),
```

so the manifests really are a build input today. Leaving them out fails the build
with `error: couldn't read src/../companies/agentic_accounting_firm/company.toml`
— nineteen times, after thirteen minutes.

Nothing else in `src/` reaches outside it at build time. The `include_str!`s that
do reach into `frontend/` and `skills/` are all inside `#[cfg(test)]` modules
(`src/company/skill_file.rs`, `src/company/workflow_file.rs`,
`src/policy/consequence.rs`), so they do not affect this stage. **If you ever run
`cargo test` in the builder stage, those two directories have to come back.** A
comment saying so would be worth adding wherever that is decided.


The `companies/` entry only exists because of `desktop.rs`. Reading the presets at
*start-up* instead of `include_str!`-ing them would take `companies/` out of the
build graph entirely — a manifest is data the binary reads when it starts, not
something the compiler needs. That is a separate change and it belongs to you;
this PR does not attempt it.


The tree this came from also pins `CARGO_BUILD_JOBS` and disables release debug
info to survive a small build VM. That is a local workaround, not something to
hard-code here — if you want it, it belongs as a proper `ARG` with a sensible
default. It is deliberately left out.