### PR TITLE
fix(test): unbreak main — set origin_parent on the relay-attribution task cards

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -6462,6 +6462,10 @@ mod tests {
             assignee: origin.to_string(),
             updated_at_millis: 0,
             origin_chat_id: Some(origin.to_string()),
+            // #1890 added this beside `origin_chat_id`: the thread a card was
+            // raised in, not just the channel. These cards are built for the
+            // relay-attribution assertions below, which do not read it.
+            origin_parent: None,
             parent_task_id: None,
             output: None,
             plan: None,


### PR DESCRIPTION
`main` does not currently compile its own lib tests. Every PR that merges main in inherits the failure, which is how I found it — #1973's gated lane went red on a file it does not touch.

## The failure

```
error[E0063]: missing field `origin_parent` in initializer of `ports::tasks::TaskRecord`
    --> src/company/runtime.rs:6456:45
     |
6456 |         let card = |id: &str, origin: &str| TaskRecord {
     |                                             ^^^^^^^^^^ missing `origin_parent`
```

Reproduced on pristine `cbab1e9cf` with the gated lane's own command:

```
$ git checkout cbab1e9cf
$ cargo check --locked --features openhuman --all-targets
error: could not compile `opencompany` (lib test) due to 1 previous error
```

## How it got in

A semantic conflict between two separately-green PRs. #1890 added `origin_parent` to `TaskRecord` (landing in #1939, `25539f6b6`); #1949 (`282e7caa7`) added this test constructor. Neither diff is wrong; they simply never saw each other.

It survived merge because the constructor is inside `#[cfg(test)]` (the module opens at line 5066). Plain `cargo check` passes, so most lanes are green — only `Rust (openhuman, tinymemory)`, which builds `--all-targets`, compiles the test code and sees it.

## The fix

One field. These cards exist for the relay-attribution assertions immediately below and never read `origin_parent`, so `None` is right and matches the struct's own default at `ports/tasks.rs:1570`.

## Validation

- `cargo check --locked --features openhuman --all-targets` — fails on `cbab1e9cf`, passes here
- `cargo test --features openhuman --lib company::runtime` — 34 passed, 0 failed
- `cargo fmt --all -- --check` — clean

Worth merging ahead of my other open PRs (#1967, #1973, #1978), since they are all red for this reason rather than their own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a test fixture to include the newly supported task-origin field.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->