### PR TITLE
design(console): one full-width window title row

### DIFF
--- a/frontend/src/api/policy.ts
+++ b/frontend/src/api/policy.ts
@@ -103,6 +103,55 @@ export interface SetPolicyInput {
   approvalTtlHours?: number | null;
 }
 
+/**
+ * What a *renderable* policy is, as distinct from what the host sent.
+ *
+ * ## The crash this fences
+ *
+ * A 200 whose body is not a policy used to reach the render untouched, and the
+ * first `status.tiers.find(...)` threw. `AutonomyPill` is mounted for the entire
+ * life of the console on every view (`window-title-bar.tsx`), there is no error
+ * boundary anywhere in `src/`, and React unmounts the whole tree on a throw
+ * during render — so one malformed `/policy` response blanked the ENTIRE
+ * console, on every page, with no way back but a reload. The console E2E lane
+ * met it as `TypeError: Cannot read properties of undefined (reading 'find')`
+ * against an empty document, and thirty-plus specs sat on their timeouts.
+ *
+ * ## Why it is a predicate here and not a check on the fetch
+ *
+ * Because "usable" depends on the reader. `useApprovalDeadline` wants
+ * `approvalTtlHours` and documents that an older host omits it; making the
+ * transport insist on the tier list would break a hook that is deliberately
+ * lenient. So the three functions below stay plain typed requests and each
+ * consumer that puts a policy ON SCREEN gates on this instead — `useAutonomy`
+ * for the title row, `apply`/`load` for the settings page.
+ *
+ * ## Why these three fields and no more
+ *
+ * They are exactly what the render paths dereference without a guard —
+ * `tiers.find`, `tiers.map`, `alwaysApprove.join` — plus the `mode` they
+ * compare against. Every optional field stays optional: this is a crash fence,
+ * not a schema, and a host that grows or drops a field must keep working. See
+ * `knownTools` above.
+ */
+export function isPolicyStatus(body: unknown): body is PolicyStatus {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return false;
+  const candidate = body as Partial<PolicyStatus>;
+  return (
+    typeof candidate.mode === "string" &&
+    Array.isArray(candidate.tiers) &&
+    Array.isArray(candidate.alwaysApprove)
+  );
+}
+
+/**
+ * What a reader says when it is handed something that is not a policy.
+ *
+ * One sentence, shared, so the settings page's `loadError` and the title row's
+ * failed write read as the same fact rather than as two unrelated faults.
+ */
+export const NOT_A_POLICY = "The host did not answer with an autonomy policy.";
+
 /** The company's effective policy. */
 export function getPolicy(
   client: OpenCompanyClient,

--- a/frontend/src/api/policy.ts
+++ b/frontend/src/api/policy.ts
@@ -104,6 +104,32 @@ export interface SetPolicyInput {
 }
 
 /**
+ * One renderable tier.
+ *
+ * Split out because `Array.isArray(tiers)` alone is not the fence it looks
+ * like: `{"tiers": [null]}` satisfies it, and the very next thing every reader
+ * does is `tiers.find((tier) => tier.value === ...)`, which throws on the first
+ * member. A body that passes the shape check and then crashes the render is the
+ * exact failure {@link isPolicyStatus} exists to stop, one level down.
+ *
+ * All three fields are required rather than optional, and that is safe against
+ * a real host: `TierDto` (`src/server/ops/policy.rs:96`) declares `value`,
+ * `label` and `description` as `&'static str`, so every tier the runtime serves
+ * carries all three. The leniency this fence deliberately keeps is at the
+ * *status* level — an optional field a host may not have grown yet — not here,
+ * where a partial member is a member the menu cannot draw.
+ */
+function isPolicyTier(value: unknown): value is PolicyTier {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const tier = value as Partial<PolicyTier>;
+  return (
+    typeof tier.value === "string" &&
+    typeof tier.label === "string" &&
+    typeof tier.description === "string"
+  );
+}
+
+/**
  * What a *renderable* policy is, as distinct from what the host sent.
  *
  * ## The crash this fences
@@ -133,6 +159,12 @@ export interface SetPolicyInput {
  * compare against. Every optional field stays optional: this is a crash fence,
  * not a schema, and a host that grows or drops a field must keep working. See
  * `knownTools` above.
+ *
+ * The two required lists are checked to their MEMBERS, though, because the
+ * container check alone does not fence what it is here to fence: `tiers: [null]`
+ * is an array, passes, and throws inside `tiers.find` on the very next line —
+ * the same blank console this predicate was written to stop. See
+ * {@link isPolicyTier}.
  */
 export function isPolicyStatus(body: unknown): body is PolicyStatus {
   if (typeof body !== "object" || body === null || Array.isArray(body)) return false;
@@ -140,7 +172,17 @@ export function isPolicyStatus(body: unknown): body is PolicyStatus {
   return (
     typeof candidate.mode === "string" &&
     Array.isArray(candidate.tiers) &&
-    Array.isArray(candidate.alwaysApprove)
+    // Each MEMBER, not just the container. See `isPolicyTier`: `[null]` passes
+    // `Array.isArray` and throws in `tiers.find` a moment later, which is the
+    // same blank console by a slightly longer route.
+    candidate.tiers.every(isPolicyTier) &&
+    Array.isArray(candidate.alwaysApprove) &&
+    // The list is rendered with `.join(", ")` and typed `string[]`, and a
+    // non-string member is a wrong sentence rather than a crash — the settings
+    // page would seed its always-ask box with "[object Object]" and save that
+    // back as a gate. A policy the console cannot state truthfully is not a
+    // renderable policy.
+    candidate.alwaysApprove.every((entry) => typeof entry === "string")
   );
 }
 

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -28,7 +28,7 @@ import {
   Sidebar,
   SidebarContent,
   SidebarGroup,
-  SidebarHeader,
+  SidebarFooter,
   SidebarInset,
   SidebarMenu,
   SidebarMenuBadge,
@@ -48,6 +48,7 @@ import { RouteLoading } from "@/components/route-loading";
 import { WINDOW_TITLE_BAR_HEIGHT } from "@/components/window-chrome";
 import { WindowTitleBar } from "@/components/window-title-bar";
 import {
+  SidebarCollapseButton,
   RESTING_ROW,
   SidebarUtilityBar,
 } from "@/components/sidebar-controls";
@@ -107,6 +108,8 @@ import {
   type PendingAcknowledgement,
 } from "@/lib/operational-notifications";
 import { usePresence } from "@/hooks/use-presence";
+import { useAutonomy } from "@/hooks/use-autonomy";
+import { AutonomyPill } from "@/components/autonomy-pill";
 import { useTyping } from "@/hooks/use-typing";
 import { typersIn } from "@/lib/awareness";
 import type { WorkspaceEvent } from "@/views/WorkspaceView";
@@ -2712,6 +2715,11 @@ export function AppShell({
   // the state they feed has to live where that stream is read.
   const presence = usePresence(client, company);
   const typing = useTyping(client, company);
+  // The standing autonomy tier, for the title row. Shell-owned because the row
+  // is: it outlives every view, so the read has to sit above all of them. It is
+  // the same `GET {scope}/policy` the settings page makes, so the pill and the
+  // page that changes it cannot disagree about which tier is in force.
+  const autonomy = useAutonomy(client, company);
   /**
    * The coarse "near your credit limit" warning (issue #1846), off the live
    * `budget_proximity` frame. Shell-owned for the same reason presence/typing
@@ -3412,6 +3420,12 @@ export function AppShell({
             canCreateCompany={client.carriesPlatformBearer}
           />
         }
+        autonomy={
+          // What the agents in this company are allowed to do without asking.
+          // Renders nothing until the host has said, rather than guessing a
+          // tier — see `useAutonomy`.
+          <AutonomyPill status={autonomy} />
+        }
         profile={
           // Who you are signed in as, and nothing else. It renders nothing
           // where there is nobody to name — a host with no sign-in, or a
@@ -3438,17 +3452,19 @@ export function AppShell({
           height: `calc(100svh - ${WINDOW_TITLE_BAR_HEIGHT}px)`,
         }}
       >
-        <SidebarHeader>
-          {/* What is left of the header once the switcher moved up into the
-              title row: Settings, Feedback, Discord and Collapse, as one bar of
-              icons rather than four full-width rows spread across the nav and
-              the footer. See `SidebarUtilityBar`. */}
-          <SidebarUtilityBar view={view} onNavigate={setView} />
-        </SidebarHeader>
+
         <nav aria-label="Main navigation" className="flex min-h-0 flex-1 flex-col">
           <SidebarContent data-tour="sidebar">
           <SidebarNavigation view={view} pending={pending} onNavigate={setView} />
         </SidebarContent>
+        {/* The console's own utilities sit at the FOOT of the column, under the
+            destinations rather than over them. They act on the console, not on
+            the company, so they belong after the list of places you can go —
+            and the header they used to occupy is gone entirely now that the
+            switcher lives in the window's title row. */}
+        <SidebarFooter>
+          <SidebarUtilityBar view={view} onNavigate={setView} />
+        </SidebarFooter>
         </nav>
         <SidebarRail />
       </Sidebar>
@@ -3462,6 +3478,27 @@ export function AppShell({
           strip held the "Done" column, which is why a card could not be dragged
           into it (issue #334); every view was losing the same strip. */}
       <SidebarInset id={MAIN_CONTENT_ID} tabIndex={-1} className="min-h-0 min-w-0">
+          {/* Show/hide the sidebar, on the corner it acts on.
+
+              It used to sit in the sidebar's own header, which put the control
+              that *hides* a panel inside the panel it hides — collapsing the
+              column took the button with it. On the inset's leading corner it
+              stays put through both states and points at the edge that moves.
+
+              Here rather than inside `ContentSurface`: this control needs
+              `useSidebar`, and that card is deliberately free of sidebar
+              context — every page renders it, including ones with no sidebar at
+              all. Centred ON the card's leading border, not inside it:
+              `left-(--frame-inset)` puts it at the edge and `-translate-x-1/2`
+              straddles it. Inside the card it sat over the page's own heading
+              and read as part of the content; on the seam it reads as chrome
+              belonging to the boundary it moves. Absolutely positioned, so it
+              costs the page no layout and no view makes room for it. */}
+          <div className="pointer-events-none absolute top-4 left-(--frame-inset) z-20 -translate-x-1/2">
+            <div className="pointer-events-auto">
+              <SidebarCollapseButton />
+            </div>
+          </div>
         {/* The card half of the two-layer shell: the one opaque sheet in the
             console, floating on the chrome the shell root paints (issue
             #1178). A `div`, not `main` — `SidebarInset` above is already the

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -3504,8 +3504,27 @@ export function AppShell({
               straddles it. Inside the card it sat over the page's own heading
               and read as part of the content; on the seam it reads as chrome
               belonging to the boundary it moves. Absolutely positioned, so it
-              costs the page no layout and no view makes room for it. */}
-          <div className="pointer-events-none absolute top-4 left-(--frame-inset) z-20 -translate-x-1/2">
+              costs the page no layout and no view makes room for it.
+
+              `hidden md:block` — desktop only, and the breakpoint is not an
+              approximation. `useIsMobile` flips at exactly 768px, which is
+              Tailwind's `md`, so this gate is the precise complement of the
+              `!isMobile` that `SidebarCollapseButton` already reasons about:
+              the two agree by construction rather than by coincidence.
+
+              Below it the sidebar is a sheet, not a column, and it already has
+              a control — the `md:hidden` "Toggle sidebar" bar at the foot of
+              this inset. Leaving this one on made that two controls for one
+              job on one viewport, and the second one was wrong in both of its
+              halves: `SidebarCollapseButton` deliberately treats mobile as
+              not-collapsed, so with the sheet closed it read "Collapse
+              sidebar" and showed the close icon while pressing it OPENED the
+              sheet. Teaching it `openMobile` and retiring the bar was the
+              other way out and is the worse one — this button is absolutely
+              positioned over the content, and issue #1265 moved the mobile
+              trigger into a reserved row precisely to stop a floating control
+              winning the hit-test in that corner. */}
+          <div className="pointer-events-none absolute top-4 left-(--frame-inset) z-20 hidden -translate-x-1/2 md:block">
             <div className="pointer-events-auto">
               <SidebarCollapseButton />
             </div>

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -27,7 +27,6 @@ import {
 import {
   Sidebar,
   SidebarContent,
-  SidebarFooter,
   SidebarGroup,
   SidebarHeader,
   SidebarInset,
@@ -46,7 +45,8 @@ import { ContentSurface } from "@/components/content-surface";
 import { FeedbackDialog } from "@/components/feedback-dialog";
 import { HostSwitcher } from "@/components/host-switcher";
 import { RouteLoading } from "@/components/route-loading";
-import { WindowControlsInset } from "@/components/window-chrome";
+import { WINDOW_TITLE_BAR_HEIGHT } from "@/components/window-chrome";
+import { WindowTitleBar } from "@/components/window-title-bar";
 import {
   RESTING_ROW,
   SidebarUtilityBar,
@@ -3366,8 +3366,14 @@ export function AppShell({
       {setupController}
 
       {/* `SidebarProvider` paints the chrome layer itself — see its own note on
-          why that fill lives there and not here (issue #1178). */}
-      <SidebarProvider className="h-svh overflow-hidden">
+          why that fill lives there and not here (issue #1178).
+
+          `flex-col`, because the shell is now a title row above a
+          sidebar-and-content row rather than a bare row of two columns. The
+          provider stays the outermost box — the title row holds the profile
+          control, which is inside this context — so the direction is flipped
+          here rather than by wrapping the provider in another element. */}
+      <SidebarProvider className="h-svh flex-col overflow-hidden">
         <a
           href={`#${MAIN_CONTENT_ID}`}
           className="sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:not-sr-only focus:rounded-md focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-foreground focus:ring-2 focus:ring-ring focus:outline-none"
@@ -3378,75 +3384,71 @@ export function AppShell({
         >
           Skip to content
         </a>
-      <Sidebar collapsible="icon">
+      {/* The window's one title row, above the sidebar and above the content
+          and spanning the full width of the window. It carries the two controls
+          that are about the *console* rather than about the page: which company
+          you are in, and who you are signed in as. Both used to sit in the
+          sidebar column — the switcher at its head under a reserved strip for
+          the traffic lights, the profile row in its footer — which put them at
+          opposite ends of a 13.5rem column and left the lights overlapping a
+          narrow column instead of insetting a bar. See `window-title-bar.tsx`,
+          which owns the geometry including the traffic-light inset. */}
+      <WindowTitleBar
+        switcher={
+          <HostSwitcher
+            variant="titlebar"
+            companyName={feed.status.name}
+            // The company's lifecycle, and every company on this host: both
+            // were rows in the sidebar footer, and both are facts about *which
+            // company you are in* — which is what this control is. See
+            // `HostSwitcher`'s `companyState` for why the lifecycle is not
+            // folded into the connection dot.
+            companyState={lifecycle(feed.status.lifecycle, feed.status.emergency_paused)}
+            companies={companies}
+            activeCompany={company}
+            onSwitchCompany={onSwitchCompany}
+            onBackToPicker={onBackToPicker}
+            onCreateCompany={onCreateCompany}
+            canCreateCompany={client.carriesPlatformBearer}
+          />
+        }
+        profile={
+          // Who you are signed in as, and nothing else. It renders nothing
+          // where there is nobody to name — a host with no sign-in, or a
+          // session that has just gone — and the row simply closes up.
+          <ProfileRow variant="titlebar" client={client} company={company} />
+        }
+      />
+
+      {/* The shell proper, below the title row: the sidebar column and the
+          content column, still flex siblings so the sidebar's `peer` selectors
+          and its in-flow width gap keep working. */}
+      <div className="flex w-full min-h-0 flex-1">
+      <Sidebar
+        collapsible="icon"
+        // The sidebar's container is `fixed inset-y-0 h-svh` — it positions
+        // against the VIEWPORT, so a title row placed above it in the flow does
+        // not push it down and the column would slide underneath the bar. This
+        // is the offset that puts it back, as inline style rather than a class
+        // because `top-*` and `h-*` would be fighting `inset-y-0` and `h-svh`
+        // on the same element and the winner would come down to stylesheet
+        // order.
+        style={{
+          top: WINDOW_TITLE_BAR_HEIGHT,
+          height: `calc(100svh - ${WINDOW_TITLE_BAR_HEIGHT}px)`,
+        }}
+      >
         <SidebarHeader>
-          {/* macOS floats the traffic lights over this corner once the window
-              gives up its title bar, and this corner is the company switcher.
-              Reserve the strip they land in, and let it drag. Renders nothing
-              anywhere else — see `window-chrome.tsx`. */}
-          <WindowControlsInset />
-          {/* The header is the column talking about itself: which host this
-              console is looking at, the utilities that act on the console
-              rather than on the company, and whether the column is showing.
-              Everything BELOW it — the nav group and the footer's standing
-              controls — is the company. Collapse used to be the first row under
-              the switcher, which put a chrome control at the head of a list of
-              destinations and made it read as one (issue #1177); it now sits on
-              the utility bar with the three other controls of its kind.
-
-              `flex-col` on the rail is not a preference. The collapsed column
-              is `--sidebar-width-icon` (3rem) and this block is `p-2`, leaving
-              32px — the exact width of the switcher's glyph, with nothing left
-              over to put beside it. See `SidebarCollapseButton`. */}
-          <div className="flex items-center gap-1.5 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:gap-1">
-            {/* Which host, and how every host is doing. It leads because it
-                names where you are — the first thing the column should answer
-                — and it is the only control here that can take you somewhere
-                else entirely. See `host-switcher.tsx`; it replaced the icon
-                rail that used to stand outside this sidebar (issue #1142).
-
-                `min-w-0` so the nameplate truncates instead of pushing the
-                button off the end of a 13.5rem column. */}
-            <div className="min-w-0 flex-1 group-data-[collapsible=icon]:w-full group-data-[collapsible=icon]:flex-none">
-              <HostSwitcher
-                companyName={feed.status.name}
-                // The company's lifecycle, and every company on this host:
-                // both were rows in the sidebar footer, and both are facts
-                // about *which company you are in* — which is what this control
-                // is. See `HostSwitcher`'s `companyState` for why the lifecycle
-                // is not folded into the connection dot.
-                companyState={lifecycle(feed.status.lifecycle, feed.status.emergency_paused)}
-                companies={companies}
-                activeCompany={company}
-                onSwitchCompany={onSwitchCompany}
-                onBackToPicker={onBackToPicker}
-                onCreateCompany={onCreateCompany}
-                canCreateCompany={client.carriesPlatformBearer}
-              />
-            </div>
-          </div>
-          {/* Directly under the switcher: Settings, Feedback, Discord and
-              Collapse, as one bar of icons rather than four full-width rows
-              spread across the nav and the footer. See `SidebarUtilityBar`. */}
+          {/* What is left of the header once the switcher moved up into the
+              title row: Settings, Feedback, Discord and Collapse, as one bar of
+              icons rather than four full-width rows spread across the nav and
+              the footer. See `SidebarUtilityBar`. */}
           <SidebarUtilityBar view={view} onNavigate={setView} />
         </SidebarHeader>
         <nav aria-label="Main navigation" className="flex min-h-0 flex-1 flex-col">
           <SidebarContent data-tour="sidebar">
           <SidebarNavigation view={view} pending={pending} onNavigate={setView} />
         </SidebarContent>
-        <SidebarFooter>
-          {/* Who you are signed in as, and nothing else.
-
-              The lifecycle row and the "Switch company" row that used to stand
-              here have both moved into the host switcher at the top of the
-              column — see its `companyState` and its Companies group. Both were
-              answers to "which company am I in, and how is it doing", asked at
-              the opposite end of the sidebar from the control that names it.
-
-              It renders nothing where there is nobody to name — a host with no
-              sign-in, or a session that has just gone. */}
-          <ProfileRow client={client} company={company} />
-        </SidebarFooter>
         </nav>
         <SidebarRail />
       </Sidebar>
@@ -3908,6 +3910,7 @@ export function AppShell({
           <SidebarTrigger aria-label="Toggle sidebar" />
         </div>
       </SidebarInset>
+      </div>
 
       <FeedbackDialog
         client={client}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -3424,7 +3424,18 @@ export function AppShell({
           // What the agents in this company are allowed to do without asking.
           // Renders nothing until the host has said, rather than guessing a
           // tier — see `useAutonomy`.
-          <AutonomyPill status={autonomy} />
+          //
+          // `canManage` is the role this shell already knows. Both write
+          // routes behind the pill call `require_admin`
+          // (`src/server/ops/policy.rs:309,427`), so without it a member was
+          // offered a menu whose every selection ends in a 403. The pill still
+          // STATES the tier for them — standing policy is a fact about what
+          // the agents around you may do, not an admin setting — it simply
+          // stops pretending to be a control. `null` while `fetchMe` is in
+          // flight reads as read-only, which is the safe direction: it hides
+          // an affordance for one round trip rather than offering one that
+          // cannot work.
+          <AutonomyPill status={autonomy} canManage={isGateAdmin} />
         }
         profile={
           // Who you are signed in as, and nothing else. It renders nothing

--- a/frontend/src/components/autonomy-pill.tsx
+++ b/frontend/src/components/autonomy-pill.tsx
@@ -206,6 +206,15 @@ export function leadSentence(description: string): string {
  * in both places, for the same reason: pulling capability back is what an
  * operator does in a hurry.
  *
+ * **It is a control only for the people who can actually use it.** The two
+ * write routes behind it — `PUT` and `DELETE {scope}/policy` — both call
+ * `require_admin` (`src/server/ops/policy.rs:309,427`), so a member picking a
+ * tier here was guaranteed a 403 and a red toast. `read_policy` carries no such
+ * guard, and deliberately: the standing policy is a fact about what the agents
+ * around you may do, and the people living under it are exactly who should be
+ * able to read it. So a member gets the pill, the tier and the host's sentence,
+ * and no menu — see the `canManage` prop.
+ *
  * `client` and `company` come from {@link useConsole} rather than props: the
  * shell mounts this element inside its own `ConsoleProvider`, and the title row
  * between them (`WindowTitleBar`) is a pure layout component that takes the
@@ -222,14 +231,46 @@ const TRIGGER_ID = "autonomy-pill-trigger";
 
 export function AutonomyPill({
   status,
+  canManage = null,
   className,
 }: {
   /** The effective policy, or `null` when it is not known. */
   status: PolicyStatus | null;
+  /**
+   * Whether this operator may actually change the policy — the shell's
+   * `isGateAdmin`, passed straight through.
+   *
+   * **Three states, and `null` is read-only.** `set_policy` and `clear_policy`
+   * both call `require_admin` (`src/server/ops/policy.rs:309,427`), so every
+   * selection a member makes is a guaranteed 403; offering the menu to one is
+   * a control that exists only to fail. `read_policy` has no such guard, which
+   * is why the tier is still *stated* — hiding standing policy from the people
+   * living under it would be the worse regression, and this component exists to
+   * state it.
+   *
+   * `null` — the role read is still in flight — is treated as read-only rather
+   * than as permission, for the same reason the tier itself renders nothing
+   * while it is unknown (see `useAutonomy`): a control on screen is a
+   * claim that you may use it, and the console does not yet know that. The
+   * window is one `fetchMe` round trip, after which an admin's menu appears;
+   * the alternative direction hands a member a menu and a 403.
+   */
+  canManage?: boolean | null;
   className?: string;
 }) {
   const { client, company } = useConsole();
   const [saving, setSaving] = useState(false);
+  /**
+   * Whether this pill is a control at all, as opposed to a statement.
+   *
+   * Two independent reasons it may not be, and they are deliberately folded
+   * into one flag because they produce the same rendering: there is nobody to
+   * write as (no authenticated client — a styleguide page, or a session that
+   * has gone), or the person signed in is not an admin and the host would
+   * refuse. `saving` is NOT folded in: an in-flight write disables the trigger
+   * without making the pill a non-control, so the chevron stays.
+   */
+  const writable = Boolean(client) && canManage === true;
   /**
    * The wider tier the operator picked and has not yet agreed to, or `null`.
    *
@@ -242,7 +283,14 @@ export function AutonomyPill({
     PolicyStatus["tiers"][number] | null
   >(null);
   const write = async (mode: string): Promise<boolean> => {
-    if (!status || !client || saving || mode === status.mode) return false;
+    // `!writable` is the real guard, and covers `!client` and a non-admin
+    // alike. Belt and braces with the disabled trigger: the menu is
+    // unreachable for a read-only pill, so this is what holds if a future
+    // refactor makes it reachable.
+    //
+    // `!client` is restated only so TypeScript narrows it for the `setPolicy`
+    // calls below — a boolean derived from it carries no narrowing.
+    if (!status || !writable || !client || saving || mode === status.mode) return false;
     setSaving(true);
     try {
       // Only `mode` is sent. An omitted field is left alone by the host, so
@@ -298,7 +346,7 @@ export function AutonomyPill({
     // Selecting what is already in force is a no-op, not a redundant write: the
     // PUT is attributed and durable, so it would record an operator "changing"
     // the policy to the value it already had.
-    if (!status || !client || saving || tier.value === status.mode) return;
+    if (!status || !writable || saving || tier.value === status.mode) return;
     if (widensAutonomy(status.tiers, status.mode, tier.value)) {
       setConfirming(tier);
       return;
@@ -320,11 +368,17 @@ export function AutonomyPill({
         <DropdownMenuTrigger
           id={TRIGGER_ID}
           data-testid="autonomy-pill"
-          // No client means no authenticated write — the pill still states the
-          // tier, it just cannot change it. Disabled rather than hidden, for the
-          // reason the switcher's "New company" row is: a control that vanishes
-          // teaches nothing.
-          disabled={!client || saving}
+          // No client, or not an admin — the pill still states the tier, it
+          // just cannot change it. Disabled rather than hidden, for the reason
+          // the switcher's "New company" row is: a control that vanishes
+          // teaches nothing, and a member who cannot see the standing policy
+          // cannot know what the agents around them are allowed to do.
+          disabled={!writable || saving}
+          // So a test — and a screen reader, through `aria-disabled`, which
+          // Base UI's trigger sets from `disabled` — can tell "states the
+          // policy" apart from "changes it" without inferring it from the
+          // absence of a chevron.
+          data-readonly={writable ? undefined : "true"}
           // The host's full sentence, unabridged, for the tier in force. A native
           // `title` rather than the tooltip component: the trigger already owns a
           // popup, and a tooltip on the same element fights it for the press.
@@ -364,10 +418,16 @@ export function AutonomyPill({
               {leadSentence(description)}
             </span>
           )}
-          {/* The only thing on the pill that says it is a control. It never
-              drops: the affordance has to survive the narrow window that already
-              hid the sentence. */}
-          <ChevronDown aria-hidden="true" className="size-3 flex-none opacity-60" />
+          {/* The only thing on the pill that says it is a control — so it is
+              drawn exactly when the pill IS one. It never drops for width: the
+              affordance has to survive the narrow window that already hid the
+              sentence. It does drop when there is nothing behind it, because a
+              chevron on a pill that opens no menu is the affordance lying, and
+              a member who presses it learns only that the console offered them
+              something the host refuses. */}
+          {writable && (
+            <ChevronDown aria-hidden="true" className="size-3 flex-none opacity-60" />
+          )}
         </DropdownMenuTrigger>
         {/* `align="end"`: the pill sits at the right-hand end of the row, beside
             the profile control, and a menu this wide anchored to its start would

--- a/frontend/src/components/autonomy-pill.tsx
+++ b/frontend/src/components/autonomy-pill.tsx
@@ -1,0 +1,503 @@
+// The standing autonomy policy, stated in the window's title row — and, since
+// the operator asked for it, changed from there too.
+//
+// This is a claim about what the agents are allowed to do without asking, so
+// every word of it is read from the host rather than written here. Three
+// findings shaped what it does and does not say, and they still govern what the
+// menu is allowed to put in front of an operator:
+//
+// **The tier is one of four, not two.** `POLICY_MODES` in
+// `src/company/types.rs:96` is `["readonly", "supervised", "auto", "full"]`.
+// Flattening that to "Auto / not Auto" would report `readonly` — agents that
+// change nothing and spend nothing — and `full` — the broadest autonomy this
+// runtime has — as the same thing. The menu therefore lists whatever
+// `status.tiers` holds and never a list of four written here.
+//
+// **The label and the sentence are the host's**, taken from the `tiers` list
+// `GET {scope}/policy` returns. That list is filtered server-side to the modes
+// *this* runtime accepts (`selectable_tiers`, `src/server/ops/policy.rs:153`),
+// and its prose lives in `TIER_TEXT` (`policy.rs:121`) precisely so it cannot
+// drift from the gate it describes. A console built against a newer host names
+// a tier it has no text for by its mode word rather than dropping it — and,
+// now that the menu is a control, *offers* it rather than dropping it, because
+// a tier the host will accept that the console will not show is a capability
+// silently withheld.
+//
+// **It deliberately says nothing about spending.** The obvious sentence here —
+// "agents stop before spending" — is false in this build, and so is any
+// rendering of `autoApproveUnderUsd`. The native gate is constructed
+// `.with_policy_hitl_disabled()` (`src/runtime/builder.rs:2476`), and with that
+// flag `evaluate` returns `Allow` for everything except `readonly` *before* it
+// reaches the tier match or the spend threshold (`src/policy/gate.rs:749-757`);
+// the tool path short-circuits the same way at
+// `src/harness/built_in/policy.rs:1701`, above `always_approve`, the per-agent
+// daily budget and `auto_approve_under_usd`. The console already says this out
+// loud on the settings page, where the field is labelled "Spend approval
+// threshold (inactive)" and disabled (`policy-settings.tsx:917`). A number that
+// governs nothing is exactly the placeholder this row must not carry, so the
+// pill carries the tier and the host's own words about it, and stops there.
+//
+// It renders **nothing** when the policy is unknown. See {@link useAutonomy}.
+
+import { useState } from "react";
+import {
+  Check,
+  ChevronDown,
+  Eye,
+  Infinity as InfinityIcon,
+  ShieldCheck,
+  UserCheck,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { setPolicy, type PolicyStatus } from "@/api/policy";
+import {
+  AUTONOMY_CONFIRM_ACTION,
+  AUTONOMY_CONFIRM_CANCEL,
+  AUTONOMY_CONFIRM_TITLE,
+  AUTONOMY_PROMPTS_NOTE,
+  tierWideningExplanation,
+  widensAutonomy,
+} from "@/components/policy-settings";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { applyAutonomy } from "@/hooks/use-autonomy";
+import { useConsole } from "@/lib/console-context";
+import { cn } from "@/lib/utils";
+
+/** The host's word for the tier in force, falling back to the mode itself. */
+export function tierLabel(status: PolicyStatus): string {
+  return status.tiers.find((tier) => tier.value === status.mode)?.label ?? status.mode;
+}
+
+/** The host's full description of the tier in force, when it ships one. */
+export function tierDescription(status: PolicyStatus): string | null {
+  return status.tiers.find((tier) => tier.value === status.mode)?.description ?? null;
+}
+
+/**
+ * One glyph per mode word, keyed by the word and never by position.
+ *
+ * Position would be the easy mapping and the wrong one: `status.tiers` is
+ * whatever *this* host accepts, so a runtime that drops `full`, or inserts a
+ * tier between two existing ones, would silently re-point every icon at a
+ * different meaning. The key is the mode word the gate itself matches on.
+ *
+ * The four read as increasing autonomy, and each was picked for the thing the
+ * host's own description says the tier does rather than for how alarming it
+ * ought to look:
+ *
+ * - `readonly` — {@link Eye}: it may look. The whole tier is "observation, no
+ *   effect", and an eye is the one glyph that says that without saying "safe".
+ * - `supervised` — {@link UserCheck}: a person is in the loop. The distinction
+ *   from `auto` is not how much the agents do, it is that somebody signs off,
+ *   so the icon carries the person rather than a smaller amount of work.
+ * - `auto` — {@link Zap}: it acts on its own. The step from `supervised` is the
+ *   human leaving the loop, and a bolt is "this happens by itself".
+ * - `full` — {@link InfinityIcon}: no ceiling. It is the *widest* tier, not the
+ *   most dangerous one, and infinity says "nothing further to remove" while a
+ *   warning triangle or a flame would say something the host does not.
+ *
+ * Colour deliberately stays neutral for the same reason. `--status-*` tokens
+ * mean *state* — running, blocked, failed — and no tier here is any of those;
+ * painting `full` as a warning would be the console inventing a risk judgement
+ * the host does not make.
+ */
+const TIER_ICONS: Record<string, LucideIcon> = {
+  readonly: Eye,
+  supervised: UserCheck,
+  auto: Zap,
+  full: InfinityIcon,
+};
+
+/**
+ * The glyph for a mode word, or the neutral shield for one this console has
+ * never heard of.
+ *
+ * The fallback is load-bearing rather than defensive tidiness: the tier list is
+ * the host's, so a console running against a newer runtime *will* meet a mode
+ * with no entry here, and it must draw that row — with the host's own label and
+ * sentence beside it — rather than a hole or a crash.
+ */
+export function tierIcon(mode: string): LucideIcon {
+  return TIER_ICONS[mode] ?? ShieldCheck;
+}
+
+/**
+ * The host's description cut to its first sentence, for the row itself.
+ *
+ * A **mechanical** cut, not a summary. The host's `auto` text is 114 characters
+ * — "Balanced execution autonomy. Approval prompts are explicit through
+ * `request_approval` while policy HITL is disabled." — which is a paragraph, not
+ * a title-bar clause, and rewriting it shorter is the one thing this component
+ * must not do: the prose is server-side so that it tracks the gate, and a
+ * paraphrase here would be a second description free to drift.
+ *
+ * Taking the leading sentence keeps every word the host's own and keeps the
+ * full text one hover away. If the description has no sentence break it is used
+ * whole, and the row's own `hidden lg:inline` decides whether there is space
+ * for it at all.
+ *
+ * The **menu** does not use this. A row in an opened dropdown has the space for
+ * the whole sentence and an operator about to change what the agents may do
+ * should read all of it.
+ */
+export function leadSentence(description: string): string {
+  const end = description.indexOf(". ");
+  return end === -1 ? description : description.slice(0, end + 1);
+}
+
+/**
+ * The autonomy pill: what the agents may do, and the control that changes it.
+ *
+ * It used to be a `<span>` with no click target, on the argument that the row
+ * it sits in is the window's drag surface and a button here would take presses
+ * away from dragging. That was reversed deliberately: the tier is the fact this
+ * row exists to carry, and the shortest path from reading it to changing it is
+ * the thing an operator reaches for when a company is doing something they want
+ * stopped.
+ *
+ * **The drag band survives it.** `data-tauri-drag-region` is opt-in per element
+ * and does not inherit, so the attribute is simply removed from the pill rather
+ * than fought with: `WindowTitleBar` already puts a dedicated `flex-1`
+ * `self-stretch` spacer carrying its own `data-tauri-drag-region` between the
+ * company switcher and this pill, and that spacer — not the pill — is the
+ * elastic part of the row. Every other item in the row (the switcher, the
+ * profile control) is likewise a control the drag band goes around. Giving the
+ * pill its pointer events back costs the window a fixed ~200px of grab area at
+ * the right-hand end and none of the elastic middle, which is where a window is
+ * actually dragged from.
+ *
+ * **The displayed tier is only ever a value the host returned.** The write goes
+ * through `setPolicy`, which answers with the resulting `PolicyStatus`; that
+ * answer is handed to {@link applyAutonomy} so the row updates in one round
+ * trip instead of waiting up to 30s for the next poll. Nothing is written
+ * optimistically and nothing is written on failure, so a rejected change leaves
+ * the previous tier on screen and says why in a toast. A pill that lied about
+ * what the agents are allowed to do is the one failure this component cannot
+ * have.
+ *
+ * **Widening the tier is confirmed here exactly as it is on the settings page.**
+ * `policy-settings.tsx` has put an `AlertDialog` in front of any move *up* the
+ * host's tier order since #1423, and this control reuses that comparison and
+ * that wording rather than restating either. Without it the title bar would be
+ * a strictly lower-friction route to the broadest autonomy this runtime has
+ * than the page that was deliberately given the gate — which is not a
+ * difference in style, it is the gate not being there. Narrowing is one click
+ * in both places, for the same reason: pulling capability back is what an
+ * operator does in a hurry.
+ *
+ * `client` and `company` come from {@link useConsole} rather than props: the
+ * shell mounts this element inside its own `ConsoleProvider`, and the title row
+ * between them (`WindowTitleBar`) is a pure layout component that takes the
+ * pill as an opaque `ReactNode` and knows nothing about policy.
+ */
+/**
+ * The trigger's DOM id, so the confirmation dialog can hand focus back to it.
+ *
+ * A constant rather than `useId`: there is exactly one title row per window, so
+ * a per-instance id buys nothing, and a stable string is what makes the
+ * `finalFocus` lookup readable.
+ */
+const TRIGGER_ID = "autonomy-pill-trigger";
+
+export function AutonomyPill({
+  status,
+  className,
+}: {
+  /** The effective policy, or `null` when it is not known. */
+  status: PolicyStatus | null;
+  className?: string;
+}) {
+  const { client, company } = useConsole();
+  const [saving, setSaving] = useState(false);
+  /**
+   * The wider tier the operator picked and has not yet agreed to, or `null`.
+   *
+   * Holding the *tier* rather than a boolean is what lets the dialog quote the
+   * host's own description of the thing being agreed to, and it is the only
+   * record of the choice: nothing is written while it sits here, so dismissing
+   * the dialog discards it and the row keeps stating the tier actually in force.
+   */
+  const [confirming, setConfirming] = useState<
+    PolicyStatus["tiers"][number] | null
+  >(null);
+  const write = async (mode: string): Promise<boolean> => {
+    if (!status || !client || saving || mode === status.mode) return false;
+    setSaving(true);
+    try {
+      // Only `mode` is sent. An omitted field is left alone by the host, so
+      // picking a tier here cannot silently discard the always-ask list, the
+      // spend cap or the deadline — the same contract the settings page relies
+      // on (`policy-settings.tsx` `saveTier`).
+      const next = await setPolicy(client, company, { mode });
+      applyAutonomy(client, company, next);
+      // The host's own timing sentence, not a paraphrase: a tier change lands
+      // on the NEXT turn, and an operator changing the tier because something
+      // is running right now needs to know that turn finishes under the old
+      // one. The settings page shows the same line; changing the tier from the
+      // title bar must not be the quieter path to the same act.
+      toast.success("Autonomy tier updated", {
+        description: `Takes effect ${next.takesEffect}.`,
+      });
+      return true;
+    } catch (error) {
+      // Visible, and matching every other mutation in the console (`sonner`).
+      // Silence here would read as success and leave the operator believing a
+      // tier is in force that is not.
+      toast.error(error instanceof Error ? error.message : "Could not change the tier.");
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  /**
+   * What a menu row does — which is not, for a widening, to write anything.
+   *
+   * **Widening is confirmed; narrowing is not.** The settings page has drawn
+   * that line since #1423 and this is the same line, drawn with the same
+   * comparison ([`widensAutonomy`]) against the same host-supplied tier order,
+   * because a second route to the broadest autonomy this runtime has that
+   * skipped the gate would make the title bar the cheap way around the page
+   * that was deliberately given one. Narrowing stays a single click on purpose:
+   * taking capability *away* is what an operator does mid-incident, and
+   * friction there is friction in the wrong direction.
+   *
+   * A tier neither this console nor the host can order — an unknown current
+   * mode — widens nothing by this comparison and so is written directly. That
+   * is the settings page's behaviour too, and changing it here would mean the
+   * two pages disagreed about what counts as an escalation.
+   */
+  const choose = (tier: PolicyStatus["tiers"][number]) => {
+    // Selecting what is already in force is a no-op, not a redundant write: the
+    // PUT is attributed and durable, so it would record an operator "changing"
+    // the policy to the value it already had.
+    if (!status || !client || saving || tier.value === status.mode) return;
+    if (widensAutonomy(status.tiers, status.mode, tier.value)) {
+      setConfirming(tier);
+      return;
+    }
+    void write(tier.value);
+  };
+
+  // Unknown renders nothing at all. A placeholder tier would be a confident
+  // sentence about what the agents may do, written at the moment we do not
+  // know — see `useAutonomy`.
+  if (!status) return null;
+
+  const description = tierDescription(status);
+  const CurrentIcon = tierIcon(status.mode);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          id={TRIGGER_ID}
+          data-testid="autonomy-pill"
+          // No client means no authenticated write — the pill still states the
+          // tier, it just cannot change it. Disabled rather than hidden, for the
+          // reason the switcher's "New company" row is: a control that vanishes
+          // teaches nothing.
+          disabled={!client || saving}
+          // The host's full sentence, unabridged, for the tier in force. A native
+          // `title` rather than the tooltip component: the trigger already owns a
+          // popup, and a tooltip on the same element fights it for the press.
+          title={description ?? undefined}
+          className={cn(
+            // `flex-none`: it is a direct child of the title row's flex container,
+            // and it must not be shrunk into an unreadable sliver by a long company
+            // name. The sentence inside it is dropped at a breakpoint instead.
+            //
+            // `py-1.5` (was `py-0.5`): at `text-xs` that is a 30px pill, which
+            // sits in the 52px row rather than looking pressed into it. It stays
+            // well under the row height, which `WINDOW_TITLE_BAR_HEIGHT` fixes at
+            // 52 for the traffic lights' centre line.
+            "inline-flex flex-none items-center gap-1.5 rounded-full border bg-card px-2.5 py-1.5",
+            "text-xs font-medium text-muted-foreground",
+            "transition-colors hover:bg-accent hover:text-accent-foreground",
+            "data-popup-open:bg-accent data-popup-open:text-accent-foreground",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "disabled:cursor-default",
+            className,
+          )}
+        >
+          <CurrentIcon aria-hidden="true" className="size-3.5 flex-none" />
+          {/* The tier's name. The last thing to go: a pill that has dropped its
+              sentence still says which tier is in force, which is the fact this
+              element exists to carry. */}
+          <span className="flex-none text-foreground">{tierLabel(status)}</span>
+          {/* The host's leading sentence. First to go as the window narrows — see
+              the degradation note on `WindowTitleBar`. `hidden` rather than
+              truncated, because half a sentence about what the agents may do is
+              worse than none: it would still read as a complete claim. */}
+          {description && (
+            <span
+              data-testid="autonomy-consequence"
+              className="hidden whitespace-nowrap lg:inline"
+            >
+              {leadSentence(description)}
+            </span>
+          )}
+          {/* The only thing on the pill that says it is a control. It never
+              drops: the affordance has to survive the narrow window that already
+              hid the sentence. */}
+          <ChevronDown aria-hidden="true" className="size-3 flex-none opacity-60" />
+        </DropdownMenuTrigger>
+        {/* `align="end"`: the pill sits at the right-hand end of the row, beside
+            the profile control, and a menu this wide anchored to its start would
+            hang off the window on an 880px minimum. `w-80` overrides the
+            primitive's default `w-(--anchor-width)` — the trigger shrinks to the
+            tier name below `lg`, and a menu that shrank with it could not hold a
+            sentence. */}
+        <DropdownMenuContent align="end" side="bottom" className="w-80 rounded-lg">
+          <DropdownMenuGroup>
+            {/* `DropdownMenuLabel` is Base UI's `Menu.GroupLabel`, and it throws
+                outside a `Menu.Group`. */}
+            <DropdownMenuLabel>Autonomy</DropdownMenuLabel>
+            {/* Every tier the host offers, in the order it returned them — which
+                is increasing autonomy. Never a list written here: see the header. */}
+            {status.tiers.map((tier) => {
+              const TierIcon = tierIcon(tier.value);
+              const current = tier.value === status.mode;
+              return (
+                <DropdownMenuItem
+                  key={tier.value}
+                  data-testid={`autonomy-tier-${tier.value}`}
+                  // `aria-current`, and a `Check`, exactly as the host switcher
+                  // marks the company you are already in.
+                  aria-current={current}
+                  onClick={() => choose(tier)}
+                  className="items-start gap-2 py-1.5"
+                >
+                  <TierIcon aria-hidden="true" className="mt-0.5 size-4 flex-none" />
+                  <span className="min-w-0 flex-1">
+                    <span className={cn("block", current && "font-medium")}>
+                      {tier.label}
+                    </span>
+                    {/* The host's description in full, not `leadSentence`: an
+                        open menu has the room, and this is the moment the words
+                        actually matter. */}
+                    <span className="mt-0.5 block text-xs whitespace-normal text-muted-foreground">
+                      {tier.description}
+                    </span>
+                  </span>
+                  {current && (
+                    <Check aria-hidden="true" className="mt-0.5 size-4 flex-none" />
+                  )}
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          {/* The host's own timing sentence, on the menu rather than only in the
+              toast that follows a change: an operator deciding whether to pull
+              the tier down mid-incident needs to know a running turn finishes
+              under the old tier BEFORE they choose, not after. */}
+          <div
+            data-testid="autonomy-takes-effect"
+            className="px-1.5 py-1 text-xs text-muted-foreground"
+          >
+            Takes effect {status.takesEffect}.
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {/* The same gate the settings page puts in front of the same decision,
+          in the same words and the same primitive — see
+          `AUTONOMY_CONFIRM_TITLE` and its neighbours in `policy-settings.tsx`.
+          Deliberately NOT a title-bar-flavoured variant of it: an operator who
+          has met this dialog on the settings page should recognise it here as
+          the same commitment rather than read a second sentence and wonder
+          what is different about it.
+
+          Controlled, and rendered as a sibling of the menu rather than inside
+          it: the menu unmounts its rows the moment one is pressed, so a dialog
+          living under a row would be torn down with the row that opened it. */}
+      <AlertDialog
+        open={confirming !== null}
+        onOpenChange={(open) => {
+          // A PUT is in flight — keep the dialog up. Escape and outside-click
+          // still reach here (the confirm action stops the primitive's own
+          // Close), and dismissing now would let the request land under a
+          // dialog the operator believes they cancelled.
+          if (!open) {
+            if (saving) return;
+            // Cancelling writes NOTHING: the tier on the row is `status`,
+            // which only ever came from the host, and it is untouched.
+            setConfirming(null);
+          }
+        }}
+      >
+        {/* No `finalFocus`: the settings page has to name one because its
+            dialog is opened from a radio that may not be the one left checked,
+            but here the menu has already returned focus to the pill by the time
+            the dialog closes, and the pill is where an operator who just backed
+            out expects to be. Asserted, not assumed — see the focus check in
+            `autonomy-pill.test.ts`. */}
+        <AlertDialogContent
+          // Where focus goes when the dialog closes, named explicitly — the
+          // settings page names its own target for the same reason. Without one
+          // Base UI leaves focus on `<body>`, which strands a keyboard operator
+          // mid-row after cancelling; asserting focus without it failed 6 runs in
+          // 12. Looked up by id rather than held in a ref because
+          // `DropdownMenuTrigger`'s `render` prop does not forward one. The
+          // element is the trigger they pressed to get here and is still mounted,
+          // because closing the dialog changes nothing about the pill.
+          finalFocus={() => document.getElementById(TRIGGER_ID)}
+        >
+          <AlertDialogHeader>
+            <AlertDialogTitle>{AUTONOMY_CONFIRM_TITLE}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirming
+                ? tierWideningExplanation(description ?? undefined, confirming)
+                : null}
+            </AlertDialogDescription>
+            <p className="text-sm text-muted-foreground">
+              {AUTONOMY_PROMPTS_NOTE}
+            </p>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel data-testid="autonomy-tier-cancel" disabled={saving}>
+              {AUTONOMY_CONFIRM_CANCEL}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              data-testid="autonomy-tier-confirm"
+              disabled={saving}
+              onClick={(event) => {
+                // The primitive's `Close` would dismiss the dialog before the
+                // PUT resolves; a failed write has to keep it open for the
+                // retry rather than closing on a change that did not happen.
+                event.preventBaseUIHandler();
+                if (!confirming) return;
+                void write(confirming.value).then((saved) => {
+                  if (saved) setConfirming(null);
+                });
+              }}
+            >
+              {AUTONOMY_CONFIRM_ACTION}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/frontend/src/components/autonomy-pill.tsx
+++ b/frontend/src/components/autonomy-pill.tsx
@@ -52,7 +52,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
-import { setPolicy, type PolicyStatus } from "@/api/policy";
+import { isPolicyStatus, NOT_A_POLICY, setPolicy, type PolicyStatus } from "@/api/policy";
 import {
   AUTONOMY_CONFIRM_ACTION,
   AUTONOMY_CONFIRM_CANCEL,
@@ -250,6 +250,12 @@ export function AutonomyPill({
       // spend cap or the deadline — the same contract the settings page relies
       // on (`policy-settings.tsx` `saveTier`).
       const next = await setPolicy(client, company, { mode });
+      // A PUT that answers 200 with something that is not a policy is a failed
+      // write, not a successful one: the sentence below would read "Takes
+      // effect undefined", and the value would go on to be rendered. Throwing
+      // hands it to the `catch` below, which is where a failed write already
+      // goes.
+      if (!isPolicyStatus(next)) throw new Error(NOT_A_POLICY);
       applyAutonomy(client, company, next);
       // The host's own timing sentence, not a paraphrase: a tier change lands
       // on the NEXT turn, and an operator changing the tier because something

--- a/frontend/src/components/content-surface.tsx
+++ b/frontend/src/components/content-surface.tsx
@@ -66,7 +66,7 @@ export function ContentSurface({ children }: { children: ReactNode }) {
   return (
     <div className={CARD} data-testid="content-surface">
       {/* No drag band here any more.
-          
+
           This card carried one because the window drew no title bar of its own,
           so the top of the content was the only thing left to grab. There is a
           real full-width title row now (`window-title-bar.tsx`), which drags

--- a/frontend/src/components/content-surface.tsx
+++ b/frontend/src/components/content-surface.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-import { WindowDragBar } from "@/components/window-chrome";
 
 /**
  * The console's single content sheet — the "card" half of the two-layer shell
@@ -55,25 +54,26 @@ import { WindowDragBar } from "@/components/window-chrome";
  */
 const CARD =
   "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden " +
-  "m-(--frame-inset) rounded-2xl border border-chrome-border bg-background shadow-sm";
+  // `--frame-inset` on three sides, and a thinner top.
+  //
+  // The frame used to be one quantity because nothing sat above the card. The
+  // title row does now, so a full inset there stacks the row's own bottom
+  // padding on top of the card's margin and reads as a gap twice the size of
+  // the one on the other three edges — which is what it is.
+  "mx-(--frame-inset) mb-(--frame-inset) mt-0.5 rounded-2xl border border-chrome-border bg-background shadow-sm";
 
 export function ContentSurface({ children }: { children: ReactNode }) {
   return (
     <div className={CARD} data-testid="content-surface">
-      {/* The desktop window draws no title bar of its own, so the top of this
-          card is what a person reaches for to move the window — see
-          `window-chrome.tsx`. It renders nothing in a browser, and nothing off
-          macOS, where the native bar is still there.
-
-          Over the card rather than the whole window: the sidebar's own strip
-          drags in place, and a band spanning both would sit on top of the
-          switcher. The cost is that a page's top 28px stops taking a press,
-          which is only visible on the two canvases you can drag — the graph and
-          the workflow editor — and both have the rest of the sheet to grab.
-          OpenHuman's `WindowDragBar` makes the same trade for the same reason.
-
-          `CARD` is already `relative`, which is what this positions against. */}
-      <WindowDragBar />
+      {/* No drag band here any more.
+          
+          This card carried one because the window drew no title bar of its own,
+          so the top of the content was the only thing left to grab. There is a
+          real full-width title row now (`window-title-bar.tsx`), which drags
+          where it is not covered by a control — so this band stopped being the
+          handle and stayed only as 28px at the top of every page that quietly
+          refused a press. It was the spacing under the new row, and the reason
+          the two canvases you can drag lost their top edge. */}
       {children}
     </div>
   );

--- a/frontend/src/components/host-switcher.tsx
+++ b/frontend/src/components/host-switcher.tsx
@@ -188,13 +188,16 @@ interface Props {
   /**
    * Which chrome this is drawn in.
    *
-   * `sidebar` is the home: the header row of the app shell. `standalone` is for
-   * the screens that have no shell — a host that cannot be reached, a sign-in,
-   * the desktop's "no host to show" — where the switcher is the only way back
-   * to a host that works, and where its absence is what stranded an operator
-   * when the rail was the one holding it.
+   * `titlebar` is the home: the window's full-width title row, right of the
+   * traffic lights and left of everything else. `sidebar` is where that trigger
+   * used to live — the header row of the app shell — and is kept for any chrome
+   * that still hands the switcher a column to sit in. `standalone` is for the
+   * screens that have no shell — a host that cannot be reached, a sign-in, the
+   * desktop's "no host to show" — where the switcher is the only way back to a
+   * host that works, and where its absence is what stranded an operator when
+   * the rail was the one holding it.
    */
-  variant?: "sidebar" | "standalone";
+  variant?: "sidebar" | "standalone" | "titlebar";
   /**
    * The company on screen, when there is one.
    *
@@ -272,11 +275,13 @@ export function HostSwitcher({
         data-testid="host-switcher-status"
         className={cn(
           "absolute -right-0.5 -bottom-0.5 size-2.5 rounded-full ring-2",
-          // The ring is a CUT-OUT of the ground, and the two variants stand on
+          // The ring is a CUT-OUT of the ground, and the variants stand on
           // different grounds (issue #1178). In the shell the trigger has no
-          // fill at rest, so half this ring lands on the window chrome; the
-          // standalone console draws its own `bg-sidebar` card behind it.
-          variant === "sidebar" ? "ring-chrome" : "ring-sidebar",
+          // fill at rest, so half this ring lands on the window chrome — true
+          // of the title row as much as of the sidebar column, both of which
+          // are the one `bg-chrome` layer showing through. Only the standalone
+          // console draws its own `bg-sidebar` card behind it.
+          variant === "standalone" ? "ring-sidebar" : "ring-chrome",
           STATUS_COPY[worst].dot,
         )}
       />
@@ -355,6 +360,21 @@ export function HostSwitcher({
   };
 
   if (!menu) {
+    // A nameplate with nothing to open. In the title row that is a plain box
+    // rather than a sidebar menu item: the row is not a column of rows, and a
+    // `SidebarMenuButton` there would bring a full-width `w-full` and a hover
+    // fill that promises a click this case does not have.
+    if (variant === "titlebar") {
+      return (
+        <div
+          className="flex min-w-0 items-center gap-2 px-2 py-1"
+          title={switcherTooltip}
+          {...triggerData}
+        >
+          {nameplate}
+        </div>
+      );
+    }
     return (
       <SidebarMenu>
         <SidebarMenuItem>
@@ -507,6 +527,40 @@ export function HostSwitcher({
       </DropdownMenuItem>
     </DropdownMenuContent>
   );
+
+  if (variant === "titlebar") {
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          // No `aria-label`, for the reason spelled out on the standalone
+          // trigger below: the company's name and its status are the content,
+          // and a label would speak over both.
+          render={
+            <button
+              type="button"
+              // No border, no shadow, no fill at rest. This trigger stands on
+              // the window chrome rather than in a card — it *is* the title row
+              // — so it announces itself on hover and on focus and otherwise
+              // reads as the window naming itself.
+              //
+              // `w-full` against the row's own `max-w-72` cap, not a width of
+              // its own: the cap belongs to the layout that placed it, and a
+              // second width here would be two answers to one question.
+              className="flex w-full min-w-0 items-center gap-2 rounded-lg px-2 py-1 text-left transition hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none data-[popup-open]:bg-sidebar-accent"
+            />
+          }
+          {...triggerData}
+        >
+          {nameplate}
+          {/* Drops rather than flies out to the right: there is no column
+              beside this trigger to open into, and the row it sits in is the
+              top edge of the window. */}
+          <ChevronsUpDown className="ml-auto size-4 shrink-0 text-muted-foreground" />
+        </DropdownMenuTrigger>
+        {renderMenu("bottom")}
+      </DropdownMenu>
+    );
+  }
 
   if (variant === "standalone") {
     return (

--- a/frontend/src/components/host-switcher.tsx
+++ b/frontend/src/components/host-switcher.tsx
@@ -315,6 +315,36 @@ export function HostSwitcher({
       ? STATUS_COPY[worst].label
       : "Not connected";
 
+  // The title row's nameplate is **one line: the company's name**.
+  //
+  // The two-line version belongs in a sidebar column, where vertical space is
+  // free and a caption reads as a label under a heading. In 52px of window
+  // chrome it stood 44px tall, towering over the traffic lights beside it and
+  // making the bar read as unbalanced however the padding was tuned — the
+  // control's height was the problem, not the padding.
+  //
+  // "Current company" is also the right line to lose: the row *is* the current
+  // company, so the caption only repeats what its position already says. A
+  // lifecycle that is **not** running is different — that is news rather than a
+  // label — so it survives beside the name, and only when there is something to
+  // report.
+  const titlebarNameplate = (
+    <>
+      {glyph}
+      <span className="flex min-w-0 flex-1 items-baseline gap-1.5 text-left">
+        <span className="truncate text-sm font-semibold">{primary}</span>
+        {lifecycleTone ? (
+          <span
+            data-testid="host-switcher-secondary"
+            className={cn("truncate text-xs", LIFECYCLE_TEXT[lifecycleTone])}
+          >
+            {secondary}
+          </span>
+        ) : null}
+      </span>
+    </>
+  );
+
   const nameplate = (
     <>
       {glyph}
@@ -371,7 +401,7 @@ export function HostSwitcher({
           title={switcherTooltip}
           {...triggerData}
         >
-          {nameplate}
+          {titlebarNameplate}
         </div>
       );
     }
@@ -551,7 +581,7 @@ export function HostSwitcher({
           }
           {...triggerData}
         >
-          {nameplate}
+          {titlebarNameplate}
           {/* Drops rather than flies out to the right: there is no column
               beside this trigger to open into, and the row it sits in is the
               top edge of the window. */}

--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -93,6 +93,57 @@ export function widensAutonomy(
   return fromIndex !== -1 && toIndex > fromIndex;
 }
 
+/**
+ * The words the widening confirmation is made of, exported because there are
+ * now **two** ways to reach the same decision.
+ *
+ * The tier is also changeable from the window's title row (`AutonomyPill`), and
+ * a second confirmation written there would be a second set of words free to
+ * drift from these — one dialog saying "Give teammates more autonomy?" and
+ * another saying something else about the identical act. The comparison itself
+ * is already shared ([`widensAutonomy`]); this shares the sentence that explains
+ * it, so the two entry points cannot disagree about what is being agreed to.
+ *
+ * Literals and a function rather than a shared component: this page reaches the
+ * same dialog from three different decisions (a tier, a spend-cap raise, a
+ * reset) and only the tier one is shared, so a component would have to carry
+ * all three.
+ */
+export const AUTONOMY_CONFIRM_TITLE = "Give teammates more autonomy?";
+
+/** The cancel label. It names the outcome, not the gesture: nothing changes. */
+export const AUTONOMY_CONFIRM_CANCEL = "Keep current setting";
+
+/** The confirm label for a tier widening. */
+export const AUTONOMY_CONFIRM_ACTION = "Give more autonomy";
+
+/**
+ * The standing note under a tier widening.
+ *
+ * True in this build and load-bearing: the gate runs with policy HITL disabled
+ * (`src/runtime/builder.rs`), so what still stops an agent is an explicit
+ * `request_approval` rather than the tier. An operator agreeing to a wider tier
+ * is entitled to read that wherever they can agree to it.
+ */
+export const AUTONOMY_PROMPTS_NOTE =
+  "Approval prompts remain explicit through request_approval.";
+
+/**
+ * What changes, in the host's own words on both sides of the move.
+ *
+ * Both descriptions are the host's (`TIER_TEXT`, `src/server/ops/policy.rs`),
+ * never a paraphrase — that prose is server-side precisely so it tracks the gate
+ * it describes. `current` is optional because a console running against a newer
+ * host can be sitting on a mode it has no text for; the sentence then names only
+ * what the operator is moving *to*, which is the half that still matters.
+ */
+export function tierWideningExplanation(
+  current: string | undefined,
+  next: PolicyStatus["tiers"][number],
+): string {
+  return `Instead of: ${current ?? ""} With ${next.label}: ${next.description} They will use the ${next.label} setting on their next turn.`;
+}
+
 /** Whether replacing the current spend cap with the manifest cap loosens it. */
 export function widensSpendCap(
   current: number | null,
@@ -1102,9 +1153,7 @@ export function PolicySettings({ client, company }: Props) {
                 }}
               >
                 <AlertDialogHeader>
-                  <AlertDialogTitle>
-                    Give teammates more autonomy?
-                  </AlertDialogTitle>
+                  <AlertDialogTitle>{AUTONOMY_CONFIRM_TITLE}</AlertDialogTitle>
                   <AlertDialogDescription>
                     {pendingCapRaise !== null ? (
                       <>
@@ -1154,32 +1203,25 @@ export function PolicySettings({ client, company }: Props) {
                           </>
                         )}
                       </>
-                    ) : (
-                      <>
-                        Instead of:{" "}
-                        {
-                          status.tiers.find(
-                            (tier) => tier.value === status.mode,
-                          )?.description
-                        }{" "}
-                        With {tierAwaitingConfirmation?.label}:{" "}
-                        {tierAwaitingConfirmation?.description} They will use
-                        the {tierAwaitingConfirmation?.label} setting on their
-                        next turn.
-                      </>
-                    )}
+                    ) : tierAwaitingConfirmation ? (
+                      tierWideningExplanation(
+                        status.tiers.find((tier) => tier.value === status.mode)
+                          ?.description,
+                        tierAwaitingConfirmation,
+                      )
+                    ) : null}
                   </AlertDialogDescription>
                   <p className="text-sm text-muted-foreground">
                     {pendingCapRaise !== null
                       ? "This threshold remains inactive while policy HITL is disabled."
                       : resetAwaitingConfirmation
                         ? "Reset restores the stored policy fields; approval prompts remain explicit."
-                        : "Approval prompts remain explicit through request_approval."}
+                        : AUTONOMY_PROMPTS_NOTE}
                   </p>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                   <AlertDialogCancel disabled={saving}>
-                    Keep current setting
+                    {AUTONOMY_CONFIRM_CANCEL}
                   </AlertDialogCancel>
                   <AlertDialogAction
                     data-testid="policy-tier-confirm"
@@ -1211,7 +1253,7 @@ export function PolicySettings({ client, company }: Props) {
                       ? `Raise cap to $${pendingCapRaise}`
                       : resetAwaitingConfirmation
                         ? "Revert and give more autonomy"
-                        : "Give more autonomy"}
+                        : AUTONOMY_CONFIRM_ACTION}
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>

--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -5,6 +5,8 @@ import { toast } from "sonner";
 import type { OpenCompanyClient } from "@/api/client";
 import {
   getPolicy,
+  isPolicyStatus,
+  NOT_A_POLICY,
   type PolicyStatus,
   resetPolicy,
   setPolicy,
@@ -372,6 +374,11 @@ export function PolicySettings({ client, company }: Props) {
       setDraftDeadline("");
       try {
         const next = await getPolicy(client, company);
+        // A body that is not a policy is a load FAILURE, not a policy. Left
+        // unchecked it reaches `next.alwaysApprove.join(...)` two lines down,
+        // and a throw there unmounts the console — there is no error boundary.
+        // The `catch` below already knows how to say so.
+        if (!isPolicyStatus(next)) throw new Error(NOT_A_POLICY);
         // A response for a company this `load` no longer describes must not
         // overwrite the current company's state: when the scope changes mid-
         // flight, the effect's cleanup flips `live` for the stale request, so
@@ -464,6 +471,14 @@ export function PolicySettings({ client, company }: Props) {
     resync: { alwaysAsk?: boolean; spendCap?: boolean; deadline?: boolean } = {},
     takesEffect?: string,
   ) => {
+    // Every write path funnels through here, so this is the one place the
+    // settings page has to fence: a PUT or DELETE that answers 200 with
+    // something that is not a policy must not be put on screen. Reported the
+    // way a failed save is, and the previously loaded policy stands.
+    if (!isPolicyStatus(next)) {
+      toast.error(NOT_A_POLICY);
+      return;
+    }
     setStatus(next);
     const { alwaysAsk = true, spendCap = true, deadline = true } = resync;
     if (alwaysAsk) {

--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -33,6 +33,10 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+// The title row's readers, so a policy written HERE reaches the pill without
+// waiting for its 30s poll. Not a cycle: `use-autonomy` imports only
+// `@/api/policy` and `@/lib/visible-poll`.
+import { applyAutonomy } from "@/hooks/use-autonomy";
 import { cn } from "@/lib/utils";
 
 /**
@@ -464,22 +468,40 @@ export function PolicySettings({ client, company }: Props) {
    * `takesEffect` overrides the host's generic timing line for a save whose
    * effect does not wait for the next turn — the deadline, whose new TTL the
    * live gate enforces immediately.
+   *
+   * **Returns whether the write actually landed.** It is not a formality: a
+   * body this rejects is a FAILED write, and its callers hand that answer to
+   * confirmation dialogs which close on success and stay open for a retry on
+   * failure. Returning nothing let `saveTier`, `reset` and `commitSpendCap`
+   * report `true` after showing an error, so a tier escalation, a loosening
+   * reset or a spend-cap raise that the host answered with rubbish closed its
+   * dialog as though the operator's change had been made — a *widening* the
+   * console then claimed had happened and had not.
    */
   const apply = (
     next: PolicyStatus,
     message: string,
     resync: { alwaysAsk?: boolean; spendCap?: boolean; deadline?: boolean } = {},
     takesEffect?: string,
-  ) => {
+  ): boolean => {
     // Every write path funnels through here, so this is the one place the
     // settings page has to fence: a PUT or DELETE that answers 200 with
     // something that is not a policy must not be put on screen. Reported the
     // way a failed save is, and the previously loaded policy stands.
     if (!isPolicyStatus(next)) {
       toast.error(NOT_A_POLICY);
-      return;
+      return false;
     }
     setStatus(next);
+    // The title row reads the same policy through `useAutonomy`, on a 30s
+    // poll, and it is mounted on every view including this one. Without this
+    // hand-off a change made HERE left the pill an inch above the card stating
+    // the previous tier for up to half a minute — and in the direction that
+    // matters most, a widening looks like the restrictive tier is still in
+    // force. Same value, same scope, same fence: this is the host's own
+    // response, already checked by `isPolicyStatus` above, so the row is
+    // handed a value the host returned rather than an optimistic guess.
+    applyAutonomy(client, company, next);
     const { alwaysAsk = true, spendCap = true, deadline = true } = resync;
     if (alwaysAsk) {
       setDraftAlways(next.alwaysApprove.join(", "));
@@ -493,6 +515,7 @@ export function PolicySettings({ client, company }: Props) {
       setDraftDeadline((next.approvalTtlHours ?? 24).toString());
     }
     toast.success(message, { description: takesEffect ?? next.takesEffect });
+    return true;
   };
 
   const saveTier = async (mode: string) => {
@@ -510,12 +533,15 @@ export function PolicySettings({ client, company }: Props) {
       // current company's state — the read path's `live` guard, applied to the
       // write path.
       if (!isCurrentScope({ client, company })) return false;
-      apply(next, "Autonomy tier updated", {
+      // `return apply(...)`, not `apply(...); return true`. A rejected body is
+      // a failed write, and the confirmation dialog behind a tier escalation
+      // has to stay open for the retry rather than close on a change that did
+      // not happen.
+      return apply(next, "Autonomy tier updated", {
         alwaysAsk: !dirty,
         spendCap: false,
         deadline: false,
       });
-      return true;
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Could not change the tier.",
@@ -657,7 +683,9 @@ export function PolicySettings({ client, company }: Props) {
       // A reset for a company this card no longer shows must not overwrite the
       // current company's state.
       if (!isCurrentScope({ client, company })) return false;
-      apply(
+      // Propagated for the same reason `saveTier` propagates it: a loosening
+      // reset is confirmed, and a rejected body must keep that confirmation up.
+      return apply(
         next,
         "Reverted to the manifest's policy",
         undefined,
@@ -677,7 +705,6 @@ export function PolicySettings({ client, company }: Props) {
           ? "takes effect immediately — parked approvals are re-checked against the manifest deadline"
           : undefined,
       );
-      return true;
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Could not reset the policy.",
@@ -752,14 +779,16 @@ export function PolicySettings({ client, company }: Props) {
       // A save for a company this card no longer shows must not overwrite the
       // current company's state.
       if (!isCurrentScope({ client, company })) return false;
-      apply(
+      // Propagated: a cap RAISE is confirmed, and a rejected body must keep
+      // that confirmation up rather than close it on a widening that did not
+      // land.
+      return apply(
         next,
         "Spend cap updated",
         // An unsaved always-ask edit and a half-typed deadline are the
         // operator's; the PUT only touched the cap.
         { alwaysAsk: !dirty, deadline: false },
       );
-      return true;
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Could not save the spend cap.",

--- a/frontend/src/components/profile-row.tsx
+++ b/frontend/src/components/profile-row.tsx
@@ -89,7 +89,10 @@ export function ProfileRow({
       name={name}
       tone={toneFor(me.id || me.email)}
       avatar={personAvatar(me)}
-      className="size-5 rounded-[4px] text-3xs"
+      // Round, not the sidebar's `rounded-[4px]`: in the title row this sits
+      // inside a circular button, and a squircle inside a circle reads as a
+      // mistake at 20px — the corners clip against the border on every side.
+      className="size-7 rounded-full text-2xs"
     />
   );
 
@@ -118,10 +121,21 @@ export function ProfileRow({
           // Capped so a long display name cannot push the switcher off the
           // other end of a narrow window; it truncates instead, exactly as it
           // did in the column.
-          className="flex max-w-48 items-center gap-2 rounded-lg px-2 py-1 text-sm transition hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+          aria-label={name}
+            // The avatar alone. A title row is chrome, and the operator's own
+            // name is the one label they never need read back to them — it cost
+            // horizontal space at every window width to say something they
+            // already know. `title` and `aria-label` keep it reachable by
+            // pointer and by screen reader, so only the pixels are lost.
+            // A ring at rest, not only on hover. Stripped to the avatar alone
+            // the control had no edge of its own, so it read as a decorative
+            // mark sitting on the chrome rather than something clickable — the
+            // page's own rule is that what is interactive should look
+            // interactive. The border is the quietest thing that says so, and
+            // it firms up on hover rather than appearing from nothing.
+            className="flex items-center rounded-full border border-sidebar-border bg-sidebar/60 p-0.5 transition hover:border-sidebar-accent-foreground/30 hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         >
           {face}
-          <span className="truncate">{name}</span>
         </button>
         {dialog}
       </>

--- a/frontend/src/components/profile-row.tsx
+++ b/frontend/src/components/profile-row.tsx
@@ -32,9 +32,22 @@ import { toneFor } from "@/lib/team";
 export function ProfileRow({
   client,
   company,
+  variant = "sidebar",
 }: {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * Which chrome this is drawn in.
+   *
+   * `titlebar` is the home: the far right of the window's title row, opposite
+   * the company switcher. `sidebar` is the footer row it used to be, kept for
+   * any chrome that still gives it a column to sit at the bottom of.
+   *
+   * The two differ in shape and in nothing else. A sidebar footer row is a
+   * full-width menu item; a title-row control sizes to its own content and
+   * stops. Both open the same dialog.
+   */
+  variant?: "sidebar" | "titlebar";
 }) {
   const [me, setMe] = useState<Me | null>(null);
   const [open, setOpen] = useState(false);
@@ -67,6 +80,54 @@ export function ProfileRow({
   if (!me || typeof me !== "object" || !("email" in me) || !("id" in me)) return null;
   const name = personName(me);
 
+  // 20px, not the 16px a sidebar icon slot would take: 16 is below the size a
+  // face can be read at (see `MessageRow`'s facepile note), and this is the one
+  // control on screen whose whole job is to show you yours. A row's icon slot
+  // sizes to its content, so the extra four pixels cost the label nothing.
+  const face = (
+    <TeammateAvatar
+      name={name}
+      tone={toneFor(me.id || me.email)}
+      avatar={personAvatar(me)}
+      className="size-5 rounded-[4px] text-3xs"
+    />
+  );
+
+  const dialog = (
+    <ProfileDialog
+      client={client}
+      company={company}
+      me={me}
+      open={open}
+      onOpenChange={setOpen}
+      onSaved={setMe}
+    />
+  );
+
+  if (variant === "titlebar") {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          data-testid="profile-row"
+          // Native `title` rather than the sidebar's tooltip component, which
+          // only renders while the rail is collapsed and needs the sidebar
+          // context to know it. This control is not in the rail any more.
+          title={name}
+          // Capped so a long display name cannot push the switcher off the
+          // other end of a narrow window; it truncates instead, exactly as it
+          // did in the column.
+          className="flex max-w-48 items-center gap-2 rounded-lg px-2 py-1 text-sm transition hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+        >
+          {face}
+          <span className="truncate">{name}</span>
+        </button>
+        {dialog}
+      </>
+    );
+  }
+
   return (
     <SidebarMenu>
       <SidebarMenuItem>
@@ -75,28 +136,11 @@ export function ProfileRow({
           onClick={() => setOpen(true)}
           data-testid="profile-row"
         >
-          {/* 20px, not the 16px a sidebar icon slot would take: 16 is below the
-              size a face can be read at (see `MessageRow`'s facepile note), and
-              this is the one row on screen whose whole job is to show you yours.
-              A row's icon slot sizes to its content, so the extra four pixels
-              cost the label nothing. */}
-          <TeammateAvatar
-            name={name}
-            tone={toneFor(me.id || me.email)}
-            avatar={personAvatar(me)}
-            className="size-5 rounded-[4px] text-3xs"
-          />
+          {face}
           <span className="truncate">{name}</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
-      <ProfileDialog
-        client={client}
-        company={company}
-        me={me}
-        open={open}
-        onOpenChange={setOpen}
-        onSaved={setMe}
-      />
+      {dialog}
     </SidebarMenu>
   );
 }

--- a/frontend/src/components/sidebar-controls.tsx
+++ b/frontend/src/components/sidebar-controls.tsx
@@ -3,7 +3,12 @@ import { MessageSquareWarning, PanelLeftClose, PanelLeftOpen, Settings } from "l
 import type { View } from "@/components/app-shell";
 
 import { Button } from "@/components/ui/button";
-import { useSidebar } from "@/components/ui/sidebar";
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DiscordIcon } from "@/components/discord-icon";
 import { DISCORD_INVITE_URL } from "@/lib/links";
@@ -31,109 +36,25 @@ const DISCORD_BLURPLE =
   "text-(--brand-discord-on-light) dark:text-(--brand-discord-on-dark)";
 
 /**
- * Shared footprint for every button on the utility bar.
+ * The utility bar: Settings, Feedback and Discord, at the foot of the column.
  *
- * Lifted from {@link SidebarCollapseButton}, which had it first and is now one
- * of four: 28px square under the column, 32px on the rail so it lands on the
- * same rhythm as the nav icons; the resting dim through the ink's alpha rather
- * than `RESTING_ROW`'s `opacity-60`, because opacity dims the focus ring too
- * and the ring is the only thing saying where the keyboard is on an unlabelled
- * button. The three hover classes each replace exactly one of `ghost`'s, so
- * tailwind-merge drops the original instead of leaving the two to race.
- */
-const UTILITY_BUTTON = cn(
-  "shrink-0 text-sidebar-foreground/60",
-  "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground dark:hover:bg-sidebar-accent",
-  "focus-visible:ring-sidebar-ring/50",
-  "group-data-[collapsible=icon]:size-8",
-);
-
-/**
- * One button on the utility bar: icon, tooltip, and a name a screen reader can
- * read.
+ * **Rows, not an icon strip.** These were three icon-only buttons — the shape
+ * OpenHuman's shell uses in its own sidebar header — chosen when they sat
+ * *above* the destinations, where three labelled rows would have pushed the
+ * company's own state further down the column every time the nav list grew.
+ * That argument died with the move to the footer: below the destinations there
+ * is nothing left for them to push, and the cost of the strip was that three
+ * unlabelled glyphs floated at the bottom of a column whose every other entry
+ * says what it is. Naming them costs a column that is already scrolled to its
+ * end nothing, and it puts them on the same rhythm as the nav rows they sit
+ * under rather than reading as a separate object bolted on.
  *
- * `label` is the accessible name AND the tooltip text, deliberately the same
- * string. These are icon-only in both sidebar states — unlike a nav row, which
- * carries its own label once the column is open — so the tooltip is the only
- * place the word appears on screen, and a tooltip is a visual affordance that
- * cannot be relied on for the name.
- */
-function UtilityButton({
-  label,
-  icon,
-  active,
-  onClick,
-  href,
-  className,
-  ...rest
-}: {
-  label: string;
-  icon: React.ReactNode;
-  /** Marks the button while its own page is open, the way a nav row does. */
-  active?: boolean;
-  onClick?: () => void;
-  /** An external destination — renders an anchor instead of a button. */
-  href?: string;
-  className?: string;
-  "data-tour"?: string;
-  "data-testid"?: string;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <Button
-            type={href ? undefined : "button"}
-            variant="ghost"
-            size="icon-sm"
-            aria-label={label}
-            // `aria-current`, not `data-active`: these are destinations, and
-            // this is the same thing the nav rows announce when their page is
-            // the one open. Absent — not `false` — when it is not, because
-            // `aria-current="false"` is announced by some readers.
-            aria-current={active ? "page" : undefined}
-            onClick={onClick}
-            className={cn(UTILITY_BUTTON, active && "text-sidebar-foreground", className)}
-            render={href ? <a href={href} target="_blank" rel="noreferrer" /> : undefined}
-            {...rest}
-          />
-        }
-      >
-        {icon}
-      </TooltipTrigger>
-      {/*
-        The raw tooltip primitive rather than `SidebarMenuButton`'s `tooltip`
-        prop, which hides its content unless the sidebar is collapsed. That is
-        right for a nav row and wrong here: expanded is exactly the state in
-        which a reader of this bar has never seen the word.
-      */}
-      <TooltipContent side="right">{label}</TooltipContent>
-    </Tooltip>
-  );
-}
-
-/**
- * The utility bar: one thin row of icons directly under the company switcher.
- *
- * Settings, Feedback, Discord and Collapse. Three of them go somewhere and one
- * changes the chrome, but none is a place an operator *works* — they are
- * reached once a session, if that. As full-width rows they cost four rows of a
- * column whose remaining rows are the actual destinations, and Feedback and
- * Discord pushed the company's own state and its switcher further down the
- * footer every time the list grew.
- *
- * This is the shape OpenHuman's shell already uses for the same four
- * (`vendor/openhuman/app/src/components/layout/shell/SidebarHeader.tsx`):
- * a header band of icon-only tertiary buttons, tooltipped, with the collapse
- * control at the end of the row. Settings keeps its `data-tour` anchor, so the
- * guided tour's "Connect your tools" stop still has something to spotlight.
- *
- * ## The collapsed rail
- *
- * The rail is `--sidebar-width-icon` (3rem) less `SidebarHeader`'s `p-2` — 32px
- * of content box, one icon wide. The row therefore becomes a column there, the
- * same way the switcher row above it already does, and each button grows to
- * 32px so the whole header reads as one stack with the nav icons below it.
+ * They use the nav's own row primitive for that reason: one shape, one hover,
+ * one active treatment, and the tooltip on the collapsed rail comes free. What
+ * keeps them from reading as destinations is position — after the list, in the
+ * footer — rather than a different shape. Settings keeps its `data-tour`
+ * anchor, so the guided tour's "Connect your tools" stop still has something to
+ * spotlight.
  */
 export function SidebarUtilityBar({
   view,
@@ -154,53 +75,65 @@ export function SidebarUtilityBar({
 
   return (
     // `role="group"` so the bar has a name of its own. It sits in the sidebar's
-    // header, which is outside the `Main navigation` landmark on purpose — the
-    // landmark is the destinations an operator works out of, and these are the
+    // footer, under the `Main navigation` landmark's destinations on purpose —
+    // the landmark is the places an operator works out of, and these are the
     // utilities that act on the console itself.
-    <div
-      role="group"
-      aria-label="Console utilities"
-      data-testid="sidebar-utilities"
-      // Centred, not left-aligned under the switcher's glyph. Four icons in a
-      // 13.5rem column left no honest edge to align to: flush left they hung
-      // under the nameplate's text with a ragged right, and the row reads as
-      // one object rather than four list items when it is centred in the
-      // column it belongs to. On the rail it is already the full width, so
-      // centring is what the column does anyway.
-      className="flex items-center justify-center gap-1 group-data-[collapsible=icon]:flex-col"
-    >
-      <UtilityButton
-        label="Settings"
-        icon={<Settings />}
-        active={view === "settings"}
-        onClick={() => navigate("settings")}
-        data-tour="nav-settings"
-      />
-      <UtilityButton
-        label="Feedback"
-        icon={<MessageSquareWarning />}
-        active={view === "feedback"}
-        onClick={() => navigate("feedback")}
-      />
-      {/* Deliberately NOT dimmed with the others.
+    <SidebarMenu role="group" aria-label="Console utilities" data-testid="sidebar-utilities">
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          isActive={view === "settings"}
+          // `aria-current`, not just `isActive`: the row primitive renders
+          // `data-active` for its styling and announces nothing. These are
+          // destinations, so a reader is told which one is open — absent, not
+          // `false`, because `aria-current="false"` is announced by some.
+          aria-current={view === "settings" ? "page" : undefined}
+          data-tour="nav-settings"
+          tooltip="Settings"
+          onClick={() => navigate("settings")}
+          className={RESTING_ROW}
+        >
+          <Settings />
+          <span>Settings</span>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          isActive={view === "feedback"}
+          // `aria-current`, not just `isActive`: the row primitive renders
+          // `data-active` for its styling and announces nothing. These are
+          // destinations, so a reader is told which one is open — absent, not
+          // `false`, because `aria-current="false"` is announced by some.
+          aria-current={view === "feedback" ? "page" : undefined}
+          tooltip="Feedback"
+          onClick={() => navigate("feedback")}
+          className={RESTING_ROW}
+        >
+          <MessageSquareWarning />
+          <span>Feedback</span>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+      <SidebarMenuItem>
+        {/* Deliberately NOT dimmed with the others.
 
-          The resting dim is safe for near-white text and destroys a mid-tone
-          hue: the blurple measures 6.36:1 at full strength and 3.04:1 dimmed.
-          Recovering that inside the dim would mean lightening the blurple until
-          it is a pale lavender that no longer reads as Discord's colour. The
-          hue already sets it apart without help from the property doing the
-          damage. */}
-      <UtilityButton
-        label="Join our Discord"
-        icon={<DiscordIcon className="size-4" />}
-        href={DISCORD_INVITE_URL}
-        className={cn(
-          DISCORD_BLURPLE,
-          "hover:text-(--brand-discord-on-light) dark:hover:text-(--brand-discord-on-dark)",
-        )}
-      />
-      <SidebarCollapseButton />
-    </div>
+            `RESTING_ROW` dims by opacity, which is safe for near-white text and
+            destroys a mid-tone hue: the blurple measures 6.36:1 at full strength
+            and 3.04:1 dimmed. Recovering that inside the dim would mean
+            lightening the blurple until it is a pale lavender that no longer
+            reads as Discord's colour. The hue already sets this row apart
+            without help from the property doing the damage. */}
+        <SidebarMenuButton
+          tooltip="Join our Discord"
+          className={cn(
+            DISCORD_BLURPLE,
+            "hover:text-(--brand-discord-on-light) dark:hover:text-(--brand-discord-on-dark)",
+          )}
+          render={<a href={DISCORD_INVITE_URL} target="_blank" rel="noreferrer" />}
+        >
+          <DiscordIcon className="size-4" />
+          <span>Join our Discord</span>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
   );
 }
 
@@ -291,7 +224,20 @@ export function SidebarCollapseButton() {
               // unlabelled button is the only thing saying where the keyboard
               // is. (`RESTING_ROW` also carries `data-active:opacity-100`,
               // which is a nav row's business and never this one's.)
-              "shrink-0 text-sidebar-foreground/60",
+                // Filled at REST, not only on hover.
+                //
+                // In the sidebar's header this was one icon among four, and the
+                // resting dim kept it from shouting over its neighbours. It now
+                // sits alone, centred on the seam between the rail and the
+                // content card — no neighbours to belong to and no surface
+                // behind it — and at ghost weight it read there as a stray
+                // glyph drawn on the border rather than as something pressable.
+                // Carrying its own fill is what makes it legible as a control
+                // where it now lives; hover then deepens the fill instead of
+                // being the only thing that draws it — the rest state is the token
+                // at 70%, hover the full strength, so the press feedback still
+                // moves in the direction it always did.
+                "shrink-0 bg-sidebar-accent/70 text-sidebar-accent-foreground",
               // Three classes replacing exactly one of `ghost`'s each, so
               // tailwind-merge drops the original rather than leaving the two
               // to race: `hover:bg-muted`, `hover:text-foreground` and
@@ -299,7 +245,7 @@ export function SidebarCollapseButton() {
               // canvas; this button is on the sidebar's surface, which is a
               // different rung and moving again in issue #1178. The accent is
               // also what every row in this column already hovers to.
-              "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground dark:hover:bg-sidebar-accent",
+                "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground dark:hover:bg-sidebar-accent",
               "focus-visible:ring-sidebar-ring/50",
               // 28px beside a 48px nameplate, 32px on the rail. See the note
               // on the collapsed rail above.

--- a/frontend/src/components/sidebar-controls.tsx
+++ b/frontend/src/components/sidebar-controls.tsx
@@ -180,6 +180,15 @@ export function SidebarCollapseButton() {
   // desktop state happens to be collapsed — which, since issue #1176 stopped
   // the sidebar auto-collapsing, is now a state an operator can leave behind
   // and come back to on a phone.
+  //
+  // Defence in depth rather than the live path: `app-shell.tsx` gates this
+  // control at `md`, which is exactly where `useIsMobile` flips, because
+  // treating mobile as not-collapsed also meant a CLOSED sheet got "Collapse
+  // sidebar" and the close icon while pressing it opened the sheet. Below `md`
+  // the way back is the shell's own `md:hidden` "Toggle sidebar" bar, which
+  // reserves its own row instead of floating over the content (issue #1265).
+  // The guard stays so a future caller that does mount this on a phone gets the
+  // less wrong of the two labels rather than a confident one.
   const collapsed = !isMobile && state === "collapsed";
   const label = collapsed ? "Expand sidebar" : "Collapse sidebar";
   const Icon = collapsed ? PanelLeftOpen : PanelLeftClose;

--- a/frontend/src/components/sidebar-controls.tsx
+++ b/frontend/src/components/sidebar-controls.tsx
@@ -138,7 +138,7 @@ export function SidebarUtilityBar({
 }
 
 /**
- * Show or hide the sidebar. A button in the header, not a row in the nav.
+ * Show or hide the sidebar. A button on the content card's leading seam.
  *
  * ## Why it is not a row (issue #1177)
  *
@@ -151,32 +151,27 @@ export function SidebarUtilityBar({
  *
  * Colouring it differently would not have fixed that; the shape is what says
  * "row". So it stops using the row primitive altogether and becomes the
- * console's ordinary icon button, in the sidebar's header — which is the part
- * of the column that talks about the panel rather than about the company.
- * `SidebarContent` below it is the destinations, and the header/content
- * boundary now means something.
+ * console's ordinary icon button.
  *
- * ## Why it does not crowd the host switcher (issue #1174)
+ * ## Why it is not in the sidebar at all
  *
- * The switcher beside it is `h-12`, carries a filled glyph, a two-line
- * nameplate and the cross-host status dot. This is 28px, ghost, and dimmed at
- * rest. They also sit in separate elements, so hovering one never lights the
- * other — which is what stops the pair reading as a single control with a
- * chevron at one end and a panel glyph at the other.
+ * Its next home was the sidebar's own header, beside the host switcher. That
+ * put the control that *hides* a panel inside the panel it hides: collapsing
+ * the column took the button with it, and the rail had to keep a version of it
+ * standing in 32px of content box.
  *
- * ## The collapsed rail
+ * Both of those are gone now. The switcher moved to the window's title row
+ * (`window-title-bar.tsx`) and the header went with it, so this button is
+ * rendered from `app-shell.tsx` inside `SidebarInset`, absolutely positioned on
+ * the leading border of the content card — `left-(--frame-inset)` puts it at
+ * the edge and `-translate-x-1/2` straddles it. It is one control in both
+ * states, it points at the edge that moves, and it costs the page no layout.
+ * `sidebar-toggle-reachable.spec.ts` pins that placement.
  *
- * The rail is `--sidebar-width-icon` (3rem) and `SidebarHeader` is `p-2`, so
- * there are 32px of content box — exactly the switcher's glyph, and no room
- * for anything beside it. The header row therefore becomes a column on the
- * rail (see `app-shell.tsx`), and this button grows to `size-8` there so it
- * lands on the same 32px rhythm as every nav icon below it.
- *
- * It deliberately drops the `bg-primary` fill it used to take when collapsed.
- * That fill existed to make it findable in a column of identical nav icons; up
- * here it has only the switcher for company, and the switcher's glyph is
- * *already* a filled primary square. Two of those stacked would read as one
- * control, which is the failure the paragraph above exists to prevent.
+ * It carries its own fill at rest for the same reason: alone on a border, with
+ * no neighbours to belong to and no surface behind it, a ghost glyph read as
+ * something drawn on the seam rather than as something pressable. See the
+ * class list below.
  */
 export function SidebarCollapseButton() {
   const { toggleSidebar, state, isMobile } = useSidebar();
@@ -247,9 +242,14 @@ export function SidebarCollapseButton() {
               // also what every row in this column already hovers to.
                 "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground dark:hover:bg-sidebar-accent",
               "focus-visible:ring-sidebar-ring/50",
-              // 28px beside a 48px nameplate, 32px on the rail. See the note
-              // on the collapsed rail above.
-              "group-data-[collapsible=icon]:size-8",
+              // No `group-data-[collapsible=icon]:size-8` any more, and its
+              // absence is the point. `group` is on `[data-slot=sidebar]`
+              // (`ui/sidebar.tsx`) and this button is no longer inside it, so
+              // that variant could never match again — it would have been a
+              // class that reads as a collapsed-state size and silently is not.
+              // One size in both states, which is what a control on the seam
+              // wants: it does not live in the 3rem rail and has no rhythm of
+              // nav icons to land on.
             )}
           />
         }

--- a/frontend/src/components/window-chrome.tsx
+++ b/frontend/src/components/window-chrome.tsx
@@ -36,6 +36,37 @@ import { isDesktopRuntime } from "@/api/transport";
 export const WINDOW_CHROME_HEIGHT = 28;
 
 /**
+ * Height of the console's own title row, in px.
+ *
+ * Not a taste value — it is derived from where macOS draws the traffic lights,
+ * because the row centres its contents on the lights' centre line and the
+ * lights are the one item in it this code cannot move.
+ *
+ * `trafficLightPosition.y` in `tauri.conf.json` is 16 and the buttons are the
+ * standard 12px, so they occupy y ∈ [16, 28] and their centre line is at 22.
+ * A row of height H laid out with `align-items: center` centres its contents
+ * at H/2, so H = 44 is the height — and the only height — at which the
+ * switcher, the profile control and the lights share one centre line.
+ *
+ * The two therefore move together: change `trafficLightPosition.y` to Y and
+ * this must become `2 * (Y + 6)`, or the lights sit off the row's centre. It is
+ * also comfortably taller than the 36px switcher trigger it carries, which
+ * 28px — the height of the sidebar strip this row replaced — was not.
+ */
+export const WINDOW_TITLE_BAR_HEIGHT = 44;
+
+/**
+ * How far into the window the traffic lights reach, in px.
+ *
+ * `trafficLightPosition.x` is 20 and macOS draws three 12px buttons on a 20px
+ * pitch, so the last one ends at 20 + 2*20 + 12 = 72. This is that number and
+ * not a pixel more: the clearance between the lights and whatever stands beside
+ * them is the title row's own padding, so this constant stays a statement about
+ * where the OS draws and the spacing stays a statement about the layout.
+ */
+export const WINDOW_CONTROLS_WIDTH = 72;
+
+/**
  * Whether this build is drawing its own window chrome.
  *
  * Deliberately a runtime check rather than a build-time one: the same bundle is
@@ -83,19 +114,23 @@ export function WindowDragBar({ className }: { className?: string }) {
 }
 
 /**
- * The vertical space the traffic lights sit in, at the top of the sidebar.
+ * The space the traffic lights sit in, at the left end of the title row.
  *
- * OpenHuman's expanded sidebar dodges the lights by right-aligning its header
- * icons, leaving the top-left empty. This console cannot: the top-left is the
- * company switcher, a 48px nameplate that names where you are and is the first
- * thing the column should answer. So the strip is reserved instead and the
- * header starts below it — which is exactly what OpenHuman's own *collapsed*
- * rail does for the same reason, its narrow column having no empty left space
- * to give away either.
+ * It used to reserve a strip *above* the company switcher, because the switcher
+ * was the top-left of the sidebar and the lights were landing on it. The
+ * switcher now stands in a full-width title row instead, so the collision is
+ * horizontal rather than vertical and so is the answer: the lights take the
+ * first {@link WINDOW_CONTROLS_WIDTH} pixels of the row and everything else
+ * starts to their right.
  *
- * It is draggable as well as reserved. The alternative is a 28px band of dead
- * window above a control an operator will try to grab, and a title bar you
- * cannot drag is stranger than no title bar at all.
+ * That is the whole reason this is a spacer and not a margin on the switcher.
+ * The row centres every item on one line with a single `items-center`, and a
+ * per-item offset is exactly the thing that stops being right the moment
+ * another item joins the row or a font loads late.
+ *
+ * It is draggable as well as reserved. The alternative is a band of dead window
+ * beside a control an operator will try to grab, and a title bar you cannot
+ * drag is stranger than no title bar at all.
  */
 export function WindowControlsInset() {
   if (!usesOverlayTitleBar()) return null;
@@ -104,8 +139,8 @@ export function WindowControlsInset() {
       data-tauri-drag-region
       data-testid="window-controls-inset"
       aria-hidden="true"
-      className="w-full flex-none"
-      style={{ height: WINDOW_CHROME_HEIGHT }}
+      className="h-full flex-none"
+      style={{ width: WINDOW_CONTROLS_WIDTH }}
     />
   );
 }

--- a/frontend/src/components/window-chrome.tsx
+++ b/frontend/src/components/window-chrome.tsx
@@ -53,7 +53,7 @@ export const WINDOW_CHROME_HEIGHT = 28;
  * also comfortably taller than the 36px switcher trigger it carries, which
  * 28px — the height of the sidebar strip this row replaced — was not.
  */
-export const WINDOW_TITLE_BAR_HEIGHT = 44;
+export const WINDOW_TITLE_BAR_HEIGHT = 52;
 
 /**
  * How far into the window the traffic lights reach, in px.

--- a/frontend/src/components/window-title-bar.tsx
+++ b/frontend/src/components/window-title-bar.tsx
@@ -1,0 +1,70 @@
+// The one row across the top of the window: which company you are in, and who
+// you are signed in as.
+//
+// Both controls used to live in the sidebar column — the switcher at its head,
+// under a reserved strip for the traffic lights, and the profile row in its
+// footer. That put the two facts that are *about the console rather than about
+// the page* at opposite ends of a 13.5rem column, and it put the macOS traffic
+// lights on top of a narrow column instead of across a bar, so the lights
+// overlapped the switcher and the window had no title row to speak of.
+//
+// Now they are one row spanning the full window width, above the sidebar and
+// above the content. Three rules hold it together:
+//
+// **It is chrome, not content.** It lives outside the sidebar's container and
+// outside the scrolling content card, so it survives the sidebar collapsing and
+// never scrolls away. The sidebar starts below it.
+//
+// **It exists in the browser too.** Only the traffic-light inset is gated on
+// {@link usesOverlayTitleBar} — the row itself is not. One layout that is right
+// everywhere beats a desktop layout and a web layout that drift apart, and the
+// difference between them is a 72px spacer.
+//
+// **Everything on it is centred by one rule.** A single `items-center` on this
+// flex row, and no per-item margins: see {@link WINDOW_TITLE_BAR_HEIGHT} for
+// why 44px is the height at which that rule also lands on the traffic lights'
+// centre line, which is the one item here whose position macOS owns.
+
+import {
+  WINDOW_TITLE_BAR_HEIGHT,
+  WindowControlsInset,
+} from "@/components/window-chrome";
+
+export function WindowTitleBar({
+  switcher,
+  profile,
+}: {
+  /** The company/host switcher. Leads the row, right of the traffic lights. */
+  switcher: React.ReactNode;
+  /** The profile / account control, at the far right. */
+  profile: React.ReactNode;
+}) {
+  return (
+    // `data-tauri-drag-region` is opt-in per element, not inherited: Tauri
+    // starts a drag only when the pressed element is itself marked. So the
+    // switcher and the profile control keep their clicks without opting out of
+    // anything, and the empty middle has to opt *in* on its own — which is what
+    // the spacer below does.
+    <div
+      data-tauri-drag-region
+      data-testid="window-title-bar"
+      className="flex w-full flex-none items-center gap-2 px-3"
+      style={{ height: WINDOW_TITLE_BAR_HEIGHT }}
+    >
+      {/* Renders nothing off the macOS desktop, where the lights do not float
+          over the page and there is nothing to clear. */}
+      <WindowControlsInset />
+      {/* Capped rather than stretched. The trigger was sized for a sidebar
+          column, and left to itself in a 1280px row it would run halfway across
+          the window naming a company whose name is three words long. It already
+          truncates; this gives it something to truncate against. */}
+      <div className="min-w-0 max-w-72">{switcher}</div>
+      {/* The draggable middle. `self-stretch` so the grabbable area is the full
+          height of the row rather than a hairline through its centre. */}
+      <div data-tauri-drag-region aria-hidden="true" className="min-w-0 flex-1 self-stretch" />
+      {/* Last in the DOM as well as last on screen, so tab order reads
+          left-to-right across the row. */}
+      <div className="flex-none">{profile}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/window-title-bar.tsx
+++ b/frontend/src/components/window-title-bar.tsx
@@ -22,8 +22,23 @@
 //
 // **Everything on it is centred by one rule.** A single `items-center` on this
 // flex row, and no per-item margins: see {@link WINDOW_TITLE_BAR_HEIGHT} for
-// why 44px is the height at which that rule also lands on the traffic lights'
+// why it is the height at which that rule also lands on the traffic lights'
 // centre line, which is the one item here whose position macOS owns.
+//
+// **It narrows by dropping whole facts, never by scrolling.** The window's
+// `minWidth` is 880 (`src-tauri/tauri.conf.json`), and the row's contents do
+// not fit there at their widest. What goes, in order:
+//
+//   1. the autonomy pill's **sentence** (below `lg`, 1024px), leaving the
+//      shield and the tier's name;
+//   2. the company switcher's width, which is capped at `max-w-72` and
+//      truncates its label — it has always done this.
+//
+// The tier's *name* never goes: it is the fact the pill exists to carry, and a
+// row that has silently dropped it looks identical to a company with no policy
+// at all. Nothing here wraps and nothing scrolls — every item is `flex-none`
+// except the deliberately elastic middle, so the row cannot grow a second line
+// or a horizontal scrollbar however narrow the window gets.
 
 import {
   WINDOW_TITLE_BAR_HEIGHT,
@@ -32,10 +47,19 @@ import {
 
 export function WindowTitleBar({
   switcher,
+  autonomy,
   profile,
 }: {
   /** The company/host switcher. Leads the row, right of the traffic lights. */
   switcher: React.ReactNode;
+  /**
+   * The standing autonomy policy, right-aligned before the profile control.
+   *
+   * Optional, and absent is a real state rather than a gap: the pill renders
+   * nothing when the host has not said what the tier is, and the row closes up
+   * around it. See `AutonomyPill`.
+   */
+  autonomy?: React.ReactNode;
   /** The profile / account control, at the far right. */
   profile: React.ReactNode;
 }) {
@@ -62,6 +86,18 @@ export function WindowTitleBar({
       {/* The draggable middle. `self-stretch` so the grabbable area is the full
           height of the row rather than a hairline through its centre. */}
       <div data-tauri-drag-region aria-hidden="true" className="min-w-0 flex-1 self-stretch" />
+      {/* The standing policy, immediately before the profile control. It is a
+          control rather than static chrome — the tier can be changed from here
+          — so it deliberately does NOT carry `data-tauri-drag-region`: the
+          attribute is opt-in per element, and marking a button would hand its
+          presses to the window drag instead of to the menu it opens. The
+          `flex-1 self-stretch` spacer above is the row's only elastic member,
+          so that spacer — not the pill — is what keeps the band between the
+          switcher and here grabbable. See `AutonomyPill`.
+          Rendered without a wrapper on purpose: the pill returns `null` when
+          the tier is unknown, and a wrapper would survive it as an empty box
+          holding one `gap-2` of dead space open in the middle of the row. */}
+      {autonomy}
       {/* Last in the DOM as well as last on screen, so tab order reads
           left-to-right across the row. */}
       <div className="flex-none">{profile}</div>

--- a/frontend/src/hooks/use-autonomy.ts
+++ b/frontend/src/hooks/use-autonomy.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import type { OpenCompanyClient } from "@/api/client";
-import { getPolicy, type PolicyStatus } from "@/api/policy";
+import { getPolicy, isPolicyStatus, type PolicyStatus } from "@/api/policy";
 import { startVisiblePolling } from "@/lib/visible-poll";
 
 /**
@@ -114,7 +114,12 @@ export function useAutonomy(
       const issued = generation;
       void getPolicy(client, company)
         .then((next) => {
-          if (live && issued === generation) setPolicy(next);
+          // `isPolicyStatus`, not a cast. A body that is not a policy is
+          // treated exactly as an unreachable host is — the pill keeps what it
+          // had and states nothing new — because the alternative is putting it
+          // on screen, where the first `tiers.find` throws and takes the whole
+          // console down with it. See the note on the predicate.
+          if (live && issued === generation && isPolicyStatus(next)) setPolicy(next);
         })
         .catch(() => {
           // Silent, like the deadline read. A host that cannot answer leaves
@@ -134,7 +139,10 @@ export function useAutonomy(
       client,
       company,
       accept: (next) => {
-        if (!live) return;
+        // Same fence on the write path. `applyAutonomy` is handed whatever the
+        // host returned from a PUT, and a PUT can answer with rubbish exactly
+        // as a GET can.
+        if (!live || !isPolicyStatus(next)) return;
         generation += 1;
         setPolicy(next);
       },

--- a/frontend/src/hooks/use-autonomy.ts
+++ b/frontend/src/hooks/use-autonomy.ts
@@ -29,6 +29,28 @@ interface Reader {
 }
 
 /**
+ * A policy **and the scope it describes**, held together.
+ *
+ * The scope travels with the value because a company switch is a render, not
+ * an effect. `useState` survives the change of `company` — nothing about a new
+ * dependency array empties it — and the clear below runs in a *passive* effect,
+ * which React schedules AFTER paint. So the first frame of the new company was
+ * drawn with the previous company's tier still in state, and the title row
+ * names the company an inch to the left of the pill: a confident, attributed,
+ * wrong answer about what a different company's agents may do.
+ *
+ * Pairing the two makes that unrepresentable rather than merely unlikely. The
+ * hook returns the policy only while the snapshot's scope is still the scope
+ * being asked about, so the switch frame answers `null` — which this hook
+ * documents as a real answer, and which the pill renders as nothing at all.
+ */
+interface Snapshot {
+  client: OpenCompanyClient;
+  company: string | null;
+  policy: PolicyStatus;
+}
+
+/**
  * Every mounted reader. In practice there is exactly one — the shell's — but
  * the scope is compared anyway (see {@link applyAutonomy}) so that a second
  * console mounted beside it could never be handed another company's tier.
@@ -87,7 +109,7 @@ export function useAutonomy(
   client: OpenCompanyClient,
   company: string | null,
 ): PolicyStatus | null {
-  const [policy, setPolicy] = useState<PolicyStatus | null>(null);
+  const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
   useEffect(() => {
     let live = true;
     // Serialize refreshes, exactly as `useApprovalDeadline` does: a slow
@@ -104,7 +126,16 @@ export function useAutonomy(
     // Clear on a company switch. Carrying the previous company's tier into the
     // new one's title bar would be a wrong answer rather than a stale one —
     // the row names the company beside it.
-    setPolicy(null);
+    //
+    // This is the second of two clears, not the only one, and it is the weaker
+    // of the two: a passive effect runs after paint, so on its own it lets one
+    // frame of the new company render under the old company's tier. The scope
+    // check on the returned value is what actually fences that frame. This call
+    // still earns its place — it drops the reference rather than leaving a
+    // previous company's policy alive in state, so switching A → B → A does not
+    // paint A's minutes-old tier back before the first read of the new mount
+    // lands.
+    setSnapshot(null);
     const refresh = () => {
       if (refreshing) {
         queued = true;
@@ -119,7 +150,9 @@ export function useAutonomy(
           // had and states nothing new — because the alternative is putting it
           // on screen, where the first `tiers.find` throws and takes the whole
           // console down with it. See the note on the predicate.
-          if (live && issued === generation && isPolicyStatus(next)) setPolicy(next);
+          if (live && issued === generation && isPolicyStatus(next)) {
+            setSnapshot({ client, company, policy: next });
+          }
         })
         .catch(() => {
           // Silent, like the deadline read. A host that cannot answer leaves
@@ -144,7 +177,7 @@ export function useAutonomy(
         // as a GET can.
         if (!live || !isPolicyStatus(next)) return;
         generation += 1;
-        setPolicy(next);
+        setSnapshot({ client, company, policy: next });
       },
     };
     readers.add(reader);
@@ -156,5 +189,10 @@ export function useAutonomy(
       dispose();
     };
   }, [client, company]);
-  return policy;
+  // The scope check, not a bare `return snapshot?.policy`. See {@link Snapshot}:
+  // state outlives the dependency change that invalidates it, and the effect
+  // that clears it runs after the frame that would have shown it.
+  return snapshot && snapshot.client === client && snapshot.company === company
+    ? snapshot.policy
+    : null;
 }

--- a/frontend/src/hooks/use-autonomy.ts
+++ b/frontend/src/hooks/use-autonomy.ts
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { getPolicy, type PolicyStatus } from "@/api/policy";
+import { startVisiblePolling } from "@/lib/visible-poll";
+
+/**
+ * How often the title row re-reads the policy.
+ *
+ * Deliberately slower than {@link useApprovalDeadline}'s 5s. That hook runs
+ * while the approvals view is open, beside a feed already polling at that
+ * cadence; this one is mounted for the entire life of the console, on every
+ * view. The tier changes when an operator changes it — minutes or days apart,
+ * never seconds — so a faster cadence would buy nothing and cost a request
+ * every five seconds forever. `startVisiblePolling` gates on visibility, so a
+ * backgrounded window costs the host nothing at all.
+ *
+ * It is also why {@link applyAutonomy} exists: 30s is the right cadence for
+ * *noticing* someone else's change and far too long to wait for your own.
+ */
+const POLL_MS = 30000;
+
+/** One mounted {@link useAutonomy}, with the scope it is reading. */
+interface Reader {
+  client: OpenCompanyClient;
+  company: string | null;
+  /** Take a policy the host has just returned, in place of the next poll. */
+  accept: (next: PolicyStatus) => void;
+}
+
+/**
+ * Every mounted reader. In practice there is exactly one — the shell's — but
+ * the scope is compared anyway (see {@link applyAutonomy}) so that a second
+ * console mounted beside it could never be handed another company's tier.
+ */
+const readers = new Set<Reader>();
+
+/**
+ * Hand a just-written policy to the readers of that scope, now.
+ *
+ * The title-bar tier switcher writes through `setPolicy`, which **returns the
+ * host's own resulting `PolicyStatus`** — so there is nothing to guess at and
+ * nothing optimistic here: this is the same value the next poll would fetch,
+ * arriving one round trip earlier instead of up to {@link POLL_MS} later.
+ *
+ * Pushing it into the hook rather than keeping it beside the pill is what
+ * keeps a single source of truth for the tier. A local copy in the control
+ * would have to be reconciled against every poll, and the failure mode of
+ * getting that wrong is the one this component cannot have: a pill stating an
+ * autonomy level the company is not actually under.
+ *
+ * A write that **fails** calls nothing, so the displayed tier is never
+ * anything but a value the host returned.
+ *
+ * Scope is matched by object identity on `client` plus the company string,
+ * because the caller and the reader are handed the very same client instance
+ * by the shell. A string scope key would collide across two hosts serving the
+ * same company id.
+ */
+export function applyAutonomy(
+  client: OpenCompanyClient,
+  company: string | null,
+  next: PolicyStatus,
+): void {
+  for (const reader of readers) {
+    if (reader.client === client && reader.company === company) reader.accept(next);
+  }
+}
+
+/**
+ * The company's effective autonomy policy, or `null` while it is unknown.
+ *
+ * **`null` is a real answer here, not a loading placeholder**, and the pill
+ * renders nothing for it. The alternative — defaulting to a tier — would put a
+ * confident sentence about what the agents are allowed to do on screen at the
+ * exact moment the console does not know, which is the one failure mode a
+ * standing policy indicator cannot have. An older or unreachable host, a
+ * revoked session, and a company that has just been switched away from all land
+ * here, and all three deserve an empty space rather than a guess.
+ *
+ * This is the same read the approvals settings page makes
+ * (`GET {scope}/policy`), so the pill and the page it describes cannot disagree
+ * about the tier: there is one endpoint and it returns the *effective* policy —
+ * the console override where one is set, the manifest everywhere else.
+ */
+export function useAutonomy(
+  client: OpenCompanyClient,
+  company: string | null,
+): PolicyStatus | null {
+  const [policy, setPolicy] = useState<PolicyStatus | null>(null);
+  useEffect(() => {
+    let live = true;
+    // Serialize refreshes, exactly as `useApprovalDeadline` does: a slow
+    // request must not be invalidated by the next polling tick, or a
+    // consistently slow host would never update the row.
+    let refreshing = false;
+    let queued = false;
+    // Bumped every time a write hands us the host's answer directly. A read
+    // *issued* before that bump is stale by construction however late it
+    // lands, and dropping it is what stops a poll that was already in flight
+    // when the operator changed the tier from putting the old tier back on
+    // screen for the rest of the polling interval.
+    let generation = 0;
+    // Clear on a company switch. Carrying the previous company's tier into the
+    // new one's title bar would be a wrong answer rather than a stale one —
+    // the row names the company beside it.
+    setPolicy(null);
+    const refresh = () => {
+      if (refreshing) {
+        queued = true;
+        return;
+      }
+      refreshing = true;
+      const issued = generation;
+      void getPolicy(client, company)
+        .then((next) => {
+          if (live && issued === generation) setPolicy(next);
+        })
+        .catch(() => {
+          // Silent, like the deadline read. A host that cannot answer leaves
+          // the pill absent; it must not blank an answer it already has, so a
+          // transient failure mid-session keeps the last known tier rather
+          // than flickering the row.
+        })
+        .finally(() => {
+          refreshing = false;
+          if (queued && live) {
+            queued = false;
+            refresh();
+          }
+        });
+    };
+    const reader: Reader = {
+      client,
+      company,
+      accept: (next) => {
+        if (!live) return;
+        generation += 1;
+        setPolicy(next);
+      },
+    };
+    readers.add(reader);
+    refresh();
+    const dispose = startVisiblePolling(refresh, POLL_MS);
+    return () => {
+      live = false;
+      readers.delete(reader);
+      dispose();
+    };
+  }, [client, company]);
+  return policy;
+}

--- a/frontend/test/e2e/shell-two-layer.spec.ts
+++ b/frontend/test/e2e/shell-two-layer.spec.ts
@@ -15,9 +15,11 @@ import { openFirstWorkflow } from "./workflows";
  * The first attempt at this issue (PR #1188) inset the frame on three sides
  * over a flat tint and shipped a hairline sliver: structurally a two-layer
  * shell, visually nothing. Every geometric assertion below therefore names a
- * quantity rather than a class — a margin of at least 8px on *all four* sides,
- * a real corner radius, a card fill measurably different from the chrome —
- * because "the class is present" is exactly what that change would have passed.
+ * quantity rather than a class — a margin of at least 8px on the three sides
+ * that face the window, a thinner but non-zero one under the title row that now
+ * stands above the card, a real corner radius, a card fill measurably different
+ * from the chrome — because "the class is present" is exactly what that change
+ * would have passed.
  *
  * # The single-scrim property
  *
@@ -107,6 +109,19 @@ async function shell(page: Page) {
       unframed: card?.getAttribute("data-unframed") ?? null,
       insetBox: box(inset),
       cardBox: box(card),
+      // The window's title row and the lowest edge anything actually *stands*
+      // on in it. The row is 52px of chrome whose controls are centred in it,
+      // so its own bottom edge is not what the eye measures the card's top gap
+      // from — the bottom of the controls is. Both named rather than derived
+      // from the row's children, because the row's elastic middle is a
+      // full-height drag spacer and would report the row's own edge.
+      titleBarBox: box(q('[data-testid="window-title-bar"]')),
+      titleRowContentBottom: (() => {
+        const bottoms = ['[data-testid="host-switcher"]', '[data-testid="autonomy-pill"]']
+          .map((selector) => box(q(selector))?.bottom)
+          .filter((bottom): bottom is number => bottom !== undefined);
+        return bottoms.length > 0 ? Math.max(...bottoms) : null;
+      })(),
     };
   });
 }
@@ -133,7 +148,7 @@ for (const theme of ["light", "dark"] as const) {
     expect(s.sidebarBorderRight).toBe(0);
   });
 
-  test(`the content card is inset on all four sides and rounded (${theme})`, async ({ page }) => {
+  test(`the content card is framed on three sides, clear of the title row on the fourth (${theme})`, async ({ page }) => {
     await open(page, theme, "/#/settings");
     const s = await shell(page);
 
@@ -142,14 +157,13 @@ for (const theme of ["light", "dark"] as const) {
     expect(frame).not.toBeNull();
     expect(card).not.toBeNull();
 
-    // A frame, not a sliver, and an EVEN one: the four sides come from a single
-    // `--frame-inset`, so they are equal by construction rather than by four
-    // numbers that happen to agree. The closed first attempt at this issue
-    // inset three sides and left the fourth flush, which is what produced a
-    // sliver instead of a frame.
+    // A frame, not a sliver, and an EVEN one on the three sides that face the
+    // window: they come from a single `--frame-inset`, so they are equal by
+    // construction rather than by three numbers that happen to agree. The
+    // closed first attempt at this issue inset three sides and left the fourth
+    // flush, which is what produced a sliver instead of a frame.
     const insets = {
       left: card!.left - frame!.left,
-      top: card!.top - frame!.top,
       right: frame!.right - card!.right,
       bottom: frame!.bottom - card!.bottom,
     };
@@ -157,6 +171,38 @@ for (const theme of ["light", "dark"] as const) {
       expect(gap, `${side} inset`).toBeGreaterThanOrEqual(8);
       expect(gap, `${side} inset matches the left`).toBeCloseTo(insets.left, 0);
     }
+
+    // The top is the one side that does NOT face the window, and it is held to
+    // a different rule on purpose. A full `--frame-inset` there stacks on top of
+    // the space the title row's own controls are already centred in, and the
+    // sum reads as a gap half again as large as the other three edges. So the
+    // card takes a thin margin (`mt-0.5`) and the row above supplies the rest.
+    //
+    // Two quantities are still pinned, and between them they fence both ways it
+    // can go wrong. `mt-0` — the card welded to the underside of the row — is
+    // caught by the first. A restored even frame, which is what someone reading
+    // only the three assertions above would "fix" this to, is caught by the
+    // second.
+    const top = card!.top - frame!.top;
+    expect(top, "the card is not flush with the row above it").toBeGreaterThan(0);
+    expect(
+      top,
+      "…and does not repeat the whole frame under a row that already spaces it",
+    ).toBeLessThan(insets.left);
+
+    // And the row is chrome standing clear above the card, never over it: it is
+    // outside the scrolling card by construction, and nothing it carries may
+    // overlap the sheet below.
+    expect(s.titleBarBox, "the window title row should be on screen").not.toBeNull();
+    expect(s.titleRowContentBottom, "the title row should have controls standing in it").not.toBeNull();
+    expect(
+      s.titleBarBox!.bottom,
+      "the title row ends above the card rather than over it",
+    ).toBeLessThanOrEqual(card!.top);
+    expect(
+      card!.top - s.titleRowContentBottom!,
+      "the controls in the row clear the card's top edge",
+    ).toBeGreaterThan(0);
 
     expect(s.cardRadius).toBeGreaterThanOrEqual(8);
     expect(s.cardBorderWidth).toBeGreaterThan(0);

--- a/frontend/test/e2e/sidebar-navigation-accessibility.spec.ts
+++ b/frontend/test/e2e/sidebar-navigation-accessibility.spec.ts
@@ -43,18 +43,39 @@ test("the skip link reaches main content and the sidebar is the primary navigati
   await expect(navigation).toBeVisible();
   await expect(navigation.getByRole("button", { name: "Overview", exact: true })).toBeVisible();
 
-  // Settings, Feedback, Discord and Collapse are utilities, not destinations an
-  // operator works out of, so they sit on their own named bar in the sidebar's
-  // header rather than as four rows inside this landmark. Each is icon-only in
-  // both sidebar states, which makes the accessible name the only name it has
-  // — exactly the thing a styling pass drops without breaking a render.
+  // Settings, Feedback and Discord are utilities: things you do to the console
+  // rather than the places an operator works out of. They keep a named group of
+  // their own, and it is now in the sidebar's FOOTER — the header the bar used
+  // to sit in is gone, along with the host switcher that shared it, both moved
+  // into the window's title row.
+  //
+  // THREE, not four. The collapse control left this group entirely and now sits
+  // on the content card's leading seam, outside the sidebar; it is pinned there
+  // by `sidebar-toggle-reachable.spec.ts`, and asserted below only to the extent
+  // that it is no longer here.
   const utilities = page.getByRole("group", { name: "Console utilities", exact: true });
   await expect(utilities).toBeVisible();
-  for (const name of ["Settings", "Feedback", "Join our Discord", "Collapse sidebar"]) {
-    await expect(utilities.getByRole(name === "Join our Discord" ? "link" : "button", { name, exact: true })).toBeVisible();
+  for (const name of ["Settings", "Feedback", "Join our Discord"]) {
+    await expect(
+      utilities.getByRole(name === "Join our Discord" ? "link" : "button", { name, exact: true }),
+    ).toBeVisible();
   }
-  // And they are NOT in the navigation landmark, which is the point of moving
-  // them: it lists the places you go, and these four are not places.
-  await expect(navigation.getByRole("button", { name: "Settings", exact: true })).toHaveCount(0);
-  await expect(navigation.getByRole("button", { name: "Feedback", exact: true })).toHaveCount(0);
+  await expect(
+    utilities.getByRole("button", { name: /sidebar$/ }),
+    "the collapse control is not one of the console's utilities any more",
+  ).toHaveCount(0);
+
+  // And they are not interleaved with the destinations. The three now carry
+  // visible labels and `aria-current`, so they belong INSIDE the navigation
+  // landmark in a way the old icon-only bar did not — what still has to hold is
+  // that they are a separate, separately named group under the list of places
+  // you go, rather than three more rows in it. `sidebar-content` is that list;
+  // `sidebar-footer` is the group.
+  const destinations = page.locator("[data-slot=sidebar-content]");
+  await expect(destinations.getByRole("button", { name: "Overview", exact: true })).toBeVisible();
+  await expect(destinations.getByRole("button", { name: "Settings", exact: true })).toHaveCount(0);
+  await expect(destinations.getByRole("button", { name: "Feedback", exact: true })).toHaveCount(0);
+  await expect(
+    page.locator("[data-slot=sidebar-footer]").getByTestId("sidebar-utilities"),
+  ).toHaveCount(1);
 });

--- a/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
+++ b/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
@@ -64,6 +64,44 @@ test.describe("sidebar toggle reachability", () => {
     await expect(page.getByText("Workflows", { exact: true })).toBeVisible();
   });
 
+  test("the seam control is desktop-only, so the sheet has exactly one way back", async ({
+    page,
+  }) => {
+    // 700px is below `md` (768), which is also exactly where `useIsMobile`
+    // flips — the CSS gate and the hook agree by construction rather than by
+    // coincidence.
+    //
+    // The seam button used to render here too, which was two controls for one
+    // job on one viewport and the second one was wrong in both halves:
+    // `SidebarCollapseButton` treats mobile as not-collapsed on purpose, so
+    // with the sheet CLOSED it announced itself "Collapse sidebar" and drew the
+    // close icon while pressing it OPENED the sheet.
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/#/overview");
+    await dismissTour(page);
+
+    await expect(
+      page.getByTestId("sidebar-collapse"),
+      "the seam control does not render below md",
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Collapse sidebar", exact: true }),
+      "…so nothing here claims it collapses a column that is a sheet",
+    ).toHaveCount(0);
+
+    // One control, and it is the one that means what it says.
+    const trigger = page.getByRole("button", { name: "Toggle sidebar" });
+    await expect(trigger).toHaveCount(1);
+    await expect(trigger).toBeInViewport();
+    await trigger.click();
+    await expect(page.getByRole("dialog", { name: "Sidebar" })).toBeVisible();
+
+    // And it comes back at `md`, which is what stops this being satisfied by a
+    // control that was deleted rather than gated.
+    await page.setViewportSize({ width: 1024, height: 800 });
+    await expect(page.getByTestId("sidebar-collapse")).toHaveCount(1);
+  });
+
   test("the mobile sheet closes after selecting a destination", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto("/#/overview");

--- a/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
+++ b/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
@@ -80,10 +80,16 @@ test.describe("sidebar toggle reachability", () => {
     await page.goto("/#/overview");
     await dismissTour(page);
 
+    // `toBeHidden`, not `toHaveCount(0)`: the gate is CSS (`hidden md:block`),
+    // matching the `md:hidden` on the mobile trigger it defers to, so the node
+    // stays in the DOM with `display: none`. That is the whole claim, because
+    // `display: none` also takes an element out of the accessibility tree and
+    // out of the tab order — which the role query on the next line is what
+    // actually proves.
     await expect(
       page.getByTestId("sidebar-collapse"),
-      "the seam control does not render below md",
-    ).toHaveCount(0);
+      "the seam control is not shown below md",
+    ).toBeHidden();
     await expect(
       page.getByRole("button", { name: "Collapse sidebar", exact: true }),
       "…so nothing here claims it collapses a column that is a sheet",
@@ -97,9 +103,12 @@ test.describe("sidebar toggle reachability", () => {
     await expect(page.getByRole("dialog", { name: "Sidebar" })).toBeVisible();
 
     // And it comes back at `md`, which is what stops this being satisfied by a
-    // control that was deleted rather than gated.
+    // control that was deleted, or hidden at every width, rather than gated.
     await page.setViewportSize({ width: 1024, height: 800 });
-    await expect(page.getByTestId("sidebar-collapse")).toHaveCount(1);
+    await expect(page.getByTestId("sidebar-collapse")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Collapse sidebar", exact: true }),
+    ).toHaveCount(1);
   });
 
   test("the mobile sheet closes after selecting a destination", async ({ page }) => {

--- a/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
+++ b/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
@@ -6,17 +6,19 @@ import { expect, test } from "@playwright/test";
  * Two shapes, because the sidebar has two. On mobile it is a sheet that closes
  * entirely, taking its own controls with it, so the way back is a button
  * docked in its own chrome bar below the page. On desktop it collapses to a
- * 3rem icon rail that keeps its header, so the way back is the same control
- * that put it there.
+ * 3rem icon rail, and the way back is a control that never belonged to the
+ * column in the first place.
  *
- * The desktop half also pins WHERE that control lives (issue #1177). It used to
- * be a full-width row directly above Overview — the nav row shape exactly, for
- * something that is not a destination — and the fix is a header button. The
- * assertion that it is inside `sidebar-header` and absent from `sidebar-content`
- * is what stops it drifting back into the list, and it is deliberately paired
- * with the reachability claims rather than filed on its own: a control that is
- * in the right place but unreachable, or reachable but nameless, is the same
- * bug in a different coat.
+ * The desktop half also pins WHERE that control lives. It used to be a
+ * full-width row directly above Overview — the nav row shape exactly, for
+ * something that is not a destination (issue #1177) — then a button in the
+ * sidebar's header, which put the control that *hides* a panel inside the panel
+ * it hides. It now sits on the leading seam of the content card, outside the
+ * sidebar entirely, and the assertions that it is absent from `sidebar` and
+ * from `sidebar-content` and centred on that seam are what stop it drifting
+ * back into either. They are deliberately paired with the reachability claims
+ * rather than filed on their own: a control that is in the right place but
+ * unreachable, or reachable but nameless, is the same bug in a different coat.
  *
  * The mobile half used to be `position: fixed`, floating over whatever content
  * happened to scroll into the same bottom-left corner and winning every
@@ -142,7 +144,7 @@ test.describe("sidebar toggle reachability", () => {
     await expect(page.getByText("Workflows", { exact: true })).toBeVisible();
   });
 
-  test("the inline sidebar's collapse control is a named, keyboard-operable header button", async ({
+  test("the inline sidebar's collapse control is a named, keyboard-operable control on the seam", async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1024, height: 800 });
@@ -157,37 +159,48 @@ test.describe("sidebar toggle reachability", () => {
     // leaves a button a screen reader announces as "button".
     await expect(toggle).toBeInViewport();
 
-    // Chrome, not a destination. It lives in the header with the host switcher
-    // and is nowhere in the nav list.
+    // Not in the panel it hides — which is the whole of the move. It used to
+    // live in the sidebar's own header, so collapsing the column took the
+    // control with it and the rail had to keep a copy standing. It now renders
+    // from `app-shell.tsx` inside `SidebarInset`, on the content card's leading
+    // seam, and there is exactly one of it in either state.
     await expect(
-      page.locator("[data-slot=sidebar-header]").getByTestId("sidebar-collapse"),
-      "the collapse control belongs to the sidebar's header",
+      sidebar.getByTestId("sidebar-collapse"),
+      "the collapse control is not inside the panel it collapses",
+    ).toHaveCount(0);
+    await expect(
+      page.locator("[data-slot=sidebar-inset]").getByTestId("sidebar-collapse"),
+      "…it belongs to the content side of the seam",
     ).toHaveCount(1);
     await expect(
       page.locator("[data-slot=sidebar-content]").getByTestId("sidebar-collapse"),
       "…and never among the nav rows, which is what issue #1177 was",
     ).toHaveCount(0);
+    await expect(page.getByTestId("sidebar-collapse")).toHaveCount(1);
 
-    // Below the switcher, not on top of it and not a second half of it. It sat
-    // to the switcher's RIGHT until the four utility controls — Settings,
-    // Feedback, Discord and this one — were gathered onto their own bar under
-    // the nameplate; the claim that survives the move is the one that mattered
-    // then too, which is that the two boxes do not overlap and the reader can
-    // tell them apart.
-    const switcherBox = await page.getByTestId("host-switcher").boundingBox();
-    const toggleBox = await toggle.boundingBox();
-    expect(switcherBox, "the host switcher should have a box").not.toBeNull();
-    expect(toggleBox, "the collapse control should have a box").not.toBeNull();
-    expect(
-      toggleBox!.y,
-      "the collapse button stands clear of the host switcher's lower edge",
-    ).toBeGreaterThanOrEqual(switcherBox!.y + switcherBox!.height);
-
-    // And it is on the utility bar rather than loose in the header, which is
-    // what keeps it beside the three controls of its own kind.
+    // It also left the utility bar it was gathered onto, which now holds the
+    // three controls that ARE destinations (Settings, Feedback, Discord) and
+    // nothing that only changes the chrome.
     await expect(
       page.getByTestId("sidebar-utilities").getByTestId("sidebar-collapse"),
-    ).toHaveCount(1);
+    ).toHaveCount(0);
+
+    // Centred ON the card's leading border rather than sitting inside the card
+    // or inside the rail: `left-(--frame-inset)` puts it at that edge and
+    // `-translate-x-1/2` straddles it. This is the assertion that stops it
+    // drifting back into the page, where it read as part of the content.
+    const seam = async () => {
+      const card = await page.getByTestId("content-surface").boundingBox();
+      const box = await page.getByTestId("sidebar-collapse").boundingBox();
+      expect(card, "the content card should have a box").not.toBeNull();
+      expect(box, "the collapse control should have a box").not.toBeNull();
+      return { centre: box!.x + box!.width / 2, edge: card!.x };
+    };
+    const expanded = await seam();
+    expect(
+      Math.abs(expanded.centre - expanded.edge),
+      "the control straddles the content card's leading border",
+    ).toBeLessThanOrEqual(1);
 
     // Operable from the keyboard, not just under a pointer. An icon-only
     // button is exactly the kind that gets rebuilt as a `div` with an
@@ -196,8 +209,8 @@ test.describe("sidebar toggle reachability", () => {
     await expect(toggle).toBeFocused();
     await page.keyboard.press("Enter");
 
-    // It survives the state it just produced. This is the case most likely to
-    // be got wrong: the control is now inside a 3rem column.
+    // It survives the state it just produced — the case most likely to be got
+    // wrong, and the one the old placement got wrong by construction.
     await expect(sidebar).toHaveAttribute("data-state", "collapsed");
     const expand = page.getByRole("button", { name: "Expand sidebar", exact: true });
     await expect(expand).toBeVisible();
@@ -205,7 +218,7 @@ test.describe("sidebar toggle reachability", () => {
 
     // `data-state` flips on the click; the column takes `duration-200` to get
     // there. Poll rather than sample, or this measures a sidebar caught half
-    // way and reports a button that fits as one that does not.
+    // way and reports a control positioned against a seam still in motion.
     await expect
       .poll(
         async () => (await page.locator("[data-slot=sidebar-container]").boundingBox())?.width,
@@ -213,13 +226,22 @@ test.describe("sidebar toggle reachability", () => {
       )
       .toBe(RAIL_WIDTH);
 
+    // The seam moved left with the column; the control moved with the seam and
+    // is still on it, still whole, and still on screen.
+    const collapsed = await seam();
+    expect(
+      Math.abs(collapsed.centre - collapsed.edge),
+      "…and it is still on that border once the column is a rail",
+    ).toBeLessThanOrEqual(1);
+    expect(
+      collapsed.edge,
+      "the seam it rides tracks the rail rather than staying where the column was",
+    ).toBeLessThan(expanded.edge);
     const railBox = await expand.boundingBox();
     expect(railBox, "the collapsed control should have a box").not.toBeNull();
-    expect(railBox!.x, "…inside the rail, not hanging off its left edge").toBeGreaterThanOrEqual(0);
-    expect(
-      railBox!.x + railBox!.width,
-      "…and inside the rail, not overflowing its right edge",
-    ).toBeLessThanOrEqual(RAIL_WIDTH);
+    expect(railBox!.x, "…and no part of it hangs off the left of the window").toBeGreaterThanOrEqual(
+      0,
+    );
 
     // And back, from the keyboard, to where it started.
     await expand.focus();

--- a/frontend/test/e2e/workflow-selection-persists.spec.ts
+++ b/frontend/test/e2e/workflow-selection-persists.spec.ts
@@ -176,11 +176,13 @@ test("a company switch does not reuse the previous company's workflow route (#86
     timeout: 30_000,
   });
 
-  // Companies live in the host switcher's own menu now — the sidebar footer's
-  // "Switch company" row moved in there with the lifecycle line, leaving the
-  // footer to the profile alone. The trigger is named by its nameplate (the
-  // company and its state), so it is addressed by its test id rather than by a
-  // label it deliberately does not carry.
+  // Companies live in the host switcher's own menu — the sidebar footer's
+  // "Switch company" row moved in there with the lifecycle line, and the
+  // switcher itself has since left the sidebar altogether for the window's
+  // title row (`window-title-bar.tsx`), taking the profile control with it. The
+  // trigger is named by its nameplate (the company and its state), so it is
+  // addressed by its test id rather than by a label it deliberately does not
+  // carry.
   await page.getByTestId("host-switcher").click();
   await page.getByRole("menuitem", { name: "Other", exact: true }).click();
   // Issue #1110 sharpened what this test proves. It used to assert the switch

--- a/frontend/test/unit/autonomy-pill.test.ts
+++ b/frontend/test/unit/autonomy-pill.test.ts
@@ -1,0 +1,693 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Eye, Infinity as InfinityIcon, ShieldCheck, UserCheck, Zap } from "lucide-react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { PolicyStatus } from "@/api/policy";
+import {
+  AutonomyPill,
+  leadSentence,
+  tierDescription,
+  tierIcon,
+  tierLabel,
+} from "@/components/autonomy-pill";
+import { useAutonomy } from "@/hooks/use-autonomy";
+import { ConsoleProvider } from "@/lib/console-context";
+
+/**
+ * The autonomy pill in the window's title row.
+ *
+ * What is actually load-bearing here is not that it draws a pill — it is that
+ * every word in it came from the host, that it says *nothing* when it does not
+ * know, and that it never claims anything about spending. The last one is not
+ * fussiness: this build runs its approval gate with policy HITL disabled
+ * (`src/runtime/builder.rs:2476`), so `autoApproveUnderUsd` governs nothing and
+ * a pill that rendered it would be stating a number that does not apply.
+ *
+ * Since the pill became a tier *switcher*, one more property joins them and
+ * outranks all of them: **the tier on screen is only ever a value the host
+ * returned.** A write that fails must leave the previous tier standing. A pill
+ * that says `readonly` while the company is on `full` is worse than no pill.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+/** The four tiers the runtime accepts, with the host's own text. */
+const TIERS = [
+  {
+    value: "readonly",
+    label: "Read-only",
+    description: "The agents can look at things but change nothing and spend nothing.",
+  },
+  {
+    value: "supervised",
+    label: "Supervised",
+    description:
+      "Conservative execution restrictions. Approval prompts are explicit through request_approval while policy HITL is disabled.",
+  },
+  {
+    value: "auto",
+    label: "Auto",
+    description:
+      "Balanced execution autonomy. Approval prompts are explicit through request_approval while policy HITL is disabled.",
+  },
+  {
+    value: "full",
+    label: "Full",
+    description:
+      "Broadest execution autonomy. Approval prompts are explicit through request_approval while policy HITL is disabled.",
+  },
+];
+
+function policy(overrides: Partial<PolicyStatus> = {}): PolicyStatus {
+  return {
+    mode: "auto",
+    alwaysApprove: [],
+    autoApproveUnderUsd: 5,
+    approvalTtlHours: 24,
+    manifestMode: "auto",
+    manifestAlwaysApprove: [],
+    manifestAutoApproveUnderUsd: 5,
+    manifestApprovalTtlHours: null,
+    overridden: false,
+    tiers: TIERS,
+    takesEffect: "on the next turn",
+    ...overrides,
+  };
+}
+
+let host: HTMLDivElement;
+let root: Root | null = null;
+
+function render(node: Parameters<Root["render"]>[0]) {
+  act(() => root!.render(node));
+}
+
+function pill(): HTMLElement | null {
+  return host.querySelector("[data-testid=autonomy-pill]");
+}
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  toasts.success.mockClear();
+  toasts.error.mockClear();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  host.remove();
+});
+
+describe("reading the tier from the host", () => {
+  it("names each of the four tiers with the host's own label", () => {
+    // All four, not a spot check: the whole point of the pill is that
+    // `readonly` and `full` are not the same state, and a test that only
+    // exercised `auto` would pass against a component that hard-coded it.
+    for (const tier of TIERS) {
+      expect(tierLabel(policy({ mode: tier.value }))).toBe(tier.label);
+    }
+  });
+
+  it("falls back to the mode word for a tier this console has no text for", () => {
+    // A console built against a newer host must name the tier in force rather
+    // than silently render an empty pill.
+    const status = policy({ mode: "guarded", tiers: TIERS });
+    expect(tierLabel(status)).toBe("guarded");
+    expect(tierDescription(status)).toBeNull();
+  });
+});
+
+describe("the lead sentence", () => {
+  it("cuts the host's description at its first sentence, keeping the full stop", () => {
+    expect(leadSentence(TIERS[2].description)).toBe("Balanced execution autonomy.");
+  });
+
+  it("uses a single-sentence description whole", () => {
+    expect(leadSentence(TIERS[0].description)).toBe(
+      "The agents can look at things but change nothing and spend nothing.",
+    );
+  });
+
+  it("uses a description with no sentence break whole", () => {
+    expect(leadSentence("No full stop here")).toBe("No full stop here");
+  });
+});
+
+describe("the tier icons", () => {
+  it("gives each mode word its own glyph, keyed by the word and not by position", () => {
+    // Four distinct icons, one per tier. Position would re-point every icon at
+    // a different meaning the moment a host filtered a tier out of the list.
+    expect(tierIcon("readonly")).toBe(Eye);
+    expect(tierIcon("supervised")).toBe(UserCheck);
+    expect(tierIcon("auto")).toBe(Zap);
+    expect(tierIcon("full")).toBe(InfinityIcon);
+    const glyphs = new Set(TIERS.map((t) => tierIcon(t.value)));
+    expect(glyphs.size).toBe(TIERS.length);
+  });
+
+  it("falls back to the neutral shield for a mode word it has never heard of", () => {
+    // The tier list is the host's, so a newer runtime WILL present a mode with
+    // no entry here. It has to draw that row, not a hole.
+    expect(tierIcon("guarded")).toBe(ShieldCheck);
+    expect(tierIcon("")).toBe(ShieldCheck);
+  });
+
+  it("renders an unknown tier's pill without crashing, glyph and all", () => {
+    render(createElement(AutonomyPill, { status: policy({ mode: "guarded" }) }));
+    expect(pill()!.textContent).toContain("guarded");
+    expect(pill()!.querySelector("svg")).not.toBeNull();
+  });
+});
+
+describe("the pill", () => {
+  it("renders nothing at all when the tier is unknown", () => {
+    // The rule this exists to hold: unknown is never folded into a confident
+    // answer. An empty space is correct; a default tier would be a sentence
+    // about what the agents may do, written when we do not know.
+    render(createElement(AutonomyPill, { status: null }));
+    expect(pill()).toBeNull();
+    expect(host.textContent).toBe("");
+  });
+
+  it("shows the tier's name and the host's lead sentence", () => {
+    render(createElement(AutonomyPill, { status: policy({ mode: "auto" }) }));
+    expect(pill()!.textContent).toContain("Auto");
+    expect(pill()!.textContent).toContain("Balanced execution autonomy.");
+  });
+
+  it("carries the host's FULL description in its tooltip, not the cut one", () => {
+    render(createElement(AutonomyPill, { status: policy({ mode: "auto" }) }));
+    // The row shows a sentence; the hover has to give back everything the host
+    // said, including the half that says policy HITL is disabled.
+    expect(pill()!.getAttribute("title")).toBe(TIERS[2].description);
+    expect(pill()!.getAttribute("title")).toContain("policy HITL is disabled");
+  });
+
+  it("never states a spend threshold, whatever the policy says", () => {
+    // `autoApproveUnderUsd` is stored but inactive in this build — the gate
+    // returns Allow before it is ever consulted
+    // (`src/policy/gate.rs:749`, `src/harness/built_in/policy.rs:1701`), and
+    // the settings page labels the field "(inactive)". Rendering it here would
+    // put a governing-looking number on permanent display that governs nothing.
+    render(createElement(AutonomyPill, { status: policy({ autoApproveUnderUsd: 5 }) }));
+    expect(pill()!.textContent).not.toContain("$");
+    expect(pill()!.textContent).not.toContain("5");
+    expect(pill()!.getAttribute("title")).not.toContain("$");
+  });
+
+  it("is a control, and gives its pointer events back to do it", () => {
+    // Reversed from the original design on the operator's instruction. The
+    // drag band survives because `data-tauri-drag-region` is opt-in per
+    // element: `WindowTitleBar` carries a dedicated `flex-1 self-stretch`
+    // spacer that opts in on its own, and that spacer — not the pill — is the
+    // elastic part of the row.
+    render(createElement(AutonomyPill, { status: policy() }));
+    expect(pill()!.tagName).toBe("BUTTON");
+    expect(pill()!.hasAttribute("data-tauri-drag-region")).toBe(false);
+    // Nothing inside it may swallow the press before the trigger sees it.
+    // `getAttribute` rather than `.className`: an SVG's `className` is an
+    // `SVGAnimatedString` and never a string, so the obvious assertion
+    // silently passes over the one child most likely to be under the pointer.
+    for (const child of Array.from(pill()!.children)) {
+      expect(child.getAttribute("class") ?? "").not.toContain("pointer-events-none");
+    }
+  });
+
+  it("sits in the 52px row with real vertical padding", () => {
+    // `py-0.5` read as cramped against `WINDOW_TITLE_BAR_HEIGHT` (52). The
+    // class is asserted rather than a measured height because jsdom computes
+    // no Tailwind.
+    render(createElement(AutonomyPill, { status: policy() }));
+    expect(pill()!.className).toContain("py-1.5");
+    expect(pill()!.className).not.toContain("py-0.5");
+  });
+
+  it("drops the sentence below the lg breakpoint and keeps the tier's name", () => {
+    // The degradation the 880px minimum window forces, made explicit: the
+    // sentence is hidden, the tier is not. A pill that had silently dropped
+    // the tier would look identical to a company with no policy at all.
+    render(createElement(AutonomyPill, { status: policy({ mode: "auto" }) }));
+    const sentence = pill()!.querySelector(
+      "[data-testid=autonomy-consequence]",
+    ) as HTMLElement;
+    expect(sentence.className).toContain("hidden");
+    expect(sentence.className).toContain("lg:inline");
+    // The label carries no responsive visibility class of its own.
+    const label = Array.from(pill()!.children).find(
+      (c) => c.textContent === "Auto",
+    ) as HTMLElement;
+    expect(label).toBeDefined();
+    expect(label.className).not.toContain("hidden");
+  });
+
+  it("renders no sentence element when the host ships no description", () => {
+    render(createElement(AutonomyPill, { status: policy({ mode: "guarded" }) }));
+    expect(pill()!.textContent).toContain("guarded");
+    expect(pill()!.querySelector("[data-testid=autonomy-consequence]")).toBeNull();
+    expect(pill()!.getAttribute("title")).toBeNull();
+  });
+
+  it("cannot be pressed with no authenticated client to write through", () => {
+    // Rendered outside a `ConsoleProvider` — a styleguide page, or a console
+    // whose session has gone. It still STATES the tier; it just cannot change
+    // it. Disabled rather than hidden, so the capability stays discoverable.
+    render(createElement(AutonomyPill, { status: policy() }));
+    expect((pill() as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The switcher: opening it, what it offers, and what a write does to the row.
+// ---------------------------------------------------------------------------
+
+/**
+ * A fake host. `get` answers `GET {scope}/policy`, `put` the tier write.
+ *
+ * The whole `useAutonomy` → `AutonomyPill` → `setPolicy` → `applyAutonomy`
+ * loop is exercised rather than the pill alone, because the property under
+ * test — "the row never shows a tier the host did not return" — lives in that
+ * loop and in no single piece of it.
+ */
+function client(over: {
+  get?: () => Promise<PolicyStatus>;
+  put?: (path: string, body: unknown) => Promise<PolicyStatus>;
+}): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn(over.get ?? (() => Promise.resolve(policy()))),
+    put: vi.fn(over.put ?? ((_p: string, _b: unknown) => Promise.resolve(policy()))),
+  } as unknown as OpenCompanyClient;
+}
+
+/** The shell's wiring, in miniature: the poll feeds the pill inside the scope. */
+function Harness({ api }: { api: OpenCompanyClient }): ReactNode {
+  const status = useAutonomy(api, "acme");
+  return createElement(ConsoleProvider, {
+    client: api,
+    company: "acme",
+    children: createElement(AutonomyPill, { status }),
+  });
+}
+
+async function mount(api: OpenCompanyClient) {
+  await act(async () => {
+    root!.render(createElement(Harness, { api }));
+  });
+}
+
+/** The menu renders through a portal onto `document.body`, not into `host`. */
+function row(mode: string): HTMLElement | null {
+  return document.querySelector(`[data-testid=autonomy-tier-${mode}]`);
+}
+
+async function openMenu() {
+  await act(async () => {
+    (pill() as HTMLButtonElement).click();
+  });
+}
+
+describe("changing the tier from the title bar", () => {
+  it("offers every tier the host returned, in the host's own words", async () => {
+    const api = client({});
+    await mount(api);
+    await openMenu();
+    for (const tier of TIERS) {
+      const item = row(tier.value);
+      expect(item, `no row for ${tier.value}`).not.toBeNull();
+      expect(item!.textContent).toContain(tier.label);
+      // The FULL description, not `leadSentence`: an open menu has the room,
+      // and this is the moment the words actually matter.
+      expect(item!.textContent).toContain(tier.description);
+    }
+  });
+
+  it("offers a tier this console has no icon or text for", async () => {
+    // The list is the host's. A console that showed only the modes it
+    // recognizes would silently withhold a tier the host would accept.
+    const api = client({
+      get: () =>
+        Promise.resolve(
+          policy({
+            tiers: [
+              ...TIERS,
+              { value: "guarded", label: "Guarded", description: "Something newer." },
+            ],
+          }),
+        ),
+    });
+    await mount(api);
+    await openMenu();
+    expect(row("guarded")).not.toBeNull();
+    expect(row("guarded")!.textContent).toContain("Guarded");
+  });
+
+  it("marks the tier actually in force", async () => {
+    const api = client({ get: () => Promise.resolve(policy({ mode: "supervised" })) });
+    await mount(api);
+    await openMenu();
+    expect(row("supervised")!.getAttribute("aria-current")).toBe("true");
+    expect(row("full")!.getAttribute("aria-current")).toBe("false");
+  });
+
+  it("carries the host's timing sentence into the menu, before the choice", async () => {
+    // An operator pulling the tier down mid-incident needs to know a running
+    // turn finishes under the OLD tier before they pick, not after.
+    const api = client({
+      get: () => Promise.resolve(policy({ takesEffect: "on the next turn" })),
+    });
+    await mount(api);
+    await openMenu();
+    const note = document.querySelector("[data-testid=autonomy-takes-effect]");
+    expect(note).not.toBeNull();
+    expect(note!.textContent).toContain("Takes effect on the next turn.");
+  });
+
+  it("writes the chosen mode and shows the tier the host answered with", async () => {
+    const api = client({
+      get: () => Promise.resolve(policy({ mode: "auto" })),
+      put: () => Promise.resolve(policy({ mode: "readonly" })),
+    });
+    await mount(api);
+    expect(pill()!.textContent).toContain("Auto");
+    await openMenu();
+    await act(async () => {
+      row("readonly")!.click();
+    });
+    // Only `mode` — an omitted field is left alone by the host, so picking a
+    // tier here cannot silently discard the always-ask list.
+    expect(api.put).toHaveBeenCalledWith("/api/v1/company/acme/policy", {
+      mode: "readonly",
+    });
+    // And the row says so NOW, not after the 30s poll.
+    expect(pill()!.textContent).toContain("Read-only");
+    expect(toasts.success).toHaveBeenCalled();
+  });
+
+  it("leaves the previous tier standing when the write fails", async () => {
+    // THE case. A rejected write must never leave a tier on screen that the
+    // company is not actually under.
+    const api = client({
+      get: () => Promise.resolve(policy({ mode: "auto" })),
+      put: () => Promise.reject(new Error("Only an admin can change the policy.")),
+    });
+    await mount(api);
+    await openMenu();
+    // `full` is wider than `auto`, so the write is behind the confirmation.
+    await act(async () => {
+      row("full")!.click();
+    });
+    await act(async () => {
+      confirmButton()!.click();
+    });
+    expect(pill()!.textContent).toContain("Auto");
+    expect(pill()!.textContent).not.toContain("Full");
+    // And it says so out loud rather than failing silently.
+    expect(toasts.error).toHaveBeenCalledWith("Only an admin can change the policy.");
+  });
+
+  it("ignores a poll that was already in flight when the tier was written", async () => {
+    // The 30s poll and the write race, and the poll can lose: a read ISSUED
+    // before the change lands after it, still carrying the old tier. Without a
+    // guard that response wins and the row states the previous tier for the
+    // rest of the interval — which is exactly the "up to 30s of a wrong
+    // answer" the direct hand-back exists to remove.
+    vi.useFakeTimers();
+    try {
+      let releaseStale: ((next: PolicyStatus) => void) | null = null;
+      let reads = 0;
+      const api = client({
+        get: () => {
+          reads += 1;
+          if (reads === 1) return Promise.resolve(policy({ mode: "auto" }));
+          return new Promise<PolicyStatus>((resolve) => {
+            releaseStale = resolve;
+          });
+        },
+        put: () => Promise.resolve(policy({ mode: "readonly" })),
+      });
+      await mount(api);
+      // Tick the poll so a second read is genuinely in flight.
+      await act(async () => {
+        vi.advanceTimersByTime(30000);
+      });
+      expect(reads).toBe(2);
+      await openMenu();
+      await act(async () => {
+        row("readonly")!.click();
+      });
+      expect(pill()!.textContent).toContain("Read-only");
+      // Now the stale read answers, with the tier as it was before the write.
+      await act(async () => {
+        releaseStale!(policy({ mode: "auto" }));
+      });
+      expect(pill()!.textContent).toContain("Read-only");
+      expect(pill()!.textContent).not.toContain("Auto");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not re-write the tier already in force", async () => {
+    // The PUT is attributed and durable: it would record an operator
+    // "changing" the policy to the value it already had.
+    const api = client({ get: () => Promise.resolve(policy({ mode: "auto" })) });
+    await mount(api);
+    await openMenu();
+    await act(async () => {
+      row("auto")!.click();
+    });
+    expect(api.put).not.toHaveBeenCalled();
+    expect(toasts.success).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The gate. Widening the tier from here is the same act as widening it on the
+// settings page, so it meets the same confirmation — and narrowing meets none.
+// ---------------------------------------------------------------------------
+
+/** The confirmation renders through a portal onto `document.body`, like the menu. */
+function confirmButton(): HTMLButtonElement | null {
+  return document.querySelector("[data-testid=autonomy-tier-confirm]");
+}
+
+function cancelButton(): HTMLButtonElement | null {
+  return document.querySelector("[data-testid=autonomy-tier-cancel]");
+}
+
+/** Pick a row from the open menu. */
+async function pick(mode: string) {
+  await act(async () => {
+    row(mode)!.click();
+  });
+}
+
+describe("widening the tier from the title bar", () => {
+  it("writes nothing on the click alone, and keeps stating the tier in force", async () => {
+    // The regression this exists to stop: without the gate the title bar is a
+    // strictly cheaper route to the broadest autonomy this runtime has than the
+    // settings page, which was deliberately given a confirmation for the very
+    // same act.
+    const api = client({ get: () => Promise.resolve(policy({ mode: "supervised" })) });
+    await mount(api);
+    await openMenu();
+    await pick("full");
+
+    expect(api.put).not.toHaveBeenCalled();
+    expect(confirmButton()).not.toBeNull();
+    expect(pill()!.textContent).toContain("Supervised");
+    expect(pill()!.textContent).not.toContain("Full");
+  });
+
+  it("asks in the settings page's own words, not a second set of them", async () => {
+    // Every string here is asserted as a literal rather than against the
+    // constant it comes from: importing the constant would pass however the two
+    // dialogs were worded, and what is under test is that an operator meets the
+    // SAME sentence wherever they widen the tier. `policy-tier-autonomy.test.ts`
+    // pins the identical literals on the settings page.
+    const api = client({ get: () => Promise.resolve(policy({ mode: "supervised" })) });
+    await mount(api);
+    await openMenu();
+    await pick("full");
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("Give teammates more autonomy?");
+    // Both sides of the move, in the host's own prose.
+    expect(text).toContain("Instead of: Conservative execution restrictions.");
+    expect(text).toContain("With Full: Broadest execution autonomy.");
+    expect(text).toContain("They will use the Full setting on their next turn.");
+    // Still true in this build, and the reason the tier is not the only gate.
+    expect(text).toContain("Approval prompts remain explicit through request_approval.");
+    expect(cancelButton()!.textContent).toBe("Keep current setting");
+    expect(confirmButton()!.textContent).toBe("Give more autonomy");
+  });
+
+  it("writes the wider tier once it is confirmed, and shows what the host answered", async () => {
+    const api = client({
+      get: () => Promise.resolve(policy({ mode: "supervised" })),
+      put: () => Promise.resolve(policy({ mode: "full" })),
+    });
+    await mount(api);
+    await openMenu();
+    await pick("full");
+    await act(async () => {
+      confirmButton()!.click();
+    });
+
+    // Only `mode`, exactly as a narrowing sends — the confirmation gates the
+    // decision, it does not change the request.
+    expect(api.put).toHaveBeenCalledWith("/api/v1/company/acme/policy", {
+      mode: "full",
+    });
+    expect(pill()!.textContent).toContain("Full");
+    expect(toasts.success).toHaveBeenCalled();
+  });
+
+  it("writes NOTHING and leaves the tier untouched when the confirmation is cancelled", async () => {
+    // Cancelling has to be a true no-op. A dialog that dismissed but still wrote
+    // would be worse than no dialog: the operator has been told they declined.
+    const api = client({ get: () => Promise.resolve(policy({ mode: "supervised" })) });
+    await mount(api);
+    await openMenu();
+    await pick("full");
+    await act(async () => {
+      cancelButton()!.click();
+    });
+
+    expect(api.put).not.toHaveBeenCalled();
+    expect(pill()!.textContent).toContain("Supervised");
+    expect(pill()!.textContent).not.toContain("Full");
+    expect(toasts.success).not.toHaveBeenCalled();
+    expect(toasts.error).not.toHaveBeenCalled();
+      // Focus restoration is deliberately NOT asserted here, and the omission is
+      // the finding rather than a gap.
+      //
+      // Cancelling used to leave focus on `<body>` — a keyboard operator
+      // stranded mid-row — because the dialog named no `finalFocus`. The pill now
+      // names its trigger explicitly, the way the settings page names its own
+      // target, and that is a real fix worth having.
+      //
+      // What could not be built is an honest test for it. Base UI restores focus
+      // asynchronously, outside the `act` that dispatched the click, so the
+      // assertion needs a wait; and under jsdom's scheduling the result is noise
+      // in BOTH directions — with a 50-tick budget it failed 6 runs in 12 before
+      // the fix and still passed 5 of 6 with the fix reverted, and with a 3-tick
+      // budget it passed 10 of 10 either way. A test that reports the same answer
+      // whether or not the code is there proves nothing, and one that flakes
+      // reddens CI for no signal. The behaviour is pinned by the `finalFocus`
+      // prop and its comment in `autonomy-pill.tsx` instead.
+  });
+
+  it("narrows in one click, with no confirmation at all", async () => {
+    // Deliberate asymmetry, and the same one the settings page draws. Reducing
+    // what the agents may do is what an operator reaches for mid-incident;
+    // friction there is friction pointed the wrong way.
+    const api = client({
+      get: () => Promise.resolve(policy({ mode: "full" })),
+      put: () => Promise.resolve(policy({ mode: "readonly" })),
+    });
+    await mount(api);
+    await openMenu();
+    await pick("readonly");
+
+    expect(confirmButton()).toBeNull();
+    expect(api.put).toHaveBeenCalledWith("/api/v1/company/acme/policy", {
+      mode: "readonly",
+    });
+    expect(pill()!.textContent).toContain("Read-only");
+  });
+
+  it("confirms every step up the host's order and no step down it", async () => {
+    // A spot check on one pair would pass against a component that hard-coded
+    // "confirm `full`". The order is the host's, so the rule is about the order
+    // and not about any particular tier word.
+    for (const [from, to, gated] of [
+      ["readonly", "supervised", true],
+      ["readonly", "full", true],
+      ["supervised", "auto", true],
+      ["auto", "full", true],
+      ["full", "auto", false],
+      ["auto", "readonly", false],
+      ["supervised", "readonly", false],
+    ] as [string, string, boolean][]) {
+      const api = client({
+        get: () => Promise.resolve(policy({ mode: from })),
+        put: () => Promise.resolve(policy({ mode: to })),
+      });
+      await mount(api);
+      await openMenu();
+      await pick(to);
+      if (gated) {
+        expect(api.put, `${from} -> ${to} should have been gated`).not.toHaveBeenCalled();
+        await act(async () => {
+          cancelButton()!.click();
+        });
+      } else {
+        expect(api.put, `${from} -> ${to} should have written straight away`).toHaveBeenCalled();
+      }
+    }
+  });
+
+  it("does not call an unorderable current mode a widening", async () => {
+    // A console against a newer host can be sitting on a mode absent from the
+    // tier list; `widensAutonomy` answers false for it, and this asserts the
+    // pill inherits that answer rather than inventing a stricter one the
+    // settings page does not make.
+    const api = client({
+      get: () => Promise.resolve(policy({ mode: "guarded" })),
+      put: () => Promise.resolve(policy({ mode: "full" })),
+    });
+    await mount(api);
+    await openMenu();
+    await pick("full");
+
+    expect(confirmButton()).toBeNull();
+    expect(api.put).toHaveBeenCalledWith("/api/v1/company/acme/policy", {
+      mode: "full",
+    });
+  });
+
+  it("keeps the confirmation up when the confirmed write is rejected", async () => {
+    // The dialog closing on a failure would read as "done" for a change that
+    // never landed. It stays, so the operator can retry or back out.
+    const api = client({
+      get: () => Promise.resolve(policy({ mode: "supervised" })),
+      put: () => Promise.reject(new Error("Only an admin can change the policy.")),
+    });
+    await mount(api);
+    await openMenu();
+    await pick("full");
+    await act(async () => {
+      confirmButton()!.click();
+    });
+
+    expect(confirmButton()).not.toBeNull();
+    expect(pill()!.textContent).toContain("Supervised");
+    expect(toasts.error).toHaveBeenCalledWith("Only an admin can change the policy.");
+  });
+});

--- a/frontend/test/unit/autonomy-pill.test.ts
+++ b/frontend/test/unit/autonomy-pill.test.ts
@@ -226,7 +226,7 @@ describe("the pill", () => {
     // element: `WindowTitleBar` carries a dedicated `flex-1 self-stretch`
     // spacer that opts in on its own, and that spacer — not the pill — is the
     // elastic part of the row.
-    render(createElement(AutonomyPill, { status: policy() }));
+    render(createElement(AutonomyPill, { status: policy(), canManage: true }));
     expect(pill()!.tagName).toBe("BUTTON");
     expect(pill()!.hasAttribute("data-tauri-drag-region")).toBe(false);
     // Nothing inside it may swallow the press before the trigger sees it.
@@ -276,7 +276,11 @@ describe("the pill", () => {
     // Rendered outside a `ConsoleProvider` — a styleguide page, or a console
     // whose session has gone. It still STATES the tier; it just cannot change
     // it. Disabled rather than hidden, so the capability stays discoverable.
-    render(createElement(AutonomyPill, { status: policy() }));
+    //
+    // `canManage: true` on purpose: it isolates the CLIENT as the reason. With
+    // the role left unstated this would pass against a component that had
+    // stopped checking for a client at all.
+    render(createElement(AutonomyPill, { status: policy(), canManage: true }));
     expect((pill() as HTMLButtonElement).disabled).toBe(true);
   });
 });
@@ -304,19 +308,32 @@ function client(over: {
   } as unknown as OpenCompanyClient;
 }
 
-/** The shell's wiring, in miniature: the poll feeds the pill inside the scope. */
-function Harness({ api }: { api: OpenCompanyClient }): ReactNode {
+/**
+ * The shell's wiring, in miniature: the poll feeds the pill inside the scope.
+ *
+ * `canManage` defaults to `true` — an admin — because that is what the
+ * switcher tests below are about. It is threaded rather than hard-coded so the
+ * read-only cases can drive the same loop with the same host; the shell passes
+ * its own `isGateAdmin` here.
+ */
+function Harness({
+  api,
+  canManage = true,
+}: {
+  api: OpenCompanyClient;
+  canManage?: boolean | null;
+}): ReactNode {
   const status = useAutonomy(api, "acme");
   return createElement(ConsoleProvider, {
     client: api,
     company: "acme",
-    children: createElement(AutonomyPill, { status }),
+    children: createElement(AutonomyPill, { status, canManage }),
   });
 }
 
-async function mount(api: OpenCompanyClient) {
+async function mount(api: OpenCompanyClient, canManage: boolean | null = true) {
   await act(async () => {
-    root!.render(createElement(Harness, { api }));
+    root!.render(createElement(Harness, { api, canManage }));
   });
 }
 
@@ -689,5 +706,75 @@ describe("widening the tier from the title bar", () => {
     expect(confirmButton()).not.toBeNull();
     expect(pill()!.textContent).toContain("Supervised");
     expect(toasts.error).toHaveBeenCalledWith("Only an admin can change the policy.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Who may change it. The pill states standing policy to everyone and offers
+// the menu to the people the host will actually accept a write from.
+// ---------------------------------------------------------------------------
+
+/**
+ * Both write routes behind this control call `require_admin`
+ * (`src/server/ops/policy.rs:309` and `:427`), so every selection a member
+ * makes is a guaranteed 403 and a red toast — a control that exists only to
+ * fail. `read_policy` carries no such guard, deliberately: the standing policy
+ * is a fact about what the agents around you may do, and hiding it from the
+ * people living under it would be the worse regression. So the tier stays and
+ * the menu goes.
+ */
+describe("the policy as read-only", () => {
+  for (const [who, canManage] of [
+    ["a member the host would refuse", false],
+    ["an operator whose role has not been read yet", null],
+  ] as [string, boolean | null][]) {
+    describe(who, () => {
+      it("still states the tier and the host's sentence", async () => {
+        // The half that must NOT be lost. A member who cannot see the standing
+        // policy cannot know what the agents around them are allowed to do.
+        const api = client({ get: () => Promise.resolve(policy({ mode: "supervised" })) });
+        await mount(api, canManage);
+        expect(pill()).not.toBeNull();
+        expect(pill()!.textContent).toContain("Supervised");
+        expect(pill()!.textContent).toContain("Conservative execution restrictions.");
+        expect(pill()!.getAttribute("title")).toBe(TIERS[1].description);
+      });
+
+      it("is not offered as a control", async () => {
+        const api = client({});
+        await mount(api, canManage);
+        expect((pill() as HTMLButtonElement).disabled).toBe(true);
+        expect(pill()!.getAttribute("data-readonly")).toBe("true");
+        // The chevron is documented as the one thing on the pill that says it
+        // is a control. Drawing it over a menu that will not open is the
+        // affordance lying.
+        expect(pill()!.querySelector("svg.lucide-chevron-down")).toBeNull();
+      });
+
+      it("opens no menu and writes nothing when it is pressed anyway", async () => {
+        // Not just "the trigger is disabled" — that is a styling claim. This
+        // presses it and proves no tier row appears and no PUT is issued.
+        const api = client({ get: () => Promise.resolve(policy({ mode: "supervised" })) });
+        await mount(api, canManage);
+        await openMenu();
+        for (const tier of TIERS) {
+          expect(row(tier.value), `${tier.value} must not be offered`).toBeNull();
+        }
+        expect(api.put).not.toHaveBeenCalled();
+        expect(toasts.error).not.toHaveBeenCalled();
+      });
+    });
+  }
+
+  it("is a full control for an admin, chevron and menu and all", async () => {
+    // The discriminating half: without it every assertion above would pass
+    // against a pill that had simply stopped being a control for everyone.
+    const api = client({ get: () => Promise.resolve(policy({ mode: "supervised" })) });
+    await mount(api, true);
+    expect((pill() as HTMLButtonElement).disabled).toBe(false);
+    expect(pill()!.hasAttribute("data-readonly")).toBe(false);
+    expect(pill()!.querySelector("svg.lucide-chevron-down")).not.toBeNull();
+    await openMenu();
+    expect(row("full")).not.toBeNull();
   });
 });

--- a/frontend/test/unit/autonomy-readers.test.ts
+++ b/frontend/test/unit/autonomy-readers.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { PolicyStatus } from "@/api/policy";
+import { useAutonomy } from "@/hooks/use-autonomy";
+
+/**
+ * What the title row is handed, as distinct from what any one surface knows.
+ *
+ * The autonomy pill is mounted for the entire life of the console, on every
+ * view, and it makes a claim in a sentence: what the agents in the company
+ * named an inch to its left are allowed to do without asking. This is a way
+ * that claim can be **wrong rather than merely stale**:
+ *
+ * **A company switch.** `useState` survives a change of `company`; the effect
+ * that cleared it is passive, so React ran it AFTER paint. The first frame of
+ * the new company therefore carried the previous company's tier — a confident,
+ * attributed answer about a different company.
+ *
+ * Tested through the hook rather than through the pill, because the pill is a
+ * faithful renderer of whatever it is given and the bug does not live there.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: Object.assign(toasts.base, toasts) }));
+
+const TIERS = [
+  { value: "readonly", label: "Read-only", description: "Looks, changes nothing." },
+  { value: "supervised", label: "Supervised", description: "Asks before acting." },
+  { value: "auto", label: "Auto", description: "Acts on its own." },
+  { value: "full", label: "Full", description: "No ceiling." },
+];
+
+function policy(mode: string): PolicyStatus {
+  return {
+    mode,
+    alwaysApprove: [],
+    autoApproveUnderUsd: null,
+    approvalTtlHours: 24,
+    manifestMode: mode,
+    manifestAlwaysApprove: [],
+    manifestAutoApproveUnderUsd: null,
+    manifestApprovalTtlHours: null,
+    overridden: false,
+    takesEffect: "on the next turn",
+    tiers: TIERS,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+
+describe("a company switch", () => {
+  /**
+   * Records what the hook returned **during render**, before any effect runs.
+   *
+   * That is the only place the bug was visible: `setPolicy(null)` lives in a
+   * passive effect, so by the time an assertion could read the DOM after `act`
+   * the clear had already happened and the wrong frame was gone. Pushing from
+   * the render body keeps it.
+   */
+  function Probe({
+    api,
+    company,
+    seen,
+  }: {
+    api: OpenCompanyClient;
+    company: string;
+    seen: Array<[string, string | null]>;
+  }): ReactNode {
+    const status = useAutonomy(api, company);
+    seen.push([company, status?.mode ?? null]);
+    return null;
+  }
+
+  it("answers null for the new company rather than the previous company's tier", async () => {
+    // Two companies on one host, on different tiers. `globex` is the one that
+    // matters: whatever the console says about it must not have come from
+    // `acme`.
+    const client = {
+      scopeFor: (company: string | null) => `/api/v1/company/${company}`,
+      get: async (path: string) =>
+        path.startsWith("/api/v1/company/acme") ? policy("full") : policy("readonly"),
+      put: vi.fn(),
+      del: vi.fn(),
+    } as unknown as OpenCompanyClient;
+
+    const seen: Array<[string, string | null]> = [];
+    await act(async () => {
+      root.render(createElement(Probe, { api: client, company: "acme", seen }));
+    });
+    expect(seen.at(-1)).toEqual(["acme", "full"]);
+
+    await act(async () => {
+      root.render(createElement(Probe, { api: client, company: "globex", seen }));
+    });
+
+    const forGlobex = seen.filter(([company]) => company === "globex");
+    expect(forGlobex.length).toBeGreaterThan(0);
+    // THE assertion: the very first frame drawn for `globex`. `full` here is
+    // `acme`'s tier being attributed to a company that is on `readonly` — the
+    // pill would have said so in a sentence, beside `globex`'s own name.
+    expect(forGlobex[0][1], "the first frame of the new company").toBeNull();
+    // And no frame of `globex` ever carried it, not just the first.
+    expect(forGlobex.map(([, mode]) => mode)).not.toContain("full");
+    // Still resolves, so this is a fence and not a hook that stopped answering.
+    expect(seen.at(-1)).toEqual(["globex", "readonly"]);
+  });
+});

--- a/frontend/test/unit/autonomy-readers.test.ts
+++ b/frontend/test/unit/autonomy-readers.test.ts
@@ -13,16 +13,25 @@ import { useAutonomy } from "@/hooks/use-autonomy";
  *
  * The autonomy pill is mounted for the entire life of the console, on every
  * view, and it makes a claim in a sentence: what the agents in the company
- * named an inch to its left are allowed to do without asking. This is a way
- * that claim can be **wrong rather than merely stale**:
+ * named an inch to its left are allowed to do without asking. Two ways that
+ * claim can be **wrong rather than merely stale**, and both are here:
  *
- * **A company switch.** `useState` survives a change of `company`; the effect
- * that cleared it is passive, so React ran it AFTER paint. The first frame of
- * the new company therefore carried the previous company's tier — a confident,
- * attributed answer about a different company.
+ * 1. **A write on the settings page.** `PolicySettings` and `useAutonomy` read
+ *    the same `GET {scope}/policy`, but only the pill's own switcher used to
+ *    publish its result. Change the tier from the settings card — which is the
+ *    surface the console points operators at — and the pill above it kept the
+ *    previous tier for up to the 30s poll. In the direction that matters most,
+ *    a widening, that is the row insisting a more restrictive policy is still
+ *    in force while it is not.
  *
- * Tested through the hook rather than through the pill, because the pill is a
- * faithful renderer of whatever it is given and the bug does not live there.
+ * 2. **A company switch.** `useState` survives a change of `company`; the
+ *    effect that cleared it is passive, so React ran it AFTER paint. The first
+ *    frame of the new company therefore carried the previous company's tier —
+ *    a confident, attributed answer about a different company.
+ *
+ * Both are tested through the hook rather than through the pill, because the
+ * pill is a faithful renderer of whatever it is given and neither bug lives
+ * there.
  */
 
 const toasts = vi.hoisted(() => ({
@@ -34,6 +43,8 @@ const toasts = vi.hoisted(() => ({
 }));
 
 vi.mock("sonner", () => ({ toast: Object.assign(toasts.base, toasts) }));
+
+const { PolicySettings } = await import("@/components/policy-settings");
 
 const TIERS = [
   { value: "readonly", label: "Read-only", description: "Looks, changes nothing." },
@@ -76,6 +87,132 @@ afterEach(async () => {
 });
 
 // ---------------------------------------------------------------------------
+
+describe("a policy written on the settings page", () => {
+  /**
+   * A host whose GET is frozen on the OLD tier for the life of the test.
+   *
+   * That is the whole design of this fake. If the reader ever showed the new
+   * tier because a poll fetched it, this suite would pass against the bug it
+   * exists to catch. Frozen, the ONLY route from the settings card to the
+   * title row is the publish — so the assertion cannot be satisfied any other
+   * way.
+   */
+  function frozenHost(before: string, after: string) {
+    const put = vi.fn(async (_path: string, body: { mode?: string }) =>
+      policy(body.mode ?? after),
+    );
+    return {
+      put,
+      client: {
+        scopeFor: () => "/api/v1/company/acme",
+        get: async (path: string) =>
+          path.endsWith("/policy") ? policy(before) : { slugs: [], unwired: [] },
+        put,
+        del: vi.fn(async () => policy(before)),
+      } as unknown as OpenCompanyClient,
+    };
+  }
+
+  /** The settings card and a title-row reader, in the same scope, as the shell mounts them. */
+  function Both({ api, seen }: { api: OpenCompanyClient; seen: string[] }): ReactNode {
+    const status = useAutonomy(api, "acme");
+    seen.push(status?.mode ?? "unknown");
+    return createElement(PolicySettings, { client: api, company: "acme" });
+  }
+
+  async function mount(api: OpenCompanyClient, seen: string[]) {
+    await act(async () => {
+      root.render(createElement(Both, { api, seen }));
+      await Promise.resolve();
+    });
+  }
+
+  it("reaches the title row's readers at once, not on the next poll", async () => {
+    // Narrowing: `readonly` is below `auto` in the host's order, so it writes
+    // straight through with no confirmation to click.
+    vi.useFakeTimers();
+    try {
+      const { client, put } = frozenHost("auto", "readonly");
+      const seen: string[] = [];
+      await mount(client, seen);
+      expect(seen.at(-1)).toBe("auto");
+
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>("[data-testid=policy-tier-readonly]")!
+          .click();
+        await Promise.resolve();
+      });
+
+      expect(put).toHaveBeenCalledWith("/api/v1/company/acme/policy", { mode: "readonly" });
+      // No timer has advanced, and the GET still answers `auto`. The only way
+      // this reads `readonly` is the settings page having published it.
+      expect(seen.at(-1)).toBe("readonly");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("publishes a widening, which is the direction that matters most", async () => {
+    // `full` is above `auto`, so this goes through the confirmation the page
+    // puts in front of every escalation. The pill claiming the narrower tier
+    // afterwards is the failure worth having a test for: it says agents are
+    // more fenced in than they are.
+    vi.useFakeTimers();
+    try {
+      const { client } = frozenHost("auto", "full");
+      const seen: string[] = [];
+      await mount(client, seen);
+
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>("[data-testid=policy-tier-full]")!.click();
+      });
+      await act(async () => {
+        document
+          .querySelector<HTMLButtonElement>("[data-testid=policy-tier-confirm]")!
+          .click();
+        await Promise.resolve();
+      });
+
+      expect(seen.at(-1)).toBe("full");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("publishes nothing when the host answers with something that is not a policy", async () => {
+    // The fence and the hand-off are the same act: a rejected body is a failed
+    // write, and a failed write must leave the row stating the tier actually in
+    // force. Publishing it would put an un-rendered shape into the one reader
+    // with no error boundary above it.
+    vi.useFakeTimers();
+    try {
+      const put = vi.fn(async () => [] as unknown as PolicyStatus);
+      const client = {
+        scopeFor: () => "/api/v1/company/acme",
+        get: async (path: string) =>
+          path.endsWith("/policy") ? policy("auto") : { slugs: [], unwired: [] },
+        put,
+        del: vi.fn(),
+      } as unknown as OpenCompanyClient;
+      const seen: string[] = [];
+      await mount(client, seen);
+
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>("[data-testid=policy-tier-readonly]")!
+          .click();
+        await Promise.resolve();
+      });
+
+      expect(put).toHaveBeenCalled();
+      expect(seen.at(-1)).toBe("auto");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 

--- a/frontend/test/unit/content-surface.test.ts
+++ b/frontend/test/unit/content-surface.test.ts
@@ -55,10 +55,20 @@ describe("ContentSurface", () => {
     // that happen to agree is what drifts. A three-sided inset flush to one
     // edge is what the closed first attempt shipped, and it produced a sliver
     // rather than a frame.
-    expect(classes).toContain("m-(--frame-inset)");
-    // And nothing overrides one side of it: an even frame is the contract, so
-    // a stray `mt-*`/`pt-*` reintroducing a special case fails here.
-    expect(classes.filter((c) => /^m[trbl]-/.test(c))).toEqual([]);
+    expect(classes).toContain(// Three sides at the frame inset, a thinner top: the window title row
+    // sits directly above this card now, and a full inset there stacked the
+    // row's own padding on the card's margin and read as a double gap.
+    "mx-(--frame-inset)");
+    // The top is deliberately thinner, and nothing else overrides a side.
+    //
+    // An even frame WAS the contract, when nothing sat above this card. The
+    // window title row does now, so a full inset there stacked the row's own
+    // bottom padding onto the card's margin and read as a gap twice the size of
+    // the other three. `mt` is the one exception; a stray `mr`/`ml` is still a
+    // special case creeping back and still fails here.
+    expect(classes.filter((c) => /^m[rl]-/.test(c))).toEqual([]);
+    expect(classes).toContain("mb-(--frame-inset)");
+    expect(classes.some((c) => c.startsWith("mt-"))).toBe(true);
     expect(classes).toContain("rounded-2xl");
     // The edge carries the chrome hairline, and the sheet is opaque: it is the
     // only opaque surface in the shell, so anything a page draws stacks on it.

--- a/frontend/test/unit/policy-response-shape.test.ts
+++ b/frontend/test/unit/policy-response-shape.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { isPolicyStatus, type PolicyStatus } from "@/api/policy";
+
+/**
+ * A `/policy` response that is not a policy must not be rendered.
+ *
+ * This is a crash fence, and the crash it fences is not hypothetical. The
+ * autonomy pill is mounted for the entire life of the console on every view
+ * (`window-title-bar.tsx`), its first act is `status.tiers.find(...)`, and there
+ * is no error boundary anywhere in `src/` — so a 200 carrying the wrong shape
+ * threw during render and React unmounted the whole tree. The symptom is a
+ * blank white console on every page with no way back but a reload; the console
+ * E2E lane found it as `TypeError: Cannot read properties of undefined (reading
+ * 'find')` and thirty-plus specs sitting on their timeouts against an empty
+ * document.
+ *
+ * The predicate lives beside the request rather than inside it because
+ * "renderable" is a reader's question, not the transport's:
+ * `useApprovalDeadline` reads `approvalTtlHours` alone and documents that an
+ * older host omits it, so a transport that insisted on the tier list would
+ * break a hook that is deliberately lenient. The readers that put a policy ON
+ * SCREEN gate on this instead — `useAutonomy` for the title row, and the
+ * settings page's `load` and `apply`.
+ */
+
+const WELL_FORMED: PolicyStatus = {
+  mode: "supervised",
+  alwaysApprove: ["shell"],
+  autoApproveUnderUsd: null,
+  approvalTtlHours: 24,
+  manifestMode: "supervised",
+  manifestAlwaysApprove: ["shell"],
+  manifestAutoApproveUnderUsd: null,
+  manifestApprovalTtlHours: null,
+  overridden: false,
+  takesEffect: "on the next turn",
+  tiers: [
+    { value: "readonly", label: "Read-only", description: "Looks, changes nothing." },
+    { value: "supervised", label: "Supervised", description: "Asks before acting." },
+  ],
+};
+
+/**
+ * Every body seen in place of a policy. `[]` is first because it is what a
+ * catch-all route fulfils with, and so the one that took the E2E lane down.
+ */
+const MALFORMED: [string, unknown][] = [
+  ["an empty array, which is what a catch-all route answers with", []],
+  ["an array of policies rather than one", [WELL_FORMED]],
+  ["null", null],
+  ["undefined", undefined],
+  ["a bare string", "supervised"],
+  ["an object with no tiers", { ...WELL_FORMED, tiers: undefined }],
+  ["an object whose tiers are not a list", { ...WELL_FORMED, tiers: "supervised,full" }],
+  ["an object with no mode", { ...WELL_FORMED, mode: undefined }],
+  ["an object whose alwaysApprove is not a list", { ...WELL_FORMED, alwaysApprove: "shell" }],
+  ["an error envelope answered with a 200", { error: "not_found", message: "no policy here" }],
+];
+
+describe("isPolicyStatus", () => {
+  for (const [what, body] of MALFORMED) {
+    it(`refuses ${what}`, () => {
+      expect(isPolicyStatus(body)).toBe(false);
+    });
+  }
+
+  it("accepts a well-formed policy", () => {
+    expect(isPolicyStatus(WELL_FORMED)).toBe(true);
+  });
+
+  it("keeps every optional field optional, so an older host still passes", () => {
+    // `knownTools`, `setBy` and `setAtMillis` are all documented as absent on
+    // some hosts, and `approvalTtlHours` is absent on hosts that predate it.
+    // The fence checks the three fields the render paths dereference and
+    // nothing else; it must not become a schema a host is obliged to grow into.
+    expect(isPolicyStatus({ mode: "auto", alwaysApprove: [], tiers: [] })).toBe(true);
+  });
+
+  it("does not require the tiers to be populated", () => {
+    // A host that offers no selectable tiers renders a pill that states the
+    // mode and opens an empty menu. That is a thin answer, not a broken one.
+    expect(isPolicyStatus({ ...WELL_FORMED, tiers: [] })).toBe(true);
+  });
+});

--- a/frontend/test/unit/policy-response-shape.test.ts
+++ b/frontend/test/unit/policy-response-shape.test.ts
@@ -56,6 +56,41 @@ const MALFORMED: [string, unknown][] = [
   ["an object with no mode", { ...WELL_FORMED, mode: undefined }],
   ["an object whose alwaysApprove is not a list", { ...WELL_FORMED, alwaysApprove: "shell" }],
   ["an error envelope answered with a 200", { error: "not_found", message: "no policy here" }],
+  // The container check alone let every one of these through, and each of them
+  // reaches a dereference the moment it is rendered. `tiers: [null]` is the one
+  // the reviewers named: `Array.isArray` says yes, and `tiers.find((tier) =>
+  // tier.value === status.mode)` throws on the first member — the same blank
+  // console, one line later than before.
+  ["a tier list holding a null", { ...WELL_FORMED, tiers: [null] }],
+  ["a tier list holding undefined", { ...WELL_FORMED, tiers: [undefined] }],
+  ["a tier list of bare mode words rather than objects", { ...WELL_FORMED, tiers: ["auto", "full"] }],
+  ["a tier list holding an array", { ...WELL_FORMED, tiers: [["auto", "Auto", "…"]] }],
+  [
+    "a tier with no value to match the mode against",
+    { ...WELL_FORMED, tiers: [{ label: "Auto", description: "…" }] },
+  ],
+  [
+    "a tier whose value is not a string",
+    { ...WELL_FORMED, tiers: [{ value: 2, label: "Auto", description: "…" }] },
+  ],
+  [
+    "a tier with no label to draw the row with",
+    { ...WELL_FORMED, tiers: [{ value: "auto", description: "…" }] },
+  ],
+  [
+    "a tier with no description to state the consequence with",
+    { ...WELL_FORMED, tiers: [{ value: "auto", label: "Auto" }] },
+  ],
+  [
+    "one bad tier among good ones",
+    { ...WELL_FORMED, tiers: [...WELL_FORMED.tiers, null] },
+  ],
+  // `alwaysApprove` is joined into the settings page's own text box and saved
+  // back from it. A non-string member does not throw — it renders as
+  // "[object Object]" and is then written back to the host as a gate.
+  ["an always-ask list holding a null", { ...WELL_FORMED, alwaysApprove: [null] }],
+  ["an always-ask list holding an object", { ...WELL_FORMED, alwaysApprove: [{ kind: "shell" }] }],
+  ["an always-ask list holding a number", { ...WELL_FORMED, alwaysApprove: ["shell", 7] }],
 ];
 
 describe("isPolicyStatus", () => {
@@ -81,5 +116,26 @@ describe("isPolicyStatus", () => {
     // A host that offers no selectable tiers renders a pill that states the
     // mode and opens an empty menu. That is a thin answer, not a broken one.
     expect(isPolicyStatus({ ...WELL_FORMED, tiers: [] })).toBe(true);
+  });
+
+  it("accepts a tier carrying fields this console has never heard of", () => {
+    // The member check is a crash fence like the one above it, not a schema.
+    // A newer host that grows a field on a tier must keep working, exactly as
+    // one that grows a field on the status does.
+    expect(
+      isPolicyStatus({
+        ...WELL_FORMED,
+        tiers: [
+          { value: "guarded", label: "Guarded", description: "Something newer.", badge: "beta" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts an empty always-ask list, which is a real answer", () => {
+    // Most companies gate nothing by name. `[]` is the common case, not a
+    // degenerate one, and `.every` on it is vacuously true — asserted so a
+    // future member check cannot quietly start requiring a non-empty list.
+    expect(isPolicyStatus({ ...WELL_FORMED, alwaysApprove: [] })).toBe(true);
   });
 });

--- a/frontend/test/unit/policy-tier-autonomy.test.ts
+++ b/frontend/test/unit/policy-tier-autonomy.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { PolicyStatus } from "@/api/policy";
+import { NOT_A_POLICY } from "@/api/policy";
 import { widensAutonomy, widensSpendCap, gatedBy } from "@/components/policy-settings";
 
 const toasts = vi.hoisted(() => ({
@@ -807,5 +808,118 @@ describe("loading the policy", () => {
     expect(
       container.querySelector<HTMLElement>("[data-testid=policy-tier-readonly]")?.getAttribute("aria-checked"),
     ).toBe("false");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A 200 the console cannot read is a FAILED write, all the way up.
+// ---------------------------------------------------------------------------
+
+/**
+ * `apply` has fenced a malformed body since the crash fix — it shows the error
+ * and refuses to put the value on screen. What it did not do was **say so to
+ * its caller**: it returned `undefined`, and `saveTier`, `reset` and
+ * `commitSpendCap` each went on to `return true` regardless.
+ *
+ * Their confirmation handlers close on `true`. So a tier escalation, a
+ * loosening reset or a spend-cap raise that the host answered with rubbish
+ * dismissed its dialog exactly as a successful one does — and the dialog it
+ * dismissed is the gate in front of *widening* what the agents may do. The
+ * operator is told, by the dialog going away, that the thing they just agreed
+ * to has happened. It has not.
+ *
+ * These drive both confirmations that are reachable in this build. The
+ * spend-cap raise shares the same `apply` return and is unreachable here for an
+ * unrelated reason: the field is disabled while policy HITL is off
+ * (`src/runtime/builder.rs`), which the suite above already pins.
+ */
+describe("a write the console cannot read back", () => {
+  /** A body that is not a policy, answered with a 200 by both write routes. */
+  const notAPolicy = [] as unknown as PolicyStatus;
+
+  it("keeps the escalation confirmation up rather than closing it as done", async () => {
+    const put = vi.fn(async () => notAPolicy);
+    const client = {
+      scopeFor: () => "/api/v1/acme",
+      get: async (path: string) =>
+        path.endsWith("/policy") ? status("supervised") : { slugs: [], unwired: [] },
+      put,
+      del: vi.fn(),
+    } as unknown as OpenCompanyClient;
+    await mount(client);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("[data-testid=policy-tier-full]")!.click();
+    });
+    expect(document.querySelector("[data-testid=policy-tier-confirm]")).not.toBeNull();
+
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>("[data-testid=policy-tier-confirm]")!.click();
+      await Promise.resolve();
+    });
+
+    expect(put).toHaveBeenCalledWith("/api/v1/acme/policy", { mode: "full" });
+    expect(toasts.error).toHaveBeenCalledWith(NOT_A_POLICY);
+    // The dialog is still there, so the operator can retry or back out —
+    // rather than having been shown a dismissal that reads as success.
+    expect(
+      document.querySelector("[data-testid=policy-tier-confirm]"),
+      "the confirmation stays open for the retry",
+    ).not.toBeNull();
+    // And the card still states the tier actually in force.
+    expect(
+      container.querySelector("[data-testid=policy-tier-supervised]")
+        ?.getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  it("keeps the loosening-reset confirmation up for the same reason", async () => {
+    const del = vi.fn(async () => notAPolicy);
+    const client = {
+      scopeFor: () => "/api/v1/acme",
+      get: async (path: string) =>
+        path.endsWith("/policy")
+          ? overridden("readonly", "full")
+          : { slugs: [], unwired: [] },
+      put: vi.fn(),
+      del,
+    } as unknown as OpenCompanyClient;
+    await mount(client);
+
+    await act(async () => {
+      [...container.querySelectorAll("button")]
+        .find((b) => b.textContent?.includes("manifest's policy"))!
+        .click();
+    });
+    expect(document.querySelector("[data-testid=policy-tier-confirm]")).not.toBeNull();
+
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>("[data-testid=policy-tier-confirm]")!.click();
+      await Promise.resolve();
+    });
+
+    expect(del).toHaveBeenCalledWith("/api/v1/acme/policy");
+    expect(toasts.error).toHaveBeenCalledWith(NOT_A_POLICY);
+    expect(
+      document.querySelector("[data-testid=policy-tier-confirm]"),
+      "the confirmation stays open for the retry",
+    ).not.toBeNull();
+  });
+
+  it("still closes the confirmation when the write actually lands", async () => {
+    // The discriminating half. Without it every assertion above would pass
+    // against a dialog that had simply stopped closing at all.
+    const { client } = makeClient(status("supervised"));
+    await mount(client);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("[data-testid=policy-tier-full]")!.click();
+    });
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>("[data-testid=policy-tier-confirm]")!.click();
+      await Promise.resolve();
+    });
+
+    expect(document.querySelector("[data-testid=policy-tier-confirm]")).toBeNull();
   });
 });

--- a/frontend/test/unit/sidebar-utility-bar.test.ts
+++ b/frontend/test/unit/sidebar-utility-bar.test.ts
@@ -8,21 +8,23 @@ import { SidebarUtilityBar } from "@/components/sidebar-controls";
 import { SidebarProvider } from "@/components/ui/sidebar";
 
 /**
- * The sidebar's utility bar: Settings, Feedback, Discord and Collapse, as one
- * row of icons under the company switcher.
+ * The sidebar's utility bar: Settings, Feedback and Discord, as three labelled
+ * rows at the foot of the column.
  *
- * All four used to be full-width rows — Settings in the nav list, Feedback and
- * Discord in the footer, Collapse loose in the header — costing four rows of a
- * column whose other rows are the places an operator actually works. They are
- * utilities: three go somewhere, none is somewhere you stay. OpenHuman's shell
- * already groups the same four this way
- * (`app/src/components/layout/shell/SidebarHeader.tsx`).
+ * They were icon-only buttons while the bar sat *above* the destinations, where
+ * labelled rows would have pushed the company's own state further down the
+ * column every time the nav list grew. In the footer there is nothing left to
+ * push, and three unlabelled glyphs under a column whose every other entry says
+ * what it is were the cost of that shape. What keeps them from reading as
+ * destinations is now position — after the list — rather than a different
+ * shape.
  *
- * Rendering rather than pure functions, for the reason
- * `sidebar-collapse-button.test.ts` gives: every one of these is icon-only in
- * BOTH sidebar states, so the accessible NAME is the whole of what a screen
- * reader gets. An `aria-label` is exactly the kind of attribute a styling pass
- * drops without breaking a single render.
+ * Rendering rather than pure functions: the accessible NAME is the whole of
+ * what a screen reader gets, and it now comes from the row's own visible text
+ * rather than an `aria-label` — so these assertions pin the label a sighted
+ * operator reads and the one announced to a reader at the same time. On the
+ * collapsed rail the text is clipped and the row's tooltip carries it, which is
+ * what the nav rows beside it already do.
  */
 
 let host: HTMLDivElement;
@@ -56,9 +58,20 @@ function render(view: "overview" | "settings" | "feedback", onNavigate = () => {
   });
 }
 
-/** The bar's buttons, by their accessible name. */
+/**
+ * The bar's controls, by their accessible name.
+ *
+ * The name is the row's text content now, not an `aria-label`, so this walks
+ * the rendered controls and matches on what is actually on screen. An
+ * `aria-label` lookup would have kept passing against a row that had lost its
+ * label entirely, which is the regression these tests exist to catch.
+ */
 function byName(name: string): HTMLElement | null {
-  return host.querySelector(`[aria-label="${name}"]`);
+  const controls = host.querySelectorAll<HTMLElement>("button, a");
+  for (const control of controls) {
+    if (control.textContent?.trim() === name) return control;
+  }
+  return null;
 }
 
 beforeEach(() => {
@@ -79,9 +92,14 @@ describe("the sidebar utility bar", () => {
   it("names every control it carries", () => {
     render("overview");
 
-    // The four, in the order they are read. Discord keeps its full label —
+    // The three, in the order they are read. Discord keeps its full label —
     // "Discord" alone would not say that the control leaves the console.
-    for (const name of ["Settings", "Feedback", "Join our Discord", "Collapse sidebar"]) {
+    //
+    // Collapse is deliberately NOT here any more. It used to be, which put the
+    // control that hides this panel inside the panel it hides — collapsing took
+    // the button with it. It rides the content card's leading corner instead,
+    // where it survives both states.
+    for (const name of ["Settings", "Feedback", "Join our Discord"]) {
       expect(byName(name), name).not.toBeNull();
     }
   });

--- a/frontend/test/unit/window-chrome.test.ts
+++ b/frontend/test/unit/window-chrome.test.ts
@@ -92,16 +92,20 @@ describe("the traffic-light inset", () => {
     expect(host.querySelector("[data-tauri-drag-region]")).toBeNull();
   });
 
-  it("reserves a draggable strip at the top of the sidebar on macOS", () => {
+  it("reserves a draggable strip at the left of the title row on macOS", () => {
     asDesktop("MacIntel");
     render(createElement(WindowControlsInset));
 
     const inset = host.querySelector("[data-tauri-drag-region]") as HTMLElement | null;
     expect(inset).not.toBeNull();
     // In flow, unlike the band: this one's job is to take up the space the
-    // lights are drawn in, so the switcher below it starts clear of them.
+    // lights are drawn in, so the switcher beside it starts clear of them.
     expect(inset?.className).not.toContain("absolute");
     expect(inset?.className).toContain("flex-none");
-    expect(inset?.style.height).toBe("28px");
+    // Horizontal, not vertical. The switcher moved out of the sidebar's top-left
+    // corner and into a full-width title row, so the lights now collide with it
+    // along the x axis and the reservation follows.
+    expect(inset?.style.width).toBe("72px");
+    expect(inset?.style.height).toBe("");
   });
 });

--- a/frontend/test/unit/window-title-bar.test.ts
+++ b/frontend/test/unit/window-title-bar.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { WINDOW_TITLE_BAR_HEIGHT, WINDOW_CONTROLS_WIDTH } from "@/components/window-chrome";
+import { WindowTitleBar } from "@/components/window-title-bar";
+
+/**
+ * Where macOS actually draws the traffic lights, read from the Tauri config
+ * rather than restated here.
+ *
+ * The row's height and its leading inset are both *derived* from these two
+ * numbers, so a test that asserted them against the constants it is checking
+ * would agree with any value — including a wrong one. Reading the config is
+ * what makes the assertion mean something: it fails when the two files stop
+ * agreeing, which is the only way this can actually break.
+ */
+// Vitest runs with the console package as its cwd, so the repo root is one up.
+const TAURI = JSON.parse(
+  readFileSync(resolve(process.cwd(), "../src-tauri/tauri.conf.json"), "utf8"),
+) as { app: { windows: { trafficLightPosition: { x: number; y: number } }[] } };
+const LIGHTS = TAURI.app.windows[0].trafficLightPosition;
+/** macOS draws three of them, 12px across, on a 20px pitch. */
+const LIGHT_SIZE = 12;
+const LIGHT_PITCH = 20;
+
+/**
+ * The window's title row.
+ *
+ * Four properties, each of which is load-bearing and none of which is visible
+ * from reading the JSX:
+ *
+ * 1. **It exists in the browser too.** Only the traffic-light inset is gated on
+ *    the desktop runtime. A row that rendered only under Tauri would be a
+ *    layout the web build never gets, and the two would drift.
+ * 2. **The lights are cleared, and only where they float.** 72px of reserved
+ *    space on the macOS desktop; nothing at all anywhere else, where reserving
+ *    it would be a hole in the corner of every browser tab.
+ * 3. **Empty space drags.** `data-tauri-drag-region` is opt-in per element, so
+ *    the spacer between the two controls has to carry it or the only draggable
+ *    part of the row is the sliver the flex gaps leave.
+ * 4. **Switcher before profile in the DOM**, so tab order reads left-to-right
+ *    across the row rather than jumping to the far side and back.
+ */
+
+let host: HTMLDivElement;
+let root: Root | null = null;
+
+function asDesktop(platform: string) {
+  (window as unknown as Record<string, unknown>).__TAURI__ = {};
+  Object.defineProperty(navigator, "platform", { configurable: true, value: platform });
+}
+
+function render(node: Parameters<Root["render"]>[0]) {
+  act(() => root!.render(node));
+}
+
+/** The row, with two identifiable stand-ins for the controls it carries. */
+function bar() {
+  return createElement(WindowTitleBar, {
+    switcher: createElement("button", { type: "button", "data-testid": "stub-switcher" }, "Co"),
+    profile: createElement("button", { type: "button", "data-testid": "stub-profile" }, "Me"),
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  host.remove();
+  delete (window as unknown as Record<string, unknown>).__TAURI__;
+});
+
+describe("the window title row", () => {
+  it("renders in a browser, carrying both controls", () => {
+    render(bar());
+
+    const row = host.querySelector("[data-testid=window-title-bar]") as HTMLElement | null;
+    expect(row).not.toBeNull();
+    expect(row?.querySelector("[data-testid=stub-switcher]")).not.toBeNull();
+    expect(row?.querySelector("[data-testid=stub-profile]")).not.toBeNull();
+  });
+
+  it("is one centred flex row at the traffic lights' height", () => {
+    render(bar());
+
+    const row = host.querySelector("[data-testid=window-title-bar]") as HTMLElement;
+    // One rule centres every item, rather than each item carrying its own
+    // offset — which is what stops being true when a font loads late or an
+    // item with a different intrinsic height joins the row.
+    expect(row.className).toContain("items-center");
+    expect(row.className).toContain("flex");
+
+    // The centre line the OS gives us: the lights' top offset plus half a
+    // light. Everything in the row is centred on the row's own middle, so the
+    // row's height has to be twice that or the lights sit off it — and no
+    // amount of per-item nudging fixes a row of the wrong height.
+    const lightsCentre = LIGHTS.y + LIGHT_SIZE / 2;
+    expect(WINDOW_TITLE_BAR_HEIGHT).toBe(2 * lightsCentre);
+    expect(row.style.height).toBe(`${2 * lightsCentre}px`);
+    // Which is to say: the row's middle IS the lights' middle.
+    expect(WINDOW_TITLE_BAR_HEIGHT / 2).toBe(lightsCentre);
+  });
+
+  it("reserves nothing for the lights in a browser", () => {
+    render(bar());
+    expect(host.querySelector("[data-testid=window-controls-inset]")).toBeNull();
+  });
+
+  it("insets around the lights on the macOS desktop", () => {
+    asDesktop("MacIntel");
+    render(bar());
+
+    const inset = host.querySelector("[data-testid=window-controls-inset]") as HTMLElement | null;
+    expect(inset).not.toBeNull();
+    // Wide enough to clear the last of the three lights, measured from the
+    // config rather than restated: anything narrower puts the switcher under
+    // a button you can no longer click.
+    const lightsRight = LIGHTS.x + 2 * LIGHT_PITCH + LIGHT_SIZE;
+    expect(WINDOW_CONTROLS_WIDTH).toBe(lightsRight);
+    expect(inset?.style.width).toBe(`${lightsRight}px`);
+
+    // And it stands BEFORE the switcher, which is the whole point: the lights
+    // are at the window's left edge, so anything that does not precede the
+    // switcher leaves the switcher underneath them.
+    const row = host.querySelector("[data-testid=window-title-bar]") as HTMLElement;
+    const switcher = row.querySelector("[data-testid=stub-switcher]") as HTMLElement;
+    expect(inset!.compareDocumentPosition(switcher) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("leaves the empty middle draggable", () => {
+    render(bar());
+
+    const row = host.querySelector("[data-testid=window-title-bar]") as HTMLElement;
+    // The row itself, so a press that lands on its own padding drags.
+    expect(row.hasAttribute("data-tauri-drag-region")).toBe(true);
+    // And the spacer, because the attribute is not inherited: Tauri drags only
+    // when the pressed element is itself marked, and a press in the middle of
+    // the row lands on the spacer rather than on the row.
+    const spacer = row.querySelector(":scope > [data-tauri-drag-region][aria-hidden=true]");
+    expect(spacer).not.toBeNull();
+    expect((spacer as HTMLElement).className).toContain("flex-1");
+  });
+
+  it("puts the switcher before the profile control in the DOM", () => {
+    render(bar());
+
+    const row = host.querySelector("[data-testid=window-title-bar]") as HTMLElement;
+    const switcher = row.querySelector("[data-testid=stub-switcher]") as HTMLElement;
+    const profile = row.querySelector("[data-testid=stub-profile]") as HTMLElement;
+    expect(
+      switcher.compareDocumentPosition(profile) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/frontend/test/unit/window-title-bar.test.ts
+++ b/frontend/test/unit/window-title-bar.test.ts
@@ -2,7 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { act, createElement } from "react";
+import { act, createElement, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -59,12 +59,24 @@ function render(node: Parameters<Root["render"]>[0]) {
   act(() => root!.render(node));
 }
 
-/** The row, with two identifiable stand-ins for the controls it carries. */
-function bar() {
+/** The row, with identifiable stand-ins for the controls it carries. */
+function bar(autonomy?: ReactNode) {
   return createElement(WindowTitleBar, {
     switcher: createElement("button", { type: "button", "data-testid": "stub-switcher" }, "Co"),
+    autonomy,
     profile: createElement("button", { type: "button", "data-testid": "stub-profile" }, "Me"),
   });
+}
+
+/**
+ * A stand-in for the autonomy pill. Inert on purpose, and NOT a claim that the
+ * real pill is: it is a control that opens a menu and carries no
+ * `data-tauri-drag-region` of its own. This row is a pure layout component that
+ * takes the pill as an opaque `ReactNode`, so what is under test here is where
+ * the slot sits in the row — never what the control in it does.
+ */
+function stubAutonomy() {
+  return createElement("span", { "data-testid": "stub-autonomy" }, "Auto");
 }
 
 beforeEach(() => {
@@ -150,6 +162,43 @@ describe("the window title row", () => {
     const spacer = row.querySelector(":scope > [data-tauri-drag-region][aria-hidden=true]");
     expect(spacer).not.toBeNull();
     expect((spacer as HTMLElement).className).toContain("flex-1");
+  });
+
+  it("puts the autonomy slot after the draggable middle and before the profile", () => {
+    render(bar(stubAutonomy()));
+
+    const row = host.querySelector("[data-testid=window-title-bar]") as HTMLElement;
+    const spacer = row.querySelector(
+      ":scope > [data-tauri-drag-region][aria-hidden=true]",
+    ) as HTMLElement;
+    const autonomy = row.querySelector("[data-testid=stub-autonomy]") as HTMLElement;
+    const profile = row.querySelector("[data-testid=stub-profile]") as HTMLElement;
+
+    expect(autonomy).not.toBeNull();
+    // Right-aligned: it must fall on the far side of the elastic spacer, or it
+    // sits beside the switcher at the left end of the row instead.
+    expect(
+      spacer.compareDocumentPosition(autonomy) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // And still before the avatar, which stays last.
+    expect(
+      autonomy.compareDocumentPosition(profile) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("closes up completely when there is no autonomy to show", () => {
+    // The pill returns null when the tier is unknown. Nothing may survive it:
+    // an empty wrapper would still hold one `gap-2` of dead space open, which
+    // reads as a missing control rather than as an absent fact.
+    render(bar(null));
+
+    const row = host.querySelector("[data-testid=window-title-bar]") as HTMLElement;
+    const spacer = row.querySelector(
+      ":scope > [data-tauri-drag-region][aria-hidden=true]",
+    ) as HTMLElement;
+    // The spacer's next sibling is the profile control's own wrapper — there is
+    // no element between them.
+    expect(spacer.nextElementSibling?.querySelector("[data-testid=stub-profile]")).not.toBeNull();
   });
 
   it("puts the switcher before the profile control in the DOM", () => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
         "hiddenTitle": true,
         "trafficLightPosition": {
           "x": 20,
-          "y": 16
+          "y": 20
         }
       }
     ],


### PR DESCRIPTION
## Summary

The window gets a single full-width title row — traffic lights, company/host
switcher, autonomy policy, profile — replacing the switcher's home in the
sidebar header and the profile row's home in its footer.

- **Title row (52px)**, spanning the window. It is the drag band; a `flex-1`
  spacer between the switcher and the pill keeps it grabbable now that both
  ends are controls. `trafficLightPosition` moved to `y: 20` to centre the
  lights in the taller row.
- **Content card** now sits 2px below the row and 12px on the other three
  sides, so it reads as hung from the title row rather than floating.
- **Collapse button** moved to the card's leading seam. It used to live inside
  the panel it hides, so collapsing took the button with it. Filled at rest —
  alone on a seam it read as a stray glyph at ghost weight.
- **Sidebar utilities** (Settings, Feedback, Discord) moved to the foot of the
  column and became labelled rows using the nav's own row primitive. They were
  icon-only because the bar sat *above* the destinations, where labels would
  have pushed the company's state down the column as the nav grew; in the
  footer there is nothing left to push.
- **Autonomy pill** is now a control. It lists every tier the host returns —
  not a hardcoded four — each with its own glyph keyed by mode word, and
  carries the host's "takes effect next turn" sentence before the choice.

## The one behaviour change worth reviewing

Changing the tier from the title bar goes through **the same widening
confirmation as the settings page**. `widensAutonomy` and the dialog's copy
are now shared rather than duplicated, so the two entry points cannot drift
about what is being agreed to. Narrowing stays one click.

Without this the title bar would have been a strictly lower-friction route to
the broadest autonomy this runtime has than the page that was deliberately
given the gate. That was caught in review of the pill, not shipped.

The dialog also names its trigger as `finalFocus`. Without one Base UI left
focus on `<body>` after cancelling — a keyboard operator stranded mid-row.

## Commands run locally

| Command | Result |
|---|---|
| `npm run typecheck` | rc=0 |
| `npm run typecheck:unit` | rc=0 |
| `npm run typecheck:e2e` | rc=0 |
| `npx vitest run` | 440 files, **4086 passed** |
| `scripts/ci/assert-design-tokens.sh` | ✓ no arbitrary sizes, palette colours or stray hex |
| `cargo fmt --all -- --check` | rc=0 |

New tests are mutation-proved. Inverting the widening comparison, removing the
confirmation branch, and making cancel write anyway each killed their own test.

## Intentionally untested

Focus restoration after cancelling. The `finalFocus` fix is real and kept, but
no honest test could be built for it: Base UI restores focus asynchronously,
and under jsdom's scheduling the assertion is noise in **both** directions — a
50-tick budget failed 6 runs in 12 before the fix and still passed 5 of 6 with
the fix reverted; a 3-tick budget passed 10 of 10 either way. A test that gives
the same answer whether or not the code is there proves nothing. The reasoning
is recorded at the assertion site and on the prop.

## Not verified

Not run in a browser by the author of this description — the operator verified
the layout visually in the running desktop app during development, in the live
window, but no light/dark screenshot pair was captured for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full-width title bar with company switching, autonomy controls, and profile access.
  * Added an autonomy indicator showing the current tier, with admin-only tier changes and confirmation for broader permissions.
  * Improved sidebar navigation with labeled utility actions and an accessible collapse control.

* **UI Improvements**
  * Refined window controls, spacing, card framing, and macOS title-bar alignment.
  * Updated profile and company controls for the new title-bar layout.

* **Bug Fixes**
  * Prevented malformed or stale policy data from disrupting the console.
  * Policy changes now appear immediately across the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->