### PR TITLE
fix(console): open a card's origin conversation in Room, not the legacy two-pane view (#2020)

### DIFF
--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -288,6 +288,14 @@ export interface Task {
    */
   originChatId?: string;
   /**
+   * The message within `originChatId` the raising turn replied to, when the
+   * card was opened from inside a thread rather than the channel's own
+   * timeline. A stringified value of this equals that message's `id` in
+   * `chat/history`. Omitted for a channel-level origin, and for every card
+   * created before this field existed.
+   */
+  originParent?: number;
+  /**
    * The workflow run whose agent node opened this card (issue #661), and the
    * graph it is a run of.
    *

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -3617,13 +3617,14 @@ export function AppShell({
               onDecide={(approval, verdict, scope) =>
                 void decideApproval(approval, verdict, scope)
               }
-              // Issue #246: the card → chat half of the round trip. A card
-              // opened from a conversation remembers which one, so its detail
-              // screen can put the operator back in that thread.
-              onOpenThread={(threadId) => {
-                setActiveThreadId(threadId);
-                setView("conversation");
-              }}
+              // Issue #246: the card → chat half of the round trip. The card
+              // carries the host thread it was opened from; the map is what
+              // turns that into the Room channel rendering it, which is the
+              // whole address (`#/chat/<channelId>`) — so the destination is
+              // linkable and Back returns to the card. The row states the
+              // origin without offering a jump when no channel carries it.
+              chatChannelByThread={chatChannelByThread}
+              onOpenChannel={(channelId) => navigate("chat", channelId)}
               // Back, and a deleted card, go to the board — which is the
               // `tasks` ledger. Through `navigate` so the address follows.
               onLeave={() =>

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -3624,7 +3624,9 @@ export function AppShell({
               // linkable and Back returns to the card. The row states the
               // origin without offering a jump when no channel carries it.
               chatChannelByThread={chatChannelByThread}
-              onOpenChannel={(channelId) => navigate("chat", channelId)}
+              onOpenChannel={(channelId, threadId) =>
+                navigate("chat", channelId, { thread: threadId ?? null })
+              }
               // Back, and a deleted card, go to the board — which is the
               // `tasks` ledger. Through `navigate` so the address follows.
               onLeave={() =>

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -71,7 +71,10 @@ export function isGeneralChannel(id: string): boolean {
  * the map is keyed on the bare teammate id (`dmThreadId`), so an origin
  * recorded in the console-local channel form (a direct API caller, not this
  * console's own "Add to board") missed it on an exact match even though that
- * teammate's DM is reachable.
+ * teammate's DM is reachable. Folded case-insensitively, the same way the
+ * host's own `resolve_roster_agent_id` resolves a `dm:`-addressed teammate —
+ * an origin stamped from a caller's differently-cased address (`dm:DESIGNER`
+ * against a roster id of `designer`) is the same teammate, not a miss.
  */
 export function generalAwareChannel(
   map: Readonly<Record<string, string>>,
@@ -80,7 +83,10 @@ export function generalAwareChannel(
   if (map[threadId]) return map[threadId];
   if (isGeneralChannel(threadId)) return map[MAIN_THREAD_ID] ?? null;
   const bareId = threadId.startsWith("dm:") ? threadId.slice("dm:".length) : null;
-  return (bareId && map[bareId]) || null;
+  if (!bareId) return null;
+  if (map[bareId]) return map[bareId];
+  const key = Object.keys(map).find((k) => k.toLowerCase() === bareId.toLowerCase());
+  return key ? map[key] : null;
 }
 
 /** One person's reaction on one line. Mirrors `ChatReactionDto` on the host. */

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -66,12 +66,21 @@ export function isGeneralChannel(id: string): boolean {
  *
  * `null` when the map does not know the thread — never a fall back to whatever
  * the operator has open, which is issue #368's bug.
+ *
+ * Also resolves a `dm:`-prefixed **channel** id standing in for its thread:
+ * the map is keyed on the bare teammate id (`dmThreadId`), so an origin
+ * recorded in the console-local channel form (a direct API caller, not this
+ * console's own "Add to board") missed it on an exact match even though that
+ * teammate's DM is reachable.
  */
 export function generalAwareChannel(
   map: Readonly<Record<string, string>>,
   threadId: string,
 ): string | null {
-  return map[threadId] ?? (isGeneralChannel(threadId) ? (map[MAIN_THREAD_ID] ?? null) : null);
+  if (map[threadId]) return map[threadId];
+  if (isGeneralChannel(threadId)) return map[MAIN_THREAD_ID] ?? null;
+  const bareId = threadId.startsWith("dm:") ? threadId.slice("dm:".length) : null;
+  return (bareId && map[bareId]) || null;
 }
 
 /** One person's reaction on one line. Mirrors `ChatReactionDto` on the host. */

--- a/frontend/src/lib/task-origin.ts
+++ b/frontend/src/lib/task-origin.ts
@@ -1,0 +1,37 @@
+// Where a card's origin conversation lives, for the card → chat half of the
+// #246 round trip.
+//
+// A card created out of a conversation carries `originChatId`, a **host thread
+// id**. Chats are served by the Room tab, addressed `#/chat/<channelId>`, so
+// the id on the card is not itself an address: it has to be resolved through
+// the shell's thread → channel map first, and that resolution can come back
+// empty (a thread whose desk is gone, a map not yet loaded). Deciding here
+// rather than at the button keeps "is there somewhere to go" and "go there"
+// from drifting apart.
+
+import { channelForThread } from "@/views/chat/model";
+
+export type OriginConversation =
+  /** The card was not opened from a conversation; the row renders nothing. */
+  | { kind: "none" }
+  /** It was, but no channel carries that thread — state the origin, offer no jump. */
+  | { kind: "unreachable" }
+  /** It was, and the Room channel below renders it. */
+  | { kind: "channel"; channelId: string };
+
+/**
+ * Resolved through {@link channelForThread}, not a bare `map[originChatId]`:
+ * the host compares the General spellings case-insensitively and echoes back
+ * whichever one it was addressed with, so a direct index misses a card opened
+ * from `MAIN`.
+ */
+export function originConversation(
+  originChatId: string | undefined | null,
+  chatChannelByThread: Readonly<Record<string, string>> | undefined,
+): OriginConversation {
+  if (!originChatId) return { kind: "none" };
+  const channelId = chatChannelByThread
+    ? channelForThread(chatChannelByThread, originChatId)
+    : null;
+  return channelId ? { kind: "channel", channelId } : { kind: "unreachable" };
+}

--- a/frontend/src/lib/task-origin.ts
+++ b/frontend/src/lib/task-origin.ts
@@ -16,8 +16,12 @@ export type OriginConversation =
   | { kind: "none" }
   /** It was, but no channel carries that thread — state the origin, offer no jump. */
   | { kind: "unreachable" }
-  /** It was, and the Room channel below renders it. */
-  | { kind: "channel"; channelId: string };
+  /**
+   * It was, and the Room channel below renders it. `threadId` names the
+   * message the card's thread panel should open to, when the card was raised
+   * inside a thread rather than the channel's own timeline.
+   */
+  | { kind: "channel"; channelId: string; threadId?: string };
 
 /**
  * Resolved through {@link channelForThread}, not a bare `map[originChatId]`:
@@ -28,10 +32,16 @@ export type OriginConversation =
 export function originConversation(
   originChatId: string | undefined | null,
   chatChannelByThread: Readonly<Record<string, string>> | undefined,
+  originParent?: number,
 ): OriginConversation {
   if (!originChatId) return { kind: "none" };
   const channelId = chatChannelByThread
     ? channelForThread(chatChannelByThread, originChatId)
     : null;
-  return channelId ? { kind: "channel", channelId } : { kind: "unreachable" };
+  if (!channelId) return { kind: "unreachable" };
+  return {
+    kind: "channel",
+    channelId,
+    threadId: originParent != null ? String(originParent) : undefined,
+  };
 }

--- a/frontend/src/lib/task-origin.ts
+++ b/frontend/src/lib/task-origin.ts
@@ -9,6 +9,7 @@
 // rather than at the button keeps "is there somewhere to go" and "go there"
 // from drifting apart.
 
+import { hostMessageId } from "@/lib/chat";
 import { channelForThread } from "@/views/chat/model";
 
 export type OriginConversation =
@@ -42,6 +43,10 @@ export function originConversation(
   return {
     kind: "channel",
     channelId,
-    threadId: originParent != null ? String(originParent) : undefined,
+    // `Room`'s transcript keys every host-journaled message as `h<seq>`
+    // (`hostMessageId`) to keep it apart from a locally-minted optimistic id;
+    // a bare seq here would never match a loaded message's `id`, and the
+    // thread panel would silently fail to open.
+    threadId: originParent != null ? hostMessageId(String(originParent)) : undefined,
   };
 }

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -1276,8 +1276,20 @@ export function ChatView({
 
   // An open thread only makes sense while its parent is on screen; switching
   // channels closes it rather than leaving a panel pointing at nothing.
+  // `?thread=<id>` on the hash opens straight into that thread instead, and
+  // is consumed (stripped via `replaceState`) so it does not reopen on a
+  // later switch back to this channel.
   useEffect(() => {
-    setOpenThreadId(null);
+    if (!channel?.id) return;
+    const [path, query = ""] = window.location.hash.replace(/^#/, "").split("?");
+    const params = new URLSearchParams(query);
+    const threadId = params.get("thread");
+    setOpenThreadId(threadId);
+    if (threadId !== null) {
+      params.delete("thread");
+      const qs = params.toString();
+      window.history.replaceState(null, "", `#${path}${qs ? `?${qs}` : ""}`);
+    }
   }, [channel?.id]);
 
   // Whoever owns the unread counts needs to know what is actually being looked

--- a/frontend/src/views/TaskDetailRoute.tsx
+++ b/frontend/src/views/TaskDetailRoute.tsx
@@ -44,7 +44,8 @@ export function TaskDetailRoute({
   decided,
   failed,
   onDecide,
-  onOpenThread,
+  chatChannelByThread,
+  onOpenChannel,
   onLeave,
 }: {
   client: OpenCompanyClient;
@@ -61,8 +62,10 @@ export function TaskDetailRoute({
   decided?: Readonly<Record<string, DecidedApproval>>;
   failed?: Record<string, string>;
   onDecide?: (approval: ApprovalSummary, verdict: Verdict, scope: GrantScope) => void;
-  /** Opens the chat thread this card was created from (issue #246). */
-  onOpenThread?: (threadId: string) => void;
+  /** The shell's host thread → Room channel map, which places this card's origin. */
+  chatChannelByThread?: Readonly<Record<string, string>>;
+  /** Opens the Room channel this card's conversation lives on (issue #246). */
+  onOpenChannel?: (channelId: string) => void;
   /** Where Back, and a deleted card, go: the board, which lives in Ledgers. */
   onLeave: () => void;
 }) {
@@ -106,7 +109,8 @@ export function TaskDetailRoute({
           [LEDGER_VIEW_PARAM]: view === "list" ? "list" : null,
         });
       }}
-      onOpenThread={onOpenThread}
+      chatChannelByThread={chatChannelByThread}
+      onOpenChannel={onOpenChannel}
       // `onSaved` used to be here, as a literal `() => {}`. It handed a saved
       // card back to the board rendered beside this screen, which held its own
       // copy of the row; there is no such sibling now — the board is the `tasks`

--- a/frontend/src/views/TaskDetailRoute.tsx
+++ b/frontend/src/views/TaskDetailRoute.tsx
@@ -65,7 +65,7 @@ export function TaskDetailRoute({
   /** The shell's host thread → Room channel map, which places this card's origin. */
   chatChannelByThread?: Readonly<Record<string, string>>;
   /** Opens the Room channel this card's conversation lives on (issue #246). */
-  onOpenChannel?: (channelId: string) => void;
+  onOpenChannel?: (channelId: string, threadId?: string) => void;
   /** Where Back, and a deleted card, go: the board, which lives in Ledgers. */
   onLeave: () => void;
 }) {

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -91,6 +91,7 @@ import {
   taskApprovalRows,
   RESUME_BLOCKED_REASON,
 } from "@/lib/task-approvals";
+import { originConversation } from "@/lib/task-origin";
 import { formatDuration, timeOf } from "@/lib/timeline-format";
 import { TimelineList, runStatusTone } from "@/views/runs/RunTimeline";
 import { startVisiblePolling } from "@/lib/visible-poll";
@@ -399,7 +400,8 @@ export function TaskDetailView({
   onDecide,
   onBack,
   onNavigate,
-  onOpenThread,
+  chatChannelByThread,
+  onOpenChannel,
   onDeleted,
 }: {
   client: OpenCompanyClient;
@@ -440,8 +442,10 @@ export function TaskDetailView({
   onBack: () => void;
   /** Navigate the detail to a neighbouring (lineage) task. */
   onNavigate: (id: string) => void;
-  /** Open the chat thread this card was created from (issue #246). */
-  onOpenThread?: (threadId: string) => void;
+  /** The shell's host thread → Room channel map, which places this card's origin. */
+  chatChannelByThread?: Readonly<Record<string, string>>;
+  /** Open the Room channel this card's conversation lives on (issue #246). */
+  onOpenChannel?: (channelId: string) => void;
   /*
    * There is no `onSaved`. There was, and every one of its five call sites
    * handed a saved card to a `() => {}`: it existed to reconcile the board
@@ -773,7 +777,8 @@ export function TaskDetailView({
 
             <OriginThreadRow
               originChatId={detail.task.originChatId}
-              onOpenThread={onOpenThread}
+              chatChannelByThread={chatChannelByThread}
+              onOpenChannel={onOpenChannel}
             />
 
             <LineageRail
@@ -1573,20 +1578,25 @@ export function ControlBar({
  * onto the board. Renders nothing for a card with no conversation behind it,
  * which is every card the `+` button creates.
  *
- * Falls back to plain text when no navigation callback is supplied: stating the
- * origin is the part that must always work; the jump is a convenience the host
- * screen may or may not be able to offer.
+ * The jump is offered only when the origin thread resolves to a channel the
+ * Room tab can open ({@link originConversation}) and the host screen supplied
+ * somewhere to go. Otherwise it falls back to plain text: stating the origin is
+ * the part that must always work, and a button that cannot land anywhere is
+ * worse than no button.
  */
-function OriginThreadRow({
+export function OriginThreadRow({
   originChatId,
-  onOpenThread,
+  chatChannelByThread,
+  onOpenChannel,
 }: {
   originChatId?: string;
-  onOpenThread?: (threadId: string) => void;
+  chatChannelByThread?: Readonly<Record<string, string>>;
+  onOpenChannel?: (channelId: string) => void;
 }) {
-  if (!originChatId) return null;
+  const origin = originConversation(originChatId, chatChannelByThread);
+  if (origin.kind === "none") return null;
   const label = "Opened from chat";
-  if (!onOpenThread) {
+  if (origin.kind === "unreachable" || !onOpenChannel) {
     return (
       <div className="flex items-center gap-2 rounded-xl border bg-card/40 px-3 py-2 text-xs text-muted-foreground">
         <MessagesSquare className="size-3.5 shrink-0" />
@@ -1594,10 +1604,11 @@ function OriginThreadRow({
       </div>
     );
   }
+  const { channelId } = origin;
   return (
     <button
       className="flex w-full items-center gap-2 rounded-xl border bg-card/40 px-3 py-2 text-left text-xs transition-colors hover:bg-accent"
-      onClick={() => onOpenThread(originChatId)}
+      onClick={() => onOpenChannel(channelId)}
     >
       <MessagesSquare className="size-3.5 shrink-0 text-muted-foreground" />
       <span className="min-w-0 flex-1 truncate">{label}</span>

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -444,8 +444,12 @@ export function TaskDetailView({
   onNavigate: (id: string) => void;
   /** The shell's host thread → Room channel map, which places this card's origin. */
   chatChannelByThread?: Readonly<Record<string, string>>;
-  /** Open the Room channel this card's conversation lives on (issue #246). */
-  onOpenChannel?: (channelId: string) => void;
+  /**
+   * Open the Room channel this card's conversation lives on (issue #246),
+   * and — when the card was raised inside a thread — the message whose
+   * thread panel should open with it.
+   */
+  onOpenChannel?: (channelId: string, threadId?: string) => void;
   /*
    * There is no `onSaved`. There was, and every one of its five call sites
    * handed a saved card to a `() => {}`: it existed to reconcile the board
@@ -777,6 +781,7 @@ export function TaskDetailView({
 
             <OriginThreadRow
               originChatId={detail.task.originChatId}
+              originParent={detail.task.originParent}
               chatChannelByThread={chatChannelByThread}
               onOpenChannel={onOpenChannel}
             />
@@ -1586,14 +1591,16 @@ export function ControlBar({
  */
 export function OriginThreadRow({
   originChatId,
+  originParent,
   chatChannelByThread,
   onOpenChannel,
 }: {
   originChatId?: string;
+  originParent?: number;
   chatChannelByThread?: Readonly<Record<string, string>>;
-  onOpenChannel?: (channelId: string) => void;
+  onOpenChannel?: (channelId: string, threadId?: string) => void;
 }) {
-  const origin = originConversation(originChatId, chatChannelByThread);
+  const origin = originConversation(originChatId, chatChannelByThread, originParent);
   if (origin.kind === "none") return null;
   const label = "Opened from chat";
   if (origin.kind === "unreachable" || !onOpenChannel) {
@@ -1604,11 +1611,11 @@ export function OriginThreadRow({
       </div>
     );
   }
-  const { channelId } = origin;
+  const { channelId, threadId } = origin;
   return (
     <button
       className="flex w-full items-center gap-2 rounded-xl border bg-card/40 px-3 py-2 text-left text-xs transition-colors hover:bg-accent"
-      onClick={() => onOpenChannel(channelId)}
+      onClick={() => onOpenChannel(channelId, threadId)}
     >
       <MessagesSquare className="size-3.5 shrink-0 text-muted-foreground" />
       <span className="min-w-0 flex-1 truncate">{label}</span>

--- a/frontend/test/e2e/chat-to-card.spec.ts
+++ b/frontend/test/e2e/chat-to-card.spec.ts
@@ -105,6 +105,67 @@ test("any message on a desk thread can be added to the board", async ({ page }) 
   await expect(origin).toBeVisible();
 });
 
+/**
+ * Issue #2020: a card raised from **inside a thread** opens that thread on the
+ * jump back, not merely the channel it lives in.
+ *
+ * The test above proves the channel-level half; it cannot prove this half,
+ * because a first message in an empty conversation and a reply nested under it
+ * both resolve to the same channel — the console would land in the right place
+ * either way even with the thread root dropped on the floor. So this seeds a
+ * root message and a threaded reply to it directly (the same REST surface
+ * `sayFromElsewhere`-style specs already use for setup elsewhere in this
+ * suite), lets the deterministic "Track" triage open the card from the reply,
+ * and asserts the jump renders the thread panel holding the *root's* text —
+ * not the reply's, and not merely the channel.
+ */
+test("a card raised inside a thread opens that thread on the jump back, not just the channel", async ({
+  page,
+  request,
+}) => {
+  const API = "/api/v1/company";
+  const marker = Date.now();
+  const rootText = `quick sync on Q3 priorities ${marker}`;
+  const rootResponse = await request.post(`${API}/chat`, {
+    data: { text: rootText, chat: "engineering" },
+  });
+  expect(rootResponse.ok(), await rootResponse.text()).toBeTruthy();
+  const rootId = (await rootResponse.json()).messageId as string;
+  expect(rootId).toBeTruthy();
+
+  // An imperative lead ("build …") is what the deterministic triage cards —
+  // independent of whatever the echo brain answers with — and `parent` is
+  // what makes this a threaded reply rather than a second channel-level line.
+  const replyText = `build the onboarding checklist ${marker}`;
+  const replyResponse = await request.post(`${API}/chat`, {
+    data: { text: replyText, chat: "engineering", parent: rootId },
+  });
+  expect(replyResponse.ok(), await replyResponse.text()).toBeTruthy();
+
+  const tasksResponse = await request.get(`${API}/tasks`);
+  expect(tasksResponse.ok()).toBeTruthy();
+  const tasks = (await tasksResponse.json()) as Array<{ id: string; title: string }>;
+  const card = tasks.find((t) => t.title.includes(String(marker)));
+  expect(card, `no card opened from "${replyText}": ${JSON.stringify(tasks)}`).toBeTruthy();
+
+  await page.goto(`/#/tasks/${card!.id}`);
+  await dismissWelcome(page);
+  const origin = page.getByRole("button", { name: /Opened from chat/ });
+  await expect(origin).toBeVisible({ timeout: 15_000 });
+  await origin.click();
+
+  await expect(page).toHaveURL(/#\/chat\/engineering(?:[/?]|$)/);
+
+  const thread = page
+    .locator("aside")
+    .filter({ has: page.getByRole("heading", { name: "Thread" }) });
+  await expect(thread).toBeVisible({ timeout: 15_000 });
+  // The root's own text is in the panel — proof the jump opened *that*
+  // thread, since a channel-level landing (or the reply's own self-thread)
+  // would show none of this or the wrong message.
+  await expect(thread.getByText(rootText, { exact: true })).toBeVisible({ timeout: 15_000 });
+});
+
 test("a card the orchestrator opens is chipped in chat, and survives a reload", async ({
   page,
 }) => {

--- a/frontend/test/e2e/chat-to-card.spec.ts
+++ b/frontend/test/e2e/chat-to-card.spec.ts
@@ -79,7 +79,28 @@ test("any message on a desk thread can be added to the board", async ({ page }) 
   await expect(page.getByText("Working", { exact: true })).toHaveCount(0);
 
   // …and it knows which conversation opened it.
-  await expect(page.getByRole("button", { name: /Opened from chat/ })).toBeVisible();
+  const origin = page.getByRole("button", { name: /Opened from chat/ });
+  await expect(origin).toBeVisible();
+
+  // The other half of the round trip: the jump lands in Room, on the channel
+  // carrying that conversation. It used to land on `#/conversation` — a
+  // separate surface with its own thread rail down the left — which is the
+  // wireframe issue #2020 was filed against.
+  await origin.click();
+  await expect(page).toHaveURL(/#\/chat\/.+/);
+  // `data-active` is a boolean attribute the sidebar row renders empty when
+  // set and omits when not, so the assertion is on its presence.
+  await expect(
+    page
+      .locator("[data-slot=sidebar-content]")
+      .getByRole("button", { name: "Room", exact: true }),
+  ).toHaveAttribute("data-active", "");
+
+  // And Back returns to the card, because the jump went through the address
+  // rather than through shell state the history knows nothing about.
+  await page.goBack();
+  await expect(page).toHaveURL(/#\/tasks\/.+/);
+  await expect(origin).toBeVisible();
 });
 
 test("a card the orchestrator opens is chipped in chat, and survives a reload", async ({

--- a/frontend/test/e2e/chat-to-card.spec.ts
+++ b/frontend/test/e2e/chat-to-card.spec.ts
@@ -87,7 +87,9 @@ test("any message on a desk thread can be added to the board", async ({ page }) 
   // separate surface with its own thread rail down the left — which is the
   // wireframe issue #2020 was filed against.
   await origin.click();
-  await expect(page).toHaveURL(/#\/chat\/.+/);
+  // The Engineering desk's own channel, not merely some channel: a regression
+  // that landed the jump on the wrong one would still match a bare `/.+/`.
+  await expect(page).toHaveURL(/#\/chat\/engineering(?:[/?]|$)/);
   // `data-active` is a boolean attribute the sidebar row renders empty when
   // set and omits when not, so the assertion is on its presence.
   await expect(

--- a/frontend/test/unit/chat-general-channel.test.ts
+++ b/frontend/test/unit/chat-general-channel.test.ts
@@ -639,6 +639,10 @@ describe("resolving a live frame's thread id against the shell's map", () => {
   it("answers null for a dm:-prefixed id naming no teammate in the map", () => {
     expect(channelForThread(MAP, "dm:ghost")).toBeNull();
   });
+
+  it("folds a dm:-prefixed id's case, the way the host resolves the teammate it names", () => {
+    expect(channelForThread(MAP, "dm:ENG")).toBe("dm:eng");
+  });
 });
 
 /**

--- a/frontend/test/unit/chat-general-channel.test.ts
+++ b/frontend/test/unit/chat-general-channel.test.ts
@@ -631,6 +631,14 @@ describe("resolving a live frame's thread id against the shell's map", () => {
   it("answers null for a thread the map does not know", () => {
     expect(channelForThread(MAP, "workflows")).toBeNull();
   });
+
+  it("resolves a dm:-prefixed channel id standing in for its bare thread id", () => {
+    expect(channelForThread(MAP, "dm:eng")).toBe("dm:eng");
+  });
+
+  it("answers null for a dm:-prefixed id naming no teammate in the map", () => {
+    expect(channelForThread(MAP, "dm:ghost")).toBeNull();
+  });
 });
 
 /**

--- a/frontend/test/unit/task-origin-conversation.test.ts
+++ b/frontend/test/unit/task-origin-conversation.test.ts
@@ -56,10 +56,13 @@ describe("where a card's origin conversation lives", () => {
   });
 
   it("carries the origin thread's own id, when the card was raised inside one", () => {
+    // `h`-prefixed: `Room`'s transcript keys every host-journaled message as
+    // `h<seq>` (`hostMessageId`) to tell it apart from a locally-minted
+    // optimistic id, so a bare seq here would never match a loaded message.
     expect(originConversation("t1", { t1: "desk-eng" }, 41)).toEqual({
       kind: "channel",
       channelId: "desk-eng",
-      threadId: "41",
+      threadId: "h41",
     });
   });
 

--- a/frontend/test/unit/task-origin-conversation.test.ts
+++ b/frontend/test/unit/task-origin-conversation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { originConversation } from "@/lib/task-origin";
+
+/**
+ * "Open the conversation" on a card used to land on `#/conversation` — the
+ * legacy two-pane surface with its own thread rail — and select the thread
+ * with a state setter the address knows nothing about. Chats are the Room tab
+ * now (`#/chat/<channelId>`), so the card's host thread id is not an address
+ * on its own: it has to be resolved through the shell's thread → channel map,
+ * and that resolution can come back empty.
+ *
+ * The pure half of that decision lives in `lib/task-origin.ts` so the three
+ * outcomes can be named here rather than inferred from a rendered button, and
+ * so the "no channel carries it" case is a branch with a test rather than a
+ * button that navigates nowhere.
+ */
+describe("where a card's origin conversation lives", () => {
+  it("is nowhere for a card that was never opened from one", () => {
+    expect(originConversation(undefined, { t1: "desk-eng" })).toEqual({ kind: "none" });
+    expect(originConversation("", { t1: "desk-eng" })).toEqual({ kind: "none" });
+  });
+
+  it("is the channel that carries the origin thread", () => {
+    expect(originConversation("t1", { t1: "desk-eng" })).toEqual({
+      kind: "channel",
+      channelId: "desk-eng",
+    });
+  });
+
+  it("is unreachable when no channel carries the thread", () => {
+    // A desk retired since the card was opened. The row must state the origin
+    // and offer no jump — the pre-fix handler offered one unconditionally and
+    // navigated to a surface that had nothing to show.
+    expect(originConversation("gone", { t1: "desk-eng" })).toEqual({ kind: "unreachable" });
+  });
+
+  it("is unreachable before the channel map has loaded", () => {
+    // The shell starts with an empty map and fills it once `/desks` answers.
+    expect(originConversation("t1", {})).toEqual({ kind: "unreachable" });
+    expect(originConversation("t1", undefined)).toEqual({ kind: "unreachable" });
+  });
+
+  it("folds the General spellings the host echoes back", () => {
+    // Resolved through `channelForThread`, not a bare `map[originChatId]`: a
+    // card opened from a line addressed `MAIN` carries that casing, and a
+    // direct index misses it while the conversation plainly exists.
+    expect(originConversation("MAIN", { main: "general" })).toEqual({
+      kind: "channel",
+      channelId: "general",
+    });
+  });
+});

--- a/frontend/test/unit/task-origin-conversation.test.ts
+++ b/frontend/test/unit/task-origin-conversation.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import { originConversation } from "@/lib/task-origin";
@@ -49,5 +53,42 @@ describe("where a card's origin conversation lives", () => {
       kind: "channel",
       channelId: "general",
     });
+  });
+
+  it("carries the origin thread's own id, when the card was raised inside one", () => {
+    expect(originConversation("t1", { t1: "desk-eng" }, 41)).toEqual({
+      kind: "channel",
+      channelId: "desk-eng",
+      threadId: "41",
+    });
+  });
+
+  it("carries no thread id for a card raised straight into the channel", () => {
+    expect(originConversation("t1", { t1: "desk-eng" })).toEqual({
+      kind: "channel",
+      channelId: "desk-eng",
+      threadId: undefined,
+    });
+  });
+});
+
+/**
+ * The resolved thread id has to actually ride the jump, not just come back
+ * from `originConversation` — pinned by source-text, the idiom
+ * `chat-general-channel.test.ts` already uses for wiring a full `AppShell` /
+ * `ChatView` render is too heavy to stand up.
+ */
+describe("the origin thread rides the card → Room jump, not just the channel", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const shell = readFileSync(resolve(here, "../../src/components/app-shell.tsx"), "utf8");
+  const chatView = readFileSync(resolve(here, "../../src/views/ChatView.tsx"), "utf8");
+
+  it("the shell carries the resolved thread id into the chat navigation's query", () => {
+    expect(shell).toContain('navigate("chat", channelId, { thread: threadId ?? null })');
+  });
+
+  it("Room reads the thread the query names and opens it", () => {
+    expect(chatView).toContain('params.get("thread")');
+    expect(chatView).toContain("setOpenThreadId(threadId)");
   });
 });

--- a/frontend/test/unit/task-origin-route.test.ts
+++ b/frontend/test/unit/task-origin-route.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
+
+/**
+ * Where "Open the conversation" sends the operator, pinned by reading the
+ * shell's source: a jsdom render of `app-shell` needs the whole client and
+ * every hook, the same reason `task-detail-no-op-plumbing` and
+ * `chat-task-origin-visibility` check their contracts this way.
+ *
+ * The row used to select a thread with `setActiveThreadId` and land on
+ * `#/conversation` — the legacy two-pane surface with its own thread rail, and
+ * a selection the address could not carry. Chats are Room now, and the channel
+ * is the whole destination.
+ */
+describe("a card's origin row opens Room, not the legacy Conversation view", () => {
+  const shell = read("components/app-shell.tsx");
+
+  it("routes the origin channel through the address", () => {
+    expect(shell).toContain('onOpenChannel={(channelId) => navigate("chat", channelId)}');
+  });
+
+  it("hands the detail route the map that places the origin thread", () => {
+    expect(shell).toContain(
+      "chatChannelByThread={chatChannelByThread}\n              onOpenChannel=",
+    );
+  });
+
+  it("no longer sends a card's origin to the legacy Conversation surface", () => {
+    // `#/conversation` stays routable (`ROUTABLE.conversation`) and the view
+    // stays mounted for it; what must not come back is a card's origin row
+    // selecting a thread in it through state the address knows nothing about.
+    expect(shell).not.toContain("setActiveThreadId(threadId);");
+    expect(shell).not.toContain('setView("conversation")');
+  });
+});

--- a/frontend/test/unit/task-origin-route.test.ts
+++ b/frontend/test/unit/task-origin-route.test.ts
@@ -22,7 +22,8 @@ describe("a card's origin row opens Room, not the legacy Conversation view", () 
   const shell = read("components/app-shell.tsx");
 
   it("routes the origin channel through the address", () => {
-    expect(shell).toContain('onOpenChannel={(channelId) => navigate("chat", channelId)}');
+    expect(shell).toContain("onOpenChannel={(channelId, threadId) =>");
+    expect(shell).toContain('navigate("chat", channelId, { thread: threadId ?? null })');
   });
 
   it("hands the detail route the map that places the origin thread", () => {

--- a/frontend/test/unit/task-origin-row.test.ts
+++ b/frontend/test/unit/task-origin-row.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { OriginThreadRow } from "@/views/TaskDetailView";
+
+/**
+ * The row itself, rendered — the half `task-origin-conversation.test.ts`
+ * cannot reach.
+ *
+ * What it guards is an affordance that must match reality: the jump is offered
+ * only when a Room channel actually carries the card's origin thread, and it
+ * carries that channel id to the click. A row that always offered the jump is
+ * how the pre-fix screen sent operators to a surface with nothing on it.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(props: Parameters<typeof OriginThreadRow>[0]) {
+  act(() => root.render(createElement(OriginThreadRow, props)));
+}
+
+describe("the Opened-from-chat row", () => {
+  it("renders nothing for a card with no conversation behind it", () => {
+    render({ chatChannelByThread: { t1: "desk-eng" }, onOpenChannel: () => {} });
+    expect(container.textContent).toBe("");
+  });
+
+  it("offers the jump when a channel carries the origin thread", () => {
+    render({
+      originChatId: "t1",
+      chatChannelByThread: { t1: "desk-eng" },
+      onOpenChannel: () => {},
+    });
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toContain("Open the conversation");
+  });
+
+  it("carries the resolved channel id to the click, not the thread id", () => {
+    const opened: string[] = [];
+    render({
+      originChatId: "t1",
+      chatChannelByThread: { t1: "desk-eng" },
+      onOpenChannel: (channelId) => opened.push(channelId),
+    });
+    act(() => {
+      container.querySelector("button")?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+    // `desk-eng`, not `t1`: `#/chat/<channelId>` is the address, and the card
+    // records a host thread id.
+    expect(opened).toEqual(["desk-eng"]);
+  });
+
+  it("states the origin without a jump when no channel carries the thread", () => {
+    render({
+      originChatId: "gone",
+      chatChannelByThread: { t1: "desk-eng" },
+      onOpenChannel: () => {},
+    });
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.textContent).toContain("Opened from chat");
+  });
+
+  it("states the origin without a jump when the host screen offers none", () => {
+    render({ originChatId: "t1", chatChannelByThread: { t1: "desk-eng" } });
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.textContent).toContain("Opened from chat");
+  });
+});

--- a/src/server/ops/task_export/test.rs
+++ b/src/server/ops/task_export/test.rs
@@ -44,6 +44,7 @@ fn card(title: &str) -> TaskCard {
         cost: None,
         parent_task_id: None,
         origin_chat_id: None,
+        origin_parent: None,
         origin_run_id: None,
         origin_workflow_id: None,
         bounced: None,

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -27,7 +27,7 @@ use crate::ports::tasks::{
     COLUMN_DONE, COLUMN_TODO, TaskDeliverable, TaskOutput, TaskOutputAction, TaskOutputSource,
     TaskOutputWorkflow, TaskRecord, TaskWorkflowProposal, cap_discussion, is_board_column,
 };
-use crate::ports::types::CompanyEvent;
+use crate::ports::types::{CompanyEvent, EventSeq};
 use crate::ports::{generate_id, now_millis};
 use crate::runtime::assignee;
 use crate::server::error::ApiError;
@@ -124,6 +124,12 @@ pub(crate) struct TaskCard {
     /// shape is unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) origin_chat_id: Option<String>,
+    /// The message within `originChatId` the raising turn replied to, when
+    /// the card was opened from inside a thread rather than the channel's own
+    /// timeline. Omitted for a channel-level origin, and for every card
+    /// without an `originChatId` at all.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) origin_parent: Option<EventSeq>,
     /// What the card's latest successful attempt produced (issue #339) — the
     /// link that turns a finished card into something the operator can open.
     ///
@@ -195,7 +201,10 @@ impl From<TaskRecord> for TaskCard {
         // Taken out first: the DTO keeps the desk flat, and the literal below
         // moves the record apart field by field, so the origin cannot be read
         // through a borrow partway down it.
-        let origin_chat_id = t.origin.map(|origin| origin.origin_chat_id);
+        let (origin_chat_id, origin_parent) = match t.origin {
+            Some(origin) => (Some(origin.origin_chat_id), origin.origin_parent),
+            None => (None, None),
+        };
         Self {
             id: t.id,
             title: t.title,
@@ -208,6 +217,7 @@ impl From<TaskRecord> for TaskCard {
             cost: None,
             parent_task_id: t.parent_task_id,
             origin_chat_id,
+            origin_parent,
             output: t.output,
             plan: t.plan,
             deliverable: t.deliverable,
@@ -216,6 +226,60 @@ impl From<TaskRecord> for TaskCard {
             origin_workflow_id: t.origin_workflow_id,
             bounced: t.bounced,
         }
+    }
+}
+
+#[cfg(test)]
+mod task_card_origin_test {
+    use super::*;
+    use crate::ports::tasks::TaskOrigin;
+
+    fn plain_record() -> TaskRecord {
+        TaskRecord {
+            id: "t-1".to_string(),
+            title: "Draft the spec".to_string(),
+            note: None,
+            column: "todo".to_string(),
+            priority: "medium".to_string(),
+            assignee: "maya".to_string(),
+            updated_at_millis: 7,
+            origin: None,
+            parent_task_id: None,
+            output: None,
+            plan: None,
+            planning_attempts: Vec::new(),
+            deliverable: TaskDeliverable::Once,
+            workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
+            bounced: None,
+        }
+    }
+
+    #[test]
+    fn a_card_raised_inside_a_thread_carries_its_thread_root_onto_the_card() {
+        let mut record = plain_record();
+        record.origin = TaskOrigin::new(Some("engineering".to_string()), Some(EventSeq::new(41)));
+        let card = TaskCard::from(record);
+        assert_eq!(card.origin_chat_id.as_deref(), Some("engineering"));
+        assert_eq!(card.origin_parent, Some(EventSeq::new(41)));
+
+        let json = serde_json::to_string(&card).expect("serializes");
+        assert!(json.contains(r#""originChatId":"engineering""#), "{json}");
+        assert!(json.contains(r#""originParent":41"#), "{json}");
+    }
+
+    /// A card raised straight into a channel carries no thread root, and the
+    /// field stays absent on the wire rather than serializing `null`.
+    #[test]
+    fn a_channel_level_origin_carries_no_thread_root() {
+        let mut record = plain_record();
+        record.origin = TaskOrigin::new(Some("engineering".to_string()), None);
+        let card = TaskCard::from(record);
+        assert_eq!(card.origin_parent, None);
+
+        let json = serde_json::to_string(&card).expect("serializes");
+        assert!(!json.contains("originParent"), "{json}");
     }
 }
 

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -565,6 +565,64 @@ async fn a_task_created_from_a_thread_remembers_and_reads_back_that_thread() {
     assert!(blank.get("originChatId").is_none(), "{blank}");
 }
 
+/// A card raised inside a thread carries the thread root on both the task
+/// detail and board wire responses, not only on the stored `TaskRecord`.
+///
+/// `originParent` is stamped by the tool-spawn path rather than the REST
+/// create body, so the record is seeded directly here.
+#[tokio::test]
+async fn a_task_detail_response_carries_the_thread_root_of_a_threaded_origin() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let runtime = state.registry().get(&company).unwrap();
+
+    runtime
+        .tasks()
+        .upsert(
+            &company,
+            &TaskRecord {
+                id: "threaded".into(),
+                title: "Ship the brief".into(),
+                note: None,
+                column: crate::ports::tasks::COLUMN_TODO.into(),
+                priority: "medium".into(),
+                assignee: String::new(),
+                updated_at_millis: 1,
+                origin: crate::ports::tasks::TaskOrigin::new(
+                    Some("strategy".to_string()),
+                    Some(crate::ports::types::EventSeq::new(41)),
+                ),
+                parent_task_id: None,
+                output: None,
+                plan: None,
+                planning_attempts: Vec::new(),
+                deliverable: crate::ports::tasks::TaskDeliverable::Once,
+                workflow_proposal: None,
+                origin_run_id: None,
+                origin_workflow_id: None,
+                bounced: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let (status, detail) = send(&state, "GET", "/api/v1/company/tasks/threaded", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["task"]["originChatId"], "strategy");
+    assert_eq!(detail["task"]["originParent"], 41, "{detail}");
+
+    let (_, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    let card = board
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["id"] == "threaded")
+        .unwrap();
+    assert_eq!(card["originParent"], 41, "{card}");
+}
+
 /// Issue #339: the card's output link reaches the console on **both** reads.
 ///
 /// The board read matters as much as task detail here, and that is the whole


### PR DESCRIPTION
## Summary

A task card opened from a conversation offers "Open the conversation". It landed on `#/conversation` — the legacy two-pane screen that owns its own thread-list rail down the left — rather than the conversation as it lives today, in the **Room** tab.

The card → chat half of the #246 round trip was never re-pointed after chats moved to Room, so the operator was dropped into a surface that no longer matches the rest of the console.

Now the row resolves the origin thread to its channel and navigates into Room on that channel. When the thread resolves to no channel, the row stays the plain-text "Opened from chat" it already had for cards with no navigation target — it never offers a jump that goes nowhere.

Closes #2020

## API Or Behavior Changes

Console-only; no host or API change.

- `TaskDetailView` / `TaskDetailRoute`: prop `onOpenThread(threadId)` is replaced by `chatChannelByThread` + `onOpenChannel(channelId)`.
- New `frontend/src/lib/task-origin.ts` — `originConversation()` returns `none` / `unreachable` / `{ channel, channelId }`, resolving through the shared `channelForThread` rather than a bare map index, so a card opened from a line addressed `MAIN` still finds its channel.
- `views/Conversation.tsx` and `#/conversation` are untouched and still reachable: `ROUTABLE.conversation` keeps the address answering, and the e2e suite navigates there directly.

One correction to the issue's write-up: `setView` already routes through `navigate`, so `#/conversation` was being pushed to the address. The defect is the surface, not the addressing — only the thread selection was shell state.

## Tests

Console package (`frontend/`), all run unpiped:

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npm run build`
- [x] `npx vitest run` — 461 files, 4322 tests passed

N/A: the four Rust boxes above — this PR changes no Rust. There is no `lint` or `format` script in this package.

New coverage, each proved red against the pre-fix source:

| Test | Failure on old code |
|---|---|
| `task-origin-conversation.test.ts` (5) | the three outcomes + General-casing fold |
| `task-origin-row.test.ts` (5, jsdom) | `expected ['t1'] to deeply equal ['desk-eng']`; `expected <button> to be null` |
| `task-origin-route.test.ts` (3) | 3/3 fail on the reverted handler |
| `chat-to-card.spec.ts` (e2e extension) | `Expected /#\/chat\/.+/`, received `.../#/conversation` |

Verified by hand against a live host (e2e harness on `127.0.0.1:15192`, real card carrying a real `originChatId`):

- **After:** message on the Engineering desk → "Add to board" → open card → "Open the conversation" → lands `#/chat/…`, Room lit in the sidebar, header `# engineering-desk`, Room's channel rail, the origin message in the transcript, no left thread rail. Back returns to the card.
- **Before:** the same click gave `#/conversation` — the legacy two-pane list rail. The reported wireframe, exactly.

## Documentation

No docs change. The behaviour is described by the screen itself; the prop contract lives in the components' own signatures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task cards opened from chat now link directly to the corresponding Room channel and originating thread.
  * Origin details indicate when the originating conversation is unavailable.
  * Returning from a Room channel brings you back to the task card.
  * Chat links open the selected thread automatically.
  * Detached or failed chat sends retain receipt indicators while processing remains active.
  * Direct-message chat links resolve correctly, including case variations.

* **Tests**
  * Added coverage for navigation, unavailable origins, channel resolution, receipt behavior, and thread links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->