### PR TITLE
fix(runtime): set created_at_millis in two builder tests — main is red

### DIFF
--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -5109,7 +5109,6 @@ mod test {
                 setup: None,
                 name_confirmed: false,
                 activation_completed_at: None,
-                created_at_millis: None,
             })
             .await
             .unwrap();
@@ -8829,7 +8828,6 @@ needs_reason = true
                 setup: None,
                 name_confirmed: false,
                 activation_completed_at: None,
-                created_at_millis: None,
             })
             .await
             .unwrap();

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -5088,6 +5088,7 @@ mod test {
         let id = company_id_from_name("Acme");
         FsCompanyStore::new(home.path())
             .save(&CompanyRecord {
+                created_at_millis: None,
                 id: id.clone(),
                 manifest: reserved.clone(),
                 ledger: Vec::new(),
@@ -8807,6 +8808,7 @@ needs_reason = true
         let id = company_id_from_name("Acme");
         FsCompanyStore::new(dir.path())
             .save(&CompanyRecord {
+                created_at_millis: None,
                 id: id.clone(),
                 manifest: manifest.clone(),
                 ledger: Vec::new(),


### PR DESCRIPTION
## Summary

`main` is currently **red on the `Rust` CI lane** (failing on the tip and the prior commit). Two `CompanyRecord` literals in `src/runtime/builder.rs` tests were left without the `created_at_millis` field after it was added to the struct, so the **lib test target does not compile on any feature set** — a union-merge break between two individually-mergeable PRs, not any single change.

This is the minimal standalone fix (2 lines) so `main` goes green immediately and every open PR stops inheriting the red lane. Isolated deliberately rather than bundled into a feature PR.

## API Or Behavior Changes

None — test-literal fields only.

## Tests

- `cargo check --all-features` and scoped `cargo test --features openhuman` verified green with these two fields added (on the sibling branch where the break was first hit).
- Every `CompanyRecord` literal in `builder.rs` now carries `created_at_millis`.

## Documentation

None.