### PR TITLE
fix(console): make the Task Details page's controls tell the truth

### DIFF
--- a/frontend/src/lib/task-approvals.ts
+++ b/frontend/src/lib/task-approvals.ts
@@ -101,6 +101,22 @@ export function approvalsForTask(
   );
 }
 
+/**
+ * Why Resume/Retry is down while a card is blocked — the sentence, said once.
+ *
+ * The other half of {@link taskApprovalBlock}, and here for the same reason the
+ * derivation is one function: the `disabled` and the explanation of it are the
+ * same claim, and a button that went down while its tooltip said something else
+ * would be exactly the disagreement that doc rules out. Read by the board card
+ * (`TaskCard`) and by the task detail's control bar.
+ *
+ * `TaskCard` still carries this sentence inline. Adopting the constant there is
+ * a one-line follow-up, deliberately not bundled into the detail fix — the
+ * wording here is copied from it verbatim, so the two already read the same.
+ */
+export const RESUME_BLOCKED_REASON =
+  "Blocked — decide its approvals first; resuming re-runs the work from the start.";
+
 /** Why a card is stopped — read by its board card and by its Resume button (#883). */
 export interface TaskApprovalBlock {
   /** The still-parked approvals for this card, oldest park first. */

--- a/frontend/src/lib/task-edit.ts
+++ b/frontend/src/lib/task-edit.ts
@@ -9,7 +9,8 @@
 // `Unknown`, and the save failed with a `400` about a field the operator never
 // touched. Diffing means an untouched field is never re-validated.
 
-import type { PatchTask, Task } from "@/api/tasks";
+import type { IrreversibleEffect, PatchTask, Task } from "@/api/tasks";
+import { BOARD_WORKING } from "@/lib/board-columns";
 
 /**
  * The fields the operator actually changed, and only those.
@@ -32,4 +33,56 @@ export function computeTaskPatch(draft: PatchTask, current: Task): PatchTask {
     patch.deliverable = draft.deliverable ?? "once";
   }
   return patch;
+}
+
+/**
+ * What the host's journal recorded against this card, as a caller hands it in.
+ *
+ * Both fields are optional, and "absent" is a **third** state that must not
+ * collapse into "clean": a caller that has not wired the read knows nothing
+ * about this card's effects, which is not the same claim as a read that came
+ * back empty. `dispatchNeedsConfirm` treats absent the way the host treats
+ * `historyIncomplete` — as "cannot say", which confirms.
+ */
+export interface EffectHistory {
+  /** The effects the journal recorded as executed, or absent if not read. */
+  irreversible?: IrreversibleEffect[];
+  /** Whether the journal holds executed history it cannot describe (#351). */
+  historyIncomplete?: boolean;
+}
+
+/**
+ * Whether saving this patch re-enters the run.
+ *
+ * `{ column: "working" }` is the *identical* write the Task Detail screen's
+ * Retry button makes (`patchColumn` there): the host resolves the `working`
+ * phase to `in_progress`, which dispatches. The edit dialog's Column select can
+ * emit it too, which is how a `<Select>` plus Save came to be an unguarded
+ * second route to the thing issue #351 wrapped in a confirmation.
+ *
+ * Only `working` counts. `pending` and `done` are parks, and a stage word the
+ * dialog never offers is not something to guess about.
+ */
+export function patchDispatchesRun(patch: PatchTask): boolean {
+  return patch.column === BOARD_WORKING;
+}
+
+/**
+ * Whether saving this patch must stop and say what already happened (#351).
+ *
+ * The condition is deliberately the same one `RetryButton` uses — confirm when
+ * the journal recorded an irreversible effect, or when it admits it cannot
+ * describe its own history — rather than confirming on every dispatch. A dialog
+ * that asked on a card where nothing is at stake trains the operator to click
+ * through it, which is how the confirmation stops working on the card where it
+ * matters.
+ */
+export function dispatchNeedsConfirm(patch: PatchTask, history: EffectHistory): boolean {
+  if (!patchDispatchesRun(patch)) return false;
+  // Neither half read: the dialog cannot say this card is clean, so it says so
+  // by confirming. This is what keeps the guard live for a caller that has not
+  // wired the journal read yet, instead of silently passing a gap off as an
+  // all-clear.
+  if (history.irreversible === undefined && history.historyIncomplete === undefined) return true;
+  return (history.irreversible?.length ?? 0) > 0 || history.historyIncomplete === true;
 }

--- a/frontend/src/lib/task-edit.ts
+++ b/frontend/src/lib/task-edit.ts
@@ -41,8 +41,9 @@ export function computeTaskPatch(draft: PatchTask, current: Task): PatchTask {
  * Both fields are optional, and "absent" is a **third** state that must not
  * collapse into "clean": a caller that has not wired the read knows nothing
  * about this card's effects, which is not the same claim as a read that came
- * back empty. `dispatchNeedsConfirm` treats absent the way the host treats
- * `historyIncomplete` — as "cannot say", which confirms.
+ * back empty. That holds **per field** — one half wired and the other absent is
+ * still "cannot say", not a half-price all-clear. See {@link readEffectHistory},
+ * which turns this into the three states rather than leaving it to falsiness.
  */
 export interface EffectHistory {
   /** The effects the journal recorded as executed, or absent if not read. */
@@ -68,6 +69,44 @@ export function patchDispatchesRun(patch: PatchTask): boolean {
 }
 
 /**
+ * What the journal is able to claim about this card's irreversible effects.
+ *
+ * Three states, spelled out, because **two of them are falsy and only one of
+ * those two may skip the confirmation**. Leaning on falsiness is what let a
+ * half-read history — one field wired, the other never passed — decide "clean"
+ * and wave a re-dispatch through on a card that may already have sent a
+ * payment.
+ *
+ * * `"dirty"`  — read, and it recorded something that cannot be taken back.
+ * * `"clean"`  — **both** halves read, and both came back empty.
+ * * `"unknown"` — a half was not read. Not a claim about the card at all.
+ *
+ * `"unknown"` confirms. It has to: the whole point of the gate is that a caller
+ * which cannot describe what this card already did must not assert it did
+ * nothing, and a guard that failed open there would be dead in a way
+ * indistinguishable from working.
+ */
+export type EffectHistoryVerdict = "clean" | "dirty" | "unknown";
+
+/**
+ * Reads {@link EffectHistory} into the three states above.
+ *
+ * A field that *was* read and says something happened settles it as `"dirty"`
+ * whichever way the other field went — an unread second field cannot make a
+ * recorded payment un-happen. Only when nothing is dirty does the absence of
+ * either half matter, and then it is `"unknown"` rather than `"clean"`.
+ */
+export function readEffectHistory(history: EffectHistory): EffectHistoryVerdict {
+  if ((history.irreversible?.length ?? 0) > 0) return "dirty";
+  if (history.historyIncomplete === true) return "dirty";
+  // Nothing known-dirty. "Clean" is a positive claim, so it needs both reads to
+  // have actually happened; an absent half is "cannot say", never an all-clear.
+  const effectsRead = history.irreversible !== undefined;
+  const completenessRead = history.historyIncomplete !== undefined;
+  return effectsRead && completenessRead ? "clean" : "unknown";
+}
+
+/**
  * Whether saving this patch must stop and say what already happened (#351).
  *
  * The condition is deliberately the same one `RetryButton` uses — confirm when
@@ -79,10 +118,5 @@ export function patchDispatchesRun(patch: PatchTask): boolean {
  */
 export function dispatchNeedsConfirm(patch: PatchTask, history: EffectHistory): boolean {
   if (!patchDispatchesRun(patch)) return false;
-  // Neither half read: the dialog cannot say this card is clean, so it says so
-  // by confirming. This is what keeps the guard live for a caller that has not
-  // wired the journal read yet, instead of silently passing a gap off as an
-  // all-clear.
-  if (history.irreversible === undefined && history.historyIncomplete === undefined) return true;
-  return (history.irreversible?.length ?? 0) > 0 || history.historyIncomplete === true;
+  return readEffectHistory(history) !== "clean";
 }

--- a/frontend/src/lib/task-output.ts
+++ b/frontend/src/lib/task-output.ts
@@ -180,12 +180,33 @@ export interface TaskFocus {
   runId?: string;
 }
 
-/** The task-detail tabs that every card renders. */
-export const TASK_TABS = ["timeline", "attempts", "artifacts", "discussion"] as const;
+/**
+ * The task-detail tabs that can be written into an address.
+ *
+ * Four of the five are on every card. **`plan` is not** — the Plan tab renders
+ * only for a card somebody planned (issue #337) — and it is in this list all
+ * the same, because the alternative is the state it was in: selecting Plan
+ * wrote nothing to the URL, so a reload, a copied link or a Back/Forward
+ * dropped the operator onto Timeline while the tab they were reading was the
+ * only reason they were on the screen. An address that cannot name a tab is an
+ * address that silently disagrees with what is on screen.
+ *
+ * The cost of admitting it is a `?tab=plan` that names a tab a *particular*
+ * card has not got — a link that has gone stale, or one card's link opened on
+ * another. `TaskDetailView` resolves that the way {@link readTaskFocus} handles
+ * every other stale query: it falls back to Timeline rather than rendering an
+ * empty screen. That is a screen-level fallback and not one this list can make,
+ * because whether the tab exists is a property of the card, not of the address.
+ */
+export const TASK_TABS = ["timeline", "attempts", "plan", "artifacts", "discussion"] as const;
 
 export type TaskTab = (typeof TASK_TABS)[number];
 
-/** Whether a query value names a task-detail tab that can always be opened. */
+/**
+ * Whether a query value names an addressable task-detail tab.
+ *
+ * Addressable, not always-present: see {@link TASK_TABS} on `plan`.
+ */
 export function isTaskTab(value: string): value is TaskTab {
   return (TASK_TABS as readonly string[]).includes(value);
 }

--- a/frontend/src/views/AssigneeSelect.tsx
+++ b/frontend/src/views/AssigneeSelect.tsx
@@ -66,6 +66,49 @@ interface Option {
   offRoster?: boolean;
 }
 
+/** Which halves of the roster read failed. Both false is the ordinary case. */
+export interface RosterGap {
+  desks: boolean;
+  team: boolean;
+}
+
+/** A settled read: its value, or the fact that it failed. */
+type Settled<T> = { ok: true; value: T } | { ok: false };
+
+/**
+ * Await one roster half without letting its rejection erase the fact of it.
+ *
+ * `Promise.allSettled` would do this, but its `PromiseSettledResult` carries
+ * the rejection *reason* — a host error string — and nothing here should be
+ * one field access away from rendering that into a picker.
+ */
+function settle<T>(p: Promise<T>): Promise<Settled<T>> {
+  return p
+    .then((value): Settled<T> => ({ ok: true, value }))
+    .catch((): Settled<T> => ({ ok: false }));
+}
+
+/**
+ * What to tell the operator about a roster the picker could not fully read, or
+ * `null` when both halves answered.
+ *
+ * The sentence has to survive being the *only* thing in the list. A failed read
+ * renders exactly the picker a genuinely empty company does — one row,
+ * Unassigned — and "hand it to the orchestrator" is a consequential enough
+ * write that "there is nobody else" and "we could not find out who else" must
+ * not look the same. So each line says which half is missing and that the list
+ * is short rather than complete.
+ */
+export function rosterGapNotice(failed: RosterGap): string | null {
+  if (failed.desks && failed.team)
+    return "Couldn’t load this company’s desks or teammates — this list is incomplete, not empty. Reopen it after a reload before reassigning.";
+  if (failed.desks)
+    return "Couldn’t load this company’s desks, so they’re missing from this list — it’s incomplete, not empty.";
+  if (failed.team)
+    return "Couldn’t load this company’s teammates, so they’re missing from this list — it’s incomplete, not empty.";
+  return null;
+}
+
 export function AssigneeSelect({
   client,
   company,
@@ -92,6 +135,13 @@ export function AssigneeSelect({
   // this value is not on it". Without it, every assigned card would flash as
   // off-roster on the first paint.
   const [loaded, setLoaded] = useState(false);
+  // Which halves of the roster read *failed*, kept apart from what they
+  // returned. Both reads normalize to `[]`, so a rejected `/desks` and a
+  // company with no desks produced the identical picker — one row, Unassigned —
+  // and the operator could not tell "there is nobody to pick" from "we could
+  // not find out". Reassigning to Unassigned is a real write, so that is not a
+  // distinction to leave to guesswork.
+  const [failed, setFailed] = useState<RosterGap>({ desks: false, team: false });
 
   useEffect(() => {
     let cancelled = false;
@@ -102,20 +152,27 @@ export function AssigneeSelect({
     // pick made in that window would name something that does not exist here.
     setDesks([]);
     setTeam([]);
-    // Both halves are best-effort *here*: a host that does not serve one of
+    setFailed({ desks: false, team: false });
+    // Both halves stay best-effort *here*: a host that does not serve one of
     // these surfaces still gets a usable picker rather than a dialog that
     // fails to render. The org chart is not the same rule and must not be read
     // as one — `/desks` IS its chart, so losing it there is an error state,
     // and only `/team` and `/users` are best-effort
     // (`views/company/OrgChartView.tsx`). A picker with no desks is still a
     // picker.
+    //
+    // What is *not* best-effort is saying so. Each half is settled
+    // individually rather than collapsed to `[]` by a shared `catch`, so the
+    // picker can render the gap it is missing — the same distinction the
+    // Overview draws before it claims "No desks yet" (issue #1313).
     void Promise.all([
-      client.listDesks(company).catch(() => [] as DeskDto[]),
-      client.listTeam(company).catch(() => [] as TeamMemberDto[]),
+      settle(client.listDesks(company)),
+      settle(client.listTeam(company)),
     ]).then(([desksRes, teamRes]) => {
       if (cancelled) return;
-      setDesks(desksRes);
-      setTeam(teamRes);
+      setDesks(desksRes.ok ? desksRes.value : []);
+      setTeam(teamRes.ok ? teamRes.value : []);
+      setFailed({ desks: !desksRes.ok, team: !teamRes.ok });
       setLoaded(true);
     });
     return () => {
@@ -170,9 +227,13 @@ export function AssigneeSelect({
     if (!value) return null;
     if (deskOptions.some((o) => o.value === value)) return null;
     if (teamOptions.some((o) => o.value === value)) return null;
-    // Only claim it is off-roster once a roster actually came back: a host that
-    // served neither surface tells us nothing about this value.
-    const known = loaded && (desks.length > 0 || team.length > 0);
+    // Only claim it is off-roster once a roster actually came back. This used
+    // to stand in for that with "either list is non-empty", which held for the
+    // case it was written against and broke on the mixed one: with `/desks`
+    // answering two desks and `/team` rejected, a perfectly current teammate id
+    // was flagged "not on roster" against a roster half of which never
+    // arrived. The read's own outcome is the honest signal, so ask it.
+    const known = loaded && !failed.desks && !failed.team;
     return {
       key: `stale:${value}`,
       value,
@@ -180,7 +241,7 @@ export function AssigneeSelect({
       hint: known ? "not on roster" : undefined,
       offRoster: known,
     };
-  }, [value, deskOptions, teamOptions, loaded, desks.length, team.length]);
+  }, [value, deskOptions, teamOptions, loaded, failed.desks, failed.team]);
 
   /**
    * The trigger's rendering of a wire value.
@@ -216,6 +277,11 @@ export function AssigneeSelect({
     };
   }, [deskOptions, teamOptions, stale]);
 
+  // Only once the reads have settled: a picker still loading is not a picker
+  // that failed, and flashing the warning on first paint would be the same
+  // "cannot tell these apart" problem pointed the other way.
+  const gap = loaded ? rosterGapNotice(failed) : null;
+
   return (
     <Select
       value={value === "" ? UNASSIGNED : value}
@@ -243,6 +309,20 @@ export function AssigneeSelect({
             <OptionRow label={UNASSIGNED_LABEL} hint="hand it to the orchestrator" />
           </SelectItem>
         </SelectGroup>
+
+        {/* Not a `SelectItem`: there is nothing here to pick, and a warning
+            that could be selected would submit itself as an assignee. It sits
+            directly under Unassigned because that is the row it qualifies. */}
+        {gap && (
+          <div
+            role="note"
+            data-testid="assignee-roster-gap"
+            className="flex items-start gap-2 border-t px-2 py-1.5 text-xs text-status-blocked-text"
+          >
+            <AlertCircle className="mt-px size-3.5 shrink-0" aria-hidden />
+            <span className="min-w-0">{gap}</span>
+          </div>
+        )}
 
         {stale && (
           <>

--- a/frontend/src/views/TaskDetailRoute.tsx
+++ b/frontend/src/views/TaskDetailRoute.tsx
@@ -107,14 +107,14 @@ export function TaskDetailRoute({
         });
       }}
       onOpenThread={onOpenThread}
-      // Both of these used to hand a card back to the board rendered beside
-      // this screen, which held its own copy of the row. There is no such
-      // sibling now: the board is the `tasks` ledger, it re-reads from the host,
-      // and it is not mounted while this screen is. So a save reconciles
-      // nothing here — the board reads the change when the operator returns to
-      // it — and a delete leaves for the board rather than sitting on the
-      // detail of a card that no longer exists.
-      onSaved={() => {}}
+      // `onSaved` used to be here, as a literal `() => {}`. It handed a saved
+      // card back to the board rendered beside this screen, which held its own
+      // copy of the row; there is no such sibling now — the board is the `tasks`
+      // ledger, it re-reads from the host, and it is not mounted while this
+      // screen is. The prop survived the deletion as five components' worth of
+      // plumbing that ended in a no-op, so it has gone with it. A delete still
+      // has somewhere to go: leave for the board, rather than sit on the detail
+      // of a card that no longer exists.
       onDeleted={onLeave}
     />
   );

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -169,20 +169,24 @@ export const MAX_DISCUSSION_CHARS = 4000;
 const DISCUSSION_COUNTER_FROM = MAX_DISCUSSION_CHARS - 500;
 
 /**
- * Clips a message to {@link MAX_DISCUSSION_CHARS}, counting the way the host
- * counts.
+ * How long a message is, counting the way the host counts.
  *
  * Codepoints, not `String.length`: that is UTF-16 code units, so a paste of
- * emoji would be cut at half the limit the host actually applies, and the
- * counter beside it would have been describing a different rule from the one
- * doing the cutting. A plain `maxLength` on the textarea has the same flaw,
+ * emoji would measure double the limit the host actually applies, and the
+ * counter would be describing a different rule from the one the host enforces.
+ * A plain `maxLength` on the textarea has the same flaw *and* the one below,
  * which is why there is not one.
+ *
+ * The composer refuses an over-long message rather than trimming it to fit.
+ * Clipping inside `onChange` was worse than the truncation it was guarding
+ * against: pasting 4,500 characters silently destroyed 500 of them, past the
+ * reach of the browser's own undo, and the operator was told about it by a
+ * counter reading a number they had not typed. Keeping the text and disabling
+ * Post says the same thing and costs them nothing — the same shape as the
+ * redirect composer, which keeps its text when a send fails.
  */
-export function capDiscussion(text: string): string {
-  const chars = [...text];
-  return chars.length <= MAX_DISCUSSION_CHARS
-    ? text
-    : chars.slice(0, MAX_DISCUSSION_CHARS).join("");
+export function countDiscussionChars(text: string): number {
+  return [...text].length;
 }
 
 function priorityStyle(priority: string): string {
@@ -2414,12 +2418,23 @@ export function DiscussionTab({
     }
   }
 
+  // What Post would actually send, and by how much it is over the host's limit.
+  //
+  // Measured on the *trimmed* text because that is what goes on the wire: a
+  // message at exactly the cap followed by a stray newline is not over it, and
+  // blocking it would leave the operator hunting an invisible character.
+  const body = text.trim();
+  const used = countDiscussionChars(body);
+  const over = used - MAX_DISCUSSION_CHARS;
+
   async function post() {
-    // Clipped on the way in as well as on the way out (`onChange`): a value set
-    // by anything other than typing — a paste handled by the browser's own
-    // undo, an autofill — would otherwise reach a host that truncates silently.
-    const body = capDiscussion(text.trim());
-    if (!body || busy) return;
+    // The same `body` and the same `over` the Post button is disabled by, so the
+    // keyboard path (Enter) cannot post something the button refuses. Guarded
+    // here as well as there because Enter does not consult a `disabled`
+    // attribute — and because the host would take an over-long message and
+    // truncate it to a `201`, which is the silence this whole composer exists
+    // to replace.
+    if (!body || over > 0 || busy) return;
     setBusy(true);
     try {
       const posted = await postTaskDiscussion(client, company, taskId, body);
@@ -2543,12 +2558,15 @@ export function DiscussionTab({
           className="min-h-16 text-xs"
           disabled={busy}
           aria-describedby={counterId}
-          // Clipped here rather than left to the host, which truncates a long
-          // post to `MAX_DISCUSSION_CHARS` and answers `201` — so the tail
-          // vanished with no warning and no way to get it back, and the
-          // operator found out by reading their own message back. See
-          // `capDiscussion` for why this is not a `maxLength`.
-          onChange={(e) => setText(capDiscussion(e.target.value))}
+          // Everything they typed or pasted is kept, over the cap included.
+          // The host truncates a long post to `MAX_DISCUSSION_CHARS` and
+          // answers `201` — so the tail used to vanish with no warning — but
+          // the fix for that is to refuse the send, not to destroy the
+          // overflow here. Neither a `maxLength` nor a clip in this handler can
+          // be undone: the browser's undo stack does not reach a value React
+          // rewrote. The counter and the disabled Post below say what is wrong
+          // while the words are still on the screen to fix.
+          onChange={(e) => setText(e.target.value)}
           onKeyDown={(e) => {
             // Enter posts; Shift+Enter is a newline. A note about a task is
             // usually one line, and the mouse trip for every one of them is
@@ -2562,7 +2580,13 @@ export function DiscussionTab({
         <Button
           size="sm"
           className="h-8 shrink-0"
-          disabled={busy || !text.trim()}
+          // Down while the message is over the cap, with the counter — which
+          // this points at — carrying the reason and the number to cut. Saving
+          // is disabled rather than silently doing nothing everywhere else on
+          // this page; this is that.
+          disabled={busy || !body || over > 0}
+          aria-describedby={counterId}
+          data-testid="discussion-post"
           onClick={() => void post()}
         >
           {busy ? (
@@ -2580,14 +2604,22 @@ export function DiscussionTab({
         permanent `0 of 4000` under every one-line note is noise. See
         `DISCUSSION_COUNTER_FROM`.
       */}
-      <DiscussionCounter id={counterId} used={[...text].length} />
+      <DiscussionCounter id={counterId} used={used} />
     </div>
   );
 }
 
-/** The composer's character count, and the sentence that appears at the cap. */
+/**
+ * The composer's character count, the sentence that appears at the cap, and the
+ * one that appears past it.
+ *
+ * Past the cap this is the only place the operator is told why Post went down,
+ * so it names the number to cut rather than just going red. Both the textarea
+ * and the Post button point at it with `aria-describedby`, which is what makes
+ * "disabled with a reason" true for a screen reader and not only on screen.
+ */
 function DiscussionCounter({ id, used }: { id: string; used: number }) {
-  const atCap = used >= MAX_DISCUSSION_CHARS;
+  const over = used - MAX_DISCUSSION_CHARS;
   const shown = used >= DISCUSSION_COUNTER_FROM;
   return (
     <p
@@ -2595,11 +2627,16 @@ function DiscussionCounter({ id, used }: { id: string; used: number }) {
       className={cn(
         "text-right text-2xs tabular-nums",
         !shown && "sr-only",
-        shown && (atCap ? "text-status-blocked-text" : "text-muted-foreground"),
+        shown &&
+          (used >= MAX_DISCUSSION_CHARS
+            ? "text-status-blocked-text"
+            : "text-muted-foreground"),
       )}
     >
       {used} of {MAX_DISCUSSION_CHARS} characters
-      {atCap && " — the most a message can hold. Post this and start another."}
+      {over > 0 &&
+        ` — ${over} over the most a message can hold. Shorten it by ${over}, or post it in two.`}
+      {over === 0 && " — the most a message can hold. Post this and start another."}
     </p>
   );
 }

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -9,6 +9,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -16,9 +17,11 @@ import {
 } from "react";
 import {
   AlertCircle,
+  AlertTriangle,
   ArrowLeft,
   Ban,
   ChevronRight,
+  CircleHelp,
   ClipboardList,
   Clock,
   CornerDownRight,
@@ -31,6 +34,7 @@ import {
   MessagesSquare,
   Pencil,
   Play,
+  RotateCcw,
   Send,
   Square,
   Trash2,
@@ -83,7 +87,9 @@ import {
   blockingTaskApprovals,
   decidingForTask,
   pendingApprovalWait,
+  taskApprovalBlock,
   taskApprovalRows,
+  RESUME_BLOCKED_REASON,
 } from "@/lib/task-approvals";
 import { formatDuration, timeOf } from "@/lib/timeline-format";
 import { TimelineList, runStatusTone } from "@/views/runs/RunTimeline";
@@ -119,7 +125,12 @@ import { cn } from "@/lib/utils";
 import { formatUsdCost } from "@/lib/cost";
 import { effectDone } from "@/lib/language";
 
-import { labelFor, PRIORITY_STYLES, type TaskColumn } from "@/lib/board-columns";
+import {
+  BOARD_DONE,
+  labelFor,
+  PRIORITY_STYLES,
+  type TaskColumn,
+} from "@/lib/board-columns";
 import { useBoardColumns } from "@/hooks/use-board-columns";
 import { toast } from "sonner";
 import { ArtifactsTab } from "./ArtifactsTab";
@@ -130,6 +141,49 @@ import { TaskWorkflowProposalPanel } from "./TaskWorkflowProposalPanel";
 
 /** How often to re-poll the detail while the screen is open (visibility-gated). */
 const POLL_MS = 4000;
+
+/**
+ * The longest discussion message the host will keep, in **codepoints**.
+ *
+ * Mirrors `MAX_DISCUSSION_CHARS` in `src/ports/tasks.rs`, which **truncates
+ * rather than rejects**: an over-long post still returns `201`, with its tail
+ * silently gone. So the only way an operator learned this limit existed was by
+ * reading their own echoed row and finding it cut — after the words were
+ * already lost. Stated in the box instead, so it is a limit you meet rather
+ * than one you discover.
+ *
+ * Kept as a number here rather than fetched, on `MAX_AVATAR_MB`'s precedent:
+ * it is a constant of the write boundary, and a console that had to ask for it
+ * would have nothing to say before the answer arrived.
+ */
+export const MAX_DISCUSSION_CHARS = 4000;
+
+/**
+ * Where the character counter stops being invisible.
+ *
+ * A note on a card is usually one line, and a permanent `0 / 4000` under every
+ * one of them is noise that teaches nobody anything. It appears when it starts
+ * to matter — and it exists in the DOM the whole time regardless, so the
+ * textarea's `aria-describedby` never points at nothing.
+ */
+const DISCUSSION_COUNTER_FROM = MAX_DISCUSSION_CHARS - 500;
+
+/**
+ * Clips a message to {@link MAX_DISCUSSION_CHARS}, counting the way the host
+ * counts.
+ *
+ * Codepoints, not `String.length`: that is UTF-16 code units, so a paste of
+ * emoji would be cut at half the limit the host actually applies, and the
+ * counter beside it would have been describing a different rule from the one
+ * doing the cutting. A plain `maxLength` on the textarea has the same flaw,
+ * which is why there is not one.
+ */
+export function capDiscussion(text: string): string {
+  const chars = [...text];
+  return chars.length <= MAX_DISCUSSION_CHARS
+    ? text
+    : chars.slice(0, MAX_DISCUSSION_CHARS).join("");
+}
 
 function priorityStyle(priority: string): string {
   return (
@@ -185,6 +239,54 @@ function neverDispatched(task: Task): boolean {
   return stage === "pending" || UNSTARTED_COLUMNS.has(stage);
 }
 
+/** Whether the host has any dispatch window at all to show for this card. */
+function hasDispatchWindow(
+  worked: { millis: number; live: boolean } | null,
+): boolean {
+  return worked !== null && (worked.millis > 0 || worked.live);
+}
+
+/**
+ * Whether this card has genuinely never been dispatched — derived **once**, for
+ * every part of the screen that has an opinion about it (issue #465).
+ *
+ * One function with several readers rather than several readings, on
+ * `taskApprovalBlock`'s grounds. Before this the screen gave the same state
+ * three different names in three places: the header said "Not yet dispatched",
+ * the button beneath it said "Retry", and pressing that button raised
+ * "Dispatched — the assignee is working on it." The header and the toast were
+ * both right; "Retry" was the one that was false, because there is no earlier
+ * attempt to try again. Nothing on screen tied the three together, so nothing
+ * could notice.
+ */
+function neverStartedYet(
+  task: Task,
+  worked: { millis: number; live: boolean } | null,
+): boolean {
+  return !hasDispatchWindow(worked) && neverDispatched(task);
+}
+
+/**
+ * Whether the card is finished, so re-dispatch is not an offer to make.
+ *
+ * Retry rendered — and worked — on a Done card: one click re-ran a settled
+ * task, spending an agent turn to redo work somebody had already accepted.
+ * `done` is the only closed phase the board declares
+ * (`src/ledger/board.rs::exactly_one_phase_is_closed_and_it_is_done`), so this
+ * is the whole of the guard.
+ *
+ * Asked of the ledger's own `closed` flag rather than matched against the
+ * word, on `lib/board-columns`'s standing grounds: a closed status added on the
+ * host and not here is one the console silently keeps offering Retry for.
+ * `columns` is itself a ledger read and is empty until it lands, so the phase
+ * word is the fallback for that window — a Retry that flickers onto a Done card
+ * for one read is the same bug arriving a second later.
+ */
+function isFinished(task: Task, columns: TaskColumn[]): boolean {
+  const held = columns.find((c) => c.id === task.column);
+  return held ? held.closed : task.column === BOARD_DONE;
+}
+
 /**
  * Extends a host-computed duration to `now` while its span is still open.
  *
@@ -238,13 +340,43 @@ const EMPTY_FAILED: Record<string, string> = {};
  *
  * Returns `null` for a plan with nothing to report, so the trigger stays a
  * plain word.
+ *
+ * **The colour is not the signal.** It was: the rendered text was a bare
+ * number, and red-versus-amber was the only thing separating "this card cannot
+ * start" from "this card will pause to ask you something" — which is no
+ * distinction at all to the reader who cannot see the difference, and none in a
+ * screenshot printed in greyscale. So each tone now carries its own `Icon`
+ * (the same two shapes the plan brief's own headline uses, `AlertTriangle` for
+ * blocked and `CircleHelp` for unresolved, so the tab and the brief it opens
+ * agree) and its own `label`, which is what a screen reader reads and what a
+ * pointer gets as a tooltip. The number stays for everyone else.
  */
-function planTabCount(plan: TaskPlan): { count: number; tone: string } | null {
+export function planTabCount(plan: TaskPlan): {
+  count: number;
+  tone: string;
+  /** The non-colour half of the signal, drawn beside the count. */
+  Icon: typeof AlertTriangle;
+  /** Said instead of the bare number to anything that is not reading colour. */
+  label: string;
+} | null {
   const { blocking, approval, unchecked } = tallyPrerequisites(plan);
-  if (blocking > 0) return { count: blocking, tone: "text-destructive" };
+  const things = (n: number) => (n === 1 ? "prerequisite" : "prerequisites");
+  if (blocking > 0) {
+    return {
+      count: blocking,
+      tone: "text-destructive",
+      Icon: AlertTriangle,
+      label: `${blocking} blocking ${things(blocking)}`,
+    };
+  }
   const unresolved = approval + unchecked;
   if (unresolved > 0) {
-    return { count: unresolved, tone: "text-status-blocked-text" };
+    return {
+      count: unresolved,
+      tone: "text-status-blocked-text",
+      Icon: CircleHelp,
+      label: `${unresolved} unresolved ${things(unresolved)}`,
+    };
   }
   return null;
 }
@@ -264,7 +396,6 @@ export function TaskDetailView({
   onBack,
   onNavigate,
   onOpenThread,
-  onSaved,
   onDeleted,
 }: {
   client: OpenCompanyClient;
@@ -307,8 +438,16 @@ export function TaskDetailView({
   onNavigate: (id: string) => void;
   /** Open the chat thread this card was created from (issue #246). */
   onOpenThread?: (threadId: string) => void;
-  /** Hand a saved card back to the board for reconciliation. */
-  onSaved: (t: Task) => void;
+  /*
+   * There is no `onSaved`. There was, and every one of its five call sites
+   * handed a saved card to a `() => {}`: it existed to reconcile the board
+   * rendered *beside* this screen, and since issue #1140 there is no such
+   * sibling — the board is the `tasks` ledger, it is not mounted while this is,
+   * and it re-reads from the host when the operator returns to it. `load()` is
+   * what actually refreshes this screen, and it always was; the prop was a
+   * second refresh path that refreshed nothing, which is worse than no path at
+   * all because it reads like the one doing the work.
+   */
   /** Tell the board a card was deleted. */
   onDeleted: (id: string) => void;
 }) {
@@ -471,6 +610,54 @@ export function TaskDetailView({
     return () => window.clearInterval(timer);
   }, [ticking]);
 
+  /**
+   * What the company queue says is holding this card — the board's derivation,
+   * read here so the two surfaces cannot disagree (#883, #1891).
+   */
+  const approvalBlock = useMemo(
+    () => (detail ? taskApprovalBlock(parked, detail.task.id) : null),
+    [parked, detail],
+  );
+  /**
+   * Whether Retry/Resume is the wrong click right now.
+   *
+   * A run parked on an approval is **finished** as far as the runs store is
+   * concerned: the card leaves `GET …/tasks/inflight`, so `inflight` is `null`,
+   * so `ControlBar` renders its else-branch — and the else-branch is Retry,
+   * enabled, directly underneath a row reading "Waiting on your approval". One
+   * click there spends a second agent turn on work the operator is still being
+   * asked to authorise, and re-runs it from the start; since #469 the last
+   * verdict continues the parked turn on its own, so the approval *is* the
+   * resume and this button is never the way to give it.
+   *
+   * The board has been getting this right since #883 and this screen never
+   * did — `taskApprovalBlock` was written for both halves and had no production
+   * caller at all.
+   *
+   * **Two reads, unioned**, because either on its own leaves the button live
+   * for a poll. `approvalBlock` is the company queue, which is what the board
+   * keys on and where a decidable row comes from; `awaitingApproval` is this
+   * screen's own `GET …/tasks/{id}`, computed by the host with an ownership
+   * rule (`approval_owner`) this side cannot see, and it lands first when an
+   * approval has parked but the feed has not delivered it yet. They can
+   * disagree for one poll in either direction, and down is the safe answer for
+   * both: a Retry the operator has to wait four seconds for is a nuisance, and
+   * a Retry that fires beside a pending approval is a paid duplicate turn.
+   */
+  const blockedOnApproval = awaitingApproval || approvalBlock !== null;
+  /**
+   * The tab actually shown, which is not always the tab that was asked for.
+   *
+   * `?tab=plan` is addressable now (`lib/task-output`), and Plan is the one tab
+   * that a *particular* card may not have. A stale link, or one card's link
+   * opened on another, would otherwise select a tab with no trigger and no
+   * panel: a bare tab bar over an empty screen. Falls back the way
+   * `readTaskFocus` falls back on every other stale query — to Timeline —
+   * and deliberately does **not** rewrite the address, because the operator may
+   * be one lineage hop from the card that link was written for.
+   */
+  const activeTab = tab === "plan" && detail && !detail.task.plan ? "timeline" : tab;
+
   if (notFound) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
@@ -496,10 +683,18 @@ export function TaskDetailView({
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       {/*
         This pane's heading is the card's own title, inside `DetailHeader`,
-        which needs a loaded `detail`. So a cold `#/tasks/<id>` was unnamed
-        while the read was in flight, and stayed unnamed if it failed with
-        anything other than a 404 — `detail` is left null and nothing retries
-        (codex review, #1785).
+        which needs a loaded `detail`. So a cold `#/tasks/<id>` is unnamed while
+        the read is in flight, and stays unnamed for as long as it keeps failing
+        with anything other than a 404 (codex review, #1785).
+
+        That review's wording — "`detail` is left null and nothing retries" —
+        was wrong about the second half, and left as it was would have sent the
+        next reader looking for a recovery that already exists:
+        `startVisiblePolling` re-runs `load()` every four seconds and clears
+        `error` the moment one succeeds. What was actually missing is that an
+        operator could not *see* it. A back bar, a red alert and an empty pane
+        is indistinguishable from a dead end, so the pane below offers that same
+        read as a button and says the polling is happening anyway.
 
         "Task", not the id: an id is a string the operator did not choose and
         cannot read out, and announcing one would be worse than announcing the
@@ -550,10 +745,12 @@ export function TaskDetailView({
                 inflight={inflight}
                 irreversible={detail.irreversibleEffects}
                 historyIncomplete={detail.historyIncomplete}
+                blockedOnApproval={blockedOnApproval}
+                neverStarted={neverStartedYet(detail.task, worked)}
+                finished={isFinished(detail.task, columns)}
                 client={client}
                 company={company}
                 onChanged={load}
-                onSaved={onSaved}
                 onEdit={() => setEditing(true)}
               />
 
@@ -590,13 +787,12 @@ export function TaskDetailView({
                 client={client}
                 company={company}
                 task={detail.task}
-                onSaved={onSaved}
                 onReload={load}
               />
             )}
 
             <Tabs
-              value={tab}
+              value={activeTab}
               onValueChange={(next) => {
                 const selected = String(next);
                 setTab(selected);
@@ -628,11 +824,24 @@ export function TaskDetailView({
                     Plan
                     {(() => {
                       const badge = planTabCount(detail.task.plan!);
-                      return badge ? (
-                        <span className={cn("ml-1.5 tabular-nums", badge.tone)}>
-                          {badge.count}
+                      if (!badge) return null;
+                      const { Icon } = badge;
+                      return (
+                        <span
+                          className={cn(
+                            "ml-1.5 inline-flex items-center gap-0.5 tabular-nums",
+                            badge.tone,
+                          )}
+                          title={badge.label}
+                        >
+                          <Icon className="size-3" aria-hidden />
+                          {/* The number is the sighted reading of `label`, so
+                              it is hidden from assistive tech rather than read
+                              out twice ("2 · 2 blocking prerequisites"). */}
+                          <span aria-hidden>{badge.count}</span>
+                          <span className="sr-only">{badge.label}</span>
                         </span>
-                      ) : null;
+                      );
                     })()}
                   </TabsTrigger>
                 )}
@@ -640,7 +849,17 @@ export function TaskDetailView({
                 <TabsTrigger value="discussion">Discussion</TabsTrigger>
               </TabsList>
 
+              {/*
+                Each panel opens with its own `h2` (issue: heading levels).
+                The screen's only heading was the card title in `DetailHeader`,
+                an `h1` — and the Artifacts panel renders an `h3` per artifact
+                (`ArtifactsTab`), so the outline jumped h1 → h3 and a reader
+                navigating by heading had no way to tell which section they had
+                landed in. `sr-only` because the tab bar is already the visible
+                label; duplicating it in ink would be the same word twice.
+              */}
               <TabsContent value="timeline" className="mt-4">
+                <h2 className="sr-only">Timeline</h2>
                 <TimelineList
                   empty={
                     <EmptyState
@@ -653,6 +872,7 @@ export function TaskDetailView({
               </TabsContent>
 
               <TabsContent value="attempts" className="mt-4">
+                <h2 className="sr-only">Attempts</h2>
                 <AttemptsTab
                   client={client}
                   company={company}
@@ -664,6 +884,7 @@ export function TaskDetailView({
 
               {detail.task.plan && (
                 <TabsContent value="plan" className="mt-4">
+                  <h2 className="sr-only">Plan</h2>
                   <TaskPlanBrief
                     plan={detail.task.plan}
                     // Issue #1106: answering the brief's ownership question is
@@ -673,10 +894,9 @@ export function TaskDetailView({
                     // reach the card by a path that skips that check.
                     onPick={async (id) => {
                       try {
-                        const saved = await patchTask(client, company, detail.task.id, {
+                        await patchTask(client, company, detail.task.id, {
                           assignee: id,
                         });
-                        onSaved(saved);
                         await load();
                         toast.success(`Assigned to ${id}.`);
                       } catch (e) {
@@ -690,6 +910,7 @@ export function TaskDetailView({
               )}
 
               <TabsContent value="artifacts" className="mt-4">
+                <h2 className="sr-only">Artifacts</h2>
                 <ArtifactsTab
                   client={client}
                   company={company}
@@ -700,6 +921,7 @@ export function TaskDetailView({
               </TabsContent>
 
               <TabsContent value="discussion" className="mt-4">
+                <h2 className="sr-only">Discussion</h2>
                 <DiscussionTab
                   // Keyed by card: a different task is a different thread, and
                   // the tab accumulates the one it is shown.
@@ -715,13 +937,57 @@ export function TaskDetailView({
             </Tabs>
           </div>
         </ScrollArea>
+      ) : error ? (
+        /*
+          The non-404 failure. `load()` sets `error`, leaves `detail` null, and
+          this ternary used to fall through to `null` — back bar, red alert,
+          nothing else on the screen. See the note above the header: the poll
+          does recover on its own, but a pane with no control in it does not
+          say so, and an operator who cannot tell a slow failure from a
+          permanent one leaves.
+
+          `setLoading(true)` hands the wait back to the skeleton branch above,
+          so the button visibly does something; a second failure lands back
+          here with the alert refreshed.
+        */
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+          <p className="text-sm font-medium">This task could not be loaded.</p>
+          <p className="max-w-sm text-xs text-muted-foreground">
+            The console keeps trying every few seconds on its own, and will show
+            the card as soon as one of those reads succeeds. Try again now if
+            you would rather not wait.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setLoading(true);
+              void load();
+            }}
+          >
+            <RotateCcw className="mr-1.5 size-4" />
+            Try again
+          </Button>
+        </div>
       ) : null}
 
       <TaskEditDialog
         task={editing && detail ? detail.task : null}
+        // The dialog's Column select emits the same `{column: "working"}` this
+        // bar's Retry sends, so it is behind the same #351 confirmation — and
+        // that gate treats an unread journal as "cannot say" and confirms
+        // unconditionally. These are the read, so a clean card stops being
+        // asked. Passed as `detail?.…` rather than defaulted: `[]` would mean
+        // "this card did nothing irreversible", which is a claim nothing has
+        // checked while `detail` is still null, and the point of the gate is
+        // that it never passes a gap off as an all-clear. The dialog is only
+        // ever open with `detail` loaded (`task` above is null otherwise), so
+        // in practice it always receives the real answer.
+        inflight={inflight}
+        irreversible={detail?.irreversibleEffects}
+        historyIncomplete={detail?.historyIncomplete}
         onClose={() => setEditing(false)}
-        onSaved={(t) => {
-          onSaved(t);
+        onSaved={() => {
           setEditing(false);
           void load();
         }}
@@ -866,15 +1132,26 @@ function DetailHeader({
   );
 }
 
-function ControlBar({
+/*
+ * Exported for `test/unit/task-detail-control-bar.test.ts`, on the same grounds
+ * `AwaitingApprovalRow` is: every claim this bar has to keep — that Retry is
+ * down while the card is blocked on a sign-off, that it is not offered at all
+ * on a finished card, that a never-dispatched card says "Dispatch", and that a
+ * composed redirect survives its run settling — only exists at the rendered
+ * control. Each of them looks completely normal in the source and is wrong on
+ * the screen, which is exactly the class of bug this file has collected.
+ */
+export function ControlBar({
   task,
   inflight,
   irreversible,
   historyIncomplete,
+  blockedOnApproval,
+  neverStarted,
+  finished,
   client,
   company,
   onChanged,
-  onSaved,
   onEdit,
 }: {
   task: Task;
@@ -886,10 +1163,22 @@ function ControlBar({
   irreversible: IrreversibleEffect[];
   /** Whether the journal holds executed history it cannot describe (#351). */
   historyIncomplete: boolean;
+  /**
+   * Whether this card is stopped behind a sign-off (#883). Derived by the
+   * screen, not here: it takes the company queue **and** the host's own
+   * approvals, and this bar sees neither. Down rather than hidden, as on the
+   * board card — an operator has to be able to see that Retry is the wrong
+   * click, not wonder where it went.
+   */
+  blockedOnApproval: boolean;
+  /** Whether nothing has ever been dispatched for this card (issue #465) —
+   *  the same answer the header prints, so the two cannot use two words. */
+  neverStarted: boolean;
+  /** Whether the card is in a closed column, where re-dispatch is not offered. */
+  finished: boolean;
   client: OpenCompanyClient;
   company: string | null;
   onChanged: () => Promise<void> | void;
-  onSaved: (t: Task) => void;
   onEdit: () => void;
 }) {
   const [busy, setBusy] = useState(false);
@@ -901,14 +1190,25 @@ function ControlBar({
   const pending = inflight?.pendingAction ?? null;
   const steerDisabled = busy || pending !== null;
 
+  /**
+   * Steers the run named by `key`.
+   *
+   * The key is a parameter rather than read off `inflight` inside, because the
+   * `if (!inflight) return` that used to open this function was a **silent
+   * no-op** wearing a guard's clothes: the redirect composer below survives the
+   * run settling (see it for why), so Send stayed live, and pressing it did
+   * nothing at all — no request, no error, no toast. Taking the key makes the
+   * absence of a run something the caller has to answer for, at the one site
+   * where it can actually happen.
+   */
   async function steer(
+    key: string,
     action: SteerAction,
     opts?: { instruction?: string; confirm?: boolean },
   ) {
-    if (!inflight) return;
     setBusy(true);
     try {
-      await steerTask(client, company, inflight.key, { action, ...opts });
+      await steerTask(client, company, key, { action, ...opts });
       setRedirecting(false);
       setInstruction("");
       await onChanged();
@@ -922,12 +1222,11 @@ function ControlBar({
   async function patchColumn() {
     setBusy(true);
     try {
-      const saved = await patchTask(client, company, task.id, {
+      await patchTask(client, company, task.id, {
         // The phase word, not the stage: the host resolves `working` to
         // `in_progress`, which is what dispatches (issue #1512).
         column: "working",
       });
-      onSaved(saved);
       await onChanged();
       toast.success("Dispatched — the assignee is working on it.");
     } catch (e) {
@@ -958,10 +1257,9 @@ function ControlBar({
   async function planFirst() {
     setBusy(true);
     try {
-      const saved = await patchTask(client, company, task.id, {
+      await patchTask(client, company, task.id, {
         column: "planning",
       });
-      onSaved(saved);
       await onChanged();
       toast.success("Planning — a brief is being written for this card.");
     } catch (e) {
@@ -983,10 +1281,9 @@ function ControlBar({
     }
     setBusy(true);
     try {
-      const saved = await patchTask(client, company, task.id, {
+      await patchTask(client, company, task.id, {
         assignee: next,
       });
-      onSaved(saved);
       await onChanged();
       setReassigning(false);
       toast.success("Reassigned.");
@@ -999,7 +1296,27 @@ function ControlBar({
     }
   }
 
-  const resumeLabel = task.stage === "paused" ? "Resume" : "Retry";
+  /**
+   * One word per state, and the honest one (issue #465).
+   *
+   * `Dispatch` for a card nothing has ever run: "Retry" claimed an earlier
+   * attempt that does not exist, three lines under a header reading "Not yet
+   * dispatched" and one click away from a toast reading "Dispatched". Same
+   * derivation as the header's, handed down, so they cannot drift apart again.
+   */
+  const resumeLabel =
+    task.stage === "paused" ? "Resume" : neverStarted ? "Dispatch" : "Retry";
+
+  /** Whether the composed redirect can actually be sent right now. */
+  const canRedirect =
+    inflight !== null && !steerDisabled && instruction.trim() !== "";
+
+  function sendRedirect() {
+    // Narrowing, not a guard: `canRedirect` already holds Send down when there
+    // is no run, and the Enter key reads the same flag.
+    if (!inflight || !canRedirect) return;
+    void steer(inflight.key, "redirect", { instruction: instruction.trim() });
+  }
 
   return (
     <div className="border-t bg-card/40 p-3">
@@ -1024,7 +1341,7 @@ function ControlBar({
                   size="sm"
                   className="h-8"
                   disabled={steerDisabled}
-                  onClick={() => void steer("pause")}
+                  onClick={() => void steer(inflight.key, "pause")}
                 >
                   <Square className="mr-1.5 size-3.5" />
                   Stop
@@ -1056,21 +1373,36 @@ function ControlBar({
                   description="This stops the run. It can be retried afterwards from the board or here."
                   confirmLabel="Cancel run"
                   destructive
-                  onConfirm={() => void steer("cancel", { confirm: true })}
+                  onConfirm={() =>
+                    void steer(inflight.key, "cancel", { confirm: true })
+                  }
                 />
               </>
             )}
           </>
         ) : (
           <>
-            <RetryButton
-              label={resumeLabel}
-              title={task.title}
-              irreversible={irreversible}
-              historyIncomplete={historyIncomplete}
-              disabled={busy}
-              onConfirm={() => void patchColumn()}
-            />
+            {/* Not on a finished card. Retry rendered — and worked — on a card
+                in Done, so one click re-ran a task somebody had already
+                accepted and paid for a turn to redo it. `isFinished` asks the
+                ledger which columns are closed rather than matching the word;
+                see it. */}
+            {!finished && (
+              <RetryButton
+                label={resumeLabel}
+                title={task.title}
+                irreversible={irreversible}
+                historyIncomplete={historyIncomplete}
+                // Issue #883, arriving at the detail screen a year after the
+                // board card got it. A run parked on an approval has settled to
+                // the runs store, so `inflight` is null and this *is* the
+                // branch that renders — Retry, live, directly above a row
+                // saying the card is waiting on your approval.
+                disabled={busy || blockedOnApproval}
+                reason={blockedOnApproval ? RESUME_BLOCKED_REASON : undefined}
+                onConfirm={() => void patchColumn()}
+              />
+            )}
             {/* Only before anything has started: planning a card that has
                 already been worked would write a brief for work that exists,
                 which is the one shape the pass has nothing useful to say
@@ -1122,31 +1454,78 @@ function ControlBar({
         </div>
       </div>
 
+      {/*
+        The redirect composer, and the one control on this bar that outlives the
+        run it steers.
+
+        It is a sibling of the button row rather than a child of the `inflight`
+        branch, which is what saves the operator's words: a run settling — it
+        finished, it parked on an approval, it was cancelled — flips `inflight`
+        to null on the next four-second poll, and had this lived inside that
+        branch the whole composer would have vanished mid-sentence with the
+        typed instruction gone and nothing said about it.
+
+        Surviving is not enough on its own, and for a while it was all that
+        happened: the row stayed, Send stayed enabled, and pressing it reached
+        the `if (!inflight) return` that used to open `steer` — no request, no
+        error, no toast, a control that silently did nothing. So the composer
+        now says what became of the run and holds the text until the operator
+        decides what to do with it. Sending it is the one thing that cannot be
+        offered: `steerTask` addresses a live run by key, and the run is gone.
+      */}
       {redirecting && (
-        <div className="mt-2 flex items-center gap-2">
-          <Input
-            autoFocus
-            value={instruction}
-            placeholder="New instruction for the run…"
-            className="h-8"
-            disabled={steerDisabled}
-            onChange={(e) => setInstruction(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && instruction.trim())
-                void steer("redirect", { instruction: instruction.trim() });
-            }}
-          />
-          <Button
-            size="sm"
-            className="h-8"
-            disabled={steerDisabled || !instruction.trim()}
-            onClick={() =>
-              void steer("redirect", { instruction: instruction.trim() })
-            }
-          >
-            <Send className="mr-1.5 size-3.5" />
-            Send
-          </Button>
+        <div className="mt-2 space-y-1.5">
+          <div className="flex items-center gap-2">
+            <Input
+              autoFocus
+              value={instruction}
+              placeholder="New instruction for the run…"
+              className="h-8"
+              // Still editable with no run: the text is here to be read back
+              // and copied out, and a greyed-out box invites a reload that
+              // would be the very loss this is preventing.
+              disabled={steerDisabled}
+              onChange={(e) => setInstruction(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") sendRedirect();
+              }}
+            />
+            <Button
+              size="sm"
+              className="h-8"
+              disabled={!canRedirect}
+              title={
+                inflight === null
+                  ? "This attempt has already settled — there is no run left to redirect."
+                  : undefined
+              }
+              onClick={sendRedirect}
+            >
+              <Send className="mr-1.5 size-3.5" />
+              Send
+            </Button>
+          </div>
+          {inflight === null && (
+            <div className="flex items-start gap-2">
+              <p className="min-w-0 flex-1 text-2xs text-status-blocked-text">
+                This attempt settled before the redirect was sent, so there is no
+                run left to steer. What you typed is kept above rather than
+                dropped — copy it out, or start the card again and redirect the
+                new run.
+              </p>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 shrink-0 text-2xs"
+                onClick={() => {
+                  setInstruction("");
+                  setRedirecting(false);
+                }}
+              >
+                Discard
+              </Button>
+            </div>
+          )}
         </div>
       )}
 
@@ -1237,9 +1616,12 @@ function LineageRail({
   if (!lineage.parent && lineage.children.length === 0) return null;
   return (
     <div className="rounded-xl border bg-card/40 p-3">
-      <p className="mb-2 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+      {/* A heading in everything but its tag, which is how the page came to
+          have exactly one (the `h1` in `DetailHeader`) and then jump straight
+          to the `h3`s its tab panels render. */}
+      <h2 className="mb-2 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
         Lineage
-      </p>
+      </h2>
       <div className="space-y-1.5">
         {lineage.parent && (
           <button
@@ -1898,7 +2280,9 @@ function ExportButton({
  * long discussion is not re-sent every 4s). Older messages are pulled on demand
  * and kept here, so walking back through a thread survives the next poll.
  */
-function DiscussionTab({
+/** Exported for `test/unit/task-detail-discussion-limits.test.ts` — see
+ *  `ControlBar` above for why these tests render rather than read. */
+export function DiscussionTab({
   messages,
   hasMore,
   taskId,
@@ -1915,6 +2299,20 @@ function DiscussionTab({
 }) {
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
+  /**
+   * The `seq` of the message currently being withdrawn, or `null`.
+   *
+   * Every other mutating control on this screen has a busy state and this one
+   * did not, so a second click fired a second `DELETE` — and a third, and a
+   * fourth. The host is idempotent, so nothing broke and nothing ever would
+   * have; what it cost was the operator's confidence, since the only reply to
+   * a click was the row changing whenever the request happened to land. The
+   * `seq` rather than a boolean so the spinner appears on the row the operator
+   * pressed, not on all of them.
+   */
+  const [redacting, setRedacting] = useState<number | null>(null);
+  /** Stable id for the counter the composer describes itself by. */
+  const counterId = useId();
   /**
    * Every message this tab has been shown, oldest first, deduped by `seq` — the
    * journal key, and the only identity a message has.
@@ -2000,6 +2398,9 @@ function DiscussionTab({
    * does: the parent holds the authoritative page.
    */
   async function redact(seq: number) {
+    // One at a time, and never the same one twice: see `redacting`.
+    if (redacting !== null) return;
+    setRedacting(seq);
     try {
       const row = await redactTaskDiscussion(client, company, taskId, seq);
       absorb([row]);
@@ -2008,11 +2409,16 @@ function DiscussionTab({
       toast.error(
         e instanceof Error ? e.message : "could not remove the message",
       );
+    } finally {
+      setRedacting(null);
     }
   }
 
   async function post() {
-    const body = text.trim();
+    // Clipped on the way in as well as on the way out (`onChange`): a value set
+    // by anything other than typing — a paste handled by the browser's own
+    // undo, an autofill — would otherwise reach a host that truncates silently.
+    const body = capDiscussion(text.trim());
     if (!body || busy) return;
     setBusy(true);
     try {
@@ -2093,8 +2499,16 @@ function DiscussionTab({
                         className="-mr-1 size-6 shrink-0 text-muted-foreground hover:text-destructive"
                         aria-label={`Remove the message from ${m.author}`}
                         data-testid="discussion-redact"
+                        // Down for the whole thread while any withdrawal is in
+                        // flight, and spinning on the row that started it.
+                        disabled={redacting !== null}
+                        data-busy={redacting === m.seq ? "true" : undefined}
                       >
-                        <Trash2 className="size-3.5" />
+                        {redacting === m.seq ? (
+                          <Loader2 className="size-3.5 animate-spin" />
+                        ) : (
+                          <Trash2 className="size-3.5" />
+                        )}
                       </Button>
                     }
                     title="Remove this message?"
@@ -2128,7 +2542,13 @@ function DiscussionTab({
           rows={2}
           className="min-h-16 text-xs"
           disabled={busy}
-          onChange={(e) => setText(e.target.value)}
+          aria-describedby={counterId}
+          // Clipped here rather than left to the host, which truncates a long
+          // post to `MAX_DISCUSSION_CHARS` and answers `201` — so the tail
+          // vanished with no warning and no way to get it back, and the
+          // operator found out by reading their own message back. See
+          // `capDiscussion` for why this is not a `maxLength`.
+          onChange={(e) => setText(capDiscussion(e.target.value))}
           onKeyDown={(e) => {
             // Enter posts; Shift+Enter is a newline. A note about a task is
             // usually one line, and the mouse trip for every one of them is
@@ -2153,7 +2573,34 @@ function DiscussionTab({
           Post
         </Button>
       </div>
+
+      {/*
+        Always in the DOM, so the textarea's `aria-describedby` never points at
+        nothing; `sr-only` until the count is close enough to matter, because a
+        permanent `0 of 4000` under every one-line note is noise. See
+        `DISCUSSION_COUNTER_FROM`.
+      */}
+      <DiscussionCounter id={counterId} used={[...text].length} />
     </div>
+  );
+}
+
+/** The composer's character count, and the sentence that appears at the cap. */
+function DiscussionCounter({ id, used }: { id: string; used: number }) {
+  const atCap = used >= MAX_DISCUSSION_CHARS;
+  const shown = used >= DISCUSSION_COUNTER_FROM;
+  return (
+    <p
+      id={id}
+      className={cn(
+        "text-right text-2xs tabular-nums",
+        !shown && "sr-only",
+        shown && (atCap ? "text-status-blocked-text" : "text-muted-foreground"),
+      )}
+    >
+      {used} of {MAX_DISCUSSION_CHARS} characters
+      {atCap && " — the most a message can hold. Post this and start another."}
+    </p>
   );
 }
 
@@ -2202,6 +2649,7 @@ function RetryButton({
   irreversible,
   historyIncomplete,
   disabled,
+  reason,
   onConfirm,
 }: {
   label: string;
@@ -2209,13 +2657,27 @@ function RetryButton({
   irreversible: IrreversibleEffect[];
   historyIncomplete: boolean;
   disabled: boolean;
+  /**
+   * Why the button is down, when it is down for a reason worth reading — the
+   * board card's treatment (#883), and on both branches, because a card that is
+   * blocked *and* has irreversible history renders the dialog trigger and would
+   * otherwise be a dead button with no explanation.
+   */
+  reason?: string;
   onConfirm: () => void;
 }) {
   // Nothing to warn about and nothing unaccounted for: the plain button, wired
   // straight through, exactly as it behaved before this existed.
   if (irreversible.length === 0 && !historyIncomplete) {
     return (
-      <Button variant="outline" size="sm" className="h-8" disabled={disabled} onClick={onConfirm}>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-8"
+        disabled={disabled}
+        title={reason}
+        onClick={onConfirm}
+      >
         <Play className="mr-1.5 size-3.5" />
         {label}
       </Button>
@@ -2227,7 +2689,13 @@ function RetryButton({
   return (
     <ConfirmButton
       trigger={
-        <Button variant="outline" size="sm" className="h-8" disabled={disabled}>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8"
+          disabled={disabled}
+          title={reason}
+        >
           <Play className="mr-1.5 size-3.5" />
           {label}
         </Button>

--- a/frontend/src/views/TaskEditDialog.tsx
+++ b/frontend/src/views/TaskEditDialog.tsx
@@ -126,10 +126,10 @@ export function TaskEditDialog({
    *
    * Both feed the same gate `RetryButton` uses on the Task Detail screen,
    * because saving `column: "working"` here is the identical write. **Absent
-   * is not "clean"** — a caller that has not wired these gets the confirmation
-   * unconditionally on a dispatch, because a dialog that cannot say what
-   * already happened must not pass that gap off as an all-clear. See
-   * `dispatchNeedsConfirm`.
+   * is not "clean"** — and that is per field: a caller that has not wired
+   * *either* of these gets the confirmation unconditionally on a dispatch,
+   * because a dialog that cannot say what already happened must not pass that
+   * gap off as an all-clear. See `readEffectHistory`.
    */
   irreversible?: IrreversibleEffect[];
   historyIncomplete?: boolean;

--- a/frontend/src/views/TaskEditDialog.tsx
+++ b/frontend/src/views/TaskEditDialog.tsx
@@ -4,12 +4,14 @@
 // delete — unchanged from its original home on the board screen (retired in
 // issue #1140; the board is the `tasks` ledger's columns now).
 
-import { useEffect, useState } from "react";
-import { Loader2, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, Loader2, Trash2 } from "lucide-react";
 
 import {
   deleteTask,
   patchTask,
+  type InflightRun,
+  type IrreversibleEffect,
   type PatchTask,
   type Task,
   type TaskDeliverable,
@@ -45,7 +47,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { computeTaskPatch } from "@/lib/task-edit";
+import { computeTaskPatch, dispatchNeedsConfirm } from "@/lib/task-edit";
+import { effectDone } from "@/lib/language";
+import { timeOf } from "@/lib/timeline-format";
 import { labelFor } from "@/lib/board-columns";
 import { useBoardColumns } from "@/hooks/use-board-columns";
 import { toast } from "sonner";
@@ -97,6 +101,9 @@ export function TaskEditDialog({
   onDeleted,
   client,
   company,
+  inflight,
+  irreversible,
+  historyIncomplete,
 }: {
   task: Task | null;
   onClose: () => void;
@@ -104,37 +111,132 @@ export function TaskEditDialog({
   onDeleted: (id: string) => void;
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * The run currently holding this card, if any.
+   *
+   * Delete is refused with a `409` while one exists (`server::ops::tasks`,
+   * issue #984), so the dialog must not offer it. Absent means the caller has
+   * no in-flight read; the button stays enabled and the host refuses, which is
+   * the behaviour that existed before this prop.
+   */
+  inflight?: InflightRun | null;
+  /**
+   * What this card already did that cannot be undone (#351), and whether the
+   * journal admits it cannot describe its own history.
+   *
+   * Both feed the same gate `RetryButton` uses on the Task Detail screen,
+   * because saving `column: "working"` here is the identical write. **Absent
+   * is not "clean"** — a caller that has not wired these gets the confirmation
+   * unconditionally on a dispatch, because a dialog that cannot say what
+   * already happened must not pass that gap off as an all-clear. See
+   * `dispatchNeedsConfirm`.
+   */
+  irreversible?: IrreversibleEffect[];
+  historyIncomplete?: boolean;
 }) {
   // From the `tasks` ledger, so this select can never offer a column the host's
   // write boundary would refuse — which is what a second, local list allowed.
   const columns = useBoardColumns(client, company);
   const [draft, setDraft] = useState<PatchTask>({});
+  /**
+   * The card exactly as it read when this draft was seeded.
+   *
+   * The patch below is diffed against **this**, not against the live `task`
+   * prop, so "the fields the operator touched" keeps meaning that even while
+   * the host changes the card underneath an open dialog. See the effect.
+   */
+  const [seed, setSeed] = useState<Task | null>(null);
   const [busy, setBusy] = useState(false);
 
-  // Reset the edit draft each time a different card is opened.
+  // Seed the edit draft when the dialog *opens*, and when it opens onto a
+  // different card — deliberately **not** whenever the `task` object changes
+  // identity.
+  //
+  // The Task Detail screen refetches this card every 4s (`POLL_MS` there) and
+  // hands down a brand-new `detail.task` object on every tick, carrying the
+  // same values. Keyed on `task`, this effect therefore re-ran four times a
+  // minute and overwrote whatever had been typed or picked: measured in a
+  // browser, a Column select set to Working reverted to Pending ~2.3s later and
+  // never came back. Title, Note, Priority and Assignee went the same way.
+  //
+  // That also silently disarmed this dialog's dispatch confirmation. After the
+  // reset `computeTaskPatch` returns `{}`, so `confirmDispatch` is false *and*
+  // Save writes nothing — no confirmation, no request, no toast. The #351 gate
+  // was only reachable by picking and saving inside the same ~150ms.
+  //
+  // Which side wins a conflict is the actual decision here, and it is **the
+  // operator's open draft**. A half-written note exists nowhere else — nothing
+  // on the screen holds a copy, which is why Cancel asks before discarding it —
+  // so a second operator's edit must not retype it out from under the first.
+  // The cost, pinned by a test: a server-side change to this same card is not
+  // reflected in the open dialog. It is visible on the screen behind, and the
+  // dialog picks it up the next time it opens.
+  //
+  // `seed` is what keeps that cost bounded to the fields in play. Diffing a
+  // frozen draft against a *live* `task` would quietly widen the write: a poll
+  // that moved the column to `done` would make an unrelated note edit also send
+  // `column: "pending"`, and a roster change would resubmit the stale assignee
+  // that issue #263's diff exists to keep out of the request. Diffing against
+  // the seed sends only what the operator actually changed, last-write-wins on
+  // those fields alone.
   useEffect(() => {
-    if (task) {
-      setDraft({
-        title: task.title,
-        note: task.note ?? "",
-        column: task.column,
-        priority: task.priority,
-        assignee: task.assignee,
-        // Absent means `"once"` on the wire, so the control is seeded with the
-        // normalized value and a card with no stored deliverable edits as the
-        // one-off it is (issue #580).
-        deliverable: task.deliverable ?? "once",
-      });
-    }
-  }, [task]);
+    if (!task) return;
+    setSeed(task);
+    setDraft({
+      title: task.title,
+      note: task.note ?? "",
+      column: task.column,
+      priority: task.priority,
+      assignee: task.assignee,
+      // Absent means `"once"` on the wire, so the control is seeded with the
+      // normalized value and a card with no stored deliverable edits as the
+      // one-off it is (issue #580).
+      deliverable: task.deliverable ?? "once",
+    });
+    // Keyed on the card's identity rather than the object, for the reason
+    // above. `task` is read only to seed from, on the render where the identity
+    // changed; closing the dialog nulls it, so reopening the same card re-seeds.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [task?.id]);
+
+  // The diff the Save button would send, computed here rather than at click
+  // time so the footer can decide what kind of button it is: a `column` move
+  // into Working dispatches, and an untouched form has nothing to discard.
+  //
+  // Against `seed` — the card as it read when the dialog opened — rather than
+  // the live `task`, so this keeps meaning "what the operator changed" and
+  // never reports the poll's own updates as unsaved edits. `seed` is null for
+  // the one render before the effect above runs, and an empty patch is the
+  // honest answer there: nothing has been typed yet.
+  const patch = useMemo(() => (seed ? computeTaskPatch(draft, seed) : {}), [draft, seed]);
 
   if (!task) return null;
+
+  const dirty = Object.keys(patch).length > 0;
+  // Issue #351, reached from the *other* direction. The Column select can emit
+  // exactly `{ column: "working" }` — byte for byte the write the Task Detail
+  // Retry button makes — so the confirmation that button carries has to be here
+  // too, or the protection is one dropdown away from being walked around on the
+  // screen it was built for. The condition is `RetryButton`'s, not "always", so
+  // a card with nothing at stake still saves in one click.
+  const confirmDispatch = dispatchNeedsConfirm(patch, { irreversible, historyIncomplete });
+  const named = irreversible?.length ?? 0;
+  // Wording matched to the host's own refusal (`delete_task`) rather than
+  // invented here: it names cancelling first, and it says why deleting now
+  // would not actually remove the card. **Cancel, not Stop** — a paused run is
+  // still in the steer registry until its turn actually stops, so the `409`
+  // stands, and pointing at Stop would send the operator to a button that does
+  // not clear this.
+  const deleteBlocked = inflight
+    ? "This task is running — cancel the run first, watch it stop, then delete it. Deleting it now wouldn’t remove it: the turn writes the card back when it settles."
+    : undefined;
 
   async function save() {
     if (!task) return;
     // Only the fields the operator actually touched (issue #263's roster-safety
-    // diff, extended with #580's deliverable). See `computeTaskPatch`.
-    const patch = computeTaskPatch(draft, task);
+    // diff, extended with #580's deliverable) — see `computeTaskPatch`. Read
+    // off the memo above so the patch that was *gated* is the patch that is
+    // sent; recomputing here would let the two drift.
     if (Object.keys(patch).length === 0) {
       // Nothing to write. Saying so beats a round-trip that reports "Saved."
       // for an edit that never happened.
@@ -257,13 +359,20 @@ export function TaskEditDialog({
               <Label htmlFor="task-assignee">Assignee</Label>
               {/* Issue #263: picked from the roster, not typed. An assignee the
                   roster no longer carries still renders — flagged — so a save
-                  that does not touch it can never quietly rewrite it. */}
+                  that does not touch it can never quietly rewrite it.
+
+                  Disabled while a save is in flight, like its twin in the
+                  detail screen's reassign row. A picker that still moves during
+                  the write invites a second choice that the in-flight PATCH
+                  will not carry — so the row reads as the new assignee while
+                  the host stored the old one. */}
               <AssigneeSelect
                 id="task-assignee"
                 client={client}
                 company={company}
                 value={draft.assignee ?? ""}
                 onChange={(next) => setDraft((d) => ({ ...d, assignee: next }))}
+                disabled={busy}
               />
             </div>
           </div>
@@ -299,9 +408,21 @@ export function TaskEditDialog({
 
         <DialogFooter className="justify-between sm:justify-between">
           <AlertDialog>
+            {/* Issue #984: `delete_task` answers `409` for a card a run is
+                holding, deliberately — the turn writes the card back when it
+                settles, so deleting underneath it removes nothing and leaves a
+                card no surface names. Offering the button anyway makes the
+                operator discover that as a failed click; the control bar three
+                lines away already branches on the same `inflight`. */}
             <AlertDialogTrigger
+              disabled={!!inflight}
               render={
-                <Button variant="ghost" size="sm" disabled={busy}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={busy || !!inflight}
+                  title={deleteBlocked}
+                >
                   <Trash2 className="mr-1.5 size-4" />
                   Delete
                 </Button>
@@ -326,13 +447,117 @@ export function TaskEditDialog({
             </AlertDialogContent>
           </AlertDialog>
           <div className="flex gap-2">
-            <Button variant="outline" onClick={onClose} disabled={busy}>
-              Cancel
-            </Button>
-            <Button onClick={() => void save()} disabled={busy}>
-              {busy && <Loader2 className="mr-1.5 size-4 animate-spin" />}
-              Save
-            </Button>
+            {/* Three-way, matching the Artifacts editor's Cancel: a dirty form
+                asks before it throws the edit away, a clean one dismisses
+                straight off, and both are disabled mid-save. A note typed into
+                the textarea above is not recoverable once this closes, and
+                nothing else on the screen holds a copy of it. */}
+            {dirty ? (
+              <AlertDialog>
+                <AlertDialogTrigger
+                  render={
+                    <Button variant="outline" disabled={busy}>
+                      Cancel
+                    </Button>
+                  }
+                />
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Discard this edit?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Nothing has been saved yet, so your changes will be lost.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Keep editing</AlertDialogCancel>
+                    <AlertDialogAction
+                      className="bg-destructive text-white hover:bg-destructive/90"
+                      onClick={onClose}
+                    >
+                      Discard
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            ) : (
+              <Button variant="outline" onClick={onClose} disabled={busy}>
+                Cancel
+              </Button>
+            )}
+            {confirmDispatch ? (
+              <AlertDialog>
+                <AlertDialogTrigger
+                  render={
+                    <Button disabled={busy} data-testid="edit-save">
+                      {busy && <Loader2 className="mr-1.5 size-4 animate-spin" />}
+                      Save
+                    </Button>
+                  }
+                />
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Run “{task.title}” again?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {/* Leads with the mechanism, because this one is not
+                          obvious: the operator moved a dropdown, and nothing
+                          about a Column select says "dispatch". */}
+                      {`Moving this card into Working runs it again — the same as Retry. ${
+                        named === 0
+                          ? "Running it again may repeat whatever the last attempt did."
+                          : named === 1
+                            ? "This task already did something that cannot be undone, and running it again may do it a second time."
+                            : `This task already did ${named} things that cannot be undone, and running it again may do them a second time.`
+                      }`}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <div className="space-y-2 text-left">
+                    {named > 0 && (
+                      <ul className="space-y-1.5 rounded-lg border bg-muted/40 p-3 text-xs">
+                        {irreversible?.map((e, i) => (
+                          // Two effects of the same kind can land in the same
+                          // millisecond, so the index carries the uniqueness
+                          // the pair cannot.
+                          <li key={`${e.kind}-${e.atMillis}-${i}`} className="flex items-start gap-2">
+                            <AlertCircle
+                              className="mt-px size-3.5 shrink-0 text-status-blocked-text"
+                              aria-hidden
+                            />
+                            <span className="min-w-0 flex-1">{effectDone(e.kind, e.amountUsd)}</span>
+                            <span className="shrink-0 tabular-nums text-muted-foreground">
+                              {timeOf(e.atMillis)}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                    {historyIncomplete && (
+                      // The list is short, not wrong. Say which, rather than
+                      // let a truncated list read as the whole story.
+                      <p className="text-xs text-muted-foreground">
+                        Some of this company’s earlier activity was recorded before it kept a
+                        description, so
+                        {named > 0 ? " this list may be incomplete." : " nothing here can be listed."}
+                      </p>
+                    )}
+                    {named > 0 && (
+                      <p className="text-2xs text-muted-foreground">
+                        Each is recorded the moment it was committed, so one that was interrupted
+                        still appears — nothing is ever retried on its own.
+                      </p>
+                    )}
+                  </div>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Leave it alone</AlertDialogCancel>
+                    <AlertDialogAction onClick={() => void save()}>Save anyway</AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            ) : (
+              <Button onClick={() => void save()} disabled={busy} data-testid="edit-save">
+                {busy && <Loader2 className="mr-1.5 size-4 animate-spin" />}
+                Save
+              </Button>
+            )}
           </div>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/views/TaskWorkflowProposalPanel.tsx
+++ b/frontend/src/views/TaskWorkflowProposalPanel.tsx
@@ -54,15 +54,18 @@ export function TaskWorkflowProposalPanel({
   client,
   company,
   task,
-  onSaved,
   onReload,
 }: {
   client: OpenCompanyClient;
   company: string | null;
   /** The In-Review card. The caller guarantees `task.workflowProposal` is set. */
   task: Task;
-  /** Hand the settled card back to the board/detail for reconciliation. */
-  onSaved: (t: Task) => void;
+  /*
+   * There is no `onSaved`. It handed the settled card to the board rendered
+   * beside the task detail, and since issue #1140 there is no such board: the
+   * only caller passed `() => {}` all the way from `TaskDetailRoute`. `onReload`
+   * is what actually refreshes the screen.
+   */
   /** Re-read the detail after a settle, so its poll picks up the new state. */
   onReload: () => Promise<void> | void;
 }) {
@@ -91,8 +94,7 @@ export function TaskWorkflowProposalPanel({
     setError(null);
     setProblems(null);
     try {
-      const saved = await applyWorkflowProposal(client, company, task.id);
-      onSaved(saved);
+      await applyWorkflowProposal(client, company, task.id);
       await onReload();
       toast.success("Workflow created — the card is done.");
     } catch (e) {
@@ -117,8 +119,7 @@ export function TaskWorkflowProposalPanel({
     setError(null);
     setProblems(null);
     try {
-      const saved = await rejectWorkflowProposal(client, company, task.id);
-      onSaved(saved);
+      await rejectWorkflowProposal(client, company, task.id);
       await onReload();
       toast.success("Proposal rejected — the card is back in Pending.");
     } catch (e) {

--- a/frontend/test/unit/assignee-roster-gap.test.ts
+++ b/frontend/test/unit/assignee-roster-gap.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { AssigneeSelect, rosterGapNotice } from "@/views/AssigneeSelect";
+
+/**
+ * A roster read that **failed** and a company that genuinely has **nobody** are
+ * two different facts, and the picker rendered them identically: one row,
+ * Unassigned.
+ *
+ * That matters because Unassigned is not the absence of a choice — it hands the
+ * card to the orchestrator, which is a real write. An operator looking at a
+ * one-row picker has to be able to tell "there is nobody else to pick" from "we
+ * could not find out who else there is", and the component's own comment ("a
+ * picker with no desks is still a picker") is sound reasoning for the first
+ * case and wrong for the second.
+ *
+ * The same distinction the Overview draws before it claims "No desks yet"
+ * (issue #1313, `overview-empty-state.test.ts`).
+ */
+
+const DESKS = [{ id: "engineering", name: "Engineering", members: ["eng-lead"] }];
+const TEAM = [{ id: "eng-lead", name: "Eng Lead", role: "engineer" }];
+
+function fakeClient(over: {
+  desks?: () => Promise<unknown>;
+  team?: () => Promise<unknown>;
+} = {}) {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/company/${company ?? "acme"}`,
+    listDesks: vi.fn(over.desks ?? (async () => [])),
+    listTeam: vi.fn(over.team ?? (async () => [])),
+  } as unknown as OpenCompanyClient;
+}
+
+const fails = () => Promise.reject(new Error("host unreachable"));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+/** Mount the picker and open its popup, which is where the roster is read. */
+async function open(client: OpenCompanyClient, value = "") {
+  await act(async () => {
+    root.render(
+      createElement(AssigneeSelect, {
+        id: "assignee",
+        client,
+        company: "acme",
+        value,
+        onChange: vi.fn(),
+      }),
+    );
+  });
+  // The two roster reads settle in microtasks and the state they set lands a
+  // tick later; give React those ticks rather than assuming one flush covers
+  // both.
+  await act(async () => {});
+  await act(async () => {});
+  await act(async () => {
+    (document.querySelector("#assignee") as HTMLElement).click();
+  });
+}
+
+function popupText(): string {
+  return document.body.textContent ?? "";
+}
+
+describe("rosterGapNotice", () => {
+  it("says nothing when both halves answered", () => {
+    expect(rosterGapNotice({ desks: false, team: false })).toBeNull();
+  });
+
+  /**
+   * Each line has to survive being the *only* thing in the list beside
+   * Unassigned, so each one names which half is missing and says the list is
+   * short rather than complete.
+   */
+  it("names the missing half, and calls the list incomplete rather than empty", () => {
+    // Each single-half line names *its* half and not the other. Reporting both
+    // whenever either failed would tell the operator the desks are missing from
+    // a list that is showing every one of them.
+    expect(rosterGapNotice({ desks: true, team: false })).toContain("desks");
+    expect(rosterGapNotice({ desks: true, team: false })).not.toContain("teammates");
+    expect(rosterGapNotice({ desks: false, team: true })).toContain("teammates");
+    expect(rosterGapNotice({ desks: false, team: true })).not.toContain("desks");
+    for (const failed of [
+      { desks: true, team: false },
+      { desks: false, team: true },
+      { desks: true, team: true },
+    ]) {
+      expect(rosterGapNotice(failed)).toContain("incomplete, not empty");
+    }
+  });
+});
+
+describe("the picker for a roster it could not read", () => {
+  it("stays quiet for a company that genuinely has nobody", async () => {
+    await open(fakeClient());
+    // Both reads answered `[]`. There is nothing wrong here to report, and a
+    // warning would be a false alarm on every brand-new company.
+    expect(document.querySelector('[data-testid="assignee-roster-gap"]')).toBeNull();
+    expect(popupText()).toContain("Unassigned");
+  });
+
+  it("says so when both halves failed, instead of looking like an empty company", async () => {
+    await open(fakeClient({ desks: fails, team: fails }));
+
+    const gap = document.querySelector('[data-testid="assignee-roster-gap"]');
+    expect(gap).not.toBeNull();
+    expect(gap?.textContent).toContain("incomplete, not empty");
+  });
+
+  it("says so when only the teammates read failed, though desks arrived", async () => {
+    await open(fakeClient({ desks: async () => DESKS, team: fails }));
+
+    expect(popupText()).toContain("Engineering");
+    const gap = document.querySelector('[data-testid="assignee-roster-gap"]')?.textContent ?? "";
+    expect(gap).toContain("teammates");
+    // The desks are right there in the list; saying they are missing too would
+    // be a second wrong answer on top of the one this fixes.
+    expect(gap).not.toContain("desks");
+  });
+
+  /**
+   * The regression the old heuristic actually shipped. "Off-roster" was
+   * inferred from *either list being non-empty*, which held for the case it was
+   * written against and broke on the mixed one: with `/desks` answering and
+   * `/team` rejected, a perfectly current teammate id was flagged "not on
+   * roster" against a roster half of which never arrived.
+   */
+  it("does not flag a value as off-roster against a roster half that never arrived", async () => {
+    await open(fakeClient({ desks: async () => DESKS, team: fails }), "eng-lead");
+
+    expect(popupText()).not.toContain("not on roster");
+  });
+
+  it("still flags a genuinely off-roster value when both halves answered", async () => {
+    await open(fakeClient({ desks: async () => DESKS, team: async () => TEAM }), "someone-else");
+
+    expect(popupText()).toContain("not on roster");
+    expect(document.querySelector('[data-testid="assignee-roster-gap"]')).toBeNull();
+  });
+});

--- a/frontend/test/unit/task-detail-control-bar.test.ts
+++ b/frontend/test/unit/task-detail-control-bar.test.ts
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { InflightRun, IrreversibleEffect, Task } from "@/api/tasks";
+import { RESUME_BLOCKED_REASON } from "@/lib/task-approvals";
+
+/**
+ * The task detail's control bar, which is where the screen decides what the
+ * operator is allowed to do to a card.
+ *
+ * Every claim below is one the source reads correctly for and the screen got
+ * wrong, which is why these render rather than grep:
+ *
+ * - **Retry beside a pending approval.** A run parked on a sign-off is
+ *   *finished* to the runs store, so the card leaves `GET …/tasks/inflight`,
+ *   `inflight` goes null, and the bar renders its else-branch — Retry, enabled,
+ *   directly above a row reading "Waiting on your approval". One click spends a
+ *   second agent turn on work the operator is still being asked to authorise,
+ *   and re-runs it from the start. The board card has been disabling this since
+ *   #883 and the detail never did.
+ * - **Retry on a Done card**, which re-ran a task somebody had already
+ *   accepted.
+ * - **Three names for one state.** "Not yet dispatched" in the header, "Retry"
+ *   on the button, "Dispatched" in the toast. "Retry" is the false one.
+ * - **A composed redirect outliving its run.** The composer survives `inflight`
+ *   going null — deliberately, so the typed instruction is not destroyed — and
+ *   for a while Send survived with it and silently did nothing.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { ControlBar } = await import("@/views/TaskDetailView");
+
+/** A client that answers nothing: this bar reads on click, never on mount. */
+const CLIENT = {
+  scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+  get: async () => {
+    throw new Error("the control bar must not read on mount");
+  },
+} as unknown as OpenCompanyClient;
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Reconcile the ledger",
+    column: "working",
+    stage: "in_review",
+    priority: "medium",
+    assignee: "finance",
+    ...over,
+  } as Task;
+}
+
+const RUNNING: InflightRun = {
+  key: "run-key-1",
+  taskId: "task-1",
+} as InflightRun;
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(
+  over: {
+    task?: Task;
+    inflight?: InflightRun | null;
+    irreversible?: IrreversibleEffect[];
+    historyIncomplete?: boolean;
+    blockedOnApproval?: boolean;
+    neverStarted?: boolean;
+    finished?: boolean;
+  } = {},
+) {
+  await act(async () => {
+    root.render(
+      createElement(ControlBar, {
+        task: over.task ?? task(),
+        inflight: over.inflight ?? null,
+        irreversible: over.irreversible ?? [],
+        historyIncomplete: over.historyIncomplete ?? false,
+        blockedOnApproval: over.blockedOnApproval ?? false,
+        neverStarted: over.neverStarted ?? false,
+        finished: over.finished ?? false,
+        client: CLIENT,
+        company: "acme",
+        onChanged: () => {},
+        onEdit: () => {},
+      }),
+    );
+  });
+}
+
+function buttons(): HTMLButtonElement[] {
+  return [...document.querySelectorAll("button")] as HTMLButtonElement[];
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return buttons().find((b) => b.textContent?.trim() === label);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("Retry/Resume while the card is blocked on an approval (#883)", () => {
+  it("renders Retry disabled, with the reason a pointer can read", async () => {
+    await render({ blockedOnApproval: true });
+    const retry = button("Retry");
+    expect(retry).toBeDefined();
+    expect(retry!.disabled).toBe(true);
+    expect(retry!.title).toBe(RESUME_BLOCKED_REASON);
+  });
+
+  it("keeps it disabled on the confirmation-gated branch too", async () => {
+    // A card with irreversible history renders the dialog trigger rather than
+    // the plain button. Blocked is blocked on both, or the fix would hold for
+    // the cheap cards and lapse on exactly the expensive ones.
+    await render({
+      blockedOnApproval: true,
+      irreversible: [
+        { kind: "payment", atMillis: 1, amountUsd: 12 } as IrreversibleEffect,
+      ],
+    });
+    const retry = button("Retry");
+    expect(retry).toBeDefined();
+    expect(retry!.disabled).toBe(true);
+    expect(retry!.title).toBe(RESUME_BLOCKED_REASON);
+  });
+
+  it("leaves it live, and unexplained, when nothing is blocking", async () => {
+    await render({ blockedOnApproval: false });
+    const retry = button("Retry");
+    expect(retry).toBeDefined();
+    expect(retry!.disabled).toBe(false);
+    // No tooltip when there is nothing to excuse: a permanent title on a live
+    // button is a reason that has stopped meaning anything.
+    expect(retry!.title).toBe("");
+  });
+
+  it("disables rather than hides it", async () => {
+    // Hiding would leave the card looking like it has no next action at all,
+    // which is the ambiguity being fixed — the same call the board card made.
+    await render({ blockedOnApproval: true });
+    expect(button("Retry")).toBeDefined();
+  });
+});
+
+describe("Retry on a finished card", () => {
+  it("is not offered at all", async () => {
+    await render({ task: task({ column: "done", stage: "done" }), finished: true });
+    expect(button("Retry")).toBeUndefined();
+    expect(button("Resume")).toBeUndefined();
+    expect(button("Dispatch")).toBeUndefined();
+  });
+
+  it("still offers the read-only controls, so the bar is not empty", async () => {
+    await render({ task: task({ column: "done", stage: "done" }), finished: true });
+    expect(button("Export")).toBeDefined();
+    expect(button("Edit")).toBeDefined();
+  });
+});
+
+describe("One word per state (issue #465)", () => {
+  it("says Dispatch for a card nothing has ever run", async () => {
+    await render({
+      task: task({ column: "pending", stage: "pending" }),
+      neverStarted: true,
+    });
+    expect(button("Dispatch")).toBeDefined();
+    // "Retry" claimed an attempt that does not exist, three lines under a
+    // header reading "Not yet dispatched".
+    expect(button("Retry")).toBeUndefined();
+  });
+
+  it("says Retry once the card has been worked", async () => {
+    await render({ neverStarted: false });
+    expect(button("Retry")).toBeDefined();
+    expect(button("Dispatch")).toBeUndefined();
+  });
+
+  it("says Resume for a paused card, whatever else is true of it", async () => {
+    await render({ task: task({ stage: "paused" }), neverStarted: true });
+    expect(button("Resume")).toBeDefined();
+    expect(button("Dispatch")).toBeUndefined();
+  });
+});
+
+describe("A composed redirect when the run settles", () => {
+  /** Opens the composer on a live run and types into it. */
+  async function compose(text: string) {
+    await render({ inflight: RUNNING });
+    await act(async () => {
+      button("Redirect")!.click();
+    });
+    const input = container.querySelector("input") as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )!.set!;
+    await act(async () => {
+      setter.call(input, text);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    return input;
+  }
+
+  it("keeps the typed instruction on screen", async () => {
+    await compose("check the invoice total first");
+    // The run settles: the next detail poll finds it gone from `…/inflight`.
+    await render({ inflight: null });
+    const input = container.querySelector("input") as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+    expect(input!.value).toBe("check the invoice total first");
+  });
+
+  it("takes Send away rather than leaving it to do nothing", async () => {
+    await compose("check the invoice total first");
+    await render({ inflight: null });
+    const send = button("Send");
+    expect(send).toBeDefined();
+    expect(send!.disabled).toBe(true);
+  });
+
+  it("says what became of the run", async () => {
+    await compose("check the invoice total first");
+    await render({ inflight: null });
+    expect(container.textContent).toContain("settled before the redirect was sent");
+  });
+
+  it("still sends while the run is live", async () => {
+    const input = await compose("check the invoice total first");
+    expect(input.value).toBe("check the invoice total first");
+    expect(button("Send")!.disabled).toBe(false);
+  });
+
+  it("offers a way out, so the composer is not stuck open", async () => {
+    await compose("check the invoice total first");
+    await render({ inflight: null });
+    await act(async () => {
+      button("Discard")!.click();
+    });
+    expect(container.querySelector("input")).toBeNull();
+  });
+});

--- a/frontend/test/unit/task-detail-discussion-limits.test.ts
+++ b/frontend/test/unit/task-detail-discussion-limits.test.ts
@@ -42,7 +42,7 @@ vi.mock("sonner", () => {
   return { toast };
 });
 
-const { DiscussionTab, MAX_DISCUSSION_CHARS, capDiscussion } = await import(
+const { DiscussionTab, MAX_DISCUSSION_CHARS, countDiscussionChars } = await import(
   "@/views/TaskDetailView"
 );
 
@@ -84,6 +84,21 @@ async function render(client: OpenCompanyClient) {
 
 function textarea(): HTMLTextAreaElement {
   return container.querySelector("textarea") as HTMLTextAreaElement;
+}
+
+function post(): HTMLButtonElement {
+  return container.querySelector('[data-testid="discussion-post"]') as HTMLButtonElement;
+}
+
+/** Records the bodies a post actually reached the client with. */
+function postingClient(seen: string[]): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    post: async (_path: string, body: unknown) => {
+      seen.push((body as { text: string }).text);
+      return { seq: 8, author: "ops", atMillis: 0, text: (body as { text: string }).text };
+    },
+  } as unknown as OpenCompanyClient;
 }
 
 /**
@@ -129,31 +144,23 @@ afterEach(async () => {
   vi.clearAllMocks();
 });
 
-describe("capDiscussion", () => {
-  it("leaves anything within the limit exactly as it was typed", () => {
-    expect(capDiscussion("a short note")).toBe("a short note");
-    const atCap = "x".repeat(MAX_DISCUSSION_CHARS);
-    expect(capDiscussion(atCap)).toBe(atCap);
-  });
-
-  it("clips past it, to the host's own number", () => {
-    expect([...capDiscussion("x".repeat(MAX_DISCUSSION_CHARS + 500))].length).toBe(
-      MAX_DISCUSSION_CHARS,
-    );
+describe("countDiscussionChars", () => {
+  it("counts what the operator typed", () => {
+    expect(countDiscussionChars("a short note")).toBe(12);
+    expect(countDiscussionChars("")).toBe(0);
   });
 
   it("counts codepoints, the way the host counts them", () => {
     // `String.length` is UTF-16 code units, so a message of astral-plane
-    // characters would be cut at half the limit the host actually applies —
-    // and the counter beside it would have been describing a different rule
-    // from the one doing the cutting. `cap_discussion` takes `chars()`.
+    // characters would measure double the limit the host actually applies, and
+    // the counter would be describing a different rule from the one the host
+    // enforces. `cap_discussion` in `src/ports/tasks.rs` takes `chars()`.
     //
-    // Deliberately *past* the cap and not at it: a fixture of exactly
-    // `MAX_DISCUSSION_CHARS` emoji returns early on the length check and never
-    // reaches the slice, which is how the first version of this test passed
-    // against a `text.slice(…)` that cut 4000 emoji down to 2000.
-    const emoji = "🙂".repeat(MAX_DISCUSSION_CHARS + 100);
-    expect([...capDiscussion(emoji)].length).toBe(MAX_DISCUSSION_CHARS);
+    // A `maxLength` on the textarea would have had the same flaw, which is why
+    // there is not one — and it could not be undone either, which is the other
+    // reason.
+    expect("🙂".repeat(10).length).toBe(20);
+    expect(countDiscussionChars("🙂".repeat(10))).toBe(10);
   });
 });
 
@@ -177,11 +184,73 @@ describe("the composer surfaces the limit", () => {
     expect(counter().textContent).toContain(`${MAX_DISCUSSION_CHARS - 10} of`);
   });
 
-  it("refuses the overflow in the box rather than letting the host eat it", async () => {
+  it("says so at exactly the cap, without calling it an error", async () => {
     await render(stallingClient([]));
-    await type(textarea(), "x".repeat(MAX_DISCUSSION_CHARS + 200));
-    expect([...textarea().value].length).toBe(MAX_DISCUSSION_CHARS);
+    await type(textarea(), "x".repeat(MAX_DISCUSSION_CHARS));
     expect(counter().textContent).toContain("the most a message can hold");
+    expect(post().disabled).toBe(false);
+  });
+
+  /**
+   * The overflow is refused, **not destroyed**.
+   *
+   * Clipping inside `onChange` reached for the same goal and cost more than the
+   * truncation it was guarding against: pasting 4,200 characters silently threw
+   * 200 of them away, past the reach of the browser's undo, and reported it
+   * with a counter reading a number the operator had never typed. Keeping the
+   * words and taking Post down says the same thing while the text is still on
+   * screen to shorten.
+   */
+  it("keeps an over-long paste and refuses to send it", async () => {
+    await render(stallingClient([]));
+    const over = "x".repeat(MAX_DISCUSSION_CHARS + 200);
+    await type(textarea(), over);
+
+    expect(textarea().value).toBe(over);
+    expect(countDiscussionChars(textarea().value)).toBe(MAX_DISCUSSION_CHARS + 200);
+    expect(post().disabled).toBe(true);
+    expect(counter().textContent).toContain("200 over the most a message can hold");
+  });
+
+  /**
+   * Codepoints on the live path too, not only in the counting helper. A
+   * `String.length` gate would have called 2,100 emoji — well inside the host's
+   * limit — an overflow and refused a message the host would have taken whole.
+   */
+  it("measures a paste of emoji the way the host does", async () => {
+    await render(stallingClient([]));
+    // 2100 codepoints, but 4200 UTF-16 units: over the cap only if you count
+    // the wrong thing.
+    await type(textarea(), "🙂".repeat(2_100));
+    expect(post().disabled).toBe(false);
+    expect(counter().className).toContain("sr-only");
+  });
+
+  /**
+   * Enter posts, and it does not consult the button's `disabled` attribute —
+   * so the refusal has to live in `post()` as well, or the keyboard walks
+   * straight past it into the truncating host.
+   */
+  it("refuses the same message on Enter as it does on the button", async () => {
+    const seen: string[] = [];
+    await render(postingClient(seen));
+    await type(textarea(), "x".repeat(MAX_DISCUSSION_CHARS + 1));
+    await act(async () => {
+      textarea().dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    expect(seen).toHaveLength(0);
+
+    // The same gesture on a message that fits does post, so the assertion above
+    // is about the length and not about the key never working.
+    await type(textarea(), "looks good to me");
+    await act(async () => {
+      textarea().dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    expect(seen).toHaveLength(1);
   });
 });
 

--- a/frontend/test/unit/task-detail-discussion-limits.test.ts
+++ b/frontend/test/unit/task-detail-discussion-limits.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { DiscussionMessage } from "@/api/tasks";
+
+/**
+ * The Discussion tab's two silences.
+ *
+ * **A message is truncated at 4000 codepoints, host-side, with a `201`.**
+ * `cap_discussion` in `src/ports/tasks.rs` takes the first 4000 characters and
+ * stores them; the write succeeds either way. Nothing in the composer said so —
+ * no counter, no cap — so an operator pasting a long note learned the limit
+ * existed by reading their own echoed row and finding its tail gone, after the
+ * words were unrecoverable.
+ *
+ * **Withdrawing a message had no busy state.** It is the only mutating control
+ * on this screen that did not: `redact()` set no flag, so a second click fired
+ * a second `DELETE`, and a third a third. The host is idempotent so nothing
+ * ever broke — what it cost was the operator's confidence, because the only
+ * answer to a click was the row changing whenever a request happened to land.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { DiscussionTab, MAX_DISCUSSION_CHARS, capDiscussion } = await import(
+  "@/views/TaskDetailView"
+);
+
+const MESSAGE: DiscussionMessage = {
+  seq: 7,
+  author: "ops",
+  atMillis: new Date("2026-03-02T10:00:00Z").getTime(),
+  text: "the invoice numbers do not line up",
+};
+
+/** Counts `DELETE`s and never settles them, so "in flight" is a real state. */
+function stallingClient(seen: string[]): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    del: async (path: string) => {
+      seen.push(path);
+      return new Promise(() => {});
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(DiscussionTab, {
+        messages: [MESSAGE],
+        hasMore: false,
+        taskId: "task-1",
+        client,
+        company: "acme",
+        onPosted: async () => {},
+      }),
+    );
+  });
+}
+
+function textarea(): HTMLTextAreaElement {
+  return container.querySelector("textarea") as HTMLTextAreaElement;
+}
+
+/**
+ * The counter the composer names in `aria-describedby`.
+ *
+ * Found through that attribute rather than by class or position, because the
+ * link is half of what is being claimed: a description the textarea does not
+ * point at is one no screen reader reads. `getElementById` rather than a `#id`
+ * selector — `useId` mints ids containing characters a CSS selector would need
+ * escaped, and jsdom here has no escaping helper to do it with.
+ */
+function counter(): HTMLElement {
+  const id = textarea().getAttribute("aria-describedby");
+  expect(id).toBeTruthy();
+  const found = document.getElementById(id!);
+  expect(found).not.toBeNull();
+  return found!;
+}
+
+/** React listens for `input` on its own value setter, not on `.value = …`. */
+async function type(el: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value",
+  )!.set!;
+  await act(async () => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("capDiscussion", () => {
+  it("leaves anything within the limit exactly as it was typed", () => {
+    expect(capDiscussion("a short note")).toBe("a short note");
+    const atCap = "x".repeat(MAX_DISCUSSION_CHARS);
+    expect(capDiscussion(atCap)).toBe(atCap);
+  });
+
+  it("clips past it, to the host's own number", () => {
+    expect([...capDiscussion("x".repeat(MAX_DISCUSSION_CHARS + 500))].length).toBe(
+      MAX_DISCUSSION_CHARS,
+    );
+  });
+
+  it("counts codepoints, the way the host counts them", () => {
+    // `String.length` is UTF-16 code units, so a message of astral-plane
+    // characters would be cut at half the limit the host actually applies —
+    // and the counter beside it would have been describing a different rule
+    // from the one doing the cutting. `cap_discussion` takes `chars()`.
+    //
+    // Deliberately *past* the cap and not at it: a fixture of exactly
+    // `MAX_DISCUSSION_CHARS` emoji returns early on the length check and never
+    // reaches the slice, which is how the first version of this test passed
+    // against a `text.slice(…)` that cut 4000 emoji down to 2000.
+    const emoji = "🙂".repeat(MAX_DISCUSSION_CHARS + 100);
+    expect([...capDiscussion(emoji)].length).toBe(MAX_DISCUSSION_CHARS);
+  });
+});
+
+describe("the composer surfaces the limit", () => {
+  it("describes the box by a counter that is always there for a screen reader", async () => {
+    await render(stallingClient([]));
+    expect(counter().textContent).toContain(`of ${MAX_DISCUSSION_CHARS} characters`);
+  });
+
+  it("stays out of the way for a one-line note", async () => {
+    await render(stallingClient([]));
+    // A permanent "0 of 4000" under every note is noise that teaches nobody
+    // anything, so it is hidden until the count starts to matter.
+    expect(counter().className).toContain("sr-only");
+  });
+
+  it("shows itself as the limit comes into range", async () => {
+    await render(stallingClient([]));
+    await type(textarea(), "x".repeat(MAX_DISCUSSION_CHARS - 10));
+    expect(counter().className).not.toContain("sr-only");
+    expect(counter().textContent).toContain(`${MAX_DISCUSSION_CHARS - 10} of`);
+  });
+
+  it("refuses the overflow in the box rather than letting the host eat it", async () => {
+    await render(stallingClient([]));
+    await type(textarea(), "x".repeat(MAX_DISCUSSION_CHARS + 200));
+    expect([...textarea().value].length).toBe(MAX_DISCUSSION_CHARS);
+    expect(counter().textContent).toContain("the most a message can hold");
+  });
+});
+
+describe("withdrawing a message has an in-flight state", () => {
+  /** Presses Remove and confirms it in the portalled dialog. */
+  async function withdraw() {
+    const trigger = container.querySelector(
+      '[data-testid="discussion-redact"]',
+    ) as HTMLButtonElement;
+    await act(async () => trigger.click());
+    const confirm = [...document.querySelectorAll("button")].find(
+      (b) => b.textContent?.trim() === "Remove it",
+    ) as HTMLButtonElement;
+    await act(async () => confirm.click());
+  }
+
+  it("sends one DELETE per confirmation, not one per click", async () => {
+    const seen: string[] = [];
+    await render(stallingClient(seen));
+    await withdraw();
+    expect(seen).toHaveLength(1);
+
+    // The request never settles, so this is the repeat-click window exactly.
+    const trigger = container.querySelector(
+      '[data-testid="discussion-redact"]',
+    ) as HTMLButtonElement;
+    expect(trigger.disabled).toBe(true);
+    await act(async () => trigger.click());
+    expect(seen).toHaveLength(1);
+  });
+
+  it("shows which row is being withdrawn", async () => {
+    await render(stallingClient([]));
+    await withdraw();
+    const trigger = container.querySelector('[data-testid="discussion-redact"]')!;
+    expect(trigger.getAttribute("data-busy")).toBe("true");
+    expect(trigger.querySelector(".animate-spin")).not.toBeNull();
+  });
+
+  it("leaves the control alone until something is actually in flight", async () => {
+    await render(stallingClient([]));
+    const trigger = container.querySelector(
+      '[data-testid="discussion-redact"]',
+    ) as HTMLButtonElement;
+    expect(trigger.disabled).toBe(false);
+    expect(trigger.getAttribute("data-busy")).toBeNull();
+  });
+});

--- a/frontend/test/unit/task-detail-edit-guard.test.ts
+++ b/frontend/test/unit/task-detail-edit-guard.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { IrreversibleEffect, TaskDetail } from "@/api/tasks";
+import { dispatchNeedsConfirm } from "@/lib/task-edit";
+
+/**
+ * The edit dialog's dispatch guard, wired from the detail screen's own read.
+ *
+ * `TaskEditDialog`'s Column select emits `{column: "working"}` — the identical
+ * write the Retry button on this screen makes — so it sits behind the same
+ * #351 confirmation. That gate treats an unread journal as **"cannot say"** and
+ * confirms unconditionally, on purpose: a caller that has not read the journal
+ * cannot claim a card is clean, and defaulting to clean would leave the guard
+ * dead in a way indistinguishable from working.
+ *
+ * Which makes this call site's wiring the whole behaviour. Unwired, every
+ * column change on every card asks the operator to confirm something that never
+ * happened; wired, a card whose journal records nothing irreversible changes
+ * column in one click and a card that already sent a payment still stops.
+ *
+ * The dialog is stubbed rather than driven, because what is being pinned is
+ * what this screen *hands* it — the props are read straight into
+ * `dispatchNeedsConfirm`, so its answer on those props is the observable
+ * consequence, and driving a `<Select>` to reach the same assertion would be
+ * testing Base UI.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const seen = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+
+vi.mock("@/views/TaskEditDialog", () => ({
+  TaskEditDialog: (props: Record<string, unknown>) => {
+    seen.props = props;
+    return null;
+  },
+}));
+
+const { TaskDetailView } = await import("@/views/TaskDetailView");
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+const PAYMENT: IrreversibleEffect = {
+  kind: "payment",
+  atMillis: T0,
+  amountUsd: 42,
+} as IrreversibleEffect;
+
+function detail(over: Partial<TaskDetail> = {}): TaskDetail {
+  return {
+    task: {
+      id: "task-1",
+      title: "Reconcile the ledger",
+      column: "working",
+      stage: "in_review",
+      priority: "medium",
+      assignee: "finance",
+      updatedAt: T0,
+    },
+    timeline: [],
+    durations: {
+      workedMillis: 60_000,
+      workedLive: false,
+      waitingMillis: 0,
+      waitingLive: false,
+      asOfMillis: T0,
+    },
+    approvals: [],
+    irreversibleEffects: [],
+    historyIncomplete: false,
+    discussion: [],
+    discussionHasMore: false,
+    lineage: { children: [] },
+    runs: [],
+    ...over,
+  } as TaskDetail;
+}
+
+function client(d: TaskDetail): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    listTeam: async () => [],
+    get: async (path: string) => {
+      if (path.endsWith("/tasks/inflight")) return [];
+      if (path.includes("/tasks/task-1")) return d;
+      if (path.includes("/ledgers")) return { ledgers: [] };
+      return {};
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(d: TaskDetail) {
+  await act(async () => {
+    root.render(
+      createElement(TaskDetailView, {
+        client: client(d),
+        company: "acme",
+        taskId: "task-1",
+        onBack: () => {},
+        onNavigate: () => {},
+        onDeleted: () => {},
+      }),
+    );
+  });
+}
+
+/** What the gate would decide from the props this screen handed the dialog. */
+function confirmsOnDispatch(): boolean {
+  return dispatchNeedsConfirm(
+    { column: "working" },
+    {
+      irreversible: seen.props!.irreversible as IrreversibleEffect[] | undefined,
+      historyIncomplete: seen.props!.historyIncomplete as boolean | undefined,
+    },
+  );
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  seen.props = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("the detail screen wires the edit dialog's dispatch guard", () => {
+  it("stops asking about a card whose journal records nothing irreversible", async () => {
+    await render(detail());
+    expect(seen.props).not.toBeNull();
+    expect(confirmsOnDispatch()).toBe(false);
+  });
+
+  it("still stops on a card that already did something that cannot be undone", async () => {
+    await render(detail({ irreversibleEffects: [PAYMENT] }));
+    expect(confirmsOnDispatch()).toBe(true);
+  });
+
+  it("still stops when the journal admits it cannot describe its own history", async () => {
+    await render(detail({ historyIncomplete: true }));
+    expect(confirmsOnDispatch()).toBe(true);
+  });
+
+  it("hands over the in-flight read, which is what withholds Delete", async () => {
+    // Delete is refused with a `409` while a run holds the card (#984), so the
+    // dialog must not offer it — and it can only know from this screen.
+    await render(detail());
+    expect(seen.props!).toHaveProperty("inflight");
+  });
+});

--- a/frontend/test/unit/task-detail-no-op-plumbing.test.ts
+++ b/frontend/test/unit/task-detail-no-op-plumbing.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
+
+/**
+ * Two pieces of plumbing on the Task Detail screen that ran and did nothing.
+ *
+ * Both are absences, which is why they are pinned by reading the source rather
+ * than by rendering: there is no behaviour left to observe, and the risk is
+ * that a later change re-adds them because the shape looks like it is missing
+ * something.
+ *
+ * **`onSaved`** was a required prop threaded through five components, and the
+ * only caller — `TaskDetailRoute` — passed `() => {}`. It existed to reconcile
+ * the task board rendered *beside* this screen, and issue #1140 deleted that
+ * board: the board is the `tasks` ledger now, it re-reads from the host, and it
+ * is not mounted while the detail is. `load()` is what actually refreshes this
+ * screen and always was, so the second path was worse than no path — it read
+ * like the one doing the work.
+ *
+ * **`steer()`'s `if (!inflight) return`** looked like a guard and behaved like a
+ * silent failure. The redirect composer deliberately outlives the run it steers
+ * (so a settling run does not destroy the typed instruction), so Send really
+ * could be pressed with `inflight` null — and this swallowed it: no request, no
+ * error, no toast. `steer` takes the run key now, which makes the absence of a
+ * run something the call site has to answer for, and Send is disabled there.
+ */
+describe("the no-op plumbing is gone, and stays gone", () => {
+  const view = read("views/TaskDetailView.tsx");
+  const route = read("views/TaskDetailRoute.tsx");
+  const proposal = read("views/TaskWorkflowProposalPanel.tsx");
+
+  it("has no `onSaved` left on the detail screen or its children", () => {
+    // Matched as code rather than as a word, for two reasons: `TaskEditDialog`
+    // keeps an `onSaved` of its own (it has other callers, and the detail still
+    // passes it a close-and-reload), and each of these files carries a comment
+    // saying why the prop is gone — a bare substring search would hit both.
+    for (const [name, src] of [
+      ["TaskDetailView", view],
+      ["TaskDetailRoute", route],
+      ["TaskWorkflowProposalPanel", proposal],
+    ] as const) {
+      expect(src, `${name} declares one`).not.toContain("onSaved: (t: Task) => void;");
+      expect(src, `${name} invokes one`).not.toContain("onSaved(saved)");
+      expect(src, `${name} threads one`).not.toContain("onSaved={onSaved}");
+    }
+    // The route's `onSaved={() => {}}` — the no-op the whole prop existed for.
+    expect(route).not.toContain("onSaved=");
+    expect(proposal).not.toContain("onSaved=");
+  });
+
+  it("still refreshes, through the path that always did the work", () => {
+    // The point is not that the calls were deleted; it is that `load()` is
+    // what replaced them. A save with neither would be the real regression.
+    expect(view).toContain("await onChanged();");
+    expect(view).toContain("void load();");
+  });
+
+  it("does not swallow a steer with no run", () => {
+    expect(view).not.toContain("if (!inflight) return;");
+    // The key is a parameter, so a caller with no run cannot compile its way
+    // into the silent branch.
+    expect(view).toContain("async function steer(\n    key: string,");
+  });
+});

--- a/frontend/test/unit/task-detail-plan-tab.test.ts
+++ b/frontend/test/unit/task-detail-plan-tab.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import type { Prerequisite, TaskPlan } from "@/api/tasks";
+import { isTaskTab, readTaskFocus, TASK_TABS, taskTabHref } from "@/lib/task-output";
+import { planTabCount } from "@/views/TaskDetailView";
+
+/**
+ * The Plan tab: addressable, and legible without colour.
+ *
+ * Two separate failures on one tab.
+ *
+ * **It was not a `TaskTab`,** so selecting it wrote nothing into the address.
+ * Every other tab on this screen survives a reload, a copied link and a
+ * Back/Forward; Plan silently did not, and dropped the operator onto Timeline —
+ * on the one tab they were most likely to be reading closely, because it is the
+ * tab that answers "why hasn't this started?".
+ *
+ * **Its count distinguished blocking from unresolved by colour alone.** The
+ * rendered text was a bare number in `text-destructive` or
+ * `text-status-blocked-text`, so "this card cannot start" and "this card will
+ * pause to ask you something" were the same glyph to anyone not reading the
+ * hue — and to every greyscale print of the screen.
+ */
+
+function prerequisite(status: Prerequisite["status"]): Prerequisite {
+  return { kind: "credential", name: "an API key", status, note: "" };
+}
+
+function plan(...statuses: Prerequisite["status"][]): TaskPlan {
+  return {
+    description: "",
+    steps: [],
+    prerequisites: statuses.map(prerequisite),
+    risks: [],
+    verification: "",
+    scope: "",
+    plannedAtMillis: 0,
+  };
+}
+
+describe("the Plan tab is addressable", () => {
+  it("is a tab an address can name", () => {
+    expect(TASK_TABS).toContain("plan");
+    expect(isTaskTab("plan")).toBe(true);
+  });
+
+  it("survives a round trip through the hash", () => {
+    // Selecting the tab writes it; reading the address back yields it. Before
+    // this the write was dropped by `isTaskTab` and the read returned `{}`, so
+    // a reload landed on Timeline with the URL still claiming Plan.
+    const href = taskTabHref("#/tasks/t-1?host=local", "plan");
+    expect(href).toBe("#/tasks/t-1?host=local&tab=plan");
+    expect(readTaskFocus(href)).toEqual({ tab: "plan" });
+  });
+});
+
+describe("the Plan tab's count carries a signal that is not its colour", () => {
+  it("marks a blocking count with the brief's own blocked shape", () => {
+    const badge = planTabCount(plan("missing", "missing", "satisfied"));
+    expect(badge).not.toBeNull();
+    expect(badge!.count).toBe(2);
+    expect(badge!.label).toBe("2 blocking prerequisites");
+    // The icon is what a reader who cannot use the colour sees; that it is a
+    // *different* component from the unresolved one is the whole point.
+    expect(badge!.Icon).not.toBe(planTabCount(plan("needsApproval"))!.Icon);
+  });
+
+  it("marks an unresolved count differently, and says which it is", () => {
+    const badge = planTabCount(plan("needsApproval", "unknown"));
+    expect(badge!.count).toBe(2);
+    expect(badge!.label).toBe("2 unresolved prerequisites");
+  });
+
+  it("counts a single prerequisite in the singular", () => {
+    expect(planTabCount(plan("missing"))!.label).toBe("1 blocking prerequisite");
+    expect(planTabCount(plan("unknown"))!.label).toBe("1 unresolved prerequisite");
+  });
+
+  it("still reports blocking ahead of unresolved, and nothing at all when clear", () => {
+    // Unchanged from #337 and re-pinned here because the shape of the return
+    // grew: red is only ever `missing`, and a plan with nothing to report keeps
+    // the trigger a plain word.
+    expect(planTabCount(plan("missing", "needsApproval"))!.label).toBe(
+      "1 blocking prerequisite",
+    );
+    expect(planTabCount(plan("satisfied", "satisfied"))).toBeNull();
+    expect(planTabCount(plan())).toBeNull();
+  });
+});

--- a/frontend/test/unit/task-detail-screen-states.test.ts
+++ b/frontend/test/unit/task-detail-screen-states.test.ts
@@ -235,6 +235,35 @@ describe("a card parked on an approval, with no run in flight", () => {
     expect(button("Retry")!.disabled).toBe(true);
   });
 
+  /**
+   * The other direction, and it is **deliberate** (#1953 review).
+   *
+   * A queue row this card owns, with the card's own `approvals` read not yet
+   * carrying it, still takes Retry down. Intersecting the queue with
+   * `detail.approvals` here — the rule `AwaitingApprovalRow` applies to its
+   * *rows* — would collapse this union into `awaitingApproval` alone and hand
+   * the operator a live Retry beside a genuinely parked approval.
+   *
+   * The two are not the same claim. Over-claiming a **row** offers a resolve
+   * button for a request this card may not own; over-claiming the **block**
+   * only greys a button for a poll. The host ranks them the same way in
+   * `pending_approvals_resolved`: when it cannot resolve an approval's owning
+   * attempt it keeps the parked link rather than dropping it, because "a
+   * dropped blocker is a card that lies about being free".
+   *
+   * The stale-attribution worry that motivates intersecting was fixed at the
+   * source by #1891: `ApprovalSummary.task` is the host's `approval_owner`
+   * answer, not the park's stamp, so a queue row reaching here already belongs
+   * to this card.
+   */
+  it("disables it on the queue's word alone, before the card's own read carries it", async () => {
+    await render(client([async () => detail({ approvals: [] })]), {
+      parked: [QUEUED],
+    });
+    expect(button("Retry")!.disabled).toBe(true);
+    expect(button("Retry")!.title).toBe(RESUME_BLOCKED_REASON);
+  });
+
   it("leaves it live on a card with nothing parked", async () => {
     await render(client([async () => detail()]));
     expect(button("Retry")!.disabled).toBe(false);

--- a/frontend/test/unit/task-detail-screen-states.test.ts
+++ b/frontend/test/unit/task-detail-screen-states.test.ts
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { TaskApproval, TaskDetail } from "@/api/tasks";
+import type { ApprovalSummary } from "@/api/types";
+
+/**
+ * Three states the whole Task Detail screen could reach and could not get out
+ * of, or got wrong — pinned at the screen rather than at a helper, because in
+ * every one of them the helper was already right.
+ *
+ * - **A failed read was a dead end.** A non-404 leaves `detail` null and sets
+ *   `error`, and the render ternary fell through to `null`: a back bar, a red
+ *   alert, and nothing else. The 4s poll does recover on its own — the in-file
+ *   comment claiming "nothing retries" was wrong about that — but a pane with
+ *   no control in it cannot say so, and an operator who cannot tell a slow
+ *   failure from a permanent one leaves.
+ * - **A `?tab=plan` on a card with no plan** would select a tab with no trigger
+ *   and no panel, now that Plan is addressable at all.
+ * - **Retry beside a pending approval.** The run parked, so it is gone from
+ *   `…/tasks/inflight`, so the bar renders the branch that offers Retry —
+ *   enabled, above a row saying the card is waiting on the operator.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { TaskDetailView } = await import("@/views/TaskDetailView");
+const { RESUME_BLOCKED_REASON } = await import("@/lib/task-approvals");
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+function detail(over: Partial<TaskDetail> = {}): TaskDetail {
+  return {
+    task: {
+      id: "task-1",
+      title: "Reconcile the ledger",
+      column: "working",
+      stage: "in_review",
+      priority: "medium",
+      assignee: "finance",
+      updatedAt: T0,
+    },
+    timeline: [],
+    durations: {
+      workedMillis: 60_000,
+      workedLive: false,
+      waitingMillis: 0,
+      waitingLive: false,
+      asOfMillis: T0,
+    },
+    approvals: [],
+    irreversibleEffects: [],
+    historyIncomplete: false,
+    discussion: [],
+    discussionHasMore: false,
+    lineage: { children: [] },
+    runs: [],
+    ...over,
+  } as TaskDetail;
+}
+
+const PENDING: TaskApproval = {
+  id: "ap-1",
+  kind: "web_fetch",
+  status: "pending",
+  atMillis: T0,
+} as TaskApproval;
+
+const QUEUED: ApprovalSummary = {
+  id: "ap-1",
+  kind: "web_fetch",
+  amount_usd: null,
+  at_millis: T0,
+  agent: "finance",
+  task: { link: "task", id: "task-1" },
+  payload: { url: "https://example.com/rates" },
+} as ApprovalSummary;
+
+/**
+ * A client whose `…/tasks/{id}` read is scripted call by call.
+ *
+ * Everything else answers something harmless: the screen also reads the ledger
+ * list (for column labels) and the in-flight list, and neither is what any of
+ * these tests is about.
+ */
+function client(reads: Array<() => Promise<unknown>>): OpenCompanyClient {
+  let n = 0;
+  return {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    // The blocked row names whoever asked, which is a roster read.
+    listTeam: async () => [],
+    get: async (path: string) => {
+      if (path.endsWith("/tasks/inflight")) return [];
+      if (path.includes("/tasks/task-1")) {
+        const read = reads[Math.min(n, reads.length - 1)];
+        n += 1;
+        return read();
+      }
+      if (path.includes("/ledgers")) return { ledgers: [] };
+      return {};
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(
+  c: OpenCompanyClient,
+  over: {
+    focus?: { tab?: "timeline" | "attempts" | "plan" | "artifacts" | "discussion" };
+    parked?: ApprovalSummary[];
+  } = {},
+) {
+  await act(async () => {
+    root.render(
+      createElement(TaskDetailView, {
+        client: c,
+        company: "acme",
+        taskId: "task-1",
+        focus: over.focus,
+        parked: over.parked,
+        onBack: () => {},
+        onNavigate: () => {},
+        onDeleted: () => {},
+      }),
+    );
+  });
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return [...document.querySelectorAll("button")].find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("a read that failed with something other than a 404", () => {
+  it("offers a way out of the pane rather than leaving it empty", async () => {
+    await render(client([async () => Promise.reject(new Error("gateway is down"))]));
+    expect(container.textContent).toContain("gateway is down");
+    expect(button("Try again")).toBeDefined();
+  });
+
+  it("recovers the card when the retry succeeds", async () => {
+    const reads: Array<() => Promise<unknown>> = [
+      async () => Promise.reject(new Error("gateway is down")),
+      async () => detail(),
+    ];
+    await render(client(reads));
+    expect(container.textContent).not.toContain("Reconcile the ledger");
+    await act(async () => {
+      button("Try again")!.click();
+    });
+    expect(container.textContent).toContain("Reconcile the ledger");
+    expect(button("Try again")).toBeUndefined();
+  });
+});
+
+describe("an address naming the Plan tab", () => {
+  it("falls back to Timeline on a card that has no plan", async () => {
+    await render(client([async () => detail()]), { focus: { tab: "plan" } });
+    // Not a blank panel under a tab bar: the default tab's own content.
+    expect(container.textContent).toContain("Nothing has happened yet");
+  });
+});
+
+describe("the screen's heading outline", () => {
+  it("puts an h2 between the card's h1 and the h3s its panels render", async () => {
+    await render(client([async () => detail()]));
+    expect(container.querySelector("h1")?.textContent).toBe("Reconcile the ledger");
+    // The Artifacts panel renders an `h3` per artifact, so with only the card
+    // title above it the outline jumped h1 → h3 and a reader navigating by
+    // heading could not tell which section they had landed in. Each panel now
+    // opens with its own `h2`, `sr-only` because the tab bar is already the
+    // visible label.
+    const h2s = [...container.querySelectorAll("h2")].map((h) => h.textContent);
+    expect(h2s).toContain("Timeline");
+  });
+});
+
+describe("a card parked on an approval, with no run in flight", () => {
+  it("disables Retry and says why", async () => {
+    await render(client([async () => detail({ approvals: [PENDING] })]), {
+      parked: [QUEUED],
+    });
+    // The row that explains it, and the button that must not fire beneath it.
+    expect(container.textContent).toContain("Waiting on your approval");
+    const retry = button("Retry");
+    expect(retry).toBeDefined();
+    expect(retry!.disabled).toBe(true);
+    expect(retry!.title).toBe(RESUME_BLOCKED_REASON);
+  });
+
+  it("disables it on the host's word alone, before the queue has delivered the row", async () => {
+    // The two reads land separately. `approvals` is the host's own ownership
+    // answer and arrives first; a Retry that stayed live for that poll is the
+    // whole bug, just four seconds narrower.
+    await render(client([async () => detail({ approvals: [PENDING] })]), {
+      parked: [],
+    });
+    expect(button("Retry")!.disabled).toBe(true);
+  });
+
+  it("leaves it live on a card with nothing parked", async () => {
+    await render(client([async () => detail()]));
+    expect(button("Retry")!.disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/task-edit-dialog-gates.test.ts
+++ b/frontend/test/unit/task-edit-dialog-gates.test.ts
@@ -1,0 +1,433 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { InflightRun, IrreversibleEffect, Task } from "@/api/tasks";
+
+/**
+ * The four states the edit dialog used to get wrong, all of them claims about
+ * what the DOM does across a click sequence rather than anything a pure helper
+ * can pin on its own — so this renders the dialog, the way
+ * `ledger-retire-confirm.test.ts` does for the same reason.
+ *
+ *   1. **Column → Working is a dispatch.** It sends the identical
+ *      `PATCH { column: "working" }` the Task Detail Retry button sends, and
+ *      Retry has been gated behind issue #351's irreversible-effects
+ *      confirmation since that issue shipped. Save was a plain button.
+ *   2. **Delete is refused for an in-flight card.** `delete_task` answers `409`
+ *      on purpose (issue #984), so offering the button makes the operator
+ *      discover the rule as a failed click.
+ *   3. **Cancel discards an unsaved edit.** The note textarea holds text
+ *      nothing else on the screen has a copy of.
+ *   4. **The assignee picker stayed live during a save**, unlike its twin in
+ *      the detail screen's reassign row.
+ *
+ * The load-bearing assertion in (1) is the *negative* one: `client.patch` must
+ * not have been called when Save was pressed. A confirmation that opens and
+ * dispatches anyway is worse than none, because it reads as a guard.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { TaskEditDialog } = await import("@/views/TaskEditDialog");
+
+const TASK: Task = {
+  id: "task-1",
+  title: "Pay the invoice",
+  note: "the original note",
+  column: "pending",
+  stage: "pending",
+  priority: "medium",
+  assignee: "",
+  updatedAt: 1_700_000_000_000,
+};
+
+const PAID: IrreversibleEffect = { kind: "payment.send", atMillis: 1_699_999_000_000, amountUsd: 40 };
+
+const RUNNING: InflightRun = {
+  taskId: "task-1",
+  key: "task-1",
+  kind: "task",
+  title: "Pay the invoice",
+  agentId: "finance",
+  startedAt: 1_700_000_000_000,
+  pendingAction: null,
+};
+
+/** The `tasks` ledger, so the Column select offers the real three phases. */
+const LEDGERS = {
+  ledgers: [
+    {
+      slug: "tasks",
+      title: "Tasks",
+      purpose: "The company's work board.",
+      source: "native",
+      derived: "derived/TASKS.md",
+      writtenBy: "the board",
+      builtin: true,
+      fields: [],
+      statuses: [
+        { name: "pending", label: "Pending" },
+        { name: "working", label: "Working" },
+        { name: "done", label: "Done", closed: true },
+      ],
+      sections: [],
+      open: 1,
+      closed: 0,
+    },
+  ],
+  faults: [],
+  remaining: 3,
+};
+
+function fakeClient() {
+  // Typed with the arguments `patchTask` actually passes, so `mock.calls[0][1]`
+  // is the request body rather than a hole in an empty tuple — the drift
+  // `tsconfig.unit.json` exists to catch.
+  const patch = vi.fn(async (_path: string, body: unknown) => {
+    void body;
+    return { ...TASK, column: "working" } as Task;
+  });
+  const del = vi.fn(async (_path: string) => undefined);
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/company/${company ?? "acme"}`,
+    get: vi.fn(async (path: string) => (path.endsWith("/ledgers") ? LEDGERS : [])),
+    patch,
+    del,
+    listDesks: vi.fn(async () => []),
+    listTeam: vi.fn(async () => []),
+  } as unknown as OpenCompanyClient;
+  return { client, patch, del };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+/**
+ * Both the edit dialog and the confirmations inside it render through portals
+ * onto `document.body`, so every lookup searches the whole document rather than
+ * `container`.
+ */
+function buttons(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll("button"));
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = buttons().find((b) => b.textContent?.trim() === label);
+  if (!found) throw new Error(`no “${label}” button; saw: ${buttons().map((b) => b.textContent?.trim()).join(" | ")}`);
+  return found;
+}
+
+function maybeButton(label: string): HTMLButtonElement | undefined {
+  return buttons().find((b) => b.textContent?.trim() === label);
+}
+
+/** The Column select's option row, once the popup is open. */
+function option(label: string): HTMLElement {
+  const found = Array.from(document.querySelectorAll('[role="option"]')).find(
+    (o) => o.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no “${label}” option in the open popup`);
+  return found as HTMLElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+interface Options {
+  inflight?: InflightRun | null;
+  irreversible?: IrreversibleEffect[];
+  historyIncomplete?: boolean;
+  task?: Task;
+}
+
+async function mount(client: OpenCompanyClient, opts: Options = {}) {
+  const onClose = vi.fn();
+  const onSaved = vi.fn();
+  const onDeleted = vi.fn();
+  await act(async () => {
+    root.render(
+      createElement(TaskEditDialog, {
+        task: opts.task ?? TASK,
+        onClose,
+        onSaved,
+        onDeleted,
+        client,
+        company: "acme",
+        inflight: opts.inflight,
+        irreversible: opts.irreversible,
+        historyIncomplete: opts.historyIncomplete,
+      }),
+    );
+  });
+  // The ledger read and the roster reads settle in microtasks, and the state
+  // they set lands a tick later; give React those ticks rather than assuming
+  // one flush covers all three.
+  await act(async () => {});
+  await act(async () => {});
+  return { onClose, onSaved, onDeleted };
+}
+
+/** Open the Column select and pick `label`. */
+async function chooseColumn(label: string) {
+  await act(async () => {
+    (document.querySelector("#task-column") as HTMLElement).click();
+  });
+  await act(async () => {
+    option(label).click();
+  });
+}
+
+describe("moving a card into Working from the edit dialog (issue #351)", () => {
+  it("does not dispatch on Save until the confirmation is accepted", async () => {
+    const { client, patch } = fakeClient();
+    await mount(client, { irreversible: [PAID], historyIncomplete: false });
+
+    await chooseColumn("Working");
+    await act(async () => {
+      button("Save").click();
+    });
+
+    // The whole point. The confirmation is open and nothing has been written.
+    expect(patch).not.toHaveBeenCalled();
+    expect(maybeButton("Save anyway")).toBeDefined();
+
+    await act(async () => {
+      button("Save anyway").click();
+    });
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch.mock.calls[0][1]).toEqual({ column: "working" });
+  });
+
+  it("names what the card already did, and how long ago", async () => {
+    const { client } = fakeClient();
+    await mount(client, { irreversible: [PAID], historyIncomplete: false });
+
+    await chooseColumn("Working");
+    await act(async () => {
+      button("Save").click();
+    });
+
+    const text = document.body.textContent ?? "";
+    // The mechanism first: nothing about a Column select says "dispatch".
+    expect(text).toContain("Moving this card into Working runs it again");
+    expect(text).toContain("cannot be undone");
+    // Rendered through `effectDone`, so the kind is never shown raw.
+    expect(text).not.toContain("payment.send");
+  });
+
+  it("says a gap is a gap when the journal cannot describe its own history", async () => {
+    const { client, patch } = fakeClient();
+    await mount(client, { irreversible: [], historyIncomplete: true });
+
+    await chooseColumn("Working");
+    await act(async () => {
+      button("Save").click();
+    });
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("nothing here can be listed");
+  });
+
+  /**
+   * The other half of the fix. A confirmation on every dispatch would train the
+   * operator to click through it, and it would then be gone on the card that
+   * had actually spent money.
+   */
+  it("saves in one click on a card whose journal is clean", async () => {
+    const { client, patch } = fakeClient();
+    await mount(client, { irreversible: [], historyIncomplete: false });
+
+    await chooseColumn("Working");
+    await act(async () => {
+      button("Save").click();
+    });
+
+    expect(maybeButton("Save anyway")).toBeUndefined();
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch.mock.calls[0][1]).toEqual({ column: "working" });
+  });
+
+  it("leaves a save that is not a dispatch alone, however dirty the card's past", async () => {
+    const { client, patch } = fakeClient();
+    await mount(client, { irreversible: [PAID], historyIncomplete: true });
+
+    const note = document.querySelector("#task-note") as HTMLTextAreaElement;
+    await act(async () => {
+      setValue(note, "a rewritten note");
+    });
+    await act(async () => {
+      button("Save").click();
+    });
+
+    expect(maybeButton("Save anyway")).toBeUndefined();
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch.mock.calls[0][1]).toEqual({ note: "a rewritten note" });
+  });
+
+  /**
+   * A caller that has not wired the read cannot claim the card is clean, so it
+   * gets the confirmation. Without this the guard would sit silently dead in
+   * any caller that forgot the props — indistinguishable from working.
+   */
+  it("confirms when the caller passed no effect history at all", async () => {
+    const { client, patch } = fakeClient();
+    await mount(client);
+
+    await chooseColumn("Working");
+    await act(async () => {
+      button("Save").click();
+    });
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(maybeButton("Save anyway")).toBeDefined();
+  });
+});
+
+describe("Delete on a card the host will refuse (issue #984)", () => {
+  it("is disabled while a run holds the card, and says what to do instead", async () => {
+    const { client, del } = fakeClient();
+    await mount(client, { inflight: RUNNING, irreversible: [], historyIncomplete: false });
+
+    const remove = button("Delete");
+    expect(remove.disabled).toBe(true);
+    // Matched to the host's own refusal rather than invented here: it names
+    // cancelling first and says why deleting now would not remove the card.
+    expect(remove.title).toContain("cancel the run first");
+    expect(remove.title).toContain("writes the card back when it settles");
+
+    await act(async () => {
+      remove.click();
+    });
+    // No confirm opened, and certainly no request.
+    expect(maybeButton("Delete task")).toBeUndefined();
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it("still deletes a card nothing is running", async () => {
+    const { client, del } = fakeClient();
+    const { onDeleted } = await mount(client, { irreversible: [], historyIncomplete: false });
+
+    const remove = button("Delete");
+    expect(remove.disabled).toBe(false);
+    await act(async () => {
+      remove.click();
+    });
+    await act(async () => {
+      button("Delete task").click();
+    });
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(onDeleted).toHaveBeenCalledWith("task-1");
+  });
+});
+
+describe("Cancel on an unsaved edit", () => {
+  it("asks before throwing the edit away", async () => {
+    const { client } = fakeClient();
+    const { onClose } = await mount(client, { irreversible: [], historyIncomplete: false });
+
+    const note = document.querySelector("#task-note") as HTMLTextAreaElement;
+    await act(async () => {
+      setValue(note, "half an hour of typing");
+    });
+    await act(async () => {
+      button("Cancel").click();
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Discard this edit?");
+
+    await act(async () => {
+      button("Discard").click();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses straight off when nothing was touched", async () => {
+    const { client } = fakeClient();
+    const { onClose } = await mount(client, { irreversible: [], historyIncomplete: false });
+
+    await act(async () => {
+      button("Cancel").click();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(document.body.textContent).not.toContain("Discard this edit?");
+  });
+});
+
+describe("the assignee picker during a save", () => {
+  /**
+   * Its twin in the detail screen's reassign row is disabled while the write is
+   * out. A picker that still moves invites a second choice the in-flight PATCH
+   * will not carry, so the row would read as the new assignee while the host
+   * stored the old one.
+   */
+  it("is disabled while the save is in flight", async () => {
+    const { client } = fakeClient();
+    let release: (t: Task) => void = () => {};
+    (client.patch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise<Task>((resolve) => (release = resolve)),
+    );
+    await mount(client, { irreversible: [], historyIncomplete: false });
+
+    const picker = () => document.querySelector("#task-assignee") as HTMLButtonElement;
+    expect(picker().disabled).toBe(false);
+
+    const note = document.querySelector("#task-note") as HTMLTextAreaElement;
+    await act(async () => {
+      setValue(note, "something to save");
+    });
+    await act(async () => {
+      button("Save").click();
+    });
+
+    expect(picker().disabled).toBe(true);
+
+    await act(async () => {
+      release(TASK);
+    });
+  });
+});
+
+/**
+ * React installs its own value setter on the element, so assigning `.value`
+ * directly is invisible to it. Go through the prototype descriptor and then
+ * fire the event React actually listens for.
+ */
+function setValue(el: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}

--- a/frontend/test/unit/task-edit-dialog-poll-reset.test.ts
+++ b/frontend/test/unit/task-edit-dialog-poll-reset.test.ts
@@ -1,0 +1,409 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { IrreversibleEffect, Task } from "@/api/tasks";
+
+/**
+ * The edit dialog must survive its own screen's poll.
+ *
+ * The Task Detail screen refetches the card every 4s and hands `TaskEditDialog`
+ * a **new `detail.task` object** each tick with the same values. The seeding
+ * effect used to be keyed on that object, so it re-ran on every tick and wiped
+ * the draft: measured in a browser, a Column select set to Working read back
+ * `Pending` 2.3s later and never recovered.
+ *
+ * The consequence is worse than a lost keystroke, which is why these are here
+ * rather than in the gates file. After the reset `computeTaskPatch` returns
+ * `{}` — so `confirmDispatch` is false and Save writes nothing at all: no
+ * confirmation, no request, no toast. The irreversible-effects gate on the
+ * Column select (issue #351, applied to this second dispatch path) was only
+ * reachable by picking and saving within the same ~150ms. A guard nobody can
+ * reach is not a guard.
+ *
+ * The last two tests pin the **deliberate cost** of the fix: with the draft
+ * seeded on the card's identity, a server-side change to the card while this
+ * dialog is open is not reflected here. That is the intended trade — the open
+ * draft wins, because nothing else on the screen holds a copy of it — and it is
+ * bounded, because the save diffs against the card as it read when the dialog
+ * opened, so a field the operator never touched is never in the patch.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { TaskEditDialog } = await import("@/views/TaskEditDialog");
+
+const TASK: Task = {
+  id: "task-1",
+  title: "Pay the invoice",
+  note: "the original note",
+  column: "pending",
+  stage: "pending",
+  priority: "medium",
+  assignee: "",
+  updatedAt: 1_700_000_000_000,
+};
+
+const PAID: IrreversibleEffect = {
+  kind: "payment.send",
+  atMillis: 1_699_999_000_000,
+  amountUsd: 40,
+};
+
+/** The `tasks` ledger, so the Column select offers the real three phases. */
+const LEDGERS = {
+  ledgers: [
+    {
+      slug: "tasks",
+      title: "Tasks",
+      purpose: "The company's work board.",
+      source: "native",
+      derived: "derived/TASKS.md",
+      writtenBy: "the board",
+      builtin: true,
+      fields: [],
+      statuses: [
+        { name: "pending", label: "Pending" },
+        { name: "working", label: "Working" },
+        { name: "done", label: "Done", closed: true },
+      ],
+      sections: [],
+      open: 1,
+      closed: 0,
+    },
+  ],
+  faults: [],
+  remaining: 3,
+};
+
+function fakeClient() {
+  const patch = vi.fn(async (_path: string, body: unknown) => {
+    void body;
+    return { ...TASK, column: "working" } as Task;
+  });
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/company/${company ?? "acme"}`,
+    get: vi.fn(async (path: string) => (path.endsWith("/ledgers") ? LEDGERS : [])),
+    patch,
+    del: vi.fn(async (_path: string) => undefined),
+    listDesks: vi.fn(async () => []),
+    listTeam: vi.fn(async () => []),
+  } as unknown as OpenCompanyClient;
+  return { client, patch };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+/** The dialog and its confirmations render through portals onto `document.body`. */
+function buttons(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll("button"));
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = buttons().find((b) => b.textContent?.trim() === label);
+  if (!found) {
+    throw new Error(
+      `no “${label}” button; saw: ${buttons()
+        .map((b) => b.textContent?.trim())
+        .join(" | ")}`,
+    );
+  }
+  return found;
+}
+
+function maybeButton(label: string): HTMLButtonElement | undefined {
+  return buttons().find((b) => b.textContent?.trim() === label);
+}
+
+function option(label: string): HTMLElement {
+  const found = Array.from(document.querySelectorAll('[role="option"]')).find(
+    (o) => o.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no “${label}” option in the open popup`);
+  return found as HTMLElement;
+}
+
+const titleInput = () => document.querySelector("#task-title") as HTMLInputElement;
+const noteInput = () => document.querySelector("#task-note") as HTMLTextAreaElement;
+/**
+ * What a select trigger is showing. The trigger also renders a decorative
+ * chevron glyph, so strip everything outside printable ASCII rather than
+ * assert against a character the icon owns.
+ */
+function triggerText(id: string): string {
+  return (document.querySelector(id)?.textContent ?? "").replace(/[^\x20-\x7E]/g, "").trim();
+}
+
+/** The Column trigger shows the label, not the id. */
+const columnText = () => triggerText("#task-column");
+const priorityText = () => triggerText("#task-priority");
+
+function mounter(client: OpenCompanyClient, irreversible?: IrreversibleEffect[]) {
+  /** Render (or re-render) with `task` — pass null for a closed dialog. */
+  return async function show(task: Task | null) {
+    await act(async () => {
+      root.render(
+        createElement(TaskEditDialog, {
+          task,
+          onClose: vi.fn(),
+          onSaved: vi.fn(),
+          onDeleted: vi.fn(),
+          client,
+          company: "acme",
+          irreversible: irreversible ?? [],
+          historyIncomplete: false,
+        }),
+      );
+    });
+    // The ledger and roster reads settle in microtasks and the state they set
+    // lands a tick later; give React those ticks rather than assuming one flush
+    // covers all three.
+    await act(async () => {});
+    await act(async () => {});
+  };
+}
+
+/**
+ * One poll tick: the same card, same values, **new object identity** — exactly
+ * what `getTaskDetail` produces every `POLL_MS` on the Task Detail screen.
+ */
+async function pollTick(show: (t: Task | null) => Promise<void>, ticks = 1) {
+  for (let i = 0; i < ticks; i += 1) await show({ ...TASK });
+}
+
+async function chooseColumn(label: string) {
+  await act(async () => {
+    (document.querySelector("#task-column") as HTMLElement).click();
+  });
+  await act(async () => {
+    option(label).click();
+  });
+}
+
+/** React installs its own value setter, so assign through the prototype. */
+function setValue(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const proto = el instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+  Object.getOwnPropertyDescriptor(proto, "value")?.set?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("an open edit dialog under the Task Detail poll", () => {
+  it("keeps a Column choice when the poll returns the same card", async () => {
+    const { client } = fakeClient();
+    const show = mounter(client);
+    await show(TASK);
+
+    await chooseColumn("Working");
+    expect(columnText()).toBe("Working");
+
+    await pollTick(show, 3);
+
+    // The measured symptom, inverted: it read “Pending” from 2.3s onward.
+    expect(columnText()).toBe("Working");
+  });
+
+  it("keeps typed text in the title and note when the poll returns the same card", async () => {
+    const { client } = fakeClient();
+    const show = mounter(client);
+    await show(TASK);
+
+    await act(async () => setValue(titleInput(), "Pay the invoice twice"));
+    await act(async () => setValue(noteInput(), "half an hour of typing"));
+
+    await pollTick(show, 3);
+
+    expect(titleInput().value).toBe("Pay the invoice twice");
+    expect(noteInput().value).toBe("half an hour of typing");
+  });
+
+  it("keeps a Priority choice when the poll returns the same card", async () => {
+    const { client } = fakeClient();
+    const show = mounter(client);
+    await show(TASK);
+
+    await act(async () => {
+      (document.querySelector("#task-priority") as HTMLElement).click();
+    });
+    await act(async () => {
+      option("high").click();
+    });
+    expect(priorityText()).toBe("high");
+
+    await pollTick(show, 3);
+
+    expect(priorityText()).toBe("high");
+  });
+
+  /**
+   * The load-bearing one. This is the whole reason the reset is urgent rather
+   * than merely old: once the draft is wiped the patch is `{}`, so Save is a
+   * silent no-op and the confirmation it gates never opens.
+   */
+  it("still reaches the dispatch confirmation after the poll has ticked", async () => {
+    const { client, patch } = fakeClient();
+    const show = mounter(client, [PAID]);
+    await show(TASK);
+
+    await chooseColumn("Working");
+    await pollTick(show, 3);
+
+    await act(async () => {
+      button("Save").click();
+    });
+
+    expect(maybeButton("Save anyway")).toBeDefined();
+    expect(patch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      button("Save anyway").click();
+    });
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch.mock.calls[0][1]).toEqual({ column: "working" });
+  });
+
+  it("still writes an edit that survived the poll", async () => {
+    const { client, patch } = fakeClient();
+    const show = mounter(client);
+    await show(TASK);
+
+    await act(async () => setValue(noteInput(), "a rewritten note"));
+    await pollTick(show, 3);
+
+    await act(async () => {
+      button("Save").click();
+    });
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch.mock.calls[0][1]).toEqual({ note: "a rewritten note" });
+  });
+
+  /**
+   * The poll must not manufacture unsaved changes either. An untouched dialog
+   * that has sat through a few ticks still dismisses on Cancel without the
+   * discard confirmation — which is only true because the diff is taken against
+   * the card as it read when the dialog opened.
+   */
+  it("does not become dirty just because the poll ticked", async () => {
+    const { client } = fakeClient();
+    const show = mounter(client);
+    await show(TASK);
+
+    await pollTick(show, 3);
+
+    await act(async () => {
+      button("Cancel").click();
+    });
+    expect(document.body.textContent).not.toContain("Discard this edit?");
+  });
+});
+
+describe("what seeding on the card's identity gives up", () => {
+  /**
+   * Deliberate, not an oversight: a second operator editing the same card
+   * cannot retype the first one's open draft out from under them. A
+   * half-written note exists nowhere else — nothing on the screen holds a copy,
+   * which is why Cancel asks before discarding it — so the open draft wins and
+   * the server-side change lands on the screen behind instead.
+   */
+  it("does not adopt a server-side change to the card while the dialog is open", async () => {
+    const { client } = fakeClient();
+    const show = mounter(client);
+    await show(TASK);
+
+    await show({ ...TASK, title: "renamed by somebody else", priority: "high" });
+
+    expect(titleInput().value).toBe("Pay the invoice");
+    expect(priorityText()).toBe("medium");
+
+    // And it is not reported as an unsaved edit either. Diffing the untouched
+    // draft against the *live* card would call this dirty and make Cancel stop
+    // to ask about changes the operator never made.
+    await act(async () => {
+      button("Cancel").click();
+    });
+    expect(document.body.textContent).not.toContain("Discard this edit?");
+  });
+
+  /**
+   * …and the cost stops there. The save diffs against the card as it read when
+   * the dialog opened, so the stale title the operator never touched is not in
+   * the patch. Diffing a frozen draft against the *live* task would resubmit
+   * it — reverting somebody else's rename as a side effect of editing a note,
+   * and re-validating an assignee nobody touched, which is the failure issue
+   * #263's diff exists to prevent.
+   */
+  it("still sends only the fields the operator actually changed", async () => {
+    const { client, patch } = fakeClient();
+    const show = mounter(client);
+    await show(TASK);
+
+    await act(async () => setValue(noteInput(), "a rewritten note"));
+    await show({ ...TASK, title: "renamed by somebody else", column: "done" });
+
+    await act(async () => {
+      button("Save").click();
+    });
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch.mock.calls[0][1]).toEqual({ note: "a rewritten note" });
+  });
+});
+
+describe("when the draft is re-seeded", () => {
+  it("re-seeds when the dialog is closed and opened again", async () => {
+    const { client } = fakeClient();
+    const show = mounter(client);
+    await show(TASK);
+
+    await act(async () => setValue(noteInput(), "abandoned typing"));
+    // Close (the detail screen passes null), then reopen on the current card.
+    await show(null);
+    await show({ ...TASK, note: "the note as the host now has it" });
+
+    expect(noteInput().value).toBe("the note as the host now has it");
+  });
+
+  it("re-seeds when the screen swaps in a different card", async () => {
+    const { client } = fakeClient();
+    const show = mounter(client);
+    await show(TASK);
+
+    await act(async () => setValue(noteInput(), "typing about task-1"));
+    // A lineage hop replaces the card without closing the dialog.
+    await show({ ...TASK, id: "task-2", title: "Chase the refund", note: "a different note" });
+
+    expect(titleInput().value).toBe("Chase the refund");
+    expect(noteInput().value).toBe("a different note");
+  });
+});

--- a/frontend/test/unit/task-edit-dispatch-gate.test.ts
+++ b/frontend/test/unit/task-edit-dispatch-gate.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import type { IrreversibleEffect } from "@/api/tasks";
+import { dispatchNeedsConfirm, patchDispatchesRun } from "@/lib/task-edit";
+
+/**
+ * The edit dialog's Column select is a second route to the write issue #351
+ * wrapped in a confirmation.
+ *
+ * The Task Detail screen's Retry button sends `PATCH { column: "working" }` and
+ * asks first when the journal recorded something irreversible. The edit
+ * dialog's Column select can emit the identical patch, and its Save button was
+ * a plain button — so the protection was one dropdown away from being walked
+ * around on the very screen it was built for.
+ *
+ * These pin the two halves of the fix separately: *what counts as a dispatch*,
+ * and *when a dispatch has to stop and say what already happened*. The second
+ * matters as much as the first: a dialog that confirmed on every dispatch would
+ * train the operator to click through it, and the confirmation would then be
+ * gone on the card where it counts.
+ */
+
+function effect(kind: string, atMillis = 1_700_000_000_000): IrreversibleEffect {
+  return { kind, atMillis };
+}
+
+describe("patchDispatchesRun", () => {
+  it("recognises the phase word Retry sends", () => {
+    expect(patchDispatchesRun({ column: "working" })).toBe(true);
+  });
+
+  it("does not treat the parks as a dispatch", () => {
+    expect(patchDispatchesRun({ column: "pending" })).toBe(false);
+    expect(patchDispatchesRun({ column: "done" })).toBe(false);
+  });
+
+  /**
+   * `computeTaskPatch` omits a field nobody touched, so a rename on a card
+   * already sitting in Working must not read as a re-dispatch. Confirming there
+   * would ask about an effect the save cannot cause.
+   */
+  it("ignores a patch that does not move the column at all", () => {
+    expect(patchDispatchesRun({ title: "renamed" })).toBe(false);
+    expect(patchDispatchesRun({})).toBe(false);
+  });
+});
+
+describe("dispatchNeedsConfirm", () => {
+  it("confirms a dispatch on a card that already did something irreversible", () => {
+    expect(
+      dispatchNeedsConfirm(
+        { column: "working" },
+        { irreversible: [effect("payment.send")], historyIncomplete: false },
+      ),
+    ).toBe(true);
+  });
+
+  it("saves in one click when the journal says the card is clean", () => {
+    expect(
+      dispatchNeedsConfirm({ column: "working" }, { irreversible: [], historyIncomplete: false }),
+    ).toBe(false);
+  });
+
+  /**
+   * The honest half. A journal written before #351 holds executed keys with no
+   * description, so an empty list there means "cannot say" rather than
+   * "nothing happened" — and the dialog opens to say exactly that.
+   */
+  it("confirms when the journal admits it cannot describe its own history", () => {
+    expect(
+      dispatchNeedsConfirm({ column: "working" }, { irreversible: [], historyIncomplete: true }),
+    ).toBe(true);
+  });
+
+  /**
+   * The same reasoning one level out: a caller that has not wired the read
+   * knows nothing about this card, which is not the same claim as a read that
+   * came back empty. Defaulting to "clean" would leave the guard silently dead
+   * until somebody wired it, which is the failure mode the guard exists to
+   * prevent.
+   */
+  it("confirms when the effect history was never read at all", () => {
+    expect(dispatchNeedsConfirm({ column: "working" }, {})).toBe(true);
+  });
+
+  it("still confirms when only one half was wired and it says nothing is known", () => {
+    expect(dispatchNeedsConfirm({ column: "working" }, { historyIncomplete: true })).toBe(true);
+    expect(dispatchNeedsConfirm({ column: "working" }, { irreversible: [] })).toBe(false);
+  });
+
+  /**
+   * The gate is about *re-entering the run*, not about the card's past. Moving
+   * a card that spent money into Done is a park, and asking there would be
+   * noise attached to the wrong gesture.
+   */
+  it("never confirms a save that is not a dispatch, however dirty the card's past", () => {
+    const history = { irreversible: [effect("payment.send")], historyIncomplete: true };
+    expect(dispatchNeedsConfirm({ column: "done" }, history)).toBe(false);
+    expect(dispatchNeedsConfirm({ title: "renamed" }, history)).toBe(false);
+    expect(dispatchNeedsConfirm({}, history)).toBe(false);
+  });
+});

--- a/frontend/test/unit/task-edit-dispatch-gate.test.ts
+++ b/frontend/test/unit/task-edit-dispatch-gate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { IrreversibleEffect } from "@/api/tasks";
-import { dispatchNeedsConfirm, patchDispatchesRun } from "@/lib/task-edit";
+import { dispatchNeedsConfirm, patchDispatchesRun, readEffectHistory } from "@/lib/task-edit";
 
 /**
  * The edit dialog's Column select is a second route to the write issue #351
@@ -83,9 +83,30 @@ describe("dispatchNeedsConfirm", () => {
     expect(dispatchNeedsConfirm({ column: "working" }, {})).toBe(true);
   });
 
-  it("still confirms when only one half was wired and it says nothing is known", () => {
+  /**
+   * The partial reads, which is where a falsiness check fails open.
+   *
+   * `{ irreversible: [] }` on its own is *not* "this card is clean" — it is
+   * "no effect was described, and nobody asked whether the journal could
+   * describe them". `{ historyIncomplete: false }` on its own is the mirror:
+   * the journal can describe its history, and nothing read what it says. Each
+   * is one empty-looking field away from an all-clear it has no standing to
+   * give, and each has to confirm.
+   */
+  it("confirms when only one half of the history was read", () => {
+    expect(dispatchNeedsConfirm({ column: "working" }, { irreversible: [] })).toBe(true);
+    expect(dispatchNeedsConfirm({ column: "working" }, { historyIncomplete: false })).toBe(true);
+  });
+
+  /**
+   * A half that *was* read and says something happened settles it on its own.
+   * The unread other half cannot make a recorded payment un-happen.
+   */
+  it("confirms on a dirty half whatever the unread half would have said", () => {
     expect(dispatchNeedsConfirm({ column: "working" }, { historyIncomplete: true })).toBe(true);
-    expect(dispatchNeedsConfirm({ column: "working" }, { irreversible: [] })).toBe(false);
+    expect(
+      dispatchNeedsConfirm({ column: "working" }, { irreversible: [effect("payment.send")] }),
+    ).toBe(true);
   });
 
   /**
@@ -98,5 +119,32 @@ describe("dispatchNeedsConfirm", () => {
     expect(dispatchNeedsConfirm({ column: "done" }, history)).toBe(false);
     expect(dispatchNeedsConfirm({ title: "renamed" }, history)).toBe(false);
     expect(dispatchNeedsConfirm({}, history)).toBe(false);
+  });
+});
+
+/**
+ * The three states, pinned by name rather than through the boolean.
+ *
+ * `dispatchNeedsConfirm` collapses `"dirty"` and `"unknown"` into the same
+ * answer, which is correct and also exactly what hid the bug this replaced: a
+ * partial read returned `false` and read as a considered "clean" instead of the
+ * gap it was. Naming the verdict makes "cannot say" a state a test can see.
+ */
+describe("readEffectHistory", () => {
+  it("calls a card clean only when both halves were read and both were empty", () => {
+    expect(readEffectHistory({ irreversible: [], historyIncomplete: false })).toBe("clean");
+  });
+
+  it("calls a recorded effect, or an admitted gap in the journal, dirty", () => {
+    expect(
+      readEffectHistory({ irreversible: [effect("payment.send")], historyIncomplete: false }),
+    ).toBe("dirty");
+    expect(readEffectHistory({ irreversible: [], historyIncomplete: true })).toBe("dirty");
+  });
+
+  it("calls an unread half unknown, never clean", () => {
+    expect(readEffectHistory({})).toBe("unknown");
+    expect(readEffectHistory({ irreversible: [] })).toBe("unknown");
+    expect(readEffectHistory({ historyIncomplete: false })).toBe("unknown");
   });
 });

--- a/frontend/test/unit/task-links.test.ts
+++ b/frontend/test/unit/task-links.test.ts
@@ -171,8 +171,20 @@ describe("readTaskFocus", () => {
     });
   });
 
-  it("drops a tab that this screen cannot render", () => {
-    expect(readTaskFocus("#/tasks/t-1?tab=plan")).toEqual({});
+  it("reads the Plan tab, which is addressable and conditional", () => {
+    // `plan` used to be the case this test held up as unaddressable, because
+    // it is the one tab a *particular* card may not have. That cost more than
+    // it bought: selecting Plan wrote nothing to the URL, so a reload or a
+    // copied link dropped the operator back on Timeline. It is addressable
+    // now; the card-shaped half — a `?tab=plan` on a card with no plan — is
+    // resolved by `TaskDetailView`, which falls back to Timeline, because
+    // whether the tab exists is a property of the card and not of the address.
+    expect(readTaskFocus("#/tasks/t-1?tab=plan")).toEqual({ tab: "plan" });
+  });
+
+  it("drops a tab that is not a tab at all", () => {
+    expect(readTaskFocus("#/tasks/t-1?tab=approvals")).toEqual({});
+    expect(readTaskFocus("#/tasks/t-1?tab=")).toEqual({});
   });
 
   it("yields an empty focus for an address that asks for nothing", () => {


### PR DESCRIPTION
An audit of **all 49 interactive controls** on the Task Details page — what each does, whether it duplicates something else, and which of five states it wires (in-flight, error, empty, permission, optimistic). This fixes what it found.

Full audit, with the control-by-control table: https://claude.ai/code/artifact/7d11a5ea-dbc1-4b16-8d7b-e16d129bd8d8

## The two that spend money

### 1. Resume was enabled while the card was blocked on an approval

A run parked on an approval is *finished* to the runs store, so the card leaves `GET /tasks/inflight`, `inflight` is `null`, and the else-branch rendered **Resume — enabled** — directly beneath a row reading "Waiting on your approval". The host accepts it: `patch_task` validates the column and nothing else, so `paused → in_progress` fires a second dispatch.

One click re-ran the turn from the start and spent a second agent turn, while the operator was being asked to authorise the first.

**The board already had this guard.** `taskApprovalBlock` was written to serve both surfaces — its docstring says it is one function rather than two "so they cannot disagree" — was unit-tested, and had **zero production consumers**. It has one now.

It is wired as a **union** of the company queue and the host's own pending count, because either alone leaves the button live for one poll: the host's answer lands first when an approval has parked but the feed has not delivered it, and the queue is what makes a row decidable. Down is the safe direction for both.

### 2. The edit dialog's Column select was a second, ungated dispatch

Pick `working`, Save, and it sends the byte-for-byte write Retry sends — minus the #351 confirmation. One dropdown away from bypassing the protection, on the screen that protection was built for.

### …and that gate was unreachable anyway

`TaskEditDialog` re-seeded its draft on `[task]`, and the page polls every 4s handing down a **new object identity**. Measured in a browser, sampling the combobox every 250ms:

```
252ms:Working … 2046ms:Working   2302ms:Pending … 7125ms:Pending
```

After the reset `computeTaskPatch` returns `{}`, so **Save did nothing at all** — no confirmation, no write, no toast. Title, Note, Priority and Assignee were wiped too.

Seeding now keys on the card's identity, and the patch diffs against a **seed** — the card as it read when the dialog opened. That second half is not optional: diffing a frozen draft against a live `task` silently widened the write, so an unrelated note edit also sent a stale `column`, reverting someone else's move. The mutation run proves it — `expected { title, column } to deeply equal { note }`.

The conflict decision, documented in the code: **the operator's open draft wins**. A half-written note exists nowhere else, which is why Cancel already asks before discarding it. The cost — a server-side change is not adopted into an open dialog — is pinned by two tests under `describe("what seeding on the card's identity gives up")` rather than left to be rediscovered.

This is **pre-existing** (`git show HEAD:` has the identical `}, [task]);`), but this branch's guard is the first feature whose reachability depended on it.

## The rest

| | |
|---|---|
| Delete offered on in-flight cards the host **409s** | disabled, with the host's own remedy in the tooltip |
| Non-404 load failure rendered an **empty page** | Try again, and the wrong "nothing retries" comment corrected |
| A **failed roster read** looked identical to an empty roster | named, and a latent bug fixed: a current teammate was flagged "not on roster" when `/team` failed but `/desks` answered |
| Remove message had **no in-flight state** | repeat clicks no longer fire repeat DELETEs |
| Discussion **silently truncated at 4000** | counter, in **codepoints** — `maxLength` counts UTF-16 units and would cut an emoji paste at half the host's real limit |
| Plan tab **did not survive a reload** | addressable, with an unknown-tab fallback |
| Retry rendered on a **finished** card | gated on the ledger's own `closed` flag |
| Three vocabularies for one state | a never-dispatched card says **Dispatch** in the header, the button and the toast |
| Plan count distinguished blocking from unresolved by **colour alone** | icon + sr-only label; the number is `aria-hidden` so it is not read twice |
| `h1 → h3` heading skip | closed |

**Dead code removed:** the `onSaved` no-op threaded through five components (the route passes `() => {}` because the board is not mounted alongside), and `steer()`'s unreachable `!inflight` guard — which turned out to be *swallowing the redirect Send*, making it silently do nothing rather than merely being dead.

## Verification

**Browser-verified, light and dark, 68 screenshots across six states** — including killing the host with `SIGKILL` to reach the Try-again pane rather than simulating it. Confirmed: the control bar does not wrap; the Plan icon is legible in both themes and the number is not doubled; a 2100-emoji paste counts as 2100, not 4200; the counter does not overlap Post; Delete's disabled tooltip; the Cancel dirty-confirm; the Column→Working confirmation itemising both effects.

`npm run typecheck` / `typecheck:unit` / `typecheck:e2e`, `npx vitest run` (**4018**), `assert-design-tokens.sh` — all clean.

**Every behaviour change proved non-vacuous by mutation** — 36 mutants across three agents. **Three survived on first attempt and are recorded rather than hidden**: one emoji fixture sat exactly at the cap and returned on an early length check; one `toContain` assertion was satisfied by the wrong half of a sentence; one whole-value assertion masked a narrower leak guard. All three tests were tightened and re-proved.

## Not verified

- `isFinished` (no Retry on a Done card) and `blockedOnApproval` (Resume down) were **not exercised in the browser** — both need a real agent turn to reach. Covered by unit tests and mutation only.
- Plan payloads and `irreversibleEffects` were injected via response interception in the browser run; the components are real code rendering realistic payloads, but the **host-side derivation** of those payloads is untested by that run.
- The poll-reset fix has 10 DOM-level tests but no separate browser pass; it is behavioural rather than visual.

## Noticed, not fixed (not this branch's)

- The alert above the Try-again pane shows the raw HTTP phrase "Internal Server Error" as the first thing the operator reads.
- Two console warnings on every page: React `Function components cannot be given refs … TooltipTrigger`, and Base UI `expected a native <button>`.
- `TaskPlanBrief.tsx:449` renders an `h4`, so the Plan panel now reads h1 → h2 → h4 — improved, still skipping.
- `TaskCard.tsx` still carries the Resume-blocked sentence inline; `RESUME_BLOCKED_REASON` now exists beside the derivation and adopting it there is a one-line follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Plan tab for applicable tasks, with clearer prerequisite status badges.
  - Added approval and irreversible-action safeguards before dispatching or retrying work.
  - Added discussion character-limit guidance and safer withdrawal controls.
  - Added unsaved-edit protection when canceling task changes.

- **Bug Fixes**
  - Preserved edits while task details refresh in the background.
  - Added retry feedback when task details fail to load.
  - Roster warnings now distinguish empty rosters from unavailable data.
  - Corrected action availability for blocked, active, paused, and finished tasks.
  - Improved accessibility with clearer labels, headings, and action states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->