### PR TITLE
fix(harness): say why a turn ended empty, and stop showing the payload (#2016)

### DIFF
--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -822,6 +822,63 @@ fn extract_array_refusal_text(value: Option<&serde_json::Value>) -> Option<Strin
     if out.is_empty() { None } else { Some(out) }
 }
 
+/// The observable facts about a turn that came back with nothing, appended to
+/// the error so the next occurrence is diagnosable rather than merely reported.
+///
+/// Issue #2016: an empty inference on staging was persistent — the harness had
+/// already retried it, and the only thing recorded was that it happened. These
+/// are what separate the causes:
+///
+/// * **usage.** Zero prompt *and* completion tokens beside a 200 is the
+///   signature of the silent provider failure this file already documents
+///   (`~438,000 input tokens -> HTTP 200, finish_reason "failed", response ""`).
+///   Nonzero prompt tokens mean the request was read and only the answer was
+///   missing, which is a different fault entirely.
+/// * **finish_reason.** `length` is truncation, `content_filter` a policy stop,
+///   `failed` the documented silent failure, absent a non-conforming provider.
+/// * **the `choices` shape.** No `choices` key, an empty array, and a present
+///   choice carrying an empty message are three different provider bugs that
+///   all reach this line identically.
+/// * **whether a refusal was present**, since a refusal that failed to extract
+///   would otherwise look like an ordinary empty turn.
+///
+/// Values only — no provider text is interpolated, so this cannot become a
+/// second route for a payload to reach a log or an operator.
+fn empty_turn_facts(payload: &serde_json::Value, finish_reason: Option<&str>) -> String {
+    let choices = match payload.get("choices") {
+        None => "absent".to_string(),
+        Some(serde_json::Value::Array(items)) if items.is_empty() => "empty".to_string(),
+        Some(serde_json::Value::Array(items)) => items.len().to_string(),
+        Some(other) => format!("not-an-array({})", json_kind(other)),
+    };
+    let usage = match parse_usage(payload) {
+        Some(usage) => format!(
+            "in={} out={} total={}",
+            usage.input_tokens, usage.output_tokens, usage.total_tokens
+        ),
+        None => "absent".to_string(),
+    };
+    let refusal = payload
+        .pointer("/choices/0/message/refusal")
+        .is_some_and(|value| !value.is_null());
+    format!(
+        " (finish_reason: {}; choices: {choices}; usage: {usage}; refusal_present: {refusal})",
+        finish_reason.unwrap_or("absent")
+    )
+}
+
+/// The JSON type of a value, for a diagnostic that must not print its contents.
+fn json_kind(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
 /// Parse an OpenAI-compatible chat-completion payload into a tinyagents
 /// [`ModelResponse`], preserving token usage, native tool calls, AND the managed
 /// billing envelope.
@@ -1039,12 +1096,9 @@ fn model_response_from_payload(payload: serde_json::Value) -> TaResult<ModelResp
     // `content_filter` stop is diagnosable rather than hidden behind a generic
     // "carried neither" string.
     if content.is_empty() && tool_calls.is_empty() {
-        let detail = finish_reason
-            .as_deref()
-            .map(|r| format!(" (finish_reason: {r})"))
-            .unwrap_or_default();
         return Err(TinyAgentsError::Model(format!(
-            "inference response carried neither choices[0].message.content nor tool_calls{detail}"
+            "inference response carried neither choices[0].message.content nor tool_calls{}",
+            empty_turn_facts(&payload, finish_reason.as_deref())
         )));
     }
 
@@ -3104,9 +3158,55 @@ mod tests {
         );
     }
 
+    /// The diagnostic issue #2016 exists for: an empty turn must say enough to
+    /// separate its causes. Zero usage beside a 200 is the signature of the
+    /// silent provider failure this file documents; nonzero prompt tokens would
+    /// mean the request was read and only the answer was missing.
+    #[test]
+    fn an_empty_turn_reports_the_facts_that_separate_its_causes() {
+        let payload = serde_json::json!({
+            "choices": [{
+                "finish_reason": "failed",
+                "message": { "role": "assistant", "content": "" }
+            }],
+            "usage": { "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0 }
+        });
+        let msg = model_response_from_payload(payload)
+            .expect_err("an empty turn is an error")
+            .to_string();
+
+        assert!(msg.contains("finish_reason: failed"), "{msg}");
+        assert!(msg.contains("choices: 1"), "{msg}");
+        assert!(msg.contains("in=0 out=0 total=0"), "{msg}");
+        assert!(msg.contains("refusal_present: false"), "{msg}");
+    }
+
+    /// The three provider bugs that reach the same line identically: no
+    /// `choices` key at all, an empty array, and a present choice with an empty
+    /// message. Only the reported shape tells them apart.
+    #[test]
+    fn an_empty_turn_distinguishes_the_choices_shapes() {
+        let absent = serde_json::json!({ "usage": { "prompt_tokens": 7 } });
+        let empty = serde_json::json!({ "choices": [] });
+        for (payload, expected) in [(absent, "choices: absent"), (empty, "choices: empty")] {
+            let msg = model_response_from_payload(payload)
+                .expect_err("an empty turn is an error")
+                .to_string();
+            assert!(msg.contains(expected), "expected {expected:?} in: {msg}");
+        }
+    }
+
     /// A missing `finish_reason` altogether is unproven, not proven-complete —
     /// the allow-list requires an explicit good status, so this must also fail
     /// closed rather than assume the omission means success.
+    ///
+    /// The *message* assertion changed with issue #2016. It used to require
+    /// that nothing be appended when no finish_reason was present; an empty turn
+    /// now always states the facts it observed, and "absent" is one of them — a
+    /// provider that sends no finish_reason is a different cause from one that
+    /// sends `failed`, and saying nothing made the two indistinguishable in a
+    /// report. The invariant this test exists for, that the turn fails rather
+    /// than promoting reasoning, is unchanged.
     #[test]
     fn missing_finish_reason_reasoning_only_turn_errors() {
         let payload = serde_json::json!({
@@ -3122,8 +3222,8 @@ mod tests {
             .expect_err("missing finish_reason must not promote reasoning to an answer");
         let msg = err.to_string();
         assert!(
-            !msg.contains("finish_reason"),
-            "no finish_reason detail should be appended when none was present, got: {msg}"
+            msg.contains("finish_reason: absent"),
+            "an absent finish_reason must be reported as absent, got: {msg}"
         );
     }
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3090,6 +3090,7 @@ mod turn_failure_notice_tests {
     /// The failure that put a wall of provider JSON into company chat, verbatim
     /// from the 1/9 round (issue #2016). None of it may reach the operator, and
     /// what they read instead has to say whether waiting will help.
+    #[cfg(feature = "openhuman")]
     #[test]
     fn a_rate_limit_reaches_the_operator_as_a_sentence_not_a_payload() {
         let raw = concat!(
@@ -3129,6 +3130,7 @@ mod turn_failure_notice_tests {
 
     /// Quota exhaustion is not wait-and-retry — somebody has to go and fix the
     /// account — so it must not be worded like a transient blip.
+    #[cfg(feature = "openhuman")]
     #[test]
     fn quota_exhaustion_points_at_the_account() {
         let notice = turn_failure_notice(concat!(
@@ -3144,6 +3146,7 @@ mod turn_failure_notice_tests {
     /// it invisible, a 402 fell through to the `Retryable` default and was
     /// reported as "temporarily unavailable" — telling an operator to wait for
     /// something that will never clear on its own.
+    #[cfg(feature = "openhuman")]
     #[test]
     fn a_status_only_our_own_prefix_carries_is_still_classified() {
         let notice = turn_failure_notice("inference returned 402 Payment Required: no credit");
@@ -3206,26 +3209,26 @@ fn turn_failure_notice(detail: &str) -> String {
 }
 
 /// The operator-facing sentence for a failure the inference path produced, or
-/// `None` when the error did not come from there.
+/// `None` when the failure did not come from there.
+///
+/// Deliberately narrow about when it blames the provider. The classifier falls
+/// back to `Retryable` for text it recognizes nothing in, so classifying every
+/// failure indiscriminately would report a tool that ran out of wall-clock as a
+/// provider outage. A cause is named only when the error is one the inference
+/// path actually emits, or carries a recognizable HTTP status.
 fn provider_failure_sentence(detail: &str) -> Option<&'static str> {
-    use tinyagents_harness::retry::{
-        ProviderFailureClass, classify_provider_failure, structured_http_status,
-    };
-
     let lower = detail.to_ascii_lowercase();
 
-    // An empty turn is its own case, and not one more retrying fixes — the
-    // harness has already retried it by the time this is written.
+    // An empty turn is its own case, and not one more retrying fixes: the
+    // harness has already retried it by the time this is written. Recognized
+    // from our own error text, so it holds in every build.
     if lower.contains("carried neither") {
         return Some(
             "This turn couldn't be finished — the AI provider returned an empty response.",
         );
     }
 
-    // Only speak about the provider when the error is one of ours from the
-    // inference path, or carries a recognizable HTTP status.
-    let status = status_after_marker(&lower, "inference returned ")
-        .or_else(|| structured_http_status(detail));
+    let status = status_after_marker(&lower, "inference returned ");
     let from_inference = lower.contains("inference returned")
         || lower.contains("inference request failed")
         || lower.contains("inference response")
@@ -3234,22 +3237,49 @@ fn provider_failure_sentence(detail: &str) -> Option<&'static str> {
         return None;
     }
 
+    classified_provider_sentence(status, detail)
+}
+
+/// The sentence for a recognized provider failure, classified through the
+/// harness's own [`classify_provider_failure`].
+///
+/// Reused rather than re-implemented: the crate already knows which 429s are
+/// transient and which mean an account needs topping up, and a second
+/// classifier here would drift from the one that decides whether to retry.
+///
+/// [`classify_provider_failure`]: tinyagents_harness::retry::classify_provider_failure
+#[cfg(feature = "openhuman")]
+fn classified_provider_sentence(status: Option<u16>, detail: &str) -> Option<&'static str> {
+    use tinyagents_harness::retry::{
+        ProviderFailureClass, classify_provider_failure, structured_http_status,
+    };
+
+    let status = status.or_else(|| structured_http_status(detail));
     Some(match classify_provider_failure(status, None, detail) {
         ProviderFailureClass::RateLimited => {
             "This turn couldn't be finished — the AI provider is rate-limiting requests."
         }
         ProviderFailureClass::NonRetryableRateLimit => {
             "This turn couldn't be finished — the AI provider reports no quota or credit left. \
-             An admin needs to check the provider account under Settings → Inference."
+             An admin needs to check the provider account under Settings."
         }
         ProviderFailureClass::NonRetryable => {
             "This turn couldn't be finished — the AI provider rejected the request, usually a \
-             model or configuration mismatch. An admin can check Settings → Inference."
+             model or configuration mismatch. An admin can check Settings."
         }
         ProviderFailureClass::UpstreamUnhealthy | ProviderFailureClass::Retryable => {
             "This turn couldn't be finished — the AI provider is temporarily unavailable."
         }
     })
+}
+
+/// The default build links no inference harness at all — it keeps the
+/// echo-brained offline behaviour — so it produces no provider failures to
+/// classify and has no classifier to reach for. The generic notice is the
+/// honest answer there.
+#[cfg(not(feature = "openhuman"))]
+fn classified_provider_sentence(_status: Option<u16>, _detail: &str) -> Option<&'static str> {
+    None
 }
 
 /// Everything a chat turn needs once it is off the request's future.

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3063,6 +3063,195 @@ async fn chat_and_emit(
     })))
 }
 
+/// The HTTP status written immediately after `marker` in `lower`, when one is.
+///
+/// `lower` must already be lowercased. Only a three-digit run counts, so a
+/// message that merely mentions the marker cannot produce a status.
+///
+/// Needed because our own errors read `inference returned 429 Too Many
+/// Requests: …`, and `structured_http_status` looks for a status at the start
+/// of the string, after a `(`, or behind an `http`/`status:` marker — none of
+/// which that shape offers. The status we already knew was therefore invisible
+/// to the classifier, leaving classification to whatever prose the provider
+/// happened to choose.
+fn status_after_marker(lower: &str, marker: &str) -> Option<u16> {
+    let rest = lower.split_once(marker)?.1.trim_start();
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    if digits.len() != 3 {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+#[cfg(test)]
+mod turn_failure_notice_tests {
+    use super::{provider_failure_sentence, turn_failure_notice};
+
+    /// The failure that put a wall of provider JSON into company chat, verbatim
+    /// from the 1/9 round (issue #2016). None of it may reach the operator, and
+    /// what they read instead has to say whether waiting will help.
+    #[test]
+    fn a_rate_limit_reaches_the_operator_as_a_sentence_not_a_payload() {
+        let raw = concat!(
+            "turn for 'frontend_engineer': inference returned 429 Too Many Requests: ",
+            r#"{"error":{"message":"Provider returned error","code":429,"metadata":"#,
+            r#"{"raw":"deepseek/deepseek-chat is temporarily rate-limited upstream. "#,
+            r#"Please retry shortly, or add your own key to accumulate your rate limits: "#,
+            r#"https://openrouter.ai/settings/integrations","provider_name":"DeepInfra"}}}"#,
+        );
+        let notice = turn_failure_notice(raw);
+
+        assert!(notice.contains("rate-limiting"), "{notice}");
+        for leaked in ["{", "openrouter.ai", "deepseek", "DeepInfra", "429"] {
+            assert!(
+                !notice.contains(leaked),
+                "the provider payload leaked {leaked:?} into chat: {notice}"
+            );
+        }
+    }
+
+    /// An empty inference is its own message: the harness has already retried it
+    /// by the time this is written, so leading with "try again" is wrong advice
+    /// and the cause is worth naming.
+    #[test]
+    fn an_empty_inference_says_so() {
+        let notice = turn_failure_notice(concat!(
+            "inference response carried neither choices[0].message.content nor tool_calls ",
+            "(finish_reason: failed; choices: 1; usage: in=0 out=0 total=0)"
+        ));
+
+        assert!(notice.contains("empty response"), "{notice}");
+        assert!(
+            !notice.contains("finish_reason"),
+            "diagnostics leaked into chat: {notice}"
+        );
+    }
+
+    /// Quota exhaustion is not wait-and-retry — somebody has to go and fix the
+    /// account — so it must not be worded like a transient blip.
+    #[test]
+    fn quota_exhaustion_points_at_the_account() {
+        let notice = turn_failure_notice(concat!(
+            "inference returned 429 Too Many Requests: ",
+            r#"{"error":{"message":"insufficient balance"}}"#
+        ));
+
+        assert!(notice.contains("quota or credit"), "{notice}");
+        assert!(notice.contains("Settings"), "{notice}");
+    }
+
+    /// A status our own error format hides from `structured_http_status`. With
+    /// it invisible, a 402 fell through to the `Retryable` default and was
+    /// reported as "temporarily unavailable" — telling an operator to wait for
+    /// something that will never clear on its own.
+    #[test]
+    fn a_status_only_our_own_prefix_carries_is_still_classified() {
+        let notice = turn_failure_notice("inference returned 402 Payment Required: no credit");
+
+        assert!(notice.contains("rejected the request"), "{notice}");
+    }
+
+    /// The guard against over-claiming. `classify_provider_failure` falls back
+    /// to `Retryable` for text it recognizes nothing in, so a tool that ran out
+    /// of wall-clock would otherwise be reported as a provider outage.
+    #[test]
+    fn a_failure_that_is_not_the_providers_is_not_blamed_on_it() {
+        let raw = "the tool call exceeded its wall-clock budget";
+
+        assert!(
+            provider_failure_sentence(raw).is_none(),
+            "a non-provider failure must not be classified as one"
+        );
+        let notice = turn_failure_notice(raw);
+        assert!(notice.contains("something went wrong"), "{notice}");
+        assert!(!notice.contains("provider"), "{notice}");
+    }
+
+    /// Whatever the cause, the operator is told the turn left nothing behind —
+    /// the one fact they need in order to decide whether to re-send.
+    #[test]
+    fn every_notice_states_that_nothing_was_half_done() {
+        for raw in [
+            "inference returned 429 Too Many Requests: rate limited",
+            "inference response carried neither choices[0].message.content nor tool_calls",
+            "something else entirely",
+        ] {
+            assert!(
+                turn_failure_notice(raw).contains("Nothing was left half-done"),
+                "missing for: {raw}"
+            );
+        }
+    }
+}
+
+/// What an operator is told when a turn could not be finished.
+///
+/// The raw error is a diagnostic and never belongs in company chat. On the
+/// rate-limit path it was a wall of provider JSON with a settings URL in it,
+/// which is what a tester saw instead of an answer (issue #2016). It is logged
+/// in full at the call site; this renders the one sentence that tells the
+/// operator whether to wait, retry, or go and fix something.
+///
+/// Deliberately narrow about when it blames the provider. `classify_provider_
+/// failure` falls back to `Retryable` for text it recognizes nothing in, so
+/// classifying every failure would describe a tool that timed out as a provider
+/// outage. A cause is named only when the error is one the inference path
+/// actually emits; anything else keeps the generic wording.
+fn turn_failure_notice(detail: &str) -> String {
+    const CLOSING: &str = "Nothing was left half-done.";
+    let cause = provider_failure_sentence(detail).unwrap_or(
+        "This turn couldn't be finished — something went wrong or a step took too long.",
+    );
+    format!("{cause} {CLOSING} Send the message again to retry.")
+}
+
+/// The operator-facing sentence for a failure the inference path produced, or
+/// `None` when the error did not come from there.
+fn provider_failure_sentence(detail: &str) -> Option<&'static str> {
+    use tinyagents::harness::retry::{
+        ProviderFailureClass, classify_provider_failure, structured_http_status,
+    };
+
+    let lower = detail.to_ascii_lowercase();
+
+    // An empty turn is its own case, and not one more retrying fixes — the
+    // harness has already retried it by the time this is written.
+    if lower.contains("carried neither") {
+        return Some(
+            "This turn couldn't be finished — the AI provider returned an empty response.",
+        );
+    }
+
+    // Only speak about the provider when the error is one of ours from the
+    // inference path, or carries a recognizable HTTP status.
+    let status = status_after_marker(&lower, "inference returned ")
+        .or_else(|| structured_http_status(detail));
+    let from_inference = lower.contains("inference returned")
+        || lower.contains("inference request failed")
+        || lower.contains("inference response")
+        || lower.contains("configured inference model");
+    if !from_inference && status.is_none() {
+        return None;
+    }
+
+    Some(match classify_provider_failure(status, None, detail) {
+        ProviderFailureClass::RateLimited => {
+            "This turn couldn't be finished — the AI provider is rate-limiting requests."
+        }
+        ProviderFailureClass::NonRetryableRateLimit => {
+            "This turn couldn't be finished — the AI provider reports no quota or credit left. \
+             An admin needs to check the provider account under Settings → Inference."
+        }
+        ProviderFailureClass::NonRetryable => {
+            "This turn couldn't be finished — the AI provider rejected the request, usually a \
+             model or configuration mismatch. An admin can check Settings → Inference."
+        }
+        ProviderFailureClass::UpstreamUnhealthy | ProviderFailureClass::Retryable => {
+            "This turn couldn't be finished — the AI provider is temporarily unavailable."
+        }
+    })
+}
+
 /// Everything a chat turn needs once it is off the request's future.
 ///
 /// A struct rather than six positional arguments because the spawn boundary is
@@ -3137,18 +3326,22 @@ fn spawn_chat_turn(turn: ChatTurn) -> JoinHandle<Result<(CycleReport, Option<Str
                     parent: reply_thread(parent, accepted.message_seq),
                     chat_id: desk.clone(),
                     agent_id: crate::ports::SYSTEM_AUTHOR.to_string(),
-                    text: format!(
-                        "This turn couldn't be finished — something went wrong or \
-                         a step took too long ({}). Nothing was left half-done. \
-                         Send the message again to retry; if it keeps failing, \
-                         try breaking it into a smaller request.",
-                        err.0
-                    ),
+                    text: turn_failure_notice(&err.0.to_string()),
                     steps: Vec::new(),
                     task_id: None,
                     mentions: Vec::new(),
                     mention_depth: 0,
                 };
+                // The raw provider text is a diagnostic, not an operator
+                // message: it is unbounded, provider-shaped, and on the rate-limit
+                // path it carried a wall of JSON and a settings URL into company
+                // chat. It stays here, in full (issue #2016).
+                tracing::warn!(
+                    company = %company,
+                    desk = %desk,
+                    detail = %err.0,
+                    "a chat turn could not be finished"
+                );
                 if let Err(journal_err) = runtime.events().append(&company, notice).await {
                     tracing::warn!(
                         company = %company,


### PR DESCRIPTION
## Summary

Closes #2016.

An empty inference on staging was **persistent**, and the code could not say why. Reproducing it locally first ruled out most of what it looked like, which is what shaped the fix:

- **Not a malformed transcript.** Ran UC1's exact shape (two questions in one channel, the first using a tool) against a real `serve` with a capturing inference stub, and checked every outbound request against the invariants a native provider enforces — tool-call/result pairing, orphan rows, `function.arguments` as a JSON string, envelope leakage. All clean.
- **Not a poisoned thread.** Scripting turn 1 to run a tool and *then* return the empty shape leaves turn 2's transcript well-formed.
- **Not a missing retry.** `tinyagents::harness::retry` already retries it — the capture shows the identical request re-sent. So "persistent" means the retry came back empty too, and more retrying cannot be the fix.
- **The 429 alongside it was already retried too.** Replaying OpenRouter's actual body through `classify_provider_failure` yields `RateLimited` (retryable); the free-tier route simply stayed limited past the attempt budget.

What was left is that the only thing recorded was *that* it happened.

**The empty-turn error now states what it observed** — finish_reason, the `choices` shape, usage, and whether a refusal was present. Each separates causes that previously arrived identically: zero usage beside a 200 is the signature of the silent provider failure this file already documents at ~438k input tokens, while nonzero prompt tokens mean the request was read and only the answer was missing; and a missing `choices` key, an empty array, and a present choice holding an empty message are three different provider bugs. Values only — no provider text is interpolated, so this cannot become a second route for a payload to escape.

**The operator no longer reads the payload.** `spawn_chat_turn` interpolated the raw error into the chat bubble, which on the rate-limit path was a wall of provider JSON with a settings URL in it — literally what a tester saw instead of an answer. They now get one sentence saying whether waiting will help, whether an admin needs to act, or whether the provider returned nothing. The raw text is logged in full at the call site.

It is deliberately narrow about when it blames the provider: `classify_provider_failure` falls back to `Retryable` for text it recognizes nothing in, so classifying every failure would report a tool that exceeded its wall-clock budget as a provider outage. A cause is named only for errors the inference path actually emits, or which carry a recognizable status.

**One extra defect the tests turned up.** Our own `inference returned 429 …` format hides the status from `structured_http_status`, which looks at the string start, after a `(`, or behind an `http`/`status:` marker — none of which that shape offers. Classification was therefore falling through to whatever prose the provider chose, and a `402 Payment Required` came out as "temporarily unavailable", telling an operator to wait for something that will never clear. `status_after_marker` recovers it from our own prefix.

## API Or Behavior Changes

No API change.

The empty-turn error message is longer and now always carries a facts suffix, including `finish_reason: absent` where it previously appended nothing. One existing test (`missing_finish_reason_reasoning_only_turn_errors`) pinned that formatting; its assertion is re-pointed and its doc says why. The invariant it exists for — that the turn fails rather than promoting reasoning — is untouched.

Operator-visible: a failed turn's notice no longer contains the provider's error text.

## Tests

6 tests over the operator notice, including the 1/9 rate-limit payload verbatim, asserting that none of `{`, `openrouter.ai`, `deepseek`, `DeepInfra` or `429` reaches chat; that quota exhaustion points at the account rather than reading as transient; that a non-provider failure is not blamed on the provider; and that every notice still tells the operator nothing was left half-done.

3 over the empty-turn facts, covering the zero-usage signature and the three `choices` shapes.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --features openhuman --all-targets -- -D warnings`
- [x] `cargo test --features openhuman --lib` — 6693 passed, 0 failed

## Documentation

No spec change — this makes an existing failure legible rather than defining new behaviour. The reasoning lives on `empty_turn_facts` and `provider_failure_sentence`.

## Note for reviewers

This is diagnosis, not a cure: #2016 stays open until the next occurrence names its cause. Filed with everything the local reproduction ruled out so the next person does not repeat it.

Independent of #2011 (based on `upstream/main`), though both touch `provider.rs` — #2011 edits the recovery path in `model_response_from_payload`, this edits the empty-turn error below it. Whichever lands second will want a look at that function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat failure notices are now concise and easier to understand.
  * Sensitive provider diagnostics are kept out of chat messages while remaining available for troubleshooting.
  * Failure notices provide more accurate classifications for supported provider errors, including rate limits, quota exhaustion, outages, rejected requests, and empty responses.
  * Empty model responses now include clearer context, including response shape, usage, refusals, and finish status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->