### PR TITLE
fix(harness): native-first capability routing — use built-in tools, Composio only for connected accounts (#1941)

### DIFF
--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -191,9 +191,9 @@ pub use types::{
     ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, PROMPT_CLASSES,
     PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan, Policy, Schedule, Skill, TIERS,
     TOOL_PROVIDERS, Tools, creation_default_grants, grants_chargebee_explicit,
-    grants_composio_explicit, grants_files_or_docs, grants_hosting_explicit, grants_media_explicit,
-    grants_paypal_explicit, grants_search_explicit, grants_workspace_write_explicit,
-    orchestrator_id,
+    grants_composio_explicit, grants_confer_native, grants_files_or_docs, grants_hosting_explicit,
+    grants_media_explicit, grants_paypal_explicit, grants_search_explicit,
+    grants_workspace_write_explicit, native_capability_namespaces, orchestrator_id,
 };
 pub use workflow_file::{
     STAGELESS_SCHEDULE_REFUSAL, STAGELESS_WORKFLOW_NOTICE, UNDELIVERABLE_SCHEDULE_REFUSAL,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -315,6 +315,37 @@ pub fn grants_search_explicit(grants: &[String]) -> bool {
         .any(|grant| grant == "search" || grant.starts_with("search."))
 }
 
+/// The [`GATEABLE_NAMESPACES`] a built-in tool can serve directly — the shared
+/// native-capability vocabulary both native-first routing levers key off.
+///
+/// It is `GATEABLE_NAMESPACES` minus `composio` (the third-party connection
+/// path, never a built-in tool) and minus `web` (the raw-HTTP family the
+/// Composio deflection guardrail governs). A future native tool flows into both
+/// levers by its [`namespace_of`](crate::harness::toolbelt::namespace_of) arm
+/// landing in this set; nothing here is a literal capability name.
+pub fn native_capability_namespaces() -> Vec<&'static str> {
+    GATEABLE_NAMESPACES
+        .iter()
+        .copied()
+        .filter(|ns| *ns != "composio" && *ns != "web")
+        .collect()
+}
+
+/// Whether a grant list confers the native namespace `ns`, mirroring the
+/// harness wiring gate: the real-money `search`/`media` families through their
+/// explicit grant helpers (the catch-all `*` never confers them), and every
+/// other namespace through the ordinary namespace rule a bare `*` satisfies.
+pub fn grants_confer_native(grants: &[String], ns: &str) -> bool {
+    use crate::runtime::tools::{NAMESPACE_SEPARATORS, extends_on_boundary};
+    match ns {
+        "search" => grants_search_explicit(grants),
+        "media" => grants_media_explicit(grants),
+        _ => grants
+            .iter()
+            .any(|grant| grant == "*" || extends_on_boundary(grant, ns, NAMESPACE_SEPARATORS)),
+    }
+}
+
 /// Whether a tool-grant list confers the **publishing** capability (issue #244)
 /// — the `files`/`docs` namespace on which both an agent's file tools and
 /// `publish_artifact` ride.
@@ -1734,6 +1765,41 @@ pub struct Schedule {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// The shared native vocabulary is exactly `GATEABLE_NAMESPACES` minus the
+    /// third-party connection path (`composio`) and the raw-HTTP family the S2
+    /// deflection governs (`web`).
+    #[test]
+    fn native_capability_vocabulary_is_gateable_minus_composio_and_web() {
+        let native: std::collections::HashSet<&str> =
+            native_capability_namespaces().into_iter().collect();
+        let expected: std::collections::HashSet<&str> = GATEABLE_NAMESPACES
+            .iter()
+            .copied()
+            .filter(|ns| *ns != "composio" && *ns != "web")
+            .collect();
+        assert_eq!(native, expected);
+        assert!(!native.contains("composio"));
+        assert!(!native.contains("web"));
+    }
+
+    /// `grants_confer_native` mirrors the harness wiring gate: the real-money
+    /// `search`/`media` families need their explicit grant (a bare `*` confers
+    /// neither), and every other native namespace rides the ordinary rule a `*`
+    /// satisfies.
+    #[test]
+    fn grants_confer_native_mirrors_the_wiring_gate() {
+        assert!(grants_confer_native(&["search".into()], "search"));
+        assert!(!grants_confer_native(&["*".into()], "search"));
+        assert!(!grants_confer_native(&["composio".into()], "search"));
+
+        assert!(grants_confer_native(&["media".into()], "media"));
+        assert!(!grants_confer_native(&["*".into()], "media"));
+
+        assert!(grants_confer_native(&["*".into()], "shell"));
+        assert!(grants_confer_native(&["shell".into()], "shell"));
+        assert!(!grants_confer_native(&["search".into()], "shell"));
+    }
 
     /// **T10 (issue #971).** A manifest that never mentions
     /// `approval_ttl_hours` parses to `None` and serializes without the key —

--- a/src/harness/built_in/build.rs
+++ b/src/harness/built_in/build.rs
@@ -886,7 +886,13 @@ pub fn build_agent(
     if toolbelt::composio_capability_admits(composio_toolkits.is_some(), &deps.capabilities)
         && let Some(toolkits) = composio_toolkits.as_deref()
     {
-        persona.push_str(&crate::harness::composio_catalog::composio_brief(toolkits));
+        let native_caps: Vec<&str> = toolbelt::native_capabilities_on_belt(&tools)
+            .into_iter()
+            .collect();
+        persona.push_str(&crate::harness::composio_catalog::composio_brief(
+            toolkits,
+            &native_caps,
+        ));
     }
 
     // Skill read surface (read-only catalogue slice). Only materializes when the
@@ -2117,6 +2123,76 @@ mod tests {
         let mut names: Vec<String> = agent.tools().iter().map(|t| t.name().to_string()).collect();
         names.sort();
         names
+    }
+
+    /// The native capabilities `native_capabilities_on_belt` reads off the SAME
+    /// agent [`built_tool_names_with_search`] builds — proving the brief's native
+    /// set is derived from tools that were actually wired, not from the grants.
+    fn built_native_caps_with_search(grants: &[&str]) -> Vec<String> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut deps = pin_deps(dir.path().to_path_buf());
+        deps.search = Some(crate::harness::search::SearchBackend::new(
+            "https://api.example.test".to_string(),
+            crate::company::credentials::Credential::from_value("managed-platform-token"),
+            crate::company::DEFAULT_SEARCH_DAILY_CALLS,
+        ));
+        let manifest_agent = ManifestAgent {
+            global: false,
+            id: "desk".to_string(),
+            role: "Desk Lead".to_string(),
+            name: None,
+            description: None,
+            tier: None,
+            harness: None,
+            tools: None,
+            delegates_to: Vec::new(),
+            context: None,
+            budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
+            model: None,
+        };
+        let policy = ApprovalPolicy::new(&Policy::default(), None);
+        let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
+        let agent = build_agent(
+            &CompanyId::new("acme"),
+            "Acme",
+            &manifest_agent,
+            policy,
+            &deps,
+            &grants,
+            &[],
+            &[],
+            None,
+            false,
+        )
+        .expect("agent builds");
+        toolbelt::native_capabilities_on_belt(agent.tools())
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// The brief's native set is read off the wired belt: an explicit `search`
+    /// grant with a credential wires `web_search`, so `search` shows up in the
+    /// belt's native capabilities — and a bare `*` (which never wires the metered
+    /// tool) does not.
+    #[test]
+    fn native_capabilities_on_belt_track_the_wired_search_tool() {
+        let granted = built_native_caps_with_search(&["search"]);
+        assert!(
+            granted.contains(&"search".to_string()),
+            "an explicit search grant wires web_search, so `search` is native on the belt: {granted:?}"
+        );
+        let wildcard = built_native_caps_with_search(&["*"]);
+        assert!(
+            !wildcard.contains(&"search".to_string()),
+            "a bare `*` wires no metered search tool, so `search` is not native on the belt: {wildcard:?}"
+        );
     }
 
     /// Build one agent under `grants` with BOTH a managed search backend and a

--- a/src/harness/built_in/composio_catalog.rs
+++ b/src/harness/built_in/composio_catalog.rs
@@ -740,7 +740,14 @@ pub fn list_tools_description() -> &'static str {
 /// non-empty names exactly the connected toolkits, and empty is open mode, where
 /// the agent is pointed at `composio_list_connections` to discover them rather
 /// than promised a provider (GitHub, say) that may not be connected.
-pub fn composio_brief(toolkits: &[String]) -> String {
+///
+/// `native_caps` are the native capability namespaces the agent actually holds a
+/// built-in tool for ([`native_capabilities_on_belt`](crate::harness::toolbelt::native_capabilities_on_belt)).
+/// Non-empty adds a precedence line: use the built-in tool for those directly,
+/// reserve Composio for connected third-party accounts with no built-in tool.
+/// Empty renders no such line, leaving the brief byte-identical to a brief that
+/// names only the Composio surface.
+pub fn composio_brief(toolkits: &[String], native_caps: &[&str]) -> String {
     let named: Vec<String> = toolkits
         .iter()
         .map(|toolkit| toolkit.trim().to_ascii_lowercase())
@@ -795,6 +802,16 @@ pub fn composio_brief(toolkits: &[String]) -> String {
             "Connected toolkits for this company: {}. Confirm their live state with \
              `composio_list_connections`.\n",
             named.join(", ")
+        ));
+    }
+
+    if !native_caps.is_empty() {
+        brief.push_str(&format!(
+            "Some of what you might reach for you already hold as built-in tools of your own: {}. \
+             Use those built-in tools directly for these — do not route them through Composio. \
+             Composio is only for the company's connected third-party accounts that have no \
+             built-in tool of your own.\n",
+            native_caps.join(", ")
         ));
     }
 
@@ -1501,7 +1518,7 @@ mod tests {
     /// sandbox brief exists to stop, one surface over.
     #[test]
     fn the_composio_brief_names_the_tools_and_the_two_step() {
-        let brief = composio_brief(&["github".to_string()]);
+        let brief = composio_brief(&["github".to_string()], &[]);
         for tool in [
             "composio_list_toolkits",
             "composio_list_connections",
@@ -1519,7 +1536,7 @@ mod tests {
     /// `http_request` — must be called out by name.
     #[test]
     fn the_composio_brief_routes_provider_apis_through_composio_not_the_web_tools() {
-        let brief = composio_brief(&["github".to_string()]);
+        let brief = composio_brief(&["github".to_string()], &[]);
         for web_tool in ["http_request", "curl", "web_fetch"] {
             assert!(
                 brief.contains(web_tool),
@@ -1534,7 +1551,7 @@ mod tests {
     /// tool for, with the exact browser overreach the issue observed named.
     #[test]
     fn the_composio_brief_forbids_promising_actions_it_has_no_tool_for() {
-        let brief = composio_brief(&["github".to_string()]);
+        let brief = composio_brief(&["github".to_string()], &[]);
         let lower = brief.to_lowercase();
         assert!(lower.contains("no browser"), "{brief}");
         assert!(lower.contains("do not promise"), "{brief}");
@@ -1551,7 +1568,7 @@ mod tests {
     /// (or equivalent), not stated as an absolute.
     #[test]
     fn the_composio_brief_does_not_unconditionally_deny_holding_a_browser_tool() {
-        let brief = composio_brief(&["github".to_string()]);
+        let brief = composio_brief(&["github".to_string()], &[]);
         let lower = brief.to_lowercase();
         assert!(
             lower.contains("unless you were separately granted a browser tool")
@@ -1566,7 +1583,7 @@ mod tests {
     /// list.
     #[test]
     fn the_composio_brief_names_the_connected_toolkits_lowercased() {
-        let brief = composio_brief(&["GitHub".to_string(), " Gmail ".to_string()]);
+        let brief = composio_brief(&["GitHub".to_string(), " Gmail ".to_string()], &[]);
         assert!(
             brief.contains("Connected toolkits for this company: github, gmail"),
             "{brief}"
@@ -1580,7 +1597,7 @@ mod tests {
     /// agent does not hold.
     #[test]
     fn the_composio_brief_does_not_advertise_github_outside_a_restricting_allowlist() {
-        let brief = composio_brief(&["slack".to_string()]);
+        let brief = composio_brief(&["slack".to_string()], &[]);
         assert!(
             !brief.to_lowercase().contains("github"),
             "an allowlist that excludes GitHub must not name it as reachable: {brief}"
@@ -1600,7 +1617,7 @@ mod tests {
     /// a toolkit that is not known-connected.
     #[test]
     fn the_composio_brief_open_mode_points_at_discovery_without_naming_a_provider() {
-        let brief = composio_brief(&[]);
+        let brief = composio_brief(&[], &[]);
         assert!(
             brief.contains("not fixed here"),
             "open mode must defer to discovery: {brief}"
@@ -1625,7 +1642,7 @@ mod tests {
     /// this company:" line.
     #[test]
     fn the_composio_brief_open_mode_does_not_name_github_before_discovery() {
-        let brief = composio_brief(&[]);
+        let brief = composio_brief(&[], &[]);
         assert!(
             !brief.contains("Connected integrations (GitHub and other SaaS)")
                 && !brief.contains("You reach GitHub"),
@@ -1642,6 +1659,52 @@ mod tests {
         // test forbade the substring "github" outright, which took the
         // example down with the claim and broke that guarantee.
         assert!(brief.contains("api.github.com"), "{brief}");
+    }
+
+    /// A native capability the agent already holds a built-in tool for is named
+    /// as such, and told to be used directly rather than routed through Composio.
+    #[test]
+    fn the_composio_brief_names_native_capabilities_as_built_in_not_composio() {
+        let brief = composio_brief(&["github".to_string()], &["search"]);
+        assert!(
+            brief.contains("built-in tools of your own: search"),
+            "the native capability must be named: {brief}"
+        );
+        assert!(
+            brief.contains("do not route them through Composio"),
+            "the precedence must tell the agent to use the built-in tool directly: {brief}"
+        );
+    }
+
+    /// Empty native caps render no precedence line, leaving the brief as it was
+    /// before native-first routing — and the S2 raw-HTTP deflection warning is
+    /// untouched either way.
+    #[test]
+    fn the_composio_brief_with_no_native_caps_is_unchanged_and_keeps_the_deflection_warning() {
+        let brief = composio_brief(&["github".to_string()], &[]);
+        assert!(
+            !brief.contains("built-in tools of your own"),
+            "no native caps must add no precedence line: {brief}"
+        );
+        // The S2 raw-HTTP deflection warning is verbatim regardless.
+        assert!(brief.contains("http_request"), "{brief}");
+        assert!(brief.contains("api.github.com"), "{brief}");
+        assert!(brief.contains("401") || brief.contains("403"), "{brief}");
+    }
+
+    /// The two levers coexist on one brief: a connected toolkit is still routed
+    /// through Composio while a native capability is called out as built-in.
+    #[test]
+    fn the_composio_brief_routes_composio_toolkits_and_native_caps_separately() {
+        let brief = composio_brief(&["gmail".to_string()], &["search"]);
+        assert!(
+            brief.contains("Connected toolkits for this company: gmail"),
+            "the connected toolkit is still routed through Composio: {brief}"
+        );
+        assert!(
+            brief.contains("built-in tools of your own: search"),
+            "the native capability is called out as built-in: {brief}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/harness/built_in/planning.rs
+++ b/src/harness/built_in/planning.rs
@@ -867,6 +867,16 @@ struct Evidence {
     /// Distinct from [`Self::composio_reachable`], which is "did the probe
     /// answer" — a liveness fact. This one is "do we hold a bearer at all".
     composio_credential: bool,
+    /// Native capability namespaces some plannable teammate holds a built-in
+    /// tool for — the company can serve these without any Composio connection.
+    ///
+    /// Union scope over the roster's grants
+    /// ([`grants_confer_native`](crate::company::grants_confer_native) over each
+    /// teammate), keyed to the shared native vocabulary
+    /// ([`native_capability_namespaces`](crate::company::native_capability_namespaces)).
+    /// A `connection`/`composio` prerequisite naming one of these is satisfied by
+    /// the built-in tool rather than parked on a connection it never needed.
+    native_capabilities: HashSet<String>,
 }
 
 impl Evidence {
@@ -916,6 +926,23 @@ fn settled_assignee(card_assignee: &str, proposed: Option<String>) -> Option<Str
         "" => proposed,
         existing => Some(existing.to_string()),
     }
+}
+
+/// The native capability namespaces the company can serve with a built-in tool,
+/// as a union over the roster: a namespace is included when **any** teammate's
+/// grants confer it. Union scope is deliberate — one teammate holding the tool
+/// means the company can do the work natively, so no card should park on a
+/// Composio connection for it.
+fn native_capabilities_of(teammates: &[TeammateBrief]) -> HashSet<String> {
+    crate::company::native_capability_namespaces()
+        .into_iter()
+        .filter(|ns| {
+            teammates
+                .iter()
+                .any(|t| crate::company::grants_confer_native(&t.grants, ns))
+        })
+        .map(str::to_string)
+        .collect()
 }
 
 /// Reads the company's own state — deterministically, with no model in the
@@ -1102,6 +1129,8 @@ async fn gather_evidence(
     )
     .await;
 
+    let native_capabilities = native_capabilities_of(&teammates);
+
     Ok(Evidence {
         company_name: record.manifest.company.name.clone(),
         policy_mode: record.manifest.policy.mode.clone(),
@@ -1120,6 +1149,7 @@ async fn gather_evidence(
         skills,
         mail_configured: runtime.mail().is_some(),
         composio_credential,
+        native_capabilities,
     })
 }
 
@@ -1595,6 +1625,16 @@ fn evidence_prompt(e: &Evidence) -> String {
 /// dispatch into work it cannot do. See `verify_connection` for the arm and
 /// issues #319/#396 for when that stops being true.
 ///
+/// **One exception precedes both arms: a capability the company already serves
+/// with a built-in tool.** When the prerequisite name is a native capability
+/// namespace some plannable teammate holds a tool for
+/// ([`Evidence::native_capabilities`]), `connection` and `composio` both return
+/// `satisfied` with a note that no Composio connection is needed — a
+/// web-research card must not park on a `composio search` connection it never
+/// needed when `web_search` is wired. This is checked before the outage
+/// `unknown` guard, so a built-in capability stays satisfied even when the
+/// Composio probe is down.
+///
 /// Permissions are checked against the **manifest** only: the tool allow-list,
 /// the agent's own list, and `[policy]`. Not the live grant set
 /// (`runtime::grants`) and not the harness [`ApprovalPolicy`] — those are the
@@ -1648,6 +1688,12 @@ async fn verify_prerequisites(
 }
 
 fn verify_connection(e: &Evidence, name: &str) -> (PrereqStatus, String) {
+    if e.native_capabilities.contains(&name.to_ascii_lowercase()) {
+        return (
+            PrereqStatus::Satisfied,
+            format!("{name} is served by a built-in tool — no Composio connection is needed"),
+        );
+    }
     match e.connections.get(&name.to_ascii_lowercase()) {
         Some((_, _, true)) => (
             PrereqStatus::Unknown,
@@ -1700,6 +1746,12 @@ fn verify_connection(e: &Evidence, name: &str) -> (PrereqStatus, String) {
 }
 
 fn verify_composio(e: &Evidence, name: &str) -> (PrereqStatus, String) {
+    if e.native_capabilities.contains(&name.to_ascii_lowercase()) {
+        return (
+            PrereqStatus::Satisfied,
+            format!("{name} is served by a built-in tool — no Composio connection is needed"),
+        );
+    }
     if !e.composio_reachable {
         return (
             PrereqStatus::Unknown,

--- a/src/harness/built_in/planning/test.rs
+++ b/src/harness/built_in/planning/test.rs
@@ -231,6 +231,7 @@ fn evidence() -> Evidence {
         skills: vec!["writing".to_string()],
         mail_configured: false,
         composio_credential: true,
+        native_capabilities: HashSet::new(),
     }
 }
 
@@ -579,6 +580,79 @@ fn composio_distinguishes_no_credential_from_no_account() {
         note.contains("no Composio credential"),
         "the operator needs to know which of the two things is missing: {note}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Native-first routing: a built-in tool pre-empts a Composio prerequisite
+// ---------------------------------------------------------------------------
+
+fn teammate_with_grants(id: &str, grants: &[&str]) -> TeammateBrief {
+    TeammateBrief {
+        id: id.to_string(),
+        role: "Role".to_string(),
+        description: None,
+        grants: grants.iter().map(|g| g.to_string()).collect(),
+        global: false,
+    }
+}
+
+/// A capability the company already serves with a built-in tool satisfies BOTH
+/// the `connection` and `composio` prerequisite kinds — with a note that says a
+/// built-in tool serves it and no Composio connection is needed — instead of
+/// parking the card on a connection it never needed.
+#[test]
+fn a_native_capability_pre_empts_both_composio_prerequisite_kinds() {
+    let mut e = evidence();
+    e.native_capabilities = HashSet::from(["search".to_string()]);
+
+    let (status, note) = verify_composio(&e, "search");
+    assert_eq!(status, PrereqStatus::Satisfied);
+    assert!(note.contains("built-in tool"), "{note}");
+    assert!(!note.contains("Connections tab"), "{note}");
+
+    let (status, note) = verify_connection(&e, "search");
+    assert_eq!(status, PrereqStatus::Satisfied);
+    assert!(note.contains("built-in tool"), "{note}");
+    assert!(!note.contains("Connections tab"), "{note}");
+}
+
+/// A prerequisite that is NOT a native capability and has no connection still
+/// parks — native-first widens nothing for a genuine third-party account.
+#[test]
+fn a_non_native_capability_without_a_connection_still_parks() {
+    let mut e = evidence();
+    e.native_capabilities = HashSet::from(["search".to_string()]);
+    assert_eq!(verify_composio(&e, "gmail").0, PrereqStatus::Missing);
+    assert_eq!(verify_connection(&e, "gmail").0, PrereqStatus::Missing);
+}
+
+/// The native branch is checked before the Composio-outage `unknown` guard, so
+/// a built-in capability stays satisfied even when the probe is down — while a
+/// genuine third-party name under the same outage still reads `unknown`.
+#[test]
+fn the_native_branch_wins_even_when_composio_is_unreachable() {
+    let mut e = evidence();
+    e.native_capabilities = HashSet::from(["search".to_string()]);
+    e.composio_reachable = false;
+    assert_eq!(verify_composio(&e, "search").0, PrereqStatus::Satisfied);
+    assert_eq!(verify_connection(&e, "search").0, PrereqStatus::Satisfied);
+    assert_eq!(verify_composio(&e, "gmail").0, PrereqStatus::Unknown);
+}
+
+/// The set is a union over the roster: an explicit `search` grant on any one
+/// teammate marks `search` native, while `*` or `composio` alone never confers
+/// the metered search family (and `composio` is not in the native vocabulary).
+#[test]
+fn native_capabilities_are_a_union_over_the_roster_grants() {
+    let set = native_capabilities_of(&[teammate_with_grants("maya", &["search"])]);
+    assert!(set.contains("search"));
+
+    let set = native_capabilities_of(&[
+        teammate_with_grants("ann", &["*"]),
+        teammate_with_grants("bob", &["composio"]),
+    ]);
+    assert!(!set.contains("search"));
+    assert!(!set.contains("composio"));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/harness/built_in/toolbelt.rs
+++ b/src/harness/built_in/toolbelt.rs
@@ -726,6 +726,24 @@ pub fn filter_by_capabilities(
     }
 }
 
+/// The native capability namespaces actually present on a built tool belt.
+///
+/// Derived the same way [`filter_by_capabilities`] reads the belt — each tool's
+/// [`namespace_of`] — kept to the shared native vocabulary
+/// ([`native_capability_namespaces`](crate::company::native_capability_namespaces)),
+/// so a tool that was wired makes its namespace show up here and one that was
+/// not never does. Sorted and unique for a stable system-prompt rendering.
+pub fn native_capabilities_on_belt(
+    tools: &[Box<dyn Tool>],
+) -> std::collections::BTreeSet<&'static str> {
+    let native = crate::company::native_capability_namespaces();
+    tools
+        .iter()
+        .filter_map(|tool| namespace_of(tool.name()))
+        .filter(|ns| native.contains(ns))
+        .collect()
+}
+
 /// Whether a [`CapabilityFilter`] denies a given namespace — the same test
 /// [`filter_by_capabilities`] applies per tool, exposed standalone so a
 /// caller that needs the outcome without a tool vector in hand (the sandbox
@@ -1104,6 +1122,54 @@ mod tests {
             GATEABLE_NAMESPACES.contains(&"search"),
             "the metered search namespace must be gateable (issue #238)"
         );
+    }
+
+    /// Every namespace `namespace_of` can emit that is neither the Composio
+    /// connection path nor the raw-HTTP `web` family must be in the shared
+    /// native vocabulary — otherwise a future native tool would be wired but
+    /// invisible to native-first routing (the brief and the classifier both key
+    /// off that vocabulary).
+    #[test]
+    fn native_vocabulary_covers_every_native_mapped_namespace() {
+        let mapped = [
+            "shell",
+            "read_workspace_state",
+            "apply_patch",
+            "git_operations",
+            "csv_export",
+            "web_fetch",
+            "http_request",
+            "curl",
+            "image_info",
+            "media_generate_image",
+            "media_generate_video",
+            "media_list_models",
+            "composio_list_toolkits",
+            "composio_list_connections",
+            "composio_list_tools",
+            "composio_authorize",
+            "composio_execute",
+            "web_search",
+            "exa_find_similar",
+            "exa_get_contents",
+            "brave_news_search",
+            "brave_image_search",
+            "brave_video_search",
+        ];
+        let native: std::collections::HashSet<&str> =
+            crate::company::native_capability_namespaces()
+                .into_iter()
+                .collect();
+        for tool in mapped {
+            let ns = namespace_of(tool).expect("mapped tool has a namespace");
+            if ns == "composio" || ns == "web" {
+                continue;
+            }
+            assert!(
+                native.contains(ns),
+                "native namespace `{ns}` (from `{tool}`) is not in the native vocabulary"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Capability grounding used to say "Composio for everything", so a native tool
that already serves a task was ignored and the card parked on a Composio
connection it never needed — a web-research task filed a `composio search`
prerequisite and parked even though the native `web_search` tool was wired.

This fixes it generally: the native-vs-Composio split is now derived from what
is actually wired, not from a hard-coded list. `search` is never a literal in
either lever — a future native tool flows in automatically by its `namespace_of`
arm.

The design is one shared vocabulary and two levers that read it from the two
sources of truth available at their layer:

- **Shared vocabulary** (`native_capability_namespaces`, always compiled):
  `GATEABLE_NAMESPACES` minus `composio` (the third-party connection path) and
  minus `web` (the raw-HTTP family the S2 deflection governs). Both levers key
  off this one set, and `grants_confer_native` mirrors the harness wiring gate
  (`search`/`media` by their explicit grant, others by the ordinary namespace
  rule).
- **Lever 1 — the brief reads the wired tools.** At the brief call site the
  fully-wired tool vector is in scope, so the native set is derived exactly the
  way `filter_by_capabilities` reads the belt. The brief then names those
  capabilities dynamically and tells the agent to use its built-in tools for
  them directly, reserving Composio for connected third-party accounts with no
  built-in tool. An empty native set renders no such line — the brief is
  byte-identical to before, and the raw-HTTP deflection warning is untouched.
- **Lever 2 — the classifier reads the grants** (deterministic backstop). The
  planning pass cannot build the harness, so it derives the native set from a
  union over the roster's grants: a namespace is native if any plannable
  teammate confers it. Before the Missing verdict and before the Composio-outage
  guard, a `connection`/`composio` prerequisite whose name is a native capability
  is satisfied with a note that a built-in tool serves it.

The S2 http-deflection guardrail and the set of Composio-only capabilities are
untouched.

## API Or Behavior Changes

- `composio_catalog::composio_brief` gains a `native_caps: &[&str]` parameter.
- `company` gains two always-compiled helpers: `native_capability_namespaces()`
  and `grants_confer_native()`.
- Planning `Evidence` gains a `native_capabilities` field; `verify_connection`
  and `verify_composio` now short-circuit to `Satisfied` for a native
  capability instead of parking on a Composio connection.
- No manifest, schema, or wire-format change. A company with no native tools on
  the belt sees identical prompts and identical prerequisite verdicts.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (also
  `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings`)
- [x] `cargo check --all-features` (new `Evidence` field)
- [x] Scoped `cargo test --features openhuman` on
  `harness::built_in::{planning,composio_catalog,toolbelt,build}` and
  `company::types::test` — all green

New coverage: brief renders the native precedence line and keeps the S2 warning
(and is unchanged when the native set is empty); the classifier satisfies both
prerequisite kinds for a native capability, wins under a Composio outage, still
parks a genuine third-party account, and derives the set as a union over the
roster grants; the shared vocabulary equals `GATEABLE` minus `{composio, web}`,
with a coverage assertion that every non-composio/non-web `namespace_of` arm is
representable so a future native tool cannot be added without updating the
vocabulary; and the brief's native set is proven to be read off the actually-
wired belt.

> Note: this branch is cut from `upstream/main` at `7474e3ca2`, on which the
> `--features openhuman` **lib-test** target does not compile — two test
> constructors in `src/runtime/builder.rs` omit the `created_at_millis` field
> added to `CompanyRecord` (a merge-race, unrelated to this change). That base
> breakage is **already fixed on current `upstream/main`**, so a rebase clears
> it and the openhuman test/clippy lanes go green. The scoped tests above were
> run with that same 2-line back-fill applied locally (NOT committed) to keep
> this PR scoped to #1941.

## Documentation

Doc comments on the new helpers, the brief, the `Evidence` field, and the
`verify_prerequisites` table describe the native-served exception. No spec/module
markdown needed — this is an internal routing refinement with no manifest or
API-surface change.

Closes #1941


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native capabilities are now detected from an agent’s available tools and explicit grants.
  * Built-in tools are preferred over Composio when they can satisfy a capability.
  * Planning recognizes native capabilities as satisfied, including during Composio outages.

* **Bug Fixes**
  * Wildcard grants no longer incorrectly imply native search or media capabilities.
  * Unrelated capabilities retain their existing missing or unknown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->