### PR TITLE
fix(harness): stop board-op chat minting a card + keep dispatch relays out of private DMs

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -6475,7 +6475,7 @@ mod tests {
         let relay = |c: &TaskRecord| {
             let origin = c.origin_chat_id.clone().expect("origin");
             let speaker = relay_speaker(&record, &origin, orchestrator);
-            relay_reply(c, orchestrator, &speaker, origin)
+            relay_reply(c, orchestrator, &speaker, origin, &[])
         };
         let replies = HashMap::from([
             ("t-dm".to_string(), relay(&dm_card)),

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -6359,6 +6359,176 @@ mod tests {
         );
     }
 
+    /// A dispatched card whose origin is a teammate's **private DM** relays as
+    /// that teammate, so the orchestrator never authors a second voice in a
+    /// one-to-one thread — while a shared desk keeps the orchestrator's voice.
+    ///
+    /// The relay is produced the way `HarnessBrain::run_task` produces it:
+    /// through [`relay_speaker`](crate::harness::built_in::brain::relay_speaker)
+    /// + `relay_reply`, so a regression that let the orchestrator reclaim the DM
+    /// voice would flip the journaled author and fail this test.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn a_private_dm_relay_is_authored_by_the_dm_agent_not_the_orchestrator() {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        use crate::harness::built_in::brain::relay_speaker;
+        use crate::harness::built_in::lifecycle::relay_reply;
+        use crate::ports::Brain;
+        use crate::ports::TaskRecord;
+        use crate::ports::brain::CycleHost;
+        use crate::ports::tasks::COLUMN_IN_REVIEW;
+        use crate::ports::types::{
+            CycleRequest, CycleResult, EventSeq, OutboundMessage, TokenUsage,
+        };
+
+        /// Replays a pre-built relay for each `TaskDispatched` it recognises.
+        struct RelayBrain {
+            replies: HashMap<String, OutboundMessage>,
+        }
+
+        #[async_trait::async_trait]
+        impl Brain for RelayBrain {
+            async fn run_cycle(
+                &self,
+                req: CycleRequest,
+                _host: &dyn CycleHost,
+            ) -> crate::Result<CycleResult> {
+                let mut channel_responses = Vec::new();
+                for event in &req.events {
+                    if let CompanyEvent::TaskDispatched { task_id, .. } = event
+                        && let Some(reply) = self.replies.get(task_id)
+                    {
+                        channel_responses.push(reply.clone());
+                    }
+                }
+                Ok(CycleResult {
+                    channel_responses,
+                    new_traces: Vec::new(),
+                    ledger_deltas: Vec::new(),
+                    token_usage: TokenUsage::default(),
+                })
+            }
+        }
+
+        let manifest_toml = "[company]\nname = \"Acme\"\n\
+             [policy]\nmode = \"full\"\n\
+             [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n\
+             [[agent]]\nid = \"writer\"\nrole = \"Writer\"\n\
+             [[group_chat]]\nid = \"strategy\"\nname = \"Strategy\"\nmembers = [\"ceo\"]\n";
+        let manifest: crate::company::CompanyManifest =
+            toml::from_str(manifest_toml).expect("manifest");
+
+        // A record standing for the same roster, to compute the relay authorship
+        // exactly as `HarnessBrain` would. Journaling never reads it; it only
+        // drives `relay_speaker`.
+        let record = crate::ports::types::CompanyRecord {
+            overlay_retired_agents: Vec::new(),
+            overlay_agent_edits: Vec::new(),
+            id: crate::ports::types::CompanyId::new("acme"),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_tool_grants: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+            name_confirmed: false,
+            activation_completed_at: None,
+            created_at_millis: None,
+        };
+
+        let orchestrator = "ceo";
+        let card = |id: &str, origin: &str| TaskRecord {
+            id: id.to_string(),
+            title: "Ship it".to_string(),
+            note: None,
+            column: COLUMN_IN_REVIEW.to_string(),
+            priority: "medium".to_string(),
+            assignee: origin.to_string(),
+            updated_at_millis: 0,
+            origin_chat_id: Some(origin.to_string()),
+            parent_task_id: None,
+            output: None,
+            plan: None,
+            planning_attempts: Vec::new(),
+            deliverable: crate::ports::tasks::TaskDeliverable::Once,
+            workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
+            bounced: None,
+        };
+        let dm_card = card("t-dm", "writer");
+        let desk_card = card("t-desk", "strategy");
+
+        // Built the way `run_task` builds them: the speaker is the origin DM's
+        // own agent, or the orchestrator for a shared surface.
+        let relay = |c: &TaskRecord| {
+            let origin = c.origin_chat_id.clone().expect("origin");
+            let speaker = relay_speaker(&record, &origin, orchestrator);
+            relay_reply(c, orchestrator, &speaker, origin)
+        };
+        let replies = HashMap::from([
+            ("t-dm".to_string(), relay(&dm_card)),
+            ("t-desk".to_string(), relay(&desk_card)),
+        ]);
+
+        let home_dir = tempfile::Builder::new()
+            .prefix("opencompany-private-dm-relay-")
+            .tempdir()
+            .expect("tempdir");
+        let id = crate::ports::types::CompanyId::new("acme");
+        let runtime = Arc::new(
+            crate::runtime::RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest)
+                .with_id(id.clone())
+                .with_brain(Arc::new(RelayBrain { replies }))
+                .build()
+                .await
+                .expect("runtime"),
+        );
+
+        for c in [&dm_card, &desk_card] {
+            let run_id = runtime.open_run(c).await;
+            Arc::clone(&runtime)
+                .run_dispatch_cycle(c.id.clone(), run_id)
+                .await;
+        }
+
+        let events = runtime
+            .events
+            .read_from(&id, EventSeq::new(0), usize::MAX)
+            .await
+            .expect("read journal");
+        let author_in = |thread: &str| {
+            events.iter().find_map(|stored| match &stored.event {
+                CompanyEvent::AgentReply {
+                    chat_id, agent_id, ..
+                } if chat_id == thread => Some(agent_id.clone()),
+                _ => None,
+            })
+        };
+
+        assert_eq!(
+            author_in("writer").as_deref(),
+            Some("writer"),
+            "a relay into the writer's private DM must be authored by the writer"
+        );
+        assert_eq!(
+            author_in("strategy").as_deref(),
+            Some("ceo"),
+            "a relay into a shared desk keeps the orchestrator's voice"
+        );
+    }
+
     /// Issue #1852: the gate that stops a dispatch relay from being posted
     /// twice.
     ///

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -190,6 +190,8 @@ const ACTION_VERBS: &[&str] = &[
     "cancel",
     "start",
     "stop",
+    "move",
+    "close",
     "implement",
     "deploy",
     "configure",
@@ -330,6 +332,32 @@ const READ_VERBS: &[&str] = &[
 /// read that lands there costs the operator nothing, whereas the gated request
 /// cost them the work.
 const READ_PHRASES: &[&str] = &["walk me through", "let me know", "remind me"];
+
+/// Phrases that point at the board or a card already on it, rather than at a new
+/// deliverable. Matched anywhere in the message, word-boundary-checked so "the
+/// card" does not fire inside "the cardstock".
+const BOARD_DEIXIS: &[&str] = &[
+    "the task card",
+    "this card",
+    "that card",
+    "the card",
+    "this task",
+    "that task",
+    "the ticket",
+    "the board",
+    "the column",
+    "the backlog",
+    "the kanban",
+];
+
+/// Mutable fields of a card. Ambiguous alone ("update the status page" is real
+/// work), so they demote only in board context — see
+/// [`field_noun_in_board_context`].
+const BOARD_FIELD_NOUNS: &[&str] = &["the status", "the priority", "the assignee"];
+
+/// Words that, immediately after a [`BOARD_FIELD_NOUNS`] phrase, mark it as the
+/// object of a board operation rather than the head of a longer noun.
+const BOARD_CONNECTIVES: &[&str] = &["on", "of", "for", "to", "and"];
 
 /// Max length of a generated task title.
 const TITLE_MAX: usize = 80;
@@ -478,12 +506,18 @@ pub fn triage_message_detailed(text: &str) -> TriageOutcome {
 
     // Frame beats interrogative: a polite instruction stays work.
     if REQUEST_FRAMES.iter().any(|f| core.starts_with(f)) && contains_action(core) {
+        if refers_to_board_entity(core) {
+            return matched(MessageTriage::Chatter);
+        }
         return matched(MessageTriage::Track(to_title(trimmed)));
     }
     if is_question(core) {
         return matched(MessageTriage::Answer);
     }
     if starts_with_action(core) {
+        if refers_to_board_entity(core) {
+            return matched(MessageTriage::Chatter);
+        }
         return matched(MessageTriage::Track(to_title(trimmed)));
     }
     // The residue. Every rule above declined, so this says only "no rule
@@ -681,6 +715,72 @@ fn starts_with_action(lower: &str) -> bool {
     // Trim trailing punctuation on the first word ("build," / "fix:").
     let first = first.trim_end_matches([',', ':', ';', '.', '!']);
     ACTION_VERBS.contains(&first)
+}
+
+/// Whether the object of the request is the board itself or a card on it — a
+/// message *about* the kanban rather than a new deliverable.
+fn refers_to_board_entity(lower: &str) -> bool {
+    if BOARD_DEIXIS.iter().any(|p| contains_word_bounded(lower, p)) {
+        return true;
+    }
+    field_noun_in_board_context(lower)
+}
+
+/// True when `phrase` occurs in `lower` with non-alphanumeric edges, so only a
+/// whole word matches.
+fn contains_word_bounded(lower: &str, phrase: &str) -> bool {
+    let bytes = lower.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = lower[from..].find(phrase) {
+        let start = from + rel;
+        let end = start + phrase.len();
+        let before = start == 0 || !bytes[start - 1].is_ascii_alphanumeric();
+        let after = end == lower.len() || !bytes[end].is_ascii_alphanumeric();
+        if before && after {
+            return true;
+        }
+        from = start + 1;
+    }
+    false
+}
+
+/// A [`BOARD_FIELD_NOUNS`] phrase used as a board operation's object: clause-final,
+/// or immediately followed by a connective/preposition/punctuation rather than a
+/// continuing noun.
+fn field_noun_in_board_context(lower: &str) -> bool {
+    let bytes = lower.as_bytes();
+    for phrase in BOARD_FIELD_NOUNS {
+        let mut from = 0;
+        while let Some(rel) = lower[from..].find(phrase) {
+            let start = from + rel;
+            let end = start + phrase.len();
+            from = start + 1;
+            let before = start == 0 || !bytes[start - 1].is_ascii_alphanumeric();
+            let after = end == lower.len() || !bytes[end].is_ascii_alphanumeric();
+            if before && after && followed_by_board_context(&lower[end..]) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Whether what trails a field noun marks it as a board operation's object: the
+/// clause ends, or the next token is punctuation or a [`BOARD_CONNECTIVES`] word
+/// — but not a continuing noun ("the status **page**").
+fn followed_by_board_context(rest: &str) -> bool {
+    let rest = rest.trim_start();
+    match rest.chars().next() {
+        None => true,
+        Some(c) if !c.is_alphanumeric() => true,
+        Some(_) => {
+            let next_word = rest
+                .split(|c: char| !c.is_alphanumeric())
+                .next()
+                .unwrap_or("");
+            BOARD_CONNECTIVES.contains(&next_word)
+        }
+    }
 }
 
 /// An action verb/phrase appears anywhere (used behind a request frame).
@@ -950,6 +1050,85 @@ mod tests {
         assert_eq!(
             triage_message("could you please fix the checkout bug?"),
             MessageTriage::Track("Fix the checkout bug".to_string())
+        );
+    }
+
+    /// The predicate the board guard turns on: deixis matches anywhere, field
+    /// nouns demote only in board context, and everything else is real work.
+    #[test]
+    fn board_entity_predicate_reads_the_object_of_the_request() {
+        // Tier 1 — deixis, matched anywhere in the message.
+        for msg in [
+            "update the status on the task card",
+            "move this card to done",
+            "close the ticket",
+            "reprioritise the backlog",
+            "look at the board",
+        ] {
+            assert!(refers_to_board_entity(msg), "should be board: {msg}");
+        }
+        // Tier 2 — a field noun that is the object of a board operation.
+        assert!(refers_to_board_entity("update the status on the board"));
+        assert!(refers_to_board_entity("bump the priority")); // clause-final
+        assert!(refers_to_board_entity("change the assignee to nova")); // connective
+        // Tier 2 — a field noun that heads a longer noun is real work.
+        assert!(!refers_to_board_entity("update the status page"));
+        assert!(!refers_to_board_entity("draft the priority list"));
+        // No board vocabulary at all.
+        for msg in [
+            "update the landing page",
+            "move the deploy to staging",
+            "create a task tracker",
+        ] {
+            assert!(!refers_to_board_entity(msg), "should not be board: {msg}");
+        }
+        // A boundary check: deixis must not fire inside a larger word.
+        assert!(!refers_to_board_entity("restock the cardstock"));
+    }
+
+    /// A board operation phrased as an instruction is a *decision* to touch the
+    /// existing card, not a new deliverable — so it is `Chatter` (Matched), not
+    /// a second `Track` card. The incident that opened the issue leads the list.
+    #[test]
+    fn a_board_operation_does_not_mint_a_second_card() {
+        for msg in [
+            "can you also update the status on the task card?",
+            "update the status on the task card",
+            "please move the card to done",
+            "can you update the priority on this task?",
+            "close the ticket",
+            "update the status on the board",
+        ] {
+            let out = triage_message_detailed(msg);
+            assert_eq!(out.triage, MessageTriage::Chatter, "should not card: {msg}");
+            assert_eq!(
+                out.confidence,
+                TriageConfidence::Matched,
+                "a board op is a decision, not an abstention: {msg}"
+            );
+            assert!(detect_task_intent(msg).is_none(), "no card for: {msg}");
+        }
+    }
+
+    /// The other side of the trade: real work that merely mentions a board word
+    /// (or a field noun heading a longer noun) still cards.
+    #[test]
+    fn real_work_that_mentions_a_field_still_cards() {
+        for (msg, title) in [
+            ("update the landing page", "Update the landing page"),
+            ("move the deploy to staging", "Move the deploy to staging"),
+            ("update the status page", "Update the status page"),
+            ("create a task tracker", "Create a task tracker"),
+        ] {
+            assert_eq!(
+                triage_message(msg),
+                MessageTriage::Track(title.to_string()),
+                "should stay work: {msg}"
+            );
+        }
+        assert_eq!(
+            triage_message("can you review the design"),
+            MessageTriage::Track("Review the design".to_string())
         );
     }
 

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -334,8 +334,11 @@ const READ_VERBS: &[&str] = &[
 const READ_PHRASES: &[&str] = &["walk me through", "let me know", "remind me"];
 
 /// Phrases that point at the board or a card already on it, rather than at a new
-/// deliverable. Matched anywhere in the message, word-boundary-checked so "the
-/// card" does not fire inside "the cardstock".
+/// deliverable. Word-boundary-checked so "the card" does not fire inside "the
+/// cardstock", and object-position-checked ([`board_deixis_is_object`]) so it
+/// only fires when the phrase is the request's actual object — not the head of
+/// a longer noun ("the board **presentation**") and not the topic of a
+/// different object ("a report **about** the board").
 const BOARD_DEIXIS: &[&str] = &[
     "the task card",
     "this card",
@@ -357,7 +360,14 @@ const BOARD_FIELD_NOUNS: &[&str] = &["the status", "the priority", "the assignee
 
 /// Words that, immediately after a [`BOARD_FIELD_NOUNS`] phrase, mark it as the
 /// object of a board operation rather than the head of a longer noun.
-const BOARD_CONNECTIVES: &[&str] = &["on", "of", "for", "to", "and"];
+///
+/// Deliberately excludes `of`: "the status **of** the landing page" makes the
+/// landing page the head of the noun phrase — the field belongs to it, so the
+/// object of the request is the page, not the card's status field on the
+/// board (PR #1949 review, CodeRabbit thread 3895107555). `on`/`to`/`for`/`and`
+/// instead introduce a board operation's target value ("change the assignee
+/// **to** nova"), which is why they stay.
+const BOARD_CONNECTIVES: &[&str] = &["on", "for", "to", "and"];
 
 /// Max length of a generated task title.
 const TITLE_MAX: usize = 80;
@@ -720,28 +730,53 @@ fn starts_with_action(lower: &str) -> bool {
 /// Whether the object of the request is the board itself or a card on it — a
 /// message *about* the kanban rather than a new deliverable.
 fn refers_to_board_entity(lower: &str) -> bool {
-    if BOARD_DEIXIS.iter().any(|p| contains_word_bounded(lower, p)) {
+    if BOARD_DEIXIS
+        .iter()
+        .any(|p| board_deixis_is_object(lower, p))
+    {
         return true;
     }
     field_noun_in_board_context(lower)
 }
 
-/// True when `phrase` occurs in `lower` with non-alphanumeric edges, so only a
-/// whole word matches.
-fn contains_word_bounded(lower: &str, phrase: &str) -> bool {
+/// True when `phrase` occurs in `lower`, word-bounded, in the request's actual
+/// object position: not the head of a longer noun ("the board
+/// **presentation**" — see [`followed_by_board_context`]) and not the topic of
+/// a different object ("a report **about** the board" — see
+/// [`preceded_by_topic_marker`]).
+fn board_deixis_is_object(lower: &str, phrase: &str) -> bool {
     let bytes = lower.as_bytes();
     let mut from = 0;
     while let Some(rel) = lower[from..].find(phrase) {
         let start = from + rel;
         let end = start + phrase.len();
+        from = start + 1;
         let before = start == 0 || !bytes[start - 1].is_ascii_alphanumeric();
         let after = end == lower.len() || !bytes[end].is_ascii_alphanumeric();
-        if before && after {
+        if before
+            && after
+            && followed_by_board_context(&lower[end..])
+            && !preceded_by_topic_marker(&lower[..start])
+        {
             return true;
         }
-        from = start + 1;
     }
     false
+}
+
+/// Whether a topic-introducing word immediately precedes a deixis phrase,
+/// making the phrase the topic of a different, earlier object ("a memo
+/// **about** the board") rather than the object of the request itself. The
+/// verb's own complement prepositions ("look **at** the board", "move it
+/// **to** the board") are not topic markers and are left alone.
+fn preceded_by_topic_marker(lead: &str) -> bool {
+    const TOPIC_MARKERS: &[&str] = &["about", "regarding", "concerning"];
+    let last_word = lead
+        .trim_end()
+        .rsplit(|c: char| !c.is_alphanumeric())
+        .next()
+        .unwrap_or("");
+    TOPIC_MARKERS.contains(&last_word)
 }
 
 /// A [`BOARD_FIELD_NOUNS`] phrase used as a board operation's object: clause-final,
@@ -1053,11 +1088,14 @@ mod tests {
         );
     }
 
-    /// The predicate the board guard turns on: deixis matches anywhere, field
-    /// nouns demote only in board context, and everything else is real work.
+    /// The predicate the board guard turns on: deixis fires only when it is
+    /// the object of the request (see
+    /// [`board_deixis_must_be_the_objects_head_not_a_modifier_or_topic`] for
+    /// the cases that must NOT fire), field nouns demote only in board
+    /// context, and everything else is real work.
     #[test]
     fn board_entity_predicate_reads_the_object_of_the_request() {
-        // Tier 1 — deixis, matched anywhere in the message.
+        // Tier 1 — deixis, matched wherever it is the object of the request.
         for msg in [
             "update the status on the task card",
             "move this card to done",
@@ -1084,6 +1122,46 @@ mod tests {
         }
         // A boundary check: deixis must not fire inside a larger word.
         assert!(!refers_to_board_entity("restock the cardstock"));
+    }
+
+    /// PR #1949 review (Codex thread 3895066476, CodeRabbit thread
+    /// 3895107555): `BOARD_DEIXIS` used to match anywhere in the message, so
+    /// a deliverable whose title merely *contains* board vocabulary — as a
+    /// compound noun, or as the topic of a different object — got misread as
+    /// the object of a board operation and demoted to `Chatter`, opening no
+    /// card. The predicate must require the deixis phrase to actually be the
+    /// object of the request, the same way [`field_noun_in_board_context`]
+    /// already requires for field nouns.
+    #[test]
+    fn board_deixis_must_be_the_objects_head_not_a_modifier_or_topic() {
+        // "the board"/"the ticket" heads a longer noun ("board presentation",
+        // "ticket booking flow") — real work, not a board operation.
+        assert!(!refers_to_board_entity("build the board presentation"));
+        assert!(!refers_to_board_entity("update the ticket booking flow"));
+        // "about"/"regarding" make the deixis phrase the *topic* of a
+        // different object ("a report"), not the object itself.
+        assert!(!refers_to_board_entity("create a report about the board"));
+        assert!(!refers_to_board_entity("write a memo regarding the board"));
+        // Genuine deixis-as-object still fires — the verb's own complement
+        // preposition ("at", "to") is not a topic marker.
+        assert!(refers_to_board_entity("look at the board"));
+        assert!(refers_to_board_entity("move this card to done"));
+    }
+
+    /// PR #1949 review (CodeRabbit thread 3895107555): `field_noun_in_board_
+    /// context` treated a trailing `of` exactly like `on`/`to`/`for`/`and`,
+    /// but `of` introduces the noun a field *belongs to* ("the status **of**
+    /// the landing page" = the landing page's status), not a board
+    /// operation's target value the way "change the assignee **to** nova"
+    /// does. Demoting real deliverable work phrased with `of` closed no card.
+    #[test]
+    fn field_noun_followed_by_of_is_not_board_context() {
+        assert!(!refers_to_board_entity(
+            "update the status of the landing page"
+        ));
+        // The other connectives are unaffected.
+        assert!(refers_to_board_entity("update the status on the board"));
+        assert!(refers_to_board_entity("change the assignee to nova"));
     }
 
     /// A board operation phrased as an instruction is a *decision* to touch the

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -331,12 +331,24 @@ fn system_notice(text: String) -> OutboundMessage {
 /// orchestrator claims the voice. A desk, the General line, an empty/unknown key
 /// — every shared surface — keeps the orchestrator as the single point of
 /// contact.
+///
+/// The unwrapped `dm:` fallback checks the roster **by id first**, mirroring
+/// [`chat_responder`](crate::runtime::delegation_tools::chat_responder)'s own
+/// `dm:` arm (issue #1743): a desk whose id collides with a teammate's must
+/// not swallow the prefixed address, because the prefix exists precisely to
+/// reach that teammate. Falling straight into the bare, desk-first
+/// [`assignee::resolve`] here would reopen #1743 in this resolver — a card
+/// dispatched from that teammate's private DM would misattribute to the
+/// orchestrator, exactly the "second voice" this function exists to prevent.
 pub(crate) fn relay_speaker(record: &CompanyRecord, origin: &str, orchestrator: &str) -> String {
     let mut resolution = assignee::resolve(record, origin);
     if matches!(resolution, assignee::AssigneeResolution::Unknown(_))
         && let Some(key) = assignee::dm_key(origin)
     {
-        resolution = assignee::resolve(record, key);
+        resolution = match record.resolve_roster_agent_id(key) {
+            Some(agent) => assignee::AssigneeResolution::Agent(agent),
+            None => assignee::resolve(record, key),
+        };
     }
     match resolution {
         assignee::AssigneeResolution::Agent(agent) if agent != orchestrator => agent,
@@ -7192,6 +7204,86 @@ members = ["engineer"]
         assert_eq!(relay_speaker(&record, "General", "chief"), "chief");
         assert_eq!(relay_speaker(&record, "", "chief"), "chief");
         assert_eq!(relay_speaker(&record, "nobody-here", "chief"), "chief");
+    }
+
+    /// A roster with a desk whose id collides with a teammate id — the exact
+    /// shape `runtime::delegation_tools::a_prefixed_dm_reaches_the_teammate_
+    /// even_when_a_desk_shares_the_id` (issue #1743) exercises for
+    /// `chat_responder`. Manifest validation does not forbid the collision.
+    fn record_with_colliding_desk_and_teammate_id() -> CompanyRecord {
+        let manifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "chief"
+role = "Chief of Staff"
+tier = "orchestrator"
+description = "Coordinates the company."
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+description = "Builds it."
+
+[[group_chat]]
+id = "engineer"
+name = "Engineering desk"
+members = ["chief"]
+"#,
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            overlay_retired_agents: Vec::new(),
+            overlay_agent_edits: Vec::new(),
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_tool_grants: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+            name_confirmed: false,
+            activation_completed_at: None,
+            created_at_millis: None,
+        }
+    }
+
+    /// PR #1949 review (Codex thread 3895066480): a `dm:` key names a
+    /// teammate even when a desk shares that id — the same invariant issue
+    /// #1743 established for `chat_responder`
+    /// (`runtime::delegation_tools::a_prefixed_dm_reaches_the_teammate_even_
+    /// when_a_desk_shares_the_id`). `relay_speaker` used to re-run the bare,
+    /// desk-first `assignee::resolve` on the key once the prefix was
+    /// stripped, so a card dispatched from that teammate's private DM
+    /// resolved to `Desk` and fell through to the orchestrator — reopening
+    /// #1743's bug in the relay's own resolver, and misattributing a private
+    /// DM's card as though it were answered on the shared desk.
+    #[test]
+    fn relay_speaker_reaches_the_dm_teammate_even_when_a_desk_shares_the_id() {
+        let record = record_with_colliding_desk_and_teammate_id();
+        assert_eq!(
+            relay_speaker(&record, "dm:engineer", "chief"),
+            "engineer",
+            "the prefix names the teammate, not the desk that shares its id"
+        );
+        // The bare key still belongs to the desk, exactly as it does for
+        // `chat_responder` — only the prefixed address reaches the teammate.
+        assert_eq!(
+            relay_speaker(&record, "engineer", "chief"),
+            "chief",
+            "the desk still answers its own bare id"
+        );
     }
 
     /// A brain over `record`, wired to a real task store.

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1783,7 +1783,13 @@ impl HarnessBrain {
             return Ok(None);
         };
         let speaker = relay_speaker(&self.record(), &origin, &orchestrator);
-        let relay = lifecycle::relay_reply(&card, &orchestrator, &speaker, origin);
+        // `speaker` goes in both slots: a refusal never claims anyone ran the
+        // card, so `relay_text`'s `responder == orchestrator` check must
+        // always hold here, regardless of who the relay speaks as (issue
+        // #1949 review, CodeRabbit thread 3895107568). Passing `orchestrator`
+        // in the responder slot instead used to fire the "ran it" credit
+        // whenever `speaker` diverged from it — i.e. every private DM.
+        let relay = lifecycle::relay_reply(&card, &speaker, &speaker, origin);
         self.journal_task_outcome(&card, &orchestrator, text, Vec::new())
             .await;
         Ok(Some(relay))
@@ -7046,6 +7052,42 @@ members = ["engineer"]
         // before journaling, since the settle already left a
         // `DeskTaskCompleted` link and this would only duplicate it.
         assert_eq!(posted.task_id.as_deref(), Some("t-origin"));
+    }
+
+    /// A refusal into a private DM must not claim anyone ran the card.
+    ///
+    /// `refuse_dispatch` used to pass the orchestrator's own id into
+    /// `relay_reply`'s `responder` slot while the DM's speaker went into the
+    /// `orchestrator` slot — the opposite of every other call site. For a
+    /// desk/shared origin the two values collide (`relay_speaker` returns the
+    /// orchestrator) and the swap is invisible, but a private DM's speaker is
+    /// the teammate, not the orchestrator, so the mismatch fires the "ran it"
+    /// credit onto a card that never ran at all (CodeRabbit review, PR #1949
+    /// thread 3895107568).
+    #[tokio::test]
+    async fn a_refused_dispatch_into_a_dm_credits_no_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        let mut c = card("t-dm-origin", "Shane");
+        // "engineer" is a real roster agent (not the orchestrator "ceo"), so
+        // `relay_speaker` claims this as a private DM and returns "engineer"
+        // instead of falling back to the orchestrator.
+        c.origin_chat_id = Some("engineer".to_string());
+        tasks
+            .upsert(&CompanyId::new("acme"), &c)
+            .await
+            .expect("seed");
+
+        let posted = brain
+            .run_task("t-dm-origin", None)
+            .await
+            .expect("run")
+            .expect("a refused card with an origin must still post back");
+        assert!(
+            !posted.text.contains("ran it"),
+            "a refusal must never credit anyone with running the card: {}",
+            posted.text
+        );
     }
 
     /// A dispatch for a card that no longer exists is a silent no-op, not an

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -320,6 +320,30 @@ fn system_notice(text: String) -> OutboundMessage {
     }
 }
 
+/// Who a dispatch relay should be authored by when it answers in the `origin`
+/// thread.
+///
+/// A card whose origin is a teammate's **private DM** must be answered by that
+/// teammate, never by the orchestrator — an orchestrator bubble in a private DM
+/// intrudes a second voice into a one-to-one thread. The origin key is resolved
+/// against the roster the same way an assignee is (the `dm:` prefix unwrapped as
+/// a fallback), and only a resolved [`AssigneeResolution::Agent`] that is not the
+/// orchestrator claims the voice. A desk, the General line, an empty/unknown key
+/// — every shared surface — keeps the orchestrator as the single point of
+/// contact.
+pub(crate) fn relay_speaker(record: &CompanyRecord, origin: &str, orchestrator: &str) -> String {
+    let mut resolution = assignee::resolve(record, origin);
+    if matches!(resolution, assignee::AssigneeResolution::Unknown(_))
+        && let Some(key) = assignee::dm_key(origin)
+    {
+        resolution = assignee::resolve(record, key);
+    }
+    match resolution {
+        assignee::AssigneeResolution::Agent(agent) if agent != orchestrator => agent,
+        _ => orchestrator.to_string(),
+    }
+}
+
 /// The single bubble a workflow-copilot turn returns (issues #416, #966).
 ///
 /// Named rather than inlined because its **author** is the load-bearing field
@@ -1696,7 +1720,9 @@ impl HarnessBrain {
         let Some(origin) = card.origin_chat_id.clone() else {
             return Ok(None);
         };
-        let relay = lifecycle::relay_reply(&card, &responder, &self.orchestrator(), origin);
+        let orchestrator = self.orchestrator();
+        let speaker = relay_speaker(&self.record(), &origin, &orchestrator);
+        let relay = lifecycle::relay_reply(&card, &responder, &speaker, origin);
         Ok(Some(relay))
     }
 
@@ -1756,7 +1782,8 @@ impl HarnessBrain {
                 .await;
             return Ok(None);
         };
-        let relay = lifecycle::relay_reply(&card, &orchestrator, &orchestrator, origin);
+        let speaker = relay_speaker(&self.record(), &origin, &orchestrator);
+        let relay = lifecycle::relay_reply(&card, &orchestrator, &speaker, origin);
         self.journal_task_outcome(&card, &orchestrator, text, Vec::new())
             .await;
         Ok(Some(relay))
@@ -7104,6 +7131,25 @@ members = ["engineer"]
             activation_completed_at: None,
             created_at_millis: None,
         }
+    }
+
+    /// A dispatch relay into a teammate's private DM is authored by that
+    /// teammate; every shared surface keeps the orchestrator's voice.
+    #[test]
+    fn relay_speaker_claims_a_private_dm_for_its_own_agent() {
+        let record = record_with_desk();
+        // A teammate DM: the origin is that teammate, so they speak.
+        assert_eq!(relay_speaker(&record, "engineer", "chief"), "engineer");
+        // The console's `dm:<id>` channel key resolves the same teammate.
+        assert_eq!(relay_speaker(&record, "dm:engineer", "chief"), "engineer");
+        // A desk is a shared surface — the orchestrator stays the one voice.
+        assert_eq!(relay_speaker(&record, "eng_desk", "chief"), "chief");
+        // The orchestrator's own DM is answered by the orchestrator, not doubled.
+        assert_eq!(relay_speaker(&record, "chief", "chief"), "chief");
+        // General / empty / unknown origins all keep the orchestrator.
+        assert_eq!(relay_speaker(&record, "General", "chief"), "chief");
+        assert_eq!(relay_speaker(&record, "", "chief"), "chief");
+        assert_eq!(relay_speaker(&record, "nobody-here", "chief"), "chief");
     }
 
     /// A brain over `record`, wired to a real task store.

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -994,6 +994,12 @@ impl HarnessBrain {
             .working_agent()
             .unwrap_or(&self.responder)
             .to_string();
+        // Every id `responder` held before a reassignment overwrote it — a
+        // hand-off's `[<old responder>] delegated to …` block stays on the
+        // note under that old name, so `relay_text`'s `known_labels` needs it
+        // too or the strip leaves that block's chrome in the relayed bubble
+        // (issue #1949 review, CodeRabbit 3895599021).
+        let mut prior_responders: Vec<String> = Vec::new();
 
         // Link the working agent to the card, and persist it BEFORE the turn
         // runs (#205). A card the CEO picked up used to keep `assignee = ""`
@@ -1245,7 +1251,8 @@ impl HarnessBrain {
                                 // The delegate answered: they own the card, and
                                 // every downstream write credits them.
                                 Some(handoff) => {
-                                    responder = handoff.delegate;
+                                    prior_responders
+                                        .push(std::mem::replace(&mut responder, handoff.delegate));
                                     let budget_paused = handoff.budget_paused;
                                     match handoff.reply {
                                         Some(reply) => {
@@ -1354,7 +1361,7 @@ impl HarnessBrain {
                     redirects += 1;
                     card.note = Some(append_result(
                         card.note.as_deref(),
-                        "operator redirect",
+                        lifecycle::OPERATOR_REDIRECT_ATTRIBUTION,
                         &fresh,
                     ));
                     if redirects > MAX_REDIRECTS_PER_DISPATCH {
@@ -1734,7 +1741,8 @@ impl HarnessBrain {
         };
         let orchestrator = self.orchestrator();
         let speaker = relay_speaker(&self.record(), &origin, &orchestrator);
-        let relay = lifecycle::relay_reply(&card, &responder, &speaker, origin);
+        let prior: Vec<&str> = prior_responders.iter().map(String::as_str).collect();
+        let relay = lifecycle::relay_reply(&card, &responder, &speaker, origin, &prior);
         Ok(Some(relay))
     }
 
@@ -1801,7 +1809,9 @@ impl HarnessBrain {
         // #1949 review, CodeRabbit thread 3895107568). Passing `orchestrator`
         // in the responder slot instead used to fire the "ran it" credit
         // whenever `speaker` diverged from it — i.e. every private DM.
-        let relay = lifecycle::relay_reply(&card, &speaker, &speaker, origin);
+        // A refusal never ran a turn, so there is no reassignment history to
+        // carry into the strip.
+        let relay = lifecycle::relay_reply(&card, &speaker, &speaker, origin, &[]);
         self.journal_task_outcome(&card, &orchestrator, text, Vec::new())
             .await;
         Ok(Some(relay))
@@ -6567,7 +6577,7 @@ members = ["engineer"]
         finished.column = "done".to_string();
         finished.note = None;
         assert_eq!(
-            lifecycle::relay_text(&finished, "maya", "ceo"),
+            lifecycle::relay_text(&finished, "maya", "ceo", &[]),
             "\"Ship the thing\" is done (maya ran it)."
         );
     }

--- a/src/harness/built_in/lifecycle.rs
+++ b/src/harness/built_in/lifecycle.rs
@@ -434,24 +434,48 @@ pub fn relay_text(card: &TaskRecord, responder: &str, orchestrator: &str) -> Str
     };
     let headline = format!("\"{}\" {status}{credit}.", card.title);
     match card.note.as_deref().filter(|n| !n.trim().is_empty()) {
-        Some(note) => format!("{headline}\n\n{}", strip_note_attribution(note)),
+        Some(note) => {
+            // The only labels a block can legitimately carry are the ones
+            // this card's own lifecycle generates: the runtime's own voice,
+            // the operator (a cancel), or whoever this relay already knows
+            // about — the responder it is crediting and the orchestrator
+            // speaking. An operator's own note text is never on this list, no
+            // matter how it happens to be bracketed (issue #1949 review,
+            // Codex thread 3895066483).
+            let known_labels = [
+                crate::runtime::advance::SYSTEM_ATTRIBUTION,
+                OPERATOR_ATTRIBUTION,
+                responder,
+                orchestrator,
+            ];
+            format!(
+                "{headline}\n\n{}",
+                strip_note_attribution(note, &known_labels)
+            )
+        }
         None => headline,
     }
 }
 
-/// Strips the `[<who>] ` attribution prefix from each block of a card note, so
-/// the relayed bubble carries the prose without the board's internal
-/// `[system]`/`[writer]` chrome. The headline already credits the doer.
+/// Strips a leading `[<label>] ` prefix from each block of a card note, so the
+/// relayed bubble carries the prose without the board's internal
+/// `[system]`/`[writer]` chrome — but only when `label` is one this card's own
+/// lifecycle actually generates (`known_labels`). The headline already
+/// credits the doer.
 ///
-/// A block is a `\n\n`-separated span. Only a leading `[word] ` prefix is
-/// removed; a block that opens with `[` but has no closing `] ` is left
-/// verbatim, and brackets later in the block are untouched.
-fn strip_note_attribution(note: &str) -> String {
+/// A block is a `\n\n`-separated span. A leading `[word] ` prefix is removed
+/// only when `word` is in `known_labels`; any other bracketed opener —
+/// including operator-authored content that happens to start with a bracket,
+/// like `[Important] Keep the legacy API` — is left verbatim. A block that
+/// opens with `[` but has no closing `] ` is also left verbatim, and brackets
+/// later in the block are untouched.
+fn strip_note_attribution(note: &str, known_labels: &[&str]) -> String {
     note.split("\n\n")
         .map(|block| {
             block
                 .strip_prefix('[')
                 .and_then(|rest| rest.split_once("] "))
+                .filter(|(label, _)| known_labels.contains(label))
                 .map_or(block, |(_, body)| body)
         })
         .collect::<Vec<_>>()
@@ -908,13 +932,31 @@ mod test {
 
         // A block that opens with `[` but never closes it stays verbatim.
         assert_eq!(
-            strip_note_attribution("[unterminated note"),
+            strip_note_attribution("[unterminated note", &["writer"]),
             "[unterminated note"
         );
         // Brackets after the leading prefix are left alone.
         assert_eq!(
-            strip_note_attribution("[writer] see [ref] below"),
+            strip_note_attribution("[writer] see [ref] below", &["writer"]),
             "see [ref] below"
+        );
+    }
+
+    /// PR #1949 review (Codex thread 3895066483): the strip used to treat ANY
+    /// leading `[label] ` span as generated attribution chrome, so an
+    /// operator-authored note that itself opens with a bracket — a heading, a
+    /// tag, a callout like "[Important] Keep the legacy API" — got silently
+    /// mangled by the relay, dropping content the operator wrote through the
+    /// task create/patch APIs. Only a label the caller actually generated
+    /// (`OPERATOR_ATTRIBUTION`, `SYSTEM_ATTRIBUTION`, the responder, or the
+    /// orchestrator) may be stripped.
+    #[test]
+    fn operator_authored_bracket_survives_the_relay() {
+        let noted = card(COLUMN_IN_REVIEW, Some("[Important] Keep the legacy API"));
+        let text = relay_text(&noted, "writer", "ceo");
+        assert!(
+            text.contains("[Important] Keep the legacy API"),
+            "an operator's own bracketed note must not be read as generated attribution: {text}"
         );
     }
 

--- a/src/harness/built_in/lifecycle.rs
+++ b/src/harness/built_in/lifecycle.rs
@@ -76,6 +76,13 @@ pub use crate::ports::tasks::{
 /// result the assignee produced.
 pub const OPERATOR_ATTRIBUTION: &str = "operator";
 
+/// The note attribution `run_task`'s redirect loop uses for the operator's own
+/// mid-flight steer instruction (issue #1949 review, CodeRabbit
+/// 3895599021) — a distinct label from [`OPERATOR_ATTRIBUTION`], not the
+/// word "operator" alone, so it needs its own entry in `relay_text`'s known
+/// set rather than piggybacking on the cancel-attribution constant.
+pub const OPERATOR_REDIRECT_ATTRIBUTION: &str = "operator redirect";
+
 /// How one dispatch run ended, independent of who ran it or what it said.
 ///
 /// This is the whole input to the lifecycle decision. Keeping it separate from
@@ -415,7 +422,22 @@ pub fn note_attribution(end: TaskRunEnd, responder: &str) -> String {
 /// and it credits the doer when the doer is somebody else. A card the
 /// orchestrator ran itself would otherwise read "… (ceo ran it)" in a bubble
 /// already attributed to `ceo`.
-pub fn relay_text(card: &TaskRecord, responder: &str, orchestrator: &str) -> String {
+///
+/// `prior_responders` names every other id this dispatch's own note blocks
+/// may already carry as attribution — chiefly, the pre-hand-off responder a
+/// mid-flight reassignment (issue #204, `run_task`'s delegate loop) leaves
+/// behind once `responder` itself has moved on to the delegate. Without it,
+/// `known_labels` only ever knew this relay's *final* two names, so a
+/// reassigned card's earlier `[<old responder>]` block survived the strip and
+/// leaked the board's internal chrome into the relay (issue #1949 review,
+/// CodeRabbit 3895599021). Pass `&[]` when this relay's dispatch never
+/// reassigned the card.
+pub fn relay_text(
+    card: &TaskRecord,
+    responder: &str,
+    orchestrator: &str,
+    prior_responders: &[&str],
+) -> String {
     let status = match card.column.as_str() {
         COLUMN_IN_REVIEW => "is ready for review",
         COLUMN_IN_PROGRESS => "is still in progress",
@@ -437,17 +459,27 @@ pub fn relay_text(card: &TaskRecord, responder: &str, orchestrator: &str) -> Str
         Some(note) => {
             // The only labels a block can legitimately carry are the ones
             // this card's own lifecycle generates: the runtime's own voice,
-            // the operator (a cancel), or whoever this relay already knows
-            // about — the responder it is crediting and the orchestrator
-            // speaking. An operator's own note text is never on this list, no
-            // matter how it happens to be bracketed (issue #1949 review,
-            // Codex thread 3895066483).
-            let known_labels = [
+            // an operator-initiated cancel, an operator's mid-flight redirect,
+            // or an identity this dispatch itself produced — the responder
+            // this relay is crediting, the orchestrator speaking, and (after a
+            // reassignment) whoever held the card before. An operator's own
+            // note text is never on this list, no matter how it happens to be
+            // bracketed (issue #1949 review, Codex thread 3895066483). Empty
+            // dynamic labels are dropped before matching — an unresolved
+            // responder/orchestrator must not turn a literal `[] ` prefix in
+            // operator-authored text into stripped attribution (CodeRabbit
+            // 3895599021).
+            let known_labels: Vec<&str> = [
                 crate::runtime::advance::SYSTEM_ATTRIBUTION,
                 OPERATOR_ATTRIBUTION,
+                OPERATOR_REDIRECT_ATTRIBUTION,
                 responder,
                 orchestrator,
-            ];
+            ]
+            .into_iter()
+            .chain(prior_responders.iter().copied())
+            .filter(|label| !label.is_empty())
+            .collect();
             format!(
                 "{headline}\n\n{}",
                 strip_note_attribution(note, &known_labels)
@@ -502,18 +534,23 @@ fn strip_note_attribution(note: &str, known_labels: &[&str]) -> String {
 /// `task_id` here too would render a second "card opened" chip for a card
 /// that is not open by the time this bubble lands. It does not reach
 /// `AgentReply::task_id` and does not survive a transcript reload.
+///
+/// `prior_responders` is forwarded to [`relay_text`] unchanged — see its
+/// docs for why a reassigned dispatch needs to name more than its own final
+/// responder.
 pub fn relay_reply(
     card: &TaskRecord,
     responder: &str,
     orchestrator: &str,
     origin_chat_id: String,
+    prior_responders: &[&str],
 ) -> OutboundMessage {
     OutboundMessage {
         message_id: None,
         task_id: Some(card.id.clone()),
         channel: orchestrator.to_string(),
         agent: None,
-        text: relay_text(card, responder, orchestrator),
+        text: relay_text(card, responder, orchestrator, prior_responders),
         mentions: Vec::new(),
         reply_to: Some(ReplyTo {
             chat_id: origin_chat_id,
@@ -619,6 +656,7 @@ mod test {
             "maya",
             "ceo",
             "strategy".to_string(),
+            &[],
         );
         assert_eq!(
             relayed.reply_to.as_ref().map(|r| r.chat_id.as_str()),
@@ -924,7 +962,7 @@ mod test {
             COLUMN_IN_REVIEW,
             Some("[system] moved to review\n\n[writer] drafted the intro"),
         );
-        let text = relay_text(&noted, "writer", "ceo");
+        let text = relay_text(&noted, "writer", "ceo", &[]);
         assert!(!text.contains("[system]"), "{text}");
         assert!(!text.contains("[writer]"), "{text}");
         assert!(text.contains("moved to review"), "{text}");
@@ -948,16 +986,82 @@ mod test {
     /// tag, a callout like "[Important] Keep the legacy API" — got silently
     /// mangled by the relay, dropping content the operator wrote through the
     /// task create/patch APIs. Only a label the caller actually generated
-    /// (`OPERATOR_ATTRIBUTION`, `SYSTEM_ATTRIBUTION`, the responder, or the
-    /// orchestrator) may be stripped.
+    /// (`OPERATOR_ATTRIBUTION`, `OPERATOR_REDIRECT_ATTRIBUTION`,
+    /// `SYSTEM_ATTRIBUTION`, the responder, the orchestrator, or a prior
+    /// responder this same dispatch reassigned away from) may be stripped.
     #[test]
     fn operator_authored_bracket_survives_the_relay() {
         let noted = card(COLUMN_IN_REVIEW, Some("[Important] Keep the legacy API"));
-        let text = relay_text(&noted, "writer", "ceo");
+        let text = relay_text(&noted, "writer", "ceo", &[]);
         assert!(
             text.contains("[Important] Keep the legacy API"),
             "an operator's own bracketed note must not be read as generated attribution: {text}"
         );
+    }
+
+    /// CodeRabbit 3895599021: `known_labels` used to know only this relay's
+    /// *final* two names, so a card whose note carries a block from BEFORE a
+    /// mid-flight reassignment (issue #204's hand-off loop reassigns
+    /// `responder` to the delegate and keeps going) leaked that prior
+    /// responder's `[<id>]` chrome straight into the operator-facing bubble —
+    /// the same class of bug `operator_authored_bracket_survives_the_relay`
+    /// fixed from the opposite direction, this time under-stripping instead
+    /// of over-stripping. `prior_responders` closes that gap, and an
+    /// operator-authored bracket that happens to match one of those prior ids
+    /// is not itself a scenario this needs to protect beyond what the
+    /// bracket-survives test above already proves for the current two names.
+    #[test]
+    fn the_relay_strips_a_reassigned_cards_prior_responder_label() {
+        let noted = card(
+            COLUMN_IN_REVIEW,
+            Some("[writer] delegated to editor: proofread the draft\n\n[editor] done"),
+        );
+        let text = relay_text(&noted, "editor", "ceo", &["writer"]);
+        assert!(!text.contains("[writer]"), "{text}");
+        assert!(!text.contains("[editor]"), "{text}");
+        assert!(
+            text.contains("delegated to editor: proofread the draft"),
+            "{text}"
+        );
+        assert!(text.contains("done"), "{text}");
+
+        // Without the prior-responder hint, the old-responder block is left
+        // exactly as `known_labels` used to leave it: attributed and leaking.
+        let unaware = relay_text(&noted, "editor", "ceo", &[]);
+        assert!(
+            unaware.contains("[writer]"),
+            "sanity check: an empty prior_responders must reproduce the pre-fix leak: {unaware}"
+        );
+    }
+
+    /// CodeRabbit 3895599021: an unresolved dynamic label (an empty
+    /// `responder`, as `refuse_dispatch` passes when nobody ran the card) must
+    /// not let a literal `[] ` prefix in operator-authored text read as
+    /// generated attribution.
+    #[test]
+    fn an_empty_responder_does_not_strip_a_literal_bracket_prefix() {
+        let noted = card(COLUMN_IN_REVIEW, Some("[] TODO: revisit this"));
+        let text = relay_text(&noted, "", "ceo", &[]);
+        assert!(
+            text.contains("[] TODO: revisit this"),
+            "an empty responder must not become a matchable known label: {text}"
+        );
+    }
+
+    /// The operator's own mid-flight redirect instruction is recorded with
+    /// its own generated label (`OPERATOR_REDIRECT_ATTRIBUTION`, distinct
+    /// from `OPERATOR_ATTRIBUTION`) by `run_task`'s steer loop — see
+    /// `harness::built_in::brain`. It must be recognized and stripped exactly
+    /// like the other generated labels.
+    #[test]
+    fn an_operator_redirect_label_is_recognized_and_stripped() {
+        let noted = card(
+            COLUMN_IN_REVIEW,
+            Some("[operator redirect] focus on the API instead"),
+        );
+        let text = relay_text(&noted, "writer", "ceo", &[]);
+        assert!(!text.contains("[operator redirect]"), "{text}");
+        assert!(text.contains("focus on the API instead"), "{text}");
     }
 
     /// The one-voice change: the bubble is the orchestrator's, and the assignee
@@ -965,7 +1069,7 @@ mod test {
     #[test]
     fn the_relay_bubble_is_the_orchestrators_and_credits_the_assignee() {
         let finished = card(COLUMN_IN_REVIEW, Some("[maya] shipped it"));
-        let msg = relay_reply(&finished, "maya", "ceo", "strategy".to_string());
+        let msg = relay_reply(&finished, "maya", "ceo", "strategy".to_string(), &[]);
 
         assert_eq!(msg.channel, "ceo", "the orchestrator owns the reply");
         assert_eq!(
@@ -988,12 +1092,12 @@ mod test {
     #[test]
     fn the_relay_does_not_credit_the_orchestrator_to_itself() {
         let finished = card(COLUMN_IN_REVIEW, None);
-        let msg = relay_reply(&finished, "ceo", "ceo", "main".to_string());
+        let msg = relay_reply(&finished, "ceo", "ceo", "main".to_string(), &[]);
         assert!(!msg.text.contains("ran it"), "{}", msg.text);
         assert_eq!(msg.text, "\"Ship the thing\" is ready for review.");
 
         // An unresolved assignee credits nobody rather than an empty paren.
-        let orphan = relay_reply(&finished, "", "ceo", "main".to_string());
+        let orphan = relay_reply(&finished, "", "ceo", "main".to_string(), &[]);
         assert!(!orphan.text.contains("ran it"), "{}", orphan.text);
     }
 
@@ -1003,12 +1107,12 @@ mod test {
     fn the_relay_reflects_the_landing_column_not_a_presumed_success() {
         let paused = card(COLUMN_PAUSED, None);
         assert!(
-            relay_text(&paused, "maya", "ceo").contains("is paused"),
+            relay_text(&paused, "maya", "ceo", &[]).contains("is paused"),
             "paused card must not read as finished"
         );
 
         let returned = card(COLUMN_TODO, Some("[operator] cancelled while in flight"));
-        let text = relay_text(&returned, "maya", "ceo");
+        let text = relay_text(&returned, "maya", "ceo", &[]);
         assert!(text.contains("is back in Pending"), "{text}");
         // Issue #301: collapsing the backlog pool into To-do is only lossless
         // because the reason rides along on the card. The relay must keep
@@ -1019,14 +1123,15 @@ mod test {
         // without an arm of its own a relay would fall through to the raw
         // column id and read `"Ship the thing" planning.`.
         for column in crate::ports::tasks::BOARD_COLUMNS {
-            let text = relay_text(&card(column, None), "maya", "ceo");
+            let text = relay_text(&card(column, None), "maya", "ceo", &[]);
             assert!(
                 !text.contains(&format!("\" {column}")),
                 "column {column} fell through to the raw-id fallback: {text}"
             );
         }
         assert!(
-            relay_text(&card(COLUMN_PLANNING, None), "maya", "ceo").contains("is being planned"),
+            relay_text(&card(COLUMN_PLANNING, None), "maya", "ceo", &[])
+                .contains("is being planned"),
             "planning needs its own sentence"
         );
     }
@@ -1037,12 +1142,12 @@ mod test {
     fn a_noteless_card_still_relays_a_complete_sentence() {
         let bare = card(COLUMN_IN_REVIEW, None);
         assert_eq!(
-            relay_text(&bare, "maya", "ceo"),
+            relay_text(&bare, "maya", "ceo", &[]),
             "\"Ship the thing\" is ready for review (maya ran it)."
         );
         let blank = card(COLUMN_IN_REVIEW, Some("   \n  "));
         assert_eq!(
-            relay_text(&blank, "maya", "ceo"),
+            relay_text(&blank, "maya", "ceo", &[]),
             "\"Ship the thing\" is ready for review (maya ran it)."
         );
     }

--- a/src/harness/built_in/lifecycle.rs
+++ b/src/harness/built_in/lifecycle.rs
@@ -434,9 +434,28 @@ pub fn relay_text(card: &TaskRecord, responder: &str, orchestrator: &str) -> Str
     };
     let headline = format!("\"{}\" {status}{credit}.", card.title);
     match card.note.as_deref().filter(|n| !n.trim().is_empty()) {
-        Some(note) => format!("{headline}\n\n{note}"),
+        Some(note) => format!("{headline}\n\n{}", strip_note_attribution(note)),
         None => headline,
     }
+}
+
+/// Strips the `[<who>] ` attribution prefix from each block of a card note, so
+/// the relayed bubble carries the prose without the board's internal
+/// `[system]`/`[writer]` chrome. The headline already credits the doer.
+///
+/// A block is a `\n\n`-separated span. Only a leading `[word] ` prefix is
+/// removed; a block that opens with `[` but has no closing `] ` is left
+/// verbatim, and brackets later in the block are untouched.
+fn strip_note_attribution(note: &str) -> String {
+    note.split("\n\n")
+        .map(|block| {
+            block
+                .strip_prefix('[')
+                .and_then(|rest| rest.split_once("] "))
+                .map_or(block, |(_, body)| body)
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
 }
 
 /// The orchestrator's relay of a finished card back into the conversation it
@@ -870,6 +889,33 @@ mod test {
         assert_eq!(note_attribution(TaskRunEnd::Completed, "maya"), "maya");
         assert_eq!(note_attribution(TaskRunEnd::Paused, "maya"), "maya");
         assert_eq!(note_attribution(TaskRunEnd::Failed, "maya"), "maya");
+    }
+
+    /// The relayed bubble drops each note block's `[<who>]` attribution — the
+    /// board's internal chrome — while keeping the prose. The headline already
+    /// says who did the work.
+    #[test]
+    fn the_relay_strips_note_attribution_but_keeps_the_prose() {
+        let noted = card(
+            COLUMN_IN_REVIEW,
+            Some("[system] moved to review\n\n[writer] drafted the intro"),
+        );
+        let text = relay_text(&noted, "writer", "ceo");
+        assert!(!text.contains("[system]"), "{text}");
+        assert!(!text.contains("[writer]"), "{text}");
+        assert!(text.contains("moved to review"), "{text}");
+        assert!(text.contains("drafted the intro"), "{text}");
+
+        // A block that opens with `[` but never closes it stays verbatim.
+        assert_eq!(
+            strip_note_attribution("[unterminated note"),
+            "[unterminated note"
+        );
+        // Brackets after the leading prefix are left alone.
+        assert_eq!(
+            strip_note_attribution("[writer] see [ref] below"),
+            "see [ref] below"
+        );
     }
 
     /// The one-voice change: the bubble is the orchestrator's, and the assignee


### PR DESCRIPTION
## Summary
Two stacked defects from one staging incident on the marketing tenant: a chat message became a bogus task card, and that card's settle-relay then intruded into an agent's private DM carrying raw speaker-labeled narration. This fixes both — the over-eager intent classifier (root) and the membership-blind relay authorship + note fold (consequence).

Closes #1947
Closes #1948

## API Or Behavior Changes
- **Chat intent (task_intent):** a request whose object refers to an existing board/card entity or a bare status/meta mutation ("the task card", "the status", "the board", "the column", "this card") is now classified as **Chatter**, not a new **Track** card. Genuine work ("update the landing page", "move the deploy to staging") still Tracks. `move`/`close` added to `ACTION_VERBS` so board-op imperatives reach the guard; a `?`-ending sentence containing `move`/`close` now classifies as Chatter rather than Answer (safe middle, no test regressed).
- **Dispatch relay (brain/runtime):** when a settled card's `origin_chat_id` resolves to another agent's private DM, the relay is authored as **that DM's own agent**, not the orchestrator — so the PM no longer posts into a DM it is not a member of.
- **Relay body (lifecycle):** the card note's `[speaker]` attribution chrome is stripped from the relayed message body; the note is board audit-trail, not prose.

## Tests
Scoped `cargo test --features openhuman` across `company::task_intent`, `company::runtime`, `harness::built_in::lifecycle`, `harness::built_in::brain` → **224 passed, 0 failed** (6 new):
- task_intent: board-entity predicate unit test + triage boundary table (board-op → Chatter, genuine work → Track).
- lifecycle: `strip_note_attribution` per-block stripping.
- brain: `relay_speaker` resolution across DM / `dm:` key / desk / self / General / empty / unknown.
- runtime: relay driven through the real `relay_speaker` + `relay_reply`, asserts journaled `AgentReply.agent_id` = the DM's agent for a private-DM origin and the orchestrator for a shared desk; original shared-desk journaling test retained as non-regression.

Gates green (foreground, feature `openhuman`): `cargo fmt --all -- --check`, `cargo clippy --all-targets --no-deps -- -D warnings`, `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings` — all exit 0 (only pre-existing vendored `openhuman` warnings).

## Documentation
N/A — internal harness behavior; no public API or user-facing doc surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Private-message relays now show the addressed teammate as the author, while shared-desk relays retain the orchestrator’s voice.
  * Refused task relays no longer incorrectly credit the wrong speaker.
  * Relay attribution remains accurate after task handoffs and redirects.
  * Board references are less likely to be misclassified as actionable work or create unintended tracking items.
  * Operator-authored bracketed notes are preserved during relaying.

* **Improvements**
  * Task triage now better recognizes actions such as moving or closing items and distinguishes board context from real work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->