### PR TITLE
fix(chat): keep the live receipt alive across the sync→async detach handoff (#2021)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1609,6 +1609,18 @@ export function AppShell({
             setLiveStepsByThread((prev) =>
               prev[threadId]?.length ? { ...prev, [threadId]: [] } : prev,
             );
+            // The receipt the detached turn carried through its queued/working
+            // window (issue #2021) is cleared on the same terminal transition
+            // that clears the live rows, under the same guard: a queued sibling
+            // still running keeps it, and this only runs once the scope checks
+            // above confirm the settle belongs to the company on screen — so a
+            // late cross-company settle cannot delete a newer company's receipt.
+            setReceiptByThread((prev) => {
+              if (!(threadId in prev)) return prev;
+              const next = { ...prev };
+              delete next[threadId];
+              return next;
+            });
           }
           setThreads((ts) =>
             ts.map((t) => {
@@ -2492,7 +2504,7 @@ export function AppShell({
    * suppression lose nothing: the frame was never dropped, only queued.
    */
   const onSendDetached = useCallback(
-    (threadId: string, turnId?: string, gen?: number) => {
+    (threadId: string, turnId?: string, _gen?: number) => {
       const held = pendingPostThreadsRef.current.detached(threadId);
       // Append, never replace (issue #1000). The serial lock queues a second
       // send behind the running turn, and a replace would stop the poll
@@ -2505,11 +2517,15 @@ export function AppShell({
         return { ...prev, [threadId]: [...turns, { turnId, queued: true }] };
       });
       held.forEach((frame) => renderAgentReply(frame));
-      // The turn is now the openTurns row's job, not the receipt's — from a
-      // 202 the working row is armed above and takes over (issue #1934).
-      clearReceipt(threadId, gen);
+      // The receipt is NOT cleared here (issue #2021). The 202 hands the turn to
+      // the open-turn row, but that row alone is a strict downgrade — bare
+      // "Queued…"/"Working…" with no elapsed clock, no picked-up-by name, no 30s
+      // stall notice. Keeping the receipt alive lets it ride the turn through the
+      // queued/working window with every #1934 affordance intact; its own frames
+      // keep bumping it, and the poll's terminal settle clears it (see
+      // `reReadSettledThread`), so it still never outlives the turn.
     },
-    [renderAgentReply, clearReceipt],
+    [renderAgentReply],
   );
   /**
    * The chat POST **threw** — no body, nothing rendered by the view (#1000).
@@ -2547,21 +2563,27 @@ export function AppShell({
     (threadId: string, gen?: number) => {
       const held = pendingPostThreadsRef.current.failed(threadId);
       held.forEach((frame) => renderAgentReply(frame));
-      // The request died; the view has rendered its `Couldn't send` line. Drop
-      // the receipt so it does not tick on over a dead POST (issue #1934) — any
-      // durable turn re-armed below drives the working row instead.
-      clearReceipt(threadId, gen);
 
       // Discover whether the host kept the turn after the request died. The
       // throw tells us nothing, but the run rows do: a `pending`/`running` row
       // naming this thread means the turn is durable and worth polling to its
       // terminal `chat/history` re-read — the SSE-less recovery path.
+      //
+      // The receipt clear now waits on this answer (issue #2021). A durable turn
+      // survived the dead request, so keeping the receipt alive lets it ride
+      // that turn through the queued/working window with its #1934 affordances
+      // (elapsed, picked-up-by, 30s stall) rather than dropping to the bare
+      // open-turn row — the poll's settle clears it. Only when NO durable turn
+      // exists is the receipt dropped here, so it never ticks on over a POST the
+      // host genuinely never kept, with the view's `Couldn't send` standing alone.
       listRuns(client, company, { status: ["pending", "running"] })
         .then((runs) => {
           if (!mountedRef.current) return;
           // A company switch that happened while the request was in flight
           // invalidates the result: the rows belong to the old company and
-          // would restore a stale turn into the new company's openTurns map.
+          // would restore a stale turn into the new company's openTurns map. The
+          // switch already wholesale-cleared this company's receipts, so leave
+          // the map alone rather than clearing a slot the new company may own.
           if (
             scopeRef.current.company !== company ||
             scopeRef.current.connection !== scope.connection ||
@@ -2573,9 +2595,13 @@ export function AppShell({
           // each has a reply to deliver. The merge appends and collapses by id.
           const durable = open[threadId];
           if (durable) setOpenTurns((prev) => mergeOpenTurns(prev, { [threadId]: durable }));
+          else clearReceipt(threadId, gen);
         })
         .catch(() => {
-          /* host without /runs, or offline — nothing to re-arm */
+          // Host without /runs, or offline — nothing to re-arm, so nothing will
+          // ever settle the receipt. Drop it (generation-guarded) so it does not
+          // tick on over a dead POST.
+          clearReceipt(threadId, gen);
         });
     },
     [client, company, renderAgentReply, clearReceipt],
@@ -3555,6 +3581,8 @@ export function AppShell({
               onReply={() => void feed.refresh()}
               taskEventTick={taskEventTick}
               liveStepsByThread={liveStepsByThread}
+              receiptByThread={receiptByThread}
+              agentNames={agentNames}
               onSendStart={onSendStart}
               onSendEnd={onSendEnd}
               onSendDetached={onSendDetached}

--- a/frontend/src/views/Conversation.tsx
+++ b/frontend/src/views/Conversation.tsx
@@ -30,6 +30,7 @@ import { ContactAvatar } from "@/views/conversation/parts";
 import { ThreadList } from "@/views/conversation/ThreadList";
 import { Transcript } from "@/views/conversation/Transcript";
 import { useConversationRuntime } from "@/views/conversation/runtime";
+import type { ChatReceipt } from "@/views/chat/ChatLiveReceipt";
 
 interface Props {
   client: OpenCompanyClient;
@@ -61,6 +62,16 @@ interface Props {
    * typing indicator and cleared by the parent when the final reply lands.
    */
   liveStepsByThread?: Record<string, TurnStep[]>;
+  /**
+   * The live receipt per thread for a chat turn this console just sent (issue
+   * #1934), keyed by host thread id. Ridden past the 202 into the queued/working
+   * window (issue #2021), so this surface keeps the same elapsed / picked-up-by /
+   * 30s-stall affordances across the detach handoff that `ChatView` does, rather
+   * than dropping to the bare typing/queued row.
+   */
+  receiptByThread?: Record<string, ChatReceipt>;
+  /** Roster agent id → display name, so the receipt names the teammate, not an id. */
+  agentNames?: Record<string, string>;
   /**
    * Marks a thread's chat POST as in flight (parent suppresses the SSE echo).
    * Returns the generation the shell stamped this send's receipt with (issue
@@ -100,6 +111,8 @@ export function Conversation({
   onReply,
   taskEventTick,
   liveStepsByThread,
+  receiptByThread,
+  agentNames,
   onSendStart,
   onSendEnd,
   onSendDetached,
@@ -151,6 +164,8 @@ export function Conversation({
         onReply={onReply}
         taskEventTick={taskEventTick}
         liveSteps={liveStepsByThread?.[active.id] ?? []}
+        receipt={receiptByThread?.[active.id]}
+        agentNames={agentNames}
         onSendStart={onSendStart}
         onSendEnd={onSendEnd}
         onSendDetached={onSendDetached}
@@ -171,6 +186,8 @@ function ChatPane({
   onReply,
   taskEventTick,
   liveSteps,
+  receipt,
+  agentNames,
   onSendStart,
   onSendEnd,
   onSendDetached,
@@ -186,6 +203,8 @@ function ChatPane({
   onReply?: () => void;
   taskEventTick?: number;
   liveSteps?: TurnStep[];
+  receipt?: ChatReceipt;
+  agentNames?: Record<string, string>;
   onSendStart?: (threadId: string) => number | undefined;
   onSendEnd?: (threadId: string, gen?: number) => void;
   onSendDetached?: (threadId: string, turnId?: string, gen?: number) => void;
@@ -243,6 +262,8 @@ function ChatPane({
           sending={sending}
           openTurn={openTurn}
           liveSteps={liveSteps}
+          receipt={receipt}
+          agentNames={agentNames}
           footer={
             <InflightStrip client={client} company={company} taskEventTick={taskEventTick} />
           }

--- a/frontend/src/views/chat/ChatLiveReceipt.tsx
+++ b/frontend/src/views/chat/ChatLiveReceipt.tsx
@@ -132,22 +132,28 @@ export function resolveReceiptAgentName(
 }
 
 /**
- * The one visible state line, progressing Sent → Picked up by <name> → On step
+ * The one visible state line, progressing Queued → Picked up by <name> → On step
  * <label>. A running step is the most specific thing to say, so it outranks the
- * name; the name outranks the bare "Sent". Pure, for the same reason
+ * name; the name outranks the base state. Pure, for the same reason
  * {@link formatElapsed} is.
+ *
+ * The base state is "Queued" while the turn is still waiting on the per-company
+ * serial lock (issue #2021 — the receipt now rides the detached turn past its
+ * 202 into the open-turn window, so the honest "waiting its turn" word must be
+ * available to it), and "Sent" otherwise.
  */
 export function receiptStateLine(
   receipt: ChatReceipt,
   steps: readonly TurnStep[] | undefined,
   agentNames: Record<string, string> | undefined,
   channel: Channel,
+  queued?: boolean,
 ): string {
   const step = runningStepLabel(steps);
   if (step) return `On step ${step}`;
   const name = resolveReceiptAgentName(receipt, agentNames, channel);
   if (name) return `Picked up by ${name}`;
-  return "Sent";
+  return queued ? "Queued" : "Sent";
 }
 
 export function ChatLiveReceipt({
@@ -155,6 +161,7 @@ export function ChatLiveReceipt({
   receipt,
   agentNames,
   steps,
+  queued,
 }: {
   channel: Channel;
   receipt: ChatReceipt;
@@ -162,6 +169,13 @@ export function ChatLiveReceipt({
   agentNames?: Record<string, string>;
   /** The turn's live steps, when any have arrived — folded below the line. */
   steps: TurnStep[];
+  /**
+   * The turn is accepted but has not taken the per-company serial lock (issue
+   * #2021). Words the base line "Queued" instead of "Sent" and stills the pulse,
+   * mirroring {@link WorkingIndicator}: a queued turn is not progressing, so the
+   * mark says so.
+   */
+  queued?: boolean;
 }) {
   const reduced = usePrefersReducedMotion();
   // Self-contained 1s clock, mounted only while this row is (the receipt is
@@ -172,7 +186,7 @@ export function ChatLiveReceipt({
   // Soft and reversible: a lull with no frame, seeded from `startedAt`, cleared
   // by the next frame that bumps `lastFrameAt`. Not an error state.
   const stalled = clock - receipt.lastFrameAt >= RECEIPT_STALL_AFTER_MS;
-  const line = receiptStateLine(receipt, steps, agentNames, channel);
+  const line = receiptStateLine(receipt, steps, agentNames, channel, queued);
 
   return (
     <div className="flex items-start gap-2.5 px-4 py-1">
@@ -192,10 +206,13 @@ export function ChatLiveReceipt({
           <span
             aria-hidden
             className={cn(
-              "size-1.5 shrink-0 rounded-full bg-status-running",
+              "size-1.5 shrink-0 rounded-full",
+              queued ? "bg-status-idle" : "bg-status-running",
               // The pulse is the "something is happening" signal; a reader who
-              // asked for stillness keeps the mark without the motion.
-              !reduced && "animate-pulse",
+              // asked for stillness keeps the mark without the motion, and a
+              // queued turn keeps it without the motion either — nothing is
+              // happening yet.
+              !reduced && !queued && "animate-pulse",
             )}
           />
           {/* `aria-hidden`, because the stable assistive line below is what a

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -434,15 +434,18 @@ export function MessageTimeline({
             />
           ),
         )}
-        {receipt && !queued ? (
+        {receipt ? (
           // The receipt for our own in-flight send (issue #1934) supersedes the
-          // typing dots and carries the live steps itself. A queued turn keeps
-          // its honest "Queued…" row instead — the receipt is a `!queued` state.
+          // typing dots and carries the live steps itself. It now rides a
+          // detached turn past its 202 into the queued/working window too (issue
+          // #2021), so `queued` words its base line and stills its pulse rather
+          // than dropping it back to the bare "Queued…"/step row.
           <ChatLiveReceipt
             channel={channel}
             receipt={receipt}
             agentNames={agentNames}
             steps={liveSteps ?? []}
+            queued={queued}
           />
         ) : liveStepCount > 0 && !queued ? (
           <LiveTurnRow channel={channel} steps={liveSteps ?? []} />

--- a/frontend/src/views/conversation/Transcript.tsx
+++ b/frontend/src/views/conversation/Transcript.tsx
@@ -20,6 +20,8 @@ import type { ChatMessage } from "@/lib/chat";
 import type { OpenTurn } from "@/lib/live-reply";
 import type { ThreadContact } from "@/lib/threads";
 import { cn } from "@/lib/utils";
+import { ChatLiveReceipt, type ChatReceipt } from "@/views/chat/ChatLiveReceipt";
+import type { Channel } from "@/views/chat/model";
 import { lineOf, type ConversationLine } from "./model";
 import {
   AddToBoardAction,
@@ -45,6 +47,15 @@ interface Props {
   openTurn?: OpenTurn;
   /** The live in-flight tool timeline, built from transient SSE frames. */
   liveSteps?: TurnStep[];
+  /**
+   * The live receipt for a turn this view just sent (issue #1934), when one is
+   * armed. Present it in place of the bare typing/queued row so a detached turn
+   * keeps its elapsed / picked-up-by / 30s-stall affordances here too (issue
+   * #2021), the same way `ChatView` does.
+   */
+  receipt?: ChatReceipt;
+  /** Roster agent id → display name, so the receipt names the teammate, not an id. */
+  agentNames?: Record<string, string>;
   /** The in-flight steer strip, rendered between transcript and composer. */
   footer?: ReactNode;
   /**
@@ -56,6 +67,25 @@ interface Props {
   readOnly?: boolean;
 }
 
+/**
+ * The minimal {@link Channel} the receipt row needs, projected from this
+ * surface's {@link ThreadContact}. `ChatLiveReceipt` reads only the avatar
+ * fields (voice/name/tone) and the company-mark flag (`kind === "channel" &&
+ * id === "main"`); a company contact wears the company mark, an agent contact
+ * is a plain `dm` so it does not.
+ */
+function contactChannel(contact: ThreadContact): Channel {
+  const company = contact.kind === "company";
+  return {
+    id: company ? "main" : `contact:${contact.name}`,
+    name: contact.name,
+    voice: contact.name,
+    kind: company ? "channel" : "dm",
+    purpose: "",
+    tone: contact.tone,
+  };
+}
+
 export function Transcript({
   contact,
   onAddToBoard,
@@ -65,6 +95,8 @@ export function Transcript({
   sending,
   openTurn,
   liveSteps,
+  receipt,
+  agentNames,
   footer,
   readOnly,
 }: Props) {
@@ -108,15 +140,28 @@ export function Transcript({
             <EmptyConversation contact={contact} />
           </AuiIf>
           <ThreadPrimitive.Messages>{renderMessage}</ThreadPrimitive.Messages>
-          {working && (
-            <>
-              {/* Live tool timeline — the running/done rows stream in over SSE as
-                  the turn works, before the final reply lands (issue: tool calls
-                  weren't visible until the turn finished). */}
-              {liveSteps && liveSteps.length > 0 && <StepTimeline steps={liveSteps} />}
-              <TypingIndicator contact={contact} queued={openTurn?.queued} />
-            </>
-          )}
+          {working &&
+            (receipt ? (
+              // Our own in-flight send (issue #1934), ridden past the 202 into
+              // the queued/working window (issue #2021): the receipt carries its
+              // own step timeline, elapsed clock and 30s-stall notice, so it
+              // supersedes the bare typing/queued row rather than sitting beside it.
+              <ChatLiveReceipt
+                channel={contactChannel(contact)}
+                receipt={receipt}
+                agentNames={agentNames}
+                steps={liveSteps ?? []}
+                queued={openTurn?.queued}
+              />
+            ) : (
+              <>
+                {/* Live tool timeline — the running/done rows stream in over SSE
+                    as the turn works, before the final reply lands (issue: tool
+                    calls weren't visible until the turn finished). */}
+                {liveSteps && liveSteps.length > 0 && <StepTimeline steps={liveSteps} />}
+                <TypingIndicator contact={contact} queued={openTurn?.queued} />
+              </>
+            ))}
         </div>
         {/* Only drawn once the operator has scrolled away from the bottom, so
             a transcript being read from the top is not covered by a control

--- a/frontend/test/e2e/chat-detached-sse-unavailable.spec.ts
+++ b/frontend/test/e2e/chat-detached-sse-unavailable.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { openChannel, reply, workingRow } from "./chat-helpers";
+import { liveReceipt, openChannel, reply, workingRow } from "./chat-helpers";
 
 import { LIVE_BRAIN } from "./capabilities";
 
@@ -87,8 +87,18 @@ test("with /events unreachable, a detached turn's reply still lands and the work
   await page.keyboard.press("Enter");
 
   // The 202 still comes back over the ordinary POST — that path never touched
-  // `/events` — so the working row arms right away regardless of the stream.
-  await expect(workingRow(page)).toBeVisible({ timeout: 10_000 });
+  // `/events` — so the in-flight indicator arms right away regardless of the
+  // stream. On a same-session send that indicator is the live receipt (issue
+  // #1934), and issue #2021 is that it must RIDE the turn past its 202 into the
+  // detached window rather than being torn down for the bare working row: the
+  // receipt keeps the elapsed clock, the picked-up-by name and the 30s stall
+  // notice the operator would otherwise lose the instant the turn detached.
+  await expect(liveReceipt(page)).toBeVisible({ timeout: 10_000 });
+  // And the downgrade the bug was: the bare working/queued row must NOT be what
+  // the operator is left with once the turn detaches. Pre-#2021 the receipt was
+  // cleared at the 202 and this row took its place; now the receipt supersedes
+  // it for the whole same-session detached turn.
+  await expect(workingRow(page)).toHaveCount(0);
 
   // The reply has exactly one possible source now: `GET {scope}/runs/{id}`
   // going terminal and the resulting `chat/history` re-read (`AppShell`'s poll
@@ -101,13 +111,17 @@ test("with /events unreachable, a detached turn's reply still lands and the work
   // must not double the bubble.
   await expect(reply(page, marker)).toHaveCount(1);
 
-  // And the row comes down. A reply that landed but left the working row
-  // spinning is the same failure users see as a turn that never finished.
-  await expect(workingRow(page)).toHaveCount(0, { timeout: 30_000 });
+  // And the indicator comes down. A reply that landed but left the receipt
+  // ticking is the same failure users see as a turn that never finished — and
+  // the receipt is cleared by the poll's own terminal settle (issue #2021),
+  // the same transition that drains the open-turn row, so neither lingers.
+  await expect(liveReceipt(page)).toHaveCount(0, { timeout: 30_000 });
+  await expect(workingRow(page)).toHaveCount(0);
 
   // Holds a moment past settle: a stray late poll tick re-adding the row, or a
   // duplicate re-hydration, would both be silent otherwise.
   await page.waitForTimeout(5_000);
+  await expect(liveReceipt(page)).toHaveCount(0);
   await expect(workingRow(page)).toHaveCount(0);
   await expect(reply(page, marker)).toHaveCount(1);
 

--- a/frontend/test/e2e/chat-helpers.ts
+++ b/frontend/test/e2e/chat-helpers.ts
@@ -37,3 +37,13 @@ export function reply(page: Page, marker: string): Locator {
 export function workingRow(page: Page): Locator {
   return page.getByTestId("working-indicator");
 }
+
+/**
+ * The live receipt for a turn this console just sent (issue #1934), which now
+ * rides a detached turn past its 202 into the queued/working window (issue
+ * #2021) — so on a same-session send it, not the bare {@link workingRow}, is the
+ * in-flight indicator.
+ */
+export function liveReceipt(page: Page): Locator {
+  return page.getByTestId("chat-live-receipt");
+}

--- a/frontend/test/unit/chat-detach-receipt.test.ts
+++ b/frontend/test/unit/chat-detach-receipt.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Source-wiring coverage for issue #2021 — the live receipt (issue #1934) riding
+ * a detached turn past its 202 into the queued/working window, on every send
+ * surface, instead of being dropped for a bare open-turn row.
+ *
+ * The behaviour lives in three large hosts that the repo already declines to
+ * mount for this kind of wiring assertion (`chat-receipt-scope-reset.test.ts`
+ * settles `AppShell` the same way): `AppShell`'s send-outcome callbacks and poll
+ * settle, `MessageTimeline`'s render gate, and `Transcript`'s working row. The
+ * *semantics* of what the receipt shows in each state are proven directly by
+ * `chat-live-receipt.test.ts` (`ChatLiveReceipt` + `receiptStateLine`); what
+ * this file locks down is that each host is actually wired into them.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, "../../", rel), "utf8");
+
+const appShell = read("src/components/app-shell.tsx");
+const messageTimeline = read("src/views/chat/MessageTimeline.tsx");
+const transcript = read("src/views/conversation/Transcript.tsx");
+const conversation = read("src/views/Conversation.tsx");
+
+/** Slice a `const <name> = useCallback(` body up to its dependency array. */
+function callbackBody(source: string, name: string, depsMarker: string): string {
+  const start = source.indexOf(`const ${name} = useCallback(`);
+  expect(start, `${name} must be present`).toBeGreaterThan(-1);
+  const end = source.indexOf(depsMarker, start);
+  expect(end, `${name}'s dependency array (${depsMarker})`).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("onSendDetached keeps the receipt alive across the 202 handoff", () => {
+  it("does not clear the receipt — the turn carries it into the open-turn window", () => {
+    const body = callbackBody(appShell, "onSendDetached", "[renderAgentReply],");
+    // The 202 still arms the open-turn row…
+    expect(body).toMatch(/setOpenTurns\(\(prev\) => \{/);
+    // …but no longer tears the receipt down: the poll's settle does that later.
+    expect(body).not.toContain("clearReceipt(");
+  });
+});
+
+describe("onSendFailed defers the receipt clear to the durable-turn answer", () => {
+  it("does not clear before it knows whether the host kept the turn", () => {
+    const body = callbackBody(appShell, "onSendFailed", "[client, company, renderAgentReply, clearReceipt],");
+    const listRunsAt = body.indexOf("listRuns(");
+    expect(listRunsAt, "onSendFailed must query the run store").toBeGreaterThan(-1);
+    // The pre-#2021 shape cleared the receipt unconditionally up front, before
+    // the listRuns query — which is exactly what dropped the affordances for a
+    // throw whose turn the host actually kept running.
+    expect(body.slice(0, listRunsAt)).not.toContain("clearReceipt(");
+  });
+
+  it("clears only when no durable turn survived (the else) or the query failed (the catch)", () => {
+    const body = callbackBody(appShell, "onSendFailed", "[client, company, renderAgentReply, clearReceipt],");
+    // A durable turn is kept alive (settle clears it); no durable turn drops it.
+    expect(body).toMatch(/else clearReceipt\(threadId, gen\);/);
+    // Offline / host without /runs — nothing will ever settle it, so drop it.
+    expect(body).toMatch(/\.catch\(\(\) => \{[\s\S]*clearReceipt\(threadId, gen\);[\s\S]*\}\);/);
+  });
+});
+
+describe("the poll's terminal settle clears the receipt under the open-turns guard", () => {
+  it("clears the receipt beside the live rows, inside the hasOtherOpenTurns guard", () => {
+    // The guard block in reReadSettledThread that already clears the live tool
+    // rows only when no sibling turn is still running — the receipt clear must
+    // sit inside the SAME guard so a queued sibling keeps it, and after the
+    // company-scope checks above it so a late cross-company settle cannot delete
+    // a newer company's receipt.
+    const guardAt = appShell.indexOf(
+      "if (!hasOtherOpenTurns(openTurnsRef.current, threadId, settledTurnId)) {",
+    );
+    expect(guardAt, "the settle guard must be present").toBeGreaterThan(-1);
+    const block = appShell.slice(guardAt, guardAt + 900);
+    expect(block).toContain("setLiveStepsByThread(");
+    expect(block).toContain("setReceiptByThread(");
+    expect(block).toMatch(/delete next\[threadId\];/);
+  });
+});
+
+describe("MessageTimeline renders the receipt in the queued state too", () => {
+  it("gates the receipt on its presence alone, not on !queued", () => {
+    // Pre-#2021 the gate was `receipt && !queued ?`, which handed a queued
+    // detached turn back to the bare "Queued…" row. It is now `receipt ?`.
+    expect(messageTimeline).not.toMatch(/\{receipt && !queued \?/);
+    expect(messageTimeline).toMatch(/\{receipt \? \(/);
+  });
+
+  it("forwards queued into ChatLiveReceipt so its base line stays honest", () => {
+    const at = messageTimeline.indexOf("<ChatLiveReceipt");
+    expect(at, "MessageTimeline must render ChatLiveReceipt").toBeGreaterThan(-1);
+    expect(messageTimeline.slice(at, at + 300)).toContain("queued={queued}");
+  });
+});
+
+describe("the Conversation surface renders the receipt too (both send surfaces)", () => {
+  it("AppShell feeds Conversation the receipt map and the name map", () => {
+    const at = appShell.indexOf("<Conversation");
+    expect(at, "AppShell must render Conversation").toBeGreaterThan(-1);
+    const block = appShell.slice(at, at + 600);
+    expect(block).toContain("receiptByThread={receiptByThread}");
+    expect(block).toContain("agentNames={agentNames}");
+  });
+
+  it("Conversation threads the resolved receipt down to the transcript", () => {
+    expect(conversation).toContain("receipt={receiptByThread?.[active.id]}");
+    expect(conversation).toMatch(/receipt=\{receipt\}/);
+  });
+
+  it("Transcript shows ChatLiveReceipt in place of the bare typing row when one is armed", () => {
+    expect(transcript).toContain("<ChatLiveReceipt");
+    expect(transcript).toMatch(/working &&\s*\n?\s*\(receipt \?/);
+    // And keeps the queued wording honest here as well.
+    const at = transcript.indexOf("<ChatLiveReceipt");
+    expect(transcript.slice(at, at + 300)).toContain("queued={openTurn?.queued}");
+  });
+});

--- a/frontend/test/unit/chat-live-receipt.test.ts
+++ b/frontend/test/unit/chat-live-receipt.test.ts
@@ -8,6 +8,7 @@ import type { TurnStep } from "@/api/types";
 import {
   ChatLiveReceipt,
   formatElapsed,
+  receiptStateLine,
   shouldClearReceipt,
   RECEIPT_STALL_AFTER_MS,
   type ChatReceipt,
@@ -48,6 +49,7 @@ async function render(props: {
   receipt: ChatReceipt;
   agentNames?: Record<string, string>;
   steps?: TurnStep[];
+  queued?: boolean;
 }) {
   await act(async () => {
     root.render(
@@ -56,6 +58,7 @@ async function render(props: {
         receipt: props.receipt,
         agentNames: props.agentNames,
         steps: props.steps ?? [],
+        queued: props.queued,
       }),
     );
   });
@@ -165,6 +168,79 @@ describe("ChatLiveReceipt", () => {
       vi.advanceTimersByTime(3_000);
     });
     expect(text()).toContain("3s");
+  });
+
+  /**
+   * Issue #2021: the receipt now rides a detached turn past its 202 into the
+   * queued/working window. In the queued state (turn accepted, still waiting on
+   * the per-company serial lock) it must word its base line "Queued" — not the
+   * synchronous "Sent" — while keeping the elapsed clock and, crucially, the 30s
+   * stall notice. This is the exact affordance the bug lost: a first question to
+   * an idle agent that detached and sat "● Queued…" for minutes with no clock
+   * and no stall.
+   */
+  it("words the base line Queued (not Sent) while the detached turn is queued", async () => {
+    await render({
+      receipt: { startedAt: BASE - 4_000, lastFrameAt: BASE - 4_000 },
+      queued: true,
+    });
+    expect(text()).toContain("Queued");
+    expect(text()).not.toContain("Sent");
+    // The clock the bare open-turn "Queued…" row never had.
+    expect(text()).toContain("4s");
+  });
+
+  it("still fires the 30s stall notice on a queued turn stuck on the serial lock", async () => {
+    await render({
+      receipt: { startedAt: BASE, lastFrameAt: BASE },
+      queued: true,
+    });
+    expect(receiptEl().dataset.stalled).toBe("false");
+    await act(async () => {
+      vi.advanceTimersByTime(RECEIPT_STALL_AFTER_MS);
+    });
+    expect(receiptEl().dataset.stalled).toBe("true");
+    expect(text()).toContain("No update for 30s");
+  });
+
+  it("progresses out of Queued to the picked-up name once a frame names an agent", async () => {
+    // The poll flips pending→running and the first live frame names the desk:
+    // the receipt leaves "Queued" for the same "Picked up by <name>" the
+    // synchronous window shows, so the handoff is seamless rather than a downgrade.
+    await render({
+      receipt: { startedAt: BASE, lastFrameAt: BASE, agentId: "a-ada" },
+      agentNames: { "a-ada": "Ada" },
+      queued: false,
+    });
+    expect(text()).toContain("Picked up by Ada");
+    expect(text()).not.toContain("Queued");
+  });
+});
+
+describe("receiptStateLine", () => {
+  const ch = channel();
+  const base: ChatReceipt = { startedAt: BASE, lastFrameAt: BASE };
+
+  it("reads Queued when queued and nothing more specific is known (issue #2021)", () => {
+    expect(receiptStateLine(base, [], undefined, ch, true)).toBe("Queued");
+  });
+
+  it("reads Sent when not queued and nothing more specific is known", () => {
+    expect(receiptStateLine(base, [], undefined, ch, false)).toBe("Sent");
+    // The queued argument is optional and defaults to the synchronous wording.
+    expect(receiptStateLine(base, [], undefined, ch)).toBe("Sent");
+  });
+
+  it("lets a named agent outrank the queued base word", () => {
+    const picked: ChatReceipt = { ...base, agentId: "a-ada" };
+    expect(receiptStateLine(picked, [], { "a-ada": "Ada" }, ch, true)).toBe("Picked up by Ada");
+  });
+
+  it("lets a running step outrank both the name and the queued base word", () => {
+    const picked: ChatReceipt = { ...base, agentId: "a-ada" };
+    expect(
+      receiptStateLine(picked, [runningStep("Searching the web")], { "a-ada": "Ada" }, ch, true),
+    ).toBe("On step Searching the web");
   });
 });
 

--- a/frontend/test/unit/chat-receipt-scope-reset.test.ts
+++ b/frontend/test/unit/chat-receipt-scope-reset.test.ts
@@ -81,13 +81,30 @@ describe("clearReceipt is generation-guarded (issue #1935 review)", () => {
     expect(appShell).toMatch(/if \(!shouldClearReceipt\(prev\[threadId\], gen\)\) return prev;/);
   });
 
-  it("every terminal send callback accepts and forwards a generation", () => {
+  it("every terminal send callback that clears the receipt accepts and forwards a generation", () => {
+    // The three callbacks that still clear the receipt keep the #1935 guard:
+    // they take the generation their own `onSendStart` returned and hand it to
+    // `clearReceipt`, so a stale cross-company clear is a no-op.
     expect(appShell).toMatch(/const onSendEnd = useCallback\(\s*\n\s*\(threadId: string, gen\?: number\) =>/);
     expect(appShell).toMatch(/const onSendStale = useCallback\(\s*\n\s*\(threadId: string, gen\?: number\) =>/);
-    expect(appShell).toMatch(
-      /const onSendDetached = useCallback\(\s*\n\s*\(threadId: string, turnId\?: string, gen\?: number\) =>/,
-    );
     expect(appShell).toMatch(/const onSendFailed = useCallback\(\s*\n\s*\(threadId: string, gen\?: number\) =>/);
+  });
+
+  it("onSendDetached no longer clears the receipt — it rides the turn into the open-turn window (issue #2021)", () => {
+    // The 202 handoff used to `clearReceipt` and hand the turn to a bare
+    // open-turn row, dropping every #1934 affordance (elapsed, picked-up-by,
+    // 30s stall). It now keeps the receipt alive; the poll's terminal settle
+    // clears it (see `reReadSettledThread`). So the generation it once forwarded
+    // to `clearReceipt` is now unused — the param is present but underscored,
+    // and no `clearReceipt` call survives inside the callback body.
+    expect(appShell).toMatch(
+      /const onSendDetached = useCallback\(\s*\n\s*\(threadId: string, turnId\?: string, _gen\?: number\) =>/,
+    );
+    const start = appShell.indexOf("const onSendDetached = useCallback(");
+    expect(start, "onSendDetached must be present").toBeGreaterThan(-1);
+    const end = appShell.indexOf("[renderAgentReply],", start);
+    expect(end, "onSendDetached's dependency array").toBeGreaterThan(start);
+    expect(appShell.slice(start, end)).not.toContain("clearReceipt(");
   });
 
   it("onSendStart mints and returns a fresh generation per armed receipt", () => {


### PR DESCRIPTION
## Summary

#1934's live receipt (picked-up-by / on-step / ticking elapsed / 30s stall) was wired to the **synchronous send window only**. When a slow turn returns `202` (detached, #983/#1000), `onSendDetached` cleared the receipt and handed the turn to an `openTurns` row rendered through `WorkingIndicator` — a bare `Queued…` / `Working…` with **no elapsed, no picked-up-by, no stall notice**. So the instant a turn went async every #1934 affordance vanished — the "● Queued… for 2 min" repro, precisely on the long turns that most need the receipt.

Fixed at the root — keep the receipt alive across the handoff and let the poll's terminal settle clear it — and swept the full blast radius rather than patching one callback.

**Sweep:** the affordances were lost across **{detached, failed-with-durable-turn} × {queued, working} × {ChatView showed a downgrade, Conversation rendered the receipt not at all}**. Both send surfaces that arm the shared `receiptByThread` (ChatView and Conversation/`useConversationRuntime`) and both openTurns states were bare.

## API Or Behavior Changes

- `ChatLiveReceipt` gains a **queued** state (base line "Queued" → picked-up-by → on-step as frames arrive; pulse stilled while queued; elapsed + 30s stall unchanged).
- `MessageTimeline` gates the receipt on presence alone (was `receipt && !queued`) and forwards `queued`.
- `AppShell`: `onSendDetached` no longer clears (live frames keep it fresh); `onSendFailed` defers the clear to the durable-turn answer (a kept turn keeps the receipt; no durable turn / offline drops it, generation-guarded); the poll's settle (`reReadSettledThread`) clears it beside the live rows, inside the same `!hasOtherOpenTurns` guard and after the company-scope checks.
- **Conversation surface** now renders `ChatLiveReceipt` in its working block (it previously showed nothing), so `#/chat` and `#/conversation` behave identically.
- Net effect: a detached/async turn keeps the receipt (agent / step / elapsed / stall) instead of a bare frozen "Queued".

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` (459 files / 4326 tests pass)
- [x] `npm run build`

New/updated: `chat-live-receipt.test.ts` (queued word, "Queued"+elapsed, 30s stall on a stuck queued turn, progression out of queued); `chat-detach-receipt.test.ts` (source-wiring, since AppShell is too large to mount — `onSendDetached` keeps it, `onSendFailed` defers, settle clears under the guard, both surfaces render it); `chat-receipt-scope-reset` updated so the three still-clearing callbacks keep the #1935 generation guard (company-B receipt not deleted by a slow company-A settle). RED-on-old proof: 11 failures against the pre-fix source. Edge cases covered: fast turn (unchanged), slow turn (kept alive→settle clears), stuck-in-pending (stall fires), multiple queued siblings (survives until the last settles), company switch mid-turn (#1935 guard untouched), reload racing the answer (bare row as before). Playwright `chat-detached-sse-unavailable.spec.ts` reworked to assert the receipt (not a bare row) carries a poll-only turn through settle; e2e execution deferred to CI (arm64 Docker constraint).

## Documentation

None — completes the #1934 receipt contract for async turns; no doc surface changed.

Closes #2021