### PR TITLE
fix(workflows): pause stops a company taking new work, and stops the work already running

### DIFF
--- a/frontend/src/views/workflows/RunFailurePanel.tsx
+++ b/frontend/src/views/workflows/RunFailurePanel.tsx
@@ -28,6 +28,8 @@ const DISPOSITION_COPY: Record<FailureDisposition, string> = {
     "The request didn't complete, so the host may or may not have started this run. Run history is the answer either way.",
   "refusal-inference":
     "The host did not start this run because inference needs attention. Update Settings → Inference, then try again.",
+  "refusal-lifecycle":
+    "This company is not running, so the host did not start this run. Resume it from the company's controls, then try again.",
   "refusal-not-wired": "This host cannot run workflows, so it did not start this run.",
   journaled: "This console saw the run start. Run history has the step it stopped at.",
   cautious:
@@ -73,7 +75,16 @@ export function RunFailurePanel({
     >
       <div className="flex items-center justify-between px-4 py-2">
         <div className="flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium">Run failed</span>
+          {/*
+            Issue B-037: a refusal is not a failure. All three refusal
+            dispositions are host answers that returned before anything was
+            spawned, so "Run failed" reads as "your workflow broke" when the
+            truth is that it never started and the operator can clear the
+            reason. The body copy below already says which reason.
+          */}
+          <span className="text-sm font-medium">
+            {disposition.startsWith("refusal-") ? "Run not started" : "Run failed"}
+          </span>
           {failure.dryRun && (
             <Badge
               variant="outline"

--- a/frontend/src/views/workflows/run-error.ts
+++ b/frontend/src/views/workflows/run-error.ts
@@ -21,6 +21,13 @@ import { ApiError } from "@/api/types";
  * host answers that as a `404`, and treating it as a run-refusal would tell the
  * operator to configure a provider the deployment cannot use — issue #514
  * exists precisely to split those two, so re-merging them here would undo it.
+ * `lifecycle_conflict` (issue B-037) is also deliberately absent, for the
+ * opposite reason to `not_wired`: it IS a `409` pre-execution refusal, but it
+ * is not cleared from Settings → Inference, and this set exists to raise a
+ * banner that points there. It classifies as `other`, which opens the failure
+ * panel — and `failureDisposition` gives it a `refusal-lifecycle` arm so the
+ * panel says the run never started and names the real fix.
+ *
  * The set is keyed on the structured `code` ONLY; never string-match the prose.
  */
 export const INFERENCE_RUN_CODES: ReadonlySet<string> = new Set([

--- a/frontend/src/views/workflows/run-failure.ts
+++ b/frontend/src/views/workflows/run-failure.ts
@@ -16,14 +16,25 @@ import { ApiError } from "@/api/types";
 import { INFERENCE_RUN_CODES } from "./run-error";
 
 /**
+ * The host's refusal when the company itself is not running — paused or
+ * archived (issue B-037).
+ *
+ * Named rather than inlined so the registry below and the disposition arm
+ * cannot drift: a code in one and not the other is exactly how the panel came
+ * to claim a paused company's run "may have started".
+ */
+export const LIFECYCLE_RUN_CODE = "lifecycle_conflict";
+
+/**
  * The codes that prove the host refused a run before it could execute.
  *
  * Kept beside the failure record rather than derived from HTTP status or an
  * envelope flag: a host can return an ordinary error envelope after beginning
- * work, while these codes name the two cases in which it did not start a run.
+ * work, while these codes name the cases in which it did not start a run.
  */
 export const PRE_EXECUTION_REFUSAL_CODES: ReadonlySet<string> = new Set([
   "not_wired",
+  LIFECYCLE_RUN_CODE,
   ...INFERENCE_RUN_CODES,
 ]);
 
@@ -79,6 +90,7 @@ export interface RunFailureContext {
 export type FailureDisposition =
   | "transport"
   | "refusal-inference"
+  | "refusal-lifecycle"
   | "refusal-not-wired"
   | "journaled"
   | "cautious";
@@ -94,6 +106,11 @@ export type FailureDisposition =
 export function failureDisposition(failure: RunFailure): FailureDisposition {
   if (!failure.fromHost) return "transport";
   if (INFERENCE_RUN_CODES.has(failure.code ?? "")) return "refusal-inference";
+  // Issue B-037: the host's pause gate returns BEFORE it spawns the run, so
+  // this is as certain a "nothing started" as the two above. Without an arm of
+  // its own it fell through to `cautious`, whose copy says the run may have
+  // started and points at a History row that does not exist.
+  if (failure.code === LIFECYCLE_RUN_CODE) return "refusal-lifecycle";
   if (failure.code === "not_wired") return "refusal-not-wired";
   if (failure.sawRunStart) return "journaled";
   return "cautious";

--- a/frontend/test/unit/workflow-run-failure-disposition.test.ts
+++ b/frontend/test/unit/workflow-run-failure-disposition.test.ts
@@ -29,6 +29,16 @@ describe("failureDisposition", () => {
     );
   });
 
+  it("treats a paused company as a refusal, never as a run that may have started", () => {
+    // B-037: the host's pause gate returns above the runner lookup, so nothing
+    // was spawned. Before this arm the code fell through to `cautious`, whose
+    // copy sends the operator to a History row that does not exist.
+    expect(failureDisposition({ ...FAILURE, code: "lifecycle_conflict" })).toBe(
+      "refusal-lifecycle",
+    );
+    expect(PRE_EXECUTION_REFUSAL_CODES.has("lifecycle_conflict")).toBe(true);
+  });
+
   it("claims a history row only after this console saw the run start", () => {
     expect(failureDisposition({ ...FAILURE, sawRunStart: true })).toBe("journaled");
     expect(failureDisposition(FAILURE)).toBe("cautious");

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -6061,6 +6061,34 @@ impl CompanyRuntime {
         self.store
             .save_importing(&record, gate_seen_to_persist)
             .await?;
+        // **Stopping the company stops the work already running** (B-037).
+        //
+        // Refusing new runs is only half of "Pause stops this company": a graph
+        // that is twenty nodes into thirty goes on calling models and spending
+        // for as long as it takes to finish, and the operator who pressed Pause
+        // — often *because* of that run — watches it keep going with no control
+        // that bites. `is_busy` already treats a live run as work; pause has to
+        // agree with it.
+        //
+        // Fired **after** the durable write, never before: the lifecycle is what
+        // `ensure_running` reads, so once it says paused nothing new can be
+        // admitted, and a run cancelled before it landed could be replaced by
+        // one racing in behind it.
+        //
+        // This is the Stop button's own path (`run_supervisor().cancel`, issue
+        // #383), not a second stop mechanism: the engine checks the token at the
+        // next node boundary, a node already executing finishes and is
+        // journaled, and a wedged one is hard-aborted after a bounded grace. So
+        // a paused run settles `cancelled` with its partial trail intact, the
+        // same outcome and the same shape as the operator pressing Stop on each
+        // one by hand.
+        //
+        // Best-effort, exactly as cancelling is everywhere else: a run
+        // registered on a superseded runtime (see `RuntimeHandover`) still
+        // finishes and still journals. Nothing here can fail the transition.
+        if to != "running" {
+            self.stop_live_runs(&to);
+        }
         self.events
             .append(
                 &self.id,
@@ -6072,6 +6100,36 @@ impl CompanyRuntime {
             )
             .await?;
         Ok(from)
+    }
+
+    /// Fires the stop signal on every workflow run this company still has in
+    /// flight, for a lifecycle that means "not running" (B-037).
+    ///
+    /// Separate from [`set_lifecycle`](Self::set_lifecycle) so the sweep is
+    /// readable and directly testable, and because the cancel is deliberately
+    /// synchronous: `RunSupervisor` is a `Mutex`-guarded map and firing a token
+    /// does not await, so there is no window between the lifecycle write and the
+    /// stop for another run to slip through.
+    ///
+    /// Deliberately **only** the workflow supervisor. A dispatched card or a
+    /// desk delegation lives in the steer registry and is stopped by its own
+    /// controls; folding them in here would make Pause a silent bulk-cancel of
+    /// work the operator never saw a Stop button for. Workflow runs are what the
+    /// promise on the settings screen is about, and what the report named.
+    fn stop_live_runs(&self, to: &str) {
+        let live = self.run_supervisor.live();
+        if live.is_empty() {
+            return;
+        }
+        tracing::info!(
+            company = %self.id,
+            lifecycle = %to,
+            runs = live.len(),
+            "company stopped: cancelling the workflow runs still in flight"
+        );
+        for (run_id, _workflow_id) in live {
+            self.run_supervisor.cancel(&run_id);
+        }
     }
 
     // -- Emergency stop (issue #86) -----------------------------------------
@@ -6689,6 +6747,75 @@ mod tests {
     /// production. Deliberately outside any feature gate: the steer registry is
     /// only wired under `openhuman`, so a test that relied on it alone would not
     /// run in the default build at all.
+    /// **B-037, the other half.** Pausing a company stops the runs it already
+    /// has in flight, not only the ones it would have started next.
+    ///
+    /// Refusing new runs was the reported symptom; this is the promise on the
+    /// same settings screen. A graph twenty nodes into thirty goes on spending
+    /// until it finishes, and the operator who pressed Pause — usually because
+    /// of that run — had no control that reached it.
+    #[tokio::test]
+    async fn pausing_a_company_stops_the_runs_already_in_flight() {
+        let (runtime, _record, _home) = runtime_and_record().await;
+
+        let (ctx, _guard) = runtime
+            .run_supervisor()
+            .begin("wf-1", false)
+            .expect("begin a workflow run");
+        assert!(
+            !ctx.cancel.is_cancelled(),
+            "the run starts un-cancelled, or this test proves nothing"
+        );
+
+        runtime
+            .set_lifecycle(
+                "paused",
+                crate::ports::types::Actor {
+                    kind: crate::ports::types::ActorKind::Operator,
+                    id: "operator".into(),
+                },
+            )
+            .await
+            .expect("pause the company");
+
+        assert!(
+            ctx.cancel.is_cancelled(),
+            "pausing must fire the stop signal on a run already executing"
+        );
+    }
+
+    /// The mirror, so the sweep cannot quietly become "cancel on every
+    /// transition": **resuming** must not stop the work it is resuming into.
+    ///
+    /// A resume runs through the same `set_lifecycle`, so a guard keyed on the
+    /// wrong side of the comparison would kill runs at exactly the moment the
+    /// operator asked for them to continue.
+    #[tokio::test]
+    async fn resuming_a_company_does_not_stop_anything() {
+        let (runtime, _record, _home) = runtime_and_record().await;
+
+        let (ctx, _guard) = runtime
+            .run_supervisor()
+            .begin("wf-1", false)
+            .expect("begin a workflow run");
+
+        runtime
+            .set_lifecycle(
+                "running",
+                crate::ports::types::Actor {
+                    kind: crate::ports::types::ActorKind::Operator,
+                    id: "operator".into(),
+                },
+            )
+            .await
+            .expect("resume the company");
+
+        assert!(
+            !ctx.cancel.is_cancelled(),
+            "resuming must leave a live run alone"
+        );
+    }
+
     #[tokio::test]
     async fn is_busy_sees_every_source_of_work() {
         let (runtime, _record, _home) = runtime_and_record().await;

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1546,6 +1546,27 @@ async fn run_workflow(
     Path(WorkflowPath { wid }): Path<WorkflowPath>,
     body: Option<Json<RunWorkflowBody>>,
 ) -> Result<RunWorkflowOk, crate::server::Rejection> {
+    // **A paused company does not take new work, and pressing Run is new work.**
+    //
+    // Every *background* path already refuses on this — the workflow scheduler
+    // (`workflow_scheduler.rs`), the task scheduler, the mailbox poller, A2A and
+    // chat all gate on `ensure_running`. This route did not, and neither does
+    // the resume path, which is why "Pause does nothing" is what an operator
+    // observes: the two unguarded surfaces are the two they drive themselves.
+    // The console meanwhile promises "Pause stops this company taking new work",
+    // and the run bills either way.
+    //
+    // **Before the runner lookup, not after.** Whether this company is paused
+    // does not depend on whether workflow execution is wired, and a host without
+    // a runner would otherwise answer `not_wired` to a paused company — a true
+    // sentence about the deployment that hides the one the operator needs. The
+    // cheap, always-correct refusal goes first so nothing can mask it.
+    //
+    // Refused with the same `LifecycleConflict` chat answers, so one pause reads
+    // identically wherever it is met, rather than a second rule with a second
+    // error shape.
+    company.runtime.ensure_running().await?;
+
     // No runner wired. THREE very different causes look identical from here —
     // `workflow_runner() == None` — and each points the operator at a different
     // next step (issues #266, #514):
@@ -4936,6 +4957,15 @@ mod tests {
         /// provisioned tenant) but whose persisted record declares an enabled
         /// workflow — the exact hosted-mode gap #70 reports.
         async fn state_with_hosted_company(home: &std::path::Path) -> AppState {
+            state_with_hosted_company_lifecycle(home, "running").await
+        }
+
+        /// The same fixture at a chosen lifecycle, so a paused company is
+        /// reachable without a second copy of the record literal.
+        async fn state_with_hosted_company_lifecycle(
+            home: &std::path::Path,
+            lifecycle: &str,
+        ) -> AppState {
             let store = FsCompanyStore::new(home.to_path_buf());
             let id = CompanyId::new("acme");
             store
@@ -4945,7 +4975,7 @@ mod tests {
                     id: id.clone(),
                     manifest: manifest_with_enabled(),
                     ledger: Vec::new(),
-                    lifecycle: "running".to_string(),
+                    lifecycle: lifecycle.to_string(),
                     overlay_agents: Vec::new(),
                     overlay_desk_members: Vec::new(),
                     overlay_desk_order: Vec::new(),
@@ -4977,6 +5007,50 @@ mod tests {
             state.registry().insert(id, std::sync::Arc::new(runtime));
             crate::server::test_support::seed_fixed_admin(&state, "acme").await;
             state
+        }
+
+        /// **A paused company refuses Run**, the same way chat already refuses.
+        ///
+        /// Every background path gates on `ensure_running` — the workflow
+        /// scheduler, the task scheduler, the mailbox poller, A2A, chat. This
+        /// route did not, so the one surface the operator drives themselves was
+        /// the one that ignored the pause: the console promises "Pause stops
+        /// this company taking new work", and pressing Run started a real billed
+        /// run anyway.
+        #[tokio::test]
+        async fn a_paused_company_refuses_to_start_a_run() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let state = state_with_hosted_company_lifecycle(&home, "paused").await;
+
+            let response = router(state)
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/v1/company/workflows/demo/run")
+                        .header("content-type", "application/json")
+                        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                        .body(Body::from("{}"))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            // Not 200, and not the 404/409 a missing runner gives — the refusal
+            // is the lifecycle's, so a paused company reads the same here as it
+            // does in chat.
+            assert_ne!(
+                response.status(),
+                StatusCode::OK,
+                "a paused company must not start a run"
+            );
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            let rendered = body.to_string();
+            assert!(
+                rendered.contains("paused"),
+                "the refusal must name the lifecycle that caused it: {rendered}"
+            );
         }
 
         #[tokio::test]

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -5036,16 +5036,22 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Not 200, and not the 404/409 a missing runner gives — the refusal
-            // is the lifecycle's, so a paused company reads the same here as it
-            // does in chat.
-            assert_ne!(
+            // Pinned to the exact status AND code, not merely "not 200"
+            // (CodeRabbit on this PR): a runner-gap 404 or an unrelated 409
+            // would satisfy `assert_ne!(.., OK)` while proving nothing about the
+            // lifecycle gate this test exists for — and the gate sits above the
+            // runner lookup precisely so the two cannot be confused.
+            assert_eq!(
                 response.status(),
-                StatusCode::OK,
-                "a paused company must not start a run"
+                StatusCode::CONFLICT,
+                "a paused company must refuse the run as a lifecycle conflict"
             );
             let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(
+                body["code"], "lifecycle_conflict",
+                "the console triages on the structured code, never the prose: {body}"
+            );
             let rendered = body.to_string();
             assert!(
                 rendered.contains("paused"),

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1548,13 +1548,19 @@ async fn run_workflow(
 ) -> Result<RunWorkflowOk, crate::server::Rejection> {
     // **A paused company does not take new work, and pressing Run is new work.**
     //
-    // Every *background* path already refuses on this — the workflow scheduler
-    // (`workflow_scheduler.rs`), the task scheduler, the mailbox poller, A2A and
-    // chat all gate on `ensure_running`. This route did not, and neither does
-    // the resume path, which is why "Pause does nothing" is what an operator
-    // observes: the two unguarded surfaces are the two they drive themselves.
-    // The console meanwhile promises "Pause stops this company taking new work",
-    // and the run bills either way.
+    // Every other path already refuses on this: the workflow scheduler
+    // (`workflow_scheduler.rs`), the task scheduler, the mailbox poller, A2A,
+    // chat, and — verified, because the first draft of this comment claimed
+    // otherwise — the approve/resume route, which gates in `run_resolve`
+    // (`operator.rs`) above both `resolve_approval_spawned` and the workflow
+    // resume it forks into. This POST was the single unguarded door, which is
+    // exactly why the report reads "chat correctly refuses with 409, and
+    // pressing Run on a workflow starts a real billed run anyway": the console
+    // promises "Pause stops this company taking new work" on the same screen.
+    //
+    // Pause deliberately does **not** stop a run already executing — `pause`
+    // only writes the lifecycle (`provision.rs` `transition`), and the promise
+    // is about *taking new work*. That is a separate question from this one.
     //
     // **Before the runner lookup, not after.** Whether this company is paused
     // does not depend on whether workflow execution is wired, and a host without


### PR DESCRIPTION
## Summary

**B-037 (p0).** The console promises *"Pause stops this company taking new
work"*. Chat honours it with a 409. Pause did neither of the two things that
promise implies for workflows: pressing **Run** started a real, billed run, and
a run already executing kept going.

Both halves are fixed here.

Reproduced live on a paused company, gated build (`--features openhuman`),
real OpenRouter-backed rig:

```
lifecycle: paused
  chat: 409
  run:  200      ← a real billed run, with model output in the response
```

## Half 1 — pressing Run started a run

Pause is enforced almost everywhere. `ensure_running` gates the workflow
scheduler, the task scheduler, the mailbox poller, the lifecycle scheduler,
A2A, the Chargebee hook, chat — **and the approve/resume route**, which funnels
both approve endpoints through `run_resolve` and gates above both
`resolve_approval_spawned` and the workflow resume it forks into.

`POST …/workflows/{wid}/run` was the single unguarded door.

*(An earlier revision of this description claimed the resume path was a second
unguarded surface. That was wrong; verified and corrected.)*

**The fix.** `company.runtime.ensure_running().await?` as the first thing
`run_workflow` does.

**Before the runner lookup, not after.** The first draft put it below, and the
test caught what that costs: a host without workflow execution answered
`not_wired` to a paused company — a true sentence about the deployment that
hides the one the operator needs. Whether a company is paused does not depend on
whether a runner is wired, so the cheap, always-correct refusal goes first where
nothing can mask it. Confirmed live: with the guard removed the same click
returns `404 not_wired`; with it, `409 lifecycle_conflict`.

Refused with the same `lifecycle_conflict` chat returns, so one pause reads
identically wherever an operator meets it.

## Half 2 — a run already executing kept going

Refusing new runs is only half the promise. A graph twenty nodes into thirty
went on calling models and spending until it finished, and the operator who
pressed Pause — usually *because* of that run — had no control that reached it.

`set_lifecycle` now fires the stop signal on every live workflow run when it
moves the company to any non-running state, **after** the durable write so
nothing can be admitted behind the cancel.

This is the Stop button's own path (`run_supervisor().cancel`, #383), not a
second stop mechanism: the engine checks the token at the next node boundary, an
executing node finishes and is journaled, and a wedged one is hard-aborted after
a bounded grace. A paused run settles `cancelled` with its trail intact.

Verified live on the same rig:

| | after pressing Pause |
|---|---|
| without the fix | lifecycle `paused`, run still `running: true` at t+32s |
| with the fix | `cancelled: true` by t+8s |

## What the console now says

`lifecycle_conflict` fell through `classifyRunError` as `other`, so the panel
headed **"Run failed"** and its `cautious` copy said the run may have started
and pointed at a History row that does not exist. `failureDisposition` gains a
`refusal-lifecycle` arm, and the heading now reads **"Run not started"** for
every refusal disposition — the two that predate this were equally misdescribed.

`lifecycle_conflict` stays out of `INFERENCE_RUN_CODES` deliberately: it is a
pre-execution refusal, but not one cleared from Settings → Inference, which is
the banner that set raises. Documented so it is not re-merged later.

## Deliberately not included

**Cards and desk delegations.** They live in the steer registry and have their
own controls; folding them into Pause would make it a silent bulk-cancel of work
no Stop button was ever shown for. Workflow runs are what the settings-screen
promise is about and what the report named.

**Runs on a superseded runtime.** A run registered before a `rebuild_company`
still finishes — inherited from `RuntimeHandover`, where cancelling is already
documented as best-effort.

## Testing

- `a_paused_company_refuses_to_start_a_run` — asserts `CONFLICT` **and**
  `code == "lifecycle_conflict"`, not merely non-200, so the runner-gap error the
  guard sits above cannot satisfy it.
- `pausing_a_company_stops_the_runs_already_in_flight`, and its mirror
  `resuming_a_company_does_not_stop_anything` — a guard keyed on the wrong side
  of that comparison would kill runs at the moment the operator asked them to
  continue.
- `workflow-run-failure-disposition.test.ts` gains the `lifecycle_conflict` case.

Each was confirmed to fail against the defect it guards before being kept.
