### PR TITLE
feat(harness): surface a parked blocker as a DM you can answer (#1862)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -704,6 +704,17 @@ export interface ApprovalSummary {
    * that can be decided.
    */
   batch?: string | null;
+  /**
+   * The shared root cause a blocker has with its siblings (#1862) — a
+   * connection id, an integration name — so every card stalled on one broken
+   * integration folds into a single question and one verdict fans back to them
+   * all.
+   *
+   * Distinct from {@link batch}: a batch is "asked in the same turn", a group
+   * is "blocked by the same cause". Absent for an ordinary approval and for a
+   * blocker particular to its own step; those group alone.
+   */
+  group_key?: string | null;
 }
 
 /**

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -24,6 +24,7 @@ import {
   FileSignature,
   FileText,
   Globe,
+  HelpCircle,
   KeyRound,
   Mail,
   MessageSquare,
@@ -32,6 +33,7 @@ import {
   Rocket,
   ShieldCheck,
   SquareKanban,
+  Unplug,
   Workflow,
   type LucideIcon,
 } from "lucide-react";
@@ -168,8 +170,41 @@ export function batchConsequences(approvals: ApprovalSummary[]): ApprovalConsequ
 const PREVIEW_LINES = 3;
 const PREVIEW_VALUE_CHARS = 160;
 
-/** The glyph for an effect kind; a shield for one this console doesn't know. */
+/** The dotted prefix every blocker effect kind carries (host `BLOCKER_EFFECT_PREFIX`). */
+const BLOCKER_KIND_PREFIX = "blocker.";
+
+/** Whether an effect kind is a parked blocker — a stop a person can answer (#1862). */
+export function isBlockerKind(kind: string): boolean {
+  return kind.startsWith(BLOCKER_KIND_PREFIX);
+}
+
+/**
+ * The operator-readable fields a blocker card renders (#1862): what stopped,
+ * what would unblock it, and the connection it is about when one groups it.
+ *
+ * Read defensively off the redactable payload — a Member's card withholds it
+ * (#618), and an older host may not carry every field — so a missing half
+ * simply renders less rather than throwing.
+ */
+export function blockerFields(a: ApprovalSummary): {
+  reason?: string;
+  needed?: string;
+  connection?: string;
+} | null {
+  if (!isBlockerKind(a.kind)) return null;
+  const payload = (a.payload ?? {}) as Record<string, unknown>;
+  const str = (v: unknown): string | undefined =>
+    typeof v === "string" && v.trim().length > 0 ? v : undefined;
+  const groupKey = str(a.group_key) ?? str(payload.group_key);
+  const connection = groupKey?.startsWith("connection:")
+    ? groupKey.slice("connection:".length)
+    : undefined;
+  return { reason: str(payload.reason), needed: str(payload.needed), connection };
+}
+
+/** The glyph for an effect kind; a question for a blocker, a shield for the unknown. */
 export function approvalIcon(kind: string): LucideIcon {
+  if (isBlockerKind(kind)) return HelpCircle;
   return KIND_ICONS[kind] ?? ShieldCheck;
 }
 
@@ -186,6 +221,40 @@ export function ApprovalHeadline({
 }) {
   const Icon = approvalIcon(a.kind);
   const consequence = approvalConsequence(a.group);
+  const blocker = blockerFields(a);
+  if (blocker) {
+    return (
+      <div className="flex flex-wrap items-start gap-4">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
+          <Icon className="size-5" />
+        </div>
+        <div className="min-w-[min(12rem,100%)] flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <p className="font-medium">{blocker.reason ?? approvalAction(a)}</p>
+            <span className="rounded-full bg-muted px-2 py-0.5 text-2xs font-medium text-foreground">
+              Blocked
+            </span>
+          </div>
+          {blocker.needed && (
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Needs: {blocker.needed}
+            </p>
+          )}
+          {blocker.connection && (
+            <p className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-muted-foreground">
+              <Unplug className="size-3.5" />
+              Reconnect {blocker.connection} in Apps to unblock
+            </p>
+          )}
+        </div>
+        {actions && (
+          <div data-approval-actions className="flex shrink-0 gap-2">
+            {actions}
+          </div>
+        )}
+      </div>
+    );
+  }
   return (
     <div className="flex flex-wrap items-start gap-4">
       <div

--- a/frontend/src/lib/mention-badge.ts
+++ b/frontend/src/lib/mention-badge.ts
@@ -16,6 +16,15 @@ function isGeneralChat(context: string | null | undefined): boolean {
 }
 
 /**
+ * The notification kinds that badge a channel on the rail: a mention (#65) and
+ * a parked blocker (#1862). Both are "somebody wants you here" — a named
+ * message, or a teammate blocked in this DM awaiting a verdict.
+ */
+export function isBadgingKind(kind: string): boolean {
+  return kind === "mention" || kind === "blocker_parked";
+}
+
+/**
  * The rendered channel a mention's `context` badges, or `undefined` when it has
  * nowhere to land.
  *
@@ -109,8 +118,10 @@ export function mentionCountsByChannel(
     if (n.readAt !== undefined) continue;
     // `kind` rather than `subjectKind`: a future notification about a message
     // that is not a mention (a reply, a reaction) must not silently start
-    // badging as one.
-    if (n.kind !== "mention") continue;
+    // badging as one. A parked blocker (#1862) is the second summons that
+    // belongs on the rail — a teammate is blocked in this DM and wants a
+    // verdict — so it badges the same way a mention does.
+    if (!isBadgingKind(n.kind)) continue;
     // A row with no channel cannot be placed on the rail. Counted nowhere
     // rather than counted somewhere arbitrary.
     if (n.context === undefined || n.context === null) continue;
@@ -171,7 +182,7 @@ export function mentionsToClear(
 ): string[] {
   return notifications
     .filter((n) => {
-      if (n.readAt !== undefined || n.kind !== "mention" || n.context === undefined) {
+      if (n.readAt !== undefined || !isBadgingKind(n.kind) || n.context === undefined) {
         return false;
       }
       let inChannel: boolean;
@@ -192,6 +203,10 @@ export function mentionsToClear(
         inChannel = channelId === mainChannelId && isGeneralChat(n.context);
       }
       if (!inChannel) return false;
+      // A parked blocker has no summoning chat message — its card renders from
+      // the approvals feed, not the transcript — so opening the DM clears it
+      // outright, without the message-loaded gates the mention path needs.
+      if (n.kind === "blocker_parked") return true;
       // A mention inside a thread reply stays until that reply is actually on
       // screen. The main timeline folds replies into their parent
       // (`buildTimeline`), so a collapsed thread hides the text even while the

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -1511,6 +1511,11 @@ export type TimelineItem =
  * the second surface just wasn't reading it.
  */
 export function approvalBatchKey(approval: ApprovalSummary): string {
+  // A blocker folds by its root cause (#1862): every card stalled on one
+  // broken integration is one question, even across turns a batch would keep
+  // apart. Falls back to the turn batch, then to the id — so an ordinary
+  // approval groups exactly as before.
+  if (approval.group_key) return `group:${approval.group_key}`;
   return approval.batch ?? `solo:${approval.id}`;
 }
 

--- a/frontend/test/unit/blocker-badge.test.ts
+++ b/frontend/test/unit/blocker-badge.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import type { NotificationDto } from "@/api/types";
+import {
+  isBadgingKind,
+  mentionCountsByChannel,
+  mentionsToClear,
+} from "@/lib/mention-badge";
+
+/**
+ * A parked blocker badges the DM it lands in (#1862), driven by the
+ * `blocker_parked` notification's `context`.
+ */
+
+const parked = (
+  over: Partial<NotificationDto> & Pick<NotificationDto, "id">,
+): NotificationDto => ({
+  kind: "blocker_parked",
+  subjectKind: "approval",
+  subjectId: "appr-1",
+  title: "eng is blocked on t-1: could not connect",
+  createdAt: 1,
+  context: "dm:eng",
+  ...over,
+});
+
+describe("isBadgingKind", () => {
+  it("badges mentions and parked blockers, nothing else", () => {
+    expect(isBadgingKind("mention")).toBe(true);
+    expect(isBadgingKind("blocker_parked")).toBe(true);
+    expect(isBadgingKind("approval_expired")).toBe(false);
+  });
+});
+
+describe("mentionCountsByChannel with blockers", () => {
+  it("counts an unread parked blocker on its DM channel", () => {
+    const counts = mentionCountsByChannel(
+      [parked({ id: "a" }), parked({ id: "b", context: "dm:ceo" })],
+      undefined,
+      new Set(["dm:eng", "dm:ceo"]),
+    );
+    expect(counts).toEqual({ "dm:eng": 1, "dm:ceo": 1 });
+  });
+
+  it("ignores a blocker already read", () => {
+    const counts = mentionCountsByChannel(
+      [parked({ id: "a", readAt: 9 })],
+      undefined,
+      new Set(["dm:eng"]),
+    );
+    expect(counts["dm:eng"]).toBeUndefined();
+  });
+});
+
+describe("mentionsToClear with blockers", () => {
+  it("clears a parked blocker when its DM is opened, with no message-loaded gate", () => {
+    const cleared = mentionsToClear(
+      [parked({ id: "a" })],
+      "dm:eng",
+      undefined,
+      new Set(["dm:eng"]),
+      new Set(["dm:eng"]),
+      new Map(),
+      null,
+      // A message set that does not contain the (approval) subject — a mention
+      // would be withheld by this gate; a blocker must clear regardless.
+      new Set<string>(),
+    );
+    expect(cleared).toEqual(["a"]);
+  });
+
+  it("does not clear a blocker for a different DM", () => {
+    const cleared = mentionsToClear(
+      [parked({ id: "a", context: "dm:ceo" })],
+      "dm:eng",
+      undefined,
+      new Set(["dm:eng"]),
+      new Set(["dm:eng", "dm:ceo"]),
+    );
+    expect(cleared).toEqual([]);
+  });
+});

--- a/frontend/test/unit/blocker-card-fields.test.ts
+++ b/frontend/test/unit/blocker-card-fields.test.ts
@@ -1,0 +1,64 @@
+import { HelpCircle } from "lucide-react";
+import { describe, expect, it } from "vitest";
+
+import type { ApprovalSummary } from "@/api/types";
+import { approvalIcon, blockerFields, isBlockerKind } from "@/components/approval-card";
+
+/**
+ * The blocker-specialized card render (#1862): the step's reason and what would
+ * unblock it, and the connection when the stop is grouped by one.
+ */
+
+function approval(over: Partial<ApprovalSummary> & Pick<ApprovalSummary, "id">): ApprovalSummary {
+  return {
+    kind: "blocker.infrastructure",
+    amount_usd: null,
+    at_millis: 0,
+    thread: "eng",
+    ...over,
+  };
+}
+
+describe("isBlockerKind", () => {
+  it("recognises the dotted blocker prefix and nothing else", () => {
+    expect(isBlockerKind("blocker.infrastructure")).toBe(true);
+    expect(isBlockerKind("blocker.information")).toBe(true);
+    expect(isBlockerKind("payment.send")).toBe(false);
+  });
+});
+
+describe("approvalIcon", () => {
+  it("gives a blocker its own glyph", () => {
+    expect(approvalIcon("blocker.infrastructure")).toBe(HelpCircle);
+    expect(approvalIcon("payment.send")).not.toBe(HelpCircle);
+  });
+});
+
+describe("blockerFields", () => {
+  it("reads reason, needed and the grouped connection off the payload", () => {
+    const fields = blockerFields(
+      approval({
+        id: "a",
+        payload: {
+          reason: "could not connect to mcp server `slack`",
+          needed: "the integration reconnected from Apps",
+        },
+        group_key: "connection:slack",
+      }),
+    );
+    expect(fields).toEqual({
+      reason: "could not connect to mcp server `slack`",
+      needed: "the integration reconnected from Apps",
+      connection: "slack",
+    });
+  });
+
+  it("is null for a non-blocker approval", () => {
+    expect(blockerFields(approval({ id: "a", kind: "payment.send" }))).toBeNull();
+  });
+
+  it("degrades to less rather than throwing when the payload is withheld", () => {
+    const fields = blockerFields(approval({ id: "a", payload: undefined, contents_hidden: true }));
+    expect(fields).toEqual({ reason: undefined, needed: undefined, connection: undefined });
+  });
+});

--- a/frontend/test/unit/blocker-card-grouping.test.ts
+++ b/frontend/test/unit/blocker-card-grouping.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import type { ApprovalSummary } from "@/api/types";
+import { approvalBatchKey, buildTimelineItems } from "@/views/chat/model";
+
+/**
+ * A blocker folds by its root cause (#1862): every card stalled on one broken
+ * integration is one question, even across turns a batch would keep apart.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+function blocker(over: Partial<ApprovalSummary> & Pick<ApprovalSummary, "id">): ApprovalSummary {
+  return {
+    kind: "blocker.infrastructure",
+    amount_usd: null,
+    at_millis: T0,
+    agent: "eng",
+    thread: "eng",
+    ...over,
+  };
+}
+
+describe("approvalBatchKey for blockers", () => {
+  it("folds blockers sharing a group_key into one key, across different batches", () => {
+    const a = blocker({ id: "a", batch: "turn-1", group_key: "connection:slack" });
+    const b = blocker({ id: "b", batch: "turn-2", group_key: "connection:slack" });
+    expect(approvalBatchKey(a)).toBe(approvalBatchKey(b));
+  });
+
+  it("keeps distinct connections apart", () => {
+    const slack = blocker({ id: "a", group_key: "connection:slack" });
+    const notion = blocker({ id: "b", group_key: "connection:notion" });
+    expect(approvalBatchKey(slack)).not.toBe(approvalBatchKey(notion));
+  });
+
+  it("groups an ungrouped blocker alone", () => {
+    const a = blocker({ id: "a" });
+    const b = blocker({ id: "b" });
+    expect(approvalBatchKey(a)).not.toBe(approvalBatchKey(b));
+  });
+
+  it("leaves an ordinary approval on its batch", () => {
+    const a: ApprovalSummary = { ...blocker({ id: "a" }), kind: "web_fetch", batch: "turn-9" };
+    expect(approvalBatchKey(a)).toBe("turn-9");
+  });
+});
+
+describe("buildTimelineItems groups connection blockers into one card", () => {
+  it("renders one card for three parks on one broken connection", () => {
+    const items = buildTimelineItems(
+      [],
+      [
+        blocker({ id: "a", group_key: "connection:slack" }),
+        blocker({ id: "b", group_key: "connection:slack" }),
+        blocker({ id: "c", group_key: "connection:slack" }),
+      ],
+    );
+    const cards = items.filter((i) => i.kind === "approval");
+    expect(cards).toHaveLength(1);
+    expect(cards[0].kind === "approval" && cards[0].approvals).toHaveLength(3);
+  });
+});

--- a/src/company/blocker_sender.rs
+++ b/src/company/blocker_sender.rs
@@ -1,0 +1,236 @@
+//! Who a parked blocker is attributed to — the teammate whose direct message
+//! it surfaces in (issue #1862).
+//!
+//! A blocker is a question, and a question in a company is asked *by* someone.
+//! [`resolve_sender`] answers "by whom", so the card lands in the operator's DM
+//! with the responsible teammate rather than in an undifferentiated queue.
+//!
+//! It is deliberately **dumb**: it reads whatever trigger-time attribution the
+//! park already carries and picks the first rung that names a real roster
+//! agent. It never inspects *why* the work stopped — the gap class is #1866's
+//! job, decided once in [`blockers`](crate::harness::built_in::blockers) — and
+//! never promises the stop will resume, which is #1863's boundary. All it
+//! decides is whose name goes on the question.
+
+use crate::ports::types::{CompanyRecord, StartedBy};
+
+/// The host's own last-resort identity, used when nothing else named a sender.
+///
+/// A reserved channel slug ([`crate::runtime::channel`]) no company can give a
+/// teammate, so a blocker with no attribution still resolves to a real,
+/// collision-free DM channel instead of vanishing.
+pub const HOST_SENDER: &str = "workflow";
+
+/// The trigger-time attribution a park carries into sender resolution.
+///
+/// Every field is optional because each park site knows a different subset: a
+/// workflow run knows its [`StartedBy`], a planning pass knows the card's
+/// assignee, and neither knows the other's. An all-`None` bag is honest — it
+/// means "nothing was named" and resolves to the orchestrator or the host.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BlockerSenderSignals {
+    /// The [`StartedBy`] of the run this stop came from, when it came from one.
+    /// Only [`StartedBy::Agent`] attributes a teammate; an operator- or
+    /// schedule-started run names nobody to route to.
+    pub started_by: Option<StartedBy>,
+    /// The desk that owns the stopped work, resolved through its lead.
+    pub owner_desk: Option<String>,
+    /// The teammate the stopped card is assigned to — the planning pass's one
+    /// piece of attribution.
+    pub assignee: Option<String>,
+}
+
+/// Resolves the teammate a blocker is attributed to, as a roster agent id.
+///
+/// The rungs, first match wins:
+/// 1. **The triggering agent.** A run an agent started owns its own stops.
+/// 2. **The owning desk's lead.** A leadless [`Auto`] desk (issue #1835)
+///    resolves `None` here — its per-message selector needs the message text a
+///    park does not have — and falls through rather than guessing a member.
+/// 3. **The card's assignee.** The planning pass's responsible teammate.
+/// 4. **The orchestrator**, which answers anything otherwise unaddressed.
+/// 5. **The host** ([`HOST_SENDER`]), so a blocker always lands somewhere real.
+///
+/// [`Auto`]: crate::ports::types::ResponderMode::Auto
+pub fn resolve_sender(record: &CompanyRecord, signals: &BlockerSenderSignals) -> String {
+    if let Some(StartedBy::Agent(id)) = &signals.started_by
+        && record.is_roster_agent(id)
+    {
+        return id.clone();
+    }
+    if let Some(desk) = &signals.owner_desk
+        && let Some(lead) = crate::runtime::delegation_tools::desk_lead(record, desk)
+    {
+        return lead;
+    }
+    if let Some(assignee) = &signals.assignee
+        && record.is_roster_agent(assignee)
+    {
+        return assignee.clone();
+    }
+    if let Some(id) = crate::company::types::orchestrator_id(&record.effective_agents()) {
+        return id.to_string();
+    }
+    HOST_SENDER.to_string()
+}
+
+/// The console channel a resolved sender's DM lives under — the id a park
+/// stamps as its thread and a badge lands on.
+pub fn dm_thread(sender: &str) -> String {
+    format!("dm:{sender}")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+
+    /// A record from a bare manifest, with every overlay empty. Agents and desks
+    /// come from the TOML; nothing else matters to sender resolution.
+    fn record(manifest_toml: &str) -> CompanyRecord {
+        CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest: toml::from_str(manifest_toml).expect("parse manifest"),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_agent_edits: Vec::new(),
+            overlay_retired_agents: Vec::new(),
+            overlay_policy: None,
+            overlay_tool_grants: None,
+            overlay_desk_tools: Default::default(),
+            overlay_budgets: Vec::new(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+            name_confirmed: false,
+            activation_completed_at: None,
+            created_at_millis: None,
+        }
+    }
+
+    const MANIFEST: &str = "[company]\nname = \"Acme\"\n\
+         [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n\
+         [[agent]]\nid = \"eng\"\nrole = \"Engineer\"\n\
+         [[agent]]\nid = \"des\"\nrole = \"Designer\"\n\
+         [[group_chat]]\nid = \"studio\"\nname = \"Studio\"\nmembers = [\"des\", \"eng\"]\n";
+
+    #[test]
+    fn the_triggering_agent_wins() {
+        let record = record(MANIFEST);
+        let sender = resolve_sender(
+            &record,
+            &BlockerSenderSignals {
+                started_by: Some(StartedBy::Agent("eng".to_string())),
+                owner_desk: Some("studio".to_string()),
+                assignee: Some("des".to_string()),
+            },
+        );
+        assert_eq!(
+            sender, "eng",
+            "the agent that started the run owns its stop"
+        );
+    }
+
+    #[test]
+    fn an_unknown_triggering_agent_falls_through() {
+        let record = record(MANIFEST);
+        let sender = resolve_sender(
+            &record,
+            &BlockerSenderSignals {
+                started_by: Some(StartedBy::Agent("ghost".to_string())),
+                owner_desk: Some("studio".to_string()),
+                assignee: None,
+            },
+        );
+        assert_eq!(
+            sender, "des",
+            "a started_by naming nobody on the roster does not win; the desk lead does"
+        );
+    }
+
+    #[test]
+    fn an_operator_started_run_does_not_attribute_an_agent() {
+        let record = record(MANIFEST);
+        let sender = resolve_sender(
+            &record,
+            &BlockerSenderSignals {
+                started_by: Some(StartedBy::Operator),
+                owner_desk: None,
+                assignee: Some("eng".to_string()),
+            },
+        );
+        assert_eq!(
+            sender, "eng",
+            "an operator-started run names no agent, so the assignee answers"
+        );
+    }
+
+    #[test]
+    fn the_owner_desk_lead_answers_when_no_agent_triggered() {
+        let record = record(MANIFEST);
+        let sender = resolve_sender(
+            &record,
+            &BlockerSenderSignals {
+                started_by: None,
+                owner_desk: Some("studio".to_string()),
+                assignee: Some("ceo".to_string()),
+            },
+        );
+        assert_eq!(
+            sender, "des",
+            "the desk's first member leads and outranks the assignee"
+        );
+    }
+
+    #[test]
+    fn the_assignee_answers_when_no_run_and_no_desk() {
+        let record = record(MANIFEST);
+        let sender = resolve_sender(
+            &record,
+            &BlockerSenderSignals {
+                started_by: None,
+                owner_desk: None,
+                assignee: Some("eng".to_string()),
+            },
+        );
+        assert_eq!(sender, "eng");
+    }
+
+    #[test]
+    fn the_orchestrator_answers_an_unattributed_stop() {
+        let record = record(MANIFEST);
+        let sender = resolve_sender(&record, &BlockerSenderSignals::default());
+        assert_eq!(
+            sender, "ceo",
+            "with nothing named, the first (orchestrator) agent answers"
+        );
+    }
+
+    #[test]
+    fn the_host_answers_when_the_company_has_no_roster() {
+        let record = record("[company]\nname = \"Empty\"\n");
+        let sender = resolve_sender(
+            &record,
+            &BlockerSenderSignals {
+                started_by: Some(StartedBy::Agent("nobody".to_string())),
+                owner_desk: Some("nowhere".to_string()),
+                assignee: Some("nobody".to_string()),
+            },
+        );
+        assert_eq!(
+            sender, HOST_SENDER,
+            "no roster names anyone; the host takes it"
+        );
+    }
+
+    #[test]
+    fn the_dm_thread_is_the_console_channel_form() {
+        assert_eq!(dm_thread("eng"), "dm:eng");
+        assert_eq!(dm_thread(HOST_SENDER), "dm:workflow");
+    }
+}

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -47,6 +47,7 @@ pub mod copilot;
 // platform token vs a static key). Always compiled: the answer decides whether a
 // company can think at all, in every build.
 pub mod billing;
+pub mod blocker_sender;
 pub mod credentials;
 pub mod dns;
 pub mod hosting;

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1388,9 +1388,17 @@ impl CompanyRuntime {
         &self,
         payload: &crate::ports::blockers::BlockerPayload,
         task_id: &str,
+        signals: crate::company::blocker_sender::BlockerSenderSignals,
     ) -> Result<ApprovalId> {
         use crate::ports::types::{Effect, EffectGroup};
         use crate::runtime::journal::{ApprovalConversation, TaskLink};
+
+        // Who this question is asked by, and therefore which DM it surfaces in.
+        // Resolved before the park so the same thread stamps the journal, the
+        // event and the notification — a card, a routed reply and a badge that
+        // cannot land in three different places.
+        let sender = self.resolve_blocker_sender(&signals).await;
+        let thread = crate::company::blocker_sender::dm_thread(&sender);
 
         let effect = Effect {
             kind: payload.effect_kind(),
@@ -1428,10 +1436,12 @@ impl CompanyRuntime {
                 &effect,
                 now_millis(),
                 TaskLink::from_task_id(Some(task_id)),
-                // No conversation: a planning pass is not anybody's turn, so
-                // there is no thread to thread the answer back into.
+                // The blocker's own conversation is the DM with the teammate it
+                // is attributed to. There is no parking turn behind it, so there
+                // is no message root to thread under — only the channel the
+                // reply routes into.
                 ApprovalConversation {
-                    thread: None,
+                    thread: Some(thread.clone()),
                     parent: None,
                 },
                 None,
@@ -1465,7 +1475,7 @@ impl CompanyRuntime {
                 CompanyEvent::ApprovalParked {
                     approval_id: approval_id.clone(),
                     effect_kind: effect.kind.clone(),
-                    thread: None,
+                    thread: Some(thread.clone()),
                 },
             )
             .await
@@ -1477,7 +1487,73 @@ impl CompanyRuntime {
                 "blocker parked and journaled, but its event-log entry failed",
             );
         }
+        self.notify_blocker_parked(&approval_id, &sender, payload)
+            .await;
         Ok(approval_id)
+    }
+
+    /// The teammate a blocker is attributed to, resolved from the live company
+    /// record (issue #1862). Falls back to the host identity when the record
+    /// cannot be loaded — a blocker must always land in a real DM channel, and
+    /// a transient store miss is not a reason to drop it on the floor.
+    #[cfg(feature = "openhuman")]
+    pub(crate) async fn resolve_blocker_sender(
+        &self,
+        signals: &crate::company::blocker_sender::BlockerSenderSignals,
+    ) -> String {
+        match self.store().load(&self.id).await {
+            Ok(Some(record)) => crate::company::blocker_sender::resolve_sender(&record, signals),
+            _ => crate::company::blocker_sender::HOST_SENDER.to_string(),
+        }
+    }
+
+    /// Files the durable "someone is blocked" notification beside the park
+    /// (issue #1862), the sibling of
+    /// [`notify_approval_expired`](Self::notify_approval_expired).
+    ///
+    /// **Title only, and deliberately no payload.** The one-line title is the
+    /// operator-readable prose the blocker already carries in `reason`; the
+    /// arguments that produced the stop stay redacted at their single point
+    /// (`pending_approvals`), exactly as the thin `ApprovalParked` frame keeps
+    /// them. `context` is the DM channel, so a badge lands on the right
+    /// conversation without the console having loaded its transcript.
+    ///
+    /// Says a person is blocked, not that answering resumes anything: resume is
+    /// #1863, and the copy must not promise it.
+    #[cfg(feature = "openhuman")]
+    async fn notify_blocker_parked(
+        &self,
+        id: &ApprovalId,
+        sender: &str,
+        payload: &crate::ports::blockers::BlockerPayload,
+    ) {
+        use crate::ports::blockers::BlockerStep;
+        let step = match &payload.step {
+            Some(BlockerStep::Task { task_id }) => task_id.clone(),
+            Some(BlockerStep::Node { node_id, .. }) => node_id.clone(),
+            None => "a question".to_string(),
+        };
+        let note = crate::ports::notifications::Notification {
+            id: crate::ports::generate_id(),
+            kind: "blocker_parked".to_string(),
+            subject: crate::ports::notifications::Subject {
+                kind: crate::ports::notifications::SubjectKind::Approval,
+                id: id.as_ref().to_string(),
+            },
+            created_at: now_millis(),
+            title: format!("{sender} is blocked on {step}: {}", payload.reason),
+            audience: None,
+            context: Some(crate::company::blocker_sender::dm_thread(sender)),
+        };
+        if let Err(err) = self.notifications().append(&self.id, &note).await {
+            tracing::warn!(
+                company = %self.id,
+                approval = %id.as_ref(),
+                error = %err,
+                "[blockers] a blocker-parked notification could not be recorded; the park \
+                 still stands, but nobody is badged for it"
+            );
+        }
     }
 
     /// Withdraws a blocker this pass just parked, because the card write that
@@ -4971,8 +5047,252 @@ impl CompanyRuntime {
                 // together" would guess at a fact the journal already records,
                 // and would guess wrong exactly when two turns overlap.
                 batch: p.batch,
+                // Issue #1862: the shared root cause, so the console folds every
+                // card stalled on one broken integration into a single question.
+                group_key: blocker_group_key_of(&p.effect),
             })
             .collect()
+    }
+
+    /// Every pending blocker sharing `group_key` — the set one verdict fans
+    /// across (issue #1862).
+    ///
+    /// Ten cards stalled on one broken OAuth grant are one question, so
+    /// answering the card answers all of them. A blocker with no `group_key`
+    /// never reaches here (the caller resolves it alone), so a solo verdict can
+    /// never fan by accident. Oldest-first, the order
+    /// [`pending`](crate::runtime::journal::Journal::pending) already returns.
+    #[cfg(feature = "openhuman")]
+    pub(crate) fn blocker_group_members(&self, group_key: &str) -> Vec<ApprovalId> {
+        self.journal
+            .pending()
+            .into_iter()
+            .filter(|p| blocker_group_key_of(&p.effect).as_deref() == Some(group_key))
+            .map(|p| p.id)
+            .collect()
+    }
+
+    /// The full group a single parked blocker belongs to — its root-cause
+    /// siblings, or itself alone when it carries no group key.
+    #[cfg(feature = "openhuman")]
+    fn blocker_group_of(&self, id: &ApprovalId) -> Vec<ApprovalId> {
+        match self
+            .journal
+            .pending()
+            .into_iter()
+            .find(|p| &p.id == id)
+            .and_then(|p| blocker_group_key_of(&p.effect))
+        {
+            Some(key) => self.blocker_group_members(&key),
+            None => vec![id.clone()],
+        }
+    }
+
+    /// The parked blockers pending in one DM, folded into root-cause groups
+    /// (issue #1862). Oldest-first, the order `pending` already returns.
+    #[cfg(feature = "openhuman")]
+    fn pending_blocker_groups(&self, desk: &str) -> Vec<PendingBlockerGroup> {
+        let prefix = format!("{}.", crate::ports::blockers::BLOCKER_EFFECT_PREFIX);
+        let mut groups: Vec<PendingBlockerGroup> = Vec::new();
+        for p in self.journal.pending() {
+            if !p.effect.kind.starts_with(&prefix) {
+                continue;
+            }
+            if !crate::server::chat_history::same_conversation(p.thread.as_deref(), Some(desk)) {
+                continue;
+            }
+            let Ok(payload) = serde_json::from_value::<crate::ports::blockers::BlockerPayload>(
+                p.effect.payload.clone(),
+            ) else {
+                continue;
+            };
+            let label: String = payload
+                .reason
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .chars()
+                .take(80)
+                .collect();
+            match &payload.group_key {
+                Some(key) => {
+                    if let Some(group) = groups.iter_mut().find(|g| g.key.as_deref() == Some(key)) {
+                        group.ids.push(p.id);
+                    } else {
+                        groups.push(PendingBlockerGroup {
+                            key: Some(key.clone()),
+                            ids: vec![p.id],
+                            label,
+                        });
+                    }
+                }
+                None => groups.push(PendingBlockerGroup {
+                    key: None,
+                    ids: vec![p.id],
+                    label,
+                }),
+            }
+        }
+        groups
+    }
+
+    /// The approval id of the parked blocker at `parent`, when the reply's
+    /// parent is a blocker card (issue #1862) — the explicit reply tier.
+    ///
+    /// Reads the event at `parent` exactly as
+    /// [`review_anchor_card`](Self::review_anchor_card) does, and answers `None`
+    /// for anything that is not a still-pending `ApprovalParked` blocker. The
+    /// two are disjoint: a review anchor is a settle pill or relay bubble, a
+    /// blocker anchor is an `ApprovalParked` event, so neither steals the
+    /// other's replies.
+    #[cfg(feature = "openhuman")]
+    async fn parked_blocker_at(&self, parent: EventSeq) -> Result<Option<ApprovalId>> {
+        let stored = self.events.read_from(&self.id, parent, 1).await?;
+        let Some(stored) = stored.into_iter().next() else {
+            return Ok(None);
+        };
+        if stored.seq != parent {
+            return Ok(None);
+        }
+        let prefix = format!("{}.", crate::ports::blockers::BLOCKER_EFFECT_PREFIX);
+        match stored.event {
+            CompanyEvent::ApprovalParked {
+                approval_id,
+                effect_kind,
+                ..
+            } if effect_kind.starts_with(&prefix) && self.is_blocker(&approval_id) => {
+                Ok(Some(approval_id))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Decides what an operator's reply in `desk` does to the blockers pending
+    /// there (issue #1862) — the read-only half, so the caller journals the
+    /// reply before anything settles.
+    ///
+    /// A reply parented to a blocker card resolves that card's whole group; an
+    /// unparented reply in a DM with a single pending group resolves it; one in
+    /// a DM with several groups is resolved only if the text names one,
+    /// otherwise it asks which and settles nothing. A reply that is not a
+    /// verdict — or a DM with no pending blocker — is
+    /// [`NotBlocker`](BlockerReplyPlan::NotBlocker), and the caller runs it as an
+    /// ordinary turn.
+    #[cfg(feature = "openhuman")]
+    pub(crate) async fn plan_blocker_reply(
+        &self,
+        desk: &str,
+        parent: Option<EventSeq>,
+        text: &str,
+    ) -> Result<BlockerReplyPlan> {
+        use crate::company::task_intent::{BlockerReplyIntent, classify_blocker_reply};
+
+        let explicit = match parent {
+            Some(parent) => self
+                .parked_blocker_at(parent)
+                .await?
+                .map(|id| self.blocker_group_of(&id)),
+            None => None,
+        };
+        let groups = self.pending_blocker_groups(desk);
+        if explicit.is_none() && groups.is_empty() {
+            return Ok(BlockerReplyPlan::NotBlocker);
+        }
+        let intent = classify_blocker_reply(text);
+        if intent == BlockerReplyIntent::Unrelated {
+            return Ok(BlockerReplyPlan::NotBlocker);
+        }
+        if let Some(ids) = explicit {
+            return Ok(BlockerReplyPlan::Resolve { ids, intent });
+        }
+        if groups.len() == 1 {
+            return Ok(BlockerReplyPlan::Resolve {
+                ids: groups[0].ids.clone(),
+                intent,
+            });
+        }
+        let lower = text.to_lowercase();
+        let mut named = groups.iter().filter(|group| {
+            group
+                .connection_hint()
+                .is_some_and(|hint| lower.contains(hint))
+        });
+        match (named.next(), named.next()) {
+            (Some(group), None) => Ok(BlockerReplyPlan::Resolve {
+                ids: group.ids.clone(),
+                intent,
+            }),
+            _ => Ok(BlockerReplyPlan::AskWhich {
+                prompt: ask_which_prompt(&groups),
+            }),
+        }
+    }
+
+    /// Records the operator's verdict on a blocker group (issue #1862), lowering
+    /// the four-way intent onto the existing Approve/Deny resolve surface and
+    /// **fanning it to every member** of the group.
+    ///
+    /// `retry` re-approves, `skip`/`cancel` deny, and `amend` overlays the
+    /// operator's correction onto the parked effect. Every arm is durably
+    /// recorded and inert until #1863 — the verdict is banked, no stopped step
+    /// re-runs here.
+    #[cfg(feature = "openhuman")]
+    pub(crate) async fn apply_blocker_reply(
+        self: &Arc<Self>,
+        ids: &[ApprovalId],
+        intent: crate::company::task_intent::BlockerReplyIntent,
+        text: &str,
+        by: Option<&Actor>,
+    ) -> Result<()> {
+        use crate::company::task_intent::BlockerReplyIntent;
+
+        let actor = by.cloned().unwrap_or_else(|| Actor {
+            kind: ActorKind::Operator,
+            id: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
+        });
+        for id in ids {
+            match intent {
+                BlockerReplyIntent::Retry => {
+                    self.resolve_approval(id, Verdict::Approve, actor.clone())
+                        .await?;
+                }
+                BlockerReplyIntent::Skip | BlockerReplyIntent::Cancel => {
+                    self.resolve_approval(id, Verdict::Deny, actor.clone())
+                        .await?;
+                }
+                BlockerReplyIntent::Amend => {
+                    let overlay = serde_json::json!({ "amendment": text });
+                    self.resolve_approval_amended(id, overlay, actor.clone())
+                        .await?;
+                }
+                BlockerReplyIntent::Unrelated => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Posts the ask-which question back into the DM (issue #1862) as a durable
+    /// reply, so it survives a reload the way any transcript line does. Attributed
+    /// to the teammate whose DM this is — the `dm:<agent>` thread names them.
+    #[cfg(feature = "openhuman")]
+    pub(crate) async fn post_blocker_prompt(&self, thread: &str, prompt: &str) -> Result<()> {
+        let agent_id = thread.strip_prefix("dm:").unwrap_or(thread).to_string();
+        self.events
+            .append(
+                &self.id,
+                CompanyEvent::AgentReply {
+                    parent: None,
+                    chat_id: thread.to_string(),
+                    agent_id,
+                    text: prompt.to_string(),
+                    steps: Vec::new(),
+                    task_id: None,
+                    mentions: Vec::new(),
+                    mention_depth: 0,
+                },
+            )
+            .await?;
+        Ok(())
     }
 
     /// Captures a feedback item: persists it to the feedback family and logs a
@@ -5475,6 +5795,80 @@ fn workflow_run_of(parked: &crate::runtime::journal::PendingApproval) -> Option<
     )
     .then(|| parked.effect.run_id.clone())
     .flatten()
+}
+
+/// The root-cause group a parked blocker belongs to (issue #1862), or `None`
+/// for an ordinary approval or an ungrouped blocker.
+///
+/// Reads the `group_key` off the blocker payload, gated on the effect kind so a
+/// non-blocker effect that happens to carry a `group_key`-shaped field is never
+/// mistaken for one.
+fn blocker_group_key_of(effect: &crate::ports::types::Effect) -> Option<String> {
+    if !effect.kind.starts_with(&format!(
+        "{}.",
+        crate::ports::blockers::BLOCKER_EFFECT_PREFIX
+    )) {
+        return None;
+    }
+    serde_json::from_value::<crate::ports::blockers::BlockerPayload>(effect.payload.clone())
+        .ok()?
+        .group_key
+}
+
+/// One root-cause group of parked blockers pending in a single DM (issue
+/// #1862): the approvals that share a cause, plus a one-line label for the
+/// ask-which prompt.
+#[cfg(feature = "openhuman")]
+struct PendingBlockerGroup {
+    /// The shared `group_key`, or `None` for a lone ungrouped blocker.
+    key: Option<String>,
+    /// Every approval in the group — the set a single verdict fans across.
+    ids: Vec<ApprovalId>,
+    /// The first line of the blocker's reason, for disambiguation copy.
+    label: String,
+}
+
+#[cfg(feature = "openhuman")]
+impl PendingBlockerGroup {
+    /// The connection name a `connection:<name>` group is about, used to match
+    /// a reply that names it. `None` for an ungrouped blocker, which therefore
+    /// never auto-resolves out of an ambiguous set — it can only be answered
+    /// from its own card.
+    fn connection_hint(&self) -> Option<&str> {
+        self.key
+            .as_deref()
+            .and_then(|k| k.strip_prefix("connection:"))
+    }
+}
+
+/// What resolving a blocker reply does, decided before anything is written.
+#[cfg(feature = "openhuman")]
+pub(crate) enum BlockerReplyPlan {
+    /// Not a verdict, or no blocker pending here — run an ordinary turn.
+    NotBlocker,
+    /// Settle these approvals with the operator's verdict.
+    Resolve {
+        ids: Vec<ApprovalId>,
+        intent: crate::company::task_intent::BlockerReplyIntent,
+    },
+    /// Several blockers pend and the reply named none — ask which, settle none.
+    AskWhich { prompt: String },
+}
+
+/// The line asked back when a DM holds several distinct blocked things and the
+/// reply did not name one (issue #1862). Says what is blocked and asks which —
+/// and deliberately does not promise that answering resumes anything (#1863).
+#[cfg(feature = "openhuman")]
+fn ask_which_prompt(groups: &[PendingBlockerGroup]) -> String {
+    let items = groups
+        .iter()
+        .enumerate()
+        .map(|(i, group)| format!("{}. {}", i + 1, group.label))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "A few different things are blocked in this chat. Which one do you mean?\n{items}\n\nReply naming it and what you'd like done."
+    )
 }
 
 /// Where a continuation's reply is journaled when the approval it resumes was
@@ -7774,9 +8168,16 @@ mod tests {
             }),
             reason: "the model `gpt-nonexistent` was rejected".to_string(),
             needed: "a model id this provider serves".to_string(),
+            group_key: None,
         };
 
-        let parked = runtime.park_blocker(&payload, "t-1").await;
+        let parked = runtime
+            .park_blocker(
+                &payload,
+                "t-1",
+                crate::company::blocker_sender::BlockerSenderSignals::default(),
+            )
+            .await;
         assert!(
             parked.is_err(),
             "an unjournaled park is reported as a failed park, so the caller returns the card"
@@ -8440,5 +8841,247 @@ mod tests {
             "a wholly refused blocked node starts no continuation, so its checkpoint lineage \
              must be pruned: {remaining:?}"
         );
+    }
+
+    /// Blocker DMs + reply attribution (issue #1862): a parked blocker surfaces
+    /// in the responsible teammate's DM, groups by root cause, and an operator's
+    /// reply routes back as a verdict.
+    #[cfg(feature = "openhuman")]
+    mod blocker_dms {
+        use crate::company::blocker_sender::BlockerSenderSignals;
+        use crate::company::runtime::{BlockerReplyPlan, CompanyRuntime};
+        use crate::company::task_intent::BlockerReplyIntent;
+        use crate::ports::blockers::{BlockerKind, BlockerPayload, BlockerSource, BlockerStep};
+        use crate::ports::types::CompanyId;
+        use std::sync::Arc;
+        use tempfile::TempDir;
+
+        async fn runtime() -> (Arc<CompanyRuntime>, TempDir) {
+            let home = tempfile::Builder::new()
+                .prefix("opencompany-blocker-dms-")
+                .tempdir()
+                .expect("tempdir");
+            let manifest: crate::company::CompanyManifest = toml::from_str(
+                "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+                 [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n\
+                 [[agent]]\nid = \"eng\"\nrole = \"Engineer\"\n",
+            )
+            .expect("manifest");
+            let runtime = Arc::new(
+                crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+                    .with_id(CompanyId::new("acme"))
+                    .build()
+                    .await
+                    .expect("runtime"),
+            );
+            (runtime, home)
+        }
+
+        fn blocker(task_id: &str, group_key: Option<&str>) -> BlockerPayload {
+            BlockerPayload {
+                kind: BlockerKind::Infrastructure,
+                source: BlockerSource::Tool,
+                step: Some(BlockerStep::Task {
+                    task_id: task_id.to_string(),
+                }),
+                reason: format!("could not connect to mcp server for {task_id}"),
+                needed: "the integration reconnected from Apps".to_string(),
+                group_key: group_key.map(str::to_string),
+            }
+        }
+
+        fn assignee(id: &str) -> BlockerSenderSignals {
+            BlockerSenderSignals {
+                started_by: None,
+                owner_desk: None,
+                assignee: Some(id.to_string()),
+            }
+        }
+
+        /// A blocker parks into its teammate's DM: the approval's thread is that
+        /// DM, and a `blocker_parked` notification is filed pointing at it — with
+        /// no payload beyond the one-line title.
+        #[tokio::test]
+        async fn a_blocker_surfaces_in_the_responsible_teammates_dm() {
+            let (runtime, _home) = runtime().await;
+            runtime
+                .park_blocker(&blocker("t-1", None), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+
+            let pending = runtime.pending_approvals();
+            assert_eq!(pending.len(), 1);
+            assert_eq!(
+                pending[0].thread.as_deref(),
+                Some("dm:eng"),
+                "the card routes into the DM with the teammate it is attributed to"
+            );
+
+            let notes = runtime
+                .notifications()
+                .list(runtime.id(), "eng")
+                .await
+                .expect("notifications");
+            let parked = notes
+                .iter()
+                .find(|n| n.notification.kind == "blocker_parked")
+                .expect("a blocker-parked notification is filed");
+            assert_eq!(parked.notification.context.as_deref(), Some("dm:eng"));
+            assert!(
+                parked.notification.title.contains("eng"),
+                "the title names who is blocked: {}",
+                parked.notification.title
+            );
+        }
+
+        /// The sender is resolved, not passed through: a park with no attribution
+        /// still lands in a real DM — the orchestrator's.
+        #[tokio::test]
+        async fn an_unattributed_blocker_falls_to_the_orchestrator_dm() {
+            let (runtime, _home) = runtime().await;
+            runtime
+                .park_blocker(
+                    &blocker("t-1", None),
+                    "t-1",
+                    BlockerSenderSignals::default(),
+                )
+                .await
+                .expect("parks");
+            assert_eq!(
+                runtime.pending_approvals()[0].thread.as_deref(),
+                Some("dm:ceo"),
+                "with nothing named, the first (orchestrator) agent answers"
+            );
+        }
+
+        /// Blockers sharing a root cause project as one group and are named by
+        /// the projection's `group_key`.
+        #[tokio::test]
+        async fn blockers_sharing_a_cause_group_together() {
+            let (runtime, _home) = runtime().await;
+            for task in ["t-1", "t-2", "t-3"] {
+                runtime
+                    .park_blocker(
+                        &blocker(task, Some("connection:slack")),
+                        task,
+                        assignee("eng"),
+                    )
+                    .await
+                    .expect("parks");
+            }
+            let members = runtime.blocker_group_members("connection:slack");
+            assert_eq!(
+                members.len(),
+                3,
+                "every card on the broken connection is one group"
+            );
+            for summary in runtime.pending_approvals() {
+                assert_eq!(summary.group_key.as_deref(), Some("connection:slack"));
+            }
+        }
+
+        /// A reply in a DM with a single pending blocker resolves it, and a
+        /// grouped reply fans the verdict to every card in the group.
+        #[tokio::test]
+        async fn a_reply_resolves_the_whole_group_and_fans_the_verdict() {
+            let (runtime, _home) = runtime().await;
+            for task in ["t-1", "t-2"] {
+                runtime
+                    .park_blocker(
+                        &blocker(task, Some("connection:slack")),
+                        task,
+                        assignee("eng"),
+                    )
+                    .await
+                    .expect("parks");
+            }
+            let plan = runtime
+                .plan_blocker_reply("dm:eng", None, "go ahead and retry")
+                .await
+                .expect("plan");
+            let ids = match plan {
+                BlockerReplyPlan::Resolve { ids, intent } => {
+                    assert_eq!(intent, BlockerReplyIntent::Retry);
+                    assert_eq!(ids.len(), 2, "one card, both parks");
+                    ids
+                }
+                _ => panic!("a single group in the DM resolves"),
+            };
+            runtime
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Retry, "go ahead and retry", None)
+                .await
+                .expect("applies");
+            assert!(
+                runtime.pending_approvals().is_empty(),
+                "the verdict fanned to every card in the group"
+            );
+        }
+
+        /// An unrelated reply is not a verdict — it falls through to an ordinary
+        /// turn rather than settling the blocker.
+        #[tokio::test]
+        async fn an_unrelated_reply_is_not_a_verdict() {
+            let (runtime, _home) = runtime().await;
+            runtime
+                .park_blocker(&blocker("t-1", None), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            let plan = runtime
+                .plan_blocker_reply("dm:eng", None, "hey, how's it going?")
+                .await
+                .expect("plan");
+            assert!(
+                matches!(plan, BlockerReplyPlan::NotBlocker),
+                "a greeting runs as a normal turn and settles nothing"
+            );
+            assert_eq!(
+                runtime.pending_approvals().len(),
+                1,
+                "the blocker still pends"
+            );
+        }
+
+        /// Two distinct blocked things in one DM: a bare verdict asks which; a
+        /// verdict naming one resolves only that one.
+        #[tokio::test]
+        async fn several_blockers_disambiguate_by_name() {
+            let (runtime, _home) = runtime().await;
+            runtime
+                .park_blocker(
+                    &blocker("t-1", Some("connection:slack")),
+                    "t-1",
+                    assignee("eng"),
+                )
+                .await
+                .expect("parks");
+            runtime
+                .park_blocker(
+                    &blocker("t-2", Some("connection:notion")),
+                    "t-2",
+                    assignee("eng"),
+                )
+                .await
+                .expect("parks");
+
+            let ambiguous = runtime
+                .plan_blocker_reply("dm:eng", None, "retry it")
+                .await
+                .expect("plan");
+            assert!(
+                matches!(ambiguous, BlockerReplyPlan::AskWhich { .. }),
+                "a bare verdict over two blocked things asks which"
+            );
+
+            let named = runtime
+                .plan_blocker_reply("dm:eng", None, "retry slack")
+                .await
+                .expect("plan");
+            match named {
+                BlockerReplyPlan::Resolve { ids, .. } => {
+                    assert_eq!(ids, runtime.blocker_group_members("connection:slack"));
+                }
+                _ => panic!("naming the connection resolves only its group"),
+            }
+        }
     }
 }

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -5146,7 +5146,7 @@ impl CompanyRuntime {
     /// blocker anchor is an `ApprovalParked` event, so neither steals the
     /// other's replies.
     #[cfg(feature = "openhuman")]
-    async fn parked_blocker_at(&self, parent: EventSeq) -> Result<Option<ApprovalId>> {
+    async fn parked_blocker_at(&self, desk: &str, parent: EventSeq) -> Result<Option<ApprovalId>> {
         let stored = self.events.read_from(&self.id, parent, 1).await?;
         let Some(stored) = stored.into_iter().next() else {
             return Ok(None);
@@ -5159,8 +5159,15 @@ impl CompanyRuntime {
             CompanyEvent::ApprovalParked {
                 approval_id,
                 effect_kind,
+                thread,
                 ..
-            } if effect_kind.starts_with(&prefix) && self.is_blocker(&approval_id) => {
+            } if effect_kind.starts_with(&prefix)
+                && crate::server::chat_history::same_conversation(
+                    thread.as_deref(),
+                    Some(desk),
+                )
+                && self.is_blocker(&approval_id) =>
+            {
                 Ok(Some(approval_id))
             }
             _ => Ok(None),
@@ -5189,7 +5196,7 @@ impl CompanyRuntime {
 
         let explicit = match parent {
             Some(parent) => self
-                .parked_blocker_at(parent)
+                .parked_blocker_at(desk, parent)
                 .await?
                 .map(|id| self.blocker_group_of(&id)),
             None => None,
@@ -9082,6 +9089,58 @@ mod tests {
                 }
                 _ => panic!("naming the connection resolves only its group"),
             }
+        }
+
+        /// An explicit reply settles only a blocker parked in the same
+        /// conversation: a verdict threaded to another DM's blocker card, sent
+        /// from a desk with no blocker of its own, runs as an ordinary turn.
+        #[tokio::test]
+        async fn an_explicit_reply_stays_within_its_conversation() {
+            let (runtime, _home) = runtime().await;
+            runtime
+                .park_blocker(
+                    &blocker("t-1", Some("connection:slack")),
+                    "t-1",
+                    assignee("eng"),
+                )
+                .await
+                .expect("parks");
+            let parent = runtime
+                .events
+                .read_from(
+                    runtime.id(),
+                    crate::ports::types::EventSeq::new(0),
+                    usize::MAX,
+                )
+                .await
+                .expect("read")
+                .into_iter()
+                .find(|stored| {
+                    matches!(
+                        stored.event,
+                        crate::ports::types::CompanyEvent::ApprovalParked { .. }
+                    )
+                })
+                .expect("the park is on the log")
+                .seq;
+
+            let same = runtime
+                .plan_blocker_reply("dm:eng", Some(parent), "retry")
+                .await
+                .expect("plan");
+            assert!(
+                matches!(same, BlockerReplyPlan::Resolve { .. }),
+                "a reply in the blocker's own DM resolves it"
+            );
+
+            let cross = runtime
+                .plan_blocker_reply("dm:ops", Some(parent), "retry")
+                .await
+                .expect("plan");
+            assert!(
+                matches!(cross, BlockerReplyPlan::NotBlocker),
+                "the same verdict from another conversation settles nothing"
+            );
         }
     }
 }

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -980,13 +980,32 @@ pub fn classify_blocker_reply(text: &str) -> BlockerReplyIntent {
     BlockerReplyIntent::Amend
 }
 
-/// Whether any whole word of `lower` is in `words` — the same word-split match
-/// [`contains_action`] uses, so `okay` matches `ok`-the-word but `okra` never
-/// matches `ok`.
+/// Whether any whole word of `lower` is in `words` and is not negated by a
+/// preceding "not"/"don't"/… within two tokens — so `okay` matches `ok`-the-word
+/// but `okra` never matches `ok`, and `don't retry` no longer reads as a retry.
 fn mentions_any(lower: &str, words: &[&str]) -> bool {
-    lower
+    let flattened = lower.replace(['\'', '\u{2019}'], "");
+    let tokens: Vec<&str> = flattened
         .split(|c: char| !c.is_alphanumeric())
-        .any(|word| words.contains(&word))
+        .filter(|token| !token.is_empty())
+        .collect();
+    tokens
+        .iter()
+        .enumerate()
+        .any(|(i, word)| words.contains(word) && !negated_before(&tokens, i))
+}
+
+/// Negations that flip a following verdict word to a non-verdict, apostrophes
+/// already stripped so `don't` reads as `dont`.
+const NEGATIONS: &[&str] = &[
+    "not", "no", "never", "cannot", "dont", "doesnt", "wont", "cant", "isnt", "arent",
+];
+
+/// Whether a negation sits within the two tokens before `i`.
+fn negated_before(tokens: &[&str], i: usize) -> bool {
+    tokens[i.saturating_sub(2)..i]
+        .iter()
+        .any(|token| NEGATIONS.contains(token))
 }
 
 /// Words that carry no instruction — greetings, thanks, fillers. A message made
@@ -1739,6 +1758,27 @@ mod blocker_reply_tests {
             classify_blocker_reply("order some okra for the office"),
             BlockerReplyIntent::Amend,
             "a substring of a verdict word is not that verdict"
+        );
+    }
+
+    #[test]
+    fn a_negated_verdict_word_is_not_that_verdict() {
+        for reply in [
+            "don't retry this",
+            "do not retry",
+            "not approved",
+            "no, cancel",
+        ] {
+            assert_ne!(
+                classify_blocker_reply(reply),
+                BlockerReplyIntent::Retry,
+                "a negated verdict word must not read as the positive verdict: {reply:?}"
+            );
+        }
+        assert_ne!(
+            classify_blocker_reply("no, cancel"),
+            BlockerReplyIntent::Cancel,
+            "a negated cancel is not a cancel"
         );
     }
 }

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -887,6 +887,166 @@ fn truncate(s: &str, max: usize) -> String {
     out
 }
 
+/// What an operator's reply to a parked blocker asks the company to do (issue
+/// #1862).
+///
+/// The four verdicts lower onto the existing [`Approve`/`Deny`] resolve surface
+/// — no new gate arm — so answering a blocker is the same durable decision as
+/// answering any approval. [`Unrelated`](Self::Unrelated) is the escape: a
+/// greeting or a question back is not a verdict, and the reply runs as an
+/// ordinary chat turn instead of settling anything.
+///
+/// Deliberately says nothing about resumption. Resolving a blocker is inert
+/// until #1863; this only records which verdict the operator gave.
+///
+/// [`Approve`/`Deny`]: crate::ports::types::Verdict
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockerReplyIntent {
+    /// Run the stopped step again as it was.
+    Retry,
+    /// Answer or correct it — the reply text carries what changed.
+    Amend,
+    /// Drop this blocker and let the work go on without it.
+    Skip,
+    /// Abandon the stopped work.
+    Cancel,
+    /// Not a verdict — ordinary conversation that must run as a normal turn.
+    Unrelated,
+}
+
+/// Words that plainly abandon the work — checked first, because "stop" and
+/// "drop" outrank every other reading.
+const CANCEL_WORDS: &[&str] = &[
+    "cancel", "abort", "abandon", "drop", "forget", "scrap", "kill", "discard",
+];
+
+/// Words that waive the blocker but keep the work going.
+const SKIP_WORDS: &[&str] = &["skip", "waive", "ignore", "bypass", "omit"];
+
+/// Words that ask for the same step again, unchanged. Strong signals only — a
+/// bare "yes"/"ok" is a [`GREETINGS`] entry and stays [`Unrelated`], so a
+/// passing affirmation in an ordinary sentence never reads as a verdict.
+///
+/// [`Unrelated`]: BlockerReplyIntent::Unrelated
+const RETRY_WORDS: &[&str] = &[
+    "retry", "again", "proceed", "continue", "approve", "approved", "rerun", "redo",
+];
+
+/// Classifies an operator's reply to a parked blocker (issue #1862),
+/// lexical-first and conservative.
+///
+/// The order is the priority: an abandon word wins over a waive word wins over
+/// a retry word, because "cancel it, but retry the other one" must read as a
+/// cancel of the thing in hand. A reply that is empty, a greeting, or a
+/// question back is [`Unrelated`](BlockerReplyIntent::Unrelated) — the operator
+/// is talking, not deciding. Everything else is
+/// [`Amend`](BlockerReplyIntent::Amend): a substantive line in a blocked
+/// teammate's DM is taken as answering the question, and the text becomes the
+/// correction.
+///
+/// Model-assisted disambiguation is #678; this is the lexical tier that abstains
+/// to [`Unrelated`] rather than guessing.
+pub fn classify_blocker_reply(text: &str) -> BlockerReplyIntent {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return BlockerReplyIntent::Unrelated;
+    }
+    let lower = trimmed.to_lowercase();
+    let bare = bare_message(&lower);
+    if GREETINGS.contains(&bare) {
+        return BlockerReplyIntent::Unrelated;
+    }
+    let core = strip_lead_ins(&lower);
+    // A question back is the operator asking, not answering — it must run as a
+    // normal turn so the teammate can respond, not settle the blocker.
+    if is_question(core) {
+        return BlockerReplyIntent::Unrelated;
+    }
+    if mentions_any(&lower, CANCEL_WORDS) {
+        return BlockerReplyIntent::Cancel;
+    }
+    if mentions_any(&lower, SKIP_WORDS) {
+        return BlockerReplyIntent::Skip;
+    }
+    if mentions_any(&lower, RETRY_WORDS) || lower.contains("go ahead") {
+        return BlockerReplyIntent::Retry;
+    }
+    // A purely social line — "hello there", "thanks so much" — carries no
+    // answer, so it runs as a normal turn rather than being taken as a
+    // correction. A single non-social word tips it to a substantive answer.
+    if is_pure_social(&lower) {
+        return BlockerReplyIntent::Unrelated;
+    }
+    BlockerReplyIntent::Amend
+}
+
+/// Whether any whole word of `lower` is in `words` — the same word-split match
+/// [`contains_action`] uses, so `okay` matches `ok`-the-word but `okra` never
+/// matches `ok`.
+fn mentions_any(lower: &str, words: &[&str]) -> bool {
+    lower
+        .split(|c: char| !c.is_alphanumeric())
+        .any(|word| words.contains(&word))
+}
+
+/// Words that carry no instruction — greetings, thanks, fillers. A message made
+/// only of these is social, not an answer.
+const SOCIAL_WORDS: &[&str] = &[
+    "hi",
+    "hii",
+    "hiya",
+    "hey",
+    "hello",
+    "howdy",
+    "yo",
+    "sup",
+    "gm",
+    "good",
+    "morning",
+    "evening",
+    "afternoon",
+    "there",
+    "thanks",
+    "thank",
+    "you",
+    "ty",
+    "thx",
+    "cheers",
+    "so",
+    "much",
+    "ok",
+    "okay",
+    "k",
+    "kk",
+    "cool",
+    "nice",
+    "great",
+    "awesome",
+    "perfect",
+    "sure",
+    "np",
+    "sg",
+    "lol",
+    "haha",
+    "please",
+];
+
+/// Whether every word of `lower` is a [`SOCIAL_WORDS`] filler — a non-empty
+/// message with nothing to act on.
+fn is_pure_social(lower: &str) -> bool {
+    let mut seen = false;
+    for word in lower.split(|c: char| !c.is_alphanumeric()) {
+        if word.is_empty() {
+            continue;
+        }
+        seen = true;
+        if !SOCIAL_WORDS.contains(&word) {
+            return false;
+        }
+    }
+    seen
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1473,5 +1633,112 @@ mod tests {
             assert!(!reply.trim().is_empty());
             assert!(reply.chars().count() <= 80, "{reply:?} is too long");
         }
+    }
+}
+
+#[cfg(test)]
+mod blocker_reply_tests {
+    use super::*;
+
+    #[test]
+    fn a_retry_word_asks_for_the_same_step_again() {
+        for reply in [
+            "retry",
+            "try it again",
+            "go ahead",
+            "yes, proceed",
+            "approved",
+        ] {
+            assert_eq!(
+                classify_blocker_reply(reply),
+                BlockerReplyIntent::Retry,
+                "reply: {reply}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_skip_word_waives_the_blocker() {
+        for reply in [
+            "skip it",
+            "waive this",
+            "just ignore it",
+            "bypass the check",
+        ] {
+            assert_eq!(
+                classify_blocker_reply(reply),
+                BlockerReplyIntent::Skip,
+                "reply: {reply}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_cancel_word_abandons_the_work() {
+        for reply in [
+            "cancel",
+            "abort this",
+            "drop it",
+            "forget about it",
+            "scrap the task",
+        ] {
+            assert_eq!(
+                classify_blocker_reply(reply),
+                BlockerReplyIntent::Cancel,
+                "reply: {reply}"
+            );
+        }
+    }
+
+    /// Abandon outranks retry: "cancel this and retry the other" is a cancel of
+    /// the thing in hand.
+    #[test]
+    fn abandon_outranks_retry_when_both_appear() {
+        assert_eq!(
+            classify_blocker_reply("cancel this one, retry the other"),
+            BlockerReplyIntent::Cancel
+        );
+    }
+
+    #[test]
+    fn a_substantive_answer_is_an_amendment() {
+        for reply in [
+            "use gpt-4o-mini instead",
+            "deploy to staging, not prod",
+            "the brief in the January doc is the current one",
+        ] {
+            assert_eq!(
+                classify_blocker_reply(reply),
+                BlockerReplyIntent::Amend,
+                "reply: {reply}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_greeting_or_a_question_back_is_unrelated() {
+        for reply in [
+            "hey",
+            "hello there",
+            "what do you mean?",
+            "which one is blocked?",
+            "   ",
+        ] {
+            assert_eq!(
+                classify_blocker_reply(reply),
+                BlockerReplyIntent::Unrelated,
+                "reply: {reply}"
+            );
+        }
+    }
+
+    /// The word match is on whole words: `okra` is not `ok`.
+    #[test]
+    fn a_verdict_word_matches_only_as_a_whole_word() {
+        assert_eq!(
+            classify_blocker_reply("order some okra for the office"),
+            BlockerReplyIntent::Amend,
+            "a substring of a verdict word is not that verdict"
+        );
     }
 }

--- a/src/harness/built_in/blockers.rs
+++ b/src/harness/built_in/blockers.rs
@@ -210,6 +210,41 @@ fn contains_bounded(haystack: &str, leaf: &str) -> bool {
     })
 }
 
+/// The connection a stop is about, when the reason names one — the key that
+/// folds ten cards stalled on one broken integration into a single question
+/// (issue #1862).
+///
+/// Only the recognised connection shapes carry a groupable identity: the phrase
+/// that identified the stop as an integration failure sits beside a backticked
+/// name (`could not connect to mcp server \`slack\``), and that name is the
+/// connection. Everything else returns `None` and groups with nothing — the
+/// same conservative default the classifier itself keeps, for the same reason:
+/// a wrong group merges two unrelated questions into one card, which is worse
+/// than two honest cards.
+///
+/// Deliberately not a general backtick scan: an auth or model-id reason also
+/// carries a backticked token (the rejected model, a key label), and grouping
+/// those would collapse distinct provider stops. The gate is that the reason
+/// matched an integration-connection shape in the first place.
+pub fn connection_group_key(reason: &str) -> Option<String> {
+    let lower = reason.to_ascii_lowercase();
+    const CONNECTION_MARKERS: &[&str] = &[
+        "could not connect to mcp server",
+        "mcp server is not connected",
+        "connection is not authorised",
+        "reconnect the app",
+    ];
+    if !CONNECTION_MARKERS.iter().any(|m| lower.contains(m)) {
+        return None;
+    }
+    let name = reason
+        .split('`')
+        .nth(1)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())?;
+    Some(format!("connection:{name}"))
+}
+
 /// The class a planning pass's missing prerequisite parks as.
 ///
 /// Not message-matched: `settle_blocked` already *knows* the card cannot
@@ -399,6 +434,37 @@ mod test {
         assert!(PREREQ_BLOCKER.kind.parks());
         assert!(AGENT_QUESTION_BLOCKER.kind.parks());
     }
+
+    /// Two cards stalled on the same integration carry the same group key, so
+    /// the console folds them into one question instead of two.
+    #[test]
+    fn a_named_connection_groups_by_its_name() {
+        let a = connection_group_key("could not connect to mcp server `slack`")
+            .expect("a named connection groups");
+        let b = connection_group_key("dispatch failed: could not connect to mcp server `slack`")
+            .expect("the same connection, a different reason");
+        assert_eq!(a, b);
+        assert_eq!(a, "connection:slack");
+        assert_ne!(
+            connection_group_key("could not connect to mcp server `notion`"),
+            Some(a),
+            "a different server is a different question"
+        );
+    }
+
+    /// The gate is that the reason matched a connection shape — a backticked
+    /// token in an auth or model-id reason is not a connection and must not
+    /// group those distinct stops together.
+    #[test]
+    fn a_backtick_outside_a_connection_shape_does_not_group() {
+        assert_eq!(connection_group_key("unknown model `gpt-nope`"), None);
+        assert_eq!(connection_group_key("invalid api key `sk-123`"), None);
+        assert_eq!(
+            connection_group_key("could not connect to mcp server"),
+            None,
+            "a connection shape with no name has nothing to group by"
+        );
+    }
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -528,6 +594,9 @@ impl openhuman_core::openhuman::tools::traits::Tool for EscalateToHumanTool {
             step: None,
             reason: reason.clone(),
             needed: AGENT_QUESTION_BLOCKER.needed.to_string(),
+            // A question is particular to its own card; nothing else shares its
+            // answer, so it groups with nothing.
+            group_key: None,
         };
         let effect = crate::ports::types::Effect {
             kind: payload.effect_kind(),

--- a/src/harness/built_in/blockers.rs
+++ b/src/harness/built_in/blockers.rs
@@ -234,10 +234,11 @@ pub fn connection_group_key(reason: &str) -> Option<String> {
         "connection is not authorised",
         "reconnect the app",
     ];
-    if !CONNECTION_MARKERS.iter().any(|m| lower.contains(m)) {
-        return None;
-    }
-    let name = reason
+    let marker_end = CONNECTION_MARKERS
+        .iter()
+        .filter_map(|m| lower.find(m).map(|pos| pos + m.len()))
+        .min()?;
+    let name = reason[marker_end..]
         .split('`')
         .nth(1)
         .map(str::trim)
@@ -463,6 +464,17 @@ mod test {
             connection_group_key("could not connect to mcp server"),
             None,
             "a connection shape with no name has nothing to group by"
+        );
+    }
+
+    /// A backticked token before the connection marker — a tool name in the
+    /// prose — is not the connection; the name after the marker is.
+    #[test]
+    fn the_name_is_read_after_the_connection_marker() {
+        assert_eq!(
+            connection_group_key("tool `search` failed: could not connect to mcp server `slack`"),
+            Some("connection:slack".to_string()),
+            "the connection is the server after the marker, not the earlier tool token"
         );
     }
 }

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -2969,6 +2969,7 @@ impl HarnessBrain {
                     task_id: task_id.to_string(),
                 },
                 reason,
+                crate::harness::built_in::blockers::connection_group_key(reason),
                 run_id,
             ),
             None => TaskRunEnd::Failed,
@@ -3012,6 +3013,7 @@ impl HarnessBrain {
         class: crate::harness::built_in::blockers::BlockerClass,
         step: BlockerStep,
         reason: &str,
+        group_key: Option<String>,
         run_id: Option<&str>,
     ) -> TaskRunEnd {
         if !class.kind.parks() {
@@ -3023,6 +3025,7 @@ impl HarnessBrain {
             step: Some(step),
             reason: reason.to_string(),
             needed: class.needed.to_string(),
+            group_key,
         };
         let effect = Effect {
             kind: payload.effect_kind(),

--- a/src/harness/built_in/planning.rs
+++ b/src/harness/built_in/planning.rs
@@ -506,6 +506,9 @@ pub async fn run_planning_pass(runtime: Arc<CompanyRuntime>, task_id: String) {
             needed: crate::harness::built_in::blockers::PREREQ_BLOCKER
                 .needed
                 .to_string(),
+            // A card's own missing prerequisites are particular to that card —
+            // they group with nothing.
+            group_key: None,
         };
         settle_blocked(
             &runtime,
@@ -719,8 +722,13 @@ async fn settle_blocked(
     // Parked **before** the card is written, so the column the operator sees
     // and the queue they would answer from cannot disagree: a card that says
     // `paused` while nothing is parked is a card nothing can release.
+    let signals = crate::company::blocker_sender::BlockerSenderSignals {
+        started_by: None,
+        owner_desk: None,
+        assignee: (!card.assignee.is_empty()).then(|| card.assignee.clone()),
+    };
     let parked = match blocker {
-        Some(payload) => match runtime.park_blocker(&payload, task_id).await {
+        Some(payload) => match runtime.park_blocker(&payload, task_id, signals).await {
             Ok(approval_id) => {
                 tracing::info!(
                     company = %runtime.id(),

--- a/src/ports/blockers.rs
+++ b/src/ports/blockers.rs
@@ -270,6 +270,19 @@ pub struct BlockerPayload {
     /// What would unblock it — the question being asked, or the action being
     /// requested.
     pub needed: String,
+    /// The root cause many parks share — a connection id, an integration name —
+    /// so that ten cards stalled on one broken OAuth grant read as one question,
+    /// not ten. `None` when the stop is particular to this step and groups with
+    /// nothing.
+    ///
+    /// Provenance, not routing: it is the id the classify site already knows
+    /// (which connection, which Composio account, which MCP server), copied
+    /// verbatim. Nothing branches on it — the console folds parks that carry the
+    /// same key into a single card, and a resolve fans its verdict to every park
+    /// in the group. Additive with a serde default, so a park written before
+    /// this field existed reads back as ungrouped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_key: Option<String>,
 }
 
 impl BlockerPayload {
@@ -426,8 +439,33 @@ mod test {
             }),
             reason: "the model id `gpt-nonexistent` was rejected".to_string(),
             needed: "a model id this provider serves".to_string(),
+            group_key: None,
         };
         assert_eq!(payload.effect_kind(), "blocker.infrastructure");
+    }
+
+    /// `group_key` is additive: a payload serialized before it existed — with no
+    /// such key — reads back as ungrouped rather than failing to parse, and a
+    /// present key round-trips.
+    #[test]
+    fn group_key_is_additive_and_round_trips() {
+        let legacy = serde_json::json!({
+            "kind": "infrastructure",
+            "source": "tool",
+            "reason": "could not connect to mcp server `slack`",
+            "needed": "the integration reconnected from Apps"
+        });
+        let parsed: BlockerPayload =
+            serde_json::from_value(legacy).expect("a pre-field payload still parses");
+        assert_eq!(parsed.group_key, None);
+
+        let grouped = BlockerPayload {
+            group_key: Some("connection:slack".to_string()),
+            ..parsed
+        };
+        let json = serde_json::to_value(&grouped).expect("serializes");
+        let back: BlockerPayload = serde_json::from_value(json).expect("parses");
+        assert_eq!(back.group_key.as_deref(), Some("connection:slack"));
     }
 
     /// The step survives a round trip through JSON, because that is how it

--- a/src/runtime/approval_ownership.rs
+++ b/src/runtime/approval_ownership.rs
@@ -147,6 +147,7 @@ mod test {
             broadly_deniable: false,
             contents_hidden: false,
             batch: None,
+            group_key: None,
         }
     }
 

--- a/src/runtime/maintenance.rs
+++ b/src/runtime/maintenance.rs
@@ -840,6 +840,7 @@ mod test {
             }),
             reason: "the model `gpt-nonexistent` was rejected".to_string(),
             needed: "a model id this provider serves".to_string(),
+            group_key: None,
         }
     }
 
@@ -881,7 +882,11 @@ mod test {
             .await
             .expect("seed");
         let approval_id = runtime
-            .park_blocker(&blocker_payload("t-1"), "t-1")
+            .park_blocker(
+                &blocker_payload("t-1"),
+                "t-1",
+                crate::company::blocker_sender::BlockerSenderSignals::default(),
+            )
             .await
             .expect("parks");
 
@@ -940,7 +945,11 @@ mod test {
             .await
             .expect("seed");
         runtime
-            .park_blocker(&blocker_payload("t-1"), "t-1")
+            .park_blocker(
+                &blocker_payload("t-1"),
+                "t-1",
+                crate::company::blocker_sender::BlockerSenderSignals::default(),
+            )
             .await
             .expect("parks");
         assert_eq!(runtime.pending_approvals().len(), 1);
@@ -1007,7 +1016,11 @@ mod test {
             .await
             .expect("seed");
         runtime
-            .park_blocker(&blocker_payload("t-3"), "t-3")
+            .park_blocker(
+                &blocker_payload("t-3"),
+                "t-3",
+                crate::company::blocker_sender::BlockerSenderSignals::default(),
+            )
             .await
             .expect("parks");
 

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -354,6 +354,21 @@ pub struct ApprovalSummary {
     /// ones, which is less information than an admin gets and still the truth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub batch: Option<String>,
+    /// The root cause a blocker shares with its siblings (issue #1862) — a
+    /// connection id, an integration name — so the console folds every card
+    /// stalled on one broken integration into a single question, and one
+    /// verdict fans back to them all.
+    ///
+    /// Distinct from [`batch`](Self::batch): a batch is "asked in the same
+    /// turn", a group is "blocked by the same cause", and two runs that never
+    /// shared a turn can still share a broken OAuth grant. Read off the blocker
+    /// payload's own `group_key`, so a console never guesses the grouping the
+    /// classifier already recorded.
+    ///
+    /// `None` — and omitted from the wire — for an ordinary approval and for a
+    /// blocker particular to its own step. A console groups those alone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_key: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/server/approval_visibility.rs
+++ b/src/server/approval_visibility.rs
@@ -177,6 +177,7 @@ mod tests {
             broadly_deniable: false,
             contents_hidden: false,
             batch: Some("turn-1".to_string()),
+            group_key: None,
         }
     }
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -2897,6 +2897,64 @@ async fn chat_and_emit(
             })));
         }
     }
+    // Issue #1862: a reply that answers a parked blocker settles its verdict
+    // rather than running a fresh turn. A reply parented to a blocker card
+    // resolves that card's group; free text in a DM that holds a single blocked
+    // thing resolves it; free text where several are blocked asks which. Runs
+    // after the review check above — the two anchor on different event kinds, so
+    // neither steals the other's replies — and only reaches here when the reply
+    // is a verdict for a blocker actually pending in this conversation;
+    // otherwise it falls through to the ordinary turn.
+    #[cfg(feature = "openhuman")]
+    {
+        let _serialized = runtime.task_writes.lock().await;
+        match runtime
+            .plan_blocker_reply(&desk, parent, &message.text)
+            .await?
+        {
+            crate::company::runtime::BlockerReplyPlan::Resolve { ids, intent } => {
+                let accepted =
+                    accept_chat_turn(&runtime, id, &message, by.as_ref(), parent, &desk).await?;
+                let message_id = accepted.message_seq.value().to_string();
+                let turn_id = accepted.turn_id.clone();
+                let applied = runtime
+                    .apply_blocker_reply(&ids, intent, &message.text, by.as_ref())
+                    .await
+                    .map_err(ApiError);
+                settle_chat_turn(&runtime, id, turn_id.as_deref(), applied.as_ref().err()).await;
+                applied?;
+                return Ok(ChatOk::Settled(Box::new(ChatResponse {
+                    responses: Vec::new(),
+                    message_id: Some(message_id),
+                    still_awaiting: None,
+                    turn_id,
+                    outcome: None,
+                    review_feedback_applied: Some(true),
+                })));
+            }
+            crate::company::runtime::BlockerReplyPlan::AskWhich { prompt } => {
+                let accepted =
+                    accept_chat_turn(&runtime, id, &message, by.as_ref(), parent, &desk).await?;
+                let message_id = accepted.message_seq.value().to_string();
+                let turn_id = accepted.turn_id.clone();
+                let posted = runtime
+                    .post_blocker_prompt(&desk, &prompt)
+                    .await
+                    .map_err(ApiError);
+                settle_chat_turn(&runtime, id, turn_id.as_deref(), posted.as_ref().err()).await;
+                posted?;
+                return Ok(ChatOk::Settled(Box::new(ChatResponse {
+                    responses: Vec::new(),
+                    message_id: Some(message_id),
+                    still_awaiting: None,
+                    turn_id,
+                    outcome: None,
+                    review_feedback_applied: Some(true),
+                })));
+            }
+            crate::company::runtime::BlockerReplyPlan::NotBlocker => {}
+        }
+    }
     // The turn runs on its own task, and the replies are journaled there too
     // (issue #882). Both used to sit in this handler's future, which hyper drops
     // the moment the peer goes away — and a reverse proxy in front of a hosted

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1621,6 +1621,9 @@ impl HarnessAgentRunner {
             }),
             reason: message.to_string(),
             needed: needed.to_string(),
+            // Nodes across runs stalled on one broken integration read as one
+            // question — populated only when the reason names a connection.
+            group_key: crate::harness::built_in::blockers::connection_group_key(message),
         };
         let effect = crate::ports::types::Effect {
             kind: payload.effect_kind(),


### PR DESCRIPTION
## Summary
Epic #1860 — a parked blocker (a stop a person can answer) now surfaces as a **card in the operator's DM with the responsible agent**, and the operator's reply is classified into a verdict and recorded. Part of the "blockers are conversations" loop; the actual **resume** of the stopped step is #1863 (deliberately inert here — this PR records and fans the verdict but promises no resumption).

Builds on #1852-P2 (#1981, reply-to-bubble machinery, reused) and #1891 (the blocked-card decide surface, specialized not rebuilt).

## API Or Behavior Changes
- **Park delivery:** `park_blocker` resolves the responsible sender (triggering agent → owning-desk lead → card assignee → orchestrator → host), stamps `thread = dm:<sender>` onto the `ApprovalConversation` + `ApprovalParked` event, and fires `notify_blocker_parked` (title-only, redaction contract preserved) so a blocker lands as a DM with a badge that survives a closed tab.
- **Root-cause grouping:** additive `group_key: Option<String>` on `BlockerPayload` (connection id), so N parks on one broken connection fold into one card and a resolve fans across the group.
- **Reply attribution:** a free-text reply in a blocker's DM is classified (Retry/Amend/Skip/Cancel/Unrelated) at `chat_and_emit` and lowered onto the existing Approve/Deny/amended surface; unrelated messages still start a normal turn; ambiguous-with-several asks which.
- **Console:** the approval card specializes for blocker kinds (reason + Blocked chip + needed + reconnect-in-Apps hint), folds grouped blockers by root cause, and badges the DM on `blocker_parked`.

## Tests
Feature `openhuman`, all foreground/green: `cargo fmt` · both clippy (`-D warnings`, incl. gated) · `cargo check --all-features`. Rust: `company::` 942 + `server::operator` 168 + new `blocker_dms` (6), reply classifier (8), sender (7), grouping/ports — 0 failed. Frontend: typecheck (×3) + `vitest run` 4299 passed (incl. 15 new) + build.

Live-verified on a running instance against a real company: our code loads, inference runs real turns, a task dispatches, and the blocker condition (unwired capability) is reached; the full park→reply→resume click-through is proven by the suites (resume itself is #1863).

## Documentation
N/A — internal harness + console behavior; no public API or doc surface.

Closes #1862

<!-- notes for review -->
- **No i18n fan-out:** the OpenCompany console has no locale system (strings are English literals); the "14 locales" rule is an openhuman-app thing — nothing to translate. Flagged as a conscious call.
- **Reply affordance = the DM composer** (implicit tier): any free-text reply in a blocker's DM is intercepted and routed to a verdict — fully functional end-to-end. A dedicated on-card textarea is a bounded follow-up (needs a new `onReply` threaded through the timeline).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parked blockers are routed to the responsible teammate’s direct message thread.
  * Related blockers caused by the same connection or integration are grouped into a single approval card.
  * Blocker cards now show status, reason, requirements, reconnection guidance, and relevant actions.
  * Replies can retry, amend, skip, or cancel blockers; multiple blockers prompt for clarification.
  * Parked blockers now generate unread badges and clear when their direct message is opened.

* **Bug Fixes**
  * Blocker details are handled safely when optional information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->