### PR TITLE
fix(e2e): find the live plan, not the truncated copy quoted above it

### DIFF
--- a/frontend/src/lib/console-routes.ts
+++ b/frontend/src/lib/console-routes.ts
@@ -198,6 +198,14 @@ export const VIEWS: View[] = Object.keys(ROUTABLE) as View[];
  * view against this one. First-run setup only offers itself when the answer is
  * "just opened" — so a default view changed in one place and not the other is
  * not a cosmetic drift, it is a company that can never be set up.
+ *
+ * There is a third place, and it is the one that actually broke (#1999): a test
+ * that opens the console at a *named* view is asserting against whatever this
+ * constant said the day it was written. When this moved from `overview` to
+ * `chat`, `company-setup.spec.ts` started arriving deep-linked and the
+ * first-run specs went red against a console that was working correctly. Tests
+ * that mean "just opened the console" must navigate to `/` — an empty hash
+ * resolves here by definition and cannot drift.
  */
 export const DEFAULT_VIEW: View = "chat";
 

--- a/frontend/test/e2e/company-setup.spec.ts
+++ b/frontend/test/e2e/company-setup.spec.ts
@@ -169,7 +169,13 @@ test("first-run setup builds a real team from three answers", async ({ page, req
     }
   });
 
-  await page.goto("/#/overview");
+  // `/` rather than a named view: `deepLinked` is `view !== DEFAULT_VIEW`, so
+  // naming any view hard-codes today's default and silently stops testing the
+  // automatic offer the day that default moves. It moved — `DEFAULT_VIEW` went
+  // from `overview` to `chat` — and this spec went red for a console that was
+  // working. An empty hash *is* "just opened the console", which is the
+  // condition the offer keys on.
+  await page.goto("/");
 
   // 1. It opens by itself — nobody clicked anything.
   const dialog = page.getByTestId("setup-dialog");
@@ -235,7 +241,11 @@ test("first-run setup builds a real team from three answers", async ({ page, req
   // 7. A reload does not re-offer setup: the roster is no longer empty, which is
   // the whole reason emptiness is the signal rather than a stored flag.
   await page.reload();
-  await page.goto("/#/overview");
+  // Also `/`, and this one is load-bearing: reopening at a named view would
+  // leave the dialog hidden because the arrival was a deep link, which is true
+  // whether or not the roster is staffed. The assertion would pass for the
+  // wrong reason and stop testing what the comment above claims.
+  await page.goto("/");
   await expect(dialog).toBeHidden();
 });
 
@@ -248,7 +258,7 @@ test("skipping setup leaves a way back in", async ({ page, request }) => {
     }
   });
 
-  await page.goto("/#/overview");
+  await page.goto("/");
   await expect(page.getByTestId("setup-dialog")).toBeVisible({ timeout: 20_000 });
 
   await page.getByTestId("setup-skip").click();

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -215,6 +215,48 @@ const SPAWN_DIRECTIVE = "SPAWNONE";
 const PLAN_DIRECTIVE = "__MOCK_PLAN__";
 
 /**
+ * The host's own briefing blocks, appended to an operator message before it
+ * reaches a model.
+ *
+ * These matter here because two of them quote **other messages verbatim**.
+ * `THREAD_INDEX_ANNOTATION` lists the opening words of the channel's other
+ * threads, truncated — so once a spec has opened a thread with a directive in
+ * it, every later message in that channel carries a chopped-off copy of that
+ * directive. A directive cut mid-payload is not a directive; it is a decoy that
+ * parses as nothing.
+ *
+ * Cutting at the earliest of these is what the host itself does to recover the
+ * operator's own words (`operator_words` in `src/runtime/delegation.rs`), and
+ * for the same reason: everything past the first marker was written by the
+ * host, not by the spec.
+ *
+ * Keep in step with the constants in `src/runtime/cycle.rs` and
+ * `src/brain/medulla/effects.rs`.
+ */
+const HOST_ANNOTATIONS = [
+  "\n\n[Open work already handed to you",
+  "\n\n[Other conversations in this channel",
+  "\n\n[Work raised in this conversation",
+  "\n\n[This request is already being built",
+  "\n\n[Attached file:",
+];
+
+/**
+ * The spec's own half of a message, with the host's briefings removed.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function specWords(text) {
+  let cut = text.length;
+  for (const marker of HOST_ANNOTATIONS) {
+    const at = text.indexOf(marker);
+    if (at >= 0 && at < cut) cut = at;
+  }
+  return text.slice(0, cut);
+}
+
+/**
  * How many steps of each plan have been served, keyed by the plan's own text.
  *
  * @type {Map<string, number>}
@@ -419,17 +461,24 @@ function findDirective(messages) {
  */
 function findPlan(messages) {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const text = textOf(messages[i]);
+    // `specWords`, not the raw text: the host appends briefings that quote
+    // other messages verbatim and truncated, so a message can carry a decoy
+    // copy of an older directive with its payload cut in half.
+    const text = specWords(textOf(messages[i]));
     const at = text.indexOf(PLAN_DIRECTIVE);
     if (at < 0) continue;
     const steps = readJsonValue(text, at + PLAN_DIRECTIVE.length, "[", "]");
     if (!Array.isArray(steps)) {
-      // A broken spec, not a plain turn. Say so loudly rather than answering
-      // with text the spec will then fail on obscurely.
+      // Say so loudly — a spec that wrote bad JSON deserves to hear it — but
+      // keep scanning rather than giving up on the whole thread. Returning null
+      // here let one unparsable directive anywhere in the history silence every
+      // real plan behind it, which is how a truncated echo took out an entire
+      // spec rather than one turn.
       process.stderr.write(
-        `[mock brain] ${PLAN_DIRECTIVE} found but its JSON payload did not parse\n`,
+        `[mock brain] ${PLAN_DIRECTIVE} found in message ${i} but its JSON payload did ` +
+          `not parse; ignoring it and looking further back\n`,
       );
-      return null;
+      continue;
     }
     // Identity is the directive and the rest of its LINE — the same key shape
     // `SPAWNONE` uses, and for both of its reasons. It is stable across the

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -461,22 +461,40 @@ function findDirective(messages) {
  */
 function findPlan(messages) {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
-    // `specWords`, not the raw text: the host appends briefings that quote
-    // other messages verbatim and truncated, so a message can carry a decoy
-    // copy of an older directive with its payload cut in half.
     const text = specWords(textOf(messages[i]));
-    const at = text.indexOf(PLAN_DIRECTIVE);
-    if (at < 0) continue;
-    const steps = readJsonValue(text, at + PLAN_DIRECTIVE.length, "[", "]");
+    // Every occurrence, newest first — not just the first one.
+    //
+    // The host prepends context to an operator message: a `## Relevant prior
+    // work` digest of earlier tasks, then the operator's own words under
+    // `## Task`. The digest quotes those earlier messages *truncated*, so when
+    // a spec opens a thread with a directive in it, later messages carry a
+    // chopped-off copy of it BEFORE the live one.
+    //
+    // `indexOf` found the decoy, and a decoy is unparsable by construction.
+    // Scanning back through occurrences puts the operator's own directive --
+    // the last one in the text -- ahead of anything quoted above it.
+    const found = [];
+    for (let at = text.indexOf(PLAN_DIRECTIVE); at >= 0; at = text.indexOf(PLAN_DIRECTIVE, at + 1)) {
+      found.push(at);
+    }
+    let at = -1;
+    let steps = null;
+    for (let k = found.length - 1; k >= 0; k -= 1) {
+      const parsed = readJsonValue(text, found[k] + PLAN_DIRECTIVE.length, "[", "]");
+      if (Array.isArray(parsed)) {
+        at = found[k];
+        steps = parsed;
+        break;
+      }
+    }
+    if (found.length === 0) continue;
     if (!Array.isArray(steps)) {
-      // Say so loudly — a spec that wrote bad JSON deserves to hear it — but
-      // keep scanning rather than giving up on the whole thread. Returning null
-      // here let one unparsable directive anywhere in the history silence every
-      // real plan behind it, which is how a truncated echo took out an entire
-      // spec rather than one turn.
+      // Loud, because a spec that wrote bad JSON deserves to hear it — but keep
+      // scanning older messages rather than abandoning the thread. Returning
+      // null here let one truncated echo silence every real plan behind it.
       process.stderr.write(
-        `[mock brain] ${PLAN_DIRECTIVE} found in message ${i} but its JSON payload did ` +
-          `not parse; ignoring it and looking further back\n`,
+        `[mock brain] ${PLAN_DIRECTIVE} appears ${found.length}x in message ${i}; none of ` +
+          `them parsed, looking further back\n`,
       );
       continue;
     }

--- a/frontend/test/unit/mock-brain.test.ts
+++ b/frontend/test/unit/mock-brain.test.ts
@@ -112,6 +112,37 @@ describe("the mock inference backend", () => {
     expect(reply.choices[0].message.content).toBe("__MOCK_LLM__ mock inference backend reply.");
   });
 
+  it("ignores a truncated directive the host echoed back, and serves the real plan", async () => {
+    // Issue #2002. The host appends briefings that quote other messages
+    // *verbatim and truncated* — `[Other conversations in this channel…` lists
+    // each thread's opening words. Once a spec opens a thread with a directive
+    // in it, every LATER message in that channel carries a chopped-off copy.
+    //
+    // That ordering is the whole bug, so the fixture has to reproduce it: the
+    // real plan is an older message, and the newest message carries only the
+    // decoy. `findPlan` scans newest-first, met the unparsable copy, and
+    // returned null for the entire thread — so the real plan behind it was
+    // never served. `orchestration-simulation.spec.ts` died exactly there:
+    // cards reached `in_review` and the closing `review_task` never ran.
+    const real = plan("echo-1", [[{ name: "review_task", arguments: { decision: "approve" } }]]);
+    const decoy =
+      "and now the next thing" +
+      "\n\n[Other conversations in this channel, for reference only):\n" +
+      '- [12] "close this out __MOCK_PLAN__ [[{\"name\":\"spawn_ta' +
+      "\n]";
+
+    const reply = await chat(
+      [
+        { role: "user", content: real },
+        { role: "user", content: decoy },
+      ],
+      ["review_task"],
+    );
+
+    const call = reply.choices[0].message.tool_calls?.[0];
+    expect(call?.function?.name).toBe("review_task");
+  });
+
   it("calls spawn_task once for a SPAWNONE prompt, with a title off the message", async () => {
     const reply = await chat([{ role: "user", content: "please track this SPAWNONE 456" }]);
 

--- a/frontend/test/unit/mock-brain.test.ts
+++ b/frontend/test/unit/mock-brain.test.ts
@@ -124,20 +124,19 @@ describe("the mock inference backend", () => {
     // returned null for the entire thread — so the real plan behind it was
     // never served. `orchestration-simulation.spec.ts` died exactly there:
     // cards reached `in_review` and the closing `review_task` never ran.
+    // The decoy sits BEFORE the live directive in the SAME message, which is
+    // how the host actually composes a turn: a `## Relevant prior work` digest
+    // quoting earlier tasks (truncated), then the operator's words under
+    // `## Task`. `indexOf` reached the decoy first, so scanning older messages
+    // was no help -- the real plan was further down the same string.
     const real = plan("echo-1", [[{ name: "review_task", arguments: { decision: "approve" } }]]);
-    const decoy =
-      "and now the next thing" +
-      "\n\n[Other conversations in this channel, for reference only):\n" +
-      '- [12] "close this out __MOCK_PLAN__ [[{\"name\":\"spawn_ta' +
-      "\n]";
+    const composed =
+      "## Relevant prior work\n" +
+      '- Task: ship the digest. __MOCK_PLAN__ [[{"name":"spawn_task","arguments":{"title":"sim gather the sou' +
+      "\n\n## Task\n" +
+      real;
 
-    const reply = await chat(
-      [
-        { role: "user", content: real },
-        { role: "user", content: decoy },
-      ],
-      ["review_task"],
-    );
+    const reply = await chat([{ role: "user", content: composed }], ["review_task"]);
 
     const call = reply.choices[0].message.tool_calls?.[0];
     expect(call?.function?.name).toBe("review_task");


### PR DESCRIPTION
Closes #2002.

## What was wrong

`Console E2E (live brain)` has failed on every PR based after #1972. `orchestration-simulation.spec.ts` drives a goal to completion with `__MOCK_PLAN__` directives; cards reached `in_review` and the closing `review_task` never ran, so it timed out waiting for `done`.

The mock brain had been saying so in its own stderr the whole time:

```
[mock brain] __MOCK_PLAN__ found but its JSON payload did not parse
```

The host composes an operator turn as a `## Relevant prior work` digest of earlier tasks, then the operator's words under `## Task`. **The digest quotes those earlier messages truncated.** So once the simulation opens its thread with a directive in the first message, every later turn carries a chopped-off copy of it — *earlier in the same string* than the live one:

```
## Relevant prior work
- Task: Ship a short market digest… __MOCK_PLAN__ [[{"name":"spawn_task",…{"title":"sim gather the sou
## Task
Both pieces are back — take a look and close them out. __MOCK_PLAN__ [[{"name":"review_task",…
```

`findPlan` took `indexOf`, met the decoy, and gave up on the whole thread.

**The host is behaving correctly.** Quoting prior work truncated is the point of that digest. What broke is the harness's assumption that the first directive in a message is the one the spec wrote.

## The fix

Collect every occurrence of the directive in a message and try them newest-first, so the operator's own directive wins over anything quoted above it. Also: on a parse failure keep scanning rather than abandoning the thread, and ignore the host's appended briefing blocks (`operator_words` does the same thing host-side, for the same reason).

## Verified by running it, not by reasoning

Worth saying plainly, because my first attempt was wrong. I initially fixed only the "keep scanning older messages" half — which is useless when the live directive is further down the *same* message. Running the spec is what caught it:

```
[mock brain] plan step 0: spawn_task + spawn_task      ← opening plan, always worked
[mock brain] plan step 0: review_task + review_task    ← the closing plan, never served before
1 passed (18.8s)
```

The unit test reproduces the real composition — decoy before the live directive in one message — and fails if the search stops at the first occurrence. I checked it fails without the fix; an earlier version of that test passed either way, which is no test at all.

## Note for #1999's neighbour

This is the second standing E2E regression this week to reach `main` through a lane that does not gate — #1972 merged with this lane already red. Once a lane is red for everyone, nobody can tell their own red from the standing red.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated task interpretation when messages contain repeated or incomplete directives.
  - The system now ignores truncated or echoed instructions and continues searching for the most recent valid plan.
  - Added clearer diagnostics when a directive cannot be parsed.
  - Prevented prior-work summaries and host-generated annotations from interfering with live task instructions.

- **Tests**
  - Added coverage for cases where an incomplete directive appears before a valid task plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->