### PR TITLE
Correct two comments and the design-system cut-out rule after #1980

### DIFF
--- a/docs/design-system/color.md
+++ b/docs/design-system/color.md
@@ -186,9 +186,11 @@ that has no shell at all.
 
 **Anything that cuts a hole in the chrome must ask for the chrome.** A `ring-2`
 around a status dot is a cut-out of the ground behind it, not a decoration. The
-two in the shell — `SidebarMenuDot`'s attention dot on the collapsed rail and
-the host switcher's status dot — take `ring-chrome`, because that is what is
-actually behind them now. `ring-sidebar` there paints a halo.
+one left in the shell — the host switcher's status dot — takes `ring-chrome`,
+because that is what is actually behind it now. `ring-sidebar` there paints a
+halo. There were two: the collapsed rail's attention dot went with
+`SidebarMenuDot` when the approvals count moved into the window's title row,
+which is chrome that never collapses.
 
 **`--accent-foreground` stays neutral.** 40 call sites pair `bg-accent` with
 `text-accent-foreground`; brand text on every hover would make the console

--- a/docs/design-system/components.md
+++ b/docs/design-system/components.md
@@ -221,8 +221,10 @@ was before the shell was rebuilt.
 
 **Anything that cuts a hole in the chrome must ask for the chrome.** A `ring-2`
 around a status dot is a cut-out of the ground behind it, not a decoration. The
-two in the shell — `SidebarMenuDot` on the collapsed rail and the host
-switcher's status dot — take `ring-chrome`. `ring-sidebar` there paints a halo.
+one left in the shell — the host switcher's status dot — takes `ring-chrome`;
+`ring-sidebar` there paints a halo. The collapsed rail's attention dot was the
+other, and went with `SidebarMenuDot` when the approvals count moved into the
+window's title row.
 
 ### The frame
 

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -3457,9 +3457,10 @@ export function AppShell({
           />
         }
         overview={
-          // The console's front page, as a glyph. It was a labelled sidebar row;
-          // in a chrome band a labelled button reads as content, so the name
-          // moves to `aria-label` and `title`. First thing the row drops as the
+          // The console's front page, as a glyph. `NAV` still carries the
+          // labelled row and will until the sidebar restructure removes it; in a
+          // chrome band a labelled button reads as content, so the name moves
+          // here to `aria-label` and `title`. First thing the row drops as the
           // window narrows — see `TITLE_BAR_LADDER`.
           <OverviewButton
             active={isNavigationActive("overview", view)}

--- a/frontend/src/components/overview-button.tsx
+++ b/frontend/src/components/overview-button.tsx
@@ -1,6 +1,7 @@
 // Overview, as a glyph in the window's title row.
 //
-// It was a labelled sidebar row. It is chrome here, and that is the whole
+// The sidebar still carries this destination as a labelled row, and will until
+// the sidebar restructure lands. Here it is chrome, and that is the whole
 // argument for dropping the word: a title row is a band of chrome, and a
 // *labelled* button in it reads as content — the same trade in reverse to the
 // one the sidebar's utility bar makes, where an unlabelled glyph in a list of


### PR DESCRIPTION
Split out of #1980, which merged at 10:15:49Z while these two commits were still
in flight. They were written against #1980's own tree and are not new work —
without them `main` ships two comments that say something untrue and two
design-system pages that describe a component #1980 deleted.

Both were found by reading the merged change, not raised by a reviewer: #1980
carried no inline review comments and no CodeRabbit review (CodeRabbit was rate
limited for its whole open life and never posted one).

## `docs(design-system)`: drop the deleted rail dot from the cut-out rule

`docs/design-system/color.md` and `docs/design-system/components.md` both state
the rule *"anything that cuts a hole in the chrome must ask for the chrome"* and
illustrate it with **two** examples, one of which is `SidebarMenuDot`. #1980
deleted that primitive. `ring-chrome` now has exactly one call site left —
`host-switcher.tsx:285`, the switcher's status dot — so a reader who greps the
example finds nothing.

The rule is unchanged. The example is corrected to the one that still exists,
and where the second went is said rather than left to a failed grep.

```
$ rg -n 'ring-chrome' frontend/src
frontend/src/components/host-switcher.tsx:285:   variant === "standalone" ? "ring-sidebar" : "ring-chrome",
```

## `docs(console)`: say the sidebar rows are still there, not that they went

`overview-button.tsx` opens "It was a labelled sidebar row", and the
`overview={...}` comment in `app-shell.tsx` repeats it. But `NAV` still carries
both Overview and Approvals — #1980's own description says so under **Not in
this PR**: *"The Approvals and Overview rows are still in `NAV` — removing them
belongs to the sidebar restructure landing in parallel."*

What moved out of the sidebar in #1980 is the **count**, not the rows. Someone
who greps `NAV` finds the row a comment says is gone, which is the drift these
comments exist to prevent. Both now say what is true and when it stops being
true.

## Verified

Run in `/Volumes/T9/opencompany-worktrees/oc-t9-wt-2` on 2026-09-01, on the tree
this PR proposes:

- `npm run typecheck` — clean.
- `npm run typecheck:unit` — clean.
- `npm run typecheck:e2e` — clean.
- `npx vitest run` — **443 files, 4164 tests, 0 failures** (same count as the
  merged tree; these commits change no behaviour and no test).
- `scripts/ci/assert-design-tokens.sh` — `✓ design tokens: no arbitrary sizes,
  no palette colours, no stray hex`.
- Both Markdown files stay under the 500-line cap: `color.md` 381,
  `components.md` 308.

Not verified: no browser pass. These are comments and prose only — no rendered
output changes, so there is nothing to look at that #1980's own browser pass did
not already cover.
