### PR TITLE
fix(console): keep the echo-brain notice on the read-only feed

### DIFF
--- a/docs/spec/runtime/ports-cognition.md
+++ b/docs/spec/runtime/ports-cognition.md
@@ -140,9 +140,14 @@ drift from reality. Reported on `GET …/capabilities` beside `mediaInBuild`,
 "what can this company actually do" — as `cognition`.
 
 The console consumes it in chat (issue #1734): on anything but `configured` the
-transcript carries a banner naming the cause and, where one exists, the remedy,
+pane carries a banner naming the cause and, where one exists, the remedy,
 and every company-side row is marked as a placeholder rather than presented as
-the teammate's own words. `ChatMessage` carries no provenance, so a company-level
+the teammate's own words. The banner is a strip **directly above the composer**
+rather than above the transcript — the caveat and the control it qualifies are
+read together — and below the typing line, so nothing sits between them. It is
+rendered on a read-only channel too, where there is no composer: the sentence is
+about attribution, not about sending, and `#Operator` is precisely a feed of
+company-authored reports rendered under a teammate's name. `ChatMessage` carries no provenance, so a company-level
 state is the only shape that answer has — see `MessageRow`'s `cognition` prop for
 why marking beats suppressing. The same state reaches `ThreadPanel`, because a
 reply read inside a thread is the same false attribution as one read in the

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -2236,9 +2236,21 @@ export function ChatView({
                 the order read correct with nobody typing and wrong with someone
                 typing.
 
-                Suppressed on a read-only channel: nothing can be sent there, so a
-                caveat about what sending produces has nothing left to qualify —
-                and the composer it would sit above is not rendered at all.
+                NOT suppressed on a read-only channel, though the composer it
+                sits above is gone there. It was, briefly, on the reasoning that
+                a caveat about sending has nothing left to qualify — but the
+                sentence is not about sending. It is about attribution: these
+                rows are not the teammate's words. `#Operator` carries
+                company-authored reports rendered under a teammate's name and
+                avatar, `MessageRow` marks each of them from the same cognition
+                state, and suppressing this left the operator with only
+                `EchoPlaceholder`'s chip — the word "Placeholder", with its
+                explanation in a `title` that touch and keyboard users never see
+                (codex review on PR #1984). A read-only feed is where a reader is
+                least able to test the attribution by asking, so it is the last
+                place to drop the only visible statement of it. With no composer
+                there, the strip simply lands under the read-only notice as the
+                bottom strip of the pane.
 
                 All four states below say "the replies in this conversation", not
                 "the replies below". They said "below" while this strip sat above
@@ -2251,7 +2263,7 @@ export function ChatView({
                 `role="status"` (not `alert`) for the reason
                 `components/ui/alert.tsx` gives — a notice present on mount should
                 not interrupt a screen reader. */}
-            {echoing && !readOnly && (
+            {echoing && (
               <p
                 role="status"
                 data-testid="chat-cognition-banner"

--- a/frontend/test/unit/chat-readonly-composer.test.ts
+++ b/frontend/test/unit/chat-readonly-composer.test.ts
@@ -295,11 +295,39 @@ describe("the harness-unavailable notice sits next to the composer", () => {
     expect(kids.indexOf(composerRoot)).toBe(kids.indexOf(strip) + 1);
   });
 
-  it("is suppressed on a read-only channel, where nothing can be sent", async () => {
+  it("still states the false attribution on a read-only feed", async () => {
+    // It was suppressed here for one commit, on the reasoning that a caveat
+    // about sending has nothing to qualify where nothing can be sent. The
+    // sentence is not about sending: `#Operator` renders company-authored
+    // reports under a teammate's name, `MessageRow` marks each of them from
+    // this same state, and with the strip gone the only explanation left was
+    // `EchoPlaceholder`'s `title` — invisible to touch and keyboard (codex
+    // review on PR #1984). A feed the reader cannot reply to is the last place
+    // to drop it.
     await mount("operator", "unavailable");
 
-    expect(banner()).toBeNull();
+    const strip = banner();
+    expect(strip).not.toBeNull();
+    expect(strip?.textContent).toContain(
+      "come from the offline echo brain rather than the teammate they appear under",
+    );
+    // Still no composer, and the read-only notice still explains the channel.
+    expect(composerInput()).toBeNull();
     expect(container.textContent).toContain("There is nothing to reply to here");
+  });
+
+  it("sits under the read-only notice, as the bottom strip of the pane", async () => {
+    await mount("operator", "unavailable");
+
+    const strip = banner()!;
+    const column = strip.parentElement!;
+    const kids = Array.from(column.children);
+    const notice = kids.find((el) => el.textContent?.includes("There is nothing to reply to here"))!;
+
+    expect(notice).not.toBeUndefined();
+    expect(kids.indexOf(notice)).toBeLessThan(kids.indexOf(strip));
+    // Nothing after it: the composer that would normally follow is not here.
+    expect(kids.indexOf(strip)).toBe(kids.length - 1);
   });
 });
 


### PR DESCRIPTION
Follow-up to #1984, which merged while this was being verified. It fixes the
one review finding that arrived after the merge — a regression #1984 itself
introduced.

## The finding (codex, P2, on #1984)

> **Keep the echo warning visible in the read-only feed.** Suppressing the
> banner there removes the visible explanation and the Settings remedy from
> precisely that feed. The remaining chip just says "Placeholder", and its
> explanation exists only in a `title` on a non-focusable `<span>`, so touch and
> keyboard users cannot discover that the named teammate did not author the
> report.

Valid. #1984 gated the cognition banner on `echoing && !readOnly`; before it,
the banner was not channel-aware at all. **This removes the gate.**

## Why the suppression was wrong on its own terms

It was justified by "nothing can be sent here, so a caveat about what sending
produces has nothing left to qualify". But the sentence is *"the replies in this
conversation come from the offline echo brain rather than the teammate they
appear under"* — a claim about **attribution of what is already on screen**.
None of the four states mentions sending. It is fully true on a read-only feed,
and a feed the reader cannot reply to is where they are least able to test the
attribution by asking, so it is the last place to drop the only visible
statement of it. The copy therefore needed no read-only variant either.

The premise was checked rather than taken on trust: `MessageRow` calls
`echoMarkerFor(message, sender, cognition)` for every company-side row with no
`byPerson`, on **every** channel — nothing about it is channel-aware — so
`#Operator`'s workflow reports, rendered under a teammate's name and avatar, are
marked exactly like a channel reply. And `EchoPlaceholder` really is a
non-focusable `<span>` whose reason lives only in a `title`.

With no composer on that channel, the strip lands under the read-only notice as
the bottom strip of the pane.

## Docs

`docs/spec/runtime/ports-cognition.md` already promised a banner "on anything
but `configured`" and said nothing about where it sits. It now says the strip is
directly above the composer, below the typing line, and kept on a read-only
channel — and why.

## Verification

```
$ npm run typecheck        # tsc -b --noEmit             → clean
$ npm run typecheck:unit   # tsc -p tsconfig.unit.json   → clean
$ npm run typecheck:e2e    # tsc -p tsconfig.e2e.json    → clean
$ npx vitest run           # Test Files 445 passed · Tests 4197 passed
$ scripts/ci/assert-design-tokens.sh
✓ design tokens: no arbitrary sizes, no palette colours, no stray hex
```

Two new tests, both mutation-proved by restoring `!readOnly`:

| Test | Failure under the mutation |
|---|---|
| the read-only feed still states the false attribution | `expected null not to be null` |
| it sits under the read-only notice, as the last child of the column | `Cannot read properties of null (reading 'parentElement')` |

**Browser, light and dark, 1440×900**, `#Operator` against a real host with
`cognition: unconfigured`: no composer, no textarea, no `data-tour` anchor, and
DOM order `["TRANSCRIPT", "READONLY-NOTICE", "BANNER"]` with the banner as the
last child — reading *"Teammates can't think yet. This company has no model
configured, so the replies in this conversation come from the offline echo brain
rather than the teammate they appear under. Choose a provider in Settings →
Inference."*

#1984's own three fixes were re-run on this build and still hold: the draft
survives a trip to `#Operator`; the tour walks **8 of 8** stops from the Operator
feed; with someone typing, the order is `["TRANSCRIPT", "TYPING", "BANNER",
"COMPOSER"]` with nothing between the notice and the composer.

## Not in scope

`EchoPlaceholder`'s chip carries its reason only in a `title` — a pre-existing
gap, not one #1984 created, whose fix is an accessible name on the chip. With
the banner restored it is no longer the only explanation on any surface. Worth
its own issue.
