### PR TITLE
console: add `data-slot` handles to the product mark

### DIFF
--- a/frontend/src/components/company-picker.tsx
+++ b/frontend/src/components/company-picker.tsx
@@ -31,11 +31,20 @@ export function CompanyPicker({ companies, onPick, onCreate, onReset, canCreate 
   return (
     <div className="min-h-svh bg-background">
       <header className="flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-2">
-          <div className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground">
+        {/* `data-slot` so a deployment can restyle the product mark with CSS
+            alone — the same convention `components/ui/*` already uses. Without a
+            handle here, every white-label deployment has to patch this JSX and
+            re-patch it on every update. */}
+        <div data-slot="brand" className="flex items-center gap-2">
+          <div
+            data-slot="brand-mark"
+            className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground"
+          >
             <Building2 className="size-4" />
           </div>
-          <span className="text-sm font-semibold">OpenCompany</span>
+          <span data-slot="brand-name" className="text-sm font-semibold">
+            OpenCompany
+          </span>
         </div>
         <ThemeToggle />
       </header>

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -355,11 +355,20 @@ export function Login({ client, company, notice, onSignedIn }: Props) {
     */
     <div className="flex min-h-svh flex-col bg-background">
       <header className="flex shrink-0 items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-2">
-          <div className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground">
+        {/* `data-slot` so a deployment can restyle the product mark with CSS
+            alone — the same convention `components/ui/*` already uses. Without a
+            handle here, every white-label deployment has to patch this JSX and
+            re-patch it on every update. */}
+        <div data-slot="brand" className="flex items-center gap-2">
+          <div
+            data-slot="brand-mark"
+            className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground"
+          >
             <Building2 className="size-4" />
           </div>
-          <span className="text-sm font-semibold">OpenCompany</span>
+          <span data-slot="brand-name" className="text-sm font-semibold">
+            OpenCompany
+          </span>
         </div>
         <ThemeToggle />
       </header>


### PR DESCRIPTION
The product mark in the login header and the company picker has no styling hook:

```tsx
<div className="flex items-center gap-2">
  <div className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground">
    <Building2 className="size-4" />
  </div>
  <span className="text-sm font-semibold">OpenCompany</span>
</div>
```

Anyone deploying OpenCompany under their own name therefore has to patch this
JSX — in two files — and re-patch it on every update. That is a maintenance cost
paid forever for what is a pure presentation change.


There is nothing to select. `className` here is layout, shared with every other
flex row in the tree, so a CSS rule cannot target it without also hitting
unrelated markup. The repo already has the right convention for exactly this —
`components/ui/*` carry `data-slot="button"`, `data-slot="card"` and so on — but
the brand block was never given one.


Three `data-slot` attributes, in the two files that render the mark:

* `data-slot="brand"` on the wrapper — enough on its own to hide the children and
  paint a logo with `background-image`;
* `data-slot="brand-mark"` on the icon tile;
* `data-slot="brand-name"` on the wordmark.

No behaviour change, no new dependency, no change to what is rendered. A
white-label deployment becomes a stylesheet:

```css
[data-slot="brand"] > * { display: none; }
[data-slot="brand"] {
  width: 8rem; height: 2rem;
  background: url(/brand/logo.svg) left center / contain no-repeat;
}
```


`tsc -p tsconfig.app.json --noEmit` is clean.