### PR TITLE
fix(client): bound every GET with a default request deadline (#2014)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1487,9 +1487,9 @@ function settleWithin<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
   });
 }
 
-/** A real `AbortError`, reusing the signal's reason when it is already one. */
+/** A real `AbortError`, reusing the signal's reason when it already is one. */
 function abortError(reason: unknown): Error {
-  if (reason instanceof Error) return reason;
+  if (reason instanceof Error && reason.name === "AbortError") return reason;
   return new DOMException("The operation was aborted.", "AbortError");
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -62,6 +62,36 @@ import {
 
 export type LifecycleAction = "pause" | "resume" | "suspend" | "archive";
 
+/** Per-call overrides for a request's deadline and cancellation. */
+export interface RequestOptions {
+  /**
+   * A caller-owned signal — an unmount, a superseded read — that cancels the
+   * request. Its abort surfaces as an `AbortError`, distinct from a timeout, so
+   * the caller can tell "I cancelled this" from "the host went away".
+   */
+  signal?: AbortSignal;
+  /**
+   * How long to wait for the host before giving up, in milliseconds. Omit for
+   * the method default ({@link DEFAULT_REQUEST_TIMEOUT_MS} on a `GET`, none on a
+   * mutation, whose duration is the host's to decide). `null` disables the
+   * bound explicitly for a read that is expected to run long.
+   */
+  timeoutMs?: number | null;
+}
+
+/**
+ * The default deadline for a `GET`.
+ *
+ * Reads are the request the console blocks a view on, and a host that accepts
+ * the connection and then never answers used to leave that view on its skeleton
+ * forever — the browser's `fetch` produces no event for a stalled response, so
+ * no `catch` an already-written load path holds ever runs (issue #2014). This
+ * turns that silence into an ordinary rejection every view's existing error
+ * state can render. Well above any healthy read; mutations opt in per call,
+ * since a chat turn or a company provision is legitimately unbounded.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
 export class OpenCompanyClient {
   readonly baseUrl: string;
   readonly defaultCompany: string | null;
@@ -123,21 +153,61 @@ export class OpenCompanyClient {
     path: string,
     body?: unknown,
     extraHeaders?: Record<string, string>,
+    options?: RequestOptions,
   ): Promise<T> {
     const headers: Record<string, string> = {};
     if (body !== undefined) headers["content-type"] = "application/json";
     Object.assign(headers, this.authHeaders(), extraHeaders);
 
+    const timeoutMs =
+      options?.timeoutMs !== undefined
+        ? options.timeoutMs
+        : method === "GET"
+          ? DEFAULT_REQUEST_TIMEOUT_MS
+          : null;
+    const caller = options?.signal;
+    const controller = new AbortController();
+    const onCallerAbort = () => controller.abort(caller?.reason);
+    if (caller) {
+      if (caller.aborted) controller.abort(caller.reason);
+      else caller.addEventListener("abort", onCallerAbort, { once: true });
+    }
+    let timedOut = false;
+    const timer =
+      timeoutMs === null
+        ? null
+        : setTimeout(() => {
+            timedOut = true;
+            controller.abort();
+          }, timeoutMs);
+
     let res: TransportResponse;
     try {
-      res = await this.transport.request({
-        method,
-        url: `${this.baseUrl}${path}`,
-        headers,
-        body: body === undefined ? undefined : JSON.stringify(body),
-      });
-    } catch {
+      res = await settleWithin(
+        this.transport.request({
+          method,
+          url: `${this.baseUrl}${path}`,
+          headers,
+          body: body === undefined ? undefined : JSON.stringify(body),
+          signal: controller.signal,
+        }),
+        controller.signal,
+      );
+    } catch (err) {
+      if (timedOut) {
+        throw new ApiError(
+          0,
+          "timeout",
+          `the company host at ${this.baseUrl || "this origin"} did not respond in time`,
+        );
+      }
+      // The caller tore the request down itself; let its `AbortError` through,
+      // the way `getBlob` does, so it can tell "cancelled" from "unreachable".
+      if (caller?.aborted) throw abortError(err);
       throw new ApiError(0, "network_error", `cannot reach the company host at ${this.baseUrl || "this origin"}`);
+    } finally {
+      if (timer !== null) clearTimeout(timer);
+      if (caller) caller.removeEventListener("abort", onCallerAbort);
     }
 
     const text = res.text;
@@ -181,8 +251,8 @@ export class OpenCompanyClient {
   }
 
   /** A typed GET, for surfaces that live outside this class (e.g. auth). */
-  get<T>(path: string): Promise<T> {
-    return this.request<T>("GET", path);
+  get<T>(path: string, options?: RequestOptions): Promise<T> {
+    return this.request<T>("GET", path, undefined, undefined, options);
   }
 
   /**
@@ -1389,6 +1459,38 @@ function attachmentFilename(header: string | null): string | undefined {
   const match = /filename="([^"]+)"/i.exec(header);
   const name = match?.[1]?.split(/[\\/]/).pop()?.trim();
   return name && name !== "." && name !== ".." ? name : undefined;
+}
+
+/**
+ * Rejects when `signal` aborts, even if `work` never settles.
+ *
+ * A transport whose `fetch` honours the signal already rejects `work` on abort;
+ * the desktop proxy cannot cancel its in-flight IPC and never would, so the
+ * abort is raised here too. Either way the caller stops waiting the instant the
+ * deadline (or its own signal) fires, and a late transport answer is dropped.
+ */
+function settleWithin<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(abortError(signal.reason));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortError(signal.reason));
+    signal.addEventListener("abort", onAbort, { once: true });
+    work.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
+/** A real `AbortError`, reusing the signal's reason when it is already one. */
+function abortError(reason: unknown): Error {
+  if (reason instanceof Error) return reason;
+  return new DOMException("The operation was aborted.", "AbortError");
 }
 
 /** How much of an unrecognised body is kept on `ApiError.detail`. */

--- a/frontend/src/api/transport/browser.ts
+++ b/frontend/src/api/transport/browser.ts
@@ -33,6 +33,10 @@ export class BrowserTransport implements Transport {
       // `TransportRequest.keepalive`. `undefined` for every other call, which
       // `fetch` treats as `false`.
       keepalive: req.keepalive,
+      // The request deadline the client attaches, so a host that accepts the
+      // connection and never answers cancels the socket instead of hanging
+      // this promise forever. `undefined` for a call with no bound.
+      signal: req.signal,
     });
 
     // Read the body here rather than handing the caller a live `Response`: the

--- a/frontend/src/api/transport/types.ts
+++ b/frontend/src/api/transport/types.ts
@@ -39,6 +39,14 @@ export interface TransportRequest {
    * request, and has no equivalent teardown-survival problem to solve.
    */
   keepalive?: boolean;
+  /**
+   * Tears the request down when it fires. `BrowserTransport` threads it to
+   * `fetch`, which cancels the socket; `ProxyTransport` cannot cancel an
+   * in-flight Tauri `invoke` and ignores it, the same way it ignores
+   * `keepalive`. The client races the abort itself either way, so a transport
+   * that cannot honour the signal still stops the caller waiting.
+   */
+  signal?: AbortSignal;
 }
 
 export interface TransportResponse {

--- a/frontend/test/e2e/mcp-load-timeout.spec.ts
+++ b/frontend/test/e2e/mcp-load-timeout.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Regression proof for #2014 — the MCP servers page hung on its skeleton forever.
+ *
+ * `GET .../mcp/servers` reaches the host through `OpenCompanyClient`'s one JSON
+ * read path, which had no timeout. A host that accepted the connection and then
+ * never answered produced no `fetch` event, so `McpServersSection`'s own `catch`
+ * — the one that flips the page to its `mcp-load-error` state — never ran, and
+ * the page sat on `<Skeleton>` with no error and no escape.
+ *
+ * The section is unchanged by the fix. The shared request deadline
+ * (`DEFAULT_REQUEST_TIMEOUT_MS`, 30s, on every GET) turns the stall into an
+ * ordinary rejection its existing error branch already renders. This drives
+ * that whole path in a real browser: intercept the list read and never answer
+ * it, then prove the page reaches its error state at the deadline instead of
+ * hanging.
+ *
+ * ## What is faked here, and what is not
+ *
+ * Only the one read is faked — held open and never fulfilled, which is the stall
+ * itself. Everything else is real: the host, the console bundle, the session,
+ * and the client's real 30s deadline (not shortened for the test — the point is
+ * that the deadline fires). `test.setTimeout(45_000)` gives that 30s room.
+ *
+ * Like the rest of `test/e2e`, this drives a running host and is not wired into
+ * CI (the Playwright config declares no `webServer`); `npm run typecheck:e2e`
+ * compiles it, nothing runs it automatically. It runs on the default Console
+ * E2E lane — the list read is stalled before any capability matters, so no
+ * `LIVE_BRAIN` feature is needed.
+ */
+
+/**
+ * The company's MCP server list, in both addressing shapes the client serves —
+ * single-company (`/api/v1/company/mcp/servers`) and platform
+ * (`/api/v1/companies/{id}/mcp/servers`). Anchored on `$` so a server's tool
+ * read (`.../mcp/servers/{name}/tools`) is left alone.
+ */
+const isMcpServerList = (url: URL) => /\/mcp\/servers$/.test(url.pathname);
+
+/**
+ * The first-run product tour opens a Radix dialog over a fresh console and would
+ * cover the page under test. Same suppression the other specs use — answer
+ * "already skipped" for whatever company id the host resolves to.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+test("the MCP page surfaces a load error at the deadline instead of hanging", async ({
+  page,
+}) => {
+  // The client's GET deadline is 30s; give the whole flow room past it.
+  test.setTimeout(45_000);
+
+  // Hold the list read open and never answer it — the stall #2014 is about. A
+  // route handler that never settles leaves the request pending, exactly as a
+  // host that accepted the connection and then went silent would.
+  await page.route(isMcpServerList, () => new Promise<never>(() => {}));
+
+  await page.goto("/#/connections/mcp");
+
+  // The page starts on its loading skeleton with no error, as it always did.
+  await expect(page.locator(".h-24.rounded-xl")).toBeVisible();
+  await expect(page.getByTestId("mcp-load-error")).toBeHidden();
+
+  // Once the 30s deadline fires, the read rejects and the section's existing
+  // error branch renders — the skeleton is gone and the error is shown.
+  const error = page.getByTestId("mcp-load-error");
+  await expect(error).toBeVisible({ timeout: 40_000 });
+  await expect(error).toContainText("Couldn't load");
+  await expect(page.locator(".h-24.rounded-xl")).toHaveCount(0);
+});

--- a/frontend/test/unit/client-request-timeout.test.ts
+++ b/frontend/test/unit/client-request-timeout.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_REQUEST_TIMEOUT_MS, OpenCompanyClient } from "@/api/client";
+import type {
+  StreamHandlers,
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from "@/api/transport";
+import { ApiError } from "@/api/types";
+
+/**
+ * The request deadline (issue #2014).
+ *
+ * Every `client.get` behind a view's load path — MCP servers, connections,
+ * agents, workspace, memory — reaches the host through the one shared `request`
+ * path, and that path had no timeout: a host that accepted the connection and
+ * then never answered left the read's promise pending forever, so the `catch`
+ * every view already holds for a failed load never ran and the view sat on its
+ * skeleton. These pin that a read now rejects at its bound instead of hanging,
+ * that a mutation is left unbounded, and that a caller's own abort stays
+ * distinguishable from a timeout.
+ *
+ * The never-settling stub below is exactly the hang. On the pre-fix client the
+ * first assertion never resolves — the test times out rather than passing.
+ */
+
+/** A transport whose reply the test stages; records every request it is handed. */
+class StubTransport implements Transport {
+  readonly seen: TransportRequest[] = [];
+
+  constructor(
+    private readonly reply: (req: TransportRequest) => Promise<Partial<TransportResponse>>,
+  ) {}
+
+  async request(req: TransportRequest): Promise<TransportResponse> {
+    this.seen.push(req);
+    const staged = await this.reply(req);
+    return {
+      status: staged.status ?? 200,
+      statusText: staged.statusText ?? "",
+      url: staged.url ?? req.url,
+      text: staged.text ?? "",
+      header: staged.header ?? (() => null),
+    };
+  }
+
+  subscribe(_url: string, _handlers: StreamHandlers): () => void {
+    return () => {};
+  }
+}
+
+/** A transport that accepts the connection and never answers. */
+const NEVER = () => new Promise<Partial<TransportResponse>>(() => {});
+
+function clientOn(transport: Transport): OpenCompanyClient {
+  return new OpenCompanyClient(
+    { baseUrl: "https://host.test", company: null, operatorToken: null, sessionHeader: null },
+    transport,
+  );
+}
+
+describe("the request deadline", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects a stalled GET with a timeout error at the default bound", async () => {
+    const client = clientOn(new StubTransport(NEVER));
+
+    const read = client.get("/api/v1/company/mcp/servers");
+    const rejection = expect(read).rejects.toMatchObject({ status: 0, code: "timeout" });
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_REQUEST_TIMEOUT_MS);
+    await rejection;
+  });
+
+  it("hands the transport a signal so a browser fetch can cancel the socket", async () => {
+    const stub = new StubTransport(async () => ({ text: "[]" }));
+    await clientOn(stub).get("/api/v1/company/mcp/servers");
+
+    expect(stub.seen).toHaveLength(1);
+    expect(stub.seen[0].signal).toBeInstanceOf(AbortSignal);
+    expect(stub.seen[0].signal?.aborted).toBe(false);
+  });
+
+  it("leaves a fast GET untouched and arms no late rejection", async () => {
+    const client = clientOn(new StubTransport(async () => ({ text: '{"ok":true}' })));
+
+    await expect(client.get("/api/v1/company")).resolves.toEqual({ ok: true });
+    // The timer for the resolved read is cleared, so time passing is a no-op.
+    await vi.advanceTimersByTimeAsync(DEFAULT_REQUEST_TIMEOUT_MS * 2);
+  });
+
+  it("honours a caller's shorter deadline", async () => {
+    const client = clientOn(new StubTransport(NEVER));
+
+    const read = client.get("/api/v1/company/memory", { timeoutMs: 5_000 });
+    const rejection = expect(read).rejects.toMatchObject({ code: "timeout" });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejection;
+  });
+
+  it("lets a caller disable the bound for a read expected to run long", async () => {
+    const client = clientOn(new StubTransport(NEVER));
+
+    let settled = false;
+    void client.get("/api/v1/company/slow", { timeoutMs: null }).then(
+      () => (settled = true),
+      () => (settled = true),
+    );
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_REQUEST_TIMEOUT_MS * 3);
+    expect(settled).toBe(false);
+  });
+
+  it("does not bound a mutation by default", async () => {
+    const client = clientOn(new StubTransport(NEVER));
+
+    let settled = false;
+    void client.post("/api/v1/company/chat", { text: "hi" }).then(
+      () => (settled = true),
+      () => (settled = true),
+    );
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_REQUEST_TIMEOUT_MS * 3);
+    expect(settled).toBe(false);
+  });
+
+  it("surfaces a caller's abort as an AbortError, not a timeout", async () => {
+    const client = clientOn(new StubTransport(NEVER));
+    const abort = new AbortController();
+
+    const read = client.get("/api/v1/company/mcp/servers", { signal: abort.signal });
+    abort.abort();
+
+    const err = await read.then(
+      () => {
+        throw new Error("expected the read to reject");
+      },
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("AbortError");
+    expect(err).not.toBeInstanceOf(ApiError);
+  });
+});

--- a/frontend/test/unit/client-request-timeout.test.ts
+++ b/frontend/test/unit/client-request-timeout.test.ts
@@ -148,4 +148,21 @@ describe("the request deadline", () => {
     expect((err as Error).name).toBe("AbortError");
     expect(err).not.toBeInstanceOf(ApiError);
   });
+
+  it("normalizes a caller's abort reason to AbortError even when it is an ordinary Error", async () => {
+    const client = clientOn(new StubTransport(NEVER));
+    const abort = new AbortController();
+
+    const read = client.get("/api/v1/company/mcp/servers", { signal: abort.signal });
+    abort.abort(new Error("superseded"));
+
+    const err = await read.then(
+      () => {
+        throw new Error("expected the read to reject");
+      },
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("AbortError");
+  });
 });

--- a/frontend/test/unit/mcp-page-load-timeout.test.ts
+++ b/frontend/test/unit/mcp-page-load-timeout.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_REQUEST_TIMEOUT_MS, OpenCompanyClient } from "@/api/client";
+import type {
+  StreamHandlers,
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from "@/api/transport";
+import { McpServersSection } from "@/views/connections/McpServersSection";
+
+/**
+ * The MCP servers page against a stalled host (issue #2014).
+ *
+ * `McpServersSection` has carried a real load-error state all along — it just
+ * never reached it, because `listMcpServers` → `client.get` sat on a `fetch`
+ * that never settled and the section's `catch` never ran, leaving the page on
+ * its loading skeleton forever. The section is unchanged by the fix; the shared
+ * request deadline turns the stall into the rejection its existing `catch`
+ * already knows how to render.
+ *
+ * On the pre-fix client this test fails: the skeleton is still on screen and
+ * `mcp-load-error` never appears after the deadline passes.
+ */
+
+/** A transport that accepts every request and answers none. */
+class StallingTransport implements Transport {
+  request(_req: TransportRequest): Promise<TransportResponse> {
+    return new Promise<TransportResponse>(() => {});
+  }
+  subscribe(_url: string, _handlers: StreamHandlers): () => void {
+    return () => {};
+  }
+}
+
+function stalledClient(): OpenCompanyClient {
+  return new OpenCompanyClient(
+    { baseUrl: "https://host.test", company: "acme", operatorToken: null, sessionHeader: null },
+    new StallingTransport(),
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.useRealTimers();
+});
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${testid}"]`);
+}
+
+describe("MCP servers page on a stalled host", () => {
+  it("replaces the skeleton with a load error once the read deadline passes", async () => {
+    const client = stalledClient();
+
+    await act(async () => {
+      root.render(
+        createElement(McpServersSection, {
+          client,
+          company: "acme",
+          canManage: false,
+          chrome: "standalone",
+        }),
+      );
+    });
+
+    // Before the deadline: the loading skeleton, and no error yet.
+    expect(container.querySelector(".h-24")).not.toBeNull();
+    expect(at("mcp-load-error")).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEFAULT_REQUEST_TIMEOUT_MS);
+    });
+
+    // After the deadline: the error state the section always had, no skeleton.
+    expect(at("mcp-load-error")).not.toBeNull();
+    expect(at("mcp-load-error")?.textContent).toContain("Couldn't load");
+    expect(container.querySelector(".h-24")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

The MCP servers page hung on its loading skeleton forever when the backend accepted the connection but never answered. The reported page was not the bug — the root was `OpenCompanyClient`: every JSON read funnels through the shared private `request()` (`frontend/src/api/client.ts`), which called the transport with **no timeout or abort**. A `fetch` against a hung host never settles, so `McpServersSection`'s existing `catch`/`mcp-load-error` state never fired and it sat on `<Skeleton>` indefinitely. Only `getBlob` accepted a signal; the whole JSON-GET path did not.

Fixed at the root so every caller is covered at once. Swept **~70 JSON-GET call sites** across `frontend/src` — all routed through `request()`, all equally vulnerable (the "MCP / connections / agents / workspace / brain load slowly or hang" cluster). No per-page change was needed: each page already had its error branch and was only ever missing the rejection to trigger it.

## API Or Behavior Changes

- `request()` now builds a per-call `AbortController` combining a default **`DEFAULT_REQUEST_TIMEOUT_MS = 30_000`** deadline (applied to **GET only**) with any caller signal, passes the signal to the transport, and races via `settleWithin` so a transport that can't honor the signal still rejects.
- New public `RequestOptions` on `get(path, options?)` — `{ signal, timeoutMs }`; `timeoutMs: null` disables the deadline for a caller that is legitimately long.
- `TransportRequest` gains `signal?: AbortSignal`, threaded to the browser `fetch` so the socket is actually cancelled (proxy/desktop transport ignores it by design, like `keepalive`).
- A stalled GET → `ApiError(0, "timeout", …)`; a caller abort (unmount/navigation) → real `AbortError`, distinct from a timeout; network errors unchanged. **Mutations stay unbounded by default** (a chat turn / provision is legitimately long). A caller signal is combined, never clobbered.
- Addresses the same root as the #2007 connections-catalog first-load hang and the F17/F18/F19 slow-page cluster — those reads are now bounded without touching their pages.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` (460 files / 4317 tests pass)
- [x] `npm run build`

New: `test/unit/client-request-timeout.test.ts` (7 — stalled GET rejects at the bound, signal really cancels, fast GET untouched, custom `timeoutMs`, `timeoutMs:null` disables, mutation unbounded, caller-abort → `AbortError` not timeout) and `test/unit/mcp-page-load-timeout.test.ts` (real `McpServersSection` + real client over a never-answering transport → skeleton before the deadline, `mcp-load-error` after). RED-on-old proof: both specs run against the pre-fix client fail 5/… (timeout + abort hang, functional error-state never renders). Playwright rung N/A — a real 30s hang→timeout collides with Playwright's own 30s timeouts and adds no coverage the functional jsdom test lacks; live-browser confirmation is the repro below.

Live repro (pending, bearer-gated tenant): Connections → MCP Servers against a hung backend → the skeleton is replaced by the "Couldn't load…" error within ~30s, not an endless skeleton; same for the sibling reads.

## Documentation

None — no public API or doc surface changed beyond the additive `get` options noted above.

Closes #2014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request cancellation and timeout controls for API calls.
  * GET requests now time out after 30 seconds by default, with options to customize or disable the limit.
  * Caller-initiated cancellations are reported distinctly from timeout errors.
  * Stalled MCP server page loads now exit the loading state and display an error after the request deadline.

* **Bug Fixes**
  * Prevented indefinitely hanging browser requests when a server accepts but does not respond.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->