### PR TITLE
fix(memory): virtualize the Brain memory list so large sets stay responsive (#2015)

### DIFF
--- a/frontend/src/components/virtual-list.tsx
+++ b/frontend/src/components/virtual-list.tsx
@@ -1,0 +1,165 @@
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useReducer,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { computeWindow, rowOffsets, totalHeight } from "@/components/virtual-window";
+
+export interface VirtualListProps<T> {
+  items: T[];
+  /**
+   * The scroll container the rows live inside. The list windows against this
+   * element's scroll position rather than owning its own scrollbar, so a page
+   * with header content above the list keeps a single scrollbar.
+   */
+  scrollElement: HTMLElement | null;
+  renderItem: (item: T, index: number) => ReactNode;
+  getKey: (item: T, index: number) => string;
+  /** Columns per row. Rows stay CSS-grid aligned across lanes. Default 1. */
+  lanes?: number;
+  /** Row height assumed before a row has been measured. Default 120. */
+  estimateRowHeight?: number;
+  /** Rows rendered beyond the viewport on each side. Default 4. */
+  overscan?: number;
+  /** Gap in px between rows and lanes. Default 12. */
+  gap?: number;
+  className?: string;
+  "data-testid"?: string;
+}
+
+export function VirtualList<T>({
+  items,
+  scrollElement,
+  renderItem,
+  getKey,
+  lanes = 1,
+  estimateRowHeight = 120,
+  overscan = 4,
+  gap = 12,
+  className,
+  "data-testid": testid,
+}: VirtualListProps<T>) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const rowEls = useRef(new Map<string, HTMLDivElement>());
+  const heights = useRef(new Map<string, number>());
+  const [, bump] = useReducer((n: number) => n + 1, 0);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewport, setViewport] = useState(0);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  const laneCount = Math.max(1, lanes);
+  const rowCount = Math.ceil(items.length / laneCount);
+
+  const rowKeyAt = useCallback(
+    (row: number): string => {
+      const index = row * laneCount;
+      const first = items[index];
+      return first ? getKey(first, index) : `row-${row}`;
+    },
+    [items, laneCount, getKey],
+  );
+
+  const rowHeights = new Array<number>(rowCount);
+  for (let r = 0; r < rowCount; r++) {
+    rowHeights[r] = heights.current.get(rowKeyAt(r)) ?? estimateRowHeight;
+  }
+  const offsets = rowOffsets(rowHeights, gap);
+  const height = totalHeight(offsets, gap);
+
+  const win = computeWindow({
+    scrollTop: scrollTop - scrollMargin,
+    viewportHeight: viewport,
+    offsets,
+    count: rowCount,
+    overscan,
+  });
+
+  const sync = useCallback(() => {
+    const el = scrollElement;
+    const wrap = wrapperRef.current;
+    if (!el || !wrap) return;
+    const nextTop = el.scrollTop;
+    const nextView = el.clientHeight;
+    const nextMargin =
+      wrap.getBoundingClientRect().top - el.getBoundingClientRect().top + el.scrollTop;
+    setScrollTop((p) => (p !== nextTop ? nextTop : p));
+    setViewport((p) => (p !== nextView ? nextView : p));
+    setScrollMargin((p) => (Math.abs(p - nextMargin) > 1 ? nextMargin : p));
+  }, [scrollElement]);
+
+  useEffect(() => {
+    const el = scrollElement;
+    if (!el) return;
+    sync();
+    el.addEventListener("scroll", sync, { passive: true });
+    window.addEventListener("resize", sync);
+    return () => {
+      el.removeEventListener("scroll", sync);
+      window.removeEventListener("resize", sync);
+    };
+  }, [scrollElement, sync]);
+
+  useLayoutEffect(() => {
+    sync();
+    let changed = false;
+    for (const [key, el] of rowEls.current) {
+      const measured = el.getBoundingClientRect().height;
+      if (measured > 0 && Math.abs((heights.current.get(key) ?? -1) - measured) > 1) {
+        heights.current.set(key, measured);
+        changed = true;
+      }
+    }
+    if (changed) bump();
+  });
+
+  const setRowEl = useCallback((key: string, el: HTMLDivElement | null) => {
+    if (el) rowEls.current.set(key, el);
+    else rowEls.current.delete(key);
+  }, []);
+
+  const rows: ReactNode[] = [];
+  for (let r = win.startIndex; r <= win.endIndex; r++) {
+    const key = rowKeyAt(r);
+    const cells: ReactNode[] = [];
+    for (let l = 0; l < laneCount; l++) {
+      const index = r * laneCount + l;
+      if (index >= items.length) break;
+      const item = items[index];
+      cells.push(<Fragment key={getKey(item, index)}>{renderItem(item, index)}</Fragment>);
+    }
+    rows.push(
+      <div
+        key={key}
+        ref={(el) => setRowEl(key, el)}
+        style={{
+          position: "absolute",
+          top: offsets[r],
+          left: 0,
+          right: 0,
+          display: "grid",
+          gridTemplateColumns: `repeat(${laneCount}, minmax(0, 1fr))`,
+          gap,
+        }}
+      >
+        {cells}
+      </div>,
+    );
+  }
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={className}
+      style={{ position: "relative", height }}
+      data-testid={testid}
+    >
+      {rows}
+    </div>
+  );
+}

--- a/frontend/src/components/virtual-list.tsx
+++ b/frontend/src/components/virtual-list.tsx
@@ -47,11 +47,31 @@ export function VirtualList<T>({
 }: VirtualListProps<T>) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const rowEls = useRef(new Map<string, HTMLDivElement>());
+  const rowKeys = useRef(new WeakMap<HTMLDivElement, string>());
   const heights = useRef(new Map<string, number>());
   const [, bump] = useReducer((n: number) => n + 1, 0);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewport, setViewport] = useState(0);
   const [scrollMargin, setScrollMargin] = useState(0);
+  const [resizeObserver] = useState<ResizeObserver | null>(() =>
+    typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver((entries) => {
+          let changed = false;
+          for (const entry of entries) {
+            const key = rowKeys.current.get(entry.target as HTMLDivElement);
+            if (!key) continue;
+            const measured = entry.contentRect.height;
+            if (measured > 0 && Math.abs((heights.current.get(key) ?? -1) - measured) > 1) {
+              heights.current.set(key, measured);
+              changed = true;
+            }
+          }
+          if (changed) bump();
+        }),
+  );
+
+  useEffect(() => () => resizeObserver?.disconnect(), [resizeObserver]);
 
   const laneCount = Math.max(1, lanes);
   const rowCount = Math.ceil(items.length / laneCount);
@@ -118,10 +138,23 @@ export function VirtualList<T>({
     if (changed) bump();
   });
 
-  const setRowEl = useCallback((key: string, el: HTMLDivElement | null) => {
-    if (el) rowEls.current.set(key, el);
-    else rowEls.current.delete(key);
-  }, []);
+  const setRowEl = useCallback(
+    (key: string, el: HTMLDivElement | null) => {
+      if (el) {
+        rowEls.current.set(key, el);
+        rowKeys.current.set(el, key);
+        resizeObserver?.observe(el);
+      } else {
+        const prev = rowEls.current.get(key);
+        if (prev) {
+          resizeObserver?.unobserve(prev);
+          rowKeys.current.delete(prev);
+        }
+        rowEls.current.delete(key);
+      }
+    },
+    [resizeObserver],
+  );
 
   const rows: ReactNode[] = [];
   for (let r = win.startIndex; r <= win.endIndex; r++) {

--- a/frontend/src/components/virtual-window.ts
+++ b/frontend/src/components/virtual-window.ts
@@ -1,0 +1,59 @@
+export interface RowWindow {
+  startIndex: number;
+  endIndex: number;
+}
+
+export function rowOffsets(rowHeights: number[], gap = 0): number[] {
+  const offsets = new Array<number>(rowHeights.length + 1);
+  offsets[0] = 0;
+  for (let i = 0; i < rowHeights.length; i++) {
+    offsets[i + 1] = offsets[i] + rowHeights[i] + gap;
+  }
+  return offsets;
+}
+
+export function totalHeight(offsets: number[], gap = 0): number {
+  const count = offsets.length - 1;
+  return count > 0 ? offsets[count] - gap : 0;
+}
+
+function rowAtOffset(offsets: number[], value: number, count: number): number {
+  let lo = 0;
+  let hi = count - 1;
+  let ans = 0;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (offsets[mid] <= value) {
+      ans = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return ans;
+}
+
+/**
+ * The `[startIndex, endIndex]` rows that intersect the viewport
+ * `[scrollTop, scrollTop + viewportHeight]`, padded by `overscan` rows on each
+ * side and clamped to the population. Returns an empty window
+ * (`endIndex < startIndex`) only when `count` is 0.
+ */
+export function computeWindow(params: {
+  scrollTop: number;
+  viewportHeight: number;
+  offsets: number[];
+  count: number;
+  overscan: number;
+}): RowWindow {
+  const { scrollTop, viewportHeight, offsets, count, overscan } = params;
+  if (count <= 0) return { startIndex: 0, endIndex: -1 };
+  const top = Math.max(0, scrollTop);
+  const bottom = top + Math.max(0, viewportHeight);
+  const first = rowAtOffset(offsets, top, count);
+  const last = rowAtOffset(offsets, bottom, count);
+  return {
+    startIndex: Math.max(0, first - overscan),
+    endIndex: Math.min(count - 1, last + overscan),
+  };
+}

--- a/frontend/src/hooks/use-media-query.ts
+++ b/frontend/src/hooks/use-media-query.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(
+    () => typeof window !== "undefined" && typeof window.matchMedia === "function"
+      ? window.matchMedia(query).matches
+      : false,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/frontend/src/hooks/use-media-query.ts
+++ b/frontend/src/hooks/use-media-query.ts
@@ -12,8 +12,12 @@ export function useMediaQuery(query: string): boolean {
     const mql = window.matchMedia(query);
     const onChange = () => setMatches(mql.matches);
     onChange();
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
   }, [query]);
 
   return matches;

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -23,6 +23,8 @@ import {
   type MemoryStats,
 } from "@/api/memory";
 import type { OpenCompanyClient } from "@/api/client";
+import { VirtualList } from "@/components/virtual-list";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { DropZone } from "@/views/memory/DropZone";
 import { EngineSection } from "@/views/memory/EngineSection";
 import { Markdown } from "@/components/markdown";
@@ -124,6 +126,8 @@ export function MemoryView({ client, company }: Props) {
   const [query, setQuery] = useState("");
   const [kind, setKind] = useState<string>("all");
   const [addOpen, setAddOpen] = useState(false);
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  const lanes = useMediaQuery("(min-width: 640px)") ? 2 : 1;
   // A generation token so a response from a previous company scope (or after
   // unmount) can't overwrite the current one.
   const gen = useRef(0);
@@ -301,7 +305,10 @@ export function MemoryView({ client, company }: Props) {
           </>
         }
       />
-      <div className="mx-auto min-h-0 w-full max-w-5xl flex-1 space-y-5 overflow-y-auto px-4 py-6">
+      <div
+        ref={setScrollEl}
+        className="mx-auto min-h-0 w-full max-w-5xl flex-1 space-y-5 overflow-y-auto px-4 py-6"
+      >
 
         <EngineSection
           client={client}
@@ -371,11 +378,15 @@ export function MemoryView({ client, company }: Props) {
         ) : filtered.length === 0 ? (
           <EmptyMemory hasEntries={entries.length > 0} />
         ) : (
-          <div className="grid gap-3 sm:grid-cols-2">
-            {filtered.map((e) => (
-              <MemoryCard key={e.id} entry={e} onDelete={() => void remove(e)} />
-            ))}
-          </div>
+          <VirtualList
+            items={filtered}
+            scrollElement={scrollEl}
+            lanes={lanes}
+            estimateRowHeight={132}
+            getKey={(e) => e.id}
+            renderItem={(e) => <MemoryCard entry={e} onDelete={() => void remove(e)} />}
+            data-testid="memory-list"
+          />
         )}
       </div>
 

--- a/frontend/test/e2e/brain-virtualization.spec.ts
+++ b/frontend/test/e2e/brain-virtualization.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * The Brain memory list windows a large set instead of mounting every row.
+ *
+ * The pure window math is proven in the unit suite; what only a browser can
+ * show is that a real 1000-item payload renders as a bounded handful of cards
+ * and that scrolling the page moves that window. The payload is staged with
+ * `page.route` rather than seeded through the host: a thousand real `POST
+ * /memory` writes would be slow and prove nothing the fabricated list does not.
+ */
+
+const COMPANY = "acme";
+const COUNT = 1000;
+
+interface WireEntry {
+  id: string;
+  kind: string;
+  origin: string;
+  editable: boolean;
+  title: string;
+  body: string;
+  source: string;
+  updatedAt: number;
+}
+
+function entries(count: number): WireEntry[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `m-${i}`,
+    kind: "fact",
+    origin: "fact",
+    editable: true,
+    title: `memory ${i}`,
+    body: "",
+    source: "operator",
+    updatedAt: 0,
+  }));
+}
+
+async function mockApi(page: Page) {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+    const status = { id: COMPANY, name: "Acme", lifecycle: "running", pending_approvals: 0 };
+
+    if (path === "/api/v1/companies") return json([status]);
+    if (path === `/api/v1/companies/${COMPANY}`) return json(status);
+
+    if (path.endsWith("/memory/stats")) {
+      return json({
+        facts: COUNT,
+        factsUpdatedAtMillis: 0,
+        lastUpdatedAtMillis: 0,
+        totalItems: COUNT,
+        teammateMemory: 0,
+        documentMemory: 0,
+        taskOutcomes: 0,
+      });
+    }
+    if (path.endsWith("/memory/engine")) {
+      return json({
+        active: "store",
+        capabilities: [],
+        selected: "store",
+        apiKeySet: false,
+        layer: "default",
+        editable: false,
+        configPath: "",
+        options: [],
+      });
+    }
+    if (path.endsWith("/memory")) {
+      return json({ items: entries(COUNT), totalContext: 0, contextTruncated: false });
+    }
+
+    if (path.endsWith("/me")) return json({ id: "op", email: "op@example.com", role: "member" });
+    return json([]);
+  });
+}
+
+/** The overflow-y-auto ancestor the list windows against. */
+async function scrollListBy(page: Page, delta: number) {
+  await page.evaluate((by) => {
+    const list = document.querySelector('[data-testid="memory-list"]');
+    let el = list?.parentElement ?? null;
+    while (el) {
+      const style = getComputedStyle(el);
+      if (/(auto|scroll)/.test(style.overflowY) && el.scrollHeight > el.clientHeight) {
+        el.scrollTop += by;
+        el.dispatchEvent(new Event("scroll"));
+        return;
+      }
+      el = el.parentElement;
+    }
+  }, delta);
+}
+
+test("Brain windows a 1000-item memory set and moves the window on scroll", async ({ page }) => {
+  await mockApi(page);
+
+  await page.goto("/#/settings/brain");
+  await expect(page.getByRole("heading", { name: "Brain", level: 1 })).toBeVisible();
+
+  const cards = page.getByTestId("memory-card");
+  await expect(cards.first()).toBeVisible({ timeout: 30_000 });
+
+  // The property under test: a windowed list mounts only the rows the viewport
+  // can show plus overscan — never the full 1000 the pre-fix view mounted.
+  const initialCount = await cards.count();
+  expect(initialCount).toBeGreaterThan(0);
+  expect(initialCount).toBeLessThan(80);
+
+  const before = await cards.allInnerTexts();
+
+  // Scroll the page well past the first window and prove the window followed:
+  // new rows mounted and the leading row is no longer row 0.
+  await scrollListBy(page, 6000);
+  await expect
+    .poll(async () => (await cards.allInnerTexts())[0], { timeout: 10_000 })
+    .not.toBe(before[0]);
+
+  const after = await cards.allInnerTexts();
+  expect(after.length).toBeGreaterThan(0);
+  expect(after.length).toBeLessThan(80);
+  // The window moved rather than grew: rows that were on screen are gone, and
+  // rows that were not are now mounted.
+  expect(after.some((t) => !before.includes(t))).toBe(true);
+  expect(before.some((t) => !after.includes(t))).toBe(true);
+});

--- a/frontend/test/unit/memory-virtualized-list.test.ts
+++ b/frontend/test/unit/memory-virtualized-list.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { MemoryEntry, MemoryList, MemoryStats } from "@/api/memory";
+import { MemoryView } from "@/views/MemoryView";
+
+let container: HTMLDivElement;
+let root: Root;
+
+const VIEWPORT = 660;
+const ROW = 132;
+
+function entries(count: number): MemoryEntry[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `m-${i}`,
+    kind: "fact" as const,
+    origin: "fact" as const,
+    editable: true,
+    title: `memory ${i}`,
+    body: "",
+    source: "operator",
+    updatedAt: 0,
+  }));
+}
+
+function stats(total: number): MemoryStats {
+  return {
+    facts: total,
+    factsUpdatedAtMillis: 0,
+    lastUpdatedAtMillis: 0,
+    totalItems: total,
+    teammateMemory: 0,
+    documentMemory: 0,
+    taskOutcomes: 0,
+  };
+}
+
+function clientFor(count: number): OpenCompanyClient {
+  const list: MemoryList = { items: entries(count), totalContext: 0, contextTruncated: false };
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: async (path: string) => {
+      if (path.endsWith("/memory/stats")) return stats(count);
+      // The engine surface is exercised by its own suite; here it may fail —
+      // EngineSection renders its own alert and the memory list still mounts.
+      if (path.endsWith("/memory/engine")) throw new Error("engine unavailable in unit");
+      if (path.endsWith("/memory")) return list;
+      throw new Error(`unexpected GET ${path}`);
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(MemoryView, { client, company: "acme" }));
+  });
+  await act(async () => {});
+  await act(async () => {});
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", { configurable: true, value: VIEWPORT });
+  Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value() {
+      return {
+        top: 0,
+        left: 0,
+        right: 300,
+        bottom: ROW,
+        width: 300,
+        height: ROW,
+        x: 0,
+        y: 0,
+        toJSON() {},
+      };
+    },
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("Brain memory list virtualization", () => {
+  it("renders only a viewport-sized window of a large memory set, not every row", async () => {
+    const count = 1000;
+    await mount(clientFor(count));
+
+    const cards = container.querySelectorAll('[data-testid="memory-card"]');
+    // The bug this guards: the old view mapped the full `filtered` array, so a
+    // 1000-item set mounted 1000 cards and locked the page. A windowed list
+    // mounts only the rows the viewport can show (plus overscan). This is the
+    // assertion that fails on the pre-fix view, which renders all `count`.
+    expect(cards.length).toBeGreaterThan(0);
+    expect(cards.length).toBeLessThan(count);
+    // A viewport of ~5 rows plus overscan is comfortably under 50; asserting a
+    // hard ceiling keeps this honest if the window math ever regresses to "all".
+    expect(cards.length).toBeLessThanOrEqual(50);
+
+    expect(container.querySelector('[data-testid="memory-list"]')).not.toBeNull();
+  });
+
+  it("mounts every card when the set is small enough to fit", async () => {
+    await mount(clientFor(3));
+    const cards = container.querySelectorAll('[data-testid="memory-card"]');
+    expect(cards.length).toBe(3);
+  });
+
+  it("renders the empty state and no windowed list when there are no memories", async () => {
+    await mount(clientFor(0));
+    expect(container.querySelector('[data-testid="memory-list"]')).toBeNull();
+    expect(container.querySelectorAll('[data-testid="memory-card"]').length).toBe(0);
+    expect(container.textContent).toContain("No memories yet.");
+  });
+});

--- a/frontend/test/unit/use-media-query-legacy-fallback.test.ts
+++ b/frontend/test/unit/use-media-query-legacy-fallback.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useMediaQuery } from "@/hooks/use-media-query";
+
+let container: HTMLDivElement;
+let root: Root;
+let last: boolean | null;
+let originalMatchMedia: typeof window.matchMedia | undefined;
+
+/**
+ * A `MediaQueryList` shaped like the older WebKitGTK builds Tauri v2's floor
+ * still admits: no `EventTarget` methods, only the deprecated
+ * `addListener`/`removeListener` pair.
+ */
+class LegacyMediaQueryList {
+  matches = false;
+  media: string;
+  private listeners = new Set<(list: LegacyMediaQueryList) => void>();
+
+  constructor(media: string) {
+    this.media = media;
+  }
+
+  addListener(fn: (list: LegacyMediaQueryList) => void) {
+    this.listeners.add(fn);
+  }
+
+  removeListener(fn: (list: LegacyMediaQueryList) => void) {
+    this.listeners.delete(fn);
+  }
+
+  listenerCount() {
+    return this.listeners.size;
+  }
+
+  fire() {
+    this.matches = true;
+    for (const fn of this.listeners) fn(this);
+  }
+}
+
+function Probe({ query }: { query: string }) {
+  last = useMediaQuery(query);
+  return null;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  last = null;
+  originalMatchMedia = window.matchMedia;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  if (originalMatchMedia) {
+    window.matchMedia = originalMatchMedia;
+  } else {
+    // @ts-expect-error jsdom does not define matchMedia by default
+    delete window.matchMedia;
+  }
+});
+
+describe("useMediaQuery against a legacy MediaQueryList", () => {
+  it("subscribes via addListener instead of throwing when addEventListener is absent", async () => {
+    const legacy = new LegacyMediaQueryList("(min-width: 768px)");
+    window.matchMedia = (() => legacy) as unknown as typeof window.matchMedia;
+
+    await act(async () => {
+      root.render(createElement(Probe, { query: "(min-width: 768px)" }));
+    });
+
+    expect(last).toBe(false);
+    expect(legacy.listenerCount()).toBe(1);
+
+    await act(async () => {
+      legacy.fire();
+    });
+    expect(last).toBe(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+    expect(legacy.listenerCount()).toBe(0);
+  });
+});

--- a/frontend/test/unit/virtual-list-resize.test.ts
+++ b/frontend/test/unit/virtual-list-resize.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { VirtualList } from "@/components/virtual-list";
+
+let container: HTMLDivElement;
+let root: Root;
+
+const ROW_HEIGHT = 40;
+
+const elementHeights = new WeakMap<Element, number>();
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  readonly observed = new Set<Element>();
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this);
+  }
+
+  observe(el: Element) {
+    this.observed.add(el);
+  }
+
+  unobserve(el: Element) {
+    this.observed.delete(el);
+  }
+
+  disconnect() {
+    this.observed.clear();
+  }
+}
+
+function stubRect(height: number) {
+  return { top: 0, left: 0, right: 300, bottom: height, width: 300, height, x: 0, y: 0, toJSON() {} };
+}
+
+function rows() {
+  return [{ id: "r0" }, { id: "r1" }, { id: "r2" }];
+}
+
+async function mount() {
+  await act(async () => {
+    root.render(
+      createElement(VirtualList<{ id: string }>, {
+        items: rows(),
+        scrollElement: null,
+        renderItem: (item) => createElement("div", { "data-testid": `cell-${item.id}` }, item.id),
+        getKey: (item) => item.id,
+        estimateRowHeight: ROW_HEIGHT,
+        gap: 0,
+        "data-testid": "vl",
+      }),
+    );
+  });
+  // The first layout-effect pass moves rows off the estimate and bumps once;
+  // that re-render's own layout effect settles with no further diff.
+  await act(async () => {});
+  await act(async () => {});
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  FakeResizeObserver.instances = [];
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = FakeResizeObserver;
+  Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value(this: HTMLElement) {
+      return stubRect(elementHeights.get(this) ?? ROW_HEIGHT);
+    },
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("VirtualList re-measures a row that resizes without a React render", () => {
+  it("subscribes every rendered row to a ResizeObserver", async () => {
+    await mount();
+    expect(FakeResizeObserver.instances.length).toBe(1);
+    expect(FakeResizeObserver.instances[0]!.observed.size).toBe(3);
+  });
+
+  it("grows the list height when a row's content resizes with no state change (e.g. a loaded image)", async () => {
+    await mount();
+    const list = container.querySelector('[data-testid="vl"]') as HTMLDivElement;
+    expect(list.style.height).toBe("120px");
+
+    const observer = FakeResizeObserver.instances[0];
+    expect(observer).toBeDefined();
+    const [row] = observer!.observed;
+    expect(row).toBeDefined();
+
+    // The row's Markdown body grows after an image finishes loading — a DOM
+    // size change with no React state update behind it, so nothing would
+    // re-render on its own.
+    elementHeights.set(row!, 90);
+    await act(async () => {
+      observer!.callback(
+        [{ target: row, contentRect: stubRect(90) } as unknown as ResizeObserverEntry],
+        observer as unknown as ResizeObserver,
+      );
+    });
+
+    expect(list.style.height).toBe("170px");
+  });
+});

--- a/frontend/test/unit/virtual-window.test.ts
+++ b/frontend/test/unit/virtual-window.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { computeWindow, rowOffsets, totalHeight } from "@/components/virtual-window";
+
+describe("rowOffsets / totalHeight", () => {
+  it("accumulates heights plus the inter-row gap", () => {
+    const offsets = rowOffsets([100, 100, 100], 10);
+    expect(offsets).toEqual([0, 110, 220, 330]);
+    // Total drops the trailing gap: three 100px rows + two 10px gaps.
+    expect(totalHeight(offsets, 10)).toBe(320);
+  });
+
+  it("is zero-length safe", () => {
+    expect(rowOffsets([], 10)).toEqual([0]);
+    expect(totalHeight([0], 10)).toBe(0);
+  });
+});
+
+describe("computeWindow", () => {
+  const uniform = (count: number, h: number, gap: number) =>
+    rowOffsets(new Array<number>(count).fill(h), gap);
+
+  it("renders only the rows intersecting the viewport, never the whole set", () => {
+    const count = 1000;
+    const offsets = uniform(count, 100, 0);
+    const win = computeWindow({
+      scrollTop: 0,
+      viewportHeight: 500,
+      offsets,
+      count,
+      overscan: 2,
+    });
+    // 5 rows fit in 500px + 2 overscan below; the window is a tiny slice of 1000.
+    expect(win.startIndex).toBe(0);
+    expect(win.endIndex).toBe(7);
+    expect(win.endIndex - win.startIndex + 1).toBeLessThan(count);
+  });
+
+  it("tracks the viewport as it scrolls and pads by overscan on both sides", () => {
+    const count = 1000;
+    const offsets = uniform(count, 100, 0);
+    const win = computeWindow({
+      scrollTop: 10_000,
+      viewportHeight: 500,
+      offsets,
+      count,
+      overscan: 3,
+    });
+    // Rows 100..105 span the viewport; overscan widens to 97..108.
+    expect(win.startIndex).toBe(97);
+    expect(win.endIndex).toBe(108);
+  });
+
+  it("clamps to the population at the ends", () => {
+    const count = 10;
+    const offsets = uniform(count, 100, 0);
+    const win = computeWindow({
+      scrollTop: 5000,
+      viewportHeight: 500,
+      offsets,
+      count,
+      overscan: 4,
+    });
+    expect(win.startIndex).toBeGreaterThanOrEqual(0);
+    expect(win.endIndex).toBe(9);
+  });
+
+  it("handles a single item", () => {
+    const win = computeWindow({
+      scrollTop: 0,
+      viewportHeight: 500,
+      offsets: rowOffsets([80], 0),
+      count: 1,
+      overscan: 4,
+    });
+    expect(win).toEqual({ startIndex: 0, endIndex: 0 });
+  });
+
+  it("returns an empty window for an empty list", () => {
+    const win = computeWindow({
+      scrollTop: 0,
+      viewportHeight: 500,
+      offsets: [0],
+      count: 0,
+      overscan: 4,
+    });
+    expect(win.endIndex).toBeLessThan(win.startIndex);
+  });
+
+  it("respects variable row heights when choosing the first visible row", () => {
+    // A tall first row pushes the viewport start past row 0 by itself.
+    const offsets = rowOffsets([1000, 100, 100, 100, 100], 0);
+    const win = computeWindow({
+      scrollTop: 1050,
+      viewportHeight: 100,
+      offsets,
+      count: 5,
+      overscan: 0,
+    });
+    // Offset 1050 lands inside row 1 (1000..1100); bottom 1150 lands in row 2.
+    expect(win.startIndex).toBe(1);
+    expect(win.endIndex).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

The Brain (memory) page loaded slowly, felt cluttered, and **locked on scroll** with a large memory set. Root cause is not Brain-specific: `MemoryView.tsx` rendered the entire `filtered` array with a bare `.map` into a grid inside the page scroller, and there was **no windowing anywhere in the frontend**. The host caps context rows at 500 but facts are uncapped, so 500+ variable-height Markdown cards all mount at once and thrash layout on every scroll frame.

Fixed with a **shared virtualization primitive** (not a Brain-only hack), and swept every unbounded-list view to find the real blast radius. The two genuine same-severity siblings — `chat/MessageTimeline.tsx` and `InboxView.tsx`, both uncapped — are flagged as follow-ups and can adopt the same primitive; the rest are soft-capped server-side (100–200) so they are noted, not urgent.

## API Or Behavior Changes

- New reusable, dependency-free primitive: `components/virtual-window.ts` (pure windowing math — `rowOffsets` / `computeWindow` / `totalHeight`, binary-searched, variable-height aware) and `components/virtual-list.tsx` (`VirtualList` — windows CSS-grid rows against the **external page scroller**, so Brain keeps its single scrollbar and layout unchanged; dynamic per-row measurement, responsive lanes, overscan). Added `hooks/use-media-query.ts` for the responsive column count.
- `MemoryView` now renders through `VirtualList` — only a viewport-sized window of cards is in the DOM. No visual change: same 2-column layout ≥640px / 1 below, same gap, same single scrollbar. Empty/single/filtered states unchanged.
- (A first spike used `@tanstack/react-virtual` but its range flip-flopped to empty non-deterministically under jsdom — a flaky-gate risk — so the dep was removed and the primitive hand-rolled deterministically. `package.json`/lock untouched.)

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` (460 files / 4319 tests pass)
- [x] `npm run build`

New: `test/unit/virtual-window.test.ts` (8 — windowing, overscan, clamping, empty/single, variable-height) and `test/unit/memory-virtualized-list.test.ts` (3 — a 1000-item set mounts only a window ≤50; a 3-item set mounts all 3; empty → "No memories yet.", no list). RED-on-old proof: reverting only `MemoryView.tsx` fails with `expected 1000 to be less than 1000`. Existing memory tests + the `styleguide-components` contract stay green (VirtualList lives in `components/`, not `components/ui/`).

Live repro (pending): Brain page against a host seeded with 500–1000+ entries → fast load, smooth scroll, no lock; only a window of cards in the DOM; filter/search still narrow; 2 cols ≥640px.

## Documentation

None — no doc surface changed. Follow-up to virtualize `MessageTimeline` and `InboxView` with the same primitive is tracked from the sweep.

Closes #2015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added virtual scrolling for memory cards, improving performance when viewing large collections.
  * Memory cards now adapt between one- and two-column layouts based on screen size.
  * Added responsive media-query support for interface behavior.

* **Bug Fixes**
  * Preserved loading, filtering, and empty-state behavior while rendering large memory lists efficiently.

* **Tests**
  * Added coverage for virtual scrolling, responsive list sizing, variable row heights, scrolling, and empty collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->