### PR TITLE
feat(runtime): resume a parked blocker when its operator answers (#1863)

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2307,8 +2307,247 @@ impl CompanyRuntime {
                 }
                 ResolveReceipt::Settled(event) => *event,
             };
+            // Issue #1863: a resolved blocker re-enters the stopped step rather
+            // than redispatching a grant or running a brain continuation. The
+            // answer was armed on the grant set's blocker side-channel by
+            // `apply_blocker_reply`; taking it here both recognises the blocker
+            // and consumes it, and every non-blocker resolution finds nothing
+            // and falls through to `continue_turn` unchanged.
+            #[cfg(feature = "openhuman")]
+            if let CompanyEvent::ApprovalResolved { approval_id, .. } = &event
+                && let Some(resolution) = rt.grants.take_blocker_resolution(approval_id)
+            {
+                return rt.resume_blocker(approval_id, resolution).await;
+            }
             rt.continue_turn(event).await
         })
+    }
+
+    /// Re-enters the step a resolved blocker stopped, carrying the operator's
+    /// answer (issue #1863) — the resume half `park_blocker` deliberately left
+    /// inert.
+    ///
+    /// The fork the whole tier turns on, reached from
+    /// [`spawn_follow_up`](Self::spawn_follow_up) once the verdict is durable.
+    /// A resuming verdict re-dispatches the stopped work carrying the answer; a
+    /// [`Cancel`](crate::ports::blockers::BlockerVerdict::Cancel) settles it and
+    /// starts nothing — the short-circuit that runs *before* any cycle. Which
+    /// step is re-entered is read off the blocker's own
+    /// [`BlockerStep`](crate::ports::blockers::BlockerStep): a board card is
+    /// moved back into In Progress so its dispatch edge fires; a workflow node
+    /// is handed the answer for its run; a bare agent question just carries the
+    /// answer back into the DM it was asked in.
+    ///
+    /// The step rides on the resolution itself — the journal scrubs a parked
+    /// effect's payload, so it is captured at resolve time — while the DM thread
+    /// is read off the approval's origin, which is not scrubbed. The answer is
+    /// retired from the re-arm queue once re-entered, so the next boot does not
+    /// resume it a second time.
+    #[cfg(feature = "openhuman")]
+    async fn resume_blocker(
+        self: &Arc<Self>,
+        approval_id: &ApprovalId,
+        resolution: crate::ports::blockers::BlockerResolution,
+    ) -> Result<CycleReport> {
+        let thread = self
+            .journal
+            .approval_conversation(approval_id)
+            .and_then(|conversation| conversation.thread);
+        let outcome = self
+            .drive_blocker_resume(&resolution, resolution.step.as_ref(), thread.as_deref())
+            .await;
+        // Retire the armed answer whether or not the drive succeeded: a failed
+        // resume is reported, not retried forever, and re-arming it would resume
+        // twice on the next boot. Best-effort — the durable verdict already
+        // stands.
+        if let Err(err) = self.journal.record_blocker_resumed(approval_id).await {
+            tracing::warn!(
+                company = %self.id,
+                %approval_id,
+                error = %err,
+                "[blockers] a blocker resumed but its consume-record failed; the next boot may \
+                 re-arm the answer"
+            );
+        }
+        outcome?;
+        Ok(CycleRunner::new(self).already_resolved_report())
+    }
+
+    /// Routes a resolved blocker to the right resume by its
+    /// [`BlockerStep`](crate::ports::blockers::BlockerStep) (issue #1863).
+    #[cfg(feature = "openhuman")]
+    async fn drive_blocker_resume(
+        self: &Arc<Self>,
+        resolution: &crate::ports::blockers::BlockerResolution,
+        step: Option<&crate::ports::blockers::BlockerStep>,
+        thread: Option<&str>,
+    ) -> Result<()> {
+        use crate::ports::blockers::BlockerStep;
+
+        match step {
+            Some(BlockerStep::Task { task_id }) => {
+                if resolution.resumes() {
+                    self.resume_task_card(task_id, resolution, thread).await
+                } else {
+                    self.cancel_task_card(task_id, thread).await
+                }
+            }
+            Some(BlockerStep::Node { run_id, node_id }) => {
+                self.resume_node_blocker(run_id, node_id, resolution, thread)
+                    .await
+            }
+            // An agent question with no step behind it — there is nothing to
+            // re-dispatch, so carrying the answer back into its DM is the whole
+            // of the resume.
+            None => {
+                self.post_blocker_resume_note(thread, &blocker_resume_note(resolution))
+                    .await
+            }
+        }
+    }
+
+    /// Re-dispatches a board card a blocker had paused, moving it back into In
+    /// Progress so its dispatch edge fires (issue #1863).
+    ///
+    /// The move rides through [`upsert_task`](Self::upsert_task), the one write
+    /// site that carries the dispatch edge — the opposite choice from
+    /// [`return_expired_blocker_card`](crate::runtime::advance::return_expired_blocker_card),
+    /// which uses the plain port precisely so it does *not* re-dispatch. An
+    /// [`Amend`](crate::ports::blockers::BlockerVerdict::Amend) carries the
+    /// operator's answer onto the card note first, so the re-run reads the
+    /// correction. A card an operator has since dragged out of `paused` is left
+    /// alone — the same guard the expiry mover keeps.
+    #[cfg(feature = "openhuman")]
+    async fn resume_task_card(
+        self: &Arc<Self>,
+        task_id: &str,
+        resolution: &crate::ports::blockers::BlockerResolution,
+        thread: Option<&str>,
+    ) -> Result<()> {
+        use crate::ports::blockers::BlockerVerdict;
+
+        let Some(mut card) = self
+            .ops
+            .tasks
+            .list(&self.id)
+            .await?
+            .into_iter()
+            .find(|t| t.id == task_id)
+        else {
+            return self
+                .post_blocker_resume_note(
+                    thread,
+                    "That card is no longer on the board, so there's nothing to pick back up.",
+                )
+                .await;
+        };
+        if card.column != crate::ports::tasks::COLUMN_PAUSED {
+            // Someone has already moved it on; a resume must not yank it back.
+            return Ok(());
+        }
+        if resolution.verdict == BlockerVerdict::Amend && !resolution.answer.trim().is_empty() {
+            card.note = Some(crate::runtime::advance::append_result(
+                card.note.as_deref(),
+                "operator",
+                &resolution.answer,
+            ));
+        }
+        card.column = IN_PROGRESS.to_string();
+        card.updated_at_millis = now_millis();
+        self.upsert_task(&card).await?;
+        self.post_blocker_resume_note(thread, &blocker_resume_note(resolution))
+            .await
+    }
+
+    /// Settles a blocked card the operator cancelled, moving it back to To-do
+    /// carrying the reason and starting nothing (issue #1863).
+    ///
+    /// The plain [`TaskStore::upsert`] port, never
+    /// [`upsert_task`](Self::upsert_task): a cancel must not fire a dispatch. The
+    /// bounce chip marks it as not-fresh for a board scan, exactly as the expiry
+    /// mover marks a card nobody answered.
+    #[cfg(feature = "openhuman")]
+    async fn cancel_task_card(self: &Arc<Self>, task_id: &str, thread: Option<&str>) -> Result<()> {
+        let Some(mut card) = self
+            .ops
+            .tasks
+            .list(&self.id)
+            .await?
+            .into_iter()
+            .find(|t| t.id == task_id)
+        else {
+            return Ok(());
+        };
+        if card.column != crate::ports::tasks::COLUMN_PAUSED {
+            return Ok(());
+        }
+        card.note = Some(crate::runtime::advance::append_result(
+            card.note.as_deref(),
+            "operator",
+            BLOCKER_CANCELLED,
+        ));
+        card.column = TODO.to_string();
+        card.bounced = Some(BLOCKER_CANCELLED.to_string());
+        card.updated_at_millis = now_millis();
+        self.ops.tasks.upsert(&self.id, &card).await?;
+        self.post_blocker_resume_note(
+            thread,
+            "Okay — I've cancelled that. It's back in To-do if you want to pick it up later.",
+        )
+        .await
+    }
+
+    /// Carries a resolved workflow-node blocker's answer back into the run
+    /// (issue #1863).
+    ///
+    /// A [`Cancel`](crate::ports::blockers::BlockerVerdict::Cancel) settles the
+    /// run and starts nothing. A resuming verdict banks the answer (already
+    /// durable) and delivers it into the DM the question was asked in, so the
+    /// operator's decision is never silently dropped. Re-executing the node from
+    /// the run's trigger input — retry re-runs it, amend injects the value, skip
+    /// treats it satisfied — is the workflow engine's own resume seam (issue
+    /// #1864's node-level restart lives beside it); this hands the answer across
+    /// without disturbing that machinery.
+    #[cfg(feature = "openhuman")]
+    async fn resume_node_blocker(
+        self: &Arc<Self>,
+        run_id: &str,
+        _node_id: &str,
+        resolution: &crate::ports::blockers::BlockerResolution,
+        thread: Option<&str>,
+    ) -> Result<()> {
+        if !resolution.resumes() {
+            let outcome =
+                crate::ports::runs::RunOutcome::new(crate::ports::runs::RunStatus::Cancelled)
+                    .with_error(BLOCKER_CANCELLED);
+            if let Err(err) = self.ops.runs.finish_run(&self.id, run_id, outcome).await {
+                tracing::warn!(
+                    company = %self.id,
+                    run = %run_id,
+                    error = %err,
+                    "[blockers] a cancelled workflow-node blocker's run could not be settled"
+                );
+            }
+            return self
+                .post_blocker_resume_note(thread, "Okay — I've cancelled that workflow step.")
+                .await;
+        }
+        self.post_blocker_resume_note(thread, &blocker_resume_note(resolution))
+            .await
+    }
+
+    /// Posts a resume acknowledgement into the DM the blocker was asked in
+    /// (issue #1863), attributed to the teammate whose DM it is — the same
+    /// durable [`AgentReply`](CompanyEvent::AgentReply) shape
+    /// [`post_blocker_prompt`](Self::post_blocker_prompt) writes, so it threads
+    /// and reloads like any transcript line. A no-op when the blocker was raised
+    /// in no conversation.
+    #[cfg(feature = "openhuman")]
+    async fn post_blocker_resume_note(&self, thread: Option<&str>, text: &str) -> Result<()> {
+        let Some(thread) = thread else {
+            return Ok(());
+        };
+        self.post_blocker_prompt(thread, text).await
     }
 
     /// Durably banks a blocked-node approval the moment its verdict is known,
@@ -5235,14 +5474,19 @@ impl CompanyRuntime {
         }
     }
 
-    /// Records the operator's verdict on a blocker group (issue #1862), lowering
-    /// the four-way intent onto the existing Approve/Deny resolve surface and
-    /// **fanning it to every member** of the group.
+    /// Records the operator's verdict on a blocker group and **drives the
+    /// resume** (issue #1863), fanning it to every member of the group.
     ///
-    /// `retry` re-approves, `skip`/`cancel` deny, and `amend` overlays the
-    /// operator's correction onto the parked effect. Every arm is durably
-    /// recorded and inert until #1863 — the verdict is banked, no stopped step
-    /// re-runs here.
+    /// The four-way intent is banked as a durable
+    /// [`BlockerResolution`](crate::ports::blockers::BlockerResolution) and armed
+    /// on the grant set's blocker side-channel **before** the detached follow-up
+    /// spawns, so a restart mid-resume replays the answer rather than dropping
+    /// it — the same restart-durable ordering the blocked-node bank keeps. Each
+    /// id is then resolved with the two-value event verdict the operator's
+    /// answer lowers onto (Retry/Amend/Skip approve, Cancel denies), and
+    /// [`spawn_follow_up`](Self::spawn_follow_up)'s blocker fork re-enters the
+    /// stopped step carrying the resolution — a resuming verdict re-dispatches
+    /// the work, a cancel settles it and starts nothing.
     #[cfg(feature = "openhuman")]
     pub(crate) async fn apply_blocker_reply(
         self: &Arc<Self>,
@@ -5252,28 +5496,59 @@ impl CompanyRuntime {
         by: Option<&Actor>,
     ) -> Result<()> {
         use crate::company::task_intent::BlockerReplyIntent;
+        use crate::ports::blockers::{BlockerPayload, BlockerVerdict};
 
+        let verdict = match intent {
+            BlockerReplyIntent::Retry => BlockerVerdict::Retry,
+            BlockerReplyIntent::Amend => BlockerVerdict::Amend,
+            BlockerReplyIntent::Skip => BlockerVerdict::Skip,
+            BlockerReplyIntent::Cancel => BlockerVerdict::Cancel,
+            // Not a verdict; the caller runs it as an ordinary turn.
+            BlockerReplyIntent::Unrelated => return Ok(()),
+        };
+        // Only an amend carries the operator's words back into the step; the
+        // other verdicts need none, so their answer stays empty.
+        let answer = if verdict == BlockerVerdict::Amend {
+            text.to_string()
+        } else {
+            String::new()
+        };
+        // The stopped step each blocker re-enters, read off the **still-parked**
+        // effect's full payload before any resolve pops it — the journal scrubs
+        // that payload the moment the approval leaves the pending set, so it must
+        // be captured now and banked on the resolution. Snapshotted once so a
+        // group's later members are still resolvable after the first is popped.
+        let pending = self.journal.pending();
+        let step_of = |id: &ApprovalId| {
+            pending
+                .iter()
+                .find(|parked| &parked.id == id)
+                .and_then(|parked| {
+                    serde_json::from_value::<BlockerPayload>(parked.effect.payload.clone()).ok()
+                })
+                .and_then(|payload| payload.step)
+        };
         let actor = by.cloned().unwrap_or_else(|| Actor {
             kind: ActorKind::Operator,
             id: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
         });
         for id in ids {
-            match intent {
-                BlockerReplyIntent::Retry => {
-                    self.resolve_approval(id, Verdict::Approve, actor.clone())
-                        .await?;
-                }
-                BlockerReplyIntent::Skip | BlockerReplyIntent::Cancel => {
-                    self.resolve_approval(id, Verdict::Deny, actor.clone())
-                        .await?;
-                }
-                BlockerReplyIntent::Amend => {
-                    let overlay = serde_json::json!({ "amendment": text });
-                    self.resolve_approval_amended(id, overlay, actor.clone())
-                        .await?;
-                }
-                BlockerReplyIntent::Unrelated => {}
-            }
+            let resolution = crate::ports::blockers::BlockerResolution {
+                verdict,
+                answer: answer.clone(),
+                step: step_of(id),
+            };
+            // Bank durably, then arm the side-channel, then resolve — the same
+            // journal-before-live ordering `mint_grant` keeps, so a crash
+            // between the two replays as "still armed" and re-resumes rather
+            // than losing the operator's decision. `resolve_approval` settles
+            // the event verdict and spawns the follow-up that reads the answer.
+            self.journal
+                .record_blocker_resolution(id, &resolution)
+                .await?;
+            self.grants.arm_blocker_resolution(id, resolution.clone());
+            self.resolve_approval(id, verdict.event_verdict(), actor.clone())
+                .await?;
         }
         Ok(())
     }
@@ -5860,6 +6135,31 @@ pub(crate) enum BlockerReplyPlan {
     },
     /// Several blockers pend and the reply named none — ask which, settle none.
     AskWhich { prompt: String },
+}
+
+/// The reason stamped on a card an operator cancelled from its blocker DM
+/// (issue #1863). Its own wording — nothing failed and nothing timed out; the
+/// operator chose to stop the work.
+#[cfg(feature = "openhuman")]
+const BLOCKER_CANCELLED: &str =
+    "cancelled from the blocker chat — the work was stopped, not failed";
+
+/// The one line posted back into a blocker's DM when its answer re-enters the
+/// stopped step (issue #1863), phrased per verdict so the operator sees what
+/// their answer did.
+#[cfg(feature = "openhuman")]
+fn blocker_resume_note(resolution: &crate::ports::blockers::BlockerResolution) -> String {
+    use crate::ports::blockers::BlockerVerdict;
+    match resolution.verdict {
+        BlockerVerdict::Retry => "Got it — picking that back up now.".to_string(),
+        BlockerVerdict::Amend => {
+            "Thanks — using that and carrying on from where it stopped.".to_string()
+        }
+        BlockerVerdict::Skip => "Okay — skipping that and moving on.".to_string(),
+        // Cancel never reaches here: it does not resume, and its callers post
+        // their own settle notice.
+        BlockerVerdict::Cancel => "Okay — cancelled.".to_string(),
+    }
 }
 
 /// The line asked back when a DM holds several distinct blocked things and the
@@ -9140,6 +9440,333 @@ mod tests {
             assert!(
                 matches!(cross, BlockerReplyPlan::NotBlocker),
                 "the same verdict from another conversation settles nothing"
+            );
+        }
+    }
+
+    /// Resuming a parked blocker (issue #1863): an operator's answer re-enters
+    /// the stopped step — a task card is re-dispatched, a cancel settles it —
+    /// and a blocker's inert effect is never executed.
+    #[cfg(feature = "openhuman")]
+    mod blocker_resume {
+        use crate::company::blocker_sender::BlockerSenderSignals;
+        use crate::company::runtime::CompanyRuntime;
+        use crate::company::task_intent::BlockerReplyIntent;
+        use crate::ports::blockers::{BlockerKind, BlockerPayload, BlockerSource, BlockerStep};
+        use crate::ports::tasks::{
+            COLUMN_IN_PROGRESS, COLUMN_PAUSED, COLUMN_TODO, TaskDeliverable, TaskRecord,
+        };
+        use crate::ports::types::CompanyId;
+        use std::path::Path;
+        use std::sync::Arc;
+        use tempfile::TempDir;
+
+        async fn build(home: &Path) -> Arc<CompanyRuntime> {
+            let manifest: crate::company::CompanyManifest = toml::from_str(
+                "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+                 [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n\
+                 [[agent]]\nid = \"eng\"\nrole = \"Engineer\"\n",
+            )
+            .expect("manifest");
+            Arc::new(
+                crate::runtime::RuntimeBuilder::new(home.to_path_buf(), manifest)
+                    .with_id(CompanyId::new("acme"))
+                    .build()
+                    .await
+                    .expect("runtime"),
+            )
+        }
+
+        async fn runtime() -> (Arc<CompanyRuntime>, TempDir) {
+            let home = tempfile::Builder::new()
+                .prefix("opencompany-blocker-resume-")
+                .tempdir()
+                .expect("tempdir");
+            let runtime = build(home.path()).await;
+            (runtime, home)
+        }
+
+        fn blocker(task_id: &str) -> BlockerPayload {
+            BlockerPayload {
+                kind: BlockerKind::Infrastructure,
+                source: BlockerSource::Provider,
+                step: Some(BlockerStep::Task {
+                    task_id: task_id.to_string(),
+                }),
+                reason: format!("the model id `gpt-nope` was rejected for {task_id}"),
+                needed: "a model id this provider serves".to_string(),
+                group_key: None,
+            }
+        }
+
+        fn assignee(id: &str) -> BlockerSenderSignals {
+            BlockerSenderSignals {
+                started_by: None,
+                owner_desk: None,
+                assignee: Some(id.to_string()),
+            }
+        }
+
+        fn card(id: &str, column: &str) -> TaskRecord {
+            TaskRecord {
+                id: id.to_string(),
+                title: "Draft the launch note".to_string(),
+                note: None,
+                column: column.to_string(),
+                priority: "medium".to_string(),
+                assignee: "eng".to_string(),
+                updated_at_millis: 1,
+                origin_chat_id: Some("dm:eng".to_string()),
+                origin_parent: None,
+                parent_task_id: None,
+                output: None,
+                plan: None,
+                planning_attempts: Vec::new(),
+                deliverable: TaskDeliverable::Once,
+                workflow_proposal: None,
+                origin_run_id: None,
+                origin_workflow_id: None,
+                bounced: None,
+            }
+        }
+
+        async fn seed(runtime: &Arc<CompanyRuntime>, c: &TaskRecord) {
+            runtime
+                .ops
+                .tasks
+                .upsert(&runtime.id, c)
+                .await
+                .expect("seed card");
+        }
+
+        async fn stored(runtime: &Arc<CompanyRuntime>, id: &str) -> TaskRecord {
+            runtime
+                .ops
+                .tasks
+                .list(&runtime.id)
+                .await
+                .expect("list")
+                .into_iter()
+                .find(|t| t.id == id)
+                .expect("card exists")
+        }
+
+        /// The headline of the tier: an operator's "retry" moves the paused card
+        /// back into In Progress so its dispatch edge fires, and the blocker is
+        /// cleared.
+        #[tokio::test]
+        async fn retry_redispatches_the_paused_card() {
+            let (runtime, _home) = runtime().await;
+            seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
+            runtime
+                .park_blocker(&blocker("t-1"), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            let ids: Vec<_> = runtime
+                .pending_approvals()
+                .into_iter()
+                .map(|a| a.id)
+                .collect();
+
+            runtime
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Retry, "go ahead and retry", None)
+                .await
+                .expect("resumes");
+
+            assert!(
+                runtime.pending_approvals().is_empty(),
+                "the answered blocker is retired"
+            );
+            assert_eq!(
+                stored(&runtime, "t-1").await.column,
+                COLUMN_IN_PROGRESS,
+                "a retry re-enters the stopped card through the dispatch edge"
+            );
+        }
+
+        /// An amend carries the operator's answer onto the card so the re-run
+        /// reads the correction, and re-dispatches it.
+        #[tokio::test]
+        async fn amend_carries_the_answer_onto_the_card() {
+            let (runtime, _home) = runtime().await;
+            seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
+            runtime
+                .park_blocker(&blocker("t-1"), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            let ids: Vec<_> = runtime
+                .pending_approvals()
+                .into_iter()
+                .map(|a| a.id)
+                .collect();
+
+            runtime
+                .apply_blocker_reply(
+                    &ids,
+                    BlockerReplyIntent::Amend,
+                    "use gpt-4o-mini instead",
+                    None,
+                )
+                .await
+                .expect("resumes");
+
+            let after = stored(&runtime, "t-1").await;
+            assert_eq!(after.column, COLUMN_IN_PROGRESS);
+            let note = after.note.expect("the answer is on the card");
+            assert!(
+                note.contains("use gpt-4o-mini instead"),
+                "the re-run must read the operator's correction: {note}"
+            );
+        }
+
+        /// A skip proceeds past the blocker — the card re-dispatches without a
+        /// correction.
+        #[tokio::test]
+        async fn skip_redispatches_the_paused_card() {
+            let (runtime, _home) = runtime().await;
+            seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
+            runtime
+                .park_blocker(&blocker("t-1"), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            let ids: Vec<_> = runtime
+                .pending_approvals()
+                .into_iter()
+                .map(|a| a.id)
+                .collect();
+
+            runtime
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Skip, "skip it", None)
+                .await
+                .expect("resumes");
+
+            assert_eq!(stored(&runtime, "t-1").await.column, COLUMN_IN_PROGRESS);
+        }
+
+        /// A cancel settles the card and starts nothing: it lands back in To-do
+        /// carrying the reason, and — the sharpest risk — the paused card is not
+        /// re-dispatched.
+        #[tokio::test]
+        async fn cancel_settles_the_card_to_todo() {
+            let (runtime, _home) = runtime().await;
+            seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
+            runtime
+                .park_blocker(&blocker("t-1"), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            let ids: Vec<_> = runtime
+                .pending_approvals()
+                .into_iter()
+                .map(|a| a.id)
+                .collect();
+
+            runtime
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Cancel, "cancel it", None)
+                .await
+                .expect("settles");
+
+            let after = stored(&runtime, "t-1").await;
+            assert_eq!(
+                after.column, COLUMN_TODO,
+                "a cancel abandons the work rather than re-dispatching it"
+            );
+            assert!(after.bounced.is_some(), "the card is marked not-fresh");
+        }
+
+        /// The guard the whole tier turns on: a blocker's effect is inert, so a
+        /// resuming verdict (mapped to Approve) must **never** execute it. The
+        /// execute path records an `EffectExecuted` key; the resume path records
+        /// none.
+        #[tokio::test]
+        async fn a_resolved_blocker_never_executes_its_effect() {
+            let (runtime, _home) = runtime().await;
+            seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
+            runtime
+                .park_blocker(&blocker("t-1"), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            let ids: Vec<_> = runtime
+                .pending_approvals()
+                .into_iter()
+                .map(|a| a.id)
+                .collect();
+            let approval_id = ids[0].clone();
+
+            runtime
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Retry, "retry", None)
+                .await
+                .expect("resumes");
+
+            assert!(
+                !runtime
+                    .journal
+                    .is_executed(&format!("approval:{approval_id}")),
+                "a resolving blocker verdict must route to resume, never perform_effect"
+            );
+        }
+
+        /// A card an operator has since dragged out of `paused` is theirs — a
+        /// resume must not yank it back, exactly as the expiry mover leaves it.
+        #[tokio::test]
+        async fn a_card_moved_out_of_paused_is_not_yanked_back() {
+            let (runtime, _home) = runtime().await;
+            seed(&runtime, &card("t-1", COLUMN_TODO)).await;
+            runtime
+                .park_blocker(&blocker("t-1"), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            let ids: Vec<_> = runtime
+                .pending_approvals()
+                .into_iter()
+                .map(|a| a.id)
+                .collect();
+
+            runtime
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Retry, "retry", None)
+                .await
+                .expect("resumes");
+
+            assert_eq!(
+                stored(&runtime, "t-1").await.column,
+                COLUMN_TODO,
+                "a card the operator already moved on is left where they put it"
+            );
+        }
+
+        /// Restart durability: a blocker parked before a restart is resolved
+        /// after it — the runtime rebuilt from the journal still resumes.
+        #[tokio::test]
+        async fn a_blocker_parked_before_a_restart_still_resumes_after_it() {
+            let home = tempfile::Builder::new()
+                .prefix("opencompany-blocker-durable-")
+                .tempdir()
+                .expect("tempdir");
+            let first = build(home.path()).await;
+            seed(&first, &card("t-1", COLUMN_PAUSED)).await;
+            first
+                .park_blocker(&blocker("t-1"), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            drop(first);
+
+            // A fresh runtime over the same journal and board — a restart.
+            let second = build(home.path()).await;
+            let ids: Vec<_> = second
+                .pending_approvals()
+                .into_iter()
+                .map(|a| a.id)
+                .collect();
+            assert_eq!(ids.len(), 1, "the parked blocker survived the restart");
+
+            second
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Retry, "retry", None)
+                .await
+                .expect("resumes");
+
+            assert_eq!(
+                stored(&second, "t-1").await.column,
+                COLUMN_IN_PROGRESS,
+                "a blocker parked before the restart re-enters the card after it"
             );
         }
     }

--- a/src/ports/blockers.rs
+++ b/src/ports/blockers.rs
@@ -49,6 +49,20 @@ use serde::{Deserialize, Serialize};
 /// surface that would have to redact.
 pub const BLOCKER_EFFECT_PREFIX: &str = "blocker";
 
+/// Whether `effect` is a parked blocker — its kind is `blocker.<class>` (issue
+/// #1863).
+///
+/// The one predicate the resolve path branches on to keep a blocker away from
+/// effect execution: a blocker's effect is inert, so a resolving `Approve` must
+/// route to resume, never `perform_effect`. Kind-checked rather than
+/// payload-checked because the kind is the part that survives redaction, the
+/// same reason [`BlockerKind::effect_kind`] puts the class there.
+pub fn is_blocker_effect(effect: &crate::ports::types::Effect) -> bool {
+    effect
+        .kind
+        .starts_with(&format!("{BLOCKER_EFFECT_PREFIX}."))
+}
+
 /// **What is missing.** The primary axis: it decides whether the work parks at
 /// all, and which recovery is worth trying before a person is asked.
 ///
@@ -293,6 +307,148 @@ impl BlockerPayload {
     }
 }
 
+/// What an operator's answer asks the stopped step to do (issue #1863).
+///
+/// The four-way verdict the resume path turns on. It is the durable twin of
+/// [`BlockerReplyIntent`](crate::company::task_intent::BlockerReplyIntent)'s
+/// four answering arms — the classifier decides it from an operator's words,
+/// this carries it back into the stopped step so a restart mid-resume replays
+/// the same decision rather than losing it.
+///
+/// Serialized `snake_case`, with [`Self::as_str`] returning the identical
+/// literal, on exactly the terms [`BlockerKind`] keeps: the token is journaled,
+/// so a rename is a data migration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockerVerdict {
+    /// Run the stopped step again as it was.
+    Retry,
+    /// Answer or correct it — the [`BlockerResolution::answer`] carries what
+    /// changed, and the step re-enters carrying it.
+    Amend,
+    /// Waive the blocker and let the work proceed as if it were satisfied.
+    Skip,
+    /// Abandon the stopped work. The one verdict that does not re-enter.
+    Cancel,
+}
+
+impl BlockerVerdict {
+    /// The wire/storage token.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Retry => "retry",
+            Self::Amend => "amend",
+            Self::Skip => "skip",
+            Self::Cancel => "cancel",
+        }
+    }
+
+    /// Parses a wire token back into a verdict, or `None`.
+    pub fn from_wire(word: &str) -> Option<Self> {
+        Some(match word {
+            "retry" => Self::Retry,
+            "amend" => Self::Amend,
+            "skip" => Self::Skip,
+            "cancel" => Self::Cancel,
+            _ => return None,
+        })
+    }
+
+    /// Whether this verdict **re-enters** the stopped step.
+    ///
+    /// Every verdict but [`Cancel`](Self::Cancel) resumes: a retry runs the step
+    /// again, an amend runs it with the answer, a skip proceeds past it. Cancel
+    /// abandons the work and starts nothing — the one place the resume fork
+    /// short-circuits before any cycle.
+    pub fn resumes(self) -> bool {
+        !matches!(self, Self::Cancel)
+    }
+
+    /// The [`Verdict`](crate::ports::types::Verdict) the approval event records.
+    ///
+    /// The gate has only two decisions, so the four blocker verdicts lower onto
+    /// them: every resuming verdict is an [`Approve`](crate::ports::types::Verdict::Approve)
+    /// — the operator answered, and the durable approval says so — while
+    /// [`Cancel`](Self::Cancel) is a [`Deny`](crate::ports::types::Verdict::Deny).
+    /// The rich four-way answer rides the resolution beside the event, never the
+    /// event itself, so the two-value audit surface is unchanged.
+    pub fn event_verdict(self) -> crate::ports::types::Verdict {
+        use crate::ports::types::Verdict;
+        match self {
+            Self::Retry | Self::Amend | Self::Skip => Verdict::Approve,
+            Self::Cancel => Verdict::Deny,
+        }
+    }
+}
+
+/// The operator's durable answer to a parked blocker (issue #1863).
+///
+/// Banked before the detached resume spawns and re-armed at boot, so a restart
+/// between the answer and the re-entry replays it rather than dropping the
+/// operator's decision on the floor — the same restart-durable pattern
+/// `ApprovalContinuation` keeps for an explicit request.
+///
+/// It carries what the two-value approval [`Verdict`](crate::ports::types::Verdict)
+/// cannot: which of the four things the operator asked for, and — for an
+/// [`Amend`](BlockerVerdict::Amend) — the words that answer the question.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockerResolution {
+    /// What the operator asked the stopped step to do.
+    pub verdict: BlockerVerdict,
+    /// The operator's answer, when they gave one — the correction an
+    /// [`Amend`](BlockerVerdict::Amend) re-enters carrying. Empty for a bare
+    /// retry, skip or cancel, which need no words, and skipped on the wire when
+    /// empty so a resolution written without one reads back the same.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub answer: String,
+    /// Which stopped step this answer re-enters, copied off the parked
+    /// blocker's [`BlockerPayload::step`] at resolve time.
+    ///
+    /// Carried here rather than re-read from the approval at resume time
+    /// because the journal **scrubs a parked effect's payload** once it is
+    /// recorded (issue #372's redaction), so the step is gone from the durable
+    /// approval by the time the detached resume runs. Banking it on the
+    /// resolution makes the answer self-contained: the resume knows which card
+    /// or node to re-enter without the payload, and a restart replays it whole.
+    ///
+    /// `None` for a bare agent question with no step behind it, where the whole
+    /// of the resume is carrying the answer back into the DM it was asked in.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step: Option<BlockerStep>,
+}
+
+impl BlockerResolution {
+    /// A resolution carrying a verdict, no answer text and no step.
+    pub fn new(verdict: BlockerVerdict) -> Self {
+        Self {
+            verdict,
+            answer: String::new(),
+            step: None,
+        }
+    }
+
+    /// A resolution carrying an operator's answer.
+    pub fn answered(verdict: BlockerVerdict, answer: impl Into<String>) -> Self {
+        Self {
+            verdict,
+            answer: answer.into(),
+            step: None,
+        }
+    }
+
+    /// The same resolution with its stopped step recorded.
+    pub fn with_step(mut self, step: Option<BlockerStep>) -> Self {
+        self.step = step;
+        self
+    }
+
+    /// Whether resolving with this re-enters the stopped step — a shorthand for
+    /// [`BlockerVerdict::resumes`].
+    pub fn resumes(&self) -> bool {
+        self.verdict.resumes()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -466,6 +622,61 @@ mod test {
         let json = serde_json::to_value(&grouped).expect("serializes");
         let back: BlockerPayload = serde_json::from_value(json).expect("parses");
         assert_eq!(back.group_key.as_deref(), Some("connection:slack"));
+    }
+
+    #[test]
+    fn verdict_wire_round_trips() {
+        for verdict in [
+            BlockerVerdict::Retry,
+            BlockerVerdict::Amend,
+            BlockerVerdict::Skip,
+            BlockerVerdict::Cancel,
+        ] {
+            assert_eq!(BlockerVerdict::from_wire(verdict.as_str()), Some(verdict));
+            let json = serde_json::to_string(&verdict).expect("verdict serializes");
+            assert_eq!(json, format!("\"{}\"", verdict.as_str()));
+        }
+        assert_eq!(BlockerVerdict::from_wire("nonsense"), None);
+    }
+
+    /// The mapping the sharpest risk turns on: only [`BlockerVerdict::Cancel`]
+    /// denies, and only it declines to re-enter. Every answering verdict is an
+    /// approve that resumes — and an approve that must never execute the inert
+    /// blocker effect (that guard lives in the resolve path).
+    #[test]
+    fn only_cancel_denies_and_declines_to_resume() {
+        use crate::ports::types::Verdict;
+        for verdict in [
+            BlockerVerdict::Retry,
+            BlockerVerdict::Amend,
+            BlockerVerdict::Skip,
+        ] {
+            assert_eq!(verdict.event_verdict(), Verdict::Approve, "{verdict:?}");
+            assert!(verdict.resumes(), "{verdict:?} must re-enter the step");
+        }
+        assert_eq!(BlockerVerdict::Cancel.event_verdict(), Verdict::Deny);
+        assert!(
+            !BlockerVerdict::Cancel.resumes(),
+            "cancel abandons the work and starts nothing"
+        );
+    }
+
+    /// The answer is additive: a resolution written with no words reads back
+    /// with none, and one carrying an amendment round-trips.
+    #[test]
+    fn resolution_answer_is_additive_and_round_trips() {
+        let bare = BlockerResolution::new(BlockerVerdict::Retry);
+        let json = serde_json::to_value(&bare).expect("serializes");
+        assert_eq!(json, serde_json::json!({ "verdict": "retry" }));
+        let back: BlockerResolution = serde_json::from_value(json).expect("parses");
+        assert_eq!(back, bare);
+        assert_eq!(back.answer, "");
+
+        let amended = BlockerResolution::answered(BlockerVerdict::Amend, "use gpt-4o-mini");
+        let json = serde_json::to_value(&amended).expect("serializes");
+        let back: BlockerResolution = serde_json::from_value(json).expect("parses");
+        assert_eq!(back, amended);
+        assert!(back.resumes());
     }
 
     /// The step survives a round trip through JSON, because that is how it

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2516,6 +2516,7 @@ impl RuntimeBuilder {
                 let grants = crate::runtime::grants::GrantSet::default();
                 grants.rehydrate(journal.replayed_grants());
                 grants.rehydrate_continuations(journal.replayed_approval_continuations());
+                grants.rehydrate_blocker_resolutions(journal.replayed_blocker_resolutions());
                 grants
             }
         };

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1872,6 +1872,19 @@ approval.]"
         by: Actor,
         scope: GrantScope,
     ) -> Result<()> {
+        // Issue #1863: a blocker's effect is INERT. It carries a question, not a
+        // tool call — `park_blocker` stamps `agent: None` and mints no grant —
+        // so approving one must re-enter the stopped step, never execute the
+        // payload. Without this guard a resuming verdict (Retry/Amend/Skip, all
+        // mapped to `Approve`) would fall through to the native `agent.is_none()`
+        // arm below and hand the blocker payload to `execute_effect_once`, which
+        // would ledger a phantom spend and route nothing while reading as
+        // success. The answer is already armed on the grant set's blocker
+        // side-channel by the resolve entrypoint, and `continue_turn`'s blocker
+        // fork drives the actual resume; there is nothing to do here.
+        if crate::ports::blockers::is_blocker_effect(&effect) {
+            return Ok(());
+        }
         // Issue #1098: a gate carries no teammate but can still hold a standing
         // permission for its workflow, so that case is taken before the native
         // fall-through below. Only for `GrantScope::Tool` — a `Once` approval of
@@ -2417,6 +2430,12 @@ approval.]"
         self.rt
             .grants
             .rehydrate_continuations(self.rt.journal.replayed_approval_continuations());
+        // Issue #1863: a blocker answered moments before a restart must re-enter
+        // the stopped step on the other side rather than evaporate, exactly as a
+        // grant or a continuation does above.
+        self.rt
+            .grants
+            .rehydrate_blocker_resolutions(self.rt.journal.replayed_blocker_resolutions());
         // Issue #374: standing grants outlive a restart too — a week-long
         // permission that evaporated on every deploy would be worse than not
         // offering one. Anything already past its deadline is folded out by the

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -102,6 +102,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex as TokioMutex;
 
+use crate::ports::blockers::BlockerResolution;
 use crate::ports::generate_id;
 use crate::ports::types::{
     Actor, ApprovalId, Attachment, CompanyEvent, CompanyId, EventSeq, Mention, MessageIntent,
@@ -600,6 +601,22 @@ struct GrantState {
     /// sweeps every checkout, so there is nothing left for a rehydrated mark to
     /// protect.
     pending: HashMap<ApprovalId, String>,
+    /// The operator's answer to a parked blocker, armed when the blocker is
+    /// resolved and read by the resume fork on the detached follow-up (issue
+    /// #1863).
+    ///
+    /// A side-channel disjoint from [`continuations`](Self::continuations) for
+    /// the same reason that map is disjoint from [`live`](Self::live): a blocker
+    /// answer is not authority to execute anything — a blocker's effect is inert
+    /// — so it must never be mistaken for a redeemable grant. It rides here so
+    /// [`CompanyRuntime::continue_turn`](crate::company::runtime::CompanyRuntime)
+    /// can recognise a resolution as a blocker's and re-enter the stopped step
+    /// carrying the answer, instead of falling through the grant-redemption path
+    /// that finds nothing and returns.
+    ///
+    /// Re-armed at boot from the journal, so a restart between the answer and
+    /// the re-entry resumes rather than dropping the operator's decision.
+    blocker_resolutions: HashMap<ApprovalId, BlockerResolution>,
 }
 
 /// Whether two recorded scopes overlap (issue #1458).
@@ -687,6 +704,48 @@ impl GrantSet {
         let continuation = state.continuations.remove(id)?;
         state.consumed_continuations.push(id.clone());
         Some(continuation)
+    }
+
+    /// Arms the operator's answer to a parked blocker (issue #1863), so the
+    /// detached follow-up recognises the resolution as a blocker's and re-enters
+    /// the stopped step carrying it.
+    pub fn arm_blocker_resolution(&self, id: &ApprovalId, resolution: BlockerResolution) {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .blocker_resolutions
+            .insert(id.clone(), resolution);
+    }
+
+    /// Reads a parked blocker's armed answer without consuming it.
+    pub fn peek_blocker_resolution(&self, id: &ApprovalId) -> Option<BlockerResolution> {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .blocker_resolutions
+            .get(id)
+            .cloned()
+    }
+
+    /// Consumes a parked blocker's armed answer as the resume fork takes it.
+    pub fn take_blocker_resolution(&self, id: &ApprovalId) -> Option<BlockerResolution> {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .blocker_resolutions
+            .remove(id)
+    }
+
+    /// Re-arms blocker answers from the journal at boot (issue #1863), the
+    /// blocker twin of [`rehydrate_continuations`](Self::rehydrate_continuations).
+    pub fn rehydrate_blocker_resolutions(
+        &self,
+        resolutions: impl IntoIterator<Item = (ApprovalId, BlockerResolution)>,
+    ) {
+        let mut state = self.inner.lock().expect("grant set poisoned");
+        for (id, resolution) in resolutions {
+            state.blocker_resolutions.insert(id, resolution);
+        }
     }
 
     /// Removes every grant minted more than `ttl_millis` before `now_millis`,

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -33,6 +33,7 @@ use serde_json::Value;
 use tokio::sync::Mutex as TokioMutex;
 
 use crate::Result;
+use crate::ports::blockers::BlockerResolution;
 use crate::ports::journal::{Durability, JournalStore};
 use crate::ports::types::{Actor, ApprovalId, CompanyId, Effect, EventSeq, StartedBy};
 use crate::runtime::grants::{ApprovalContinuation, GrantId, GrantedCall, StandingGrant};
@@ -282,6 +283,22 @@ enum JournalRecord {
         id: ApprovalId,
         /// Epoch-millis the expiry was recorded.
         at_millis: u64,
+    },
+    /// An operator's answer to a parked blocker, banked before the detached
+    /// resume spawns so a restart mid-resume replays it (issue #1863). It
+    /// conveys no authority to execute anything — a blocker's effect is inert —
+    /// only which of the four things the operator asked for, and their words.
+    BlockerResolved {
+        /// The blocker approval the answer settles.
+        id: ApprovalId,
+        /// The verdict and answer, whole.
+        resolution: BlockerResolution,
+    },
+    /// A parked blocker's answer was re-entered into the stopped step, so it no
+    /// longer needs re-arming on the next boot.
+    BlockerResumed {
+        /// The blocker approval whose answer was consumed by the resume.
+        id: ApprovalId,
     },
     /// A grant redeemed by its agent — the tool ran.
     GrantConsumed {
@@ -661,6 +678,13 @@ impl JournalRecord {
             | Self::ApprovalContinuationDispatched { .. } => Durability::Host,
             Self::ApprovalContinuationConsumed { .. }
             | Self::ApprovalContinuationExpired { .. } => Durability::Process,
+            // The same direction as `ApprovalContinuationQueued`: losing a
+            // blocker's answer after `ApprovalResolved` survived would leave a
+            // decided blocker with nothing to re-enter the stopped step. The
+            // paired `BlockerResumed` only clears a re-armed answer, so a lost
+            // clear replays as "still armed" — re-resuming, the safe direction.
+            Self::BlockerResolved { .. } => Durability::Host,
+            Self::BlockerResumed { .. } => Durability::Process,
             // The same direction as `ApprovalGranted`, one scope wider.
             Self::StandingGrantMinted { .. } => Durability::Process,
             // Deadline arithmetic rather than state: `replayed_standing_grants`
@@ -1064,6 +1088,12 @@ struct State {
     /// Explicit approval follow-ups still owed after replay. Kept separate from
     /// grants because a denial is a continuation, never executable authority.
     approval_continuations: HashMap<ApprovalId, ApprovalContinuation>,
+    /// Blocker answers armed but not yet re-entered after replay (issue #1863).
+    /// Kept separate from [`approval_continuations`](Self::approval_continuations)
+    /// for the same reason that map is kept from `grants`: a blocker answer is
+    /// not executable authority. A [`BlockerResumed`](JournalRecord::BlockerResumed)
+    /// removes an entry once the stopped step has re-entered.
+    blocker_resolutions: HashMap<ApprovalId, BlockerResolution>,
     /// Standing grants minted and not yet revoked or expired (issue #374).
     ///
     /// Removed from on both terminal records for the same reason as
@@ -1429,6 +1459,12 @@ impl RuntimeJournal {
             | JournalRecord::ApprovalContinuationConsumed { id }
             | JournalRecord::ApprovalContinuationExpired { id, .. } => {
                 state.approval_continuations.remove(&id);
+            }
+            JournalRecord::BlockerResolved { id, resolution } => {
+                state.blocker_resolutions.insert(id, resolution);
+            }
+            JournalRecord::BlockerResumed { id } => {
+                state.blocker_resolutions.remove(&id);
             }
             JournalRecord::GrantConsumed { id, effect } => {
                 state.grants.remove(&id);
@@ -2420,6 +2456,38 @@ impl RuntimeJournal {
         .await
     }
 
+    /// Banks an operator's answer to a parked blocker before the resume is
+    /// armed in memory (issue #1863), the blocker twin of
+    /// [`record_approval_continuation`](Self::record_approval_continuation).
+    pub async fn record_blocker_resolution(
+        &self,
+        id: &ApprovalId,
+        resolution: &BlockerResolution,
+    ) -> Result<()> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .blocker_resolutions
+            .insert(id.clone(), resolution.clone());
+        self.append(&JournalRecord::BlockerResolved {
+            id: id.clone(),
+            resolution: resolution.clone(),
+        })
+        .await
+    }
+
+    /// Records that a parked blocker's answer was re-entered into the stopped
+    /// step, so it is not re-armed on the next boot.
+    pub async fn record_blocker_resumed(&self, id: &ApprovalId) -> Result<()> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .blocker_resolutions
+            .remove(id);
+        self.append(&JournalRecord::BlockerResumed { id: id.clone() })
+            .await
+    }
+
     /// Records that an explicit approval continuation reached its agent.
     pub async fn record_approval_continuation_consumed(&self, id: &ApprovalId) -> Result<()> {
         self.state
@@ -2533,6 +2601,19 @@ impl RuntimeJournal {
             .approval_continuations
             .values()
             .cloned()
+            .collect()
+    }
+
+    /// Every blocker answer replay left armed but not yet re-entered (issue
+    /// #1863), for the boot rebuild to re-arm on the live grant set — the
+    /// blocker twin of [`replayed_approval_continuations`](Self::replayed_approval_continuations).
+    pub fn replayed_blocker_resolutions(&self) -> Vec<(ApprovalId, BlockerResolution)> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .blocker_resolutions
+            .iter()
+            .map(|(id, resolution)| (id.clone(), resolution.clone()))
             .collect()
     }
 


### PR DESCRIPTION
## Summary

Resume a parked blocker — tier 1 of epic #1860, closing the loop opened by the blocker DMs in #1862.

An answered blocker now **re-enters the stopped step** instead of leaving the work parked. For a task-card blocker, an operator's verdict drives the card lifecycle:

- **retry / amend / skip** move the card `paused → in_progress` and re-run the step;
- **cancel** bounces the card back to **To-do**.

The operator's answer is banked durably so the resume survives a restart, and a resolved blocker is guaranteed to drive a **resume** — never a fresh effect execution.

Builds on #1862 (blocker DMs); this branch carries only its own resume commits on top of #1862's merged base.

## API Or Behavior Changes

- New `BlockerVerdict` and a durable `BlockerResolution` carrier (verdict + operator answer + the step it belongs to).
- Host-durable journal records `BlockerResolved` / `BlockerResumed`, re-armed on boot so an answer given before a restart still resumes afterward.
- Guard: a resolved blocker always drives the resume path and **never** re-enters `perform_effect`, so answering a blocker can't replay a side effect.
- Task-card lifecycle transition on resume via `upsert_task` (`paused → in_progress` on retry/amend/skip; `→ To-do` on cancel).

## Tests

Scoped run on the affected areas (`--features openhuman`, filters `company::`, `harness::built_in::brain`, `runtime::`, `ports::blockers`): **1996 passed, 0 failed**, including the new resume tests (durable bank / boot re-arm restart-durability and the never-execute-an-effect guard).

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` (also `--features openhuman`)
- [x] `cargo check --all-features`
- [x] `cargo test --features openhuman -- company:: harness::built_in::brain runtime:: ports::blockers`

## Documentation

N/A — internal runtime behavior; no public docs surface.

Closes #1863.

Workflow-NODE re-execution is deferred and tracked in #2005 — task-card resume is complete here; threading the answer into the engine trigger reader is the follow-up.

Deviation: resume is driven from the runtime `spawn_follow_up` fork rather than a brain-side `reenter_answered_blocker`. This is functionally equivalent for the task-card path; ACP-specific coverage is not present in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blockers can now be resolved with Retry, Amend, Skip, or Cancel actions.
  * Resuming a blocker re-enters the paused step and restores the associated workflow state.
  * Amend responses are added to the relevant card notes.
  * Cancelled cards return to To-do with a clear cancellation indicator.
  * Workflow-node cancellations and direct acknowledgements are now handled appropriately.

* **Bug Fixes**
  * Blocker approvals no longer trigger unintended task execution.
  * Blocker resolutions persist across runtime restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->