### PR TITLE
test(workflows): direct units for the settle path, and a WorkflowRun serde migration table (#1963)

### DIFF
--- a/src/workflows/migration_test.rs
+++ b/src/workflows/migration_test.rs
@@ -1,0 +1,417 @@
+//! Issue #1963: the serde migration table for [`WorkflowRun`].
+//!
+//! `WorkflowRun` has nine fields and sixteen `#[serde(default)]` attributes
+//! between it and the row types it carries. Every one of them is a promise that
+//! a payload written before that field existed still loads — and the promise is
+//! kept by an attribute nobody has to write, so breaking it is silent. The spec
+//! puts it plainly: a missing `#[serde(default)]` here is *silent history loss,
+//! not a compile error*.
+//!
+//! That matters because [`CompanyEvent::WorkflowRunFinished`] is **replayed at
+//! boot**. A field added without its default does not fail the build, does not
+//! fail a test that round-trips a freshly-constructed value, and does not fail
+//! the first run after the deploy. It fails on the next boot, by dropping every
+//! historical run event that predates it — quietly, as a shorter list.
+//!
+//! Before this file there was exactly one such test
+//! (`blocked_node_test::a_pre_881_run_payload_still_deserializes`), covering two
+//! of the nine fields. The shapes below were recovered from git history rather
+//! than invented: `git log -S"pub <field>" -- src/ports/workflow_runner.rs`
+//! names the commit that added each one, and the struct at that commit's parent
+//! is the shape a payload written the day before carried. They came in strictly
+//! additive declaration order, so each era is a prefix of the next.
+//!
+//! One issue in this file's remit has no era of its own. **#1008** changed what
+//! the blocked arm *puts* in `output` — `Value::Null` before it, the upstream
+//! capture after — without changing the field's shape, so it appears below as a
+//! payload case rather than a field arrival. And **#1862** added `started_by`
+//! to `WorkflowRunStarted`, a sibling event and not a `WorkflowRun` field; it is
+//! already pinned by `ports::types`'
+//! `a_pre_1862_run_started_line_still_replays_with_no_sender`, and duplicating
+//! it here would be a second copy that drifts.
+
+use serde_json::{Value, json};
+
+use crate::ports::WorkflowRun;
+
+/// One historical on-disk shape, named for the change it predates.
+struct Era {
+    /// What a reader of a failure needs first: which payload broke.
+    label: &'static str,
+    /// The commit that added the field this shape predates, so the next
+    /// person can read the diff rather than trust this file.
+    added_by: &'static str,
+    /// The payload as a `WorkflowRunFinished` of that era carried it.
+    payload: Value,
+}
+
+/// Every shape a `WorkflowRun` has ever been journaled in, oldest first.
+///
+/// Each is a strict prefix of the one after it — that is not a simplification,
+/// it is what the history shows: no field was ever removed, renamed or
+/// reordered, and every addition landed at the end of the struct.
+fn eras() -> Vec<Era> {
+    let base = json!({
+        "output": { "nodes": { "draft": { "items": [] } } },
+        "pending_approvals": ["gate"]
+    });
+    let mut shapes = Vec::new();
+    let mut current = base.clone();
+
+    shapes.push(Era {
+        label: "pre-#170 (before output-node delivery)",
+        added_by: "0728d9a2e added deliveries",
+        payload: current.clone(),
+    });
+
+    extend(&mut current, "deliveries", json!([]));
+    shapes.push(Era {
+        label: "pre-#383 (before a run could be stopped)",
+        added_by: "3a4d1380d added cancelled",
+        payload: current.clone(),
+    });
+
+    extend(&mut current, "cancelled", json!(false));
+    shapes.push(Era {
+        label: "pre-#542 (before per-node rows)",
+        added_by: "406626cbb added nodes",
+        payload: current.clone(),
+    });
+
+    extend(&mut current, "nodes", json!([]));
+    shapes.push(Era {
+        label: "pre-#638 (before operator notices)",
+        added_by: "4d723c755 added notices",
+        payload: current.clone(),
+    });
+
+    extend(&mut current, "notices", json!([]));
+    shapes.push(Era {
+        label: "pre-#661 (before board rows)",
+        added_by: "1c06157ca added board",
+        payload: current.clone(),
+    });
+
+    extend(&mut current, "board", json!([]));
+    shapes.push(Era {
+        label: "pre-#881/#880 (before blocked nodes and approval receipts)",
+        added_by: "fa846eded added blocked_nodes and approvals",
+        payload: current.clone(),
+    });
+
+    extend(&mut current, "blocked_nodes", json!([]));
+    extend(&mut current, "approvals", json!([]));
+    shapes.push(Era {
+        label: "current",
+        added_by: "(head)",
+        payload: current,
+    });
+
+    shapes
+}
+
+/// Appends one field to a payload, keeping the eras honest about being
+/// prefixes of each other.
+fn extend(payload: &mut Value, field: &str, value: Value) {
+    payload
+        .as_object_mut()
+        .expect("an era payload is always an object")
+        .insert(field.to_string(), value);
+}
+
+/// Issue #1963: every shape a `WorkflowRun` was ever journaled in still
+/// deserializes.
+///
+/// The table is the point. A single hand-written legacy payload — which is what
+/// existed before this file — pins whichever era its author happened to
+/// remember, and says nothing about the five between it and today. Adding a
+/// field without `#[serde(default)]` breaks exactly the eras older than it,
+/// which is every row above the one the author was thinking about.
+///
+/// A unit test on a constructed `WorkflowRun` cannot catch this: it serializes
+/// and deserializes the *current* shape, which always round-trips no matter
+/// what the defaults say.
+#[test]
+fn every_historical_run_payload_still_deserializes() {
+    for era in eras() {
+        let run: WorkflowRun = serde_json::from_value(era.payload.clone()).unwrap_or_else(|err| {
+            panic!(
+                "a {} payload no longer loads ({err}) — see {}. This is replayed at boot, so \
+                 the symptom is a company's run history getting shorter, not a red build.",
+                era.label, era.added_by
+            )
+        });
+        assert_eq!(
+            run.pending_approvals,
+            vec!["gate".to_string()],
+            "{}: what the payload did carry must survive the migration",
+            era.label
+        );
+        assert_eq!(
+            run.output["nodes"]["draft"]["items"],
+            json!([]),
+            "{}: and so must the engine output envelope",
+            era.label
+        );
+    }
+}
+
+/// Issue #1963: every field a historical payload omits reads back at its
+/// documented default, rather than at whatever a later field's absence happens
+/// to produce.
+///
+/// "It deserializes" is only half the promise. A replayed pre-#383 run that
+/// loaded with `cancelled: true` would put every run in a company's history
+/// into the stopped-by-an-operator bucket, which is a worse outcome than the
+/// parse failing. So the oldest shape is checked field by field.
+#[test]
+fn a_pre_170_payload_defaults_every_field_that_did_not_exist_yet() {
+    let run: WorkflowRun = serde_json::from_value(json!({
+        "output": Value::Null,
+        "pending_approvals": []
+    }))
+    .expect("the oldest shape a WorkflowRun was ever written in must still load");
+
+    assert!(run.deliveries.is_empty(), "#170: routed nothing");
+    assert!(
+        !run.cancelled,
+        "#383: a run written before the stop button existed was never stopped — \
+         defaulting this true would file every historical run as operator-stopped"
+    );
+    assert!(run.nodes.is_empty(), "#542: no per-node rows were recorded");
+    assert!(
+        run.notices.is_empty(),
+        "#638: nothing was said to the operator"
+    );
+    assert!(run.board.is_empty(), "#661: no card was opened");
+    assert!(
+        run.blocked_nodes.is_empty(),
+        "#881: nobody was waiting on a human"
+    );
+    assert!(run.approvals.is_empty(), "#880: nothing was parked");
+}
+
+/// Issue #1963 (#1008): the blocked arm used to journal `"output": null`, on
+/// the argument that an engine `Err` has no final state. It now threads the
+/// upstream capture through instead. The old payloads are still on disk and
+/// still replay, and a null output must stay null rather than being coerced
+/// into an empty envelope that would read as "this node produced nothing".
+#[test]
+fn a_pre_1008_blocked_payload_keeps_its_null_output_rather_than_gaining_an_envelope() {
+    let run: WorkflowRun = serde_json::from_value(json!({
+        "output": Value::Null,
+        "pending_approvals": ["spec"],
+        "deliveries": [],
+        "cancelled": false,
+        "nodes": [{ "node_id": "spec", "status": "blocked", "elapsed_ms": 12 }],
+        "notices": [],
+        "board": [],
+        "blocked_nodes": [{ "nodeId": "spec", "tools": ["publish_artifact"] }]
+    }))
+    .expect("a pre-#1008 blocked run must still replay");
+
+    assert_eq!(
+        run.output,
+        Value::Null,
+        "a run that recorded no output must not be read as one that recorded an empty one"
+    );
+    assert_eq!(run.blocked_nodes.len(), 1);
+}
+
+/// Issue #1963: the row types nested inside a run carry their own defaults, and
+/// they are the easier half to forget — the outer struct is what a reviewer
+/// looks at when a field is added.
+///
+/// Three of them at once, because a payload only exercises a nested default if
+/// the outer field is populated: a pre-#1014 node row (no `diagnostics`), a
+/// pre-#1143 blocked node (no `stranded`, and no `approval_ids`/`unparkable`
+/// either), and a delivery row written before `reason` was a closed set.
+#[test]
+fn the_row_types_nested_in_a_run_default_their_own_later_fields() {
+    let run: WorkflowRun = serde_json::from_value(json!({
+        "output": Value::Null,
+        "pending_approvals": [],
+        "deliveries": [{
+            "node": "report",
+            "kind": "email",
+            "status": "sent",
+            "detail": "sent to the owner"
+        }],
+        "cancelled": false,
+        "nodes": [{ "node_id": "draft", "status": "ok", "elapsed_ms": 41 }],
+        "notices": [],
+        "board": [{ "action": "spawned", "taskId": "task-3" }],
+        "blocked_nodes": [{ "nodeId": "spec", "tools": ["publish_artifact"] }],
+        "approvals": [{ "outcome": "parked" }]
+    }))
+    .expect("a run whose nested rows predate their own later fields must still load");
+
+    assert!(
+        run.nodes[0].diagnostics.is_empty(),
+        "#1014: a row written before diagnostics existed has no broken wiring to report"
+    );
+    assert_eq!(
+        run.deliveries[0].reason,
+        crate::ports::DeliveryReason::Unspecified,
+        "a delivery row written before the closed set existed reads as Unspecified, \
+         not as one of the real reasons"
+    );
+    assert_eq!(
+        run.blocked_nodes[0].stranded, 0,
+        "#1143: stranded is computed on the read and never journaled, so a stored \
+         row always reads zero"
+    );
+    assert_eq!(
+        run.blocked_nodes[0].unparkable, 0,
+        "and an absent count is zero, never a guess from the survivors"
+    );
+    assert!(run.blocked_nodes[0].approval_ids.is_empty());
+    assert!(
+        run.board[0].title.is_none(),
+        "a board row's optional fields stay absent rather than becoming empty strings"
+    );
+    assert!(run.approvals[0].node_id.is_none());
+    assert!(run.approvals[0].tool.is_none());
+}
+
+/// A fully-populated run, with every field carrying something a default would
+/// not produce — so a round-trip that silently dropped one is visible.
+fn a_run_with_nothing_left_at_its_default() -> WorkflowRun {
+    WorkflowRun {
+        output: json!({ "run": { "id": "run-1" }, "nodes": { "draft": { "items": [1] } } }),
+        pending_approvals: vec!["gate".to_string(), "spec".to_string()],
+        deliveries: vec![crate::ports::DeliveryReport {
+            node: "report".to_string(),
+            kind: "email".to_string(),
+            target: Some("owner@example.test".to_string()),
+            status: crate::ports::DeliveryStatus::Sent,
+            detail: "sent to the owner".to_string(),
+            reason: crate::ports::DeliveryReason::OwnerEmailed,
+        }],
+        cancelled: true,
+        nodes: vec![crate::ports::WorkflowRunNodeRow {
+            node_id: "draft".to_string(),
+            status: crate::ports::types::WorkflowNodeStatus::Blocked,
+            elapsed_ms: 41,
+            diagnostics: vec!["node.draft.config.body".to_string()],
+        }],
+        notices: vec!["A notice.".to_string()],
+        board: vec![crate::ports::WorkflowRunBoardRow {
+            action: crate::ports::WorkflowBoardAction::Spawned,
+            task_id: Some("task-3".to_string()),
+            title: Some("Draft the spec".to_string()),
+            assignee: Some("editor".to_string()),
+        }],
+        blocked_nodes: vec![crate::ports::WorkflowBlockedNode {
+            node_id: "spec".to_string(),
+            tools: vec!["publish_artifact".to_string()],
+            approval_ids: vec!["appr-1".to_string()],
+            unparkable: 2,
+            stranded: 0,
+        }],
+        approvals: vec![crate::ports::WorkflowRunApprovalRow {
+            node_id: Some("spec".to_string()),
+            tool: Some("publish_artifact".to_string()),
+            outcome: crate::ports::WorkflowApprovalOutcome::Parked,
+            approval_id: Some("appr-1".to_string()),
+        }],
+    }
+}
+
+/// Issue #1963: a full round-trip loses nothing.
+///
+/// The counterpart to the table above, and the half that catches the opposite
+/// mistake: a `skip_serializing_if` predicate that is wrong for a populated
+/// value drops a real field on the way out, and the payload then loads
+/// perfectly at its default — so the migration tests above all still pass while
+/// the data is gone.
+///
+/// Compared as JSON because `WorkflowRun` has no `PartialEq`, which is also why
+/// this had no test.
+#[test]
+fn a_fully_populated_run_survives_a_round_trip_unchanged() {
+    let wire = serde_json::to_value(a_run_with_nothing_left_at_its_default())
+        .expect("a run always serializes");
+    let back: WorkflowRun =
+        serde_json::from_value(wire.clone()).expect("and always deserializes again");
+    let again = serde_json::to_value(&back).expect("as does the value that came back");
+
+    assert_eq!(
+        wire, again,
+        "a field that survives serialization but not the read back is history \
+         loss the migration table cannot see: it would load at its default and \
+         look fine"
+    );
+}
+
+/// Issue #1963: a default-valued run serializes to the pre-#880 wire form
+/// exactly, so a reader written before `approvals` existed still parses what a
+/// current writer emits.
+///
+/// This is the `skip_serializing_if` half of the contract, and the direction
+/// the migration table cannot check: the table proves old payloads load in a
+/// new reader, and this proves new payloads load in an old one. Both matter
+/// during a rollout, when the two are running side by side against one
+/// `events.jsonl`.
+#[test]
+fn a_default_valued_run_still_serializes_as_the_pre_880_wire_form() {
+    let run = WorkflowRun {
+        output: Value::Null,
+        pending_approvals: Vec::new(),
+        deliveries: Vec::new(),
+        cancelled: false,
+        nodes: Vec::new(),
+        notices: Vec::new(),
+        board: Vec::new(),
+        blocked_nodes: Vec::new(),
+        approvals: Vec::new(),
+    };
+
+    let wire = serde_json::to_value(&run).expect("a run always serializes");
+    let keys: Vec<&str> = wire
+        .as_object()
+        .expect("a run serializes as an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+
+    assert_eq!(
+        keys,
+        vec![
+            "output",
+            "pending_approvals",
+            "deliveries",
+            "cancelled",
+            "nodes",
+            "notices",
+            "board",
+            "blocked_nodes"
+        ],
+        "a run that parked nothing must emit no `approvals` key at all — the \
+         skip_serializing_if #880 added so already-persisted lines stayed \
+         byte-for-byte what they were"
+    );
+}
+
+/// Issue #1963: a run that *did* park writes the key, so the skip above is a
+/// property of the value rather than of the field.
+///
+/// Without this the assertion above would pass against a build that never
+/// serialized `approvals` at all, which is silent loss of the receipts #880
+/// exists to keep.
+#[test]
+fn a_run_that_parked_an_approval_does_emit_the_receipts() {
+    let wire = serde_json::to_value(a_run_with_nothing_left_at_its_default())
+        .expect("a run always serializes");
+
+    assert_eq!(
+        wire["approvals"][0]["approvalId"],
+        json!("appr-1"),
+        "the receipt is the whole of #880 — it must be on the wire when there is one"
+    );
+    assert_eq!(
+        wire["blocked_nodes"][0]["unparkable"],
+        json!(2),
+        "and a non-zero unparkable count is the loud case, never skipped"
+    );
+}

--- a/src/workflows/migration_test.rs
+++ b/src/workflows/migration_test.rs
@@ -38,9 +38,9 @@ use crate::ports::WorkflowRun;
 struct Era {
     /// What a reader of a failure needs first: which payload broke.
     label: &'static str,
-    /// The commit that added the field this shape predates, so the next
+    /// The commit that ended this era by adding the next field, so the next
     /// person can read the diff rather than trust this file.
-    added_by: &'static str,
+    ended_by: &'static str,
     /// The payload as a `WorkflowRunFinished` of that era carried it.
     payload: Value,
 }
@@ -60,42 +60,42 @@ fn eras() -> Vec<Era> {
 
     shapes.push(Era {
         label: "pre-#170 (before output-node delivery)",
-        added_by: "0728d9a2e added deliveries",
+        ended_by: "0728d9a2e added deliveries",
         payload: current.clone(),
     });
 
     extend(&mut current, "deliveries", json!([]));
     shapes.push(Era {
         label: "pre-#383 (before a run could be stopped)",
-        added_by: "3a4d1380d added cancelled",
+        ended_by: "3a4d1380d added cancelled",
         payload: current.clone(),
     });
 
     extend(&mut current, "cancelled", json!(false));
     shapes.push(Era {
         label: "pre-#542 (before per-node rows)",
-        added_by: "406626cbb added nodes",
+        ended_by: "406626cbb added nodes",
         payload: current.clone(),
     });
 
     extend(&mut current, "nodes", json!([]));
     shapes.push(Era {
         label: "pre-#638 (before operator notices)",
-        added_by: "4d723c755 added notices",
+        ended_by: "4d723c755 added notices",
         payload: current.clone(),
     });
 
     extend(&mut current, "notices", json!([]));
     shapes.push(Era {
         label: "pre-#661 (before board rows)",
-        added_by: "1c06157ca added board",
+        ended_by: "1c06157ca added board",
         payload: current.clone(),
     });
 
     extend(&mut current, "board", json!([]));
     shapes.push(Era {
         label: "pre-#881/#880 (before blocked nodes and approval receipts)",
-        added_by: "fa846eded added blocked_nodes and approvals",
+        ended_by: "fa846eded added blocked_nodes and approvals",
         payload: current.clone(),
     });
 
@@ -103,7 +103,7 @@ fn eras() -> Vec<Era> {
     extend(&mut current, "approvals", json!([]));
     shapes.push(Era {
         label: "current",
-        added_by: "(head)",
+        ended_by: "(head)",
         payload: current,
     });
 
@@ -136,9 +136,11 @@ fn every_historical_run_payload_still_deserializes() {
     for era in eras() {
         let run: WorkflowRun = serde_json::from_value(era.payload.clone()).unwrap_or_else(|err| {
             panic!(
-                "a {} payload no longer loads ({err}) — see {}. This is replayed at boot, so \
-                 the symptom is a company's run history getting shorter, not a red build.",
-                era.label, era.added_by
+                "a {} payload no longer loads: {err}. A field added without \
+                 #[serde(default)] breaks every era older than it; this era ran until {}. \
+                 WorkflowRunFinished is replayed at boot, so the symptom is a company's run \
+                 history getting shorter, not a red build.",
+                era.label, era.ended_by
             )
         });
         assert_eq!(

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -44,6 +44,11 @@ mod gated_tool_call_test;
 /// node reaches the Approvals page and survives the next chat cycle.
 #[cfg(test)]
 mod gated_tool_turn_test;
+/// Issue #1963: the serde migration table for `WorkflowRun` — every shape it
+/// was ever journaled in still deserializes, a full round-trip loses nothing,
+/// and a default-valued run still serializes as the old wire form.
+#[cfg(test)]
+mod migration_test;
 /// Issue #978: a run that fans out to N gated nodes is cleared by approving,
 /// not multiplied by it — the composition of #395, #243 and #469 that each of
 /// their own suites is blind to.

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -2351,6 +2351,15 @@ mod tests {
         }
     }
 
+    // Issue #1963: direct units for the settle path's pure helpers, split out
+    // because this file is already the largest in the crate and a suite
+    // appended to the bottom of its test module disappears into it. The
+    // `include!` idiom is the one `tinyflows::engine_tests` uses, and it is
+    // what lets these reach the private functions they exercise.
+    include!("runner/pure_units_part_01_tests.rs");
+    include!("runner/pure_units_part_02_tests.rs");
+    include!("runner/pure_units_part_03_tests.rs");
+
     /// The third half of that reconciliation, and the one that was missing
     /// (CodeRabbit review on #1905): what the **journal** records.
     ///

--- a/src/workflows/runner/pure_units_part_01_tests.rs
+++ b/src/workflows/runner/pure_units_part_01_tests.rs
@@ -1,0 +1,264 @@
+// ── issue #1963: direct units for the settle-path reclassification ──────────
+//
+// Included into `runner::tests` by `include!`, so `node_row` and everything
+// `use super::*` already pulled in is in scope here. Split out because
+// `runner.rs` is the largest file in the crate and a suite appended to its
+// test module disappears into it.
+//
+// Every function below was reachable only through a whole driven run before
+// this file existed: the settle path is where the host's readings — blocked,
+// capped, errored, cancelled — are applied to the engine's own account of what
+// happened, and a driven run can only ever exercise one arm at a time.
+
+/// Issue #1963: `reclassify_blocked` runs once per settle arm today, but three
+/// call sites reach it (`blocked_run`, and the two arms of `run_workflow_inner`)
+/// and nothing structurally stops a fourth from folding two of them together.
+///
+/// A driven run could not have caught a non-idempotent relabel: each arm calls
+/// it exactly once, so the second application never happens in a test that
+/// starts from a graph. Pinned directly instead.
+#[test]
+fn reclassify_blocked_changes_nothing_when_it_runs_a_second_time() {
+    let blocked = vec![crate::ports::WorkflowBlockedNode {
+        node_id: "spec".to_string(),
+        tools: vec!["publish_artifact".to_string()],
+        approval_ids: vec!["appr-1".to_string()],
+        unparkable: 0,
+        stranded: 0,
+    }];
+    let mut nodes = vec![
+        node_row("fetch", WorkflowNodeStatus::Ok),
+        node_row("spec", WorkflowNodeStatus::Error),
+    ];
+    let mut pending = Vec::new();
+
+    reclassify_blocked(&mut nodes, &mut pending, &blocked);
+    let nodes_after_one = nodes.clone();
+    let pending_after_one = pending.clone();
+
+    reclassify_blocked(&mut nodes, &mut pending, &blocked);
+
+    assert_eq!(
+        nodes, nodes_after_one,
+        "a second pass must not move a row that is already Blocked"
+    );
+    assert_eq!(
+        pending, pending_after_one,
+        "a second pass must not list the same node twice — the console renders \
+         every entry as a node name, so a duplicate reads as two waits"
+    );
+}
+
+/// Issue #1963 (issue #881's union contract): the engine's own gate list and
+/// the host's blocked list are unioned into one `pending_approvals`, and a run
+/// can populate both. The engine pauses a `requires_approval` `tool_call` node
+/// and the host blocks an agent node — but nothing forbids the same id
+/// reaching both lists, and a duplicate would render as two separate waits on
+/// one node.
+///
+/// Unreachable from a driven run: producing an id on both lists at once needs a
+/// graph where one node is simultaneously an engine gate and a host-blocked
+/// agent turn, which the node kinds do not allow.
+#[test]
+fn a_node_already_on_pending_approvals_is_not_listed_a_second_time() {
+    let blocked = vec![crate::ports::WorkflowBlockedNode {
+        node_id: "gate".to_string(),
+        tools: vec!["send_email".to_string()],
+        approval_ids: Vec::new(),
+        unparkable: 1,
+        stranded: 0,
+    }];
+    let mut nodes = vec![node_row("gate", WorkflowNodeStatus::Error)];
+    let mut pending = vec!["gate".to_string()];
+
+    reclassify_blocked(&mut nodes, &mut pending, &blocked);
+
+    assert_eq!(
+        pending,
+        vec!["gate".to_string()],
+        "the blocked ids are unioned into pending_approvals, not appended to it"
+    );
+}
+
+/// Issue #1963: a blocked node that never produced a row at all still has to
+/// reach `pending_approvals`.
+///
+/// `nodes` is fed by the progress observer, which records a node when its
+/// execution *finishes*. A node whose turn was refused before it could report —
+/// and a hard-abort drain that lost the frame — leaves no row, and the loop
+/// that relabels rows would then silently drop the node from the operator's
+/// list. The two halves of `reclassify_blocked` are separate loops precisely
+/// so this cannot happen, and that separation is what this pins.
+///
+/// A driven run cannot reach it: every path that produces a
+/// `WorkflowBlockedNode` also produces the node's row, so the case only exists
+/// as a shape the function must survive.
+#[test]
+fn a_blocked_node_absent_from_nodes_still_reaches_pending_approvals() {
+    let blocked = vec![crate::ports::WorkflowBlockedNode {
+        node_id: "never_reported".to_string(),
+        tools: vec!["publish_artifact".to_string()],
+        approval_ids: vec!["appr-9".to_string()],
+        unparkable: 0,
+        stranded: 0,
+    }];
+    let mut nodes = vec![node_row("fetch", WorkflowNodeStatus::Ok)];
+    let mut pending = Vec::new();
+
+    reclassify_blocked(&mut nodes, &mut pending, &blocked);
+
+    assert_eq!(
+        pending,
+        vec!["never_reported".to_string()],
+        "a blocked node with no row must still be something the run says it is \
+         waiting on — otherwise the approval card has no run that admits to it"
+    );
+    assert_eq!(
+        nodes[0].status,
+        WorkflowNodeStatus::Ok,
+        "and the rows that do exist are left alone"
+    );
+}
+
+/// Issue #1963: the relabel is one-directional. An `Error` row for a blocked
+/// node becomes `Blocked`; nothing here ever writes `Error`.
+///
+/// That direction is the whole of issue #881 — the engine's `Error` is honest
+/// (the capability did return an error) but it is not a failure, and journaling
+/// it as one puts every blocked run in the failure count. Reversing it would
+/// restore exactly the bug #881 removed, and no driven run would notice,
+/// because a blocked run's assertions are about `blocked_nodes` and
+/// `pending_approvals` rather than about the row's own status.
+#[test]
+fn an_error_row_for_a_blocked_node_becomes_blocked_and_never_the_reverse() {
+    let blocked = vec![
+        crate::ports::WorkflowBlockedNode {
+            node_id: "errored".to_string(),
+            tools: vec!["publish_artifact".to_string()],
+            approval_ids: Vec::new(),
+            unparkable: 0,
+            stranded: 0,
+        },
+        crate::ports::WorkflowBlockedNode {
+            node_id: "finished_ok".to_string(),
+            tools: vec!["send_email".to_string()],
+            approval_ids: Vec::new(),
+            unparkable: 0,
+            stranded: 0,
+        },
+    ];
+    let mut nodes = vec![
+        node_row("errored", WorkflowNodeStatus::Error),
+        node_row("finished_ok", WorkflowNodeStatus::Ok),
+        node_row("bystander", WorkflowNodeStatus::Error),
+    ];
+    let mut pending = Vec::new();
+
+    reclassify_blocked(&mut nodes, &mut pending, &blocked);
+
+    assert_eq!(
+        nodes[0].status,
+        WorkflowNodeStatus::Blocked,
+        "the engine's Error for a parked node is the report #881 relabels"
+    );
+    assert_eq!(
+        nodes[1].status,
+        WorkflowNodeStatus::Blocked,
+        "a blocked node's row is Blocked whatever the engine said about it"
+    );
+    assert_eq!(
+        nodes[2].status,
+        WorkflowNodeStatus::Error,
+        "a node nobody blocked keeps its genuine failure — hiding a real error \
+         behind \"waiting on approval\" is the lie #881 exists to remove"
+    );
+    assert!(
+        !nodes
+            .iter()
+            .any(|row| row.node_id == "bystander" && row.status == WorkflowNodeStatus::Blocked),
+        "and nothing here may invent a block for an unblocked node"
+    );
+}
+
+/// Issue #1963: an empty blocked list is a no-op, including on
+/// `pending_approvals`. The common case by a wide margin — nearly every run
+/// blocks on nobody — and the early return is what keeps a clean run's engine
+/// gate list untouched.
+#[test]
+fn reclassify_blocked_leaves_the_engines_own_gate_list_alone_when_nothing_blocked() {
+    let mut nodes = vec![
+        node_row("fetch", WorkflowNodeStatus::Ok),
+        node_row("review", WorkflowNodeStatus::Error),
+    ];
+    let before = nodes.clone();
+    let mut pending = vec!["engine_gate".to_string()];
+
+    reclassify_blocked(&mut nodes, &mut pending, &[]);
+
+    assert_eq!(nodes, before, "no block, no relabel");
+    assert_eq!(
+        pending,
+        vec!["engine_gate".to_string()],
+        "the engine's own paused-gate list survives untouched"
+    );
+}
+
+/// Issue #1963: `only_blocked_nodes_errored` MUST be read before
+/// `reclassify_capped_nodes` runs, and reordering them turns an ordinary
+/// blocked run into a reported failure.
+///
+/// The design comment at the call site says so in prose; nothing asserted it.
+/// `only_blocked_nodes_errored` decides whether every errored row belongs to a
+/// blocked node, and `reclassify_capped_nodes` *creates* `Error` rows out of
+/// `Ok` ones. Run the relabel first and the capped node's fresh `Error` is a
+/// row no `WorkflowBlockedNode` covers, so the containment check fails and the
+/// run reports a genuine failure it did not have.
+///
+/// No driven run reaches this: it needs one node blocked on an approval *and* a
+/// sibling truncated at `max_tool_iterations` in the same run, which is two
+/// independent rare paths that no fixture drives together. This test builds the
+/// state both orders would see and shows they disagree.
+#[test]
+fn the_blocked_containment_check_must_be_read_before_the_capped_relabel() {
+    let blocked = vec![crate::ports::WorkflowBlockedNode {
+        node_id: "spec".to_string(),
+        tools: vec!["publish_artifact".to_string()],
+        approval_ids: vec!["appr-1".to_string()],
+        unparkable: 0,
+        stranded: 0,
+    }];
+    let capped = vec!["summarize".to_string()];
+    // What the settle arm actually receives: the blocked node reported `Error`
+    // (its capability returned one, which is how the branch halted under the
+    // default `on_error = "stop"`), and the capped node reported `Ok` because
+    // the engine saw a completed turn.
+    let engine_rows = vec![
+        node_row("spec", WorkflowNodeStatus::Error),
+        node_row("summarize", WorkflowNodeStatus::Ok),
+    ];
+
+    // The order the code keeps.
+    let as_written = only_blocked_nodes_errored(&engine_rows, &blocked);
+    assert!(
+        as_written,
+        "read before the capped relabel, every errored row belongs to a blocked \
+         node — so this run is a block, not a failure"
+    );
+
+    // The order a reorder would produce.
+    let mut reordered = engine_rows.clone();
+    reclassify_capped_nodes(&mut reordered, &capped);
+    let after_reorder = only_blocked_nodes_errored(&reordered, &blocked);
+
+    assert!(
+        !after_reorder,
+        "the capped relabel adds an Error row no blocked node covers, so reading \
+         the check afterwards is what makes the two orders disagree — if this \
+         ever holds, the assertion below has stopped proving anything"
+    );
+    assert_ne!(
+        as_written, after_reorder,
+        "reordering these two must change the run's verdict — a capped node \
+         beside a blocked one would be reported as a genuine failure"
+    );
+}

--- a/src/workflows/runner/pure_units_part_02_tests.rs
+++ b/src/workflows/runner/pure_units_part_02_tests.rs
@@ -1,0 +1,308 @@
+// ── issue #1963: direct units for artifact folding and the settle notices ───
+//
+// The second half of the `include!`d suite (see `pure_units_part_01_tests.rs`
+// for why these live outside `runner.rs`).
+
+/// One captured-artifact map, in the shape `RunArtifacts::take` hands the
+/// settle path: node id -> array of artifact rows.
+fn artifact_rows(node_id: &str) -> serde_json::Map<String, Value> {
+    let mut rows = serde_json::Map::new();
+    rows.insert(
+        node_id.to_string(),
+        serde_json::json!([{ "source": "spec.md", "title": "Spec" }]),
+    );
+    rows
+}
+
+/// Issue #1963: an artifact belongs to a node the engine reported nothing for.
+///
+/// This is the entire reason `merge_run_artifacts` exists beside
+/// `merge_transcripts`, which deliberately refuses to invent a slot: a node that
+/// wrote a file and *then* errored has real files and no engine output, and
+/// dropping them would make the inspector show neither text nor files for a
+/// node that produced one of them.
+///
+/// A driven run cannot isolate this: on every arm the artifact map arrives
+/// alongside a `nodes` map the engine or the observer already populated, so the
+/// create-the-slot branch is only ever taken incidentally.
+#[test]
+fn an_artifact_for_a_node_the_engine_never_reported_gets_its_own_empty_slot() {
+    let merged = merge_run_artifacts(serde_json::json!({}), &artifact_rows("draft"));
+
+    assert_eq!(
+        merged["draft"]["items"],
+        serde_json::json!([]),
+        "an invented slot must truthfully show no reply text"
+    );
+    assert_eq!(
+        merged["draft"]["artifacts"][0]["source"],
+        serde_json::json!("spec.md"),
+        "while still surfacing the file the node actually wrote"
+    );
+}
+
+/// Issue #1963: folding artifacts never rewrites what the engine reported.
+/// The merge is additive by construction — it inserts one `artifacts` key —
+/// and a regression that replaced the slot instead would silently drop every
+/// node's output on a run that captured a file.
+#[test]
+fn folding_artifacts_leaves_a_reported_nodes_items_untouched() {
+    let engine = serde_json::json!({
+        "draft": { "items": [{ "json": { "text": "the draft" } }] },
+        "review": { "items": [] }
+    });
+
+    let merged = merge_run_artifacts(engine.clone(), &artifact_rows("draft"));
+
+    assert_eq!(
+        merged["draft"]["items"], engine["draft"]["items"],
+        "the engine's own items are not this function's to rewrite"
+    );
+    assert!(
+        merged["review"].get("artifacts").is_none(),
+        "a node that wrote no file gets no artifacts key at all"
+    );
+}
+
+/// Issue #1963: a `nodes` value of another shape must not swallow the
+/// artifacts.
+///
+/// Two of the five settle sites hand in a value that can legitimately be
+/// `Null` — the failure and blocked arms build theirs from the progress
+/// observer's map, which is empty when the drain timed out. Returning the
+/// non-object untouched (the stance `merge_transcripts` takes) would discard
+/// every captured file on exactly the arms where the artifacts are the only
+/// record left.
+#[test]
+fn a_non_object_nodes_value_is_replaced_rather_than_losing_the_artifacts() {
+    let merged = merge_run_artifacts(Value::Null, &artifact_rows("draft"));
+
+    assert_eq!(
+        merged["draft"]["artifacts"][0]["title"],
+        serde_json::json!("Spec"),
+        "a null nodes map must not take the captured files down with it"
+    );
+}
+
+/// Issue #1963: no captured artifact, no change — including for a value the
+/// merge would otherwise have coerced into an object. Nearly every run captures
+/// nothing, so this early return is the path almost all traffic takes.
+#[test]
+fn merging_no_artifacts_returns_the_nodes_map_exactly_as_it_arrived() {
+    let empty = serde_json::Map::new();
+
+    assert_eq!(
+        merge_run_artifacts(Value::Null, &empty),
+        Value::Null,
+        "an empty capture must not coerce a null map into an object"
+    );
+    let engine = serde_json::json!({ "draft": { "items": [] } });
+    assert_eq!(
+        merge_run_artifacts(engine.clone(), &empty),
+        engine,
+        "nor touch a real one"
+    );
+}
+
+/// Issue #1963: the envelope wrapper reaches through `outcome.output`'s own
+/// `{ "run": …, "nodes": … }` shape — the third of the three shapes the five
+/// settle sites pass, and the only one where the artifacts must be folded a
+/// level down rather than at the top.
+///
+/// A shape mismatch here loses artifacts on the clean-finish arm alone, which
+/// is the arm every ordinary run takes and the one whose tests assert about
+/// node output rather than about files.
+#[test]
+fn the_envelope_folds_artifacts_into_the_engines_nodes_key_and_leaves_run_alone() {
+    let output = serde_json::json!({
+        "run": { "id": "run-1" },
+        "nodes": { "draft": { "items": [{ "json": { "text": "the draft" } }] } }
+    });
+
+    let merged = merge_run_artifacts_envelope(output, &artifact_rows("draft"));
+
+    assert_eq!(
+        merged["run"]["id"],
+        serde_json::json!("run-1"),
+        "the envelope's sibling keys are not the merge's to touch"
+    );
+    assert_eq!(
+        merged["nodes"]["draft"]["artifacts"][0]["source"],
+        serde_json::json!("spec.md"),
+        "the artifacts belong one level down, beside the node's items"
+    );
+    assert_eq!(
+        merged["nodes"]["draft"]["items"][0]["json"]["text"],
+        serde_json::json!("the draft"),
+        "and the node's own output survives the fold"
+    );
+}
+
+/// Issue #1963: an envelope with no `nodes` key at all still gets one. A graph
+/// whose only node errored produces an envelope carrying `run` and nothing
+/// else, and the file that node wrote before it failed is then the run's only
+/// surviving product.
+#[test]
+fn an_envelope_with_no_nodes_key_gains_one_holding_the_artifacts() {
+    let merged = merge_run_artifacts_envelope(
+        serde_json::json!({ "run": { "id": "run-2" } }),
+        &artifact_rows("draft"),
+    );
+
+    assert_eq!(
+        merged["nodes"]["draft"]["items"],
+        serde_json::json!([]),
+        "the invented node slot still says the node produced no reply text"
+    );
+    assert_eq!(
+        merged["nodes"]["draft"]["artifacts"][0]["title"],
+        serde_json::json!("Spec")
+    );
+}
+
+/// Issue #1963: a non-object `outcome.output` is wrapped in a fresh `nodes`
+/// envelope rather than being merged into or returned bare — so the value the
+/// run reports keeps the one shape every downstream reader parses.
+#[test]
+fn a_non_object_engine_output_is_wrapped_in_a_nodes_envelope() {
+    let merged = merge_run_artifacts_envelope(Value::Null, &artifact_rows("draft"));
+
+    assert!(
+        merged.get("nodes").is_some(),
+        "the result must still be an envelope: {merged}"
+    );
+    assert_eq!(
+        merged["nodes"]["draft"]["artifacts"][0]["source"],
+        serde_json::json!("spec.md")
+    );
+}
+
+/// Issue #1963: with nothing captured the envelope is returned byte-identical,
+/// non-object values included — the wrapper must not manufacture a `nodes` key
+/// on the overwhelming majority of runs that wrote no file.
+#[test]
+fn an_envelope_with_no_artifacts_is_returned_exactly_as_it_arrived() {
+    let empty = serde_json::Map::new();
+    let output = serde_json::json!({ "run": { "id": "run-3" } });
+
+    assert_eq!(
+        merge_run_artifacts_envelope(output.clone(), &empty),
+        output,
+        "no capture, no envelope rewrite"
+    );
+    assert_eq!(
+        merge_run_artifacts_envelope(Value::Null, &empty),
+        Value::Null,
+        "and a null output stays null rather than becoming an empty envelope"
+    );
+}
+
+/// Issue #1963 (issue #1865's sentence half): the notice names the step and
+/// says the run kept going, which is the fact that distinguishes it from a
+/// stopped run's headline.
+#[test]
+fn the_errored_node_notice_names_the_step_and_says_the_run_continued_past_it() {
+    let notice = errored_node_notice("summarize");
+
+    assert!(
+        notice.contains("\"summarize\""),
+        "the operator must not have to open the canvas to find the red chip: \
+         {notice}"
+    );
+    assert!(
+        notice.contains("the run continued past it"),
+        "a degraded run is not a stopped one, and the sentence has to say so: \
+         {notice}"
+    );
+}
+
+/// Issue #1963: the notice covers two causes — a genuinely errored capability
+/// under `on_error = "continue"`, and an agent turn truncated at the iteration
+/// cap — and the row carries no reason text to tell them apart (issue #371's
+/// no-`String`-arm invariant). Claiming either one would be a guess printed to
+/// an operator as fact.
+///
+/// A driven run reaches only one cause at a time, so nothing that starts from a
+/// graph can notice the wording drifting toward whichever cause its fixture
+/// happens to exercise.
+#[test]
+fn the_errored_node_notice_never_claims_which_of_its_two_causes_it_was() {
+    let notice = errored_node_notice("summarize").to_lowercase();
+
+    for guess in ["approval", "iteration", "cap", "budget", "timed out"] {
+        assert!(
+            !notice.contains(guess),
+            "the row carries no reason, so the sentence must not name one \
+             (\"{guess}\"): {notice}"
+        );
+    }
+}
+
+/// Issue #1963: the persist-failure notice tells the operator the run itself
+/// survived. Without that sentence a lost inspector snapshot reads as a lost
+/// run, and the operator re-runs work that already completed.
+#[test]
+fn the_persist_failure_notice_says_the_run_itself_was_unaffected() {
+    let notice = run_output_persist_failed_notice();
+
+    assert!(
+        notice.contains("The run itself was unaffected"),
+        "a lost snapshot must not read as a lost run: {notice}"
+    );
+    assert!(
+        notice.contains("reopening it later"),
+        "and it has to say when the operator will notice: {notice}"
+    );
+}
+
+/// Issue #1963: a structural graph problem is the caller's, and reaches the
+/// console as a 4xx rather than a harness fault — the distinction the whole of
+/// `map_engine_error` exists to draw.
+#[test]
+fn a_validation_engine_error_maps_to_an_invalid_request() {
+    let mapped = map_engine_error(tinyflows::error::EngineError::Validation(
+        tinyflows::error::ValidationError::MissingTrigger,
+    ));
+
+    match mapped {
+        OpenCompanyError::InvalidRequest(message) => assert!(
+            message.contains("workflow graph is invalid") && message.contains("no trigger node"),
+            "the operator needs the engine's own reason, not just the category: \
+             {message}"
+        ),
+        other => {
+            panic!("a validation failure is the author's to fix, not a harness fault: {other}")
+        }
+    }
+}
+
+/// Issue #1963: every other engine failure is a harness error. The match's
+/// catch-all arm means a variant added to `EngineError` upstream lands here
+/// silently, so this pins that each of the current ones does — including
+/// `Input`, which the vendored engine documents as raised *before any node
+/// runs* and which is therefore the most tempting to reclassify.
+///
+/// A driven run can only produce whichever variant its fixture provokes; the
+/// mapping is a total function and is tested as one.
+#[test]
+fn every_non_validation_engine_error_maps_to_a_harness_error() {
+    let cases = vec![
+        tinyflows::error::EngineError::Capability("the tool refused".to_string()),
+        tinyflows::error::EngineError::Unimplemented("subflows"),
+        tinyflows::error::EngineError::LoopLimit {
+            node: "retry".to_string(),
+            limit: 5,
+        },
+    ];
+
+    for err in cases {
+        let described = err.to_string();
+        match map_engine_error(err) {
+            OpenCompanyError::Harness(message) => assert_eq!(
+                message, described,
+                "the engine's own wording must survive the mapping intact"
+            ),
+            other => panic!("\"{described}\" is a runtime failure, not a bad request: {other}"),
+        }
+    }
+}

--- a/src/workflows/runner/pure_units_part_03_tests.rs
+++ b/src/workflows/runner/pure_units_part_03_tests.rs
@@ -1,0 +1,194 @@
+// ── issue #1963: direct units for the blocked-run constructor ───────────────
+//
+// The third part of the `include!`d suite (see `pure_units_part_01_tests.rs`).
+// `blocked_run` is the settle arm that turns an engine `Err` into an `Ok` run,
+// and each of its emptied fields is a claim the doc comment makes in prose and
+// nothing asserted.
+
+/// One blocked node, with the shape the drain actually produces.
+fn blocked_node(node_id: &str, approval_ids: &[&str]) -> crate::ports::WorkflowBlockedNode {
+    crate::ports::WorkflowBlockedNode {
+        node_id: node_id.to_string(),
+        tools: vec!["publish_artifact".to_string()],
+        approval_ids: approval_ids.iter().map(|id| id.to_string()).collect(),
+        unparkable: 0,
+        stranded: 0,
+    }
+}
+
+/// Issue #1963 (issue #881): a blocked run settles `Ok`, with no `cancelled`
+/// flag and no deliveries, and lists every blocked node as something the run is
+/// waiting on.
+///
+/// The three together are one claim: a node waiting for a human is neither a
+/// failure nor a stop, and a run that halted short must not mail anybody a
+/// report of work it did not finish. A driven blocked-run test asserts about
+/// the node's own status; nothing asserted that `deliveries` is empty *by
+/// construction* rather than because the fixture's graph routed nothing.
+#[test]
+fn a_blocked_run_settles_uncancelled_with_no_deliveries_and_every_block_pending() {
+    let run = blocked_run(BlockedRun {
+        nodes: vec![
+            node_row("fetch", WorkflowNodeStatus::Ok),
+            node_row("spec", WorkflowNodeStatus::Error),
+        ],
+        blocked: vec![blocked_node("spec", &["appr-1"])],
+        notices: crate::workflows::caps::RunNotices::default(),
+        board: Vec::new(),
+        approvals: Vec::new(),
+        output: serde_json::json!({ "fetch": { "items": [] } }),
+    });
+
+    assert!(
+        !run.cancelled,
+        "a blocked run is not a stopped one — the console's three terminal \
+         wordings stay distinguishable only if this stays false"
+    );
+    assert!(
+        run.deliveries.is_empty(),
+        "deliver_outputs is deliberately not reached: {:?}",
+        run.deliveries
+    );
+    assert_eq!(
+        run.pending_approvals,
+        vec!["spec".to_string()],
+        "the blocked node is what the run is waiting on"
+    );
+    assert_eq!(
+        run.nodes[1].status,
+        WorkflowNodeStatus::Blocked,
+        "and its row agrees, rather than keeping the engine's Error"
+    );
+    assert_eq!(
+        run.nodes[0].status,
+        WorkflowNodeStatus::Ok,
+        "while the node that finished before the block keeps its result"
+    );
+}
+
+/// Issue #1963 (issue #1008): the upstream capture is threaded through, not
+/// emptied.
+///
+/// `output` used to be `Value::Null` here, on the argument that the engine
+/// returned an error rather than a final state. Everything upstream of the
+/// block had in fact run to completion, so the run inspector said "no output
+/// for this node" about a node that had just written a draft. The caller
+/// removes the blocked nodes' own entries before handing the map in — so
+/// "the blocked node produced nothing" stays literally true — and this pins
+/// that `blocked_run` neither re-empties the map nor re-adds the block.
+#[test]
+fn a_blocked_run_reports_what_the_nodes_upstream_of_the_block_produced() {
+    let run = blocked_run(BlockedRun {
+        nodes: vec![node_row("spec", WorkflowNodeStatus::Error)],
+        blocked: vec![blocked_node("spec", &["appr-1"])],
+        notices: crate::workflows::caps::RunNotices::default(),
+        board: Vec::new(),
+        approvals: Vec::new(),
+        output: serde_json::json!({
+            "fetch": { "items": [{ "json": { "text": "the draft" } }] }
+        }),
+    });
+
+    assert_eq!(
+        run.output["fetch"]["items"][0]["json"]["text"],
+        serde_json::json!("the draft"),
+        "the work the run did before it blocked is still the run's to report"
+    );
+    assert!(
+        run.output.get("spec").is_none(),
+        "and the blocked node itself stays absent: {}",
+        run.output
+    );
+}
+
+/// Issue #1963 (issues #661 / #880): `board` and `approvals` are threaded in
+/// rather than emptied, for the reason the sibling `cancelled_run` spells out —
+/// a card is durable the moment it is written, and zeroing the rows would leave
+/// cards on the operator's board and Approvals page that no run admits to
+/// opening.
+#[test]
+fn a_blocked_run_keeps_the_receipts_for_cards_its_nodes_already_opened() {
+    let run = blocked_run(BlockedRun {
+        nodes: vec![node_row("spec", WorkflowNodeStatus::Error)],
+        blocked: vec![blocked_node("spec", &["appr-1"])],
+        notices: crate::workflows::caps::RunNotices::default(),
+        board: vec![crate::ports::WorkflowRunBoardRow {
+            action: crate::ports::WorkflowBoardAction::Spawned,
+            task_id: Some("task-7".to_string()),
+            title: Some("Draft the spec".to_string()),
+            assignee: None,
+        }],
+        approvals: vec![crate::ports::WorkflowRunApprovalRow {
+            node_id: Some("spec".to_string()),
+            tool: Some("publish_artifact".to_string()),
+            outcome: crate::ports::WorkflowApprovalOutcome::Parked,
+            approval_id: Some("appr-1".to_string()),
+        }],
+        output: Value::Null,
+    });
+
+    assert_eq!(
+        run.board.len(),
+        1,
+        "a card that is already on the board needs a run that admits to it"
+    );
+    assert_eq!(
+        run.approvals.len(),
+        1,
+        "and so does a card that is already on the Approvals page"
+    );
+    assert_eq!(
+        run.blocked_nodes.len(),
+        1,
+        "the structural blocked row rides out alongside them"
+    );
+}
+
+/// Issue #1963: the block's sentence is appended to whatever the nodes already
+/// raised, in blocked order, and never replaces them.
+///
+/// A node can overflow the approval cap (issue #638) and then block, so both
+/// notices are owed. Ordering matters to the reader: the notices collected
+/// during the run describe what happened, and the block's sentence describes
+/// why the run stopped.
+#[test]
+fn the_blocks_sentence_is_appended_after_the_notices_the_nodes_already_raised() {
+    let notices = crate::workflows::caps::RunNotices::default();
+    notices.push("An earlier notice from a node.".to_string());
+
+    let run = blocked_run(BlockedRun {
+        nodes: vec![
+            node_row("spec", WorkflowNodeStatus::Error),
+            node_row("review", WorkflowNodeStatus::Error),
+        ],
+        blocked: vec![
+            blocked_node("spec", &["appr-1"]),
+            blocked_node("review", &[]),
+        ],
+        notices,
+        board: Vec::new(),
+        approvals: Vec::new(),
+        output: Value::Null,
+    });
+
+    assert_eq!(
+        run.notices.len(),
+        3,
+        "one pre-existing notice plus one sentence per blocked node: {:?}",
+        run.notices
+    );
+    assert_eq!(
+        run.notices[0], "An earlier notice from a node.",
+        "what the nodes raised comes first"
+    );
+    assert!(
+        run.notices[1].contains("\"spec\"") && run.notices[2].contains("\"review\""),
+        "and the block sentences follow in blocked order: {:?}",
+        run.notices
+    );
+    assert_eq!(
+        run.pending_approvals,
+        vec!["spec".to_string(), "review".to_string()],
+        "both blocked nodes are waited on, in the same order"
+    );
+}


### PR DESCRIPTION
Closes #1963.

`src/workflows/` is a host adapter, not an engine: it lowers on-disk TOML onto vendored `tinyflows`, supplies capabilities, and applies host-side readings — blocked, capped, cancelled, delivery — on the way out. The settle path is where those readings are applied, and almost none of it had a direct test. Everything below is test-only; no production behaviour changes.

## 1. Direct units for the settle path's pure helpers (23 tests)

Seven functions in `runner.rs` appeared only in doc comments, never in a test. A driven run can exercise one settle arm at a time, so several of these shapes are unreachable from a graph fixture at all.

- **`reclassify_blocked`** — its sibling `reclassify_capped_nodes` had three units and this had none. Pinned: idempotence across a second pass; `pending_approvals` unioned rather than appended (a duplicate renders as two waits on one node); a blocked node **absent** from `nodes` still reaching `pending_approvals`; and the relabel being one-directional — an `Error` row for a blocked node becomes `Blocked`, and nothing here ever writes `Error`. Reversing that direction restores exactly the bug #881 removed, and no driven run would notice.
- **`merge_run_artifacts` / `merge_run_artifacts_envelope`** — reached from five settle sites with three different envelope shapes (bare map, `{"nodes": …}`, `outcome.output`'s `{"run": …, "nodes": …}`). A shape mismatch at one site loses artifacts on that arm only. All three shapes covered, plus the non-object and empty-capture paths.
- **`errored_node_notice`**, **`map_engine_error`** (total function, every `EngineError` arm), **`blocked_run`**, **`run_output_persist_failed_notice`**.

**And the ordering nobody asserted.** `only_blocked_nodes_errored` must be read **before** `reclassify_capped_nodes`. The design comment at `runner.rs` says so in prose; nothing pinned it. `reclassify_capped_nodes` *creates* `Error` rows out of `Ok` ones, so running it first adds a row no `WorkflowBlockedNode` covers, the containment check fails, and a capped-node-plus-blocked-node run is reported as a genuine failure it did not have. The test builds the state both orders see and shows they disagree.

No driven run reaches that: it needs one node blocked on an approval *and* a sibling truncated at `max_tool_iterations` in the same run, which no fixture drives together.

## 2. Serde migration table for `WorkflowRun` (7 tests)

`WorkflowRun` has nine fields and sixteen `#[serde(default)]` attributes between it and the rows it carries. Exactly one migration test existed, covering two fields.

`CompanyEvent::WorkflowRunFinished` is **replayed at boot**, so — in the spec's own words — a missing `#[serde(default)]` is *silent history loss, not a compile error*. It does not fail the build, does not fail a round-trip of a freshly-constructed value, and does not fail the first run after deploy. It fails on the next boot, by dropping every historical run event older than the new field.

The seven eras were **recovered from git history, not invented**: `git log -S"pub <field>"` names the commit that added each field, and the struct at that commit's parent is the shape of the day before. The fields arrived strictly additively in declaration order, so each era is a prefix of the next.

| era | ended by |
|---|---|
| pre-#170 | `0728d9a2e` added `deliveries` |
| pre-#383 | `3a4d1380d` added `cancelled` |
| pre-#542 | `406626cbb` added `nodes` |
| pre-#638 | `4d723c755` added `notices` |
| pre-#661 | `1c06157ca` added `board` |
| pre-#881/#880 | `fa846eded` added `blocked_nodes` + `approvals` |

Plus the nested rows' own later fields (#1014 `diagnostics`, #1143 `stranded`, `DeliveryReason`), the #1008 payload change (`output` went from `Null` to the upstream capture on the blocked arm without changing shape), a lossless full round-trip, and the direction the table cannot check: a default-valued run still serializing as the **pre-#880 wire form**, so an old reader parses what a new writer emits during a rollout.

**#1862** is deliberately absent: it added `started_by` to `WorkflowRunStarted`, a sibling event and not a `WorkflowRun` field, and is already pinned by `ports::types`' `a_pre_1862_run_started_line_still_replays_with_no_sender`. Duplicating it here would be a second copy that drifts. Noted in the file's module doc.

### The table was mutation-verified

Removing `#[serde(default)]` from `notices` fails the pre-#170 and pre-#638-and-older eras with `missing field notices`, and the failure message says a missing default breaks every era older than the field. Reverted before commit.

## Layout

`runner.rs` is already the largest file in the crate, so the units are `include!`d fragments under `src/workflows/runner/` — the idiom `tinyflows::engine_tests` uses, and what lets them reach the private functions they exercise. Each fragment is under 500 lines. The migration table is a sibling `src/workflows/migration_test.rs`, matching what `src/workflows/` already does.

No new cargo feature and no new CI lane: everything runs in the existing gated lane, `cargo test --locked --features openhuman --tests`.

## Verification

| command | result |
|---|---|
| `cargo fmt --all -- --check` | clean, exit 0 |
| `cargo clippy --all-targets --features openhuman -- -D warnings` | exit 0, zero errors (only pre-existing vendored `openhuman` unused-import warnings) |
| `cargo test --locked --features openhuman --tests` | exit 0 — **6497 passed, 0 failed, 3 ignored** |
| `scripts/ci/assert-feature-lanes.sh` | exit 0 — 29 features, 21 with a lane, 8 compile-only, 0 owed a lane |

**Test count: 6467 → 6497 (+30).** All 30 new tests were confirmed present by name in the full run's output; the before-count is that total minus the 30.

## House style

Test names are full English sentences stating the property. Every test carries a doc comment naming its issue and why a unit test could not have caught it otherwise. Every assertion carries a message saying what the failure means.
