### PR TITLE
fix(threads): the two #1890 defects that landed after the merge

### DIFF
--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -1070,7 +1070,22 @@ function inlineFirstReplies(
     if (!roots.has(rootId)) continue;
     const root = position.get(rootId);
     const first = bucket[0];
-    const answer = first === undefined ? undefined : position.get(first.id);
+    // **Only the runtime's own answer is ever promoted** (codex on #1972).
+    //
+    // `bucket[0]` is merely the earliest reply, and that is the *operator's*
+    // own follow-up whenever they wrote again before the agent answered — a
+    // thread they deliberately opened, flattened back into the channel, with
+    // the answer they were waiting for still folded behind the root's chip. The
+    // reader sees their own words twice and the reply not at all, which is the
+    // failure this promotion exists to prevent, in the one case where a person
+    // was demonstrably treating the exchange as a thread.
+    //
+    // A `system` line is excluded on the same terms: a settle marker is
+    // runtime-generated but it is not an answer, and #1890 B put markers in the
+    // thread that raised the card on purpose. Promoting one back into the
+    // channel would undo that from the render side.
+    if (first === undefined || first.from !== "company") continue;
+    const answer = position.get(first.id);
     if (root === undefined || answer === undefined) continue;
     const own = new Set(bucket.map((r) => r.id));
     let interleaved = false;

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -1084,7 +1084,19 @@ function inlineFirstReplies(
     // runtime-generated but it is not an answer, and #1890 B put markers in the
     // thread that raised the card on purpose. Promoting one back into the
     // channel would undo that from the render side.
-    if (first === undefined || first.from !== "company") continue;
+    //
+    // **`from` alone does not say "the runtime wrote this".** `fromHistory`
+    // projects `from` off `mine`, so *another signed-in person's* reply arrives
+    // as `company` too, carrying `byPerson` to tell them apart — and without
+    // that term a colleague answering first was promoted exactly as the
+    // operator's own follow-up had been, reproducing this defect for everyone
+    // except the viewer (codex + coderabbit on #2001).
+    //
+    // Only an explicit `true` blocks it. `undefined` means the host did not
+    // say, and it is what *every* locally built company line carries — this
+    // console's own POST, an `AgentReplyEvent` — so reading it as "might be a
+    // person" would fold the live answer this promotion exists for.
+    if (first === undefined || first.from !== "company" || first.byPerson) continue;
     const answer = position.get(first.id);
     if (root === undefined || answer === undefined) continue;
     const own = new Set(bucket.map((r) => r.id));

--- a/frontend/test/unit/chat-timeline.test.ts
+++ b/frontend/test/unit/chat-timeline.test.ts
@@ -43,7 +43,7 @@ describe("buildTimeline", () => {
     const entries = buildTimeline(
       [
         message({ id: "a", text: "can we ship?" }),
-        message({ id: "b", text: "yes", parentId: "a" }),
+        message({ id: "b", from: "company", text: "yes", parentId: "a" }),
       ],
       CHANNEL,
       [],
@@ -53,6 +53,48 @@ describe("buildTimeline", () => {
     // And it is not ALSO on the parent's chip: a reader seeing the answer must
     // not be told there is one more thing to open.
     expect(entries[0].replies).toEqual([]);
+  });
+
+  /**
+   * The operator replied to their own root before the agent got there.
+   *
+   * `bucket[0]` is merely the earliest reply, so that follow-up was promoted
+   * into the channel and the agent's actual answer stayed folded behind the
+   * root's chip — a thread a person deliberately opened, flattened, showing
+   * them their own words twice and the reply not at all (codex on #1972).
+   */
+  it("keeps a thread folded when the operator replied first, not the agent", () => {
+    const entries = buildTimeline(
+      [
+        message({ id: "a", text: "can we ship?" }),
+        message({ id: "b", text: "…or next week?", parentId: "a", at: T0 + 1 }),
+        message({ id: "c", from: "company", text: "yes", parentId: "a", at: T0 + 2 }),
+      ],
+      CHANNEL,
+      [],
+    );
+
+    expect(entries.map((e) => e.message.id)).toEqual(["a"]);
+    expect(entries[0].replies.map((r) => r.id)).toEqual(["b", "c"]);
+  });
+
+  /**
+   * A settle marker is runtime-generated but it is not an answer, and #1890 B
+   * put markers in the thread that raised the card on purpose. Promoting one
+   * into the channel would undo that from the render side.
+   */
+  it("keeps a thread folded when a system marker is its first line", () => {
+    const entries = buildTimeline(
+      [
+        message({ id: "a", text: "draft the launch email" }),
+        message({ id: "b", from: "system", text: "finished → In review", parentId: "a", at: T0 + 1 }),
+      ],
+      CHANNEL,
+      [],
+    );
+
+    expect(entries.map((e) => e.message.id)).toEqual(["a"]);
+    expect(entries[0].replies.map((r) => r.id)).toEqual(["b"]);
   });
 
   it("folds the pair instead once another conversation interleaved", () => {
@@ -101,7 +143,7 @@ describe("buildTimeline", () => {
     const entries = buildTimeline(
       [
         message({ id: "a" }),
-        message({ id: "b", parentId: "a", at: T0 + 1 }),
+        message({ id: "b", from: "company", parentId: "a", at: T0 + 1 }),
         message({ id: "c", parentId: "a", at: T0 + 2 }),
       ],
       CHANNEL,
@@ -129,7 +171,7 @@ describe("buildTimeline", () => {
     const entries = buildTimeline(
       [
         message({ id: "a", text: "can we ship?" }),
-        message({ id: "b", text: "yes", parentId: "a", at: T0 + 1 }),
+        message({ id: "b", from: "company", text: "yes", parentId: "a", at: T0 + 1 }),
         message({ id: "c", text: "when?", parentId: "b", at: T0 + 2 }),
       ],
       CHANNEL,
@@ -194,7 +236,7 @@ describe("buildTimeline", () => {
     const entries = buildTimeline(
       [
         message({ id: "a" }),
-        message({ id: "b", parentId: "a", at: T0 + 1 }),
+        message({ id: "b", from: "company", parentId: "a", at: T0 + 1 }),
         message({ id: "c", parentId: "b", at: T0 + 2 }),
       ],
       CHANNEL,

--- a/frontend/test/unit/chat-timeline.test.ts
+++ b/frontend/test/unit/chat-timeline.test.ts
@@ -79,6 +79,57 @@ describe("buildTimeline", () => {
   });
 
   /**
+   * A colleague is not the runtime.
+   *
+   * `fromHistory` projects `from` off `mine`, so another signed-in person's
+   * reply arrives as `company` and is told apart only by `byPerson`. Without
+   * that term their message was promoted just as the operator's own follow-up
+   * had been — the same defect, for every viewer except the one who wrote it
+   * (codex + coderabbit on #2001).
+   */
+  it("keeps a thread folded when a colleague replied before the runtime did", () => {
+    const entries = buildTimeline(
+      [
+        message({ id: "a", text: "can we ship?" }),
+        message({
+          id: "b",
+          from: "company",
+          byPerson: true,
+          text: "asking the team",
+          parentId: "a",
+          at: T0 + 1,
+        }),
+        message({ id: "c", from: "company", text: "yes", parentId: "a", at: T0 + 2 }),
+      ],
+      CHANNEL,
+      [],
+    );
+
+    expect(entries.map((e) => e.message.id)).toEqual(["a"]);
+    expect(entries[0].replies.map((r) => r.id)).toEqual(["b", "c"]);
+  });
+
+  /**
+   * `undefined` is not `true`, and the difference is what keeps the ordinary
+   * case working: every locally built company line — this console's own POST,
+   * an `AgentReplyEvent` — leaves `byPerson` unset, and only `fromHistory` ever
+   * sets it. Reading "unset" as "might be a person" would fold the live answer
+   * this promotion exists for.
+   */
+  it("still promotes a runtime answer that carries no byPerson at all", () => {
+    const entries = buildTimeline(
+      [
+        message({ id: "a", text: "can we ship?" }),
+        message({ id: "b", from: "company", text: "yes", parentId: "a", at: T0 + 1 }),
+      ],
+      CHANNEL,
+      [],
+    );
+
+    expect(entries.map((e) => e.message.id)).toEqual(["a", "b"]);
+  });
+
+  /**
    * A settle marker is runtime-generated but it is not an answer, and #1890 B
    * put markers in the thread that raised the card on purpose. Promoting one
    * into the channel would undo that from the render side.

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -3869,9 +3869,27 @@ impl HarnessPool {
         let augmented = if crate::runtime::delegation::is_chat_only_turn() {
             message.to_string()
         } else {
+            // **Retrieved on the operator's own words, injected into the
+            // composed message** (#1890 review). `message` may already carry
+            // this turn's in-memory briefings — open work, the settled-work
+            // digest, the thread index, attachment markers — and those are for
+            // the model to read, not for the store to search on. Retrieving on
+            // them made the query drift toward whatever the briefings happened
+            // to name: the settled digest is a list of finished card titles, so
+            // a conversation that had just closed some work recalled *that*
+            // work rather than what the operator was asking about, and grew
+            // more biased with every card that finished.
+            //
+            // `operator_words` is the existing seam for this — the same cut the
+            // triage decision takes, and for the same reason its docs give: the
+            // annotations are not something anybody typed.
             let hits = deps
                 .context
-                .search(company, message, memory_loop::RETRIEVE_TOP_K)
+                .search(
+                    company,
+                    crate::runtime::delegation::operator_words(message),
+                    memory_loop::RETRIEVE_TOP_K,
+                )
                 .await?;
             memory_loop::inject(message, &hits)
         };
@@ -6548,6 +6566,64 @@ description = "Builds the product."
             .await
             .unwrap();
         assert_eq!(stored.len(), 2, "the second turn stores its outcome too");
+    }
+
+    /// Recall is driven by **what the operator typed**, not by the briefings
+    /// this turn folded onto it.
+    ///
+    /// The composed message can carry the open-work briefing, the settled-work
+    /// digest, the thread index or attachment markers. Those are for the model
+    /// to read; searching on them makes the query something nobody asked. Under
+    /// this store's substring matching that costs the recall outright — any
+    /// briefing at all and nothing matches — and under a vector store it drifts
+    /// instead, toward whatever the briefing happens to name. The settled digest
+    /// is a list of finished card titles, so a conversation that had just closed
+    /// some work pulled *that* work in, and the bias grew with every card that
+    /// finished.
+    ///
+    /// Found by the `orchestration-simulation` E2E, which went red the moment
+    /// two cards settled in the conversation it drives (#1890 review).
+    #[tokio::test]
+    async fn recall_searches_the_operators_words_not_the_briefings() {
+        let fx = fixture();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+        // Turn one stores an outcome whose body carries "alpha".
+        pool.run(
+            &rec.id,
+            "ceo",
+            "alpha task",
+            &fx.deps,
+            crate::runtime::delegation::ChatTarget::default(),
+        )
+        .await
+        .expect("first turn");
+
+        // Turn two asks the same thing, with a briefing folded on — the shape
+        // every turn takes once a card has settled in the conversation.
+        let briefed = format!(
+            "alpha{} has finished — this is where each card landed:\n- something else\n]",
+            crate::runtime::cycle::SETTLED_WORK_ANNOTATION
+        );
+        let second = pool
+            .run(
+                &rec.id,
+                "ceo",
+                &briefed,
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
+            .await
+            .expect("second turn")
+            .reply;
+
+        assert!(
+            second.contains("Relevant prior work"),
+            "the operator asked about alpha, so alpha is recalled — the briefing \
+             appended after their words must not change what is searched for: {second:?}"
+        );
     }
 
     /// A pool serving one named harness builds only the agents bound to it.


### PR DESCRIPTION
Two review findings on #1972 that were fixed after it merged, so they are on `main` now. Both were verified before the merge landed; the commits simply missed it by about a minute.

Closes nothing — follow-up to #1890.

## 1. Recall was searching on the briefings, not on what the operator typed

`built_in` searched the context store with `message`, and by the time the harness sees it, `message` may carry this turn's in-memory briefings — the open-work briefing, the settled-work digest, the thread index, attachment markers. Those are for the model to read. Searching on them asks the store a question nobody typed.

The settled digest is a list of finished card titles, so a conversation that had just closed some work recalled *that* work rather than what was being asked about. It compounds: every card that finishes lengthens the digest and skews the next turn further.

`operator_words` is the existing seam for exactly this — the same cut the triage decision takes, whose docs already argue that the annotations are not something anybody typed. The model still gets the full briefed message; only the search changes.

**How it was found.** `Console E2E (live brain)` › `orchestration-simulation` went red on the #1972 branch and green on `main`. The drift pulled in the stored text of the goal message, which carries a `__MOCK_PLAN__` directive; `memory_loop::inject` truncates a recalled snippet mid-JSON and prepends it above the operator's words, so the mock's `findPlan` — `indexOf`, then bail on a payload that does not parse — never reached the real directive and served no plan. The close-out `review_task` pair never ran.

That job is `skipped` on most `main` pushes, so this is not currently visible as a red check. The behaviour is there regardless.

## 2. An operator-opened thread was flattened into the channel

`inlineFirstReplies` promoted `bucket[0]`, which is merely the earliest reply. Whenever the operator wrote again before the agent answered, that follow-up was the one laid out inline: a thread the person deliberately opened, flattened back into the channel, with the answer they were waiting for still folded behind the root's chip. They see their own words twice and the reply not at all.

A `system` line is excluded on the same terms — a settle marker is runtime-generated but it is not an answer, and #1890 B put markers in the thread that raised the card on purpose.

Four existing fixtures authored the *answer* as `from: "you"` (the `message()` default) while their names and comments called it an answer. They passed either way, so they could not have caught this; they now say who is speaking.

## Verification

- `orchestration-simulation`, `chat-dispatch-marker`, `chat-to-card` under `PW_LIVE_BRAIN=1` — 7 passed, including the simulation that was failing
- `pnpm vitest run` — 443 files / 4158 tests; `tsc -b --noEmit` clean
- `cargo test --locked`, `--features openhuman`, `--features openhuman,tinymemory`; clippy on default + `openhuman`; `cargo fmt --check`

Each fix has a test confirmed to fail with the fix reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat thread folding so inline replies appear only when an appropriate runtime response is the first reply.
  * Kept threads folded when an operator, colleague, or system message appears first.
  * Preserved inline display for runtime responses without additional authorship details.
  * Improved context retrieval by ignoring briefing and annotation text, helping surface more relevant prior work.
  * Added regression coverage for chat folding and context retrieval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->