### PR TITLE
feat(console): move OAuth and MCP into a top-level Connections section

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -98,7 +98,7 @@ L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
 | [runtime/planning.md](runtime/planning.md) | The Planning station: pass contract, prerequisite verdicts, boot sweep |
 | [runtime/ledgers.md](runtime/ledgers.md) | Dynamic ledgers: declared record shapes, the append-only fold, who may delete, the `derived/` folder |
 | [runtime/ledger-statuses.md](runtime/ledger-statuses.md) | How many statuses a ledger may declare, the board's phase/stage split, and how a retired status word heals |
-| [runtime/ledgers-console-ia.md](runtime/ledgers-console-ia.md) | The console surface over ledgers: naming ("ledger" is internal-only), per-list sidebar rows, Manage Lists, the declare wizard |
+| [runtime/ledgers-console-ia.md](runtime/ledgers-console-ia.md) | The console surface over ledgers: naming ("ledger" is internal-only), per-list sidebar rows, Manage Lists, the declare wizard — and, as the console's IA record, Rule 6 on nav-vs-routing and Rule 7 on the Connections section |
 | [runtime/pages.md](runtime/pages.md) | Agent-authored internal dashboard pages: the `pages/<slug>/` convention, the compile-on-write contract, and the two-part isolation model |
 | [runtime/orchestration/README.md](runtime/orchestration/README.md) | Making a many-agent company converge: the three collapses, the three principles, phasing |
 | [runtime/orchestration/memory.md](runtime/orchestration/memory.md) | One memory contract: `MemoryProvider` replaces three ports, and the host decorator that keeps tenants apart |

--- a/docs/spec/runtime/ledgers-console-ia.md
+++ b/docs/spec/runtime/ledgers-console-ia.md
@@ -366,6 +366,76 @@ removing a sidebar row. A future change that parks a complete surface must add
 its visible notice in the same change; a future change that retires one must
 replace the route deliberately.
 
+## Rule 7: Connections is a section, not two settings tabs
+
+Added after the fact, by the change that moved OAuth and MCP Servers out of
+Settings. Recorded here because this file says at the bottom that it is the one
+to update first when the console IA changes.
+
+**What moved.** Two settings sub-pages became a top-level nav row with two
+sub-pages of its own:
+
+| address | before | after |
+| --- | --- | --- |
+| `#/connections` | rewritten → `#/settings/oauth` | **real** — the section, defaulting to Apps |
+| `#/connections/apps` | — | the accounts page, renamed from OAuth |
+| `#/connections/mcp` | — | the MCP page |
+| `#/oauth` | → `#/settings/oauth` | → `#/connections/apps` |
+| `#/mcp` | → `#/settings/mcp` | → `#/connections/mcp` |
+| `#/settings/oauth` | the page | → `#/connections/apps` |
+| `#/settings/mcp` | the page | → `#/connections/mcp` |
+| `#/settings/connections` | **dead** — silently landed on General | → `#/connections` |
+
+**Why a section and not a settings tab.** The same argument
+`docs/spec/runtime/finance-console.md` makes about Billing, and the one that
+took Brain out of the rail. Settings is where an operator changes how the
+company is configured — a place they visit once, on the way to something else.
+Which apps the company can act through, and which tool servers its teammates can
+call, is not that: it is read repeatedly, it changes as the work changes, and an
+operator arrives at it asking "can my teammates do X yet?". Two clicks down a
+settings rail is the wrong depth for a question asked that often.
+
+**Why only two of the five.** Inference, Hosting and Search stayed in Settings'
+Integrations group, which survives with three rows. Each is a credential form
+that belongs beside the one thing it unlocks — the model, the deploy target, the
+search provider — which is the argument `views/settings-pages.ts` makes twice.
+Filing them under a section named for the act of connecting would undo it.
+
+**This is not a revert of the Connections split.** A single "Connections" *page*
+once carried five subjects — accounts, MCP, inference, channels, repositories —
+and was deliberately broken apart because each was something an operator
+scrolled past on the way to another. That decision was about one question per
+page, and it stands: Apps and MCP Servers are still two pages. What is new is
+that they have a parent. Composio stays on the Apps page for the same rule read
+the other way: `ProvidersSection` reads Composio's credential state to decide
+what every provider tile renders, so splitting them would separate a credential
+from the thing it unlocks.
+
+**Why "Apps".** "OAuth" names the protocol a connection happens to run on rather
+than what an operator is looking for, which is Gmail, Slack, Notion — and under
+a parent already called Connections it said the same word twice. Only the
+surface strings change; the file, the component and every internal name stay
+`OAuth*`, exactly the split Rule 1 makes for "ledger".
+
+**Rule 6 is satisfied by promotion, not by an exemption.** Both pages gained a
+nav row rather than losing one, so neither needs one of Rule 6's four
+treatments. What Rule 6 governs here is the addresses they left behind: all four
+are **retired** in its sense — routed through `REWRITE_RETIRED` to the real
+successor, with no page left pretending to be a live destination.
+`#/settings/connections` is the case that shows why that clause is not
+bookkeeping. It named no `SETTINGS_PAGES` id, so the unknown-sub repair dropped
+the operator on **General** — a real page that was not the one the link
+promised, which is worse than an address that plainly fails, because it looks
+like it worked. It was live in four places in the setup flow the whole time.
+
+**The nav row sits between Finance and Workflows.** Finance and Connections are
+the two rows about the world outside this company — the money it moves through
+Chargebee and PayPal, and the apps and tool servers its teammates act through.
+Workflows and Observatory are the "what the agents did" pair and read as one
+thing when adjacent. Draft 1 above counted 9 fixed `NAV` entries against the
+15-list cap; this makes 10, which does not change that draft's arithmetic enough
+to reopen it.
+
 ## What stays out of scope
 
 - `LedgerSpec`, the fold, `LedgerStore`, the derived-Markdown guard, and every

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -8,6 +8,7 @@ import {
   type LucideIcon,
   MessagesSquare,
   Network,
+  Plug,
   ShieldCheck,
   BookText,
   Wallet,
@@ -169,6 +170,7 @@ import { TaskDetailRoute } from "@/views/TaskDetailRoute";
 import { InboxView } from "@/views/InboxView";
 import { FeedbackView } from "@/views/FeedbackView";
 import { UnknownRouteView } from "@/views/UnknownRouteView";
+import { ConnectionsSection } from "@/views/connections/ConnectionsSection";
 import { SettingsSection } from "@/views/SettingsSection";
 import { useLocalScope } from "@/connections/ConnectionContext";
 
@@ -334,6 +336,21 @@ const NAV: NavItem[] = [
   // Chargebee and PayPal surfaces the host had no HTTP route for until
   // `server::ops::finance`. See docs/spec/runtime/finance-console.md.
   { view: "finances", label: "Finance", icon: Wallet },
+  // Beside Finance, and above the Workflows/Observatory pair, because that is
+  // the seam it belongs on. Finance and Connections are the two rows about the
+  // world *outside* this company — the money it moves through Chargebee and
+  // PayPal, and the apps and tool servers its teammates act through — while
+  // Workflows and Observatory are the "what the agents did" pair and read as
+  // one thing when adjacent. Splitting either pair to slot this in would cost
+  // more than it bought.
+  //
+  // Not in Settings, which is where it used to live as two sub-pages. A
+  // settings rail is for configuration an operator sets once; which apps the
+  // company can act through is something they come back to and read, and it
+  // changes as the work does — the same argument that moved Billing out to
+  // Finance (docs/spec/runtime/finance-console.md) and Brain out to its own
+  // row. See docs/spec/runtime/ledgers-console-ia.md, Rule 7.
+  { view: "connections", label: "Connections", icon: Plug },
   { view: "workflows", label: "Workflows", icon: Workflow },
   // What the agents actually did, run by run — the read-only companion to
   // Workflows' authoring canvas. See docs/spec/runtime/deep-trace.md.
@@ -1174,8 +1191,8 @@ export function AppShell({
   // Runs once; StrictMode's double invoke is harmless because the first run
   // clears the params the second reads.
   //
-  // The accounts page is `#/settings/oauth` since the Connections split, so the
-  // bounce-back lands there rather than on a top-level view.
+  // The accounts page is `#/connections/apps` since it left the settings rail
+  // for the Connections section, so the bounce-back lands there.
   //
   // Before issue #300 the host answered a cancelled or expired handshake with a
   // JSON body, which the browser rendered as the page — a dead end with no way
@@ -1198,7 +1215,7 @@ export function AppShell({
       "",
       window.location.pathname + (query ? `?${query}` : "") + stripLegacyConnectParams(window.location.hash),
     );
-    setView("settings", "oauth");
+    setView("connections", "apps");
     // The callback param carries the raw provider id (e.g. "slack"); show the
     // catalog display name ("Slack") when we know it, falling back to the id.
     const providerName = providerId
@@ -3968,6 +3985,14 @@ export function AppShell({
                 onNavigate={(page) => navigate("finances", page)}
               />
             </Suspense>
+          )}
+          {view === "connections" && (
+            <ConnectionsSection
+              client={client}
+              company={company}
+              sub={sub}
+              onNavigate={(page) => navigate("connections", page)}
+            />
           )}
           {view === "settings" && (
             <SettingsSection

--- a/frontend/src/lib/console-route-rewrites.ts
+++ b/frontend/src/lib/console-route-rewrites.ts
@@ -1,6 +1,7 @@
 import { BOARD_LEDGER } from "@/lib/board-columns";
 import { type View, VIEWS } from "@/lib/console-routes";
 import { taskIdFromSegment } from "@/lib/task-route";
+import { isConnectionPage } from "@/views/connection-pages";
 import { isSettingsPage } from "@/views/settings-pages";
 
 /**
@@ -30,6 +31,15 @@ export const REWRITE_RETIRED = (
   // render a settings rail around a page that is no longer in one.
   if (head === "memory") return ["brain", null];
   if (head === "settings" && sub === "brain") return ["brain", null];
+  // Apps and MCP Servers left the settings rail for the Connections section.
+  // Both of their settings addresses are rewritten onto it, and so is
+  // `#/settings/connections` — the address the pre-split Connections page had,
+  // which named no `SETTINGS_PAGES` id and therefore landed an operator on
+  // General while looking like a link that worked. It was still live in four
+  // places in the setup flow when this section was built.
+  if (head === "settings" && sub === "oauth") return ["connections", "apps"];
+  if (head === "settings" && sub === "mcp") return ["connections", "mcp"];
+  if (head === "settings" && sub === "connections") return ["connections", null];
   // Settings owns a fixed table of sub-pages, unlike the entity ids beneath
   // Team and Workspace. Do not render General under an address that names no
   // page: a bookmark or shared link must say where it actually lands.
@@ -42,11 +52,19 @@ export const REWRITE_RETIRED = (
   // detail sub-page (issue #264), it is what the org chart's rows and the chat
   // pane's chips link to, and it is deliberately a page so it can be linked.
   if (head === "team" && !sub) return ["company", null];
-  // `#/connections` predates the split into OAuth / MCP / Inference; the
-  // accounts it named are the OAuth page.
-  if (head === "connections") return ["settings", "oauth"];
-  if (head === "oauth") return ["settings", "oauth"];
-  if (head === "mcp") return ["settings", "mcp"];
+  // `#/connections` is a real address again. It predates the split into OAuth /
+  // MCP / Inference, then spent that time rewritten onto the OAuth page; it now
+  // names the section those two pages live in, which is closer to what it
+  // always meant. Bare is left alone — the section defaults to Apps the way
+  // `#/finances` defaults to its Overview. A segment that names no sub-page is
+  // repaired rather than swallowed, for the reason the Settings branch above
+  // gives: an address that quietly shows a different page looks like a link
+  // that worked.
+  if (head === "connections" && sub !== null && !isConnectionPage(sub)) {
+    return ["connections", null];
+  }
+  if (head === "oauth") return ["connections", "apps"];
+  if (head === "mcp") return ["connections", "mcp"];
   if (head === "people") return ["settings", "people"];
   // An empty hash is the normal console entry point and uses the router's
   // Overview fallback. Keep the head as the sub-page for every non-empty

--- a/frontend/src/lib/console-routes.ts
+++ b/frontend/src/lib/console-routes.ts
@@ -64,6 +64,15 @@ export type View =
   | "observatory"
   | "pages"
   | "finances"
+  /**
+   * What this company can reach outside itself: the apps its teammates act
+   * through, and the tool servers they can call.
+   *
+   * Two settings sub-pages (`#/settings/oauth`, `#/settings/mcp`) until they
+   * got a section of their own. Both old addresses still resolve, rewritten by
+   * `console-route-rewrites.ts`.
+   */
+  | "connections"
   | "settings"
   | "feedback"
   /** The first-run setup dialog, opened from a direct address or Settings. */
@@ -153,6 +162,13 @@ const ROUTABLE: Record<View, true> = {
    * routes all three; see docs/spec/runtime/finance-console.md.
    */
   finances: true,
+  /**
+   * Apps (the third-party accounts, Composio included) and MCP Servers, under
+   * one nav row. Its sub-pages ride the second hash segment
+   * (`#/connections/mcp`), so this one entry routes both — the same shape
+   * `finances` above uses. See docs/spec/runtime/ledgers-console-ia.md, Rule 7.
+   */
+  connections: true,
   settings: true,
   /** No nav row: linked from the sidebar footer instead. */
   feedback: true,

--- a/frontend/src/setup/SetupController.tsx
+++ b/frontend/src/setup/SetupController.tsx
@@ -6,6 +6,7 @@ import { useLocalScope } from "@/connections/ConnectionContext";
 import type { LocalScope } from "@/connections/types";
 import { shouldOfferSetup, teamIsUnstaffed } from "@/lib/company-setup";
 import { ReadTimeoutError, withReadTimeout } from "@/lib/read-timeout";
+import { settingsHref } from "@/views/settings-pages";
 import { SetupDialog } from "./SetupDialog";
 import {
   clearSetupRedesign,
@@ -20,8 +21,20 @@ import {
   setupSkipped,
 } from "./state";
 
-/** Where "Set up a model" sends the operator. */
-const MODEL_SETTINGS = "#/settings/connections";
+/**
+ * Where "Set up a model" sends the operator.
+ *
+ * `#/settings/inference`, via the typed helper, so this cannot name a page that
+ * does not exist. It said `#/settings/connections` for as long as the pre-split
+ * Connections page was where a model was wired — an address that matched no
+ * `SETTINGS_PAGES` id after the split and was therefore repaired onto
+ * **General**, which is not where a model is set up. The constant is named
+ * `MODEL_SETTINGS` and it now points at the model.
+ *
+ * `onModelSettings` below compares the live hash against this, so the two
+ * cannot drift: the check is the same string as the destination.
+ */
+const MODEL_SETTINGS = settingsHref("inference");
 
 /**
  * How long the gate's roster read (`client.listTeam`, just below) is allowed

--- a/frontend/src/setup/SetupDialog.tsx
+++ b/frontend/src/setup/SetupDialog.tsx
@@ -30,6 +30,7 @@ import {
 import { cn } from "@/lib/utils";
 import { initials, toneFor } from "@/lib/team";
 import { TEAM_TONES } from "@/lib/team";
+import { settingsHref } from "@/views/settings-pages";
 
 /**
  * How long each created agent stays on screen before the next write starts.
@@ -191,7 +192,7 @@ export function SetupDialog({
    * Whether the operator may change where the company's model calls go.
    *
    * The actions the notice offers — wiring a model, restarting to pick one up —
-   * are an admin's (the Connections form and its restart control render only
+   * are an admin's (the Inference form and its restart control render only
    * under management authority and the host refuses the writes for a member),
    * so a member is told to ask an admin rather than handed a dead-end link.
    * `null` while the role read is outstanding: the admin actions are withheld
@@ -831,8 +832,16 @@ function InferenceNotice({
           "Carry on with the standard team."
         ) : offered && canManage ? (
           <>
+            {/* Both arms land on Inference. "Set up a model" obviously does;
+                so does "Restart the company", because the restart this notice
+                means is the one `restartRequired` names — a company whose
+                stored model postdates its running brain — and the control that
+                performs it renders on the Inference card
+                (`views/connections/InferenceSection.tsx`), not on General.
+                This said `#/settings/connections`, which named no settings
+                page and was repaired onto General, where neither action is. */}
             <a
-              href="#/settings/connections"
+              href={settingsHref("inference")}
               onClick={onLeave}
               className="font-medium underline underline-offset-4"
             >
@@ -988,7 +997,7 @@ function BuildOut({
           */}
           {fallback === "no_model" && harnessReachable && canManage === true && (
             <a
-              href="#/settings/connections"
+              href={settingsHref("inference")}
               onClick={onRedesign}
               data-testid="setup-add-model"
               className={buttonVariants({ variant: "outline" })}
@@ -1026,7 +1035,7 @@ function BuildOut({
               </Button>
               {canManage === true && (
                 <a
-                  href="#/settings/connections"
+                  href={settingsHref("inference")}
                   onClick={onRedesign}
                   data-testid="setup-check-connection"
                   className={buttonVariants({ variant: "outline" })}

--- a/frontend/src/tour/steps.ts
+++ b/frontend/src/tour/steps.ts
@@ -15,7 +15,7 @@ import type { View } from "@/components/app-shell";
  */
 export interface TourStop {
   view: View;
-  /** A section's sub-page, when the stop lives inside one (`#/settings/…`). */
+  /** A section's sub-page, when the stop lives inside one (`#/connections/…`). */
   sub?: string;
   target: string;
   title: string;
@@ -67,11 +67,19 @@ export const TOUR: TourStop[] = [
     body: "Anything that needs your sign-off before it happens waits here. Nothing risky runs without you.",
   },
   {
-    // The accounts page is `#/settings/oauth` since the Connections split, so
-    // the stop navigates there and spotlights the nav row that leads to it.
-    view: "settings",
-    sub: "oauth",
-    target: '[data-tour="nav-settings"]',
+    // The accounts page is `#/connections/apps` since it left the settings rail
+    // for its own section, so the stop navigates there and spotlights the
+    // Connections nav row that leads to it.
+    //
+    // That row is the point of the change. This stop is titled "Connect your
+    // tools" and used to spotlight **Settings**, because the accounts page was
+    // a settings sub-page and the utility bar's `nav-settings` anchor was the
+    // nearest always-mounted thing to point at. An operator following the tour
+    // was shown a gear and told it was where tools get connected. The stop now
+    // names the same surface the sidebar does.
+    view: "connections",
+    sub: "apps",
+    target: '[data-tour="nav-connections"]',
     placement: "right",
     title: "Connect your tools",
     body: "Plug in the tools your company already uses — Gmail, Slack, Notion — so your teammates can act for real.",

--- a/frontend/src/views/McpServersView.tsx
+++ b/frontend/src/views/McpServersView.tsx
@@ -31,8 +31,11 @@ interface Props {
  * one source of truth per question, and a tab does not break it.
  *
  * The rows live in [`McpServersSection`](./connections/McpServersSection.tsx),
- * which the Apps page also renders inline — that is the same surface, not a
- * copy.
+ * rendered `standalone` because this page is the whole of it. Apps does **not**
+ * render it: `ConnectionsSection` sends the bare `#/connections` to `OAuthView`
+ * and `#/connections/mcp` here, and `OAuthView` renders no MCP section at all.
+ * That is still one surface rather than two — this page is its only caller
+ * (issue #414).
  */
 export function McpServersView({ client, company }: Props) {
   // Adding or removing a server changes what tools the company's agents can

--- a/frontend/src/views/McpServersView.tsx
+++ b/frontend/src/views/McpServersView.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 /**
- * Settings, MCP Servers: the company's tool servers, said two ways.
+ * Connections, MCP Servers: the company's tool servers, said two ways.
  *
  * **Connections** is the list — a row per server with its status and its
  * controls as icons. **mcp.json** is the same configuration as one document, in
@@ -31,8 +31,8 @@ interface Props {
  * one source of truth per question, and a tab does not break it.
  *
  * The rows live in [`McpServersSection`](./connections/McpServersSection.tsx),
- * which the Connections page also renders inline — that is the same surface, not
- * a copy.
+ * which the Apps page also renders inline — that is the same surface, not a
+ * copy.
  */
 export function McpServersView({ client, company }: Props) {
   // Adding or removing a server changes what tools the company's agents can

--- a/frontend/src/views/OAuthView.tsx
+++ b/frontend/src/views/OAuthView.tsx
@@ -56,14 +56,31 @@ const COMPOSIO_PROBE_TIMEOUT_MS = 5_000;
 const PROBE_TIMED_OUT = Symbol("composio-probe-timed-out");
 
 /**
- * OAuth: the third-party accounts this company signs in to and acts through.
+ * Apps: the third-party accounts this company signs in to and acts through.
  *
  * One question per page. This page used to be "Connections" and carried five
  * unrelated ones — the accounts below, the MCP tool servers, which model the
  * company thinks with, its Telegram channel and its bound repositories — so
  * every one of them was something an operator scrolled past on the way to
- * another. MCP (`#/settings/mcp`) and inference (`#/settings/inference`) are
+ * another. MCP (`#/connections/mcp`) and inference (`#/settings/inference`) are
  * their own pages now; channels and repositories left the product entirely.
+ *
+ * # Why the title is "Apps" and not "OAuth"
+ *
+ * It is called **Apps** since it moved to `#/connections/apps`. "OAuth" names
+ * the protocol a connection happens to run on, which is not the thing an
+ * operator came to this page to find — they are looking for Gmail, Slack,
+ * Notion. It also read as a stutter under a section already called Connections.
+ * The file, the component and every internal name stay `OAuth*`: the protocol
+ * is exactly what the code is about, and renaming it would be a mechanical
+ * diff across the module for no surface benefit. The same split Rule 1 of
+ * `docs/spec/runtime/ledgers-console-ia.md` makes for "ledger".
+ *
+ * Composio stays on this page. `ComposioSection` looks self-contained, but
+ * `ProvidersSection` reads its `credentialSource`, `granted`, `openMode` and
+ * catalog warning to decide what every provider tile renders — the credential
+ * is the engine the provider list runs on, and splitting them would separate a
+ * credential from what it unlocks.
  */
 export function OAuthView({ client, company }: Props) {
   const [load, setLoad] = useState<Load>("loading");
@@ -533,7 +550,7 @@ export function OAuthView({ client, company }: Props) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <PageHeader
-        title="OAuth"
+        title="Apps"
         width="5xl"
         description={
           <>

--- a/frontend/src/views/SettingsSection.tsx
+++ b/frontend/src/views/SettingsSection.tsx
@@ -7,8 +7,6 @@ import { cn } from "@/lib/utils";
 import { InferenceView } from "@/views/InferenceView";
 import { HostingView } from "@/views/HostingView";
 import { SearchView } from "@/views/SearchView";
-import { McpServersView } from "@/views/McpServersView";
-import { OAuthView } from "@/views/OAuthView";
 import { PeopleView } from "@/views/PeopleView";
 import { SkillsView } from "@/views/SkillsView";
 import { SettingsView } from "@/views/SettingsView";
@@ -42,9 +40,14 @@ interface Props {
  *
  * Everything that configures the company rather than running it lives here,
  * behind a sub-sidebar: the connection and lifecycle controls, who can sign in,
- * which third-party accounts are linked, and which tool servers are installed.
- * Each is its own route (`#/settings/people`), so a sub-page is linkable and
- * survives a refresh exactly as a top-level view does.
+ * which model teammates think with, where its sites deploy and where it
+ * searches. Each is its own route (`#/settings/people`), so a sub-page is
+ * linkable and survives a refresh exactly as a top-level view does.
+ *
+ * Which third-party accounts are linked and which tool servers are installed
+ * used to be here too. They are the Connections section now — see
+ * `views/connections/ConnectionsSection.tsx` for why, and note that the three
+ * credential forms still on this rail stayed on purpose.
  */
 export function SettingsSection({ client, company, feed, sub, onFlag, onResetCompany }: Props) {
   const page = resolveSettingsPage(sub);
@@ -144,8 +147,12 @@ export function SettingsSection({ client, company, feed, sub, onFlag, onResetCom
           />
         )}
         {page === "people" && <PeopleView client={client} company={company} />}
-        {page === "oauth" && <OAuthView client={client} company={company} />}
-        {page === "mcp" && <McpServersView client={client} company={company} />}
+        {/* OAuth and MCP Servers were here. They are the Connections section
+            now (`#/connections/apps`, `#/connections/mcp`) — what the company
+            can act through is read repeatedly, and a settings rail is where an
+            operator changes configuration once. Both old addresses still
+            resolve, rewritten by `console-route-rewrites.ts`. Inference stayed:
+            a credential form belongs beside the one thing it unlocks. */}
         {page === "inference" && <InferenceView client={client} company={company} />}
         {/* Billing was here. It moved to Finance → Invoicing and Finance → Wallet
             (docs/spec/runtime/finance-console.md): a credential form belongs

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -94,6 +94,7 @@ import { WorkflowCreateDialog } from "@/views/WorkflowCreateDialog";
 import { useAskerNames } from "@/components/approval-card";
 import type { DecidedApproval } from "@/views/chat/model";
 import { cn } from "@/lib/utils";
+import { settingsHref } from "@/views/settings-pages";
 import { startVisiblePolling } from "@/lib/visible-poll";
 import type { NodeRunState } from "@/lib/workflow-sample";
 import { workflowSavedToast } from "@/lib/workflow-saved-toast";
@@ -3059,9 +3060,16 @@ export function WorkflowsView({
                   ? "This company has no inference provider configured, so workflows can't run. Set a provider under Settings → Inference, then run again."
                   : runRefusal.message}
               </span>
+              {/* Inference, not the accounts page. The sentence above says "Set
+                  a provider under Settings → Inference" and the button says
+                  "Set up inference", but the href was `#/settings/oauth` — so
+                  following it landed the operator on the third-party accounts
+                  page, which cannot configure a model. Found while moving that
+                  page to `#/connections/apps`; the typed helper is what stops
+                  it recurring. */}
               {runRefusal.code === "inference_required" && (
                 <a
-                  href="#/settings/oauth"
+                  href={settingsHref("inference")}
                   className={cn(buttonVariants({ variant: "outline", size: "sm" }))}
                   data-testid="workflow-run-inference-cta"
                 >

--- a/frontend/src/views/connection-pages.ts
+++ b/frontend/src/views/connection-pages.ts
@@ -1,0 +1,74 @@
+// The Connections section's sub-page table, and the helpers that read it.
+//
+// A leaf module, exactly as `settings-pages.ts` is, and for the same reason:
+// anything *pointing at* a sub-page — prose, a route rewrite — has to name one
+// without importing the section, which imports every view under it. The route
+// rewrites in `lib/console-route-rewrites.ts` are the case that forces it here:
+// they run on the router's own path, so a static import of the section from
+// there would pull `OAuthView` and `McpServersView` in behind them.
+//
+// Modelled on `finance/FinanceSection.tsx`'s `FINANCE_PAGES`, which keeps its
+// table inside the section because nothing outside needs to read it. This one
+// is read from two other modules, so it lives on its own.
+
+import { Blocks, LayoutGrid, type LucideIcon } from "lucide-react";
+
+/**
+ * The sub-pages that live under Connections. The id is the hash's second
+ * segment.
+ *
+ * Two, not five. A single "Connections" page once carried third-party
+ * accounts, MCP servers, inference, channels and repositories, and was
+ * deliberately broken apart because each was something an operator scrolled
+ * past on the way to another (see the comment above the `oauth` entry in
+ * `settings-pages.ts`, and `OAuthView`'s own header). That decision was about
+ * one-question-per-page, and it stands: these are still two pages. What is new
+ * is that they have a parent, which is a different thing from being merged
+ * back together.
+ *
+ * Inference, Hosting and Search deliberately did **not** move here. Each is a
+ * credential form that belongs beside the one thing it unlocks — the model, the
+ * deploy target, the search provider — which is the argument `settings-pages.ts`
+ * makes twice, and filing them under a section named for the act of connecting
+ * would undo it.
+ */
+export const CONNECTION_PAGES = [
+  {
+    id: "apps",
+    label: "Apps",
+    icon: LayoutGrid,
+    hint: "The apps your teammates act through",
+  },
+  {
+    id: "mcp",
+    label: "MCP Servers",
+    icon: Blocks,
+    hint: "Tool servers and their tools",
+  },
+] as const satisfies readonly { id: string; label: string; icon: LucideIcon; hint: string }[];
+
+export type ConnectionPage = (typeof CONNECTION_PAGES)[number]["id"];
+
+export const DEFAULT_CONNECTION_PAGE: ConnectionPage = "apps";
+
+/** Whether a hash segment names a real sub-page. */
+export function isConnectionPage(sub: string | null): sub is ConnectionPage {
+  return CONNECTION_PAGES.some((page) => page.id === sub);
+}
+
+/** The sub-page a hash segment resolves to, defaulting to Apps. */
+export function resolveConnectionPage(sub: string | null): ConnectionPage {
+  return isConnectionPage(sub) ? sub : DEFAULT_CONNECTION_PAGE;
+}
+
+/**
+ * The console hash a link to one Connections sub-page needs.
+ *
+ * Typed for the same reason `settingsHref` is: a link written against this
+ * cannot outlive the page it points at. `#/settings/connections` — hard-coded
+ * in four places, pointing at a page that stopped existing when Connections was
+ * split — is what happens without it.
+ */
+export function connectionsHref(page: ConnectionPage): string {
+  return `#/connections/${page}`;
+}

--- a/frontend/src/views/connections/ConnectionsSection.tsx
+++ b/frontend/src/views/connections/ConnectionsSection.tsx
@@ -1,0 +1,122 @@
+import type { OpenCompanyClient } from "@/api/client";
+import { cn } from "@/lib/utils";
+import {
+  CONNECTION_PAGES,
+  type ConnectionPage,
+  resolveConnectionPage,
+} from "@/views/connection-pages";
+import { McpServersView } from "@/views/McpServersView";
+import { OAuthView } from "@/views/OAuthView";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+  /** The hash's second segment, e.g. `mcp` in `#/connections/mcp`. */
+  sub: string | null;
+  onNavigate: (page: ConnectionPage) => void;
+}
+
+/**
+ * Connections, as a section rather than two settings tabs.
+ *
+ * Modelled on `finance/FinanceSection.tsx`, deliberately and down to the
+ * breakpoint: a `w-60` sub-rail on `sm:` and up, a scrolling chip row below it,
+ * and each sub-page its own route (`#/connections/mcp`) so it is linkable and
+ * survives a refresh exactly as a top-level view does.
+ *
+ * # Why this replaced Settings → OAuth and Settings → MCP Servers
+ *
+ * The same argument `docs/spec/runtime/finance-console.md` makes about Billing.
+ * Settings is where an operator changes how the company is configured — a place
+ * they visit once, on the way to something else. Which apps the company can act
+ * through, and which tool servers its teammates can call, is not that: it is
+ * read repeatedly, it changes as the company's work changes, and an operator
+ * arrives at it asking "can my teammates do X yet?" rather than "what is this
+ * company's configuration?". Two clicks down a settings rail is the wrong depth
+ * for a question asked that often.
+ *
+ * # This is not a revert of the Connections split
+ *
+ * A single "Connections" **page** once carried five subjects and was broken
+ * apart on purpose (see the comment above the `oauth` entry in
+ * `settings-pages.ts`). Nothing here puts them back on one page: Apps and MCP
+ * Servers are still two pages answering one question each. What they gain is a
+ * parent, which is what the original split had no room to give them — and the
+ * three credential forms that argument also covers (Inference, Hosting, Search)
+ * deliberately stayed in Settings, beside the things they unlock.
+ *
+ * # Only the parent is new
+ *
+ * `OAuthView` and `McpServersView` are re-parented, not rewritten. The one
+ * content change is `OAuthView`'s title: the page is called **Apps** now,
+ * because "OAuth" names the protocol a connection happens to use rather than
+ * the thing an operator came to find, and under a section already named
+ * Connections it said the same word twice.
+ */
+export function ConnectionsSection({ client, company, sub, onNavigate }: Props) {
+  const page = resolveConnectionPage(sub);
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <nav
+        aria-label="Connections"
+        className="hidden w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-3 sm:flex"
+      >
+        {/* A visual caption for the rail, not a heading. The `nav` is already
+            named by its `aria-label`, so an `h2` here adds nothing for a screen
+            reader and breaks the document outline: the rail renders before the
+            sub-page, so heading navigation would meet a section-level heading
+            ahead of the page's own `h1` (issue #1392). */}
+        <div className="px-2 pb-2 pt-1 text-xs font-medium text-muted-foreground">
+          Connections
+        </div>
+        {CONNECTION_PAGES.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onNavigate(item.id)}
+            aria-current={page === item.id ? "page" : undefined}
+            className={cn(
+              "flex items-start gap-2.5 rounded-lg px-2 py-2 text-left transition-colors",
+              page === item.id ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
+            )}
+          >
+            <item.icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <span className="min-w-0">
+              <span className="block text-sm font-medium">{item.label}</span>
+              <span className="block text-xs text-muted-foreground">{item.hint}</span>
+            </span>
+          </button>
+        ))}
+      </nav>
+
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {/* On the macOS desktop `ContentSurface` overlays every page's top 28px
+            with a pointer-events-enabled drag band (`WindowDragBar`, z-20), and
+            this row is the one page top that sits in it below `sm`. `relative
+            z-30` gives the chips their own stacking context above that band —
+            the same fix `SettingsSection`'s chip row carries, for the same
+            reason (issue #1383's neighbour). */}
+        <div className="relative z-30 flex gap-1 overflow-x-auto border-b p-2 sm:hidden">
+          {CONNECTION_PAGES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onNavigate(item.id)}
+              aria-current={page === item.id ? "page" : undefined}
+              className={cn(
+                "shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                page === item.id ? "bg-accent text-accent-foreground" : "text-muted-foreground",
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        {page === "apps" && <OAuthView client={client} company={company} />}
+        {page === "mcp" && <McpServersView client={client} company={company} />}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -140,9 +140,10 @@ type ToolsState =
 /**
  * How the page around this section frames it.
  *
- * - `inline` — a section among others (Connections). The page has plenty else
- *   to show, so a host with no MCP surface renders nothing here at all.
- * - `standalone` — the whole page is this section (Settings, MCP Servers). The
+ * - `inline` — a section among others. The page has plenty else to show, so a
+ *   host with no MCP surface renders nothing here at all. The default, and
+ *   since the Connections split no page embeds it.
+ * - `standalone` — the whole page is this section (`#/connections/mcp`). The
  *   page supplies the heading, and a host with no MCP surface says so, because
  *   the alternative is a page that is simply blank.
  */
@@ -171,9 +172,11 @@ interface Props {
  * List A's routes at all. That dispatch is
  * [`mcpRowControls`](@/lib/mcp-registry)'s.
  *
- * This is the console's **only** MCP surface, reached from two places: the
- * Connections page renders it `inline`, Settings, MCP Servers renders it
- * `standalone`. Settings used to carry a second implementation of this screen
+ * This is the console's **only** MCP surface, and it has exactly one caller:
+ * [`McpServersView`](../McpServersView.tsx), the `#/connections/mcp` page,
+ * which renders it `standalone`. Apps (`OAuthView`) does **not** render it —
+ * MCP is a page beside Apps under Connections, not a section inline on it.
+ * Settings used to carry a second implementation of this screen
  * against an API no host has ever served (`{ servers }` wrappers, `server_id`
  * keys, `/connect` and `/disconnect` routes), which crashed on open — a second
  * surface is how the two came to disagree, so there is one (issue #414).
@@ -689,15 +692,15 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
   return (
     <section className="space-y-3">
       {/* `h2` in both chromes, and it lands one level under the page's `h1`
-          either way (issue #1392). Inline on Apps it is a peer of
-          the company key, Composio and providers, which all head their
-          sections at the same level —
-          `test/unit/connections-section-heading-level.test.ts` holds them
-          together, because promoting this one alone would read to a screen
-          reader as though every section after it were a subsection of MCP
-          Servers. Standalone on `#/connections/mcp` the page's own `h1` is "MCP
+          either way (issue #1392). Standalone on `#/connections/mcp` — the only
+          way this section is rendered — the page's own `h1` is already "MCP
           Servers", so this names what it actually heads there instead of
-          repeating it. */}
+          repeating it. `test/unit/page-section-heading-level.test.ts` pins that
+          pairing: heading at `h3` under that `h1` would read to a screen reader
+          as a subsection of a section that does not exist. `inline` stays at
+          `h2` for the mirror-image reason — on a page of peer sections,
+          promoting this one alone would read as though every section after it
+          were a subsection of MCP Servers. */}
       <div className="flex items-center gap-2">
         {chrome === "inline" && <Server className="size-4 text-muted-foreground" />}
         <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -689,13 +689,13 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
   return (
     <section className="space-y-3">
       {/* `h2` in both chromes, and it lands one level under the page's `h1`
-          either way (issue #1392). Inline on Connections it is a peer of
+          either way (issue #1392). Inline on Apps it is a peer of
           the company key, Composio and providers, which all head their
           sections at the same level —
           `test/unit/connections-section-heading-level.test.ts` holds them
           together, because promoting this one alone would read to a screen
           reader as though every section after it were a subsection of MCP
-          Servers. Standalone on `#/settings/mcp` the page's own `h1` is "MCP
+          Servers. Standalone on `#/connections/mcp` the page's own `h1` is "MCP
           Servers", so this names what it actually heads there instead of
           repeating it. */}
       <div className="flex items-center gap-2">

--- a/frontend/src/views/settings-pages.ts
+++ b/frontend/src/views/settings-pages.ts
@@ -9,11 +9,9 @@
 // that again — a page id that is not here is a type error.
 
 import {
-  Blocks,
   BrainCircuit,
   ChartColumnBig,
   Globe,
-  KeyRound,
   Search,
   type LucideIcon,
   Settings2,
@@ -39,10 +37,22 @@ export const SETTINGS_PAGES = [
   },
   // One question per page. "Connections" carried five — third-party accounts,
   // MCP servers, inference, channels, repositories — so each was something an
-  // operator scrolled past on the way to another. The first three are pages
-  // now; the last two left the product.
-  { id: "oauth", label: "OAuth", icon: KeyRound, hint: "Third-party accounts you act through", group: "integrations" },
-  { id: "mcp", label: "MCP Servers", icon: Blocks, hint: "Tool servers and their tools", group: "integrations" },
+  // operator scrolled past on the way to another. The first three became pages;
+  // the last two left the product.
+  //
+  // Two of those three then left this rail entirely: third-party accounts (as
+  // **Apps**) and MCP servers are the Connections section now, at
+  // `#/connections/apps` and `#/connections/mcp`, because what the company can
+  // act through is something an operator reads repeatedly rather than
+  // configures once. Both `#/settings/oauth` and `#/settings/mcp` still
+  // resolve, rewritten onto the section by `console-route-rewrites.ts`, so
+  // every link minted while they lived here works.
+  //
+  // Inference stayed, and so did Hosting and Search below it, for the reason
+  // stated twice in this file: a credential form belongs beside the one thing
+  // it unlocks. The model, the deploy target and the search provider are three
+  // such things; filing them under a section named for the act of connecting
+  // would separate each credential from what it is for.
   { id: "inference", label: "Inference", icon: BrainCircuit, hint: "The model teammates think with", group: "integrations" },
   // A credential form belongs beside what it unlocks. An operator looking for
   // "where do I put my Vercel token" searches for hosting, so it sits here
@@ -102,11 +112,16 @@ export function settingsPageLabel(page: SettingsPage): string {
  * The console hash a link to one Settings sub-page needs.
  *
  * Typed for the same reason `settingsPageLabel` is: a link written against this
- * cannot outlive the page it points at. `#/settings/connections` is still
- * hard-coded in three places in `SetupDialog`, pointing at a page that stopped
- * existing when Connections was split into OAuth / MCP / Inference — which is
- * the failure issue #1476 was filed for, one release earlier, over a different
- * dead link.
+ * cannot outlive the page it points at.
+ *
+ * `#/settings/connections` was the standing counter-example: hard-coded in four
+ * places across `SetupController` and `SetupDialog`, naming a page that stopped
+ * existing when Connections was split into OAuth / MCP / Inference, and so
+ * repaired onto General — a dead link that looked like a working one, which is
+ * the failure issue #1476 was filed for a release earlier. All four are typed
+ * calls to this function now, and all four turned out to mean Inference: every
+ * one of them is reached because the company has no usable model. The address
+ * itself also answers again, rewritten onto the Connections section.
  */
 export function settingsHref(page: SettingsPage): string {
   return `#/settings/${page}`;

--- a/frontend/test/e2e/composio-account-choice.spec.ts
+++ b/frontend/test/e2e/composio-account-choice.spec.ts
@@ -72,7 +72,7 @@ async function openConnections(page: Page): Promise<void> {
   });
   expect(set.ok(), `setting the composio token failed: ${set.status()}`).toBeTruthy();
 
-  await page.goto("/#/settings/oauth");
+  await page.goto("/#/connections/apps");
   const skip = page.getByRole("button", { name: "Skip for now" });
   await skip
     .waitFor({ state: "visible", timeout: 10_000 })

--- a/frontend/test/e2e/composio-provider-detail.spec.ts
+++ b/frontend/test/e2e/composio-provider-detail.spec.ts
@@ -106,7 +106,7 @@ async function openConnections(page: Page): Promise<void> {
   });
   expect(set.ok(), `setting the composio token failed: ${set.status()}`).toBeTruthy();
 
-  await page.goto("/#/settings/oauth");
+  await page.goto("/#/connections/apps");
   await dismissTour(page);
   await expect(page.getByRole("heading", { name: "Providers" })).toBeVisible({ timeout: 30_000 });
 }
@@ -300,7 +300,7 @@ test("usage is counted per provider, and an unmetered host reports no figure", a
     (route) => route.fulfill({ status: 404, json: { error: "not_found" } }),
   );
 
-  // `reload`, not another `goto`. The URL is already `#/settings/oauth`, so
+  // `reload`, not another `goto`. The URL is already `#/connections/apps`, so
   // a `goto` to it is a same-document no-op that leaves this panel open — and
   // while a Radix dialog is open everything behind it is `aria-hidden`, so the
   // wait for the Providers heading would time out against a page that is fine.
@@ -404,7 +404,7 @@ test("a member is told what is connected and offered nothing that changes it", a
     expect((await verified.json()).role).toBe("member");
 
     const memberPage = await memberContext.newPage();
-    await memberPage.goto("/#/settings/oauth");
+    await memberPage.goto("/#/connections/apps");
     await dismissTour(memberPage);
     await expect(memberPage.getByTestId("connections-read-only")).toBeVisible({ timeout: 30_000 });
 

--- a/frontend/test/e2e/connections-authority.spec.ts
+++ b/frontend/test/e2e/connections-authority.spec.ts
@@ -4,8 +4,9 @@ import { expect, test } from "@playwright/test";
  * Issue #403 — the connection pages must not offer a member controls the host
  * refuses.
  *
- * Since the Connections split there are three of them: OAuth (`#/settings/oauth`),
- * MCP (`#/settings/mcp`) and Inference (`#/settings/inference`). Each carries
+ * Since the Connections split there are three of them, now across two sections:
+ * Apps (`#/connections/apps`), MCP (`#/connections/mcp`) and Inference
+ * (`#/settings/inference`). Each carries
  * its own read-only banner and its own credential fields, so each is driven
  * here — a split that left one page still inviting a member to paste a token
  * would be exactly the regression this spec is about.
@@ -95,7 +96,7 @@ test("a member sees what is connected but is offered nothing that changes it", a
     await signInAsMember(page.request, memberContext.request);
     const memberPage = await memberContext.newPage();
 
-    // ---- OAuth: the third-party accounts the company acts through ----------
+    // ---- Apps: the third-party accounts the company acts through -----------
     await openSettingsPage(memberPage, "oauth");
 
     // The page says why, in the operator's language.
@@ -117,7 +118,7 @@ test("a member sees what is connected but is offered nothing that changes it", a
 
     // But the read is intact — a member can still see what the company is
     // wired to, which is what explains why an agent can reach a provider.
-    await expect(memberPage.getByRole("heading", { name: "OAuth" })).toBeVisible();
+    await expect(memberPage.getByRole("heading", { name: "Apps" })).toBeVisible();
     const status = await memberPage.request.get("/api/v1/company/composio");
     expect(status.ok()).toBeTruthy();
     expect(await status.text()).not.toContain("token");
@@ -144,7 +145,7 @@ test("a member sees what is connected but is offered nothing that changes it", a
 test("an admin is still offered every control across the three pages", async ({ page }) => {
   await openSettingsPage(page, "oauth");
   // The member's banner is absent, and the credential surface is present.
-  // The company-credential key is the OAuth page's write surface on every
+  // The company-credential key is the Apps page's write surface on every
   // build: the Composio token card only renders when the host reports a
   // composio credential the admin may override (default-feature hosts never
   // do), so it is not the invariant to assert here.

--- a/frontend/test/e2e/connections-native-not-offered.spec.ts
+++ b/frontend/test/e2e/connections-native-not-offered.spec.ts
@@ -60,7 +60,7 @@ const CONSOLE_ONLY = ["dropbox", "stripe", "hubspot", "twitter", "linkedin"];
  * navigation resolves, so an immediate `isVisible()` check races it and wins.
  */
 async function openConnections(page: Page): Promise<void> {
-  await page.goto("/#/settings/oauth");
+  await page.goto("/#/connections/apps");
   const skip = page.getByRole("button", { name: "Skip for now" });
   await skip
     .waitFor({ state: "visible", timeout: 10_000 })

--- a/frontend/test/e2e/connections-one-list.spec.ts
+++ b/frontend/test/e2e/connections-one-list.spec.ts
@@ -45,7 +45,7 @@ type Page = import("@playwright/test").Page;
  * per run.
  */
 async function openConnections(page: Page): Promise<void> {
-  await page.goto("/#/settings/oauth");
+  await page.goto("/#/connections/apps");
   const skip = page.getByRole("button", { name: "Skip for now" });
   await skip
     .waitFor({ state: "visible", timeout: 10_000 })

--- a/frontend/test/e2e/mcp.spec.ts
+++ b/frontend/test/e2e/mcp.spec.ts
@@ -44,7 +44,7 @@ async function openMcpSettings(page: Page) {
     });
 }
 
-test("Settings MCP lists the company's servers instead of crashing on open", async ({ page }) => {
+test("the MCP page lists the company's servers instead of crashing on open", async ({ page }) => {
   const pageErrors: string[] = [];
   page.on("pageerror", (error) => pageErrors.push(error.message));
 

--- a/frontend/test/e2e/mcp.spec.ts
+++ b/frontend/test/e2e/mcp.spec.ts
@@ -34,7 +34,7 @@ type Page = import("@playwright/test").Page;
 
 /** The MCP settings page, with the product tour dismissed if it appears. */
 async function openMcpSettings(page: Page) {
-  await page.goto("/#/settings/mcp");
+  await page.goto("/#/connections/mcp");
   const skip = page.getByRole("button", { name: "Skip for now" });
   await skip
     .waitFor({ state: "visible", timeout: 10_000 })

--- a/frontend/test/e2e/oauth-onboarding-resume.spec.ts
+++ b/frontend/test/e2e/oauth-onboarding-resume.spec.ts
@@ -45,7 +45,7 @@ async function tourKey(page: Page): Promise<string> {
   return key!;
 }
 
-test("a legacy hash callback lands on the OAuth page with its cancellation message", async ({ page }) => {
+test("a legacy hash callback lands on the Apps page with its cancellation message", async ({ page }) => {
   // This is the query the former callback used after an operator cancelled at
   // the provider consent screen. Before the original fix it answered with
   // `{"error":"provider returned: access_denied"}` as the document body.
@@ -57,7 +57,7 @@ test("a legacy hash callback lands on the OAuth page with its cancellation messa
 
   // The console renders — the operator is not stranded on raw JSON.
   await dismissWelcome(page);
-  await expect(page.getByRole("heading", { name: "OAuth", level: 1 })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Apps", level: 1 })).toBeVisible();
 
   // The fragment query is stripped, so a refresh doesn't re-fire the toast.
   await expect
@@ -88,7 +88,7 @@ test("an unknown failure code still produces a usable message", async ({ page })
   await page.goto("/connections?connect_error=something_new_2099");
   await expect(page.getByText(/couldn't connect/i)).toBeVisible();
   await dismissWelcome(page);
-  await expect(page.getByRole("heading", { name: "OAuth", level: 1 })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Apps", level: 1 })).toBeVisible();
 });
 
 test("the tour resumes on the accounts stop after a redirect", async ({ page }) => {
@@ -101,25 +101,30 @@ test("the tour resumes on the accounts stop after a redirect", async ({ page }) 
   await skip.click();
   const key = await tourKey(page);
 
-  // Seed exactly what `armTourResume` writes just before the OAuth page hands
+  // Seed exactly what `armTourResume` writes just before the Apps page hands
   // the browser to the provider: mid-tour, on the accounts stop, no
   // completed/skipped flag (the tour never finished).
   //
-  // `"settings"`, NOT `"connections"`. The marker stores the stop's `view`
-  // (`TourController`'s `before` hook publishes `stop.view` through
-  // `setActiveTourStop`), and the accounts page is a *page of the Settings
-  // section* — the stop is `{ view: "settings", sub: "oauth" }`. This
-  // spec seeded the pre-move value, which no `TOUR` stop matches, so the
-  // controller's `findIndex` returned -1 and the resume was correctly skipped.
-  // The spec had gone stale against a deliberate product change; it was not
-  // catching a resume bug. See the unit suite's `tour-resume.test.ts`, which
-  // pins the stop-view ⇄ marker coupling directly so this cannot rot again
-  // without a fast test saying so.
+  // `"connections"`. The marker stores the stop's `view` (`TourController`'s
+  // `before` hook publishes `stop.view` through `setActiveTourStop`), and the
+  // accounts page is a page of the **Connections** section — the stop is
+  // `{ view: "connections", sub: "apps" }`.
+  //
+  // This literal has been wrong twice, in opposite directions, which is why it
+  // is commented at this length. It first read `"connections"` against a tour
+  // whose stop was `{ view: "settings", sub: "oauth" }`, so `findIndex`
+  // returned -1 and the resume was silently skipped — the spec had gone stale
+  // against a deliberate product change rather than catching a bug. It was
+  // corrected to `"settings"`, and the section move has now made
+  // `"connections"` right again. Nothing about a hand-seeded string tells you
+  // which of those worlds you are in, so the coupling is pinned by
+  // `test/unit/tour-resume.test.ts` instead: it asserts the stop's literal
+  // `view` and fails in seconds when the tour is reorganised.
   await page.evaluate(
     ([k]) =>
       window.localStorage.setItem(
         k,
-        JSON.stringify({ pendingResume: { view: "settings", at: Date.now() } }),
+        JSON.stringify({ pendingResume: { view: "connections", at: Date.now() } }),
       ),
     [key],
   );

--- a/frontend/test/e2e/workflow-run-inference.spec.ts
+++ b/frontend/test/e2e/workflow-run-inference.spec.ts
@@ -76,5 +76,5 @@ test("a run refused for a missing inference provider shows a persistent, linked 
   // …and it links the operator to where they fix it.
   const cta = page.getByTestId("workflow-run-inference-cta");
   await expect(cta).toBeVisible();
-  await expect(cta).toHaveAttribute("href", "#/settings/oauth");
+  await expect(cta).toHaveAttribute("href", "#/settings/inference");
 });

--- a/frontend/test/unit/connections-navigation.test.ts
+++ b/frontend/test/unit/connections-navigation.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { TOUR } from "@/tour/steps";
+import {
+  CONNECTION_PAGES,
+  connectionsHref,
+  DEFAULT_CONNECTION_PAGE,
+  isConnectionPage,
+  resolveConnectionPage,
+} from "@/views/connection-pages";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
+
+/**
+ * The Connections section: Apps and MCP Servers, out of the Settings rail.
+ *
+ * The counterpart to `settings-navigation.test.ts`, which holds the rail they
+ * left. What is worth pinning here is the part a reviewer cannot see by reading
+ * either file alone — that the section's two pages are exactly the two that
+ * moved, that its rail is built the way the other two rails are, and that the
+ * one stop in the guided tour whose title is "Connect your tools" points at the
+ * nav row that now leads there.
+ */
+describe("the Connections section", () => {
+  it("carries exactly the two pages that left the Settings rail", () => {
+    expect(CONNECTION_PAGES.map((page) => page.id)).toEqual(["apps", "mcp"]);
+  });
+
+  it("does not take the three credential forms with them", () => {
+    // Inference, Hosting and Search stayed in Settings on purpose: a credential
+    // form belongs beside the one thing it unlocks. Asserted from this side as
+    // well as from `settings-navigation.test.ts`, because "Connections grew a
+    // fourth page" and "Settings lost a page" are the same mistake seen from
+    // two directions, and only one of the two files would fail.
+    const ids = CONNECTION_PAGES.map((page) => page.id as string);
+    for (const stayed of ["inference", "hosting", "search"]) {
+      expect(ids, `${stayed} belongs beside what it unlocks`).not.toContain(stayed);
+    }
+  });
+
+  it("leads with Apps, so the section is never an empty frame", () => {
+    expect(DEFAULT_CONNECTION_PAGE).toBe("apps");
+    expect(resolveConnectionPage(null)).toBe("apps");
+    expect(resolveConnectionPage("not-a-page")).toBe("apps");
+    expect(resolveConnectionPage("mcp")).toBe("mcp");
+  });
+
+  it("distinguishes its page ids from unknown sub-hashes", () => {
+    expect(isConnectionPage("apps")).toBe(true);
+    expect(isConnectionPage("oauth")).toBe(false);
+    expect(isConnectionPage(null)).toBe(false);
+  });
+
+  it("mints hashes under its own section, not under Settings", () => {
+    // The typed helper exists so a link cannot outlive the page it names —
+    // the defect `#/settings/connections` was for four releases.
+    expect(connectionsHref("apps")).toBe("#/connections/apps");
+    expect(connectionsHref("mcp")).toBe("#/connections/mcp");
+  });
+
+  it("gives every page a label and a hint, so the rail says what each is for", () => {
+    for (const page of CONNECTION_PAGES) {
+      expect(page.label, page.id).toBeTruthy();
+      expect(page.hint, page.id).toBeTruthy();
+      // A hint is what the rail shows under the label; repeating the label
+      // there tells an operator nothing they cannot already see.
+      expect(page.hint, page.id).not.toBe(page.label);
+    }
+  });
+
+  it("renames the accounts page to Apps everywhere it is named", () => {
+    // Three places, and they have to agree: the rail's row, the rail's hint,
+    // and the page's own `h1`. A rename that reaches two of the three leaves an
+    // operator clicking "Apps" and landing on a page headed "OAuth".
+    expect(CONNECTION_PAGES.find((p) => p.id === "apps")?.label).toBe("Apps");
+    expect(read("views/OAuthView.tsx")).toContain('title="Apps"');
+    expect(read("views/OAuthView.tsx")).not.toContain('title="OAuth"');
+  });
+
+  it("builds its rail the way the Settings and Finance rails are built", () => {
+    const section = read("views/connections/ConnectionsSection.tsx");
+    // Named, and named without a heading: the rail renders before the sub-page,
+    // so an `h2` here would land ahead of that page's own `h1` (issue #1392).
+    // `nav-rail-headings.test.ts` owns the heading half across every rail; this
+    // pins that the accessible name it relies on is present on this one.
+    expect(section).toMatch(/<nav\s+aria-label="Connections"/);
+    // A `w-60` rail from `sm:` up, with a scrolling chip row below it.
+    expect(section).toContain("w-60");
+    expect(section).toContain("sm:flex");
+    expect(section).toContain("sm:hidden");
+  });
+
+  it("still renders Composio on the Apps page rather than splitting it out", () => {
+    // `ComposioSection` looks self-contained, but `ProvidersSection` reads its
+    // credential state to decide what every provider tile renders — the
+    // credential is the engine the provider list runs on. Splitting them would
+    // separate a credential from what it unlocks, which is the one thing this
+    // whole section is arranged around not doing.
+    const oauth = read("views/OAuthView.tsx");
+    expect(oauth).toContain("<ComposioSection");
+    expect(oauth).toContain("<ProvidersSection");
+  });
+});
+
+describe("the guided tour's Connect-your-tools stop", () => {
+  const stop = TOUR.find((s) => s.title === "Connect your tools");
+
+  it("exists", () => {
+    expect(stop).toBeDefined();
+  });
+
+  it("spotlights the nav row that actually leads to the tools", () => {
+    // It used to navigate to `{ view: "settings", sub: "oauth" }` and spotlight
+    // `nav-settings` — so a step titled "Connect your tools" pointed an operator
+    // at a gear. The row exists now, so the step names the same surface the
+    // sidebar does.
+    expect(stop!.view).toBe("connections");
+    expect(stop!.sub).toBe("apps");
+    expect(stop!.target).toBe('[data-tour="nav-connections"]');
+  });
+
+  it("targets an anchor the sidebar actually renders", () => {
+    // The shell writes `data-tour={`nav-${item.view}`}` per NAV row, so the
+    // selector above resolves only while a row with this view exists. A tour
+    // step whose anchor never mounts degrades to a skipped step — silently,
+    // which is why this is asserted rather than left to the browser.
+    const shell = read("components/app-shell.tsx");
+    expect(shell).toContain('data-tour={`nav-${item.view}`}');
+    expect(shell).toContain('{ view: "connections", label: "Connections", icon: Plug }');
+  });
+});

--- a/frontend/test/unit/connections-navigation.test.ts
+++ b/frontend/test/unit/connections-navigation.test.ts
@@ -101,9 +101,13 @@ describe("the Connections section", () => {
     // credential is the engine the provider list runs on. Splitting them would
     // separate a credential from what it unlocks, which is the one thing this
     // whole section is arranged around not doing.
+    // Matched at the JSX element boundary rather than as a substring. A bare
+    // `toContain("<ComposioSection")` is satisfied by `<ComposioSectionAnything`,
+    // so renaming the element past it proved nothing — verified by mutating it
+    // to `<ComposioSectionRemoved`, which passed.
     const oauth = read("views/OAuthView.tsx");
-    expect(oauth).toContain("<ComposioSection");
-    expect(oauth).toContain("<ProvidersSection");
+    expect(oauth).toMatch(/<ComposioSection[\s/>]/);
+    expect(oauth).toMatch(/<ProvidersSection[\s/>]/);
   });
 });
 
@@ -131,6 +135,14 @@ describe("the guided tour's Connect-your-tools stop", () => {
     // which is why this is asserted rather than left to the browser.
     const shell = read("components/app-shell.tsx");
     expect(shell).toContain('data-tour={`nav-${item.view}`}');
-    expect(shell).toContain('{ view: "connections", label: "Connections", icon: Plug }');
+    // Anchored to the start of the line, so a **commented-out** row does not
+    // satisfy it. `toContain` did: `// { view: "connections", … }` still holds
+    // the substring, and a commented row renders no anchor at all — which is
+    // precisely how `#/pages` spent four months unreachable behind a row that
+    // read as present (issue #1311). Verified by commenting this row out; the
+    // substring form passed, this form fails.
+    expect(shell).toMatch(
+      /^\s*\{ view: "connections", label: "Connections", icon: Plug \},$/m,
+    );
   });
 });

--- a/frontend/test/unit/console-routes.test.ts
+++ b/frontend/test/unit/console-routes.test.ts
@@ -133,9 +133,15 @@ describe("resolving an address", () => {
   // has a real replacement; asserting the replacement (and that the address bar
   // follows it) is what keeps a bookmark or habit written before the move alive.
   it.each([
-    ["#/connections", "settings", "oauth"],
-    ["#/oauth", "settings", "oauth"],
-    ["#/mcp", "settings", "mcp"],
+    // Apps and MCP Servers left the settings rail for the Connections section.
+    // Four addresses reach them from before that move: the two bare aliases
+    // that predate the original Connections split, and the two settings
+    // addresses they answered at for as long as they were sub-pages — which are
+    // the ones an operator is most likely to have bookmarked.
+    ["#/oauth", "connections", "apps"],
+    ["#/mcp", "connections", "mcp"],
+    ["#/settings/oauth", "connections", "apps"],
+    ["#/settings/mcp", "connections", "mcp"],
     ["#/people", "settings", "people"],
     ["#/work", "ledgers", "tasks"],
     ["#/settings/not-a-page", "settings", "general"],
@@ -160,6 +166,41 @@ describe("resolving an address", () => {
       expect(window.location.hash).toBe("#/brain");
     },
   );
+
+  // The two addresses that rewrite onto the *section* rather than one of its
+  // pages, so the replacement hash is bare.
+  //
+  // `#/settings/connections` is the dead link this section was built over. It
+  // named the pre-split Connections page, matched no `SETTINGS_PAGES` id after
+  // the split, and so was repaired onto **General** by the branch above — an
+  // operator following it landed on a real page that was not the one the link
+  // promised, which is worse than a 404 because it looks like it worked. It was
+  // still live in four places in the setup flow. It answers again now.
+  //
+  // `#/connections/not-a-page` is the same rule one level down: the section
+  // owns a fixed table of sub-pages, so a segment naming none is repaired to
+  // the section rather than silently rendering Apps under an address that says
+  // something else.
+  it.each(["#/settings/connections", "#/connections/not-a-page"])(
+    "rewrites %s onto the Connections section itself",
+    async (hash) => {
+      rewrite = REWRITE_RETIRED;
+      await visit(hash);
+      expect(seen).toEqual(["connections", null]);
+      expect(window.location.hash).toBe("#/connections");
+    },
+  );
+
+  // `#/connections` is a real address rather than a rewrite now, which is the
+  // load-bearing half of this move: it used to be sent to `#/settings/oauth`.
+  // Named on its own so a regression reads as "the section stopped answering"
+  // rather than as one row of the `VIEWS` loop above.
+  it("answers #/connections as the section itself, not as a rewrite", async () => {
+    rewrite = REWRITE_RETIRED;
+    await visit("#/connections");
+    expect(seen).toEqual(["connections", null]);
+    expect(window.location.hash).toBe("#/connections");
+  });
 
   // #1867 review: `#/work` is a bare-only alias onto the ledgers board — the
   // Work surface's real sub-pages are addressed under `#/ledgers/...` (for

--- a/frontend/test/unit/page-header-adoption.test.ts
+++ b/frontend/test/unit/page-header-adoption.test.ts
@@ -3,7 +3,13 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { VIEWS as ROUTED_VIEWS, type View } from "@/lib/console-routes";
-import { FINANCE_NAMED_BY, NAMED_BY, SETTINGS_NAMED_BY, type Leaf } from "./support/routed-views";
+import {
+  CONNECTIONS_NAMED_BY,
+  FINANCE_NAMED_BY,
+  NAMED_BY,
+  SETTINGS_NAMED_BY,
+  type Leaf,
+} from "./support/routed-views";
 
 /**
  * Every page's title comes from `PageHeader`. A view that hand-rolls an `<h1>`
@@ -233,12 +239,14 @@ describe("every routed view is named by something (#1763)", () => {
   });
 
   it("has every section page rendering a PageHeader too", () => {
-    // Settings and Finance are one routed view each over ten and three
-    // bookmarkable addresses. A `Record` keyed on their own tables means a new
-    // page with no row is a compile error; this is the runtime half.
+    // Settings, Finance and Connections are one routed view each over seven,
+    // three and two bookmarkable addresses. A `Record` keyed on their own
+    // tables means a new page with no row is a compile error; this is the
+    // runtime half.
     const offenders = [
       ...Object.entries(SETTINGS_NAMED_BY).map(([id, f]) => [`settings/${id}`, f] as const),
       ...Object.entries(FINANCE_NAMED_BY).map(([id, f]) => [`finances/${id}`, f] as const),
+      ...Object.entries(CONNECTIONS_NAMED_BY).map(([id, f]) => [`connections/${id}`, f] as const),
     ]
       .filter(([, file]) => !(SOURCES.get(file) ?? "").includes("<PageHeader"))
       .map(([page, file]) => `${page} is named by ${file}, which renders no <PageHeader>`);

--- a/frontend/test/unit/page-header-precedes-every-return.test.ts
+++ b/frontend/test/unit/page-header-precedes-every-return.test.ts
@@ -2,9 +2,16 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import { VIEWS, type View } from "@/lib/console-routes";
+import { CONNECTION_PAGES } from "@/views/connection-pages";
 import { FINANCE_PAGES } from "@/views/finance/FinanceSection";
 import { SETTINGS_PAGES } from "@/views/settings-pages";
-import { FINANCE_NAMED_BY, NAMED_BY, SETTINGS_NAMED_BY, type Leaf } from "./support/routed-views";
+import {
+  CONNECTIONS_NAMED_BY,
+  FINANCE_NAMED_BY,
+  NAMED_BY,
+  SETTINGS_NAMED_BY,
+  type Leaf,
+} from "./support/routed-views";
 
 /**
  * A routed view's header is the first thing it can render — in every state
@@ -82,6 +89,7 @@ const GUARDED_COMPONENTS: string[] = [
   ),
   ...Object.values(SETTINGS_NAMED_BY),
   ...Object.values(FINANCE_NAMED_BY),
+  ...Object.values(CONNECTIONS_NAMED_BY),
 ].map((file) => file.slice(file.lastIndexOf("/") + 1).replace(/\.tsx$/, ""));
 
 /**
@@ -319,6 +327,7 @@ describe("every state of a routed view renders a heading (#1785)", () => {
       ...VIEWS.flatMap((v) => NAMED_BY[v].map(headerFile)).filter((f): f is string => f !== null),
       ...Object.values(SETTINGS_NAMED_BY),
       ...Object.values(FINANCE_NAMED_BY),
+      ...Object.values(CONNECTIONS_NAMED_BY),
     ];
     const missing = files
       .filter((file) => {
@@ -394,6 +403,31 @@ describe("every state of a routed view renders a heading (#1785)", () => {
       offenders,
       `A finance page has a state that renders no page header. Same fix as the ` +
         `routed views above.\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("has no connections page returning JSX without a heading in it", () => {
+    // The third section like Settings, and the one this sweep was blind to
+    // (codex review on #1977). `#/connections/mcp` is bookmarkable and `mcp` is
+    // not a `View`, so the routed-view sweep above cannot reach `McpServersView`
+    // at all: `NAMED_BY.connections` names `OAuthView.tsx`, because Apps is what
+    // the bare route renders. Apps was therefore covered only incidentally, as
+    // that default leaf, and MCP was covered by nothing — a future unnamed
+    // loading or error state on it would have passed a guard whose whole claim
+    // is that it covers every bookmarkable subpage. Iterating the page table is
+    // what makes both of them covered on purpose.
+    const offenders = CONNECTION_PAGES.flatMap(({ id }) => {
+      const file = CONNECTIONS_NAMED_BY[id];
+      const source = readFileSync(`${VIEWS_DIR}/${file}`, "utf8");
+      return returnsWithoutHeader(source, file).map(
+        (r) => `connections/${id} (${file}:${r.line}) returns with no heading in it: ${r.text}`,
+      );
+    });
+
+    expect(
+      offenders,
+      `A connections page has a state that renders no page header. Same fix as ` +
+        `the routed views above.\n${offenders.join("\n")}`,
     ).toEqual([]);
   });
 

--- a/frontend/test/unit/settings-navigation.test.ts
+++ b/frontend/test/unit/settings-navigation.test.ts
@@ -14,6 +14,25 @@ const here = dirname(fileURLToPath(import.meta.url));
 const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
 
 describe("Settings navigation (issue #1468)", () => {
+  it("keeps the Integrations group, which the Connections move did not empty", () => {
+    // Apps and MCP Servers left this rail for `#/connections`. Inference,
+    // Hosting and Search stayed, deliberately: each is a credential form
+    // beside the one thing it unlocks, which is the argument the file makes
+    // twice. Pinned by id rather than by count so that "the group survived" and
+    // "it survived with the right three" are the same assertion.
+    const integrations = SETTINGS_PAGES.filter((page) => page.group === "integrations");
+    expect(integrations.map((page) => page.id)).toEqual(["inference", "hosting", "search"]);
+  });
+
+  it("no longer carries the two pages that became the Connections section", () => {
+    // Widened to `string` for the same reason the Brain assertion below is:
+    // once these ids are gone from the table they are not in the union, so a
+    // narrow comparison is a type error rather than the assertion being made.
+    const ids = SETTINGS_PAGES.map((page) => page.id as string);
+    expect(ids).not.toContain("oauth");
+    expect(ids).not.toContain("mcp");
+  });
+
   it("groups every settings page exactly once", () => {
     expect(SETTINGS_PAGE_GROUPS.map((group) => group.label)).toEqual([
       "Identity & lifecycle",
@@ -51,13 +70,14 @@ describe("Settings navigation (issue #1468)", () => {
   it("renders linkable rows and gives narrow-screen navigation its missing context", () => {
     const section = read("views/SettingsSection.tsx");
     // The settings sub-pages (one view per SETTINGS_PAGES id). Devices and
-    // Connections became pages of their own elsewhere in the redesign, so the
-    // list tracks the ids settings-pages.ts actually declares.
+    // Connections became pages of their own elsewhere in the redesign, and Apps
+    // (the third-party accounts) and MCP Servers then left this rail entirely
+    // for the Connections section — `connections-navigation.test.ts` holds them
+    // to the same rules there. The list tracks the ids settings-pages.ts
+    // actually declares.
     const settingsPages = [
       "SettingsView.tsx",
       "PeopleView.tsx",
-      "OAuthView.tsx",
-      "McpServersView.tsx",
       "InferenceView.tsx",
       "HostingView.tsx",
       "SearchView.tsx",

--- a/frontend/test/unit/setup-dialog-inference.test.ts
+++ b/frontend/test/unit/setup-dialog-inference.test.ts
@@ -252,7 +252,11 @@ describe("readiness is the addressed company's, not the host's", () => {
     expect(notice?.textContent).not.toContain("can't reach a model");
     const restartLink = linkNamed("Restart the company");
     expect(restartLink).toBeTruthy();
-    expect(restartLink).toHaveProperty("hash", "#/settings/connections");
+    // Inference. The restart this notice means is the one `restartRequired`
+    // names, and the control that performs it renders on the Inference card.
+    // This asserted `#/settings/connections` — an address that named no
+    // settings page and was repaired onto General, where the control is not.
+    expect(restartLink).toHaveProperty("hash", "#/settings/inference");
 
     // Following it is starting setup, not declining it — same as "Set up a
     // model", so the return reopens the dialog.
@@ -394,7 +398,9 @@ describe('"Set up a model" is starting setup, not declining it', () => {
     await show(clientWith());
     const link = linkNamed("Set up a model");
     expect(link, "no model link on the notice").toBeTruthy();
-    expect(link).toHaveProperty("hash", "#/settings/connections");
+    // Where a model is actually set up. See the restart assertion above for
+    // why this used to name a page that did not exist.
+    expect(link).toHaveProperty("hash", "#/settings/inference");
 
     await click(link!);
 

--- a/frontend/test/unit/setup-resume-after-model.test.ts
+++ b/frontend/test/unit/setup-resume-after-model.test.ts
@@ -150,7 +150,9 @@ async function leaveForModelSettings() {
     await new Promise((r) => setTimeout(r, 0));
   });
   // jsdom does not follow the anchor's href, so drive the navigation it implies.
-  await goTo("#/settings/connections");
+  // `#/settings/inference` since the model links were corrected off the dead
+  // `#/settings/connections`, which named no settings page at all.
+  await goTo("#/settings/inference");
 }
 
 describe("leaving to wire a model", () => {
@@ -179,7 +181,7 @@ describe("leaving to wire a model", () => {
     await mount(clientWith(BASELINE));
     await leaveForModelSettings();
     // A sub-page of the same settings area is not "coming back".
-    await goTo("#/settings/connections?provider=openrouter");
+    await goTo("#/settings/inference?provider=openrouter");
     expect(dialog()).toBeNull();
   });
 
@@ -192,7 +194,7 @@ describe("leaving to wire a model", () => {
 
     root = createRoot(container);
     // `deepLinked` as `AppShell` computes it for this address: a reload on
-    // `#/settings/connections` is a named view, so nothing opens unprompted and
+    // `#/settings/inference` is a named view, so nothing opens unprompted and
     // the resume is the only thing that could.
     await mount(clientWith(BASELINE), true);
     expect(dialog(), "reloaded on the settings page — they have not returned yet").toBeNull();
@@ -263,7 +265,7 @@ describe("leaving to wire a model", () => {
 
     // The next return reads successfully: the debt pays out and setup reopens.
     failing = false;
-    await goTo("#/settings/connections");
+    await goTo("#/settings/inference");
     await goTo("#/overview");
     expect(dialog(), "the retried return should resume setup").toBeTruthy();
   });
@@ -336,7 +338,7 @@ describe("leaving to wire a model", () => {
     expect(setupResuming(SCOPE)).toBe(false);
 
     // And it stays shut across a return trip: "later" means later.
-    await goTo("#/settings/connections");
+    await goTo("#/settings/inference");
     await goTo("#/overview");
     expect(dialog()).toBeNull();
   });

--- a/frontend/test/unit/support/routed-views.ts
+++ b/frontend/test/unit/support/routed-views.ts
@@ -7,6 +7,7 @@
  */
 
 import type { View } from "@/lib/console-routes";
+import type { ConnectionPage } from "@/views/connection-pages";
 import type { FinancePage } from "@/views/finance/FinanceSection";
 import type { SettingsPage } from "@/views/settings-pages";
 
@@ -155,6 +156,12 @@ export const NAMED_BY: Record<View, Names> = {
   pages: [{ pageHeader: "PagesView.tsx" }],
   /** See `FINANCE_NAMED_BY`: `#/finances/<page>` is a three-page section. */
   finances: [{ pageHeader: "FinancesView.tsx" }],
+  /**
+   * See `CONNECTIONS_NAMED_BY`: `#/connections/<page>` is a two-page section.
+   * `ConnectionsSection` is the rail frame; the pages carry the headings. The
+   * bare route renders Apps, so that is the leaf named here.
+   */
+  connections: [{ pageHeader: "OAuthView.tsx" }],
   /** `SettingsSection` is the tab frame; `SettingsView` is the page. */
   settings: [{ pageHeader: "SettingsView.tsx" }],
   feedback: [{ pageHeader: "FeedbackView.tsx" }],
@@ -183,7 +190,7 @@ export const NAMED_BY: Record<View, Names> = {
 
 /**
  * The same question one level down: Settings is a single routed view whose
- * `sub` segment picks one of ten pages, each of which draws its own
+ * `sub` segment picks one of seven pages, each of which draws its own
  * `PageHeader`. `#/settings/people` is an address an operator can bookmark, so
  * "the routed views are covered" is not the whole answer — `PeopleView`'s
  * loading state had no `h1` and no routed-view check could have seen it.
@@ -195,13 +202,29 @@ export const NAMED_BY: Record<View, Names> = {
 export const SETTINGS_NAMED_BY: Record<SettingsPage, string> = {
   general: "SettingsView.tsx",
   people: "PeopleView.tsx",
-  oauth: "OAuthView.tsx",
-  mcp: "McpServersView.tsx",
   inference: "InferenceView.tsx",
   hosting: "HostingView.tsx",
   search: "SearchView.tsx",
   skills: "SkillsView.tsx",
   usage: "UsageView.tsx",
+};
+
+/**
+ * Connections is the third section like Settings: one routed view whose `sub`
+ * segment picks one of two pages, each drawing its own `PageHeader`.
+ * `#/connections/mcp` is a bookmarkable address and `mcp` is not a `View`, so
+ * the routed-view sweep cannot see it — the same blind spot `#/settings/people`
+ * and `#/finances/wallet` have.
+ *
+ * `Record<ConnectionPage, …>` over `CONNECTION_PAGES`, so a third connections
+ * page with no row is a compile error.
+ *
+ * Both files were rows in `SETTINGS_NAMED_BY` until the section was built. The
+ * pages did not change; only which table has to account for them did.
+ */
+export const CONNECTIONS_NAMED_BY: Record<ConnectionPage, string> = {
+  apps: "OAuthView.tsx",
+  mcp: "McpServersView.tsx",
 };
 
 /**
@@ -215,11 +238,11 @@ export const SETTINGS_NAMED_BY: Record<SettingsPage, string> = {
  * `Record<FinancePage, …>` over `FINANCE_PAGES`, so a fourth finance page with
  * no row is a compile error.
  *
- * These two and `company` are the complete set of sub-dispatching routes. The
+ * These three and `company` are the complete set of sub-dispatching routes. The
  * check was a grep over `src/views/**` for `sub ===`, `if (sub)` and
  * `resolve*Page`: it finds `CompanyView` (three leaves, enumerated above),
  * `TeamView` (`AgentDetailView`, enumerated), `app-shell`'s `MANAGE_SEGMENT`
- * split under `ledgers` (enumerated), `SettingsSection`, and this. `ChatView`
+ * split under `ledgers` (enumerated), `SettingsSection`, `ConnectionsSection`, and this. `ChatView`
  * and `LedgersView` also read `sub`, but to select a channel or a list *within
  * themselves* rather than to render a different component, so they contribute
  * no leaf.

--- a/frontend/test/unit/support/routed-views.ts
+++ b/frontend/test/unit/support/routed-views.ts
@@ -55,8 +55,9 @@ import type { SettingsPage } from "@/views/settings-pages";
  *
  *   - `page-header-precedes-every-return.test.ts` asks a strictly weaker,
  *     decidable question — is there *any* JSX `return` textually above the
- *     header? — over every routed view and every settings page, so a new route
- *     is covered the day it is added.
+ *     header? — over every routed view and over every sub-page of the three
+ *     sections below (Settings, Finance, Connections), so a new route or a new
+ *     sub-page is covered the day it is added.
  *   - `settings-page-named-in-every-state.test.ts` renders six of those pages
  *     in their loading and error states and asks the DOM for the `h1`, which
  *     is the only evidence that actually proves it.
@@ -220,7 +221,12 @@ export const SETTINGS_NAMED_BY: Record<SettingsPage, string> = {
  * page with no row is a compile error.
  *
  * Both files were rows in `SETTINGS_NAMED_BY` until the section was built. The
- * pages did not change; only which table has to account for them did.
+ * pages did not change; only which table has to account for them did — and
+ * moving them is what briefly dropped `McpServersView` out of
+ * `page-header-precedes-every-return.test.ts` altogether, since that test swept
+ * the two other section tables and not this one (codex review on #1977). Apps
+ * kept its cover by luck rather than by rule: it is also `NAMED_BY.connections`,
+ * the leaf the bare route renders. Both sweeps read this table now.
  */
 export const CONNECTIONS_NAMED_BY: Record<ConnectionPage, string> = {
   apps: "OAuthView.tsx",

--- a/frontend/test/unit/tour-resume.test.ts
+++ b/frontend/test/unit/tour-resume.test.ts
@@ -54,10 +54,10 @@ function stopIndexFor(view: string | null): number {
 
 describe("the stop-view ⇄ resume-marker contract", () => {
   /** The one stop that hands the browser to a third party, so the only one that arms. */
-  const connections = TOUR.find((s) => s.sub === "oauth");
+  const connections = TOUR.find((s) => s.sub === "apps");
 
   it("still has an accounts stop at all", () => {
-    expect(connections, "the tour should still have an OAuth stop").toBeDefined();
+    expect(connections, "the tour should still have an Apps stop").toBeDefined();
   });
 
   it("pins the view the accounts stop publishes", () => {
@@ -70,14 +70,21 @@ describe("the stop-view ⇄ resume-marker contract", () => {
     //
     // If this fails, the tour was reorganised: update the e2e spec's seed in
     // the same commit.
-    expect(connections!.view).toBe("settings");
+    //
+    // It has now failed once and been updated exactly that way. The accounts
+    // page left the Settings rail for the Connections section, so the stop is
+    // `{ view: "connections", sub: "apps" }` and the marker it publishes is
+    // `"connections"` — which is what `oauth-onboarding-resume.spec.ts` seeds.
+    // The literal below and that seed are the coupling; this test is the fast
+    // half of it.
+    expect(connections!.view).toBe("connections");
   });
 
   it("leaves the lookup unambiguous, so a resume lands on the stop that armed it", () => {
     // The controller resolves a marker with `findIndex` — FIRST match wins.
     // Views are not unique across the tour (there are two `overview` stops and
     // two `chat` stops), so this is only safe while the arming stop is the sole
-    // holder of its view. Add a second Settings stop ahead of Connections and
+    // holder of its view. Add a second Connections stop ahead of this one and
     // the operator silently resumes on the wrong one; nothing else would catch
     // that, because the tour still runs and still shows *a* stop.
     const sharingItsView = TOUR.filter((s) => s.view === connections!.view);


### PR DESCRIPTION
## What this does

Moves **OAuth** and **MCP Servers** out of the Settings rail into a new
top-level **Connections** nav section, modelled on Finance.

```
Connections                 <- new nav row, between Finance and Workflows
├─ Apps          #/connections/apps    (the OAuth page, renamed; Composio included)
└─ MCP Servers   #/connections/mcp

Settings keeps: General, People, Inference, Hosting, Search, Skills, Usage
```

A settings rail is where an operator changes configuration once. Which apps the
company can act through, and which tool servers its teammates can call, is read
repeatedly and changes as the work does — the same argument that moved Billing
out to Finance (`finance-console.md`) and Brain out to its own row.

Built on `FinanceSection`'s pattern: a `w-60` sub-rail on `sm:` and up, a
scrolling chip row below it, a `CONNECTION_PAGES` table whose `id` is the hash's
second segment, `resolveConnectionPage(sub)`, and each sub-page a real route.

## This is not a revert of the Connections split

A reviewer will reasonably read "Connections is back" as undoing the decision in
the comment above the `oauth` entry in `settings-pages.ts`. It does not.

That decision was about a single **page** carrying five subjects — accounts, MCP,
inference, channels, repositories — so each was something an operator scrolled
past on the way to another. One question per page still holds: Apps and MCP
Servers are still two pages, answering one question each. What is new is that
they have a **parent**.

**Inference, Hosting and Search deliberately stayed in Settings.** Each is a
credential form beside the one thing it unlocks — the model, the deploy target,
the search provider — which is the argument `settings-pages.ts` makes twice.
The Integrations group survives with three rows.

**Composio stays on the Apps page**, for the same rule read the other way.
`ComposioSection` looks self-contained (4 props), but `ProvidersSection` reads
its `credentialSource`, `granted`, `openMode` and catalog warning to decide what
every provider tile renders — the credential is the engine the provider list
runs on.

## Route map — every address minted before this change still works

| address | before | after |
| --- | --- | --- |
| `#/connections` | rewritten → `settings/oauth` | **real** — the section, defaulting to Apps |
| `#/connections/apps` | — | the Apps page |
| `#/connections/mcp` | — | the MCP page |
| `#/oauth` | → `settings/oauth` | → `connections/apps` |
| `#/mcp` | → `settings/mcp` | → `connections/mcp` |
| `#/settings/oauth` | the page | → `connections/apps` |
| `#/settings/mcp` | the page | → `connections/mcp` |
| `#/settings/connections` | **dead — silently landed on General** | → `connections` |
| `#/connections/<unknown>` | — | → `connections` (repaired, not swallowed) |

## The dead link this fixes

`#/settings/connections` matched no `SETTINGS_PAGES` id, so the unknown-sub
repair dropped the operator on **General** — a real page that was not the one the
link promised, which is worse than an address that plainly fails because it looks
like it worked. `settings-pages.ts:101-110` documented it as outstanding.

It was live in four places. Checked individually rather than rewritten as a
batch, and **all four turned out to mean Inference**:

- `SetupController.tsx` `MODEL_SETTINGS` — the constant is about the model.
- `SetupDialog.tsx:835` — offers "Set up a model" **or** "Restart the company".
  Both land on Inference: the restart this notice means is the one
  `restartRequired` names, and the control that performs it renders on the
  Inference card (`InferenceSection.tsx:898`), not on General.
- `SetupDialog.tsx:991` — "Add a model in Settings".
- `SetupDialog.tsx:1029` — "Check connection in Settings" (the model's).

**A fifth, found on the way:** `WorkflowsView.tsx:3064`'s run-refusal CTA says
"Set a provider under Settings → Inference" and its button says "Set up
inference" — but it hrefed `#/settings/oauth`, the accounts page, which cannot
configure a model. In scope because it is a link into the page this PR moves.

All five now go through the typed `settingsHref`, which exists so a link cannot
outlive the page it names.

## Everything else that moved with it

- **Guided tour step 7** is titled *"Connect your tools"* and spotlighted
  `nav-settings` — an operator was shown a gear and told it was where tools get
  connected. It targets `nav-connections` now.
- **`nav-rail-headings.test.ts`** (#1392): the new rail's caption is a `div`
  named via `aria-label`, exactly as Finance's is.
- **`chat-approval-line.spec.ts`** builds `nav-${label.toLowerCase()}`; the view
  is `connections` and the label **Connections**, so they match.
- `settings-navigation.test.ts`, `console-routes.test.ts`, `routed-views.ts`
  (+`CONNECTIONS_NAMED_BY`), `page-header-adoption.test.ts`, `tour-resume.test.ts`,
  and eight e2e specs updated.
- **`ledgers-console-ia.md`** gains **Rule 7** recording the move and its
  reasoning. 460 lines, under the ceiling.

## Scope

Step 1 is a move, not a refactor. `OAuthView` and `McpServersView` are
re-parented with no content change beyond the rename to **Apps** (its label, its
rail hint, its `PageHeader` title) — "OAuth" names the protocol a connection runs
on rather than what an operator is looking for, and under a parent called
Connections it said the same word twice. The file, component and internal names
stay `OAuth*`, the same split Rule 1 makes for "ledger".

## Verification

| gate | result |
| --- | --- |
| `npm run typecheck` | pass |
| `npm run typecheck:unit` | pass |
| `npm run typecheck:e2e` | pass |
| `npx vitest run` | **443 files, 4151 tests, 0 failures** |
| `scripts/ci/assert-design-tokens.sh` | pass |
| `npm run e2e` (Console E2E lane) | **350 passed, 26 skipped, 0 failed (6.0m)** |

**Browser-verified** against a real host on an isolated data dir: all 10
addresses above, **light and dark**, 20/20 landing on the right hash with the
right `h1`. The sidebar shows one `Connections` row; the Settings rail shows
exactly `General, People, Inference, Hosting, Search, Skills, Usage`; the
Connections rail shows `Apps, MCP Servers`.

**Mutation-proved.** Six mutations; two of them exposed that my own new
assertions were too weak and were strengthened before being re-mutated:

- `toContain("<ComposioSection")` was satisfied by `<ComposioSectionRemoved` —
  deleting Composio from the Apps page passed 12/12. Now matched at the JSX
  element boundary.
- `toContain('{ view: "connections", … }')` was satisfied by a **commented-out**
  NAV row, which renders no `data-tour` anchor at all — the exact shape that left
  `#/pages` unreachable for four months (#1311). Now anchored to line start.

The other four each failed as intended; dropping the `#/settings/connections`
repair reproduces the original defect verbatim (`['settings','general']`).

## Note on #1969

The original brief warned of an `app-shell.tsx` conflict with #1969. That PR has
since merged; this branch is based on `upstream/main` @ `7ddd403ac`, which
already contains it. No conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level **Connections** section to the sidebar.
  * Moved **Apps** and **MCP Servers** from Settings into Connections.
  * Added dedicated Apps and MCP navigation, with Apps as the default page.
  * Renamed the OAuth page to **Apps** in the interface.
  * Updated the guided tour to direct users to Connections.

* **Bug Fixes**
  * Updated setup and inference links to open the correct Inference settings page.
  * Preserved compatibility by redirecting legacy Connections, OAuth, and MCP links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->