### PR TITLE
ci: run the Markdown line cap in a job that always runs (#1974)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,31 @@ jobs:
       - name: Assert desktop feature sets agree
         run: scripts/ci/assert-desktop-features.sh
 
+  # The 500-line Markdown cap, asserted rather than trusted (issue #695), in a
+  # job that always runs (issue #1974).
+  #
+  # This used to ride `Console` because that job is Node-only and cheap. But
+  # `Console` is gated on the `frontend` path filter, and `docs/**` is not in
+  # it — so the Markdown cap skipped on exactly the pull requests that change
+  # Markdown. A docs-only PR could add a 900-line file and go green.
+  #
+  # That is the same failure the `frontend` filter's own comment records for
+  # `scripts/ci/**`: "a guard that asserts nothing merges green. That is how
+  # the broken `assert-single-tauri-app.sh` got in." Adding `**/*.md` to the
+  # frontend filter would close it too, but it would keep a repository-wide
+  # rule hostage to a console path list — which is what created the gap. A
+  # policy check with no toolchain belongs in a job with no gate.
+  markdown-cap:
+    name: Markdown line cap
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - run: ./scripts/ci/assert-md-line-cap.sh
+
   rust:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
@@ -1578,15 +1603,6 @@ jobs:
       # the failure as one. See docs/design-system/README.md.
       - run: ./scripts/ci/assert-design-tokens.sh
 
-      # The 500-line Markdown cap, asserted rather than trusted (issue #695).
-      #
-      # `CLAUDE.md` has stated the rule since the beginning and nothing measured
-      # it, so three files drifted past — one to 699 lines — a paragraph at a
-      # time. Same family as the check above: a policy grep, no toolchain
-      # needed, and a separate step so a failure is named as a policy failure
-      # rather than a build one. It rides the Console job because that job is
-      # Node-only and cheap; the rule itself is repository-wide.
-      - run: ./scripts/ci/assert-md-line-cap.sh
 
       # The release-notes generator, which is otherwise only ever exercised by a
       # `workflow_dispatch` release — the one moment nobody wants to discover a


### PR DESCRIPTION
Closes #1974.

## The gap

`assert-md-line-cap.sh` ran inside the **Console** job:

```yaml
console:
  name: Console
  if: needs.changes.outputs.frontend == 'true'
```

`docs/**` is not in the `frontend` path filter, so the 500-line Markdown cap **skipped on exactly the pull requests that change Markdown**. A docs-only PR could add a 900-line file and go green; a PR touching one frontend file and one Markdown file got it checked.

The rule has therefore been unenforced for every documentation-only change since it was added — which is most of the changes it exists to govern.

## Why a new job rather than a filter entry

The workflow already knows this failure mode. The `frontend` filter carries this comment about why `scripts/ci/**` is listed there:

> a PR touching only `scripts/ci/**` skipped `Console` entirely, and a guard that asserts nothing merges green. That is how the broken `assert-single-tauri-app.sh` got in.

Adding `**/*.md` to the same filter would close this instance the same way. I did not, because it keeps a repository-wide rule hostage to a console path list — which is the thing that created the gap in the first place, and it would need remembering again the next time a policy check is added.

The check needs no toolchain and has nothing to do with the console. It now sits in its own always-run job beside `Actions pinned`, which is the existing precedent for a single-purpose repository-wide policy job.

**Moved, not duplicated.** The Console job keeps `assert-design-tokens.sh` and loses only this step; `assert-md-line-cap.sh` is referenced exactly once in the workflow.

## Validation

- `python3 -c "yaml.safe_load(...)"` — parses; 14 jobs; `markdown-cap` has no `if:`
- Console still runs the design-token check; no longer runs the md cap; `markdown-cap` does
- `bash scripts/ci/assert-md-line-cap.sh` → passes on this tree, so making it always run does not turn main red
- The new `uses:` is the same SHA-pinned checkout the other jobs use, so `Actions pinned` stays green

## Provenance

Spotted by @oxoxDev while reviewing #1967, which is docs-only and so skipped the check it was adding 400 lines of Markdown under.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration checks by running markdown line-length validation as an independent, always-executed check.
  * Separated markdown validation from the console-related checks for clearer build status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->