### PR TITLE
feat(chat): a live receipt for a sent instruction (#1934)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -136,6 +136,7 @@ import { Overview } from "@/views/Overview";
 import { CompanyView } from "@/views/company/CompanyView";
 import { ManageListsView } from "@/views/company/ManageListsView";
 import { ChatView } from "@/views/ChatView";
+import type { ChatReceipt } from "@/views/chat/ChatLiveReceipt";
 import {
   channelForThread,
   channelIdForThread,
@@ -897,6 +898,17 @@ export function AppShell({
   const [liveStepsByThread, setLiveStepsByThread] = useState<
     Record<string, (TurnStep & { toolCallId?: string })[]>
   >({});
+  // The live receipt for each synchronous chat turn in flight (issue #1934),
+  // keyed by host thread id — armed on `onSendStart`, bumped by every live
+  // frame (which also captures who picked the turn up), and cleared on whichever
+  // outcome the POST reaches. Its lifecycle mirrors `liveStepsByThread`'s: the
+  // reply landing on `onSendEnd` is what clears it, exactly as the reply bubble
+  // is appended, so the two swap with no empty frame between them.
+  const [receiptByThread, setReceiptByThread] = useState<Record<string, ChatReceipt>>({});
+  // Roster agent id → display name, so the receipt names the teammate rather
+  // than rendering a raw id (issue #1934). Populated by the desks/roster read
+  // below, which already fetches the roster this is derived from.
+  const [agentNames, setAgentNames] = useState<Record<string, string>>({});
   // The threads with a chat POST currently in flight, so the SSE `agent_reply`
   // echo for each is suppressed — the awaited POST reply is the authoritative,
   // steps-bearing copy (fixes the duplicate-bubble race).
@@ -1384,6 +1396,10 @@ export function AppShell({
         // `[[group_chat]]` used to be given three fabricated ones here.
         const chatDesks = desks.map(deskFromDto);
         const roster = team.map(fromDto);
+        // The name map the live receipt resolves an agent id through (issue
+        // #1934) — derived from the roster this effect already read, so it costs
+        // no extra request and is scoped to the company the effect ran for.
+        setAgentNames(Object.fromEntries(roster.map((m) => [m.id, m.name])));
         // Keep the addressing this loop resolves, not just its side effect.
         setChatChannelByThread(channelMap(chatDesks, roster));
         // The channel `ChatView` lands on when the hash names none, which since
@@ -1444,6 +1460,9 @@ export function AppShell({
         // rehydration attempt (it's the one every deployment has).
         if (cancelled || requestCompany !== company) return;
         const fallbackDesks = defaultDesks();
+        // No roster answered, so no agent names for this company — clear rather
+        // than carry the previous company's map into a receipt here (#1934).
+        setAgentNames({});
         setChatChannelByThread(channelMap(fallbackDesks, []));
         // Exactly what the success path above does, and for the same reason:
         // the landing channel is `#general`, always. This used to read
@@ -2332,19 +2351,40 @@ export function AppShell({
   // Mark/unmark a thread's in-flight POST. `onSendStart` also resets its live
   // timeline so a fresh turn starts clean; `onSendEnd` clears it because the
   // final reply now carries the authoritative folded steps.
+  // Drop a thread's receipt when its POST reaches any terminal outcome (issue
+  // #1934). `onSendEnd` is the resolved path and clears it as the reply bubble
+  // lands; a detached/failed/stale POST clears it too, so a receipt never
+  // outlives the send bracket that armed it — from there the openTurns-driven
+  // working row is the live surface, not the receipt.
+  const clearReceipt = useCallback((threadId: string) => {
+    setReceiptByThread((prev) => {
+      if (!prev[threadId]) return prev;
+      const next = { ...prev };
+      delete next[threadId];
+      return next;
+    });
+  }, []);
   const onSendStart = useCallback((threadId: string) => {
     pendingPostThreadsRef.current.started(threadId);
     activeTurnThreadRef.current = threadId;
     setLiveStepsByThread((prev) => ({ ...prev, [threadId]: [] }));
+    // `lastFrameAt` seeds to `startedAt` so the stall check is "no frame for
+    // 30s" from the send, not an instant stall.
+    const now = Date.now();
+    setReceiptByThread((prev) => ({ ...prev, [threadId]: { startedAt: now, lastFrameAt: now } }));
   }, []);
-  const onSendEnd = useCallback((threadId: string) => {
-    pendingPostThreadsRef.current.ended(threadId);
-    if (activeTurnThreadRef.current === threadId) activeTurnThreadRef.current = null;
-    setLiveStepsByThread((prev) => {
-      if (!prev[threadId]?.length) return prev;
-      return { ...prev, [threadId]: [] };
-    });
-  }, []);
+  const onSendEnd = useCallback(
+    (threadId: string) => {
+      pendingPostThreadsRef.current.ended(threadId);
+      if (activeTurnThreadRef.current === threadId) activeTurnThreadRef.current = null;
+      setLiveStepsByThread((prev) => {
+        if (!prev[threadId]?.length) return prev;
+        return { ...prev, [threadId]: [] };
+      });
+      clearReceipt(threadId);
+    },
+    [clearReceipt],
+  );
   /**
    * A chat POST that resolved for a company the operator has since left
    * (issue #1000).
@@ -2363,9 +2403,15 @@ export function AppShell({
    * clear a live step timeline or the `activeTurnThreadRef` fallback that a
    * *current* company's own in-flight POST is using.
    */
-  const onSendStale = useCallback((threadId: string) => {
-    pendingPostThreadsRef.current.detached(threadId);
-  }, []);
+  const onSendStale = useCallback(
+    (threadId: string) => {
+      pendingPostThreadsRef.current.detached(threadId);
+      // The reply belongs to a company the operator has left; nothing about
+      // this turn is in the active scope, so its receipt must not linger.
+      clearReceipt(threadId);
+    },
+    [clearReceipt],
+  );
   /**
    * The host accepted the turn and handed back its id instead of its answer
    * (issue #983).
@@ -2399,8 +2445,11 @@ export function AppShell({
         return { ...prev, [threadId]: [...turns, { turnId, queued: true }] };
       });
       held.forEach((frame) => renderAgentReply(frame));
+      // The turn is now the openTurns row's job, not the receipt's — from a
+      // 202 the working row is armed above and takes over (issue #1934).
+      clearReceipt(threadId);
     },
-    [renderAgentReply],
+    [renderAgentReply, clearReceipt],
   );
   /**
    * The chat POST **threw** — no body, nothing rendered by the view (#1000).
@@ -2438,6 +2487,10 @@ export function AppShell({
     (threadId: string) => {
       const held = pendingPostThreadsRef.current.failed(threadId);
       held.forEach((frame) => renderAgentReply(frame));
+      // The request died; the view has rendered its `Couldn't send` line. Drop
+      // the receipt so it does not tick on over a dead POST (issue #1934) — any
+      // durable turn re-armed below drives the working row instead.
+      clearReceipt(threadId);
 
       // Discover whether the host kept the turn after the request died. The
       // throw tells us nothing, but the run rows do: a `pending`/`running` row
@@ -2465,7 +2518,7 @@ export function AppShell({
           /* host without /runs, or offline — nothing to re-arm */
         });
     },
-    [client, company, renderAgentReply],
+    [client, company, renderAgentReply, clearReceipt],
   );
 
   // Fold one live turn frame into the in-flight thread's timeline: a `tool_call`
@@ -2679,6 +2732,18 @@ export function AppShell({
         rows.push({ kind: "thinking", status: "ok", label: "Thinking" });
       }
       return { ...prev, [threadId]: rows };
+    });
+    // Keep this thread's receipt alive off the same frame (issue #1934): a frame
+    // arriving means the turn is advancing, so bump `lastFrameAt` (which clears
+    // any stall) and capture the first agent id we see. Guarded on an existing
+    // receipt — a stray background frame for a thread we never sent on must not
+    // conjure one, mirroring the `if (!threadId) return` guard above.
+    setReceiptByThread((prev) => {
+      const existing = prev[threadId];
+      if (!existing) return prev;
+      const frameAgentId = "agentId" in event ? event.agentId : undefined;
+      const agentId = existing.agentId ?? (frameAgentId || undefined);
+      return { ...prev, [threadId]: { ...existing, lastFrameAt: Date.now(), agentId } };
     });
   }, []);
 
@@ -3292,6 +3357,8 @@ export function AppShell({
           scopeRef={scopeRef}
               openTurns={openTurns}
               liveStepsByThread={liveStepsByThread}
+              receiptByThread={receiptByThread}
+              agentNames={agentNames}
               unread={unread}
               onChannelViewed={onChannelViewed}
               onChatPaneVisibilityChange={onChatPaneVisibilityChange}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -136,7 +136,7 @@ import { Overview } from "@/views/Overview";
 import { CompanyView } from "@/views/company/CompanyView";
 import { ManageListsView } from "@/views/company/ManageListsView";
 import { ChatView } from "@/views/ChatView";
-import type { ChatReceipt } from "@/views/chat/ChatLiveReceipt";
+import { shouldClearReceipt, type ChatReceipt } from "@/views/chat/ChatLiveReceipt";
 import {
   channelForThread,
   channelIdForThread,
@@ -1256,6 +1256,23 @@ export function AppShell({
     setDecidedApprovals({});
     setDecidingApprovals(new Map());
     setFailedApprovals({});
+    // Another company's live receipts are another namespace too (issue #1935
+    // review, codex 3892523790 / coderabbit 3892517512). Host thread ids like
+    // `main` recur across companies, so left uncleared here a switch could
+    // render the previous company's still-ticking "Sent"/"Picked up by" row
+    // on the new company's identically-named thread until that thread's own
+    // next send re-arms it. The generation-guarded `clearReceipt` (see
+    // `shouldClearReceipt`) closes the OTHER half of this bug — a late
+    // completion from the old company arriving *after* this reset must not
+    // delete whatever the new company has since armed — this reset only
+    // covers the instant of the switch itself.
+    setReceiptByThread((prev) => (Object.keys(prev).length === 0 ? prev : {}));
+    // The name map a receipt resolves an agent id through is exactly as
+    // company-scoped as the receipts it names (same issue). Cleared here too
+    // rather than left to the roster fetch below: that fetch is async, so
+    // without this an id captured off a fresh frame on the new company would
+    // resolve through the previous company's roster until it answers.
+    setAgentNames((prev) => (Object.keys(prev).length === 0 ? prev : {}));
 
     // How far each channel's cold hydration has got, and which thread's
     // request is still in flight, so the 5-second poll below (`rehydrateAll`
@@ -2356,14 +2373,24 @@ export function AppShell({
   // lands; a detached/failed/stale POST clears it too, so a receipt never
   // outlives the send bracket that armed it — from there the openTurns-driven
   // working row is the live surface, not the receipt.
-  const clearReceipt = useCallback((threadId: string) => {
+  //
+  // `gen`, when given, is the generation the clearing send's own `onSendStart`
+  // returned (issue #1935 review — see `shouldClearReceipt`'s doc for the
+  // cross-company race this closes). Omitted by `Conversation`/
+  // `conversation/runtime.ts`'s calls, which clear unconditionally as before.
+  const clearReceipt = useCallback((threadId: string, gen?: number) => {
     setReceiptByThread((prev) => {
-      if (!prev[threadId]) return prev;
+      if (!shouldClearReceipt(prev[threadId], gen)) return prev;
       const next = { ...prev };
       delete next[threadId];
       return next;
     });
   }, []);
+  // The generation counter a receipt is stamped with at arm time (issue #1935
+  // review). A plain ref, not state: it drives no render on its own, only the
+  // value handed back to the caller and threaded through to whichever
+  // terminal callback eventually clears the receipt it stamped.
+  const receiptGenRef = useRef(0);
   const onSendStart = useCallback((threadId: string) => {
     pendingPostThreadsRef.current.started(threadId);
     activeTurnThreadRef.current = threadId;
@@ -2371,17 +2398,22 @@ export function AppShell({
     // `lastFrameAt` seeds to `startedAt` so the stall check is "no frame for
     // 30s" from the send, not an instant stall.
     const now = Date.now();
-    setReceiptByThread((prev) => ({ ...prev, [threadId]: { startedAt: now, lastFrameAt: now } }));
+    const gen = ++receiptGenRef.current;
+    setReceiptByThread((prev) => ({
+      ...prev,
+      [threadId]: { startedAt: now, lastFrameAt: now, gen },
+    }));
+    return gen;
   }, []);
   const onSendEnd = useCallback(
-    (threadId: string) => {
+    (threadId: string, gen?: number) => {
       pendingPostThreadsRef.current.ended(threadId);
       if (activeTurnThreadRef.current === threadId) activeTurnThreadRef.current = null;
       setLiveStepsByThread((prev) => {
         if (!prev[threadId]?.length) return prev;
         return { ...prev, [threadId]: [] };
       });
-      clearReceipt(threadId);
+      clearReceipt(threadId, gen);
     },
     [clearReceipt],
   );
@@ -2404,11 +2436,14 @@ export function AppShell({
    * *current* company's own in-flight POST is using.
    */
   const onSendStale = useCallback(
-    (threadId: string) => {
+    (threadId: string, gen?: number) => {
       pendingPostThreadsRef.current.detached(threadId);
       // The reply belongs to a company the operator has left; nothing about
-      // this turn is in the active scope, so its receipt must not linger.
-      clearReceipt(threadId);
+      // this turn is in the active scope, so its receipt must not linger —
+      // unless a newer send has already re-armed this thread id for the
+      // company now on screen, in which case `gen` (this stale send's own
+      // generation) will not match and `clearReceipt` leaves it alone.
+      clearReceipt(threadId, gen);
     },
     [clearReceipt],
   );
@@ -2432,7 +2467,7 @@ export function AppShell({
    * suppression lose nothing: the frame was never dropped, only queued.
    */
   const onSendDetached = useCallback(
-    (threadId: string, turnId?: string) => {
+    (threadId: string, turnId?: string, gen?: number) => {
       const held = pendingPostThreadsRef.current.detached(threadId);
       // Append, never replace (issue #1000). The serial lock queues a second
       // send behind the running turn, and a replace would stop the poll
@@ -2447,7 +2482,7 @@ export function AppShell({
       held.forEach((frame) => renderAgentReply(frame));
       // The turn is now the openTurns row's job, not the receipt's — from a
       // 202 the working row is armed above and takes over (issue #1934).
-      clearReceipt(threadId);
+      clearReceipt(threadId, gen);
     },
     [renderAgentReply, clearReceipt],
   );
@@ -2484,13 +2519,13 @@ export function AppShell({
    * behind it is not a working row to be invented.
    */
   const onSendFailed = useCallback(
-    (threadId: string) => {
+    (threadId: string, gen?: number) => {
       const held = pendingPostThreadsRef.current.failed(threadId);
       held.forEach((frame) => renderAgentReply(frame));
       // The request died; the view has rendered its `Couldn't send` line. Drop
       // the receipt so it does not tick on over a dead POST (issue #1934) — any
       // durable turn re-armed below drives the working row instead.
-      clearReceipt(threadId);
+      clearReceipt(threadId, gen);
 
       // Discover whether the host kept the turn after the request died. The
       // throw tells us nothing, but the run rows do: a `pending`/`running` row

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -147,8 +147,15 @@ interface Props {
    * flight. Without this bracket the shell's live injection and the awaited
    * reply below both render and the bubble doubles — the exact duplicate-bubble
    * race the Conversation surface already brackets against.
+   *
+   * Returns the generation the shell stamped this send's receipt with (issue
+   * #1935 review). `send` threads it back through whichever terminal callback
+   * this POST reaches, so the shell can tell "my own armed receipt settling"
+   * apart from "a newer send already re-armed this reused thread id" — see
+   * `shouldClearReceipt`. `undefined` when the shell has nothing to say (no
+   * handler wired), which callers must treat the same as "clear unconditionally".
    */
-  onSendStart?: (threadId: string) => void;
+  onSendStart?: (threadId: string) => number | undefined;
   /**
    * Who is present right now, keyed by user id. Empty when the host has no
    * presence route, or when nobody else is connected to this replica.
@@ -172,14 +179,14 @@ interface Props {
   resolveTypingNames?: (chatId: string, parentId?: string) => string[];
   /** Called as a composer is typed in; the caller throttles. */
   onTyping?: (chatId: string, parentId?: string) => void;
-  onSendEnd?: (threadId: string) => void;
+  onSendEnd?: (threadId: string, gen?: number) => void;
   /**
    * The host accepted the turn and answered `202` instead of the reply
    * (issue #983). Distinct from `onSendEnd`, which says the turn is *over*:
    * this one says the POST is over and the turn is not, so the shell keeps the
    * working row up and stops suppressing the live reply frame.
    */
-  onSendDetached?: (threadId: string, turnId?: string) => void;
+  onSendDetached?: (threadId: string, turnId?: string, gen?: number) => void;
   /**
    * The chat POST **threw** rather than answering (issue #1000).
    *
@@ -190,9 +197,9 @@ interface Props {
    * the request that started it, so that held frame is the only copy of the
    * answer anyone is going to get.
    */
-  onSendFailed?: (threadId: string) => void;
+  onSendFailed?: (threadId: string, gen?: number) => void;
   /** Called when a delayed response belongs to a previous company scope. */
-  onSendStale?: (threadId: string) => void;
+  onSendStale?: (threadId: string, gen?: number) => void;
   /**
    * The shell's live company ref, so the stale-response check keeps observing
    * company switches after this view unmounts.
@@ -1470,7 +1477,13 @@ export function ChatView({
     // `AgentReply` for our own turn too and pushes it over SSE mid-await, so
     // without this the shell injects that echo *and* the awaited reply lands
     // below — two bubbles for one turn.
-    if (chatId) onSendStart?.(chatId);
+    //
+    // The generation the shell stamped this send's receipt with, if any
+    // (issue #1935 review). Threaded through to whichever terminal callback
+    // this POST reaches below, so a clear this send triggers can never delete
+    // a receipt a *later* send has since armed for the same (possibly
+    // cross-company-reused) thread id — see `shouldClearReceipt`.
+    const gen = chatId ? onSendStart?.(chatId) : undefined;
     // Which of the POST's three outcomes actually happened, decided here and
     // reported once in the `finally`. Only `"resolved"` means the reply is on
     // screen; the other two leave a turn running on the host and the stream as
@@ -1513,7 +1526,7 @@ export function ChatView({
           scopeAtSend.client !== latestScope.client)
       ) {
         outcome = "stale";
-        if (chatId) onSendStale?.(chatId);
+        if (chatId) onSendStale?.(chatId, gen);
         // The POST itself succeeded and journaled — this branch only
         // discards the reply because the scope moved on, so anything the
         // request carried (an attachment among them) is durably claimed.
@@ -1535,7 +1548,7 @@ export function ChatView({
         // Nothing to render: the reply arrives on the stream, and durably in
         // `chat/history` when the shell sees the turn go terminal. The working
         // row stays up, driven by the open turn rather than by this POST.
-        if (chatId) onSendDetached?.(chatId, answer.turnId);
+        if (chatId) onSendDetached?.(chatId, answer.turnId, gen);
         return true;
       }
       const reply = answer;
@@ -1604,7 +1617,7 @@ export function ChatView({
           scopeAtSend.client !== latestScope.client)
       ) {
         outcome = "stale";
-        if (chatId) onSendStale?.(chatId);
+        if (chatId) onSendStale?.(chatId, gen);
         // Unlike the try-block's stale branch above, the request THREW here —
         // whether it journaled before failing is unknown, not "no" (see this
         // function's doc comment), so this is `undefined`, not `false`.
@@ -1632,8 +1645,8 @@ export function ChatView({
       // answer. Routing the throw here is the drop this whole change removes,
       // put back on the one path the feature exists for.
       if (chatId) {
-        if (outcome === "resolved") onSendEnd?.(chatId);
-        else if (outcome === "failed") onSendFailed?.(chatId);
+        if (outcome === "resolved") onSendEnd?.(chatId, gen);
+        else if (outcome === "failed") onSendFailed?.(chatId, gen);
       }
       setSending(false);
     }

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -72,6 +72,7 @@ import {
 } from "./chat/mentions";
 import { echoCause } from "./chat/EchoPlaceholder";
 import { MessageTimeline } from "./chat/MessageTimeline";
+import type { ChatReceipt } from "./chat/ChatLiveReceipt";
 import { ThreadPanel } from "./chat/ThreadPanel";
 import { useLocalScope } from "@/connections/ConnectionContext";
 import {
@@ -226,6 +227,20 @@ interface Props {
    * started, which is most of what issue #367 is about.
    */
   liveStepsByThread?: Record<string, TurnStep[]>;
+  /**
+   * The live receipt for a synchronous chat turn in flight, keyed by **host
+   * thread id** (issue #1934) — resolved to this channel's thread the same way
+   * `liveStepsByThread` is. Present between the operator's send and the reply
+   * landing; absent otherwise. Drives the "Sent → Picked up → on step" row that
+   * fills the gap the composer used to leave silent.
+   */
+  receiptByThread?: Record<string, ChatReceipt>;
+  /**
+   * Roster agent id → display name, captured by the shell's desks/roster read
+   * (issue #1934). Lets the receipt name whoever picked the turn up rather than
+   * rendering a raw id; a miss falls back to the channel voice.
+   */
+  agentNames?: Record<string, string>;
   /** Channel id → unread count, for the rail's badges. Owned by the shell. */
   unread?: Record<string, number>;
   /**
@@ -357,6 +372,8 @@ export function ChatView({
   scopeRef,
   openTurns,
   liveStepsByThread,
+  receiptByThread,
+  agentNames,
   unread,
   mentions,
   mentionFeedRevision,
@@ -1316,6 +1333,10 @@ export function ChatView({
   const activeIsDesk =
     active.kind === "channel" && (desks ?? []).some((d) => d.id === active.id);
   const liveSteps = activeThreadId ? liveStepsByThread?.[activeThreadId] : undefined;
+  // The live receipt for this channel's thread (issue #1934), resolved exactly
+  // as `liveSteps` above — same host thread id, same open-thread exclusion at
+  // the render site below.
+  const receipt = activeThreadId ? receiptByThread?.[activeThreadId] : undefined;
   /**
    * The turn this channel is waiting on, if any (issue #983).
    *
@@ -2088,6 +2109,10 @@ export function ChatView({
               typing={(sending || !!openTurn) && !openThreadId}
               queued={!!openTurn?.queued}
               liveSteps={openThreadId ? undefined : liveSteps}
+              // Thread-panel receipts are out of v1 (issue #1934): excluded here
+              // the same way `liveSteps` is when a thread is open.
+              receipt={openThreadId ? undefined : receipt}
+              agentNames={agentNames}
               onOpenThread={setOpenThreadId}
               onReact={react}
               onDismissCard={(taskId) => void dismissCard(taskId)}

--- a/frontend/src/views/Conversation.tsx
+++ b/frontend/src/views/Conversation.tsx
@@ -61,17 +61,23 @@ interface Props {
    * typing indicator and cleared by the parent when the final reply lands.
    */
   liveStepsByThread?: Record<string, TurnStep[]>;
-  /** Marks a thread's chat POST as in flight (parent suppresses the SSE echo). */
-  onSendStart?: (threadId: string) => void;
+  /**
+   * Marks a thread's chat POST as in flight (parent suppresses the SSE echo).
+   * Returns the generation the shell stamped this send's receipt with (issue
+   * #1935 review, codex 3892702774) — forwarded straight through to
+   * `ChatPane`/`useConversationRuntime`, which threads it to whichever
+   * terminal callback below the POST reaches.
+   */
+  onSendStart?: (threadId: string) => number | undefined;
   /** Clears the in-flight mark + live timeline once the POST resolves. */
-  onSendEnd?: (threadId: string) => void;
+  onSendEnd?: (threadId: string, gen?: number) => void;
   /**
    * The host accepted the turn and answered `202` rather than the reply
    * (issue #983). Unlike `onSendEnd` this does NOT end the turn — it only ends
    * the POST, so the parent keeps the working row up and stops suppressing the
    * live reply frame, which in this mode is the delivery path.
    */
-  onSendDetached?: (threadId: string, turnId?: string) => void;
+  onSendDetached?: (threadId: string, turnId?: string, gen?: number) => void;
   /**
    * The chat POST **threw** (issue #1000). The third outcome, and not
    * `onSendEnd`: that one promises the parent the reply is already on screen,
@@ -79,7 +85,7 @@ interface Props {
    * nothing and the turn usually outlives the request, so that frame is the
    * only copy of the answer.
    */
-  onSendFailed?: (threadId: string) => void;
+  onSendFailed?: (threadId: string, gen?: number) => void;
   /** Turns accepted but not settled, by thread id — survives a reload (#983). */
   openTurns?: Record<string, OpenTurn[]>;
 }
@@ -180,10 +186,10 @@ function ChatPane({
   onReply?: () => void;
   taskEventTick?: number;
   liveSteps?: TurnStep[];
-  onSendStart?: (threadId: string) => void;
-  onSendEnd?: (threadId: string) => void;
-  onSendDetached?: (threadId: string, turnId?: string) => void;
-  onSendFailed?: (threadId: string) => void;
+  onSendStart?: (threadId: string) => number | undefined;
+  onSendEnd?: (threadId: string, gen?: number) => void;
+  onSendDetached?: (threadId: string, turnId?: string, gen?: number) => void;
+  onSendFailed?: (threadId: string, gen?: number) => void;
   /** This thread's turn, when one is accepted but not settled (#983). */
   openTurn?: OpenTurn;
   onOpenList: () => void;

--- a/frontend/src/views/chat/ChatLiveReceipt.tsx
+++ b/frontend/src/views/chat/ChatLiveReceipt.tsx
@@ -38,11 +38,52 @@ export const RECEIPT_STALL_AFTER_MS = 30_000;
  * and bumps on every live frame, so the stall check is "no frame for 30s"
  * rather than "no reply for 30s". `agentId` is captured off the first frame
  * that names one and never rendered raw — it is resolved to a display name.
+ *
+ * `gen` is the generation the send that armed this receipt was stamped with
+ * (issue #1935 review). Host thread ids like `main` recur across companies,
+ * so without it a slow POST from a company the operator has since left can
+ * land after a *new* send has re-armed the same thread id and delete that
+ * newer receipt out from under the company actually on screen. See
+ * {@link shouldClearReceipt}.
  */
 export interface ChatReceipt {
   startedAt: number;
   lastFrameAt: number;
   agentId?: string;
+  gen?: number;
+}
+
+/**
+ * Whether a clear request for a thread's receipt should actually delete it.
+ *
+ * The bug this guards (issue #1935 review, codex 3892523790 / coderabbit
+ * 3892517512): thread ids are reused across companies (`main` above all), and
+ * `AppShell`'s `onSendStale`/`onSendEnd`/`onSendDetached`/`onSendFailed` all
+ * clear a receipt by thread id alone. Send it from company A, switch to
+ * company B, send again on the same thread id — B's send arms a *new*
+ * receipt — and when A's slow POST finally settles, its own clear call must
+ * not delete B's receipt just because they share a thread id.
+ *
+ * Each armed receipt is stamped with the generation counter value current at
+ * arm time; each terminal callback is handed the generation its own
+ * `onSendStart` call returned. A clear only proceeds when the receipt
+ * currently on file carries that same generation — if a newer send has
+ * re-armed the slot in between, the generations differ and the clear is a
+ * no-op, leaving the newer receipt alone.
+ *
+ * `gen === undefined` clears unconditionally. That is not a loophole — it is
+ * `Conversation`/`conversation/runtime.ts`'s calling convention, which
+ * predates generation-tagging and never races a company switch the way
+ * `ChatView`'s sends do (the parked conversation view has no scope to switch
+ * out from under).
+ */
+export function shouldClearReceipt(
+  current: Pick<ChatReceipt, "gen"> | undefined,
+  gen: number | undefined,
+): boolean {
+  if (!current) return false;
+  if (gen === undefined) return true;
+  return current.gen === gen;
 }
 
 /**

--- a/frontend/src/views/chat/ChatLiveReceipt.tsx
+++ b/frontend/src/views/chat/ChatLiveReceipt.tsx
@@ -57,12 +57,13 @@ export interface ChatReceipt {
  * Whether a clear request for a thread's receipt should actually delete it.
  *
  * The bug this guards (issue #1935 review, codex 3892523790 / coderabbit
- * 3892517512): thread ids are reused across companies (`main` above all), and
- * `AppShell`'s `onSendStale`/`onSendEnd`/`onSendDetached`/`onSendFailed` all
- * clear a receipt by thread id alone. Send it from company A, switch to
- * company B, send again on the same thread id — B's send arms a *new*
- * receipt — and when A's slow POST finally settles, its own clear call must
- * not delete B's receipt just because they share a thread id.
+ * 3892517512, and its sibling codex 3892702774): thread ids are reused across
+ * companies (`main` above all), and `AppShell`'s
+ * `onSendStale`/`onSendEnd`/`onSendDetached`/`onSendFailed` all clear a
+ * receipt by thread id alone. Send it from company A, switch to company B,
+ * send again on the same thread id — B's send arms a *new* receipt — and when
+ * A's slow POST finally settles, its own clear call must not delete B's
+ * receipt just because they share a thread id.
  *
  * Each armed receipt is stamped with the generation counter value current at
  * arm time; each terminal callback is handed the generation its own
@@ -71,18 +72,34 @@ export interface ChatReceipt {
  * re-armed the slot in between, the generations differ and the clear is a
  * no-op, leaving the newer receipt alone.
  *
- * `gen === undefined` clears unconditionally. That is not a loophole — it is
- * `Conversation`/`conversation/runtime.ts`'s calling convention, which
- * predates generation-tagging and never races a company switch the way
- * `ChatView`'s sends do (the parked conversation view has no scope to switch
- * out from under).
+ * `gen === undefined` now REFUSES to clear (issue #1935 review, codex
+ * 3892702774 — reversing the original "clears unconditionally" reading of
+ * this branch). That original reading treated an omitted generation as
+ * `Conversation`'s calling convention, on the assumption the parked
+ * conversation view "has no scope to switch out from under" — which was
+ * wrong: `#/conversation` is a live, still-routable surface (`ROUTABLE.
+ * conversation` in `console-routes.ts`), it stays mounted across a company
+ * switch exactly like `ChatView`, and its own `useConversationRuntime` send
+ * never generation-tagged its calls — so a slow Conversation POST from
+ * company A could delete a newer `ChatView` (or Conversation) receipt on
+ * company B through the identical reused-thread-id race, just missing the
+ * `shouldClearReceipt` guard that was supposed to close it everywhere.
+ *
+ * `Conversation`'s `useConversationRuntime` is now generation-tagged too (see
+ * `runtime.ts`), so every current caller always supplies a defined `gen` and
+ * this branch is not load-bearing for them. It stays fail-closed rather than
+ * being deleted so a FUTURE send surface that forgets to capture and forward
+ * `onSendStart`'s return value cannot reintroduce this exact leak by omission
+ * — the failure mode of forgetting becomes a receipt that lingers until the
+ * next send or company switch clears it, never a live receipt deleted out
+ * from under a different company.
  */
 export function shouldClearReceipt(
   current: Pick<ChatReceipt, "gen"> | undefined,
   gen: number | undefined,
 ): boolean {
   if (!current) return false;
-  if (gen === undefined) return true;
+  if (gen === undefined) return false;
   return current.gen === gen;
 }
 

--- a/frontend/src/views/chat/ChatLiveReceipt.tsx
+++ b/frontend/src/views/chat/ChatLiveReceipt.tsx
@@ -113,7 +113,7 @@ export function ChatLiveReceipt({
   const elapsed = Math.max(0, clock - receipt.startedAt);
   // Soft and reversible: a lull with no frame, seeded from `startedAt`, cleared
   // by the next frame that bumps `lastFrameAt`. Not an error state.
-  const stalled = clock - receipt.lastFrameAt > RECEIPT_STALL_AFTER_MS;
+  const stalled = clock - receipt.lastFrameAt >= RECEIPT_STALL_AFTER_MS;
   const line = receiptStateLine(receipt, steps, agentNames, channel);
 
   return (

--- a/frontend/src/views/chat/ChatLiveReceipt.tsx
+++ b/frontend/src/views/chat/ChatLiveReceipt.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from "react";
+
+import type { TurnStep } from "@/api/types";
+import { cn } from "@/lib/utils";
+import { TeammateAvatar } from "@/components/teammate-avatar";
+import { StepTimeline } from "./StepTimeline";
+import { runningStepLabel } from "./WorkingIndicator";
+import type { Channel } from "./model";
+
+/**
+ * The live receipt for a chat instruction the operator just sent (issue #1934).
+ *
+ * Between hitting send and the reply landing there used to be a dead gap — the
+ * composer cleared, and nothing said the turn had been taken until the whole
+ * answer arrived, which for a long turn is many silent seconds. This is the row
+ * that fills that gap: **Sent** the instant the POST is armed, **Picked up by
+ * <teammate>** once the first live frame names who answered, **On step <label>**
+ * while a step is in flight — each with a ticking elapsed readout so the wait is
+ * legible rather than a frozen spinner.
+ *
+ * It is deliberately reversible. If no frame arrives (or advances) for
+ * {@link RECEIPT_STALL_AFTER_MS}, it adds a soft "still waiting" note — not an
+ * error, not a terminal state. Any new frame, or the reply itself, clears it.
+ * The receipt clears the moment the real reply bubble lands (`AppShell`'s
+ * `onSendEnd`), so there is never a frame where both the reply and the receipt
+ * are absent.
+ *
+ * The state line reuses {@link runningStepLabel} — the same source
+ * `WorkingIndicator` derives its line from — so the two surfaces never phrase
+ * the same step differently (the #264 drift rule). The teammate is always shown
+ * by name; a raw agent id is never rendered.
+ */
+export const RECEIPT_STALL_AFTER_MS = 30_000;
+
+/**
+ * What `AppShell` tracks per thread for the duration of a synchronous chat
+ * turn. `startedAt` fixes the elapsed clock; `lastFrameAt` seeds to `startedAt`
+ * and bumps on every live frame, so the stall check is "no frame for 30s"
+ * rather than "no reply for 30s". `agentId` is captured off the first frame
+ * that names one and never rendered raw — it is resolved to a display name.
+ */
+export interface ChatReceipt {
+  startedAt: number;
+  lastFrameAt: number;
+  agentId?: string;
+}
+
+/**
+ * Elapsed since a turn was sent — `Ns` under a minute, `m:ss` beyond it. Kept a
+ * pure function so the format is unit-testable without a clock.
+ */
+export function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}:${String(seconds).padStart(2, "0")}` : `${seconds}s`;
+}
+
+/**
+ * The teammate on the other end of this receipt, by name — never a raw id.
+ *
+ * Resolves the captured `agentId` against the roster's name map, falling back
+ * to the channel's own voice and then a neutral "a teammate" so an unresolved
+ * id is still shown as a person rather than an opaque token. `undefined` only
+ * when no frame has named an agent yet, which is the "Sent" state.
+ */
+export function resolveReceiptAgentName(
+  receipt: ChatReceipt,
+  agentNames: Record<string, string> | undefined,
+  channel: Channel,
+): string | undefined {
+  if (!receipt.agentId) return undefined;
+  return agentNames?.[receipt.agentId] ?? channel.voice ?? "a teammate";
+}
+
+/**
+ * The one visible state line, progressing Sent → Picked up by <name> → On step
+ * <label>. A running step is the most specific thing to say, so it outranks the
+ * name; the name outranks the bare "Sent". Pure, for the same reason
+ * {@link formatElapsed} is.
+ */
+export function receiptStateLine(
+  receipt: ChatReceipt,
+  steps: readonly TurnStep[] | undefined,
+  agentNames: Record<string, string> | undefined,
+  channel: Channel,
+): string {
+  const step = runningStepLabel(steps);
+  if (step) return `On step ${step}`;
+  const name = resolveReceiptAgentName(receipt, agentNames, channel);
+  if (name) return `Picked up by ${name}`;
+  return "Sent";
+}
+
+export function ChatLiveReceipt({
+  channel,
+  receipt,
+  agentNames,
+  steps,
+}: {
+  channel: Channel;
+  receipt: ChatReceipt;
+  /** Roster agent id → display name, so the receipt never shows a raw id. */
+  agentNames?: Record<string, string>;
+  /** The turn's live steps, when any have arrived — folded below the line. */
+  steps: TurnStep[];
+}) {
+  const reduced = usePrefersReducedMotion();
+  // Self-contained 1s clock, mounted only while this row is (the receipt is
+  // present). `feed.now` is too coarse for a seconds readout, so this owns its
+  // own interval and tears it down on unmount.
+  const clock = useReceiptClock();
+  const elapsed = Math.max(0, clock - receipt.startedAt);
+  // Soft and reversible: a lull with no frame, seeded from `startedAt`, cleared
+  // by the next frame that bumps `lastFrameAt`. Not an error state.
+  const stalled = clock - receipt.lastFrameAt > RECEIPT_STALL_AFTER_MS;
+  const line = receiptStateLine(receipt, steps, agentNames, channel);
+
+  return (
+    <div className="flex items-start gap-2.5 px-4 py-1">
+      <TeammateAvatar
+        name={channel.voice ?? channel.name}
+        tone={channel.tone}
+        avatar={channel.member?.avatar}
+        company={channel.kind === "channel" && channel.id === "main"}
+        className="size-9 shrink-0"
+      />
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <span
+          data-testid="chat-live-receipt"
+          data-stalled={stalled ? "true" : "false"}
+          className="flex w-fit items-center gap-2 rounded-full bg-muted px-3 py-2 text-sm text-muted-foreground"
+        >
+          <span
+            aria-hidden
+            className={cn(
+              "size-1.5 shrink-0 rounded-full bg-status-running",
+              // The pulse is the "something is happening" signal; a reader who
+              // asked for stillness keeps the mark without the motion.
+              !reduced && "animate-pulse",
+            )}
+          />
+          {/* `aria-hidden`, because the stable assistive line below is what a
+              screen reader should read — the visible line changes as the turn
+              advances, and re-announcing every transition is noise. */}
+          <span aria-hidden className="truncate">
+            {line}
+          </span>
+          <span aria-hidden className="shrink-0 tabular-nums text-2xs text-muted-foreground/80">
+            {formatElapsed(elapsed)}
+          </span>
+          <span className="sr-only">Waiting for a reply…</span>
+        </span>
+        {stalled && (
+          <p role="status" className="px-1 text-2xs text-muted-foreground">
+            No update for 30s… still waiting.
+          </p>
+        )}
+        {/* Kept below the line when steps exist; renders nothing otherwise. */}
+        <StepTimeline steps={steps} defaultOpen />
+      </div>
+    </div>
+  );
+}
+
+/** A 1-second clock that lives exactly as long as the row it drives. */
+function useReceiptClock(): number {
+  const [clock, setClock] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setClock(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return clock;
+}
+
+/**
+ * Whether the viewer asked for reduced motion, kept live. Mirrors
+ * `WorkingIndicator`'s hook — reads `false` where `matchMedia` is unavailable,
+ * and prefers the modern `addEventListener` spelling with the deprecated
+ * `addListener` as the fallback older WebKitGTK builds still need.
+ */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia?.("(prefers-reduced-motion: reduce)");
+    if (!mql) return;
+    setReduced(mql.matches);
+    const onChange = () => setReduced(mql.matches);
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, []);
+  return reduced;
+}

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -7,6 +7,7 @@ import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { ApprovalRow } from "./ApprovalRow";
+import { ChatLiveReceipt, type ChatReceipt } from "./ChatLiveReceipt";
 import { MessageRow } from "./MessageRow";
 import { StepTimeline } from "./StepTimeline";
 import { WorkingIndicator } from "./WorkingIndicator";
@@ -48,6 +49,17 @@ interface Props {
    * an inbound message kicked off shows its work here too (issue #367).
    */
   liveSteps?: TurnStep[];
+  /**
+   * The live receipt for a synchronous chat turn this console just sent (issue
+   * #1934). When present it supersedes {@link TypingRow} — it says "Sent →
+   * Picked up → on step" with a ticking clock instead of bare typing dots — and
+   * folds the same {@link StepTimeline} below the line when steps exist. Absent
+   * for an inbound turn this console never started, which still falls to the
+   * `liveSteps`/`typing` rows below.
+   */
+  receipt?: ChatReceipt;
+  /** Roster agent id → display name, so the receipt never shows a raw id. */
+  agentNames?: Record<string, string>;
   onOpenThread: (messageId: string) => void;
   onReact: (messageId: string, emoji: string) => void;
   /** Deletes the board card a line opened, and drops its chip (issue #984). */
@@ -148,6 +160,8 @@ export function MessageTimeline({
   typing,
   queued,
   liveSteps,
+  receipt,
+  agentNames,
   onOpenThread,
   onReact,
   onDismissCard,
@@ -364,7 +378,17 @@ export function MessageTimeline({
             />
           ),
         )}
-        {liveStepCount > 0 && !queued ? (
+        {receipt && !queued ? (
+          // The receipt for our own in-flight send (issue #1934) supersedes the
+          // typing dots and carries the live steps itself. A queued turn keeps
+          // its honest "Queued…" row instead — the receipt is a `!queued` state.
+          <ChatLiveReceipt
+            channel={channel}
+            receipt={receipt}
+            agentNames={agentNames}
+            steps={liveSteps ?? []}
+          />
+        ) : liveStepCount > 0 && !queued ? (
           <LiveTurnRow channel={channel} steps={liveSteps ?? []} />
         ) : (
           typing && <TypingRow channel={channel} queued={queued} />

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -182,6 +182,8 @@ export function MessageTimeline({
   latestBudgetPauseMessageIdByAgent,
 }: Props) {
   const scroller = useRef<HTMLDivElement>(null);
+  /** The inner column whose own height rule 2b's `ResizeObserver` watches. */
+  const content = useRef<HTMLDivElement>(null);
   const liveStepCount = liveSteps?.length ?? 0;
   // Rows that arrived locally — a message sent before hydration landed — are
   // still worth showing while the rest of the history is in flight. It is only
@@ -297,6 +299,37 @@ export function MessageTimeline({
     return () => observer.disconnect();
   }, []);
 
+  // Rule 2b — content that grows without moving any of rule 2's dependencies
+  // (issue #1935 review, coderabbit 3892517543). `ChatLiveReceipt`'s 30s
+  // "still waiting" note is timed by a clock entirely internal to that
+  // component: nothing here re-renders when it appears, so rule 2 never fires
+  // and the note can land under the fold with no follow-scroll to reveal it.
+  // A live receipt is the concrete case, but the same gap exists for any
+  // in-place child growth this component was not told about.
+  //
+  // Rule 3's `ResizeObserver` cannot double as this one — it watches the
+  // *scroller's own border box*, which content overflowing inside an
+  // `overflow-y-auto` container never changes; that is the whole reason the
+  // container scrolls instead of growing. This one watches the *content*
+  // column instead — the inner wrapper whose height the rows and receipt
+  // actually determine — so it fires on exactly the growth rule 3 cannot see,
+  // and stays silent on the box-only resizes (composer growing, window
+  // resizing) rule 3 exists for, which do not move this column's own height.
+  useEffect(() => {
+    const contentEl = content.current;
+    const scrollerEl = scroller.current;
+    if (!contentEl || !scrollerEl || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      // Nothing to follow while the transcript is still on the wire, same as
+      // rule 2 — a cold load's content grows repeatedly as history lands, and
+      // rule 1 owns the anchor until it has.
+      if (historyPending || !following.current) return;
+      scrollerEl.scrollTo({ top: scrollerEl.scrollHeight, behavior: "smooth" });
+    });
+    observer.observe(contentEl);
+    return () => observer.disconnect();
+  }, [historyPending]);
+
   return (
     <div ref={scroller} onScroll={trackFollowing} className="flex-1 overflow-y-auto">
       {/*
@@ -318,7 +351,10 @@ export function MessageTimeline({
        * about what "empty" means — a channel whose intro claimed emptiness
        * while the wrapper anchored for content would jump on every load.
        */}
-      <div className={cn("flex min-h-full flex-col pb-4", empty ? "justify-start" : "justify-end")}>
+      <div
+        ref={content}
+        className={cn("flex min-h-full flex-col pb-4", empty ? "justify-start" : "justify-end")}
+      >
         {/* `empty` only drives the top padding, and the skeleton fills the
             same space real rows will — so a loading channel is spaced like a
             full one and the intro does not jump down and back up. That is also

--- a/frontend/src/views/conversation/runtime.ts
+++ b/frontend/src/views/conversation/runtime.ts
@@ -38,14 +38,22 @@ export interface ConversationRuntimeOptions {
   setMessages: (threadId: string, updater: (m: ChatMessage[]) => ChatMessage[]) => void;
   /** Called after a reply lands, so the shell can refresh approvals/status. */
   onReply?: () => void;
-  /** Marks this thread's chat POST as in flight (parent suppresses the SSE echo). */
-  onSendStart?: (threadId: string) => void;
+  /**
+   * Marks this thread's chat POST as in flight (parent suppresses the SSE
+   * echo). Returns the generation the shell stamped this send's receipt with
+   * (issue #1935 review, codex 3892702774) — captured below and threaded
+   * through whichever terminal outcome this POST reaches, so the shell can
+   * tell "my own armed receipt settling" apart from a newer send having
+   * re-armed the same (possibly cross-company-reused) thread id in the
+   * meantime. See `shouldClearReceipt` in `ChatLiveReceipt.tsx`.
+   */
+  onSendStart?: (threadId: string) => number | undefined;
   /** Clears the in-flight mark + live timeline once the POST resolves. */
-  onSendEnd?: (threadId: string) => void;
+  onSendEnd?: (threadId: string, gen?: number) => void;
   /** The host answered `202` and the turn continues on the stream (#983). */
-  onSendDetached?: (threadId: string, turnId?: string) => void;
+  onSendDetached?: (threadId: string, turnId?: string, gen?: number) => void;
   /** The chat POST threw and the turn probably outlived it (#1000). */
-  onSendFailed?: (threadId: string) => void;
+  onSendFailed?: (threadId: string, gen?: number) => void;
   /** Whether a turn is open on this thread — a live POST or a detached one. */
   running: boolean;
   /** Reports a send starting/ending, so the view can hold its working row. */
@@ -107,7 +115,14 @@ export function useConversationRuntime(opts: ConversationRuntimeOptions): Conver
       if (!text) return;
       setMessages(thread.id, (m) => [...m, makeMessage("you", text)]);
       setSending(true);
-      onSendStart?.(thread.id);
+      // The generation the shell stamped this send's receipt with, if any
+      // (issue #1935 review, codex 3892702774). Threaded through to whichever
+      // terminal callback this POST reaches below, so a clear this send
+      // triggers can never delete a receipt a *later* send — on this same
+      // Conversation surface, or on `ChatView` for the same reused thread id —
+      // has since armed. See `shouldClearReceipt`'s doc for the cross-company
+      // race this closes.
+      const gen = onSendStart?.(thread.id);
       // Which of the POST's three outcomes happened, reported once in the
       // `finally`. Only `"resolved"` means the reply reached the screen — the
       // other two leave a turn running with the stream as its delivery path.
@@ -124,7 +139,7 @@ export function useConversationRuntime(opts: ConversationRuntimeOptions): Conver
           // The reply arrives on the stream, and durably in `chat/history` when
           // the turn settles. Nothing to render here — but the id IS known now,
           // at accept time rather than at settle, which is the improvement.
-          onSendDetached?.(thread.id, answer.turnId);
+          onSendDetached?.(thread.id, answer.turnId, gen);
           return;
         }
         const replies = answer.responses.length
@@ -157,8 +172,8 @@ export function useConversationRuntime(opts: ConversationRuntimeOptions): Conver
         // parent the reply is on screen and so licenses it to drop the live frame
         // it held; a throw rendered nothing and the turn carries on regardless, so
         // that frame is the only copy of the answer this console will be handed.
-        if (outcome === "resolved") onSendEnd?.(thread.id);
-        else if (outcome === "failed") onSendFailed?.(thread.id);
+        if (outcome === "resolved") onSendEnd?.(thread.id, gen);
+        else if (outcome === "failed") onSendFailed?.(thread.id, gen);
       }
     },
     [

--- a/frontend/test/unit/chat-live-receipt.test.ts
+++ b/frontend/test/unit/chat-live-receipt.test.ts
@@ -8,6 +8,7 @@ import type { TurnStep } from "@/api/types";
 import {
   ChatLiveReceipt,
   formatElapsed,
+  shouldClearReceipt,
   RECEIPT_STALL_AFTER_MS,
   type ChatReceipt,
 } from "@/views/chat/ChatLiveReceipt";
@@ -182,5 +183,50 @@ describe("formatElapsed", () => {
 
   it("floors a negative elapsed to zero", () => {
     expect(formatElapsed(-1_000)).toBe("0s");
+  });
+});
+
+describe("shouldClearReceipt", () => {
+  it("clears an unstamped-generation request unconditionally (Conversation's calling convention)", () => {
+    expect(shouldClearReceipt({ gen: 7 }, undefined)).toBe(true);
+    expect(shouldClearReceipt(undefined, undefined)).toBe(false);
+  });
+
+  it("clears a matching generation — the ordinary same-scope resolve", () => {
+    expect(shouldClearReceipt({ gen: 3 }, 3)).toBe(true);
+  });
+
+  it("does not delete a company B receipt when company A's stale send settles late", () => {
+    // issue #1935 review — codex 3892523790 / coderabbit 3892517512. Host
+    // thread ids like `main` recur across companies, so this is not a
+    // hypothetical mismatch: the same thread id genuinely holds two
+    // different companies' receipts in sequence within one browser tab.
+    //
+    // Sequence: operator sends on company A's "main" thread (gen 1 armed).
+    // Before A's POST resolves, the operator switches to company B and
+    // sends on B's own "main" thread too — same thread id, new generation
+    // (gen 2) re-arms the slot. A's slow POST finally settles and its
+    // `onSendStale` fires with the generation IT was armed with (1), not
+    // whatever is currently on file.
+    const armedForCompanyA = 1;
+    const armedForCompanyB = 2;
+    const currentReceipt: ChatReceipt = {
+      startedAt: 2_000,
+      lastFrameAt: 2_000,
+      gen: armedForCompanyB,
+    };
+
+    // Company A's late completion must not win against company B's receipt.
+    expect(shouldClearReceipt(currentReceipt, armedForCompanyA)).toBe(false);
+
+    // Company B's own completion, naming its own generation, still may.
+    expect(shouldClearReceipt(currentReceipt, armedForCompanyB)).toBe(true);
+  });
+
+  it("is a no-op (not a throw) when nothing is armed for the thread at all", () => {
+    // A stray terminal callback for a thread whose receipt was already
+    // cleared (or never armed, e.g. a background frame) must not attempt to
+    // delete a key that is not there.
+    expect(shouldClearReceipt(undefined, 5)).toBe(false);
   });
 });

--- a/frontend/test/unit/chat-live-receipt.test.ts
+++ b/frontend/test/unit/chat-live-receipt.test.ts
@@ -8,6 +8,7 @@ import type { TurnStep } from "@/api/types";
 import {
   ChatLiveReceipt,
   formatElapsed,
+  RECEIPT_STALL_AFTER_MS,
   type ChatReceipt,
 } from "@/views/chat/ChatLiveReceipt";
 import type { Channel } from "@/views/chat/model";
@@ -140,6 +141,20 @@ describe("ChatLiveReceipt", () => {
     await render({ receipt: { startedAt: BASE, lastFrameAt: BASE + 31_000 } });
     expect(receiptEl().dataset.stalled).toBe("false");
     expect(text()).not.toContain("No update for 30s");
+  });
+
+  it("is already stalled at exactly the 30s threshold, not a tick after (issue #1935 review)", async () => {
+    // coderabbit 3892517524: `clock - lastFrameAt > RECEIPT_STALL_AFTER_MS`
+    // reads exactly 30,000ms as "not yet stalled", so the notice appeared
+    // about a second late. `>=` is the fix under test.
+    const receipt: ChatReceipt = { startedAt: BASE, lastFrameAt: BASE };
+    await render({ receipt });
+
+    await act(async () => {
+      vi.advanceTimersByTime(RECEIPT_STALL_AFTER_MS);
+    });
+    expect(receiptEl().dataset.stalled).toBe("true");
+    expect(text()).toContain("No update for 30s");
   });
 
   it("advances the elapsed readout as its own clock ticks", async () => {

--- a/frontend/test/unit/chat-live-receipt.test.ts
+++ b/frontend/test/unit/chat-live-receipt.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TurnStep } from "@/api/types";
+import {
+  ChatLiveReceipt,
+  formatElapsed,
+  type ChatReceipt,
+} from "@/views/chat/ChatLiveReceipt";
+import type { Channel } from "@/views/chat/model";
+
+/**
+ * Coverage for the chat live receipt (issue #1934) — the row that fills the gap
+ * between a sent instruction and its reply. The unit runner has no
+ * testing-library, so this renders through `react-dom/client` directly (the
+ * same shape `use-typing.test.ts` and `inference-model-picker.test.ts` use) and
+ * drives its self-contained 1s clock with fake timers.
+ */
+
+const BASE = 1_700_000_000_000;
+
+function channel(overrides: Partial<Channel> = {}): Channel {
+  return {
+    id: "engineering",
+    name: "engineering",
+    voice: "Engineering",
+    kind: "channel",
+    purpose: "",
+    tone: "sky",
+    ...overrides,
+  };
+}
+
+function runningStep(label: string): TurnStep {
+  return { kind: "tool_call", status: "running", label };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(props: {
+  channel?: Channel;
+  receipt: ChatReceipt;
+  agentNames?: Record<string, string>;
+  steps?: TurnStep[];
+}) {
+  await act(async () => {
+    root.render(
+      createElement(ChatLiveReceipt, {
+        channel: props.channel ?? channel(),
+        receipt: props.receipt,
+        agentNames: props.agentNames,
+        steps: props.steps ?? [],
+      }),
+    );
+  });
+}
+
+function text(): string {
+  return container.textContent ?? "";
+}
+
+function receiptEl(): HTMLElement {
+  const el = container.querySelector<HTMLElement>('[data-testid="chat-live-receipt"]');
+  if (!el) throw new Error("receipt row not rendered");
+  return el;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.useFakeTimers();
+  vi.setSystemTime(BASE);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+describe("ChatLiveReceipt", () => {
+  it("shows Sent with an elapsed readout when no agent and no steps", async () => {
+    await render({ receipt: { startedAt: BASE - 5_000, lastFrameAt: BASE - 5_000 } });
+    expect(text()).toContain("Sent");
+    expect(text()).toContain("5s");
+    expect(text()).not.toContain("Picked up by");
+  });
+
+  it("names the teammate once an agent id resolves", async () => {
+    await render({
+      receipt: { startedAt: BASE, lastFrameAt: BASE, agentId: "a-ada" },
+      agentNames: { "a-ada": "Ada" },
+    });
+    expect(text()).toContain("Picked up by Ada");
+    // A raw agent id is never rendered.
+    expect(text()).not.toContain("a-ada");
+  });
+
+  it("falls back to the channel voice for an unresolvable agent id", async () => {
+    await render({
+      channel: channel({ voice: "Front desk" }),
+      receipt: { startedAt: BASE, lastFrameAt: BASE, agentId: "a-ghost" },
+      agentNames: {},
+    });
+    expect(text()).toContain("Picked up by Front desk");
+    expect(text()).not.toContain("a-ghost");
+  });
+
+  it("shows the running step label when a step is in flight", async () => {
+    await render({
+      receipt: { startedAt: BASE, lastFrameAt: BASE, agentId: "a-ada" },
+      agentNames: { "a-ada": "Ada" },
+      steps: [runningStep("Searching the web")],
+    });
+    expect(text()).toContain("On step Searching the web");
+  });
+
+  it("goes stalled after 30s with no frame, and a fresh frame clears it", async () => {
+    const receipt: ChatReceipt = { startedAt: BASE, lastFrameAt: BASE };
+    await render({ receipt });
+    expect(receiptEl().dataset.stalled).toBe("false");
+
+    // Push the self-contained clock past the 30s stall window with no new frame.
+    await act(async () => {
+      vi.advanceTimersByTime(31_000);
+    });
+    expect(receiptEl().dataset.stalled).toBe("true");
+    expect(text()).toContain("No update for 30s");
+
+    // A fresh frame bumps lastFrameAt (a new receipt object from the shell) —
+    // the stall is soft and reversible, so it clears without a remount.
+    await render({ receipt: { startedAt: BASE, lastFrameAt: BASE + 31_000 } });
+    expect(receiptEl().dataset.stalled).toBe("false");
+    expect(text()).not.toContain("No update for 30s");
+  });
+
+  it("advances the elapsed readout as its own clock ticks", async () => {
+    await render({ receipt: { startedAt: BASE, lastFrameAt: BASE } });
+    expect(text()).toContain("0s");
+    await act(async () => {
+      vi.advanceTimersByTime(3_000);
+    });
+    expect(text()).toContain("3s");
+  });
+});
+
+describe("formatElapsed", () => {
+  it("renders sub-minute durations as seconds", () => {
+    expect(formatElapsed(0)).toBe("0s");
+    expect(formatElapsed(5_400)).toBe("5s");
+    expect(formatElapsed(59_999)).toBe("59s");
+  });
+
+  it("rolls into m:ss at a minute and pads the seconds", () => {
+    expect(formatElapsed(60_000)).toBe("1:00");
+    expect(formatElapsed(65_000)).toBe("1:05");
+    expect(formatElapsed(605_000)).toBe("10:05");
+  });
+
+  it("floors a negative elapsed to zero", () => {
+    expect(formatElapsed(-1_000)).toBe("0s");
+  });
+});

--- a/frontend/test/unit/chat-live-receipt.test.ts
+++ b/frontend/test/unit/chat-live-receipt.test.ts
@@ -187,8 +187,17 @@ describe("formatElapsed", () => {
 });
 
 describe("shouldClearReceipt", () => {
-  it("clears an unstamped-generation request unconditionally (Conversation's calling convention)", () => {
-    expect(shouldClearReceipt({ gen: 7 }, undefined)).toBe(true);
+  it("refuses to clear when the request carries no generation (fail-safe)", () => {
+    // issue #1935 review, codex 3892702774 — reversed from the original
+    // "clears unconditionally" reading of an omitted generation. That
+    // reading assumed `Conversation` never races a company switch; it does
+    // (see the cross-surface test below), and treating "no generation" as
+    // "clear anyway" is exactly the loophole that let it. A caller with no
+    // generation cannot prove which send armed the receipt it is trying to
+    // clear, so the safe default is to leave it alone — the worst a future
+    // caller that forgets to thread `onSendStart`'s return value can do is
+    // leak a receipt, never delete a different company's live one.
+    expect(shouldClearReceipt({ gen: 7 }, undefined)).toBe(false);
     expect(shouldClearReceipt(undefined, undefined)).toBe(false);
   });
 
@@ -221,6 +230,37 @@ describe("shouldClearReceipt", () => {
 
     // Company B's own completion, naming its own generation, still may.
     expect(shouldClearReceipt(currentReceipt, armedForCompanyB)).toBe(true);
+  });
+
+  it("does not delete a ChatView receipt when a Conversation send from the old company settles late", () => {
+    // issue #1935 review, codex 3892702774 — the sibling of the test above,
+    // through the OTHER door. `#/conversation` is a second, still-routable
+    // send surface (`ROUTABLE.conversation` in console-routes.ts) that stays
+    // mounted across a company switch exactly like `ChatView` does, and
+    // shares the same `receiptByThread` map in `AppShell`.
+    //
+    // Sequence: operator is on `#/conversation` for company A and sends on
+    // the "main" thread (gen 1 armed, captured from `onSendStart`'s return).
+    // Before that POST resolves, the operator switches to company B and
+    // switches to `#/chat`, sending on B's own "main" thread (gen 2 re-arms
+    // the slot). Conversation's slow POST for company A finally settles and
+    // its `onSendEnd` fires with the generation IT captured (1) — not
+    // whatever is currently on file — exactly like `ChatView`'s own case,
+    // just originating from `useConversationRuntime` instead of `ChatView.send`.
+    const armedByConversationForCompanyA = 1;
+    const armedByChatViewForCompanyB = 2;
+    const currentReceipt: ChatReceipt = {
+      startedAt: 5_000,
+      lastFrameAt: 5_000,
+      gen: armedByChatViewForCompanyB,
+    };
+
+    // Conversation's late company-A completion must not win against
+    // ChatView's newer company-B receipt on the same reused thread id.
+    expect(shouldClearReceipt(currentReceipt, armedByConversationForCompanyA)).toBe(false);
+
+    // ChatView's own completion, naming its own generation, still may.
+    expect(shouldClearReceipt(currentReceipt, armedByChatViewForCompanyB)).toBe(true);
   });
 
   it("is a no-op (not a throw) when nothing is armed for the thread at all", () => {

--- a/frontend/test/unit/chat-receipt-scope-reset.test.ts
+++ b/frontend/test/unit/chat-receipt-scope-reset.test.ts
@@ -99,3 +99,55 @@ describe("clearReceipt is generation-guarded (issue #1935 review)", () => {
     expect(appShell).toMatch(/return gen;\s*\n\s*\}, \[\]\);/);
   });
 });
+
+/**
+ * `Conversation`'s own send surface (issue #1935 review, codex 3892702774).
+ *
+ * `#/conversation` is a second, still-routable surface — `ROUTABLE.
+ * conversation` in `console-routes.ts` — that shares `AppShell`'s
+ * `onSendStart`/`onSendEnd`/`onSendDetached`/`onSendFailed` and therefore the
+ * same `receiptByThread` map `ChatView` writes into. Its send lives in
+ * `useConversationRuntime` (`views/conversation/runtime.ts`), which — like
+ * `AppShell` — is a hook wired into a large host component (`ChatPane`,
+ * itself inside `Conversation`), not something worth mounting whole for this.
+ *
+ * `shouldClearReceipt`'s own suite in `chat-live-receipt.test.ts` proves the
+ * *semantics* directly, including a case modelled explicitly on this
+ * Conversation → ChatView cross-surface race. What this block locks down is
+ * that `runtime.ts` actually *wires* into those semantics — captures
+ * `onSendStart`'s return value and forwards it to every terminal call —
+ * rather than the fix living only on the `ChatView` side of the same map.
+ */
+const runtimeTs = readFileSync(
+  resolve(here, "../../src/views/conversation/runtime.ts"),
+  "utf8",
+);
+
+describe("Conversation's send surface generation-tags its receipt clears too", () => {
+  it("captures onSendStart's return value instead of discarding it", () => {
+    // The pre-fix shape was a bare `onSendStart?.(thread.id);` statement —
+    // the call happened, but nothing captured what it returned, so every
+    // terminal callback below had nothing to forward and fell through to
+    // `shouldClearReceipt`'s undefined-generation branch on every single
+    // send from this surface.
+    expect(runtimeTs).not.toMatch(/^\s*onSendStart\?\.\(thread\.id\);\s*$/m);
+    expect(runtimeTs).toMatch(/const gen = onSendStart\?\.\(thread\.id\);/);
+  });
+
+  it("forwards that generation to all three terminal outcomes", () => {
+    expect(runtimeTs).toMatch(/onSendDetached\?\.\(thread\.id, answer\.turnId, gen\);/);
+    expect(runtimeTs).toMatch(/onSendEnd\?\.\(thread\.id, gen\);/);
+    expect(runtimeTs).toMatch(/onSendFailed\?\.\(thread\.id, gen\);/);
+  });
+
+  it("declares onSendStart as returning a generation, not void", () => {
+    // A `void`-typed signature would silently defeat the capture above by
+    // letting a caller assign `gen` and never mean it — TypeScript would
+    // accept `const gen = onSendStart?.(thread.id)` either way, so the
+    // capture line alone does not prove the *type* was updated to promise a
+    // value exists to capture.
+    expect(runtimeTs).toMatch(
+      /onSendStart\?: \(threadId: string\) => number \| undefined;/,
+    );
+  });
+});

--- a/frontend/test/unit/chat-receipt-scope-reset.test.ts
+++ b/frontend/test/unit/chat-receipt-scope-reset.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Source-wiring coverage for the receipt/agent-name company-scope reset
+ * (issue #1935 review, codex 3892523790).
+ *
+ * `AppShell` is too large, and pulls in too much (SSE, the authenticated
+ * client, routing) to mount in a unit test — `chat-realtime-poll.test.ts`
+ * settles the same way for its own wiring, reading the source and asserting
+ * on the literal reset calls rather than mounting the component. The
+ * behaviour those calls produce (a receipt/name-map object reference change)
+ * is exercised directly and exhaustively by `shouldClearReceipt`'s own suite
+ * in `chat-live-receipt.test.ts`; what this file locks down is that the reset
+ * calls are actually *wired into the scope-change effect*, not merely
+ * defined somewhere in the file.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appShell = readFileSync(resolve(here, "../../src/components/app-shell.tsx"), "utf8");
+
+/**
+ * The body of the `useEffect` keyed on `[client, company]` that resets every
+ * other company-scoped map (`chatChannelByThread`, `transcripts`,
+ * `decidedApprovals`, …) on a switch — the same effect `receiptByThread` and
+ * `agentNames` belong in. Sliced out so the assertions below cannot pass by
+ * matching a `setReceiptByThread`/`setAgentNames` call anywhere else in the
+ * file (both names appear elsewhere too: the send-outcome callbacks and the
+ * roster fetch's own async reset).
+ */
+function scopeChangeEffectBody(): string {
+  const start = appShell.indexOf("const requestCompany = company;");
+  expect(start, "the [client, company] effect's marker line").toBeGreaterThan(-1);
+  const end = appShell.indexOf("}, [client, company]);", start);
+  expect(end, "the effect's closing dependency array").toBeGreaterThan(start);
+  return appShell.slice(start, end);
+}
+
+describe("company-switch reset wires receiptByThread and agentNames", () => {
+  it("clears receiptByThread synchronously in the scope-change effect", () => {
+    const body = scopeChangeEffectBody();
+    expect(body).toMatch(/setReceiptByThread\(\(prev\) =>/);
+  });
+
+  it("clears agentNames synchronously in the scope-change effect", () => {
+    const body = scopeChangeEffectBody();
+    expect(body).toMatch(/setAgentNames\(\(prev\) =>/);
+  });
+
+  it("does not merely reference the setters without calling them", () => {
+    // A regex match against an identifier alone (e.g. a comment mentioning
+    // `setAgentNames`) would pass the two tests above without the reset
+    // actually being wired. Confirms both are real call expressions inside
+    // the slice, immediately preceding the rest-of-map reset idiom
+    // (`Object.keys(prev).length === 0 ? prev : {}`) every sibling reset in
+    // this same effect already uses.
+    const body = scopeChangeEffectBody();
+    expect(body).toMatch(
+      /setReceiptByThread\(\(prev\) => \(Object\.keys\(prev\)\.length === 0 \? prev : \{\}\)\);/,
+    );
+    expect(body).toMatch(
+      /setAgentNames\(\(prev\) => \(Object\.keys\(prev\)\.length === 0 \? prev : \{\}\)\);/,
+    );
+  });
+});
+
+describe("clearReceipt is generation-guarded (issue #1935 review)", () => {
+  it("routes every clear through shouldClearReceipt rather than deleting unconditionally", () => {
+    expect(appShell).toContain(
+      'import { shouldClearReceipt, type ChatReceipt } from "@/views/chat/ChatLiveReceipt";',
+    );
+    // The old body deleted whenever `prev[threadId]` was truthy, with no
+    // generation check at all — this is the shape that let a stale
+    // `onSendStale` from an old company delete a newer company's receipt.
+    expect(appShell).not.toMatch(/if \(!prev\[threadId\]\) return prev;\s*\n\s*const next = \{ \.\.\.prev \};\s*\n\s*delete next\[threadId\];/);
+    expect(appShell).toMatch(/if \(!shouldClearReceipt\(prev\[threadId\], gen\)\) return prev;/);
+  });
+
+  it("every terminal send callback accepts and forwards a generation", () => {
+    expect(appShell).toMatch(/const onSendEnd = useCallback\(\s*\n\s*\(threadId: string, gen\?: number\) =>/);
+    expect(appShell).toMatch(/const onSendStale = useCallback\(\s*\n\s*\(threadId: string, gen\?: number\) =>/);
+    expect(appShell).toMatch(
+      /const onSendDetached = useCallback\(\s*\n\s*\(threadId: string, turnId\?: string, gen\?: number\) =>/,
+    );
+    expect(appShell).toMatch(/const onSendFailed = useCallback\(\s*\n\s*\(threadId: string, gen\?: number\) =>/);
+  });
+
+  it("onSendStart mints and returns a fresh generation per armed receipt", () => {
+    expect(appShell).toContain("const receiptGenRef = useRef(0);");
+    expect(appShell).toMatch(/const gen = \+\+receiptGenRef\.current;/);
+    // Stamped onto the receipt it arms, and handed back to the caller so
+    // `ChatView.send` can thread it through whichever terminal outcome fires.
+    expect(appShell).toMatch(/\[threadId\]: \{ startedAt: now, lastFrameAt: now, gen \},/);
+    expect(appShell).toMatch(/return gen;\s*\n\s*\}, \[\]\);/);
+  });
+});

--- a/frontend/test/unit/chat-scroll-anchor.test.ts
+++ b/frontend/test/unit/chat-scroll-anchor.test.ts
@@ -41,30 +41,61 @@ const VIEWPORT_HEIGHT = 800;
  */
 let viewportHeight = VIEWPORT_HEIGHT;
 /**
- * Every live `ResizeObserver` callback, so a test can fire one.
+ * Every live `ResizeObserver` instance, so a test can fire the one watching a
+ * particular element.
  *
  * jsdom performs no layout and ships no `ResizeObserver` at all, so nothing
  * would ever call these on their own — which is the same reason the geometry
  * above is stubbed. The suite is asserting *which* anchoring call the component
  * makes when its box changes, not that a browser would have noticed.
+ *
+ * Target-tracking (rather than a flat array of bare callbacks) matters as of
+ * issue #1935: the component now registers two observers — rule 3 on the
+ * scroller's own box, rule 2b on the content column inside it — and a real
+ * browser only fires the one whose *observed element* actually resized. A
+ * mock that fired every registered callback regardless of target would have
+ * `shrinkViewport` (a scroller-box event) also trip rule 2b, which no browser
+ * would ever do for a resize the content column did not itself undergo.
  */
-let resizeCallbacks: Array<() => void> = [];
-
 class TestResizeObserver {
-  constructor(callback: () => void) {
-    resizeCallbacks.push(callback);
+  target: Element | null = null;
+  constructor(private readonly callback: ResizeObserverCallback) {
+    resizeObservers.push(this);
   }
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  observe(el: Element) {
+    this.target = el;
+  }
+  unobserve() {
+    this.target = null;
+  }
+  disconnect() {
+    this.target = null;
+  }
+  /** Invoke as a real observer would when its target resizes. */
+  fire() {
+    this.callback([] as unknown as ResizeObserverEntry[], this as unknown as ResizeObserver);
+  }
+}
+let resizeObservers: TestResizeObserver[] = [];
+
+/** Fire every observer currently watching `el`, as a browser would. */
+function fireResizeObservers(el: Element) {
+  act(() => {
+    for (const ro of resizeObservers) {
+      if (ro.target === el) ro.fire();
+    }
+  });
 }
 
 /** Shrink the pane by `px` and tell the component, as a browser would. */
 function shrinkViewport(px: number) {
   viewportHeight -= px;
-  act(() => {
-    for (const fire of resizeCallbacks) fire();
-  });
+  fireResizeObservers(scroller());
+}
+/** Grow the transcript column by `px` without touching any rule-2 prop. */
+function growContent(px: number) {
+  contentHeight += px;
+  fireResizeObservers(content());
 }
 /**
  * How tall the transcript is *right now* (issue #1224).
@@ -187,6 +218,11 @@ function scroller(): HTMLElement {
   return container.firstElementChild as HTMLElement;
 }
 
+/** The content column rule 2b observes — the scroller's one child. */
+function content(): HTMLElement {
+  return scroller().firstElementChild as HTMLElement;
+}
+
 beforeEach(() => {
   // React only treats `act` as a real boundary when this is set; without it
   // effects still run but React warns, and the warning is the honest signal
@@ -196,7 +232,7 @@ beforeEach(() => {
   scrollTop = 0;
   contentHeight = CONTENT_HEIGHT;
   viewportHeight = VIEWPORT_HEIGHT;
-  resizeCallbacks = [];
+  resizeObservers = [];
   savedResizeObserver = globalThis.ResizeObserver;
   (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = TestResizeObserver;
   stubGeometry();
@@ -530,5 +566,63 @@ describe("where an empty channel's intro sits", () => {
 
     expect(wrapper().className).toContain("justify-end");
     expect(wrapper().className).not.toContain("justify-start");
+  });
+});
+
+/**
+ * Rule 2b — content growing without moving any of rule 2's watched props
+ * (issue #1935 review, coderabbit 3892517543).
+ *
+ * `ChatLiveReceipt`'s "still waiting" note appears off a clock entirely
+ * internal to that component: none of `items.length`, `typing`, `queued` or
+ * `liveStepCount` change when it does, so rule 2 (keyed on exactly those)
+ * never fires. `growContent` below stands in for that note landing — the
+ * transcript column gets taller with no rule-2 dependency moving — which is
+ * the general shape of the gap, not just this one receipt's case of it.
+ *
+ * These fire only the observer targeting the *content* column, mirroring what
+ * a real `ResizeObserver` would do: a composer-driven scroller-box resize
+ * (`shrinkViewport`, exercised in "the composer growing under the
+ * transcript" above) must not also trip this one, and the reverse — asserted
+ * by rule 3's own suite still passing unchanged now that the mock is
+ * target-aware.
+ */
+describe("content growing without a tracked prop changing", () => {
+  it("follows a live receipt's stall note into view", () => {
+    const ch = channel("engineering");
+    render(ch, items(40, ch));
+    calls = [];
+
+    growContent(64);
+
+    expect(calls).toEqual([{ top: contentHeight, behavior: "smooth" }]);
+  });
+
+  it("leaves a reader alone who has scrolled up to read history", () => {
+    const ch = channel("engineering");
+    render(ch, items(40, ch));
+
+    scrollTop = 100;
+    act(() => {
+      scroller().dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    calls = [];
+
+    growContent(64);
+
+    expect(calls).toHaveLength(0);
+    expect(scrollTop).toBe(100);
+  });
+
+  it("does nothing while history is still on the wire", () => {
+    // Same gate rule 2 uses: a cold load's content grows repeatedly as
+    // history lands, and rule 1 owns the anchor until it has (issue #1224).
+    const ch = channel("engineering");
+    render(ch, [], true);
+    calls = [];
+
+    growContent(64);
+
+    expect(calls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1934. Turns the send-to-reply gap in chat into an honest **live receipt** instead of a dead pause. The instant a message is sent, the thread shows a receipt row that narrates the turn: **Sent → Picked up by _<agent>_ → on step _<label>_ → ticking elapsed**, with a soft, reversible **"no update for 30s"** note if a turn goes quiet. It clears exactly as the real reply lands — no duplicate bubble.

From the UX audit (Ankita + Gaf) Part 1 #3 — *"the waiting experience is the worst moment in the product, and it is one grey word."* This is the trust moment a first-time user judges us on; the work was already reliable, the gap was purely communication.

Frontend-only. The data was already on the wire — live `turn_stream` frames carry `agentId` + `chatId` over the existing `{scope}/events` SSE and `use-events` hook; we just weren't surfacing it as a receipt. No backend, no schema, no new event.

**Deferred (tracked, not silently dropped):**
- **Cancel** an in-flight chat turn — genuinely blocked on the synchronous chat model (a bare chat turn has no `InflightRegistry` entry, so no cancel target). Follow-up.
- **Backend enqueue/pickup ack frame** — not needed: the first `turn_stream` frame already carries `agent_id` + `chat_id`, so "picked up by _<agent>_" is truthful without it. Revisit only if the sent→first-frame window measures long.

## API Or Behavior Changes

No API changes. Behavior: while a chat POST is in flight, the thread now renders a `ChatLiveReceipt` row (supersedes the old static "Replying…" `TypingRow`; `LiveTurnRow`/`StepTimeline` still render tool detail). Agent attribution resolves `agentId → name`, falling back to the channel voice, then a generic "a teammate" — never a raw id. Thread-panel (open-thread) receipt is out of v1, matching the existing open-thread live-step exclusion.

## Tests

- New `frontend/test/unit/chat-live-receipt.test.ts` (9 tests, fake timers): Sent + elapsed; resolvable agent name; channel-voice fallback; running-step label; >30s stall + reversal; live 1s clock tick; `formatElapsed` seconds → m:ss.
- Gates green from `frontend/`: `typecheck`, `typecheck:unit`, `typecheck:e2e` all exit 0; `vitest run` → 3844 passed (3844); `npm run build` ✓ (only the pre-existing chunk-size advisory). No `.rs` changed, so the Rust gates are unaffected.

## Documentation

No doc changes — self-contained UI component, no public API or config surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live receipts for synchronous chat turns, showing sent, pickup, active steps, elapsed time, and teammate details.
  * Added live step timelines and clear messaging when a turn appears stalled for 30 seconds.
  * Receipts update as activity arrives and disappear when turns complete, fail, or close.
  * Added reduced-motion support, fallback teammate naming, and improved follow-scroll behavior as receipt content grows.
  * Prevented receipts and teammate names from appearing across company changes or being cleared by stale activity.

* **Tests**
  * Added coverage for receipt states, timing, stall recovery, motion behavior, scope isolation, and elapsed-time formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->