### PR TITLE
chore(deps): migrate to the split TinyAgents crates and bump openhuman

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6951,10 +6951,6 @@ name = "tinycortex-api"
 version = "0.1.1"
 
 [[patch.unused]]
-name = "tinyplace"
-version = "2.0.4"
-
-[[patch.unused]]
 name = "whisper-rs-sys"
 version = "0.15.0"
 source = "git+https://github.com/tinyhumansai/whisper-rs-sys.git?branch=main#229cb4c97e41ca302d3f13b1fa7e93a9b417a5f9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1438,7 +1438,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1566,7 +1566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3181,7 +3181,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3315,8 +3315,9 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.20",
- "tinyagents",
+ "tinyagents-harness",
  "tinyflows",
+ "tinyinference",
  "tinymcp",
  "tinymemory",
  "tinymemory-api",
@@ -3339,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.18"
+version = "0.63.19"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3389,22 +3390,23 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.20",
- "tinyagents",
+ "tinyagents-graph",
+ "tinyagents-harness",
+ "tinyagents-language",
+ "tinyagents-registry",
+ "tinyagents-session",
  "tinybus",
- "tinychannels",
- "tinycortex",
- "tinycortex-api",
+ "tinychannels-bus",
+ "tinyconnectors-bus",
  "tinyhosts",
  "tinyhumans-sdk",
+ "tinyinference",
  "tinyjuice-bus",
  "tinymcp",
  "tinymcp-bus",
- "tinymemory",
  "tinymemory-api",
  "tinymemory-bus",
- "tinymemory-core",
- "tinymemory-tinycortex",
- "tinyplace",
+ "tinymemory-sources",
  "tinyruntime-bus",
  "tinytools",
  "tokio",
@@ -3902,7 +3904,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4236,7 +4238,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4684,7 +4686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5224,7 +5226,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5316,8 +5318,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyagents"
-version = "2.1.1"
+name = "tinyagents-graph"
+version = "2.1.2"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "reqwest",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tinyagents-harness",
+ "tinyagents-language",
+ "tinyagents-tracing",
+ "tinyinference",
+ "tokio",
+]
+
+[[package]]
+name = "tinyagents-harness"
+version = "2.1.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5332,14 +5353,52 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.20",
+ "tinyagents-tracing",
+ "tinyinference",
  "tinytools",
  "tokio",
- "tracing",
 ]
 
 [[package]]
+name = "tinyagents-language"
+version = "2.1.2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tinyagents-harness",
+]
+
+[[package]]
+name = "tinyagents-registry"
+version = "2.1.2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tinyagents-graph",
+ "tinyagents-harness",
+ "tinyagents-language",
+ "tinyinference",
+]
+
+[[package]]
+name = "tinyagents-session"
+version = "2.1.2"
+dependencies = [
+ "chrono",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tinyagents-harness",
+ "tinyagents-tracing",
+]
+
+[[package]]
+name = "tinyagents-tracing"
+version = "2.1.2"
+
+[[package]]
 name = "tinybus"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -5352,7 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "tinybus-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5360,79 +5419,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinychannels"
-version = "0.1.0"
+name = "tinychannels-bus"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
  "chrono",
- "directories",
- "futures",
- "futures-util",
  "hex",
  "hmac 0.12.1",
  "parking_lot",
  "rand 0.10.2",
- "reqwest",
- "rusqlite",
- "rustls",
- "rustls-pki-types",
- "schemars",
- "serde",
- "serde_json",
- "sha1 0.10.7",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "tokio",
- "tokio-rustls",
- "tokio-tungstenite",
- "tracing",
- "url",
- "urlencoding",
- "uuid",
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "tinycortex"
-version = "0.1.1"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "dirs 5.0.1",
- "futures",
- "log",
- "parking_lot",
- "rand 0.10.2",
- "regex",
- "reqwest",
- "rusqlite",
  "schemars",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.20",
- "tinyagents",
- "tinycortex-api",
  "tokio",
- "toml",
  "tracing",
  "uuid",
- "walkdir",
 ]
 
 [[package]]
-name = "tinycortex-api"
-version = "0.1.1"
+name = "tinyconnectors-bus"
+version = "0.7.1"
 dependencies = [
- "tinymemory-api",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "tinyflows"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -5450,16 +5468,16 @@ dependencies = [
 
 [[package]]
 name = "tinyhosts"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "hex",
  "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",
- "sha1 0.10.7",
+ "sha1 0.11.0",
  "thiserror 2.0.20",
 ]
 
@@ -5479,26 +5497,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyinference"
+version = "0.2.1"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "httpdate",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "tokio",
+]
+
+[[package]]
 name = "tinyjuice-bus"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tinymcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
- "dirs 5.0.1",
+ "base64 0.23.1",
+ "dirs 6.0.0",
  "futures-util",
  "parking_lot",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tinymcp-bus",
  "tokio",
@@ -5508,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "tinymcp-bus"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "schemars",
  "serde",
@@ -5517,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "tinymemory"
-version = "1.13.3"
+version = "1.13.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5564,38 +5598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinymemory-core"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "dirs 6.0.0",
- "futures",
- "log",
- "parking_lot",
- "rand 0.10.2",
- "regex",
- "reqwest",
- "rusqlite",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.20",
- "tinyagents",
- "tinycortex",
- "tinycortex-api",
- "tinymemory-api",
- "tinymemory-sources",
- "tinymemory-sync",
- "tokio",
- "tracing",
- "url",
- "uuid",
- "walkdir",
-]
-
-[[package]]
 name = "tinymemory-remote"
 version = "0.1.0"
 dependencies = [
@@ -5632,64 +5634,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinymemory-sync"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "log",
- "serde",
- "serde_json",
- "tracing",
-]
-
-[[package]]
-name = "tinymemory-tinycortex"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "log",
- "rusqlite",
- "serde",
- "serde_json",
- "tinycortex",
- "tinymemory-api",
- "tinymemory-core",
- "tokio",
- "uuid",
-]
-
-[[package]]
-name = "tinyplace"
-version = "2.0.4"
-dependencies = [
- "aes",
- "async-trait",
- "base64 0.22.1",
- "bs58",
- "cbc",
- "chrono",
- "curve25519-dalek",
- "ed25519-dalek",
- "futures-util",
- "hkdf",
- "hmac 0.12.1",
- "rand 0.8.7",
- "reqwest",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "tokio",
- "tokio-tungstenite",
- "url",
- "x25519-dalek",
-]
-
-[[package]]
 name = "tinyruntime-bus"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6435,7 +6381,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6991,6 +6937,22 @@ dependencies = [
  "log",
  "simd-adler32",
 ]
+
+[[patch.unused]]
+name = "tinychannels"
+version = "0.1.2"
+
+[[patch.unused]]
+name = "tinycortex"
+version = "0.1.2"
+
+[[patch.unused]]
+name = "tinycortex-api"
+version = "0.1.1"
+
+[[patch.unused]]
+name = "tinyplace"
+version = "2.0.4"
 
 [[patch.unused]]
 name = "whisper-rs-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -605,7 +605,11 @@ tinycortex = { path = "vendor/openhuman/vendor/tinycortex" }
 # their public trait identities remain identical.
 tinycortex-api = { path = "vendor/openhuman/vendor/tinycortex/api" }
 tinychannels = { path = "vendor/openhuman/vendor/tinychannels" }
-tinyplace = { path = "vendor/openhuman/vendor/tinyplace/sdk/rust" }
+# No `tinyplace` entry: openhuman dropped the submodule, so the path this
+# patched onto no longer exists at the pin and Cargo fails to load the source
+# outright — a patch path is resolved eagerly, whatever the feature set. Nothing
+# here consumes the crate either; the `tinyplace` FEATURE above is unrelated (it
+# only turns on `reqwest`).
 # Arrived with the #499 pin bump, and is NOT a submodule — openhuman vendors it
 # as a plain in-tree directory. Replicated for the same reason as the entries
 # above, but the reason it matters here is specific: without it Cargo resolves

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,21 @@ fs2 = "0.4"
 # and `axum`, so this is a direct-use declaration, not new compilation.
 tower = { version = "0.5", features = ["util"] }
 
-tinyagents = { path = "vendor/openhuman/vendor/tinyagents", optional = true, features = ["sqlite"] }
+# TinyAgents was split into a workspace of focused crates upstream, and the
+# model layer moved further still into `tinyinference` (a submodule of
+# tinyagents). There is no longer a single `tinyagents` package to depend on —
+# the old path now resolves to a virtual manifest — so this names the two
+# members opencompany actually uses, exactly as openhuman does:
+#
+# - `tinyagents-harness` — the agent loop's `tool` types.
+# - `tinyinference` — `ChatModel`, `ModelRequest`/`Response`, `Message`, `Usage`.
+#
+# Paths rebased onto the vendored checkout, same as the WS4 entries below, so
+# there is still one checkout and one crate identity.
+tinyagents-harness = { path = "vendor/openhuman/vendor/tinyagents/crates/tinyagents-harness", optional = true, features = [
+    "sqlite",
+] }
+tinyinference = { path = "vendor/openhuman/vendor/tinyagents/vendor/tinyinference/crates/tinyinference", optional = true }
 
 # WS4: openhuman embedded as a library (the harness). Only links under the
 # `openhuman` feature; the default build pulls none of this enormous native
@@ -390,7 +404,7 @@ default = ["oauth", "platform-jwt", "documents", "tinymemory"]
 # It is already in the default set via `oauth`, so this adds nothing there.
 documents = ["dep:pdf-extract", "dep:calamine", "dep:quick-xml", "dep:zip", "dep:reqwest"]
 
-tiny = ["tinyagents"]
+tiny = ["tinyagents-harness", "tinyinference"]
 # WS4: embed `vendor/openhuman` (`openhuman_core`) directly as the tenant agent
 # harness via `AgentBuilder`. `src/harness/` compiles only under this feature;
 # the default build stays offline and echo-brained (byte-for-byte unaffected).
@@ -565,16 +579,26 @@ paypal = ["dep:reqwest"]
 [patch."https://github.com/tinyhumansai/tinymemory"]
 tinymemory-api = { path = "vendor/openhuman/vendor/tinymemory/crates/tinymemory-api" }
 
+# The same hazard one crate over: `tinycortex` depends on `tinyinference` by git
+# rev, which `[patch.crates-io]` does not rewrite either. Without this entry
+# cargo resolves a second `tinyinference` beside the path copy openhuman and
+# this crate use, and the two `ChatModel`s are different types. Replicated from
+# openhuman's own Cargo.toml with the path rebased onto the vendored checkout.
+[patch."https://github.com/tinyhumansai/tinyinference"]
+tinyinference = { path = "vendor/openhuman/vendor/tinyagents/vendor/tinyinference/crates/tinyinference" }
+
 [patch.crates-io]
-# Reuse OpenHuman's own TinyAgents pin (2.1.0). This satisfies OpenHuman's
-# `^2.1` requirement while keeping a single checkout and crate identity.
-tinyagents = { path = "vendor/openhuman/vendor/tinyagents" }
+# No `tinyagents` entry: the crate no longer exists as a package (the workspace
+# split), and nothing in the graph asks crates.io for it any more — openhuman
+# names the members by path and tinyflows dropped the requirement. An entry here
+# would point at a virtual manifest and fail resolution outright.
 # WS4: openhuman's own Cargo.toml `[patch.crates-io]` is ignored when it is a
 # path dependency, so its vendored-submodule patches must be replicated here
 # (paths rebased onto `vendor/openhuman/vendor/...`). These entries are inert in
 # the default build — none of these crates are in the graph until the
 # `openhuman` feature is on — so they leave the offline build unaffected.
-tinyflows = { path = "vendor/openhuman/vendor/tinyflows" }
+# tinyflows split into a workspace too; the package now lives in `crates/`.
+tinyflows = { path = "vendor/openhuman/vendor/tinyflows/crates/tinyflows" }
 tinycortex = { path = "vendor/openhuman/vendor/tinycortex" }
 # `tinymemory-core` consumes the TinyCortex contract by version while
 # OpenHuman consumes the implementation by path. Keep both on one checkout so

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -107,5 +107,6 @@ webhooks       | compile-only | - | Only `HttpWebhookSink` / `HmacSha256Signer` 
 dns            | compile-only | - | Only `HickoryDnsResolver` is gated. The `DnsResolver` trait, `StaticDnsResolver` and the pure record generation test at default features.
 
 # --- Compile-only, no gated test exists yet ---------------------------------
-tiny           | compile-only | - | A dependency switch: it brings the vendored `tinyagents` crate into scope for `openhuman`. No code is gated on `tiny` itself, so there is nothing for a lane to run.
-tinyagents     | compile-only | - | The implicit feature of the optional `tinyagents` dependency, enabled only via `tiny`. Nothing is gated on it directly.
+tiny           | compile-only | - | A dependency switch: it brings the vendored TinyAgents crates into scope for `openhuman`. No code is gated on `tiny` itself, so there is nothing for a lane to run.
+tinyagents-harness | compile-only | - | The implicit feature of the optional `tinyagents-harness` dependency, enabled only via `tiny`. Nothing is gated on it directly. (Upstream split `tinyagents` into a workspace, so the single `tinyagents` feature this replaces no longer names a crate.)
+tinyinference  | compile-only | - | The implicit feature of the optional `tinyinference` dependency — the model layer TinyAgents moved upstream — enabled only via `tiny`. Nothing is gated on it directly.

--- a/scripts/ci/init-vendored-submodules.sh
+++ b/scripts/ci/init-vendored-submodules.sh
@@ -126,10 +126,26 @@ if [ -z "${VENDORED_CRATES}" ]; then
   exit 1
 fi
 
+# SSH-DECLARED SUBMODULES ARE REWRITTEN TO HTTPS
+#
+# The URLs come from whatever `.gitmodules` upstream wrote, and they are not
+# consistent: `tinyagents` declares `vendor/tinyinference` as
+# `git@github.com:tinyhumansai/tinyinference.git` while every one of its
+# siblings uses `https://`. A developer with an SSH key never notices; CI
+# authenticates with a token and has no key at all, so the clone fails with
+# "Could not read from remote repository" and every Rust lane dies in the
+# checkout step, before a crate compiles.
+#
+# Rewritten per invocation with `-c` rather than `git config --global`: this
+# script also runs on developer machines, and quietly mutating a person's
+# global git config to fix a CI problem is not this script's business. The
+# repositories are the same either way — only the transport differs.
+REWRITE_SSH='url.https://github.com/.insteadOf=git@github.com:'
+
 # Unquoted on purpose — the newline-separated list becomes one argument per
 # path. Submodule paths carry no whitespace.
 # shellcheck disable=SC2086
-git -C vendor/openhuman submodule update --init --depth 1 ${VENDORED_CRATES}
+git -C vendor/openhuman -c "${REWRITE_SSH}" submodule update --init --depth 1 ${VENDORED_CRATES}
 
 # SECOND LEVEL: each of the crates just checked out may itself declare
 # `vendor/`-prefixed submodules that its own manifest needs (a path dependency
@@ -181,5 +197,5 @@ for crate in ${VENDORED_CRATES}; do
   fi
 
   # shellcheck disable=SC2086
-  git -C "${crate_path}" submodule update --init --depth 1 ${NESTED_CRATES}
+  git -C "${crate_path}" -c "${REWRITE_SSH}" submodule update --init --depth 1 ${NESTED_CRATES}
 done

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -136,7 +136,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -392,7 +392,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -509,15 +509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -685,15 +676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -1382,7 +1364,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1593,7 +1575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2483,7 +2465,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -2653,7 +2635,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -3175,7 +3156,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3277,7 +3258,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3618,8 +3599,9 @@ dependencies = [
  "sha2 0.10.9",
  "swc_core",
  "thiserror 2.0.20",
- "tinyagents",
+ "tinyagents-harness",
  "tinyflows",
+ "tinyinference",
  "tinymcp",
  "tinymemory",
  "tinymemory-api",
@@ -3659,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.18"
+version = "0.63.19"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3709,22 +3691,23 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.20",
- "tinyagents",
+ "tinyagents-graph",
+ "tinyagents-harness",
+ "tinyagents-language",
+ "tinyagents-registry",
+ "tinyagents-session",
  "tinybus",
- "tinychannels",
- "tinycortex",
- "tinycortex-api",
+ "tinychannels-bus",
+ "tinyconnectors-bus",
  "tinyhosts",
  "tinyhumans-sdk",
+ "tinyinference",
  "tinyjuice-bus",
  "tinymcp",
  "tinymcp-bus",
- "tinymemory",
  "tinymemory-api",
  "tinymemory-bus",
- "tinymemory-core",
- "tinymemory-tinycortex",
- "tinyplace",
+ "tinymemory-sources",
  "tinyruntime-bus",
  "tinytools",
  "tokio",
@@ -3801,7 +3784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4321,7 +4304,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4351,8 +4334,6 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -4362,7 +4343,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -4375,16 +4356,6 @@ dependencies = [
  "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4661,7 +4632,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4670,7 +4641,6 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5102,6 +5072,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5238,7 +5219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5615,7 +5596,7 @@ dependencies = [
  "once_cell",
  "rustc-hash",
  "serde",
- "sha1",
+ "sha1 0.10.7",
  "string_enum",
  "swc_atoms",
  "swc_common",
@@ -6101,7 +6082,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -6129,7 +6110,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6221,8 +6202,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyagents"
-version = "2.1.1"
+name = "tinyagents-graph"
+version = "2.1.2"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "reqwest 0.12.28",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tinyagents-harness",
+ "tinyagents-language",
+ "tinyagents-tracing",
+ "tinyinference",
+ "tokio",
+]
+
+[[package]]
+name = "tinyagents-harness"
+version = "2.1.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6237,14 +6237,52 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.20",
+ "tinyagents-tracing",
+ "tinyinference",
  "tinytools",
  "tokio",
- "tracing",
 ]
 
 [[package]]
+name = "tinyagents-language"
+version = "2.1.2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tinyagents-harness",
+]
+
+[[package]]
+name = "tinyagents-registry"
+version = "2.1.2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tinyagents-graph",
+ "tinyagents-harness",
+ "tinyagents-language",
+ "tinyinference",
+]
+
+[[package]]
+name = "tinyagents-session"
+version = "2.1.2"
+dependencies = [
+ "chrono",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tinyagents-harness",
+ "tinyagents-tracing",
+]
+
+[[package]]
+name = "tinyagents-tracing"
+version = "2.1.2"
+
+[[package]]
 name = "tinybus"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -6257,7 +6295,7 @@ dependencies = [
 
 [[package]]
 name = "tinybus-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6265,79 +6303,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinychannels"
-version = "0.1.0"
+name = "tinychannels-bus"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
  "chrono",
- "directories",
- "futures",
- "futures-util",
  "hex",
  "hmac",
  "parking_lot",
  "rand 0.10.2",
- "reqwest 0.12.28",
- "rusqlite",
- "rustls",
- "rustls-pki-types",
- "schemars 1.2.2",
- "serde",
- "serde_json",
- "sha1",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "tokio",
- "tokio-rustls",
- "tokio-tungstenite",
- "tracing",
- "url",
- "urlencoding",
- "uuid",
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "tinycortex"
-version = "0.1.1"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "dirs 5.0.1",
- "futures",
- "log",
- "parking_lot",
- "rand 0.10.2",
- "regex",
- "reqwest 0.12.28",
- "rusqlite",
  "schemars 1.2.2",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.20",
- "tinyagents",
- "tinycortex-api",
  "tokio",
- "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
- "walkdir",
 ]
 
 [[package]]
-name = "tinycortex-api"
-version = "0.1.1"
+name = "tinyconnectors-bus"
+version = "0.7.1"
 dependencies = [
- "tinymemory-api",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "tinyflows"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -6355,16 +6352,16 @@ dependencies = [
 
 [[package]]
 name = "tinyhosts"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "hex",
  "percent-encoding",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.11.0",
  "thiserror 2.0.20",
 ]
 
@@ -6384,26 +6381,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyinference"
+version = "0.2.1"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "httpdate",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "tokio",
+]
+
+[[package]]
 name = "tinyjuice-bus"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tinymcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
- "dirs 5.0.1",
+ "base64 0.23.1",
+ "dirs 6.0.0",
  "futures-util",
  "parking_lot",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tinymcp-bus",
  "tokio",
@@ -6413,7 +6426,7 @@ dependencies = [
 
 [[package]]
 name = "tinymcp-bus"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "schemars 1.2.2",
  "serde",
@@ -6422,7 +6435,7 @@ dependencies = [
 
 [[package]]
 name = "tinymemory"
-version = "1.13.3"
+version = "1.13.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6456,38 +6469,6 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.20",
  "uuid",
-]
-
-[[package]]
-name = "tinymemory-core"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "dirs 6.0.0",
- "futures",
- "log",
- "parking_lot",
- "rand 0.10.2",
- "regex",
- "reqwest 0.12.28",
- "rusqlite",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.20",
- "tinyagents",
- "tinycortex",
- "tinycortex-api",
- "tinymemory-api",
- "tinymemory-sources",
- "tinymemory-sync",
- "tokio",
- "tracing",
- "url",
- "uuid",
- "walkdir",
 ]
 
 [[package]]
@@ -6527,64 +6508,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinymemory-sync"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "log",
- "serde",
- "serde_json",
- "tracing",
-]
-
-[[package]]
-name = "tinymemory-tinycortex"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "log",
- "rusqlite",
- "serde",
- "serde_json",
- "tinycortex",
- "tinymemory-api",
- "tinymemory-core",
- "tokio",
- "uuid",
-]
-
-[[package]]
-name = "tinyplace"
-version = "2.0.4"
-dependencies = [
- "aes",
- "async-trait",
- "base64 0.22.1",
- "bs58",
- "cbc",
- "chrono",
- "curve25519-dalek",
- "ed25519-dalek",
- "futures-util",
- "hkdf",
- "hmac",
- "rand 0.8.7",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "tokio",
- "tokio-tungstenite",
- "url",
- "x25519-dalek",
-]
-
-[[package]]
 name = "tinyruntime-bus"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -7003,7 +6928,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7037,7 +6962,7 @@ dependencies = [
  "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.7",
  "thiserror 2.0.20",
 ]
 
@@ -7533,7 +7458,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7611,20 +7536,7 @@ dependencies = [
  "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7723,30 +7635,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8351,3 +8245,15 @@ dependencies = [
  "log",
  "simd-adler32",
 ]
+
+[[patch.unused]]
+name = "tinychannels"
+version = "0.1.2"
+
+[[patch.unused]]
+name = "tinycortex"
+version = "0.1.2"
+
+[[patch.unused]]
+name = "tinycortex-api"
+version = "0.1.1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -162,11 +162,12 @@ tauri-build = { version = "2", features = [] }
 [patch."https://github.com/tinyhumansai/tinymemory"]
 tinymemory-api = { path = "../vendor/openhuman/vendor/tinymemory/crates/tinymemory-api" }
 
+[patch."https://github.com/tinyhumansai/tinyinference"]
+tinyinference = { path = "../vendor/openhuman/vendor/tinyagents/vendor/tinyinference/crates/tinyinference" }
+
 [patch.crates-io]
-tinyagents = { path = "../vendor/openhuman/vendor/tinyagents" }
-tinyflows = { path = "../vendor/openhuman/vendor/tinyflows" }
+tinyflows = { path = "../vendor/openhuman/vendor/tinyflows/crates/tinyflows" }
 tinycortex = { path = "../vendor/openhuman/vendor/tinycortex" }
 tinycortex-api = { path = "../vendor/openhuman/vendor/tinycortex/api" }
 tinychannels = { path = "../vendor/openhuman/vendor/tinychannels" }
-tinyplace = { path = "../vendor/openhuman/vendor/tinyplace/sdk/rust" }
 motosan-ai-oauth = { path = "../vendor/openhuman/vendor/motosan-ai-oauth" }

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -4291,8 +4291,8 @@ impl HarnessBrain {
 mod tests {
     use super::*;
 
-    use tinyagents::harness::message::Message;
-    use tinyagents::harness::model::{ChatModel, ModelRequest, ModelResponse};
+    use tinyinference::message::Message;
+    use tinyinference::model::{ChatModel, ModelRequest, ModelResponse};
 
     use crate::company::CompanyManifest;
     use crate::harness::provider::{HarnessModel, MockProvider};
@@ -5000,8 +5000,8 @@ description = "Builds it."
             &self,
             _state: &(),
             _request: ModelRequest,
-        ) -> tinyagents::Result<ModelResponse> {
-            Err(tinyagents::TinyAgentsError::Model(
+        ) -> tinyinference::Result<ModelResponse> {
+            Err(tinyinference::Error::Model(
                 "USER_INSUFFICIENT_CREDITS: insufficient budget for this account — add credits \
                  to continue"
                     .to_string(),
@@ -10346,7 +10346,7 @@ members = ["eng1", "eng2"]
             &self,
             _state: &(),
             request: ModelRequest,
-        ) -> tinyagents::Result<ModelResponse> {
+        ) -> tinyinference::Result<ModelResponse> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             if let Some(action) = self.actions.lock().unwrap().pop_front() {
                 let key = if self.key.is_empty() {
@@ -10692,10 +10692,10 @@ members = ["eng1", "eng2"]
     fn a_triage_request_is_recognised_as_one() {
         let triage = ModelRequest {
             messages: vec![
-                tinyagents::harness::message::Message::system(
+                tinyinference::message::Message::system(
                     crate::harness::triage::system_prompt_for_test(),
                 ),
-                tinyagents::harness::message::Message::user("hello".to_string()),
+                tinyinference::message::Message::user("hello".to_string()),
             ],
             ..ModelRequest::default()
         };
@@ -10706,10 +10706,8 @@ members = ["eng1", "eng2"]
         );
         let turn = ModelRequest {
             messages: vec![
-                tinyagents::harness::message::Message::system(
-                    "You are the CEO of Acme.".to_string(),
-                ),
-                tinyagents::harness::message::Message::user("ship it".to_string()),
+                tinyinference::message::Message::system("You are the CEO of Acme.".to_string()),
+                tinyinference::message::Message::user("ship it".to_string()),
             ],
             ..ModelRequest::default()
         };
@@ -10745,7 +10743,7 @@ members = ["eng1", "eng2"]
             &self,
             _state: &(),
             request: ModelRequest,
-        ) -> tinyagents::Result<ModelResponse> {
+        ) -> tinyinference::Result<ModelResponse> {
             if is_selection_request(&request) {
                 self.selector_calls
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -10772,10 +10770,10 @@ members = ["eng1", "eng2"]
     fn a_selection_request_is_recognised_as_one() {
         let selection = ModelRequest {
             messages: vec![
-                tinyagents::harness::message::Message::system(
+                tinyinference::message::Message::system(
                     crate::harness::selector::system_prompt_for_test(),
                 ),
-                tinyagents::harness::message::Message::user("who owns login?".to_string()),
+                tinyinference::message::Message::user("who owns login?".to_string()),
             ],
             ..ModelRequest::default()
         };
@@ -11097,7 +11095,7 @@ members = ["eng1", "eng2"]
             &self,
             _state: &(),
             request: ModelRequest,
-        ) -> tinyagents::Result<ModelResponse> {
+        ) -> tinyinference::Result<ModelResponse> {
             // Issue #678: a triage escalation is a classification, not a turn.
             // It rides the same `HarnessModel` handle the roster runs on, so
             // without this it would consume a scripted push and shift every
@@ -11115,7 +11113,7 @@ members = ["eng1", "eng2"]
             }
             let invoke = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
             if self.faults.fail_from.is_some_and(|from| invoke >= from) {
-                return Err(tinyagents::TinyAgentsError::Model(
+                return Err(tinyinference::Error::Model(
                     "the delegate's provider fell over".to_string(),
                 ));
             }

--- a/src/harness/built_in/build.rs
+++ b/src/harness/built_in/build.rs
@@ -1177,7 +1177,7 @@ pub fn build_agent(
     let agent_definition_name = manifest_agent.id.as_str();
 
     let mut agent = AgentBuilder::default()
-        // `HarnessModel` upcasts to the tinyagents `ChatModel<()>` the builder's
+        // `HarnessModel` upcasts to the tinyinference `ChatModel<()>` the builder's
         // native injection seam takes (the old `Provider` adapter is gone).
         .chat_model(deps.provider.clone() as Arc<dyn tinyinference::model::ChatModel<()>>)
         .memory(memory)

--- a/src/harness/built_in/build.rs
+++ b/src/harness/built_in/build.rs
@@ -1103,7 +1103,6 @@ pub fn build_agent(
 
     let prompt_builder = SystemPromptBuilder::for_subagent(
         persona, /* omit_identity */ true, /* omit_safety_preamble */ false,
-        /* omit_skills_catalog */ true,
     );
 
     let model = deps
@@ -1180,7 +1179,7 @@ pub fn build_agent(
     let mut agent = AgentBuilder::default()
         // `HarnessModel` upcasts to the tinyagents `ChatModel<()>` the builder's
         // native injection seam takes (the old `Provider` adapter is gone).
-        .chat_model(deps.provider.clone() as Arc<dyn tinyagents::harness::model::ChatModel<()>>)
+        .chat_model(deps.provider.clone() as Arc<dyn tinyinference::model::ChatModel<()>>)
         .memory(memory)
         .tools(tools)
         .tool_dispatcher(tool_dispatcher)

--- a/src/harness/built_in/confine.rs
+++ b/src/harness/built_in/confine.rs
@@ -315,7 +315,7 @@ pub fn build_confined_agent(
     let tools: Vec<Box<dyn Tool>> = Vec::new();
 
     AgentBuilder::default()
-        .chat_model(deps.provider.clone() as Arc<dyn tinyagents::harness::model::ChatModel<()>>)
+        .chat_model(deps.provider.clone() as Arc<dyn tinyinference::model::ChatModel<()>>)
         .memory(memory)
         .tools(tools)
         .tool_dispatcher(tool_dispatcher)
@@ -324,7 +324,6 @@ pub fn build_confined_agent(
             confined_persona(company_name, confinement),
             /* omit_identity */ true,
             /* omit_safety_preamble */ false,
-            /* omit_skills_catalog */ true,
         ))
         .model_name(model)
         .workspace_dir(workspace)

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -210,7 +210,7 @@ use crate::runtime::builder::agent_scoped_grants;
 #[derive(Clone)]
 pub struct HarnessDeps {
     /// The inference model shared across a company's agents. A [`HarnessModel`]
-    /// is a tinyagents [`ChatModel<()>`](tinyinference::model::ChatModel)
+    /// is a tinyinference [`ChatModel<()>`](tinyinference::model::ChatModel)
     /// plus the telemetry slug the cost hook reads live per turn; it upcasts to
     /// `Arc<dyn ChatModel<()>>` at the openhuman `AgentBuilder::chat_model` seam.
     pub provider: Arc<dyn HarnessModel>,

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -210,7 +210,7 @@ use crate::runtime::builder::agent_scoped_grants;
 #[derive(Clone)]
 pub struct HarnessDeps {
     /// The inference model shared across a company's agents. A [`HarnessModel`]
-    /// is a tinyagents [`ChatModel<()>`](tinyagents::harness::model::ChatModel)
+    /// is a tinyagents [`ChatModel<()>`](tinyinference::model::ChatModel)
     /// plus the telemetry slug the cost hook reads live per turn; it upcasts to
     /// `Arc<dyn ChatModel<()>>` at the openhuman `AgentBuilder::chat_model` seam.
     pub provider: Arc<dyn HarnessModel>,
@@ -1748,7 +1748,7 @@ const WALL_CLOCK_CEILING_LEAVES: [&str; 2] = [
 ///
 /// **Whole phrases, not the words `wall-clock budget`.** A provider's response
 /// body reaches this chain verbatim — `provider.rs` raises
-/// `TinyAgentsError::Model(format!("hosted inference returned {status}: {text}"))`
+/// `InferenceError::Model(format!("hosted inference returned {status}: {text}"))`
 /// — so a hosted or BYOK endpoint that says anything about a wall-clock budget
 /// of its own would otherwise be reported as this ceiling, complete with a
 /// measured duration of a second or two and an instruction to raise
@@ -5221,7 +5221,7 @@ mod tests {
     use std::sync::Mutex as StdMutex;
 
     use async_trait::async_trait;
-    use tinyagents::harness::model::{ChatModel, ModelRequest, ModelResponse};
+    use tinyinference::model::{ChatModel, ModelRequest, ModelResponse};
 
     use crate::company::CompanyManifest;
     use crate::harness::provider::MockProvider;
@@ -7206,11 +7206,11 @@ description = "Builds the product."
             &self,
             _state: &(),
             _request: ModelRequest,
-        ) -> tinyagents::Result<ModelResponse> {
+        ) -> tinyinference::Result<ModelResponse> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             match self.script.lock().unwrap().pop_front() {
                 Some(Ok(reply)) => Ok(ModelResponse::assistant(reply)),
-                Some(Err(err)) => Err(tinyagents::TinyAgentsError::Model(err)),
+                Some(Err(err)) => Err(tinyinference::Error::Model(err)),
                 None => Ok(ModelResponse::assistant("exhausted")),
             }
         }
@@ -7448,7 +7448,7 @@ description = "Builds the product."
     }
 
     /// A provider's response body reaches this chain verbatim — `provider.rs`
-    /// raises `TinyAgentsError::Model("hosted inference returned {status}: {text}")`
+    /// raises `InferenceError::Model("hosted inference returned {status}: {text}")`
     /// — so an endpoint with a wall-clock budget of its own must not be read as
     /// OpenHuman's per-turn ceiling. That misdiagnosis is worse than the plain
     /// wrapper: it would report the second the request took as if it were a
@@ -11545,7 +11545,7 @@ budget_usd_daily = 0.0
         use std::sync::Mutex as StdMutex;
 
         use futures::stream::{self, BoxStream};
-        use tinyagents::harness::model::{ModelRequest, ModelResponse};
+        use tinyinference::model::{ModelRequest, ModelResponse};
 
         use crate::ports::events::EventStreamItem;
         use crate::ports::types::{CompanyEvent, EventSeq, StoredEvent};
@@ -11670,7 +11670,7 @@ budget_usd_daily = 0.0
                 &self,
                 _state: &(),
                 request: ModelRequest,
-            ) -> tinyagents::Result<ModelResponse> {
+            ) -> tinyinference::Result<ModelResponse> {
                 let joined = request
                     .messages
                     .iter()

--- a/src/harness/built_in/planning.rs
+++ b/src/harness/built_in/planning.rs
@@ -1608,7 +1608,7 @@ async fn call_model(
 
 /// Recovers the token/cost totals from a completed call.
 ///
-/// Cost is not on tinyagents' [`Usage`](tinyinference::usage::Usage) — the
+/// Cost is not on tinyinference's [`Usage`](tinyinference::usage::Usage) — the
 /// managed backend reports it in a billing envelope the provider re-projects
 /// onto [`ModelResponse::raw`] under `openhuman_usage_meta`. Reading it here
 /// rather than inventing a price is what keeps the Usage view's planning spend

--- a/src/harness/built_in/planning.rs
+++ b/src/harness/built_in/planning.rs
@@ -95,8 +95,8 @@ use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use serde::Deserialize;
-use tinyagents::harness::message::Message;
-use tinyagents::harness::model::{ModelRequest, ModelResponse};
+use tinyinference::message::Message;
+use tinyinference::model::{ModelRequest, ModelResponse};
 
 use crate::company::runtime::CompanyRuntime;
 use crate::harness::HarnessDeps;
@@ -1608,7 +1608,7 @@ async fn call_model(
 
 /// Recovers the token/cost totals from a completed call.
 ///
-/// Cost is not on tinyagents' [`Usage`](tinyagents::harness::usage::Usage) — the
+/// Cost is not on tinyagents' [`Usage`](tinyinference::usage::Usage) — the
 /// managed backend reports it in a billing envelope the provider re-projects
 /// onto [`ModelResponse::raw`] under `openhuman_usage_meta`. Reading it here
 /// rather than inventing a price is what keeps the Usage view's planning spend

--- a/src/harness/built_in/planning/test.rs
+++ b/src/harness/built_in/planning/test.rs
@@ -18,9 +18,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
-use tinyagents::harness::model::{ChatModel, ModelResponse};
-use tinyagents::harness::usage::Usage;
-use tinyagents::{Result as TaResult, TinyAgentsError};
+use tinyinference::model::{ChatModel, ModelResponse};
+use tinyinference::usage::Usage;
+use tinyinference::{Error as InferenceError, Result as TaResult};
 
 use super::*;
 use crate::company::CompanyManifest;
@@ -126,7 +126,7 @@ impl ChatModel<()> for ScriptedModel {
                     None => response,
                 })
             }
-            None => Err(TinyAgentsError::Model("the brain is down".to_string())),
+            None => Err(InferenceError::Model("the brain is down".to_string())),
         }
     }
 }

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -34,13 +34,13 @@ use std::sync::{Arc, LazyLock, OnceLock, RwLock};
 
 use async_trait::async_trait;
 
-use tinyagents::harness::message::{AssistantMessage, ContentBlock, Message};
-use tinyagents::harness::model::{
+use tinyinference::message::{AssistantMessage, ContentBlock, Message};
+use tinyinference::model::{
     ChatModel, Modalities, ModelProfile, ModelRequest, ModelResponse, ToolChoice,
 };
-use tinyagents::harness::tool::{ToolCall, ToolSchema};
-use tinyagents::harness::usage::Usage;
-use tinyagents::{Result as TaResult, TinyAgentsError};
+use tinyinference::tool::{ToolCall, ToolSchema};
+use tinyinference::usage::Usage;
+use tinyinference::{Error as InferenceError, Result as TaResult};
 
 use crate::app::config::EnvSource;
 use crate::company::Inference;
@@ -843,7 +843,7 @@ fn model_response_from_payload(payload: serde_json::Value) -> TaResult<ModelResp
             .iter()
             .any(|call| call.name == crate::ports::types::REQUEST_APPROVAL_EFFECT_KIND)
     {
-        return Err(TinyAgentsError::Model(
+        return Err(InferenceError::Model(
             "inference returned request_approval with sibling tool calls; the whole batch was \
              refused so the approval boundary cannot be crossed"
                 .to_string(),
@@ -954,7 +954,7 @@ fn model_response_from_payload(payload: serde_json::Value) -> TaResult<ModelResp
             .as_deref()
             .map(|r| format!(" (finish_reason: {r})"))
             .unwrap_or_default();
-        return Err(TinyAgentsError::Model(format!(
+        return Err(InferenceError::Model(format!(
             "inference response requested a tool call that failed to parse{detail}"
         )));
     }
@@ -1043,7 +1043,7 @@ fn model_response_from_payload(payload: serde_json::Value) -> TaResult<ModelResp
             .as_deref()
             .map(|r| format!(" (finish_reason: {r})"))
             .unwrap_or_default();
-        return Err(TinyAgentsError::Model(format!(
+        return Err(InferenceError::Model(format!(
             "inference response carried neither choices[0].message.content nor tool_calls{detail}"
         )));
     }
@@ -1265,7 +1265,7 @@ impl ChatModel<()> for HostedProvider {
         // Resolved per request, never captured: on the hosted platform this reads
         // a token file the cluster rewrites in place every few minutes.
         let bearer = self.config.credential.current().await.map_err(|e| {
-            TinyAgentsError::Model(format!("resolving the TinyHumans credential: {e}"))
+            InferenceError::Model(format!("resolving the TinyHumans credential: {e}"))
         })?;
         if let Some(bearer) = &bearer {
             http = http.bearer_auth(bearer);
@@ -1277,7 +1277,7 @@ impl ChatModel<()> for HostedProvider {
         let response = http
             .send()
             .await
-            .map_err(|e| TinyAgentsError::Model(format!("hosted inference request failed: {e}")))?;
+            .map_err(|e| InferenceError::Model(format!("hosted inference request failed: {e}")))?;
         let status = response.status();
         if !status.is_success() {
             // A rejected bearer may mean the platform rotated the token early;
@@ -1294,9 +1294,9 @@ impl ChatModel<()> for HostedProvider {
             // default `[inference]`.
             if let Some(advice) = model_unavailable_advice(status, &error, &models_url, None, None)
             {
-                return Err(TinyAgentsError::Model(advice));
+                return Err(InferenceError::Model(advice));
             }
-            return Err(TinyAgentsError::Model(error));
+            return Err(InferenceError::Model(error));
         }
 
         // Published only now, once *this* request has come back 2xx, and
@@ -1313,7 +1313,7 @@ impl ChatModel<()> for HostedProvider {
         *self.telemetry_model.write().unwrap() = Some(crate::metering::ModelSlug::classify(model));
 
         let payload: serde_json::Value = response.json().await.map_err(|e| {
-            TinyAgentsError::Model(format!("hosted inference response was not JSON: {e}"))
+            InferenceError::Model(format!("hosted inference response was not JSON: {e}"))
         })?;
         model_response_from_payload(payload)
     }
@@ -1702,7 +1702,7 @@ impl ChatModel<()> for TenantProvider {
         let decl = self
             .resolve()
             .await
-            .map_err(|e| TinyAgentsError::Model(e.to_string()))?;
+            .map_err(|e| InferenceError::Model(e.to_string()))?;
         let messages = wire_messages(&request.messages);
         let model = request.model.as_deref().unwrap_or(DEFAULT_HOSTED_MODEL);
         let temperature = request.temperature.unwrap_or(0.0);
@@ -1716,7 +1716,7 @@ impl ChatModel<()> for TenantProvider {
             &request.tool_choice,
         )
         .await
-        .map_err(|e| TinyAgentsError::Model(e.to_string()))?;
+        .map_err(|e| InferenceError::Model(e.to_string()))?;
         // Always this harness's real id — `self.scope.id` is meaningful
         // whether or not this is the company's *default* harness (the
         // default's own `[harness.inference]` beats the company mapping the
@@ -1732,7 +1732,7 @@ impl ChatModel<()> for TenantProvider {
             Some(decl.source),
         )
         .await
-        .map_err(|e| TinyAgentsError::Model(e.to_string()))?;
+        .map_err(|e| InferenceError::Model(e.to_string()))?;
         // Classified from `plan.model` — the exact string that goes on the wire,
         // *after* the tenant `[inference].models` table has been applied — so
         // the sample names what actually ran rather than the tier that was
@@ -3217,13 +3217,13 @@ mod tests {
     /// are the outbound half of native tool calling.
     #[test]
     fn tools_and_tool_history_serialize_to_openai_wire() {
-        use tinyagents::harness::message::Message;
+        use tinyinference::message::Message;
 
         let tools = wire_tools(&[ToolSchema {
             name: "check_inventory".to_string(),
             description: "look up stock".to_string(),
             parameters: serde_json::json!({ "type": "object" }),
-            format: tinyagents::harness::tool::ToolFormat::default(),
+            format: tinyinference::tool::ToolFormat::default(),
         }]);
         let mut body = serde_json::json!({ "model": "chat-v1" });
         attach_tools(&mut body, tools, &ToolChoice::Required, true);
@@ -3238,7 +3238,7 @@ mod tests {
                 name: "check_inventory".to_string(),
                 description: "look up stock".to_string(),
                 parameters: serde_json::json!({ "type": "object" }),
-                format: tinyagents::harness::tool::ToolFormat::default(),
+                format: tinyinference::tool::ToolFormat::default(),
             }]),
             &ToolChoice::Required,
             false,

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -1,6 +1,6 @@
 //! Inference model implementations for the embedded harness.
 //!
-//! openhuman's inference now runs on tinyagents [`ChatModel<()>`] (the old
+//! openhuman's inference now runs on tinyinference [`ChatModel<()>`] (the old
 //! `Provider` trait was deleted upstream), so opencompany brings its own
 //! implementations. Consistent with the spec non-goal "not a model host", only
 //! two production surfaces ship:
@@ -69,7 +69,7 @@ pub const OPENROUTER_TITLE: &str = "OpenCompany";
 /// backend-charged USD. Must match openhuman's `OPENHUMAN_USAGE_META_KEY`.
 const OPENHUMAN_USAGE_META_KEY: &str = "openhuman_usage_meta";
 
-/// A harness inference model: a tinyagents [`ChatModel<()>`] plus the telemetry
+/// A harness inference model: a tinyinference [`ChatModel<()>`] plus the telemetry
 /// slug OpenCompany attributes per-turn cost to.
 ///
 /// `ChatModel` carries no provider identity, so this thin supertrait re-adds the
@@ -645,7 +645,7 @@ static MANAGED_PROFILE: LazyLock<ModelProfile> = LazyLock::new(|| ModelProfile {
 });
 
 /// Extract token usage from an OpenAI-compatible chat-completion payload as a
-/// tinyagents [`Usage`], or `None` when the payload carries no `usage` block.
+/// tinyinference [`Usage`], or `None` when the payload carries no `usage` block.
 ///
 /// Cached-input tokens follow the same precedence the legacy path used: the
 /// `openhuman.usage.cached_input_tokens` envelope wins over the standard
@@ -715,7 +715,7 @@ fn inject_usage_meta(
     }
 }
 
-/// Parse the OpenAI `choices[0].message.tool_calls[]` array into tinyagents
+/// Parse the OpenAI `choices[0].message.tool_calls[]` array into tinyinference
 /// [`ToolCall`]s. `function.arguments` arrives as a JSON **string**, which is
 /// parsed back into a value; an unparseable blob is preserved verbatim and the
 /// call is flagged [`ToolCall::invalid`] (mirroring tinyagents' tolerance of

--- a/src/harness/built_in/selector.rs
+++ b/src/harness/built_in/selector.rs
@@ -38,8 +38,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tinyagents::harness::message::Message;
-use tinyagents::harness::model::{ModelRequest, ModelResponse};
+use tinyinference::message::Message;
+use tinyinference::model::{ModelRequest, ModelResponse};
 
 use crate::harness::HarnessDeps;
 use crate::harness::build::model_for_tier;

--- a/src/harness/built_in/steps.rs
+++ b/src/harness/built_in/steps.rs
@@ -1416,9 +1416,41 @@ mod tests {
     /// "unreadable: No such file or directory" reads as a broken test rather
     /// than as the vendored tree having been rearranged underneath it. The
     /// needle these tests pin may well still exist; only its address changed.
+    /// **The module, not one file.** Upstream splits a large module into
+    /// `foo.rs` + `foo_part_NN.rs` as it grows, and the #5767-era pin moved both
+    /// needles below out of their parent and into a `_part_02`. The parent still
+    /// exists — it just declares the parts now — so reading it alone finds
+    /// nothing and the canary fires as though the *behaviour* changed. Reading
+    /// the siblings keeps the coupling honest across a split: what these tests
+    /// pin is the needle, not the file it lives in.
     fn vendored(relative: &str) -> String {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(relative);
-        std::fs::read_to_string(&path).unwrap_or_else(|err| {
+        let mut all = read_vendored(&path, relative);
+        if let (Some(dir), Some(stem)) = (path.parent(), path.file_stem()) {
+            let prefix = format!("{}_part_", stem.to_string_lossy());
+            let mut parts: Vec<_> = std::fs::read_dir(dir)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with(&prefix) && n.ends_with(".rs"))
+                })
+                .collect();
+            // Deterministic order, so a failure message is reproducible.
+            parts.sort();
+            for part in parts {
+                all.push('\n');
+                all.push_str(&std::fs::read_to_string(&part).unwrap_or_default());
+            }
+        }
+        all
+    }
+
+    fn read_vendored(path: &std::path::Path, relative: &str) -> String {
+        std::fs::read_to_string(path).unwrap_or_else(|err| {
             let basename = relative.rsplit('/').next().unwrap_or(relative);
             panic!(
                 "vendored source {} is unreadable: {err}\n\

--- a/src/harness/built_in/triage.rs
+++ b/src/harness/built_in/triage.rs
@@ -54,8 +54,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tinyagents::harness::message::Message;
-use tinyagents::harness::model::{ModelRequest, ModelResponse};
+use tinyinference::message::Message;
+use tinyinference::model::{ModelRequest, ModelResponse};
 
 use crate::harness::HarnessDeps;
 use crate::harness::build::model_for_tier;

--- a/src/harness/built_in/workflow_build.rs
+++ b/src/harness/built_in/workflow_build.rs
@@ -60,8 +60,8 @@ use std::time::Duration;
 
 use regex::Regex;
 use serde::Deserialize;
-use tinyagents::harness::message::Message;
-use tinyagents::harness::model::{ModelRequest, ModelResponse};
+use tinyinference::message::Message;
+use tinyinference::model::{ModelRequest, ModelResponse};
 
 use crate::company::runtime::CompanyRuntime;
 use crate::company::{

--- a/src/harness/built_in/workflow_build/agent.rs
+++ b/src/harness/built_in/workflow_build/agent.rs
@@ -3,7 +3,7 @@
 //! PR-1 wired the effective-tool set; PR-2 turns the copilot into a real
 //! tool-using [`Agent`](oh::agent::Agent) built fresh per request. It reuses the
 //! roster's inference engine (`deps.provider`, an `Arc<dyn HarnessModel>` that
-//! upcasts to the tinyagents `ChatModel<()>` the builder's native-injection seam
+//! upcasts to the tinyinference `ChatModel<()>` the builder's native-injection seam
 //! takes), the same seam [`build_agent`](crate::harness::build::build_agent)
 //! uses for a company teammate — so the copilot's spend is captured as
 //! backend-charged USD on the agent's own per-turn usage, not the token-only

--- a/src/harness/built_in/workflow_build/agent.rs
+++ b/src/harness/built_in/workflow_build/agent.rs
@@ -118,7 +118,7 @@ pub(super) fn build_copilot_agent(
     let _ = std::fs::create_dir_all(&workspace);
 
     let mut agent = AgentBuilder::default()
-        .chat_model(deps.provider.clone() as Arc<dyn tinyagents::harness::model::ChatModel<()>>)
+        .chat_model(deps.provider.clone() as Arc<dyn tinyinference::model::ChatModel<()>>)
         .memory(memory)
         .tools(tools)
         .tool_dispatcher(tool_dispatcher)

--- a/src/harness/built_in/workflow_build/test.rs
+++ b/src/harness/built_in/workflow_build/test.rs
@@ -16,10 +16,10 @@ use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
-use tinyagents::harness::model::{ChatModel, ModelProfile, ModelResponse};
-use tinyagents::harness::tool::ToolCall;
-use tinyagents::harness::usage::Usage;
-use tinyagents::{Result as TaResult, TinyAgentsError};
+use tinyinference::model::{ChatModel, ModelProfile, ModelResponse};
+use tinyinference::tool::ToolCall;
+use tinyinference::usage::Usage;
+use tinyinference::{Error as InferenceError, Result as TaResult};
 
 use super::agent::copilot_persona;
 use super::tools::{
@@ -117,7 +117,7 @@ impl ChatModel<()> for ScriptedModel {
             runtime.tasks().upsert(runtime.id(), &card).await.unwrap();
         }
         if self.fail {
-            return Err(TinyAgentsError::Model("the brain is down".to_string()));
+            return Err(InferenceError::Model("the brain is down".to_string()));
         }
         let reply = self.replies[index.min(self.replies.len() - 1)].clone();
         Ok(ModelResponse::assistant(reply))

--- a/src/harness/profile_draft.rs
+++ b/src/harness/profile_draft.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde::Deserialize;
-use tinyagents::harness::message::Message;
-use tinyagents::harness::model::{ModelRequest, ModelResponse};
+use tinyinference::message::Message;
+use tinyinference::model::{ModelRequest, ModelResponse};
 
 use crate::company::profile_draft::{
     DraftRefusal, ProfileDraft, ProfileField, ProfileSubject, Sibling, TurnRole,

--- a/src/harness/roster_build.rs
+++ b/src/harness/roster_build.rs
@@ -44,8 +44,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde::Deserialize;
-use tinyagents::harness::message::Message;
-use tinyagents::harness::model::{ModelRequest, ModelResponse};
+use tinyinference::message::Message;
+use tinyinference::model::{ModelRequest, ModelResponse};
 
 use crate::company::setup::{
     AgentFocus, FallbackReason, MAX_AGENTS, MAX_DESCRIPTION, MIN_AGENTS, ProposedAgent,
@@ -819,8 +819,8 @@ mod test {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use async_trait::async_trait;
-    use tinyagents::Result as TaResult;
-    use tinyagents::harness::model::ChatModel;
+    use tinyinference::Result as TaResult;
+    use tinyinference::model::ChatModel;
 
     /// A model that answers from a script, one reply per call, and remembers the
     /// prompts it was sent.
@@ -889,7 +889,7 @@ mod test {
     #[async_trait]
     impl ChatModel<()> for UnreachableModel {
         async fn invoke(&self, _state: &(), _request: ModelRequest) -> TaResult<ModelResponse> {
-            Err(tinyagents::TinyAgentsError::Model(
+            Err(tinyinference::Error::Model(
                 "provider refused the call".to_string(),
             ))
         }

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -2200,9 +2200,11 @@ pub fn standing_scope_of(tool: &str, args: &serde_json::Value) -> Option<String>
 /// catalogue has never heard of it.
 #[cfg(feature = "openhuman")]
 fn composio_toolkit_of(slug: &str) -> Option<String> {
-    use openhuman_core::openhuman::memory::sync::composio::providers::{
-        catalog_for_toolkit, toolkit_from_slug,
-    };
+    // The curated catalogue moved upstream into TinyMemory's Composio
+    // vocabulary; `tinymemory_api` re-exports `tinymemory_bus::composio`
+    // wholesale, so this is the same items openhuman itself now uses.
+    use tinymemory_api::composio::catalogs::catalog_for_toolkit;
+    use tinymemory_api::composio::scopes::toolkit_from_slug;
     let toolkit = toolkit_from_slug(slug)?;
     // The slug's prefix is *some* word for every non-empty slug, so the
     // catalogue lookup is what separates a real toolkit from a typo.
@@ -2220,9 +2222,8 @@ fn composio_toolkit_of(_slug: &str) -> Option<String> {
 /// curated catalogue? Unknown is **not** a read.
 #[cfg(feature = "openhuman")]
 fn composio_catalog_lookup(slug: &str) -> CatalogLookup {
-    use openhuman_core::openhuman::memory::sync::composio::providers::{
-        ToolScope, catalog_for_toolkit, find_curated, toolkit_from_slug,
-    };
+    use tinymemory_api::composio::catalogs::catalog_for_toolkit;
+    use tinymemory_api::composio::scopes::{ToolScope, find_curated, toolkit_from_slug};
     let Some(toolkit) = toolkit_from_slug(slug) else {
         return CatalogLookup::UnknownToolkit { toolkit: None };
     };
@@ -3612,9 +3613,7 @@ mod tests {
     #[test]
     #[cfg(feature = "openhuman")]
     fn we_do_not_fall_back_to_the_upstream_read_default() {
-        use openhuman_core::openhuman::memory::sync::composio::providers::{
-            ToolScope, classify_unknown,
-        };
+        use tinymemory_api::composio::scopes::{ToolScope, classify_unknown};
         assert_eq!(
             classify_unknown("GITHUB_INVENT_A_NEW_VERB"),
             ToolScope::Read,
@@ -3662,9 +3661,8 @@ mod tests {
     #[test]
     #[cfg(feature = "openhuman")]
     fn the_fallback_never_calls_a_curated_write_a_read() {
-        use openhuman_core::openhuman::memory::sync::composio::providers::{
-            ToolScope, agent_ready_toolkits, catalog_for_toolkit,
-        };
+        use tinymemory_api::composio::catalogs::catalog_for_toolkit;
+        use tinymemory_api::composio::scopes::{ToolScope, agent_ready_toolkits};
 
         let entries: Vec<_> = agent_ready_toolkits()
             .into_iter()

--- a/src/tiny/status.rs
+++ b/src/tiny/status.rs
@@ -19,8 +19,12 @@ impl RuntimeModuleStatus {
         vec![
             Self {
                 name: "tinyagents",
-                enabled: cfg!(feature = "tinyagents"),
-                role: "agent harness, graphs, registry, and RLM runtime",
+                // The checkout is still `tinyagents`, but it is a workspace now
+                // and this crate links two of its members: the harness, and
+                // `tinyinference` (vendored under it) for the model layer. The
+                // graph/registry/RLM members are openhuman's, not ours.
+                enabled: cfg!(feature = "tinyagents-harness"),
+                role: "agent harness and inference model layer",
                 path: "vendor/openhuman/vendor/tinyagents",
             },
             Self {

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -4448,14 +4448,14 @@ mod tests {
     }
 
     #[async_trait]
-    impl tinyagents::harness::model::ChatModel<()> for RecoverJudgeProvider {
+    impl tinyinference::model::ChatModel<()> for RecoverJudgeProvider {
         async fn invoke(
             &self,
             _state: &(),
-            _request: tinyagents::harness::model::ModelRequest,
-        ) -> tinyagents::Result<tinyagents::harness::model::ModelResponse> {
+            _request: tinyinference::model::ModelRequest,
+        ) -> tinyinference::Result<tinyinference::model::ModelResponse> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok(tinyagents::harness::model::ModelResponse::assistant(
+            Ok(tinyinference::model::ModelResponse::assistant(
                 "{\"verdict\":\"recover\"}".to_string(),
             ))
         }
@@ -4552,14 +4552,14 @@ mod tests {
     }
 
     #[async_trait]
-    impl tinyagents::harness::model::ChatModel<()> for EscalatingJudgeProvider {
+    impl tinyinference::model::ChatModel<()> for EscalatingJudgeProvider {
         async fn invoke(
             &self,
             _state: &(),
-            _request: tinyagents::harness::model::ModelRequest,
-        ) -> tinyagents::Result<tinyagents::harness::model::ModelResponse> {
+            _request: tinyinference::model::ModelRequest,
+        ) -> tinyinference::Result<tinyinference::model::ModelResponse> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok(tinyagents::harness::model::ModelResponse::assistant(
+            Ok(tinyinference::model::ModelResponse::assistant(
                 "{\"verdict\":\"escalate\",\"gap\":\"information\"}".to_string(),
             ))
         }

--- a/src/workflows/judge.rs
+++ b/src/workflows/judge.rs
@@ -3,8 +3,8 @@
 use std::time::Duration;
 
 use serde::Deserialize;
-use tinyagents::harness::message::Message;
-use tinyagents::harness::model::{ModelRequest, ModelResponse};
+use tinyinference::message::Message;
+use tinyinference::model::{ModelRequest, ModelResponse};
 
 use crate::harness::HarnessDeps;
 use crate::harness::build::model_for_tier;
@@ -657,12 +657,12 @@ mod tests {
     }
 
     #[async_trait]
-    impl tinyagents::harness::model::ChatModel<()> for PanicIfInvokedProvider {
+    impl tinyinference::model::ChatModel<()> for PanicIfInvokedProvider {
         async fn invoke(
             &self,
             _state: &(),
             _request: ModelRequest,
-        ) -> tinyagents::Result<ModelResponse> {
+        ) -> tinyinference::Result<ModelResponse> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(ModelResponse::assistant(
                 "{\"verdict\":\"continue\"}".to_string(),

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -5753,12 +5753,12 @@ to = "done"
     }
 
     #[async_trait]
-    impl tinyagents::harness::model::ChatModel<()> for RecordingSlowProvider {
+    impl tinyinference::model::ChatModel<()> for RecordingSlowProvider {
         async fn invoke(
             &self,
             _state: &(),
-            request: tinyagents::harness::model::ModelRequest,
-        ) -> tinyagents::Result<tinyagents::harness::model::ModelResponse> {
+            request: tinyinference::model::ModelRequest,
+        ) -> tinyinference::Result<tinyinference::model::ModelResponse> {
             // Scan the whole conversation, not just the last user turn: the
             // openhuman harness reshapes an agent node's authored instruction
             // into a multi-message prompt, so the node's marker can land in any
@@ -5781,7 +5781,7 @@ to = "done"
                     () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
                 }
             }
-            Ok(tinyagents::harness::model::ModelResponse::assistant(
+            Ok(tinyinference::model::ModelResponse::assistant(
                 "acknowledged".to_string(),
             ))
         }
@@ -7438,12 +7438,12 @@ to = "done"
     }
 
     #[async_trait]
-    impl tinyagents::harness::model::ChatModel<()> for StallingProvider {
+    impl tinyinference::model::ChatModel<()> for StallingProvider {
         async fn invoke(
             &self,
             _state: &(),
-            _request: tinyagents::harness::model::ModelRequest,
-        ) -> tinyagents::Result<tinyagents::harness::model::ModelResponse> {
+            _request: tinyinference::model::ModelRequest,
+        ) -> tinyinference::Result<tinyinference::model::ModelResponse> {
             self.entered.notify_waiters();
             // Never returns. The run is stopped by the future being dropped,
             // which is the mechanism under test.
@@ -7802,15 +7802,15 @@ to = "ceo"
     }
 
     #[async_trait]
-    impl tinyagents::harness::model::ChatModel<()> for ReleasableProvider {
+    impl tinyinference::model::ChatModel<()> for ReleasableProvider {
         async fn invoke(
             &self,
             _state: &(),
-            _request: tinyagents::harness::model::ModelRequest,
-        ) -> tinyagents::Result<tinyagents::harness::model::ModelResponse> {
+            _request: tinyinference::model::ModelRequest,
+        ) -> tinyinference::Result<tinyinference::model::ModelResponse> {
             self.entered.notify_waiters();
             self.release.notified().await;
-            Ok(tinyagents::harness::model::ModelResponse::assistant(
+            Ok(tinyinference::model::ModelResponse::assistant(
                 "released".to_string(),
             ))
         }
@@ -8043,17 +8043,17 @@ to = "done"
     }
 
     #[async_trait]
-    impl tinyagents::harness::model::ChatModel<()> for GatedProvider {
+    impl tinyinference::model::ChatModel<()> for GatedProvider {
         async fn invoke(
             &self,
             state: &(),
-            request: tinyagents::harness::model::ModelRequest,
-        ) -> tinyagents::Result<tinyagents::harness::model::ModelResponse> {
+            request: tinyinference::model::ModelRequest,
+        ) -> tinyinference::Result<tinyinference::model::ModelResponse> {
             self.entered.notify_waiters();
             // `notify_one` carries a permit, so a release that lands before this
             // registers is not lost — no ordering race with the test.
             self.release.notified().await;
-            tinyagents::harness::model::ChatModel::invoke(&self.inner, state, request).await
+            tinyinference::model::ChatModel::invoke(&self.inner, state, request).await
         }
     }
 
@@ -8182,14 +8182,14 @@ to = "done"
     }
 
     #[async_trait]
-    impl tinyagents::harness::model::ChatModel<()> for CountingProvider {
+    impl tinyinference::model::ChatModel<()> for CountingProvider {
         async fn invoke(
             &self,
             state: &(),
-            request: tinyagents::harness::model::ModelRequest,
-        ) -> tinyagents::Result<tinyagents::harness::model::ModelResponse> {
+            request: tinyinference::model::ModelRequest,
+        ) -> tinyinference::Result<tinyinference::model::ModelResponse> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            tinyagents::harness::model::ChatModel::invoke(&self.inner, state, request).await
+            tinyinference::model::ChatModel::invoke(&self.inner, state, request).await
         }
     }
 


### PR DESCRIPTION
## Summary

The vendored openhuman pin was **908 commits behind** and nothing newer could
land: upstream split `tinyagents` into a workspace, so there is no `tinyagents`
package any more and the existing path dependency resolved to a virtual
manifest — the build stopped before it began. This does the migration and takes
the pin to openhuman `main` (`c6a06abcf` → `61d25fe21`, 949 commits / 67 PRs).

The immediate reason is **openhuman #5767**. The 600s per-turn ceiling doubled
as the per-call bound, because the harness hands each model call the turn's
*remainder* — so a long **productive** turn died. It is now a per-call ceiling
(900s, `OPENHUMAN_MODEL_CALL_TIMEOUT_SECS`) with the turn deadline demoted to a
runaway guard (600s → 3600s). Seen in the field as a turn dying at 10m00s while
reporting 263768 ms of budget still remaining.

Operators who want the old behaviour can pin it back:
`OPENHUMAN_MODEL_CALL_TIMEOUT_SECS=0 OPENHUMAN_AGENT_TURN_TIMEOUT_SECS=600`.

## The migration

Four upstream moves, none of them a rename this crate could have guessed:

| was | now |
|---|---|
| `tinyagents::harness::{model,message,usage,tool}` | `tinyinference::*` |
| `tinyagents::{Result,TinyAgentsError}` in `ChatModel` impls | `tinyinference::{Result,Error}` |
| `openhuman::memory::sync::composio::providers::*` | `tinymemory_api::composio::{catalogs,scopes}` |
| `SystemPromptBuilder::for_subagent(_, _, _, omit_skills_catalog)` | 3 args (openhuman #5815) |

The model layer moved out of tinyagents entirely, into `tinyinference` (vendored
beneath it). `TinyAgentsError` still exists in the harness crate for everything
else, which is why the `Timeout` doc reference here is unchanged.

The curated Composio catalogue moved into TinyMemory's Composio vocabulary.
`tinymemory_api` re-exports `tinymemory_bus::composio` wholesale, so this needs
**no new dependency** — the policy surface deciding whether an action is a read
keeps the same catalogue rather than degrading to "unknown".

**Manifest.** Two path deps replace one. `[patch."…/tinyinference"]` collapses
`tinycortex`'s git-rev dependency onto the same checkout — two copies would mean
two `ChatModel`s and a type mismatch, the hazard the neighbouring `tinymemory`
entry already documents. `[patch.crates-io] tinyagents` goes: nothing asks
crates.io for it any more. `tinyflows` rebases onto its own `crates/` member,
same workspace split.

## Two fixes that are not mechanical

- **`/spec` reported the TinyAgents runtime module as `enabled: false` on every
  build.** `cfg!(feature = "tinyagents")` no longer names a feature, and a `cfg`
  on a missing feature is simply false — no error, just a wrong answer on a
  surface operators read to see what a host is running. Clippy's
  `unexpected_cfgs` caught it.
- **Both vendored-source canaries fired without a behaviour change.** They read
  one openhuman file each to pin behaviour we depend on, and upstream splits
  large modules into `foo_part_NN.rs` as they grow. Both needles moved into a
  `_part_02` while the parent stayed as the module root. The coupled behaviour
  is intact — the loop still labels a tool row from the tool's **name** (so
  `StepLabels` is still needed, not redundant), and the truncation wording is
  unchanged. `vendored()` now reads the module rather than the file, which is
  what its own doc already argued: "the basenames survive reorgs, the parents do
  not."

## Review notes

**This is not reviewable as a diff of the submodule.** 949 commits is what any
bump reaching #5767 has to cross — the pin was already 908 behind before that
fix existed. Going to `main` adds 41 beyond the minimum. If a tighter delta is
wanted, `193fa6b40` (the #5767 merge) is the smallest pin that contains the fix.

One flake seen and not fixed here:
`workflows::runner::tests::a_cancelled_checkpointed_initial_run_that_finishes_inside_grace_does_not_deliver`
timed out once under the full suite and passes 3/3 in isolation — a cancellation
grace-window test running against 6684 tests in parallel.

## Verification

- `cargo test --locked` — 4492 passed
- `cargo test --locked --features openhuman --tests`
- `cargo test --locked --features openhuman,tinymemory --tests` — the lane a
  submodule bump breaks first
- `cargo clippy` on default, `openhuman`, and `acp,runner,tinymemory`
- `cargo fmt --all -- --check`

## Related

- openhuman #5767 (`Closes` its "opencompany `vendor/openhuman` bump" follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Maintenance**
  - Updated the underlying inference and agent-harness components to align with their latest package structure.
  - Refreshed bundled OpenHuman components and related integrations for compatibility.
  - Updated toolkit catalogue access to use current supported interfaces.
  - Improved compatibility when initializing bundled components in automated environments.

- **Bug Fixes**
  - Improved loading of split bundled files, providing more reliable assembly and clearer missing-file diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->