### PR TITLE
fix(approvals): a channel-level message is the root its approval resumes in

### DIFF
--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -972,7 +972,7 @@ impl<'a> CycleRunner<'a> {
             // the same trigger events, from the same retained origins. Issue
             // #435 widened this to the channel *and* the thread within it, in
             // one pass, so the pair always describes a single message.
-            cycle_conversation(&request.events, |id| {
+            cycle_conversation(&request.events, &request.event_seqs, |id| {
                 self.rt.journal.approval_conversation(id)
             }),
         );
@@ -3013,14 +3013,34 @@ fn cycle_task_id(
 /// conversation altogether. A finer key must never cost a coarser answer that
 /// was already right. Dropping to `None` here means "the channel is the
 /// answer", which is precisely the pre-#435 behaviour.
+/// # A channel-level message is its own thread root (issue #1890)
+///
+/// `OperatorMessage::parent` is `None` for a message sent straight into a
+/// channel, and reading it verbatim recorded "no thread" for the approval —
+/// so the continuation after a sign-off landed flat in the channel while the
+/// *pre-approval* reply to the very same message landed under it. The reply
+/// path has not read `parent` verbatim since #1890: `reply_thread` is
+/// `asked_in.unwrap_or(message_seq)`, because an unparented message is the
+/// root of its own thread. This applies that same rule, which is why the
+/// sequence numbers are needed here at all — a `CompanyEvent` is a body with
+/// no identity, and a root can only name itself if something tells it its own
+/// seq.
+///
+/// `seqs` is positionally aligned with `events` ([`CycleRequest::event_seqs`])
+/// and may be **empty**: a caller that builds a request without threading seqs
+/// is documented and supported. An absent seq degrades to `None` — today's
+/// answer — rather than to a guess. The runtime always populates them, so the
+/// paths an operator actually drives get the root; a seq-less caller keeps the
+/// behaviour it already had.
 fn cycle_conversation(
     events: &[CompanyEvent],
+    seqs: &[EventSeq],
     approval_conversation: impl Fn(&ApprovalId) -> Option<ApprovalConversation>,
 ) -> ApprovalConversation {
     // `(channel, thread-root-within-it)`. The channel is what rivals; the root
     // rides along and is demoted to `None` on disagreement — see above.
     let mut found: Option<(String, Option<EventSeq>)> = None;
-    for event in events {
+    for (index, event) in events.iter().enumerate() {
         let candidate = match event {
             // The one event that names a thread outright. An unaddressed message
             // (`chat: None`) went to the orchestrator with no conversation of its
@@ -3038,7 +3058,11 @@ fn cycle_conversation(
                 let Some(chat) = chat else {
                     return ApprovalConversation::default();
                 };
-                Some((chat.clone(), *parent))
+                // `parent` when it names one, otherwise this message's own seq
+                // — the `reply_thread` rule, see the header. `seqs` may be
+                // shorter than `events` (or empty), and then there is nothing
+                // honest to fall back to.
+                Some((chat.clone(), parent.or_else(|| seqs.get(index).copied())))
             }
             CompanyEvent::ApprovalResolved { approval_id, .. } => {
                 match approval_conversation(approval_id) {
@@ -9118,30 +9142,31 @@ members = ["writer"]
 
         // An addressed message names the thread outright.
         assert_eq!(
-            cycle_conversation(&[addressed("desk-finance")], approval_conversation).thread,
+            cycle_conversation(&[addressed("desk-finance")], &[], approval_conversation).thread,
             Some("desk-finance".into()),
         );
         // The whole point, stated as an assertion: the desk channel and a DM to
         // that desk's lead are different stamps, even though the same agent
         // answers both.
         assert_eq!(
-            cycle_conversation(&[addressed("agent-cfo")], approval_conversation).thread,
+            cycle_conversation(&[addressed("agent-cfo")], &[], approval_conversation).thread,
             Some("agent-cfo".into()),
         );
         // A follow-up cycle inherits the thread from the approval it resolves, so
         // a turn needing a second sign-off re-parks in the same channel.
         assert_eq!(
-            cycle_conversation(&[resolved("appr-desk")], approval_conversation).thread,
+            cycle_conversation(&[resolved("appr-desk")], &[], approval_conversation).thread,
             Some("desk-finance".into()),
         );
         assert_eq!(
-            cycle_conversation(&[resolved("appr-dm")], approval_conversation).thread,
+            cycle_conversation(&[resolved("appr-dm")], &[], approval_conversation).thread,
             Some("agent-cfo".into()),
         );
         // An approval with no origin at all claims nothing — and does not block.
         assert_eq!(
             cycle_conversation(
                 &[resolved("appr-unknown"), addressed("desk-finance")],
+                &[],
                 approval_conversation
             )
             .thread,
@@ -9150,12 +9175,13 @@ members = ["writer"]
         // An unaddressed message went to the orchestrator with no conversation of
         // its own. It is a rival, not a pass-through.
         assert_eq!(
-            cycle_conversation(&[unaddressed()], approval_conversation).thread,
+            cycle_conversation(&[unaddressed()], &[], approval_conversation).thread,
             None
         );
         assert_eq!(
             cycle_conversation(
                 &[addressed("desk-finance"), unaddressed()],
+                &[],
                 approval_conversation
             )
             .thread,
@@ -9167,6 +9193,7 @@ members = ["writer"]
         assert_eq!(
             cycle_conversation(
                 &[addressed("desk-finance"), addressed("agent-cfo")],
+                &[],
                 approval_conversation,
             )
             .thread,
@@ -9176,6 +9203,7 @@ members = ["writer"]
         assert_eq!(
             cycle_conversation(
                 &[addressed("desk-finance"), resolved("appr-desk")],
+                &[],
                 approval_conversation,
             )
             .thread,
@@ -9185,6 +9213,7 @@ members = ["writer"]
         assert_eq!(
             cycle_conversation(
                 &[addressed("desk-finance"), resolved("appr-none")],
+                &[],
                 approval_conversation,
             )
             .thread,
@@ -9217,6 +9246,7 @@ members = ["writer"]
             assert_eq!(
                 cycle_conversation(
                     &[addressed("desk-finance"), rival.clone()],
+                    &[],
                     approval_conversation
                 )
                 .thread,
@@ -9264,6 +9294,7 @@ members = ["writer"]
             assert_eq!(
                 cycle_conversation(
                     &[addressed("desk-finance"), record.clone()],
+                    &[],
                     approval_conversation
                 )
                 .thread,
@@ -9273,12 +9304,66 @@ members = ["writer"]
         }
         // And alone neither claims a conversation of its own.
         assert_eq!(
-            cycle_conversation(&[workspace_changed()], approval_conversation).thread,
+            cycle_conversation(&[workspace_changed()], &[], approval_conversation).thread,
             None,
         );
         assert_eq!(
-            cycle_conversation(&[workflow_node_started()], approval_conversation).thread,
+            cycle_conversation(&[workflow_node_started()], &[], approval_conversation).thread,
             None,
+        );
+    }
+
+    /// A message sent straight into a channel is the root of its own thread,
+    /// and the approval raised from it inherits that root (issue #1890).
+    ///
+    /// `OperatorMessage::parent` is `None` for such a message, and reading it
+    /// verbatim recorded "no thread". The visible cost was a transcript that
+    /// contradicted itself: the reply *before* the sign-off landed under the
+    /// question (`reply_thread` treats an unparented message as its own root),
+    /// and the continuation *after* it landed flat in the channel. Same
+    /// conversation, two different answers to "which thread is this".
+    ///
+    /// Reproduced by hand on the repro rig before it was fixed:
+    ///
+    /// ```text
+    /// 37  parentId=None  operator  THREAD-THREE: deploy to staging
+    /// 42  parentId=37    ceo       Done with step 3.      <- reply: threaded
+    /// 46  parentId=None  ceo       Done with step 5.      <- continuation: flat
+    /// ```
+    #[test]
+    fn a_channel_level_message_is_the_root_its_approval_resumes_in() {
+        let addressed = || CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
+            parent: None,
+            text: "deploy to staging".into(),
+            by: None,
+            chat: Some("general".into()),
+            deliverable: None,
+            attachments: Vec::new(),
+        };
+        let none = |_: &ApprovalId| None;
+
+        assert_eq!(
+            cycle_conversation(&[addressed()], &[EventSeq::new(37)], none),
+            ApprovalConversation {
+                thread: Some("general".into()),
+                parent: Some(EventSeq::new(37)),
+            },
+            "the message's own seq is the thread it resumes in"
+        );
+
+        // **Absent seqs degrade to today's answer, never to a guess.** A caller
+        // that builds a request without threading seqs is documented and
+        // supported (`CycleRequest::event_seqs`), and inventing a root for one
+        // would write a wrong parent where there is currently an honest absent
+        // one.
+        assert_eq!(
+            cycle_conversation(&[addressed()], &[], none),
+            ApprovalConversation {
+                thread: Some("general".into()),
+                parent: None,
+            },
+            "no seq, no root — the channel is still the answer"
         );
     }
 
@@ -9326,23 +9411,31 @@ members = ["writer"]
 
         // A message asked inside a thread names both keys.
         assert_eq!(
-            cycle_conversation(&[in_thread("desk-finance", Some(7))], approval_conversation),
+            cycle_conversation(
+                &[in_thread("desk-finance", Some(7))],
+                &[],
+                approval_conversation
+            ),
             conv(Some("desk-finance"), Some(7)),
         );
         // A message asked straight in the channel names only the channel —
         // the pre-#435 behaviour, which must not change.
         assert_eq!(
-            cycle_conversation(&[in_thread("desk-finance", None)], approval_conversation),
+            cycle_conversation(
+                &[in_thread("desk-finance", None)],
+                &[],
+                approval_conversation
+            ),
             conv(Some("desk-finance"), None),
         );
         // A follow-up cycle inherits the thread as well as the channel, so a
         // second sign-off re-parks under the same root rather than flat.
         assert_eq!(
-            cycle_conversation(&[resolved("appr-threaded")], approval_conversation),
+            cycle_conversation(&[resolved("appr-threaded")], &[], approval_conversation),
             conv(Some("desk-finance"), Some(7)),
         );
         assert_eq!(
-            cycle_conversation(&[resolved("appr-flat")], approval_conversation),
+            cycle_conversation(&[resolved("appr-flat")], &[], approval_conversation),
             conv(Some("desk-finance"), None),
         );
         // The same thread twice is not ambiguous.
@@ -9352,6 +9445,7 @@ members = ["writer"]
                     in_thread("desk-finance", Some(7)),
                     resolved("appr-threaded")
                 ],
+                &[],
                 approval_conversation,
             ),
             conv(Some("desk-finance"), Some(7)),
@@ -9367,6 +9461,7 @@ members = ["writer"]
                     in_thread("desk-finance", Some(7)),
                     in_thread("desk-finance", Some(9)),
                 ],
+                &[],
                 approval_conversation,
             ),
             conv(Some("desk-finance"), None),
@@ -9384,7 +9479,7 @@ members = ["writer"]
             ],
         ] {
             assert_eq!(
-                cycle_conversation(&batch, approval_conversation),
+                cycle_conversation(&batch, &[], approval_conversation),
                 conv(Some("desk-finance"), None),
             );
         }
@@ -9396,6 +9491,7 @@ members = ["writer"]
                     in_thread("desk-finance", Some(9)),
                     resolved("appr-threaded"),
                 ],
+                &[],
                 approval_conversation,
             ),
             conv(Some("desk-finance"), None),
@@ -9409,6 +9505,7 @@ members = ["writer"]
                     in_thread("desk-finance", Some(7)),
                     in_thread("agent-cfo", Some(7)),
                 ],
+                &[],
                 approval_conversation,
             ),
             ApprovalConversation::default(),
@@ -9425,6 +9522,7 @@ members = ["writer"]
                         run_id: None,
                     },
                 ],
+                &[],
                 approval_conversation,
             ),
             ApprovalConversation::default(),


### PR DESCRIPTION
## Summary

Ask something straight in a channel, let the agent park an approval, sign it off
— and the answer comes back **flat in the channel** rather than under the
question. The reply *before* the sign-off lands correctly, so one conversation
ends up with two different answers to "which thread is this":

```
37  parentId=None  operator  THREAD-THREE: deploy to staging
42  parentId=37    ceo       Done with step 3.      <- reply: threaded
46  parentId=None  ceo       Done with step 5.      <- continuation: flat
```

## Cause

`cycle_conversation` read `OperatorMessage::parent` verbatim, and that is `None`
for a message sent straight into a channel — so the approval's origin recorded
"no thread" (`ApprovalParked` carries only the channel) and the continuation
inherited it.

The reply path has not read `parent` verbatim since #1890: `reply_thread` is
`asked_in.unwrap_or(message_seq)`, because an unparented message is the root of
its own thread. This applies the same rule.

That is why the signature changes. A `CompanyEvent` is a body with **no identity
of its own** — the seq lives on `StoredEvent` — so a root cannot name itself
unless something tells it its own seq. `CycleRequest` already carries
`event_seqs`, positionally aligned with `events`; it simply was not passed down.

## Scope, and why this survived

**Only the `None` case changes.** A message already inside a thread carries
`Some(parent)` and took the correct path before — verified on the rig, where
`47 → 52 → 56` are all `parentId=37` on both binaries.

Which is also why nobody hit it earlier: the transcript is right whenever you
opened a thread first, and wrong only when you did not — the common way people
actually chat.

**Absent seqs degrade to today's answer, never to a guess.** `event_seqs` is
documented as empty for a caller that builds a request without threading them,
and inventing a root there would write a *wrong* parent where there is currently
an honest absent one. The runtime always populates them, so the paths an
operator drives get the root. The second half of the new test pins that.

## Verification

Live host, same data dir, before and after — only the binary differs:

```
63  parentId=None  operator  FIXED-CHECK: roll the release
68  parentId=63    ceo       Done with step 13.
72  parentId=63    ceo       Done with step 15.     <- threaded
```

- `cargo test --locked` — 4505 passed
- `cargo test --locked --features openhuman --tests`
- `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- The new test is confirmed to fail with the one line reverted
  (`parent: None` vs `Some(EventSeq(37))`).

## What this is not

Found while chasing a reported "thread panel auto-switches context during
approvals". **That does not reproduce** — driven through the console on
`upstream/main`, the panel stayed on the thread it was opened on at every step:
when a rival root appeared, when a second gate parked, immediately on clicking
Approve for another thread's card, and after the continuation landed.
`setOpenThreadId` is written only by explicit user actions.

This is a different defect found on the way, and a better fit for the
contamination that report was really about: a continuation landing at channel
level is exactly what a channel-level seed reads into the next turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved approval conversation tracking for channel-level operator messages by using their event sequence when available.
  * Preserved previous behavior when sequence information is unavailable.
  * Maintained existing handling for ambiguous channel and thread contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->