### PR TITLE
fix(workflows): re-execute a workflow node when its blocker is answered (#2005)

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2639,22 +2639,50 @@ impl CompanyRuntime {
         .await
     }
 
-    /// Carries a resolved workflow-node blocker's answer back into the run
-    /// (issue #1863).
+    /// Re-enters the workflow node a resolved blocker stopped, carrying the
+    /// operator's answer into the run (issues #1863, #2005).
     ///
     /// A [`Cancel`](crate::ports::blockers::BlockerVerdict::Cancel) settles the
-    /// run and starts nothing. A resuming verdict banks the answer (already
-    /// durable) and delivers it into the DM the question was asked in, so the
-    /// operator's decision is never silently dropped. Re-executing the node from
-    /// the run's trigger input — retry re-runs it, amend injects the value, skip
-    /// treats it satisfied — is the workflow engine's own resume seam (issue
-    /// #1864's node-level restart lives beside it); this hands the answer across
-    /// without disturbing that machinery.
+    /// run and starts nothing — the short-circuit that runs before any cycle.
+    ///
+    /// A resuming verdict re-dispatches the run. A paused workflow run is
+    /// *settled*, not suspended (see
+    /// [`workflow_resume`](crate::runtime::workflow_resume)'s module docs), so
+    /// re-entry means a fresh supervised run started from the blocked run's own
+    /// trigger input with the answer threaded onto it under
+    /// [`CONTINUATION_BLOCKER_KEY`](crate::runtime::workflow_resume::CONTINUATION_BLOCKER_KEY).
+    /// The executing node reads it back and acts on the verdict: a retry runs
+    /// again as it was, an amend runs again carrying the operator's words, a
+    /// skip does not run at all and the branch proceeds past it.
+    ///
+    /// The facts that re-dispatch needs — workflow id, trigger input,
+    /// attribution, checkpoint lineage — are the blocked-node stash the park
+    /// armed (`stash_node_blocker_resume`), keyed per (run, node). Reusing that
+    /// key rather than a second registry is what makes the at-most-once
+    /// guarantee hold across both ways into this node: the gated-call resume and
+    /// this one share
+    /// [`is_blocked_node_dispatched`](crate::runtime::journal::RuntimeJournal::is_blocked_node_dispatched),
+    /// so whichever arrives second records the decision and launches nothing.
+    ///
+    /// **Every failure is loud.** A stash this host no longer holds, a graph
+    /// that has since been deleted, a build with no workflow execution wired —
+    /// each returns `Err`, which
+    /// [`resume_blocker`](Self::resume_blocker) propagates. Reporting a resume
+    /// that did not happen as success is the silent drop the blocker family
+    /// exists to close.
+    ///
+    /// Re-running from the trigger costs the upstream nodes again unless
+    /// #1864's node-level checkpoint restart is available for this lineage;
+    /// `spawn_blocked_node_continuation` picks the cheaper of the two. What it
+    /// must never cost is a second report: the delivery (#438), outward-call
+    /// (#846) and denial (#978) ledgers ride the same trigger input this
+    /// threads onto, unchanged, and `deliver_outputs` skips a node either
+    /// ledger already names.
     #[cfg(feature = "openhuman")]
     async fn resume_node_blocker(
         self: &Arc<Self>,
         run_id: &str,
-        _node_id: &str,
+        node_id: &str,
         resolution: &crate::ports::blockers::BlockerResolution,
         thread: Option<&str>,
     ) -> Result<()> {
@@ -2674,6 +2702,74 @@ impl CompanyRuntime {
                 .post_blocker_resume_note(thread, "Okay — I've cancelled that workflow step.")
                 .await;
         }
+        let turn = crate::runtime::workflow_resume::workflow_node_turn_key(run_id, node_id);
+        // Read without taking: the spawn below can still fail, and retiring the
+        // stash first would leave a restart with no pending decision and no run
+        // to continue — the stranding shape `resume_blocked_agent_node`'s own
+        // Stage 4 comment describes.
+        let Some(stashed) = self.blocked_nodes.peek(&turn) else {
+            self.post_blocker_resume_note(
+                thread,
+                "I have your answer, but this host no longer holds that workflow run — re-run \
+                 the workflow to pick it back up.",
+            )
+            .await?;
+            self.retire_blocked_stash(&turn).await;
+            return Err(OpenCompanyError::InvalidRequest(format!(
+                "a blocker on workflow node `{node_id}` of run `{run_id}` was answered, but \
+                 this host no longer holds the run's stash, so the node cannot be re-entered"
+            )));
+        };
+        // A continuation already launched for this node — by the gated-call
+        // resume, or by a ghost decision replaying this one — must not launch a
+        // second. Same guard, same reason as `resume_blocked_agent_node`: the
+        // dispatch marker is host-durable and the run behind it is not idempotent.
+        if self.journal.is_blocked_node_dispatched(&turn) {
+            tracing::warn!(
+                company = %self.id,
+                %turn,
+                "[blockers] a blocker was answered on a node whose continuation was already \
+                 dispatched; recording the answer and retiring the stash without launching a \
+                 second continuation"
+            );
+            self.retire_blocked_stash(&turn).await;
+            return self
+                .post_blocker_resume_note(thread, &blocker_resume_note(resolution))
+                .await;
+        }
+        let input = crate::runtime::workflow_resume::blocker_continuation_input(
+            stashed.input,
+            node_id,
+            resolution,
+        )?;
+        if let Err(error) = crate::runtime::workflow_resume::spawn_blocked_node_continuation(
+            self,
+            &turn,
+            &stashed.workflow_id,
+            input,
+            stashed.started_by,
+            stashed.thread_id,
+            stashed.workflow_fingerprint,
+        )
+        .await
+        {
+            // The stash is deliberately left in place — nothing was admitted and
+            // nothing was marked dispatched, so it stays recoverable, exactly as
+            // `resume_blocked_agent_node`'s own failure arm keeps it. Said out
+            // loud in the blocker's own DM as well as returned, because the
+            // operator answered a question and is owed the news that the answer
+            // did not land.
+            self.post_blocker_resume_note(
+                thread,
+                &format!(
+                    "I have your answer, but that workflow step could not be restarted right \
+                     now: {error}"
+                ),
+            )
+            .await?;
+            return Err(error);
+        }
+        self.retire_blocked_stash(&turn).await;
         self.post_blocker_resume_note(thread, &blocker_resume_note(resolution))
             .await
     }
@@ -10085,6 +10181,406 @@ mod tests {
                 stored(&runtime, "t-1").await.column,
                 COLUMN_TODO,
                 "a console Deny abandons the work rather than re-dispatching it"
+            );
+        }
+    }
+
+    /// Issue #2005: the workflow-NODE half of the blocker resume — the answer
+    /// reaching the engine's trigger reader, not just the DM.
+    ///
+    /// The workflow runner is the only double, on `workflow_resume`'s own
+    /// reasoning: what is under test is whether a continuation run is started,
+    /// with what trigger input, and how many times.
+    #[cfg(feature = "openhuman")]
+    mod node_blocker_resume {
+        use std::sync::{Arc, Mutex};
+
+        use async_trait::async_trait;
+        use serde_json::{Value, json};
+
+        use crate::company::CompanyManifest;
+        use crate::company::runtime::CompanyRuntime;
+        use crate::company::task_intent::BlockerReplyIntent;
+        use crate::ports::blockers::{
+            BlockerKind, BlockerPayload, BlockerSource, BlockerStep, BlockerVerdict,
+        };
+        use crate::ports::types::{CompanyId, Effect, EffectGroup};
+        use crate::ports::{WorkflowRun, WorkflowRunContext, WorkflowRunner};
+        use crate::runtime::RuntimeBuilder;
+        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+        use crate::runtime::workflow_resume::{
+            CONTINUATION_BLOCKER_KEY, blocker_answer_for, workflow_node_turn_key,
+        };
+
+        const RUN_ID: &str = "run-that-blocked";
+        const NODE_ID: &str = "draft";
+        const WORKFLOW_TOML: &str = r#"
+id = "reporting"
+name = "Reporting"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "draft"
+kind = "output"
+name = "Draft"
+[[edge]]
+from = "start"
+to = "draft"
+"#;
+
+        #[derive(Clone, Debug)]
+        struct StartedRun {
+            workflow_id: String,
+            input: Value,
+        }
+
+        #[derive(Default)]
+        struct RecordingRunner {
+            started: Mutex<Vec<StartedRun>>,
+        }
+
+        impl RecordingRunner {
+            fn started(&self) -> Vec<StartedRun> {
+                self.started.lock().expect("recording runner").clone()
+            }
+        }
+
+        #[async_trait]
+        impl WorkflowRunner for RecordingRunner {
+            async fn run(
+                &self,
+                _company: &CompanyId,
+                workflow: &crate::company::WorkflowFile,
+                input: Value,
+                _ctx: &WorkflowRunContext,
+            ) -> crate::Result<WorkflowRun> {
+                self.started
+                    .lock()
+                    .expect("recording runner")
+                    .push(StartedRun {
+                        workflow_id: workflow.id.clone(),
+                        input,
+                    });
+                Ok(WorkflowRun {
+                    output: json!({ "ok": true }),
+                    pending_approvals: Vec::new(),
+                    deliveries: Vec::new(),
+                    cancelled: false,
+                    nodes: Vec::new(),
+                    notices: Vec::new(),
+                    board: Vec::new(),
+                    blocked_nodes: Vec::new(),
+                    approvals: Vec::new(),
+                })
+            }
+        }
+
+        fn manifest() -> CompanyManifest {
+            toml::from_str(
+                "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+                 [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n\
+                 [[agent]]\nid = \"eng\"\nrole = \"Engineer\"\n",
+            )
+            .expect("manifest")
+        }
+
+        fn seed_home() -> tempfile::TempDir {
+            let dir = tempfile::Builder::new()
+                .prefix("opencompany-node-blocker-")
+                .tempdir()
+                .expect("tempdir");
+            let workflows = dir.path().join("workflows");
+            std::fs::create_dir_all(&workflows).expect("workflows dir");
+            std::fs::write(workflows.join("reporting.toml"), WORKFLOW_TOML).expect("seed graph");
+            dir
+        }
+
+        async fn runtime(
+            home: &std::path::Path,
+            with_runner: bool,
+        ) -> (Arc<CompanyRuntime>, Arc<RecordingRunner>) {
+            let mut rt = RuntimeBuilder::new(home.to_path_buf(), manifest())
+                .with_id(CompanyId::new("acme"))
+                .with_seed_dir(home.to_path_buf())
+                .build()
+                .await
+                .expect("runtime builds");
+            let runner = Arc::new(RecordingRunner::default());
+            if with_runner {
+                rt.set_workflow_runner(runner.clone());
+            }
+            (Arc::new(rt), runner)
+        }
+
+        /// Parks a node blocker exactly as `park_node_blocker_as` does, and
+        /// arms the same per-(run, node) stash its `stash_node_blocker_resume`
+        /// writes at park time.
+        async fn park_node_blocker(rt: &Arc<CompanyRuntime>, input: Value) -> String {
+            park_node_blocker_stashed(rt, input, true).await
+        }
+
+        async fn park_node_blocker_stashed(
+            rt: &Arc<CompanyRuntime>,
+            input: Value,
+            stash: bool,
+        ) -> String {
+            let payload = BlockerPayload {
+                kind: BlockerKind::Infrastructure,
+                source: BlockerSource::Provider,
+                step: Some(BlockerStep::Node {
+                    run_id: RUN_ID.to_string(),
+                    node_id: NODE_ID.to_string(),
+                }),
+                reason: "the model id `gpt-nope` was rejected".to_string(),
+                needed: "a model id this provider serves".to_string(),
+                group_key: None,
+            };
+            let effect = Effect {
+                kind: payload.effect_kind(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::to_value(&payload).expect("payload"),
+                agent: None,
+                run_id: Some(RUN_ID.to_string()),
+            };
+            let id = rt
+                .approvals
+                .park(rt.id(), effect.clone())
+                .await
+                .expect("parks");
+            rt.journal()
+                .record_parked(
+                    &id,
+                    &effect,
+                    crate::ports::now_millis(),
+                    TaskLink::Unlinked,
+                    ApprovalConversation::default(),
+                    None,
+                )
+                .await
+                .expect("journals");
+            if stash {
+                let turn = workflow_node_turn_key(RUN_ID, NODE_ID);
+                rt.blocked_nodes.arm_checkpointed(
+                    &turn,
+                    "reporting",
+                    &input,
+                    &crate::ports::types::StartedBy::from_scheduled(false),
+                    None,
+                    None,
+                );
+                rt.journal()
+                    .record_blocked_node_stashed_checkpointed(
+                        &turn,
+                        "reporting",
+                        &input,
+                        &crate::ports::types::StartedBy::from_scheduled(false),
+                        None,
+                        None,
+                    )
+                    .await
+                    .expect("stashes");
+            }
+            id.to_string()
+        }
+
+        async fn answer(
+            rt: &Arc<CompanyRuntime>,
+            id: &str,
+            intent: BlockerReplyIntent,
+            text: &str,
+        ) {
+            let ids = vec![crate::ports::types::ApprovalId::from(id.to_string())];
+            rt.apply_blocker_reply(&ids, intent, text, None)
+                .await
+                .expect("applies");
+        }
+
+        /// The acceptance headline: a workflow parked at a failed node and
+        /// answered `retry` re-runs, and the answer is on the trigger input the
+        /// re-run carries — not banked in the DM and dropped.
+        #[tokio::test]
+        async fn retry_re_runs_the_node_with_the_answer_in_the_trigger_input() {
+            let home = seed_home();
+            let (rt, runner) = runtime(home.path(), true).await;
+            let id = park_node_blocker(&rt, json!({ "topic": "quarterly numbers" })).await;
+
+            answer(&rt, &id, BlockerReplyIntent::Retry, "go ahead and retry").await;
+
+            let started = runner.started();
+            assert_eq!(started.len(), 1, "a retry re-enters the node exactly once");
+            assert_eq!(started[0].workflow_id, "reporting");
+            assert_eq!(
+                started[0].input["topic"], "quarterly numbers",
+                "the blocked run's own trigger input is replayed"
+            );
+            let carried = blocker_answer_for(&started[0].input, NODE_ID)
+                .expect("readable")
+                .expect("the answer rides the trigger input");
+            assert_eq!(carried.verdict, BlockerVerdict::Retry);
+        }
+
+        /// An amend carries the operator's words into the re-run, the workflow
+        /// twin of the card path's note append.
+        #[tokio::test]
+        async fn amend_carries_the_operators_words_into_the_re_run() {
+            let home = seed_home();
+            let (rt, runner) = runtime(home.path(), true).await;
+            let id = park_node_blocker(&rt, json!({ "topic": "quarterly numbers" })).await;
+
+            answer(
+                &rt,
+                &id,
+                BlockerReplyIntent::Amend,
+                "use gpt-4o-mini instead",
+            )
+            .await;
+
+            let started = runner.started();
+            assert_eq!(started.len(), 1);
+            let carried = blocker_answer_for(&started[0].input, NODE_ID)
+                .expect("readable")
+                .expect("the answer rides the trigger input");
+            assert_eq!(carried.verdict, BlockerVerdict::Amend);
+            assert_eq!(
+                carried.answer, "use gpt-4o-mini instead",
+                "the correction must reach the node, or the re-run repeats the failure"
+            );
+        }
+
+        /// A skip proceeds past the node: the run is re-entered carrying a
+        /// verdict the node reads as "waived", rather than being abandoned.
+        #[tokio::test]
+        async fn skip_continues_the_run_past_the_node() {
+            let home = seed_home();
+            let (rt, runner) = runtime(home.path(), true).await;
+            let id = park_node_blocker(&rt, json!({ "topic": "quarterly numbers" })).await;
+
+            answer(&rt, &id, BlockerReplyIntent::Skip, "skip it").await;
+
+            let started = runner.started();
+            assert_eq!(started.len(), 1, "a skip still continues the run");
+            let carried = blocker_answer_for(&started[0].input, NODE_ID)
+                .expect("readable")
+                .expect("the answer rides the trigger input");
+            assert_eq!(carried.verdict, BlockerVerdict::Skip);
+        }
+
+        /// The one verdict that starts nothing.
+        #[tokio::test]
+        async fn cancel_starts_no_run() {
+            let home = seed_home();
+            let (rt, runner) = runtime(home.path(), true).await;
+            let id = park_node_blocker(&rt, json!({ "topic": "quarterly numbers" })).await;
+
+            answer(&rt, &id, BlockerReplyIntent::Cancel, "cancel that").await;
+
+            assert!(
+                runner.started().is_empty(),
+                "a cancel abandons the work rather than re-entering it"
+            );
+        }
+
+        /// The ledgers ride the same trigger input the answer is threaded onto,
+        /// so a continuation still knows what the blocked run already sent
+        /// (issues #438 / #846 / #978).
+        #[tokio::test]
+        async fn a_skip_continuation_still_carries_what_the_run_already_sent() {
+            let home = seed_home();
+            let (rt, runner) = runtime(home.path(), true).await;
+            let input = json!({
+                "topic": "quarterly numbers",
+                crate::runtime::workflow_resume::CONTINUATION_DELIVERED_KEY: [
+                    { "node": "report", "kind": "owner" }
+                ],
+                crate::runtime::workflow_resume::CONTINUATION_PERFORMED_KEY: [
+                    { "node": "post", "tool": "send", "result": { "ok": true } }
+                ],
+                crate::runtime::workflow_resume::CONTINUATION_DENIED_KEY: ["refused-gate"],
+            });
+            let id = park_node_blocker(&rt, input).await;
+
+            answer(&rt, &id, BlockerReplyIntent::Skip, "skip it").await;
+
+            let started = runner.started();
+            assert_eq!(started.len(), 1);
+            let carried = &started[0].input;
+            assert_eq!(
+                crate::runtime::workflow_resume::delivered_in_input(carried).len(),
+                1,
+                "the report the blocked run already delivered must not be sent twice"
+            );
+            assert_eq!(
+                crate::runtime::workflow_resume::performed_in_input(carried).len(),
+                1,
+                "the call the blocked run already made must not be made twice"
+            );
+            assert_eq!(
+                crate::runtime::workflow_resume::denied_in_input(carried),
+                vec!["refused-gate".to_string()],
+                "a gate the operator already refused must not be asked about again"
+            );
+        }
+
+        /// Answering twice re-enters the node once: the second decision finds
+        /// the continuation already dispatched and launches nothing.
+        #[tokio::test]
+        async fn a_node_is_re_entered_once_however_many_answers_land() {
+            let home = seed_home();
+            let (rt, runner) = runtime(home.path(), true).await;
+            let first = park_node_blocker(&rt, json!({ "topic": "quarterly numbers" })).await;
+            answer(&rt, &first, BlockerReplyIntent::Retry, "retry").await;
+
+            let second = park_node_blocker(&rt, json!({ "topic": "quarterly numbers" })).await;
+            answer(&rt, &second, BlockerReplyIntent::Retry, "retry").await;
+
+            assert_eq!(
+                runner.started().len(),
+                1,
+                "the dispatch marker is what stops a second continuation for one node"
+            );
+        }
+
+        /// A host that no longer holds the run's stash reports it rather than
+        /// acknowledging a resume that did not happen.
+        #[tokio::test]
+        async fn an_answer_with_no_run_to_re_enter_is_reported_not_swallowed() {
+            let home = seed_home();
+            let (rt, runner) = runtime(home.path(), true).await;
+            let id = park_node_blocker_stashed(&rt, json!({ "topic": "quarterly numbers" }), false)
+                .await;
+
+            let ids = vec![crate::ports::types::ApprovalId::from(id)];
+            let outcome = rt
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Retry, "retry", None)
+                .await;
+
+            assert!(
+                outcome.is_err(),
+                "an answer that reached no run must not read as a resume"
+            );
+            assert!(runner.started().is_empty());
+        }
+
+        /// The reserved key is never written for a verdict that starts no run.
+        #[tokio::test]
+        async fn a_cancelled_answer_never_reaches_a_trigger_input() {
+            let home = seed_home();
+            let (rt, runner) = runtime(home.path(), true).await;
+            let id = park_node_blocker(&rt, json!({ "topic": "quarterly numbers" })).await;
+
+            answer(&rt, &id, BlockerReplyIntent::Cancel, "cancel that").await;
+
+            assert!(
+                runner
+                    .started()
+                    .iter()
+                    .all(|run| run.input.get(CONTINUATION_BLOCKER_KEY).is_none()),
+                "a cancel writes no answer onto any trigger input"
             );
         }
     }

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2686,6 +2686,7 @@ impl CompanyRuntime {
         resolution: &crate::ports::blockers::BlockerResolution,
         thread: Option<&str>,
     ) -> Result<()> {
+        let turn = crate::runtime::workflow_resume::workflow_node_turn_key(run_id, node_id);
         if !resolution.resumes() {
             let outcome =
                 crate::ports::runs::RunOutcome::new(crate::ports::runs::RunStatus::Cancelled)
@@ -2698,11 +2699,36 @@ impl CompanyRuntime {
                     "[blockers] a cancelled workflow-node blocker's run could not be settled"
                 );
             }
+            let stashed = self.blocked_nodes.peek(&turn);
+            self.prune_checkpoint_lineage_of_stash(stashed.as_ref())
+                .await;
+            self.retire_blocked_stash(&turn).await;
             return self
                 .post_blocker_resume_note(thread, "Okay — I've cancelled that workflow step.")
                 .await;
         }
-        let turn = crate::runtime::workflow_resume::workflow_node_turn_key(run_id, node_id);
+        // A continuation already launched for this node — by the gated-call
+        // resume, or by a ghost decision replaying this one — must not launch a
+        // second. Same guard, same reason as `resume_blocked_agent_node`: the
+        // dispatch marker is host-durable and the run behind it is not
+        // idempotent. Checked before the stash below is required: a node
+        // parking more than one blocker card shares this turn's stash, and
+        // resolving the first already retired it on dispatch — a second card's
+        // answer must find the dispatch marker and be acknowledged, not read
+        // the missing stash as "this host no longer holds the run".
+        if self.journal.is_blocked_node_dispatched(&turn) {
+            tracing::warn!(
+                company = %self.id,
+                %turn,
+                "[blockers] a blocker was answered on a node whose continuation was already \
+                 dispatched; recording the answer and retiring the stash without launching a \
+                 second continuation"
+            );
+            self.retire_blocked_stash(&turn).await;
+            return self
+                .post_blocker_resume_note(thread, &blocker_resume_note(resolution))
+                .await;
+        }
         // Read without taking: the spawn below can still fail, and retiring the
         // stash first would leave a restart with no pending decision and no run
         // to continue — the stranding shape `resume_blocked_agent_node`'s own
@@ -2720,23 +2746,6 @@ impl CompanyRuntime {
                  this host no longer holds the run's stash, so the node cannot be re-entered"
             )));
         };
-        // A continuation already launched for this node — by the gated-call
-        // resume, or by a ghost decision replaying this one — must not launch a
-        // second. Same guard, same reason as `resume_blocked_agent_node`: the
-        // dispatch marker is host-durable and the run behind it is not idempotent.
-        if self.journal.is_blocked_node_dispatched(&turn) {
-            tracing::warn!(
-                company = %self.id,
-                %turn,
-                "[blockers] a blocker was answered on a node whose continuation was already \
-                 dispatched; recording the answer and retiring the stash without launching a \
-                 second continuation"
-            );
-            self.retire_blocked_stash(&turn).await;
-            return self
-                .post_blocker_resume_note(thread, &blocker_resume_note(resolution))
-                .await;
-        }
         let input = crate::runtime::workflow_resume::blocker_continuation_input(
             stashed.input,
             node_id,
@@ -3626,11 +3635,8 @@ impl CompanyRuntime {
             // stop holding; retire it the same way that branch does and move
             // on, without touching the dispatched check below, which exists
             // solely to guard the *approved* replay path.
-            if !self
-                .blocked_nodes
-                .peek(&turn)
-                .is_some_and(|stashed| stashed.approved)
-            {
+            let stashed = self.blocked_nodes.peek(&turn);
+            if !stashed.as_ref().is_some_and(|stashed| stashed.approved) {
                 tracing::info!(
                     company = %self.id,
                     %turn,
@@ -3638,6 +3644,8 @@ impl CompanyRuntime {
                      with nothing approved, before its retirement could run; retiring the stash \
                      now instead of leaving it to rehydrate on every future boot"
                 );
+                self.prune_checkpoint_lineage_of_stash(stashed.as_ref())
+                    .await;
                 self.retire_blocked_stash(&turn).await;
                 continue;
             }
@@ -10318,13 +10326,14 @@ to = "draft"
         /// arms the same per-(run, node) stash its `stash_node_blocker_resume`
         /// writes at park time.
         async fn park_node_blocker(rt: &Arc<CompanyRuntime>, input: Value) -> String {
-            park_node_blocker_stashed(rt, input, true).await
+            park_node_blocker_stashed(rt, input, true, None).await
         }
 
         async fn park_node_blocker_stashed(
             rt: &Arc<CompanyRuntime>,
             input: Value,
             stash: bool,
+            thread_id: Option<&str>,
         ) -> String {
             let payload = BlockerPayload {
                 kind: BlockerKind::Infrastructure,
@@ -10370,7 +10379,7 @@ to = "draft"
                     "reporting",
                     &input,
                     &crate::ports::types::StartedBy::from_scheduled(false),
-                    None,
+                    thread_id,
                     None,
                 );
                 rt.journal()
@@ -10379,7 +10388,7 @@ to = "draft"
                         "reporting",
                         &input,
                         &crate::ports::types::StartedBy::from_scheduled(false),
-                        None,
+                        thread_id,
                         None,
                     )
                     .await
@@ -10545,14 +10554,61 @@ to = "draft"
             );
         }
 
+        /// Two blocker cards on one node share one stash: only the first park
+        /// arms it. Resolving the first dispatches and retires that shared
+        /// stash — the second card's answer must then find the dispatch
+        /// marker and be acknowledged, not read the now-missing stash as "this
+        /// host no longer holds the run".
+        #[tokio::test]
+        async fn a_second_card_on_the_same_node_is_acknowledged_once_the_first_dispatches() {
+            let home = seed_home();
+            let (rt, runner) = runtime(home.path(), true).await;
+            let first = park_node_blocker(&rt, json!({ "topic": "quarterly numbers" })).await;
+            let second = park_node_blocker_stashed(
+                &rt,
+                json!({ "topic": "quarterly numbers" }),
+                false,
+                None,
+            )
+            .await;
+
+            answer(&rt, &first, BlockerReplyIntent::Retry, "retry").await;
+            assert_eq!(
+                runner.started().len(),
+                1,
+                "the first answer dispatches the node"
+            );
+
+            let ids = vec![crate::ports::types::ApprovalId::from(second)];
+            let outcome = rt
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Retry, "retry", None)
+                .await;
+
+            assert!(
+                outcome.is_ok(),
+                "the second card's answer must be acknowledged once the dispatch marker is set, \
+                 not returned as an error: {outcome:?}"
+            );
+            assert_eq!(
+                runner.started().len(),
+                1,
+                "the dispatch marker must still stop a second continuation for this node"
+            );
+        }
+
         /// A host that no longer holds the run's stash reports it rather than
         /// acknowledging a resume that did not happen.
         #[tokio::test]
         async fn an_answer_with_no_run_to_re_enter_is_reported_not_swallowed() {
             let home = seed_home();
             let (rt, runner) = runtime(home.path(), true).await;
-            let id = park_node_blocker_stashed(&rt, json!({ "topic": "quarterly numbers" }), false)
-                .await;
+            let id = park_node_blocker_stashed(
+                &rt,
+                json!({ "topic": "quarterly numbers" }),
+                false,
+                None,
+            )
+            .await;
 
             let ids = vec![crate::ports::types::ApprovalId::from(id)];
             let outcome = rt
@@ -10581,6 +10637,205 @@ to = "draft"
                     .iter()
                     .all(|run| run.input.get(CONTINUATION_BLOCKER_KEY).is_none()),
                 "a cancel writes no answer onto any trigger input"
+            );
+        }
+
+        /// A cancel must retire the per-node stash it parked with — in memory
+        /// and durably — and prune the checkpoint lineage that stash names,
+        /// the same as every other terminal outcome on this queue.
+        #[cfg(feature = "openhuman")]
+        #[tokio::test]
+        async fn a_cancelled_answer_retires_the_stash_and_prunes_its_checkpoint() {
+            use tinyflows::graph::Checkpointer;
+
+            let home = seed_home();
+            let mut rt = crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), manifest())
+                .with_id(CompanyId::new("acme"))
+                .with_seed_dir(home.path().to_path_buf())
+                .build()
+                .await
+                .expect("runtime builds");
+            let checkpoints = std::sync::Arc::new(
+                crate::workflows::checkpoint_store::WorkflowCheckpointStore::new(
+                    home.path().join("checkpoints"),
+                ),
+            );
+            checkpoints
+                .put(tinyflows::graph::Checkpoint {
+                    thread_id: RUN_ID.to_string(),
+                    checkpoint_id: "c1".to_string(),
+                    run_id: Some(RUN_ID.to_string()),
+                    parent_checkpoint_id: None,
+                    namespace: Vec::new(),
+                    state: json!({}),
+                    next_nodes: vec![tinyflows::graph::ids::NodeId::new(NODE_ID)],
+                    completed_tasks: Vec::new(),
+                    pending_writes: Vec::new(),
+                    interrupts: Vec::new(),
+                    pending_activations: None,
+                    barrier_arrivals: Vec::new(),
+                    metadata: Value::Null,
+                })
+                .await
+                .expect("seed checkpoint");
+            rt.set_workflow_checkpoints(checkpoints.clone());
+            let rt = Arc::new(rt);
+
+            let payload = BlockerPayload {
+                kind: BlockerKind::Infrastructure,
+                source: BlockerSource::Provider,
+                step: Some(BlockerStep::Node {
+                    run_id: RUN_ID.to_string(),
+                    node_id: NODE_ID.to_string(),
+                }),
+                reason: "the model id `gpt-nope` was rejected".to_string(),
+                needed: "a model id this provider serves".to_string(),
+                group_key: None,
+            };
+            let effect = Effect {
+                kind: payload.effect_kind(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::to_value(&payload).expect("payload"),
+                agent: None,
+                run_id: Some(RUN_ID.to_string()),
+            };
+            let id = rt
+                .approvals
+                .park(rt.id(), effect.clone())
+                .await
+                .expect("parks");
+            rt.journal()
+                .record_parked(
+                    &id,
+                    &effect,
+                    crate::ports::now_millis(),
+                    TaskLink::Unlinked,
+                    ApprovalConversation::default(),
+                    None,
+                )
+                .await
+                .expect("journals");
+            let turn = workflow_node_turn_key(RUN_ID, NODE_ID);
+            let input = json!({ "topic": "quarterly numbers" });
+            rt.blocked_nodes.arm_checkpointed(
+                &turn,
+                "reporting",
+                &input,
+                &crate::ports::types::StartedBy::from_scheduled(false),
+                Some(RUN_ID),
+                None,
+            );
+            rt.journal()
+                .record_blocked_node_stashed_checkpointed(
+                    &turn,
+                    "reporting",
+                    &input,
+                    &crate::ports::types::StartedBy::from_scheduled(false),
+                    Some(RUN_ID),
+                    None,
+                )
+                .await
+                .expect("stashes");
+
+            rt.apply_blocker_reply(&[id], BlockerReplyIntent::Cancel, "cancel that", None)
+                .await
+                .expect("applies");
+
+            assert!(
+                !rt.blocked_nodes.is_armed(&turn),
+                "a cancel must retire the stash it parked with, not leave it stranded until \
+                 restart"
+            );
+            assert!(
+                rt.journal()
+                    .blocked_stashes()
+                    .iter()
+                    .all(|(recorded_turn, ..)| recorded_turn != &turn),
+                "the durable stash mirror must be retired too"
+            );
+            let remaining = checkpoints
+                .get_thread(RUN_ID)
+                .await
+                .expect("checkpoint read");
+            assert!(
+                remaining.is_empty(),
+                "a cancel must prune the checkpoint lineage its stash named, the same as every \
+                 other terminal outcome: {remaining:?}"
+            );
+        }
+
+        /// The restart reconciler's own retire path for an unapproved stranded
+        /// stash (a cancel that crashed before its own cleanup ran, or any
+        /// other resolved-with-nothing-approved shape) must prune that stash's
+        /// checkpoint lineage too, not only release the stash.
+        #[cfg(feature = "openhuman")]
+        #[tokio::test]
+        async fn reconcile_stranded_blocked_nodes_prunes_checkpoint_lineage_for_an_unapproved_stash()
+         {
+            use tinyflows::graph::Checkpointer;
+
+            let home = seed_home();
+            let mut rt = crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), manifest())
+                .with_id(CompanyId::new("acme"))
+                .with_seed_dir(home.path().to_path_buf())
+                .build()
+                .await
+                .expect("runtime builds");
+            let checkpoints = std::sync::Arc::new(
+                crate::workflows::checkpoint_store::WorkflowCheckpointStore::new(
+                    home.path().join("checkpoints"),
+                ),
+            );
+            checkpoints
+                .put(tinyflows::graph::Checkpoint {
+                    thread_id: RUN_ID.to_string(),
+                    checkpoint_id: "c1".to_string(),
+                    run_id: Some(RUN_ID.to_string()),
+                    parent_checkpoint_id: None,
+                    namespace: Vec::new(),
+                    state: json!({}),
+                    next_nodes: vec![tinyflows::graph::ids::NodeId::new(NODE_ID)],
+                    completed_tasks: Vec::new(),
+                    pending_writes: Vec::new(),
+                    interrupts: Vec::new(),
+                    pending_activations: None,
+                    barrier_arrivals: Vec::new(),
+                    metadata: Value::Null,
+                })
+                .await
+                .expect("seed checkpoint");
+            rt.set_workflow_checkpoints(checkpoints.clone());
+
+            // Stashed but never parked (or already resolved with nothing left
+            // in the journal's live set) — the same "stranded, unapproved"
+            // shape a crash mid-cleanup leaves behind.
+            let turn = workflow_node_turn_key(RUN_ID, NODE_ID);
+            rt.blocked_nodes.arm_checkpointed(
+                &turn,
+                "reporting",
+                &json!({ "topic": "quarterly numbers" }),
+                &crate::ports::types::StartedBy::from_scheduled(false),
+                Some(RUN_ID),
+                None,
+            );
+
+            rt.reconcile_stranded_blocked_nodes().await;
+
+            assert!(
+                !rt.blocked_nodes.is_armed(&turn),
+                "an unapproved stranded stash must be retired"
+            );
+            let remaining = checkpoints
+                .get_thread(RUN_ID)
+                .await
+                .expect("checkpoint read");
+            assert!(
+                remaining.is_empty(),
+                "the reconciler must prune the checkpoint lineage an unapproved stranded stash \
+                 names, not only release the stash: {remaining:?}"
             );
         }
     }

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -370,6 +370,23 @@ pub const CONTINUATION_PERFORMED_KEY: &str = "__opencompany_performed";
 /// question and stack a duplicate card.
 pub const CONTINUATION_DENIED_KEY: &str = "__opencompany_denied";
 
+/// The reserved trigger-input key an **answered node blocker** rides into a
+/// continuation run under (issue #2005).
+///
+/// Reserved on [`CONTINUATION_DELIVERED_KEY`]'s terms — host-written, host-read,
+/// opaque to the engine — and stripped before two parked gates are compared
+/// ([`is_same_gate`]) for the reason all three ledger keys are.
+///
+/// Where it differs from them is the direction it is allowed to fail in.
+/// A ledger says what must NOT happen again, so a garbled one degrades to
+/// "deliver / call / ask" — the pre-ledger behaviour, and safe. This key
+/// carries the operator's own decision about a stopped node, so degrading it to
+/// "nothing known" is exactly the silent drop the blocker family exists to
+/// prevent. [`blocker_answers_in_input`] therefore reads it strictly and fails
+/// loudly, and the caller settles the node rather than running it as if nobody
+/// had answered.
+pub const CONTINUATION_BLOCKER_KEY: &str = "__opencompany_blockers";
+
 /// What approving a workflow gate actually does, in the operator's own terms.
 ///
 /// This rides the card as [`PAYLOAD_NOTE`] rather than living only in a design
@@ -515,6 +532,145 @@ pub fn denied_in_input(input: &Value) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// One node whose blocker an operator has answered, riding a continuation's
+/// trigger input under [`CONTINUATION_BLOCKER_KEY`] (issue #2005).
+///
+/// The durable [`BlockerResolution`](crate::ports::blockers::BlockerResolution)
+/// narrowed to what the engine side needs: which node the answer is about, what
+/// the operator asked for, and the words an
+/// [`Amend`](crate::ports::blockers::BlockerVerdict::Amend) re-enters carrying.
+/// `node` is the run's own resolved node id — the graph node when there is one,
+/// the agent ref otherwise — which is the same identity
+/// [`BlockerStep::Node`](crate::ports::blockers::BlockerStep::Node) and
+/// [`WorkflowBlockedNode::node_id`](crate::ports::WorkflowBlockedNode::node_id)
+/// carry, so the park and the re-entry agree by construction.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockerAnswer {
+    /// The node the answer re-enters.
+    pub node: String,
+    /// What the operator asked that node to do.
+    pub verdict: crate::ports::blockers::BlockerVerdict,
+    /// The operator's words, for the verdict that carries them.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub answer: String,
+}
+
+/// Every answered blocker riding `input`, or a loud error for a key that is
+/// present and unreadable (issue #2005).
+///
+/// Strict where [`delivered_in_input`] and its siblings are tolerant, and the
+/// asymmetry is the point — see [`CONTINUATION_BLOCKER_KEY`]. A row that names
+/// a verdict this build does not know, or that is not an answer at all, means
+/// the host and the engine disagree about what the operator decided; running
+/// the node as though nobody had answered would spend a turn on the identical
+/// failure and re-park the identical question, with the answer gone.
+///
+/// An absent key is not an error: it is a first run, and every node runs as it
+/// always did.
+pub fn blocker_answers_in_input(input: &Value) -> Result<Vec<BlockerAnswer>> {
+    let Some(raw) = input.get(CONTINUATION_BLOCKER_KEY) else {
+        return Ok(Vec::new());
+    };
+    let rows = raw.as_array().ok_or_else(|| {
+        OpenCompanyError::InvalidRequest(format!(
+            "a workflow run's trigger input carries `{CONTINUATION_BLOCKER_KEY}` as something \
+             other than a list of answered blockers, so an operator's answer cannot be read"
+        ))
+    })?;
+    rows.iter()
+        .map(|row| {
+            serde_json::from_value::<BlockerAnswer>(row.clone()).map_err(|err| {
+                OpenCompanyError::InvalidRequest(format!(
+                    "a workflow run's trigger input carries an unreadable answered blocker \
+                     under `{CONTINUATION_BLOCKER_KEY}`: {err}"
+                ))
+            })
+        })
+        .collect()
+}
+
+/// The answer riding `input` for `node`, if the operator gave one.
+///
+/// The one call an executing node makes. Errors on the same terms
+/// [`blocker_answers_in_input`] does, and on one more:
+/// [`Cancel`](crate::ports::blockers::BlockerVerdict::Cancel) never starts a
+/// run — the resume fork short-circuits before any cycle — so finding one here
+/// means a cancelled blocker's answer reached a running graph, and the node
+/// must stop rather than quietly carry on as if the operator had said yes.
+pub fn blocker_answer_for(input: &Value, node: &str) -> Result<Option<BlockerAnswer>> {
+    let Some(answer) = blocker_answers_in_input(input)?
+        .into_iter()
+        .find(|answer| answer.node == node)
+    else {
+        return Ok(None);
+    };
+    if !answer.verdict.resumes() {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "workflow node `{node}` was reached carrying a `{}` blocker answer, which starts \
+             no run at all",
+            answer.verdict.as_str()
+        )));
+    }
+    Ok(Some(answer))
+}
+
+/// Writes `answer` onto the trigger input under [`CONTINUATION_BLOCKER_KEY`],
+/// superseding any earlier answer for the same node (issue #2005).
+///
+/// Accumulating rather than replacing the whole list, on [`with_denied`]'s
+/// reasoning: a graph whose second node blocks after the first was answered
+/// must not forget the first, or the continuation re-runs a node the operator
+/// already skipped. Last write per node wins — a node retried, blocked again
+/// and then skipped is skipped, because the newer decision is the operator's
+/// current one.
+///
+/// A non-object input becomes one carrying just this key: there is nowhere else
+/// to put it, and [`with_approvals`] already takes the same liberty.
+pub fn with_blocker_answer(input: Value, answer: &BlockerAnswer) -> Value {
+    let mut answers = blocker_answers_in_input(&input).unwrap_or_default();
+    answers.retain(|prior| prior.node != answer.node);
+    answers.push(answer.clone());
+    let mut map = match input {
+        Value::Object(map) => map,
+        _ => Map::new(),
+    };
+    map.insert(
+        CONTINUATION_BLOCKER_KEY.to_string(),
+        serde_json::json!(answers),
+    );
+    Value::Object(map)
+}
+
+/// The trigger input a node blocker's continuation runs with (issue #2005):
+/// the blocked run's own input, plus the operator's answer for `node`.
+///
+/// Refuses a non-resuming verdict rather than building an input for it. A
+/// [`Cancel`](crate::ports::blockers::BlockerVerdict::Cancel) settles the run
+/// and starts nothing, so reaching here with one is a caller that skipped the
+/// fork — loud beats a continuation that re-runs the work the operator asked to
+/// abandon.
+pub fn blocker_continuation_input(
+    input: Value,
+    node: &str,
+    resolution: &crate::ports::blockers::BlockerResolution,
+) -> Result<Value> {
+    if !resolution.resumes() {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow continuation was asked for on node `{node}` with a `{}` blocker \
+             answer, which abandons the work rather than re-entering it",
+            resolution.verdict.as_str()
+        )));
+    }
+    Ok(with_blocker_answer(
+        input,
+        &BlockerAnswer {
+            node: node.to_string(),
+            verdict: resolution.verdict,
+            answer: resolution.answer.clone(),
+        },
+    ))
 }
 
 /// The gate node a parked [`WORKFLOW_APPROVE_KIND`] effect is asking about, or
@@ -864,16 +1020,17 @@ fn decided_input(effect: &Effect) -> Option<Value> {
 /// `input` with the reserved host-threaded ledger keys removed. A non-object
 /// input is returned as-is — there is nothing to strip.
 ///
-/// All three keys, and none is optional: a continuation's input differs from
+/// All four keys, and none is optional: a continuation's input differs from
 /// the paused run's by exactly these — the delivery ledger (#438), the
-/// outward-call ledger (#846) and the denial ledger (#978) — so letting any of
-/// those differences count would make every continuation gate a "new" decision
-/// and stack a duplicate card.
+/// outward-call ledger (#846), the denial ledger (#978) and an answered node
+/// blocker (#2005) — so letting any of those differences count would make every
+/// continuation gate a "new" decision and stack a duplicate card.
 fn without_ledger(mut input: Value) -> Value {
     if let Value::Object(map) = &mut input {
         map.remove(CONTINUATION_DELIVERED_KEY);
         map.remove(CONTINUATION_PERFORMED_KEY);
         map.remove(CONTINUATION_DENIED_KEY);
+        map.remove(CONTINUATION_BLOCKER_KEY);
     }
     input
 }
@@ -2228,6 +2385,172 @@ mod tests {
         let input = single_continuation_input(&card).expect("continues");
         assert!(input.get(CONTINUATION_DELIVERED_KEY).is_none(), "{input}");
         assert!(delivered_in_input(&input).is_empty());
+    }
+
+    // ── Issue #2005: the answered-blocker key ────────────────────────────────
+
+    fn resolution(
+        verdict: crate::ports::blockers::BlockerVerdict,
+        answer: &str,
+    ) -> crate::ports::blockers::BlockerResolution {
+        crate::ports::blockers::BlockerResolution::answered(verdict, answer)
+    }
+
+    /// A first run carries no answer, and reading one is not an error — it is
+    /// the ordinary case for every node that never blocked.
+    #[test]
+    fn an_input_with_no_answered_blocker_reads_as_nothing() {
+        let input = serde_json::json!({ "request": "x" });
+        assert!(
+            blocker_answers_in_input(&input)
+                .expect("readable")
+                .is_empty()
+        );
+        assert!(
+            blocker_answer_for(&input, "draft")
+                .expect("readable")
+                .is_none()
+        );
+    }
+
+    /// The headline of the thread: the verdict and the operator's words ride
+    /// the continuation's trigger input, keyed by the node they re-enter.
+    #[test]
+    fn an_answer_rides_the_trigger_input_keyed_by_its_node() {
+        use crate::ports::blockers::BlockerVerdict;
+        let input = blocker_continuation_input(
+            serde_json::json!({ "request": "x" }),
+            "draft",
+            &resolution(BlockerVerdict::Amend, "use gpt-4o-mini"),
+        )
+        .expect("continues");
+        assert_eq!(input["request"], "x", "the blocked run's input is kept");
+        let answer = blocker_answer_for(&input, "draft")
+            .expect("readable")
+            .expect("the answer is there");
+        assert_eq!(answer.verdict, BlockerVerdict::Amend);
+        assert_eq!(answer.answer, "use gpt-4o-mini");
+        assert!(
+            blocker_answer_for(&input, "other")
+                .expect("readable")
+                .is_none(),
+            "an answer is about one node, not the graph"
+        );
+    }
+
+    /// A two-blocker lineage must not forget the first node's answer when the
+    /// second is decided — the same accumulation the denial ledger keeps.
+    #[test]
+    fn a_second_nodes_answer_does_not_forget_the_first() {
+        use crate::ports::blockers::BlockerVerdict;
+        let first = blocker_continuation_input(
+            serde_json::json!({ "request": "x" }),
+            "draft",
+            &resolution(BlockerVerdict::Skip, ""),
+        )
+        .expect("continues");
+        let second =
+            blocker_continuation_input(first, "review", &resolution(BlockerVerdict::Retry, ""))
+                .expect("continues");
+        assert_eq!(
+            blocker_answers_in_input(&second).expect("readable").len(),
+            2
+        );
+        assert_eq!(
+            blocker_answer_for(&second, "draft")
+                .expect("readable")
+                .expect("kept")
+                .verdict,
+            BlockerVerdict::Skip
+        );
+    }
+
+    /// A node retried, blocked again and then skipped is skipped: the operator's
+    /// newest decision is the one in force.
+    #[test]
+    fn a_later_answer_supersedes_an_earlier_one_for_the_same_node() {
+        use crate::ports::blockers::BlockerVerdict;
+        let first = blocker_continuation_input(
+            serde_json::json!({ "request": "x" }),
+            "draft",
+            &resolution(BlockerVerdict::Retry, ""),
+        )
+        .expect("continues");
+        let second =
+            blocker_continuation_input(first, "draft", &resolution(BlockerVerdict::Skip, ""))
+                .expect("continues");
+        assert_eq!(
+            blocker_answers_in_input(&second).expect("readable").len(),
+            1,
+            "one node carries one live decision"
+        );
+        assert_eq!(
+            blocker_answer_for(&second, "draft")
+                .expect("readable")
+                .expect("kept")
+                .verdict,
+            BlockerVerdict::Skip
+        );
+    }
+
+    /// The asymmetry with the ledgers, pinned: an unreadable answer is loud.
+    /// Degrading it to "nobody answered" would re-run the node into the
+    /// identical failure with the operator's decision gone.
+    #[test]
+    fn an_unreadable_answer_is_loud_rather_than_ignored() {
+        let not_a_list = serde_json::json!({ CONTINUATION_BLOCKER_KEY: "retry" });
+        assert!(blocker_answers_in_input(&not_a_list).is_err());
+
+        let unknown_verdict = serde_json::json!({
+            CONTINUATION_BLOCKER_KEY: [{ "node": "draft", "verdict": "shrug" }]
+        });
+        assert!(blocker_answers_in_input(&unknown_verdict).is_err());
+        assert!(blocker_answer_for(&unknown_verdict, "draft").is_err());
+
+        let no_node = serde_json::json!({
+            CONTINUATION_BLOCKER_KEY: [{ "verdict": "retry" }]
+        });
+        assert!(blocker_answers_in_input(&no_node).is_err());
+    }
+
+    /// A cancel abandons the work, so neither the writer nor the reader will
+    /// carry one into a run.
+    #[test]
+    fn a_cancelled_answer_is_refused_at_both_ends() {
+        use crate::ports::blockers::BlockerVerdict;
+        assert!(
+            blocker_continuation_input(
+                serde_json::json!({ "request": "x" }),
+                "draft",
+                &resolution(BlockerVerdict::Cancel, ""),
+            )
+            .is_err(),
+            "a cancel builds no continuation input"
+        );
+        let smuggled = serde_json::json!({
+            CONTINUATION_BLOCKER_KEY: [{ "node": "draft", "verdict": "cancel" }]
+        });
+        assert!(
+            blocker_answer_for(&smuggled, "draft").is_err(),
+            "a node reached carrying a cancel must stop, not carry on"
+        );
+    }
+
+    /// The key describes what was already decided, not what is being decided,
+    /// so it must not split one gate into two cards on a continuation.
+    #[test]
+    fn an_answered_blocker_is_not_part_of_a_gates_identity() {
+        use crate::ports::blockers::BlockerVerdict;
+        let input = serde_json::json!({ "request": "x" });
+        let paused = gate_effect("digest", "gate", &input, "run-1", &[], &[], None);
+        let resumed_input =
+            blocker_continuation_input(input, "draft", &resolution(BlockerVerdict::Retry, ""))
+                .expect("continues");
+        let resumed = gate_effect("digest", "gate", &resumed_input, "run-2", &[], &[], None);
+        assert!(
+            is_same_gate(&paused, &resumed),
+            "one gate, one decision, however many blockers the lineage answered"
+        );
     }
 
     /// The ledger must not make a continuation's gate look like a *different*

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -3253,8 +3253,7 @@ fn blocked_diagnosis(node_id: Option<&str>, agent_ref: &str, parked: &ParkedCall
     } else if parked.blockers == waiting {
         format!(
             " {} a question the agent raised, not a call waiting to be authorised: answering it \
-             re-enters this step — retry runs it again, an answer runs it again carrying your \
-             words, skip moves past it, and cancel stops the run.",
+             re-enters this step — approving runs it again, and denying stops the run.",
             if waiting == 1 {
                 "The card is"
             } else {
@@ -6181,7 +6180,7 @@ mod tests {
             "an answered blocker does re-enter the step it stopped: {text}"
         );
         assert!(
-            text.contains("cancel stops the run"),
+            text.contains("denying stops the run"),
             "and the one verdict that starts nothing has to be named: {text}"
         );
 

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1578,6 +1578,71 @@ impl HarnessAgentRunner {
     /// failure and park the identical question. The gated-call case does not
     /// have that problem — approving there mints the grant that makes the
     /// retry succeed.
+    /// Stashes what re-entering `resolved_node_id` will need once its blocker
+    /// is answered (issue #2005): the workflow, this run's trigger input, its
+    /// attribution, and the checkpoint lineage #1864's node-level restart
+    /// resumes from.
+    ///
+    /// A blocker park cannot borrow the gated-call path's stash. That one is
+    /// armed in [`park_gated_calls`](Self::park_gated_calls) only once there is
+    /// a gated call to park — a turn that parked nothing else returns before
+    /// reaching it — and the runner's settle-time pass deliberately refuses to
+    /// arm a turn that is not already armed, so a blocker-only node reached the
+    /// resume with no run to continue. Written here, at park time and before
+    /// any card is clickable, on exactly the ordering the gated-call arm keeps.
+    ///
+    /// Keyed per (run, node) like its sibling, so a node that parked a gated
+    /// call *and* then blocked shares one stash and one dispatch marker: either
+    /// answer re-enters the node once, and the second finds the continuation
+    /// already dispatched rather than launching a duplicate. Arming is
+    /// first-write-wins, so the two cannot disagree.
+    ///
+    /// No [`ContinuationQueue`](crate::runtime::continuation::ContinuationQueue)
+    /// arm accompanies it. A blocker parks with no turn key by design — see
+    /// [`park_node_blocker`](Self::park_node_blocker) — and its resume is driven
+    /// by the answer itself, not by a decision batch emptying.
+    ///
+    /// Best-effort on the durable half, matching every other park-time write
+    /// here: a failed journal append leaves the in-memory stash serving the
+    /// no-restart case, and failing the node over it would be the wrong trade.
+    async fn stash_node_blocker_resume(
+        &self,
+        parking: &crate::workflows::delivery::DeliveryParking,
+        resolved_node_id: &str,
+    ) {
+        let turn =
+            crate::runtime::workflow_resume::workflow_node_turn_key(&self.run_id, resolved_node_id);
+        parking.blocked_nodes.arm_checkpointed(
+            &turn,
+            &self.workflow_id,
+            &self.trigger_input,
+            &self.started_by,
+            Some(&self.checkpoint_thread_id),
+            self.workflow_fingerprint.as_deref(),
+        );
+        if let Err(error) = parking
+            .journal
+            .record_blocked_node_stashed_checkpointed(
+                &turn,
+                &self.workflow_id,
+                &self.trigger_input,
+                &self.started_by,
+                Some(&self.checkpoint_thread_id),
+                self.workflow_fingerprint.as_deref(),
+            )
+            .await
+        {
+            tracing::warn!(
+                company = %self.company,
+                run_id = %self.run_id,
+                node = resolved_node_id,
+                %error,
+                "workflow agent node: a parked blocker's continuation facts could not be \
+                 durably stashed; the in-memory stash still covers an answer without a restart"
+            );
+        }
+    }
+
     async fn park_node_blocker(&self, resolved_node_id: &str, message: &str) -> Option<String> {
         let class = crate::harness::built_in::blockers::classify_blocker_message(message)?;
         self.park_node_blocker_as(
@@ -1649,6 +1714,8 @@ impl HarnessAgentRunner {
             .await
         {
             Ok(approval_id) => {
+                self.stash_node_blocker_resume(parking, resolved_node_id)
+                    .await;
                 tracing::info!(
                     company = %self.company,
                     run_id = %self.run_id,
@@ -1783,6 +1850,8 @@ impl HarnessAgentRunner {
                 .await
             {
                 Ok(approval_id) => {
+                    self.stash_node_blocker_resume(parking, resolved_node_id)
+                        .await;
                     push_tool(&mut summary.tools, &blocker_request.tool);
                     summary.approval_ids.push(approval_id.to_string());
                     summary.blockers += 1;

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1823,18 +1823,20 @@ impl HarnessAgentRunner {
             .partition(|r| r.effect.kind.starts_with("blocker."));
         requests = remaining;
 
-        let blocker_stash_already_armed = !blocker_requests.is_empty()
+        let blocker_stash_pre_existing = !blocker_requests.is_empty()
             && self
                 .deps
                 .delivery
                 .as_ref()
                 .and_then(|d| d.parking.as_ref())
                 .is_some_and(|parking| parking.blocked_nodes.is_armed(node_turn));
+        let mut blocker_stash_armed_this_call = false;
         if !blocker_requests.is_empty()
             && let Some(parking) = self.deps.delivery.as_ref().and_then(|d| d.parking.as_ref())
         {
             self.stash_node_blocker_resume(parking, resolved_node_id)
                 .await;
+            blocker_stash_armed_this_call = true;
         }
         for mut blocker_request in blocker_requests {
             // Extract the blocker payload from the effect, add the node step, and park it.
@@ -1946,7 +1948,8 @@ impl HarnessAgentRunner {
             // none filed no receipt at all — `summary.unparkable` stayed 0 and
             // the node read as clean. The discard bookkeeping now happens
             // first; this only has to flush what it recorded.
-            if !blocker_stash_already_armed
+            if blocker_stash_armed_this_call
+                && !blocker_stash_pre_existing
                 && summary.approval_ids.is_empty()
                 && let Some(parking) = self.deps.delivery.as_ref().and_then(|d| d.parking.as_ref())
             {
@@ -6465,6 +6468,64 @@ mod tests {
             );
         assert_eq!(stashed.1, "wf-1825-p1b");
         assert_eq!(stashed.2, trigger_input);
+    }
+
+    /// A node whose turn parks neither a gated call nor a blocker must never
+    /// touch the blocked-node stash at all — `park_gated_calls` runs on every
+    /// ordinary node, and most never block. The release-on-total-failure
+    /// cleanup this queues must only fire for a turn this very call armed.
+    #[tokio::test]
+    async fn park_gated_calls_leaves_an_unstashed_turn_untouched() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-2005-release-guard-")
+            .tempdir()
+            .expect("tempdir");
+        let (deps, _journal) =
+            crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+        let trigger_input = json!({ "topic": "quarterly numbers" });
+        let board_claim = Arc::new(deps.delegations.claim_board("run-2005-guard"));
+        let publish_refusal_claim = Arc::new(
+            deps.pending_publishes
+                .claim_refusals_for_run("run-2005-guard"),
+        );
+        let runner = HarnessAgentRunner::new(
+            single_turn(&deps),
+            deps,
+            crate::workflows::gated_tool_turn_test::record(),
+            CompanyId::new("acme"),
+            "reporting".to_string(),
+            "run-2005-guard".to_string(),
+            None,
+            trigger_input,
+            crate::ports::types::StartedBy::Operator,
+            RunNotices::default(),
+            RunBoard::default(),
+            RunBlocks::default(),
+            RunCappedNodes::default(),
+            RunApprovals::default(),
+            RunArtifacts::default(),
+            board_claim,
+            publish_refusal_claim,
+        );
+
+        let node_turn =
+            crate::runtime::workflow_resume::workflow_node_turn_key(&runner.run_id, "work");
+
+        // Nothing was ever queued for this node's turn — no blocker, no gated
+        // call — so this call never armed a stash for it.
+        let summary = runner
+            .park_gated_calls(Some("work"), "work", &node_turn)
+            .await;
+        assert_eq!(summary.approval_ids.len(), 0);
+
+        // A turn that never touches the journal never creates the file.
+        let raw = tokio::fs::read_to_string(dir.path().join("journal.jsonl"))
+            .await
+            .unwrap_or_default();
+        assert!(
+            !raw.contains("BlockedNodeReleased"),
+            "a turn this call never stashed must not durably record a release for it: {raw}"
+        );
     }
 
     /// Issue #1825 (P2, third follow-up — found by chatgpt-codex-connector): a

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1700,6 +1700,13 @@ impl HarnessAgentRunner {
             agent: None,
             run_id: Some(self.run_id.clone()),
         };
+
+        let turn =
+            crate::runtime::workflow_resume::workflow_node_turn_key(&self.run_id, resolved_node_id);
+        let already_stashed = parking.blocked_nodes.is_armed(&turn);
+        self.stash_node_blocker_resume(parking, resolved_node_id)
+            .await;
+
         match parking
             .park_and_journal(
                 &self.company,
@@ -1714,8 +1721,6 @@ impl HarnessAgentRunner {
             .await
         {
             Ok(approval_id) => {
-                self.stash_node_blocker_resume(parking, resolved_node_id)
-                    .await;
                 tracing::info!(
                     company = %self.company,
                     run_id = %self.run_id,
@@ -1727,6 +1732,22 @@ impl HarnessAgentRunner {
                 Some(approval_id.to_string())
             }
             Err(err) => {
+                if !already_stashed {
+                    parking.blocked_nodes.release(&turn);
+                    if let Err(release_err) =
+                        parking.journal.record_blocked_node_released(&turn).await
+                    {
+                        tracing::warn!(
+                            company = %self.company,
+                            run_id = %self.run_id,
+                            node = resolved_node_id,
+                            error = %release_err,
+                            "workflow agent node: a blocker's stash could not be durably \
+                             retired after its park failed; a stale entry may linger until \
+                             a manual sweep"
+                        );
+                    }
+                }
                 // Loud, and then the node settles `Failed` as it did before:
                 // holding a run open on a question that reached nobody would be
                 // strictly worse than the failure it replaced.
@@ -1801,6 +1822,20 @@ impl HarnessAgentRunner {
             .into_iter()
             .partition(|r| r.effect.kind.starts_with("blocker."));
         requests = remaining;
+
+        let blocker_stash_already_armed = !blocker_requests.is_empty()
+            && self
+                .deps
+                .delivery
+                .as_ref()
+                .and_then(|d| d.parking.as_ref())
+                .is_some_and(|parking| parking.blocked_nodes.is_armed(node_turn));
+        if !blocker_requests.is_empty()
+            && let Some(parking) = self.deps.delivery.as_ref().and_then(|d| d.parking.as_ref())
+        {
+            self.stash_node_blocker_resume(parking, resolved_node_id)
+                .await;
+        }
         for mut blocker_request in blocker_requests {
             // Extract the blocker payload from the effect, add the node step, and park it.
             let mut payload: crate::ports::blockers::BlockerPayload =
@@ -1850,8 +1885,6 @@ impl HarnessAgentRunner {
                 .await
             {
                 Ok(approval_id) => {
-                    self.stash_node_blocker_resume(parking, resolved_node_id)
-                        .await;
                     push_tool(&mut summary.tools, &blocker_request.tool);
                     summary.approval_ids.push(approval_id.to_string());
                     summary.blockers += 1;
@@ -1913,6 +1946,27 @@ impl HarnessAgentRunner {
             // none filed no receipt at all — `summary.unparkable` stayed 0 and
             // the node read as clean. The discard bookkeeping now happens
             // first; this only has to flush what it recorded.
+            if !blocker_stash_already_armed
+                && summary.approval_ids.is_empty()
+                && let Some(parking) = self.deps.delivery.as_ref().and_then(|d| d.parking.as_ref())
+            {
+                parking.blocked_nodes.release(node_turn);
+                if let Err(error) = parking
+                    .journal
+                    .record_blocked_node_released(node_turn)
+                    .await
+                {
+                    tracing::warn!(
+                        company = %self.company,
+                        run_id = %self.run_id,
+                        node_turn,
+                        %error,
+                        "workflow agent node: every blocker for this node failed to park, but \
+                         retiring the stash armed for it also failed durably; a stale entry may \
+                         linger until a manual sweep"
+                    );
+                }
+            }
             self.approvals.extend(rows);
             return summary;
         }
@@ -3237,13 +3291,10 @@ fn blocked_diagnosis(node_id: Option<&str>, agent_ref: &str, parked: &ParkedCall
             if parked.unparkable == 1 { "it" } else { "them" }
         ));
     }
-    // What deciding the cards actually does, which is not one answer. A gated
-    // call's park carries the node's turn key, so a verdict re-runs the turn and
-    // the run goes on. A blocker's does not — it is parked `Unlinked` with no
-    // continuation, because answering a question is not authorising a call — and
-    // its answer re-enters the step down its own path instead, which is what the
-    // four words mean rather than a bare approve. Saying only "this continues"
-    // for a blocker would hide that a cancel stops the run.
+    // Gated calls and blocker questions resume differently: a gated call's
+    // approval re-runs the turn, a blocker's approve/deny re-enters or stops
+    // the step — the sentence below has to name only the verdicts the console
+    // can actually send for whichever shape (or mix) is waiting.
     let resume = if waiting == 0 {
         String::new()
     } else if parked.blockers == 0 {
@@ -3262,8 +3313,8 @@ fn blocked_diagnosis(node_id: Option<&str>, agent_ref: &str, parked: &ParkedCall
         )
     } else {
         " Some of these are gated tool calls, which continue this run when approved; the rest \
-         are questions the agent raised, which re-enter the step they stopped — retry, answer or \
-         skip carries it on, cancel stops the run."
+         are questions the agent raised, which re-enter the step they stopped — approving runs \
+         it again, and denying stops the run."
             .to_string()
     };
     format!(
@@ -6200,6 +6251,16 @@ mod tests {
             "a mixed node has to describe both, since neither sentence is true of all of it: \
              {text}"
         );
+        assert!(
+            text.contains("denying stops the run"),
+            "a mixed node's blocker cards still only resolve by approve or deny, the same \
+             vocabulary the blocker-only branch above uses: {text}"
+        );
+        assert!(
+            !text.contains("retry") && !text.contains("skip") && !text.contains("cancel"),
+            "the console only reaches approve/deny on a workflow-node blocker, so a mixed node \
+             must not promise verdicts it cannot send: {text}"
+        );
 
         // Nothing was parked at all — every call failed to park — so there is
         // no card to promise anything about.
@@ -8486,6 +8547,270 @@ mod tests {
                 .expect("a parked blocker must stash the run its answer re-enters");
             assert_eq!(stashed.workflow_id, "reporting");
             assert_eq!(stashed.input, trigger_input);
+        }
+
+        /// A resolver racing in against a live blocker park must always find
+        /// the stash already armed. This spies on the approval gate's own
+        /// `park` call and captures whether the stash is armed at that exact
+        /// point — deterministic, no wall-clock race needed, on the same
+        /// principle as
+        /// `park_and_journal_arms_the_continuation_slot_before_the_card_is_parkable`
+        /// in `workflows::delivery`.
+        #[tokio::test]
+        async fn park_node_blocker_as_arms_the_stash_before_the_card_is_parkable() {
+            use crate::ports::ApprovalGate;
+            use crate::ports::types::{Actor, ApprovalId, Effect, PolicyDecision, Verdict};
+
+            struct Spy {
+                inner: Arc<dyn ApprovalGate>,
+                blocked_nodes: crate::runtime::blocked_nodes::BlockedNodeQueue,
+                turn: String,
+                armed_at_park: std::sync::Mutex<Option<bool>>,
+            }
+
+            #[async_trait]
+            impl ApprovalGate for Spy {
+                async fn evaluate(
+                    &self,
+                    company: &CompanyId,
+                    effect: &Effect,
+                ) -> crate::Result<PolicyDecision> {
+                    self.inner.evaluate(company, effect).await
+                }
+
+                async fn park(
+                    &self,
+                    company: &CompanyId,
+                    effect: Effect,
+                ) -> crate::Result<ApprovalId> {
+                    *self.armed_at_park.lock().expect("spy lock") =
+                        Some(self.blocked_nodes.is_armed(&self.turn));
+                    self.inner.park(company, effect).await
+                }
+
+                async fn resolve(
+                    &self,
+                    id: &ApprovalId,
+                    verdict: Verdict,
+                    by: Actor,
+                ) -> crate::Result<Option<Effect>> {
+                    self.inner.resolve(id, verdict, by).await
+                }
+            }
+
+            let dir = tmp("oc-2005-race-a-");
+            let (mut deps, _journal) =
+                crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+            let parking = deps
+                .delivery
+                .clone()
+                .expect("delivery")
+                .parking
+                .clone()
+                .expect("parking");
+
+            let run_id = "run-2005-race-a".to_string();
+            let turn = workflow_node_turn_key(&run_id, "gather");
+            let spy = Arc::new(Spy {
+                inner: parking.approvals.clone(),
+                blocked_nodes: parking.blocked_nodes.clone(),
+                turn: turn.clone(),
+                armed_at_park: std::sync::Mutex::new(None),
+            });
+            let mut spied_parking = parking.clone();
+            spied_parking.approvals = spy.clone();
+            deps.delivery.as_mut().expect("delivery").parking = Some(spied_parking);
+
+            let trigger_input = json!({ "topic": "quarterly numbers" });
+            let board_claim = Arc::new(deps.delegations.claim_board(&run_id));
+            let publish_refusal_claim =
+                Arc::new(deps.pending_publishes.claim_refusals_for_run(&run_id));
+            let runner = HarnessAgentRunner::new(
+                single_turn(&deps),
+                deps,
+                crate::workflows::gated_tool_turn_test::record(),
+                CompanyId::new("acme"),
+                "reporting".to_string(),
+                run_id,
+                None,
+                trigger_input,
+                crate::ports::types::StartedBy::Operator,
+                RunNotices::default(),
+                RunBoard::default(),
+                RunBlocks::default(),
+                RunCappedNodes::default(),
+                RunApprovals::default(),
+                RunArtifacts::default(),
+                board_claim,
+                publish_refusal_claim,
+            );
+
+            let parked = runner
+                .park_node_blocker_as(
+                    "gather",
+                    "the model id `gpt-nope` was rejected",
+                    BlockerKind::Infrastructure,
+                    BlockerSource::Provider,
+                    "a model id this provider serves",
+                )
+                .await;
+            assert!(parked.is_some(), "the blocker parks");
+
+            let captured = spy
+                .armed_at_park
+                .lock()
+                .expect("spy lock")
+                .expect("park was called");
+            assert!(
+                captured,
+                "the blocked-node stash must already be armed by the time the approval gate's \
+                 park() runs, before the card becomes resolvable to a concurrent operator"
+            );
+        }
+
+        /// The same proof as above, for the sibling site: a blocker card
+        /// extracted from a node's gated-call batch inside `park_gated_calls`.
+        #[tokio::test]
+        async fn park_gated_calls_blocker_extraction_arms_the_stash_before_the_first_card_is_parkable()
+         {
+            use crate::harness::policy::{ApprovalRequest, ApprovalScope};
+            use crate::ports::ApprovalGate;
+            use crate::ports::blockers::BlockerPayload;
+            use crate::ports::types::{
+                Actor, ApprovalId, Effect, EffectGroup, PolicyDecision, Verdict,
+            };
+
+            struct Spy {
+                inner: Arc<dyn ApprovalGate>,
+                blocked_nodes: crate::runtime::blocked_nodes::BlockedNodeQueue,
+                turn: String,
+                armed_at_park: std::sync::Mutex<Option<bool>>,
+            }
+
+            #[async_trait]
+            impl ApprovalGate for Spy {
+                async fn evaluate(
+                    &self,
+                    company: &CompanyId,
+                    effect: &Effect,
+                ) -> crate::Result<PolicyDecision> {
+                    self.inner.evaluate(company, effect).await
+                }
+
+                async fn park(
+                    &self,
+                    company: &CompanyId,
+                    effect: Effect,
+                ) -> crate::Result<ApprovalId> {
+                    *self.armed_at_park.lock().expect("spy lock") =
+                        Some(self.blocked_nodes.is_armed(&self.turn));
+                    self.inner.park(company, effect).await
+                }
+
+                async fn resolve(
+                    &self,
+                    id: &ApprovalId,
+                    verdict: Verdict,
+                    by: Actor,
+                ) -> crate::Result<Option<Effect>> {
+                    self.inner.resolve(id, verdict, by).await
+                }
+            }
+
+            let dir = tmp("oc-2005-race-b-");
+            let (mut deps, _journal) =
+                crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+            let parking = deps
+                .delivery
+                .clone()
+                .expect("delivery")
+                .parking
+                .clone()
+                .expect("parking");
+
+            let run_id = "run-2005-race-b".to_string();
+            let turn = workflow_node_turn_key(&run_id, "work");
+            let spy = Arc::new(Spy {
+                inner: parking.approvals.clone(),
+                blocked_nodes: parking.blocked_nodes.clone(),
+                turn: turn.clone(),
+                armed_at_park: std::sync::Mutex::new(None),
+            });
+            let mut spied_parking = parking.clone();
+            spied_parking.approvals = spy.clone();
+            deps.delivery.as_mut().expect("delivery").parking = Some(spied_parking);
+
+            let queue = deps.approval_requests.clone();
+            let trigger_input = json!({ "topic": "quarterly numbers" });
+            let board_claim = Arc::new(deps.delegations.claim_board(&run_id));
+            let publish_refusal_claim =
+                Arc::new(deps.pending_publishes.claim_refusals_for_run(&run_id));
+            let runner = HarnessAgentRunner::new(
+                single_turn(&deps),
+                deps,
+                crate::workflows::gated_tool_turn_test::record(),
+                CompanyId::new("acme"),
+                "reporting".to_string(),
+                run_id.clone(),
+                None,
+                trigger_input,
+                crate::ports::types::StartedBy::Operator,
+                RunNotices::default(),
+                RunBoard::default(),
+                RunBlocks::default(),
+                RunCappedNodes::default(),
+                RunApprovals::default(),
+                RunArtifacts::default(),
+                board_claim,
+                publish_refusal_claim,
+            );
+
+            let payload = BlockerPayload {
+                kind: BlockerKind::Information,
+                source: BlockerSource::AgentQuestion,
+                step: None,
+                reason: "which quarter should I report?".to_string(),
+                needed: "the quarter to report on".to_string(),
+                group_key: None,
+            };
+            let effect_kind = payload.effect_kind();
+            let reason = payload.reason.clone();
+            let payload_value = serde_json::to_value(&payload).expect("payload serializes");
+
+            let claim = queue.claim(ApprovalScope::Run(run_id.clone()));
+            claim
+                .scoped(async {
+                    queue.push(ApprovalRequest {
+                        tool: "escalate_to_human".to_string(),
+                        reason,
+                        effect: Effect {
+                            kind: effect_kind,
+                            group: EffectGroup::Other,
+                            amount_usd: None,
+                            established_thread: false,
+                            first_time_counterparty: false,
+                            payload: payload_value,
+                            agent: None,
+                            run_id: None,
+                        },
+                    });
+                })
+                .await;
+
+            claim
+                .scoped(runner.park_gated_calls(Some("work"), "work", &turn))
+                .await;
+
+            let captured = spy
+                .armed_at_park
+                .lock()
+                .expect("spy lock")
+                .expect("park was called");
+            assert!(
+                captured,
+                "a blocker card extracted from a node's gated-call batch must find the stash \
+                 already armed by the time the approval gate's park() runs"
+            );
         }
     }
 }

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -2250,7 +2250,7 @@ impl HarnessAgentRunner {
             );
             self.notices.push(notice);
         }
-        let message = compose_turn_message(&instruction, self.run_request.as_deref());
+        let mut message = compose_turn_message(&instruction, self.run_request.as_deref());
         // Issue #881: which node this is. `translate` writes it in the
         // first-class config layer beside `agent_ref` (config cannot shadow
         // it), because the vendored `AgentRunner` boundary carries no node
@@ -2281,6 +2281,90 @@ impl HarnessAgentRunner {
         self.halted.retract(&lineage_node);
         let node_turn =
             crate::runtime::workflow_resume::workflow_node_turn_key(&self.run_id, &lineage_node);
+
+        // ── Issue #2005: the operator's answer to this node's blocker ────────
+        //
+        // The engine-side half of the blocker family. #1863 banked the verdict
+        // and delivered it into the DM; a workflow node's re-entry rides the
+        // trigger input instead, because a paused run is settled and the only
+        // way back in is a fresh run carrying what the last one learned. The
+        // answer is read here, before an attempt row is minted or a token is
+        // spent, so a `skip` costs nothing.
+        //
+        // A malformed answer fails the node rather than degrading to "nobody
+        // answered". The degrade is the exact silent drop this family exists to
+        // close: the node would spend a turn on the identical failure, park the
+        // identical question, and the operator's decision would be gone.
+        let blocker_answer = match crate::runtime::workflow_resume::blocker_answer_for(
+            &self.trigger_input,
+            &lineage_node,
+        ) {
+            Ok(answer) => answer,
+            Err(err) => {
+                let message = format!("workflow node `{lineage_node}`: {err}");
+                tracing::error!(
+                    company = %self.company,
+                    workflow = %self.workflow_id,
+                    run_id = %self.run_id,
+                    node = %lineage_node,
+                    "workflow agent node: {message}"
+                );
+                return Err(EngineError::Capability(message));
+            }
+        };
+        if let Some(answer) = &blocker_answer {
+            use crate::ports::blockers::BlockerVerdict;
+            match answer.verdict {
+                // Waived: the node does not run at all, and the branch below it
+                // proceeds on a host-authored output. Running it would re-park
+                // the very question the operator just declined to answer.
+                BlockerVerdict::Skip => {
+                    let reply = "This step was skipped: an operator waived the blocker it \
+                                 stopped on."
+                        .to_string();
+                    tracing::info!(
+                        company = %self.company,
+                        workflow = %self.workflow_id,
+                        run_id = %self.run_id,
+                        node = %lineage_node,
+                        "workflow agent node: skipped on the operator's answer to its blocker"
+                    );
+                    return Ok((
+                        json!({ "text": reply, "agent_ref": agent_ref }),
+                        crate::harness::built_in::TurnOutcome {
+                            reply,
+                            steps: Vec::new(),
+                            hit_iteration_cap: false,
+                            abnormal_stop: None,
+                            halted_for_spend: None,
+                            budget_paused: None,
+                        },
+                    ));
+                }
+                // Corrected: the node runs again carrying the operator's words,
+                // the same shape `resume_task_card` gives an amended card — the
+                // correction has to reach the turn, or the re-run repeats the
+                // failure it was answering.
+                BlockerVerdict::Amend if !answer.answer.trim().is_empty() => {
+                    message = format!(
+                        "{message}\n\n## Answer from the operator\n{}",
+                        answer.answer.trim()
+                    );
+                }
+                // A bare amend and a retry both re-run the step as it was.
+                BlockerVerdict::Amend | BlockerVerdict::Retry => {}
+                // `blocker_answer_for` refuses this arm before it can be built,
+                // and a cancel starts no run in the first place.
+                BlockerVerdict::Cancel => {
+                    let message = format!(
+                        "workflow node `{lineage_node}` was reached carrying a cancelled \
+                         blocker answer"
+                    );
+                    return Err(EngineError::Capability(message));
+                }
+            }
+        }
+
         // The node runs in its roster agent's sandbox, not the workflow tool
         // workspace. Snapshot it immediately before inference so the post-turn
         // drain can distinguish this node's writes from files already there.
@@ -3153,13 +3237,13 @@ fn blocked_diagnosis(node_id: Option<&str>, agent_ref: &str, parked: &ParkedCall
             if parked.unparkable == 1 { "it" } else { "them" }
         ));
     }
-    // What deciding the cards actually does, which is not one answer
-    // (CodeRabbit review on #1905). A gated call's park carries the node's turn
-    // key, so a verdict re-runs the turn and the run goes on. A blocker's does
-    // not — it is parked `Unlinked` with no continuation, deliberately, because
-    // answering a question is not authorising a call — so deciding it resumes
-    // nothing until #1863/#1864. Promising an auto-resume for those is how an
-    // operator ends up approving a card and watching a run that never moves.
+    // What deciding the cards actually does, which is not one answer. A gated
+    // call's park carries the node's turn key, so a verdict re-runs the turn and
+    // the run goes on. A blocker's does not — it is parked `Unlinked` with no
+    // continuation, because answering a question is not authorising a call — and
+    // its answer re-enters the step down its own path instead, which is what the
+    // four words mean rather than a bare approve. Saying only "this continues"
+    // for a blocker would hide that a cancel stops the run.
     let resume = if waiting == 0 {
         String::new()
     } else if parked.blockers == 0 {
@@ -3169,8 +3253,8 @@ fn blocked_diagnosis(node_id: Option<&str>, agent_ref: &str, parked: &ParkedCall
     } else if parked.blockers == waiting {
         format!(
             " {} a question the agent raised, not a call waiting to be authorised: answering it \
-             is recorded against the card, but it does not restart this run — re-run the \
-             workflow once the answer is in hand.",
+             re-enters this step — retry runs it again, an answer runs it again carrying your \
+             words, skip moves past it, and cancel stops the run.",
             if waiting == 1 {
                 "The card is"
             } else {
@@ -3179,8 +3263,8 @@ fn blocked_diagnosis(node_id: Option<&str>, agent_ref: &str, parked: &ParkedCall
         )
     } else {
         " Some of these are gated tool calls, which continue this run when approved; the rest \
-         are questions the agent raised, which are recorded but do not restart it — re-run the \
-         workflow once those are answered."
+         are questions the agent raised, which re-enter the step they stopped — retry, answer or \
+         skip carries it on, cancel stops the run."
             .to_string()
     };
     format!(
@@ -6062,6 +6146,11 @@ mod tests {
     /// "Approving the card continues this run automatically" for both, which
     /// for a blocker is an operator approving a card and then watching a run
     /// that never moves.
+    ///
+    /// Issue #2005 moved the truthful line rather than removing the rule: a
+    /// blocker's answer now DOES re-enter the step, but not by approving — the
+    /// four verdicts differ, and one of them stops the run. The card must
+    /// describe that, not borrow the gated call's sentence.
     #[test]
     fn the_diagnosis_only_promises_a_resume_it_can_keep() {
         let gated = ParkedCalls {
@@ -6085,11 +6174,15 @@ mod tests {
         let text = blocked_diagnosis(Some("work"), "writer", &blocker);
         assert!(
             !text.contains("continues this run automatically"),
-            "a blocker resumes nothing until #1863/#1864: {text}"
+            "a blocker is not decided by approving it: {text}"
         );
         assert!(
-            text.contains("does not restart this run"),
-            "and it has to say so, not merely omit the promise: {text}"
+            text.contains("re-enters this step"),
+            "an answered blocker does re-enter the step it stopped: {text}"
+        );
+        assert!(
+            text.contains("cancel stops the run"),
+            "and the one verdict that starts nothing has to be named: {text}"
         );
 
         let mixed = ParkedCalls {
@@ -6103,7 +6196,8 @@ mod tests {
         };
         let text = blocked_diagnosis(Some("work"), "writer", &mixed);
         assert!(
-            text.contains("continue this run when approved") && text.contains("do not restart it"),
+            text.contains("continue this run when approved")
+                && text.contains("re-enter the step they stopped"),
             "a mixed node has to describe both, since neither sentence is true of all of it: \
              {text}"
         );
@@ -6118,7 +6212,7 @@ mod tests {
         };
         let text = blocked_diagnosis(Some("work"), "writer", &none_parked);
         assert!(!text.contains("Approving the card"), "{text}");
-        assert!(!text.contains("does not restart"), "{text}");
+        assert!(!text.contains("re-enters this step"), "{text}");
     }
 
     #[tokio::test]
@@ -8040,5 +8134,359 @@ mod tests {
         )
         .await;
         assert!(blocks.take().is_empty());
+    }
+
+    /// Issue #2005: the engine-side trigger reader — what an answered blocker
+    /// riding the continuation's trigger input actually does to the node it
+    /// names.
+    mod node_blocker_answer {
+        use super::*;
+        use crate::ports::blockers::{BlockerKind, BlockerSource, BlockerVerdict};
+        use crate::runtime::workflow_resume::{
+            BlockerAnswer, CONTINUATION_BLOCKER_KEY, with_blocker_answer, workflow_node_turn_key,
+        };
+
+        const RUN_ID: &str = "run-2005";
+
+        /// A turn double that records the message it was handed, so an amend's
+        /// injection is provable and a skip's non-execution is too.
+        struct MessageRecordingTurn {
+            messages: std::sync::Mutex<Vec<String>>,
+        }
+
+        impl MessageRecordingTurn {
+            fn new() -> Self {
+                Self {
+                    messages: std::sync::Mutex::new(Vec::new()),
+                }
+            }
+
+            fn messages(&self) -> Vec<String> {
+                self.messages.lock().expect("messages").clone()
+            }
+        }
+
+        #[async_trait]
+        impl RunTurn for MessageRecordingTurn {
+            async fn run(
+                &self,
+                _company: &CompanyId,
+                _agent_id: &str,
+                message: &str,
+                _chat_id: crate::runtime::delegation::ChatTarget<'_>,
+            ) -> crate::Result<crate::harness::TurnOutcome> {
+                self.messages
+                    .lock()
+                    .expect("messages")
+                    .push(message.to_string());
+                Ok(ok_outcome())
+            }
+
+            async fn run_steered(
+                &self,
+                _company: &CompanyId,
+                _agent_id: &str,
+                message: &str,
+                _control: &crate::company::steer::SteerControl,
+                _chat_id: crate::runtime::delegation::ChatTarget<'_>,
+                _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+            ) -> crate::Result<crate::harness::TurnOutcome> {
+                self.messages
+                    .lock()
+                    .expect("messages")
+                    .push(message.to_string());
+                Ok(ok_outcome())
+            }
+
+            async fn run_steered_background(
+                &self,
+                _company: &CompanyId,
+                _agent_id: &str,
+                message: &str,
+                _control: &crate::company::steer::SteerControl,
+                _chat: crate::runtime::delegation::ChatTarget<'_>,
+                _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+            ) -> crate::Result<crate::harness::TurnOutcome> {
+                self.messages
+                    .lock()
+                    .expect("messages")
+                    .push(message.to_string());
+                Ok(ok_outcome())
+            }
+
+            async fn run_background_workflow(
+                &self,
+                _company: &CompanyId,
+                _agent_id: &str,
+                message: &str,
+                _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+                _workflow_run_id: &str,
+                _node_id: &str,
+            ) -> crate::Result<crate::harness::TurnOutcome> {
+                self.messages
+                    .lock()
+                    .expect("messages")
+                    .push(message.to_string());
+                Ok(ok_outcome())
+            }
+        }
+
+        fn answered(node: &str, verdict: BlockerVerdict, answer: &str) -> Value {
+            with_blocker_answer(
+                json!({ "topic": "quarterly numbers" }),
+                &BlockerAnswer {
+                    node: node.to_string(),
+                    verdict,
+                    answer: answer.to_string(),
+                },
+            )
+        }
+
+        async fn runner_with(
+            dir: &std::path::Path,
+            turn: Arc<MessageRecordingTurn>,
+            trigger_input: Value,
+        ) -> HarnessAgentRunner {
+            let (deps, _journal) = crate::workflows::gated_tool_turn_test::deps(String::new(), dir);
+            let board_claim = Arc::new(deps.delegations.claim_board(RUN_ID));
+            let publish_refusal_claim =
+                Arc::new(deps.pending_publishes.claim_refusals_for_run(RUN_ID));
+            HarnessAgentRunner::new(
+                turn,
+                deps,
+                crate::workflows::gated_tool_turn_test::record(),
+                CompanyId::new("acme"),
+                "reporting".to_string(),
+                RUN_ID.to_string(),
+                None,
+                trigger_input,
+                crate::ports::types::StartedBy::Operator,
+                RunNotices::default(),
+                RunBoard::default(),
+                RunBlocks::default(),
+                RunCappedNodes::default(),
+                RunApprovals::default(),
+                RunArtifacts::default(),
+                board_claim,
+                publish_refusal_claim,
+            )
+        }
+
+        fn tmp(prefix: &str) -> tempfile::TempDir {
+            tempfile::Builder::new()
+                .prefix(prefix)
+                .tempdir()
+                .expect("tempdir")
+        }
+
+        /// A skip proceeds past the node without spending a turn on the
+        /// question the operator just waived.
+        #[tokio::test]
+        async fn a_skipped_node_does_not_run_its_turn() {
+            let dir = tmp("oc-2005-skip-");
+            let turn = Arc::new(MessageRecordingTurn::new());
+            let runner = runner_with(
+                dir.path(),
+                turn.clone(),
+                answered("gather", BlockerVerdict::Skip, ""),
+            )
+            .await;
+
+            let (value, outcome) = runner
+                .run_turn("researcher", json!({ "node_id": "gather", "prompt": "go" }))
+                .await
+                .expect("a skipped node still produces an output the branch can bind");
+
+            assert!(
+                turn.messages().is_empty(),
+                "a waived node must not spend a turn: {:?}",
+                turn.messages()
+            );
+            assert!(outcome.reply.contains("skipped"), "{}", outcome.reply);
+            assert_eq!(value["agent_ref"], "researcher");
+        }
+
+        /// An amend re-runs the node carrying the operator's correction — the
+        /// workflow twin of the card path's note append.
+        #[tokio::test]
+        async fn an_amended_node_re_runs_carrying_the_operators_words() {
+            let dir = tmp("oc-2005-amend-");
+            let turn = Arc::new(MessageRecordingTurn::new());
+            let runner = runner_with(
+                dir.path(),
+                turn.clone(),
+                answered("gather", BlockerVerdict::Amend, "use gpt-4o-mini instead"),
+            )
+            .await;
+
+            runner
+                .run_turn("researcher", json!({ "node_id": "gather", "prompt": "go" }))
+                .await
+                .expect("an amended node runs");
+
+            let messages = turn.messages();
+            assert_eq!(messages.len(), 1, "the node runs exactly once");
+            assert!(
+                messages[0].contains("use gpt-4o-mini instead"),
+                "the correction has to reach the turn, or the re-run repeats the failure: {}",
+                messages[0]
+            );
+        }
+
+        /// A retry runs the step again as it was — no correction to inject.
+        #[tokio::test]
+        async fn a_retried_node_runs_again_as_it_was() {
+            let dir = tmp("oc-2005-retry-");
+            let turn = Arc::new(MessageRecordingTurn::new());
+            let runner = runner_with(
+                dir.path(),
+                turn.clone(),
+                answered("gather", BlockerVerdict::Retry, ""),
+            )
+            .await;
+
+            runner
+                .run_turn("researcher", json!({ "node_id": "gather", "prompt": "go" }))
+                .await
+                .expect("a retried node runs");
+
+            let messages = turn.messages();
+            assert_eq!(messages.len(), 1);
+            assert!(
+                !messages[0].contains("Answer from the operator"),
+                "a bare retry carries no words: {}",
+                messages[0]
+            );
+        }
+
+        /// One node's answer is not the graph's: every other node runs as it
+        /// always did.
+        #[tokio::test]
+        async fn an_answer_for_another_node_leaves_this_one_alone() {
+            let dir = tmp("oc-2005-other-");
+            let turn = Arc::new(MessageRecordingTurn::new());
+            let runner = runner_with(
+                dir.path(),
+                turn.clone(),
+                answered("review", BlockerVerdict::Skip, ""),
+            )
+            .await;
+
+            runner
+                .run_turn("researcher", json!({ "node_id": "gather", "prompt": "go" }))
+                .await
+                .expect("an unanswered node runs");
+
+            assert_eq!(turn.messages().len(), 1);
+        }
+
+        /// An unreadable answer fails the node rather than degrading to
+        /// "nobody answered" — the degrade would spend a turn on the identical
+        /// failure with the operator's decision gone.
+        #[tokio::test]
+        async fn an_unreadable_answer_fails_the_node_rather_than_running_it() {
+            let dir = tmp("oc-2005-garbled-");
+            let turn = Arc::new(MessageRecordingTurn::new());
+            let runner = runner_with(
+                dir.path(),
+                turn.clone(),
+                json!({
+                    CONTINUATION_BLOCKER_KEY: [{ "node": "gather", "verdict": "shrug" }]
+                }),
+            )
+            .await;
+
+            let outcome = runner
+                .run_turn("researcher", json!({ "node_id": "gather", "prompt": "go" }))
+                .await;
+
+            assert!(outcome.is_err(), "a garbled answer must stop the node");
+            assert!(turn.messages().is_empty(), "and must not spend a turn");
+        }
+
+        /// A cancel starts no run at all, so a node reached carrying one is a
+        /// host bug — and stops loudly rather than carrying on as if the
+        /// operator had said yes.
+        #[tokio::test]
+        async fn a_cancelled_answer_stops_the_node() {
+            let dir = tmp("oc-2005-cancel-");
+            let turn = Arc::new(MessageRecordingTurn::new());
+            let runner = runner_with(
+                dir.path(),
+                turn.clone(),
+                json!({
+                    CONTINUATION_BLOCKER_KEY: [{ "node": "gather", "verdict": "cancel" }]
+                }),
+            )
+            .await;
+
+            let outcome = runner
+                .run_turn("researcher", json!({ "node_id": "gather", "prompt": "go" }))
+                .await;
+
+            assert!(outcome.is_err());
+            assert!(turn.messages().is_empty());
+        }
+
+        /// The other half of the thread: a blocker's park has to stash what the
+        /// answer's re-entry will need. The gated-call arm cannot cover it — a
+        /// turn that parked no gated call returns before reaching that arm, and
+        /// the runner's settle-time pass refuses to arm a turn that is not
+        /// already armed — so without this the answer reaches a resume with no
+        /// run to continue.
+        #[tokio::test]
+        async fn parking_a_node_blocker_stashes_the_run_its_answer_re_enters() {
+            let dir = tmp("oc-2005-stash-");
+            let (deps, _journal) =
+                crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+            let parking = deps
+                .delivery
+                .clone()
+                .expect("delivery")
+                .parking
+                .clone()
+                .expect("parking");
+            let trigger_input = json!({ "topic": "quarterly numbers" });
+            let board_claim = Arc::new(deps.delegations.claim_board(RUN_ID));
+            let publish_refusal_claim =
+                Arc::new(deps.pending_publishes.claim_refusals_for_run(RUN_ID));
+            let runner = HarnessAgentRunner::new(
+                single_turn(&deps),
+                deps,
+                crate::workflows::gated_tool_turn_test::record(),
+                CompanyId::new("acme"),
+                "reporting".to_string(),
+                RUN_ID.to_string(),
+                None,
+                trigger_input.clone(),
+                crate::ports::types::StartedBy::Operator,
+                RunNotices::default(),
+                RunBoard::default(),
+                RunBlocks::default(),
+                RunCappedNodes::default(),
+                RunApprovals::default(),
+                RunArtifacts::default(),
+                board_claim,
+                publish_refusal_claim,
+            );
+
+            let parked = runner
+                .park_node_blocker_as(
+                    "gather",
+                    "the model id `gpt-nope` was rejected",
+                    BlockerKind::Infrastructure,
+                    BlockerSource::Provider,
+                    "a model id this provider serves",
+                )
+                .await;
+            assert!(parked.is_some(), "the blocker parks");
+
+            let stashed = parking
+                .blocked_nodes
+                .peek(&workflow_node_turn_key(RUN_ID, "gather"))
+                .expect("a parked blocker must stash the run its answer re-enters");
+            assert_eq!(stashed.workflow_id, "reporting");
+            assert_eq!(stashed.input, trigger_input);
+        }
     }
 }


### PR DESCRIPTION
## Summary

The last deferred half of the blocker-resume work. #1863 fully resumes a **task-card** blocker — retry/amend/skip re-run the card, cancel bounces it — but for a **workflow-node** blocker it only delivered the operator's answer into the DM and banked the resolution. The answer never reached the engine, so the node was never re-executed, and the resume path returned `Ok` after posting a DM note: it reported a resume that had not happened.

Now the answer is threaded onto the blocked run's own trigger input under a reserved key, and the engine reads it before the node runs:

- `retry` — run the step as it was
- `amend` — run it again with the operator's words appended to the turn message
- `skip` — do not run it at all; yield a host-authored output and proceed
- `cancel` — start no run (unchanged from #1863)
- anything else — stop the node with `EngineError::Capability`

The fork sits at the top of `run_turn`, before an attempt row is minted or a token is spent, so a waived node costs nothing.

Closes #2005

## API Or Behavior Changes

- New reserved trigger-input key `__opencompany_blockers` (`runtime/workflow_resume.rs`), a fourth member of the established `__opencompany_*` family, carrying `BlockerAnswer { node, verdict, answer }`. Reader and writer are strict: a malformed payload is an `Err`, not a shrug. The key is stripped by `without_ledger`, so a continuation carrying an answer is still the same gate and does not stack a duplicate card.
- Blocker park now stashes the run per `(run, node)` with a durable mirror, from both `park_node_blocker_as` and the agent-declared `blocker.*` park. This had to be added rather than inherited: the gated-call arm only arms when there is a gated call to park, so a blocker-only node previously reached resume with nothing to continue.
- Re-entry is idempotent. Reusing `workflow_node_turn_key` means this path and the gated-call resume share `is_blocked_node_dispatched`, so a node is re-entered at most once whichever answer arrives first.
- Blocked-node card copy updated: it used to promise "does not restart this run", which this makes false.
- Tier-1 semantics — the node's upstream re-runs. #1864's node-level checkpoint restart is the tier-2 that avoids that; not attempted here.

**Two judgement calls worth a reviewer's eye:**

1. **`amend` re-runs carrying the answer rather than injecting it as the node's value.** The issue sketched "inject the value", but `BlockerVerdict::Amend`'s own doc calls the answer "the correction an Amend re-enters carrying", and #1863's task-card path appends it to the note and re-dispatches. Injecting an operator's free text as the node's deliverable contradicts both. It is a one-arm change if the reviewer prefers the other reading.
2. **The issue's premise was wrong.** It referred to "the reserved key #1863 added" — no such key exists; #2006 touched only `ports/blockers.rs`, `runtime/{builder,cycle,grants,journal}.rs` and `company/runtime.rs`. Hence the new key rather than reuse.

**Known limit, deliberately out of scope.** If `spawn_blocked_node_continuation` fails retryably (concurrency ceiling), the stash is left for a later boot's `reconcile_stranded_blocked_nodes`, matching the gated-call arm. That reconcile re-dispatches from the un-amended stash input, so the node re-runs without the answer and the operator is re-asked — visible, not silent, but not carried. Closing it means re-arming the stash with the amended input before spawn.

## How #1863's silent-drop guard is preserved

Its three parts, each extended rather than bypassed:

1. `settle_approved_effect` returns early for a blocker effect — untouched. Re-dispatch runs from `resume_blocker`, downstream of that guard, never through `execute_effect_once`.
2. Bank durably → arm → resolve → `take_blocker_resolution` consumes → `record_blocker_resumed` retires — untouched; only the body of the `BlockerStep::Node` arm changed.
3. `resume_blocker` does `outcome?` — the load-bearing one. Every new failure path (no stash, graph gone, no runner wired, spawn refused) returns `Err` **and** says so in the blocker's DM, so a failure is loud on both channels instead of reported as success.

## Tests

Run unpiped, exit codes captured:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings`
- [x] `cargo test --locked` — 4507 passed, 0 failed
- [x] `cargo test --locked --features openhuman --lib` — 6716 passed, 0 failed
- [x] `cargo test --locked --features openhuman --tests` — all targets, 0 failed

22 new tests, each block proved red by reverting the source:

- **Resume driver** (8) — reverting `resume_node_blocker` turns 6 red: `a retry re-enters the node exactly once / left: 0 / right: 1`, the same for skip and amend, the ledger test, `a_node_is_re_entered_once_however_many_answers_land`, and `an answer that reached no run must not read as a resume`. The two that stay green are the #1863 cancel guards, correctly unmoved.
- **Engine reader** (7) — removing the fork and the stash arm turns 5 red: `a waived node must not spend a turn`, `the correction has to reach the turn, or the re-run repeats the failure`, `a garbled answer must stop the node`, cancel's `outcome.is_err()`, and `a parked blocker must stash the run its answer re-enters`.
- **Reserved key** (7) — a tolerant reader and no `without_ledger` strip turn 2 red: the malformed-payload assertion and `an_answered_blocker_is_not_part_of_a_gates_identity`.

The no-duplicate-report criterion is covered by `a_skip_continuation_still_carries_what_the_run_already_sent`, asserting the #438 / #846 / #978 ledgers survive onto the continuation input.

Not done: no live console run of park → answer → re-execute against a booted instance. Coverage is unit and integration only.

## Documentation

No separate docs change; the reserved key and the verdict arms are documented at their definitions, and the blocked-node card copy is corrected in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operators can answer blockers to re-enter the affected workflow step.
  * Approving or amending a blocker reruns the step with the operator’s response; skipping produces a skipped result.
  * Retrying reruns the step unchanged, while cancellation settles the run without restarting it.

* **Bug Fixes**
  * Blocked workflow runs now resume from the correct step after an answer.
  * Duplicate, invalid, or missing responses are handled safely.
  * Restart and cancellation cleanup now removes stale workflow checkpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->