### PR TITLE
fix(approvals): an expired approval settles the run that was waiting on it

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1632,6 +1632,7 @@ impl CompanyRuntime {
     pub(crate) async fn unpark_blocker(self: &Arc<Self>, id: &ApprovalId) -> Result<()> {
         self.retire_approval(id, ExpiryReason::CardUnwritable, now_millis())
             .await
+            .map(|_released| ())
     }
 
     /// Thin `&self` wrapper around
@@ -2267,10 +2268,16 @@ impl CompanyRuntime {
         let unanswered = self.unanswered_blocker(id);
         let is_blocker = self.is_blocker(id);
         let waiting_run = self.parked_workflow_run(id);
-        self.retire_approval(id, ExpiryReason::Ttl, now_millis())
+        let released = self
+            .retire_approval(id, ExpiryReason::Ttl, now_millis())
             .await?;
-        self.finish_expiry(id, is_blocker, unanswered, waiting_run)
-            .await;
+        self.finish_expiry(
+            id,
+            is_blocker,
+            unanswered,
+            waiting_run.filter(|_| !released),
+        )
+        .await;
         Ok(())
     }
 
@@ -4651,9 +4658,14 @@ impl CompanyRuntime {
             // Issue B-012: and which workflow run was waiting on it, for the
             // same before-the-retirement reason as the two above.
             let waiting_run = self.parked_workflow_run(id);
-            self.retire_approval(id, ExpiryReason::Ttl, now).await?;
-            self.finish_expiry(id, is_blocker, unanswered, waiting_run)
-                .await;
+            let released = self.retire_approval(id, ExpiryReason::Ttl, now).await?;
+            self.finish_expiry(
+                id,
+                is_blocker,
+                unanswered,
+                waiting_run.filter(|_| !released),
+            )
+            .await;
         }
         Ok(expired)
     }
@@ -4703,6 +4715,15 @@ impl CompanyRuntime {
         // for work refused *by design* by the compiler or a step; here the
         // decision was made by the clock and nobody chose it. Not `Failed`:
         // nothing errored.
+        //
+        // **Only when the expiry released nothing** (CodeRabbit on this PR).
+        // `retire_approval` deliberately resumes a workflow run whose *last*
+        // outstanding gate expired — "a workflow run releases even on an empty
+        // batch … so its approved siblings are not stranded" — and that resume
+        // is spawned, not awaited. Cancelling unconditionally would race it,
+        // and would cancel a run that is legitimately continuing with the
+        // expiry banked as a deny. The caller passes `None` in that case, so
+        // this settles exactly the rows nothing else will ever revisit.
         //
         // Best-effort and last, like everything else here: a row that cannot be
         // written must not undo a default-deny that already happened.
@@ -4922,12 +4943,19 @@ impl CompanyRuntime {
     /// records `Deny`. That is the safety property the whole change rests on:
     /// an approval disappearing from the queue must never read as one that was
     /// granted.
+    /// Returns whether this retirement **released a continuation** — a turn or
+    /// workflow run that was waiting on the approval and has now been told.
+    ///
+    /// The caller needs to know, because a released workflow run goes on to
+    /// settle itself and must not be marked cancelled underneath the resume
+    /// this spawns (CodeRabbit on the B-012 PR). Only an expiry that releases
+    /// nothing leaves a row nobody will ever revisit.
     async fn retire_approval(
         self: &Arc<Self>,
         id: &ApprovalId,
         reason: ExpiryReason,
         at_millis: u64,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let explicit_request = self
             .approval_gate
             .take_expired_effect(id)
@@ -4963,9 +4991,15 @@ impl CompanyRuntime {
                         by,
                     },
                 ))));
-                return Ok(());
+                // Released: the asking agent's continuation is queued and its
+                // settled verdict spawned, so this run has been told and will
+                // settle itself. Cancelling it here would race that (CodeRabbit
+                // on the B-012 PR). The error arm above deliberately falls
+                // through instead — nothing was queued, so nothing was told.
+                return Ok(true);
             }
         }
+        let mut released_continuation = false;
         // Issue #469: releasing the turn this approval was blocking, and
         // running its continuation when this expiry was the last thing it
         // waited on. Spawned rather than awaited: the continuation is a full
@@ -4988,6 +5022,9 @@ impl CompanyRuntime {
                 // siblings are not stranded. A brain turn with nothing to
                 // report owes no cycle, exactly as before.
                 if workflow_run || !batch.is_empty() {
+                    // Told to the caller: a released run settles itself, and
+                    // must not be cancelled underneath this resume.
+                    released_continuation = true;
                     let rt = Arc::clone(self);
                     let released = id.clone();
                     let turn = turn.clone();
@@ -5029,7 +5066,7 @@ impl CompanyRuntime {
                 "approval expiry journaled but its event-log entry failed",
             );
         }
-        Ok(())
+        Ok(released_continuation)
     }
 
     /// Expires every single-use grant the agent never redeemed, and tells the
@@ -8314,6 +8351,95 @@ mod tests {
             row.status,
             RunStatus::Cancelled,
             "a default-denied gate leaves the run cancelled, not still waiting"
+        );
+    }
+
+    /// **The other half of B-012** (CodeRabbit on the B-012 PR). An expiry that
+    /// *releases* the run must not also cancel it.
+    ///
+    /// `retire_approval` deliberately resumes a workflow run whose last
+    /// outstanding gate expired — "a workflow run releases even on an empty
+    /// batch … so its approved siblings are not stranded" (issue #978) — and it
+    /// **spawns** that resume rather than awaiting it. The first cut of B-012
+    /// cancelled the row unconditionally, which both raced the resume and
+    /// cancelled a run that was legitimately continuing with the expiry banked
+    /// as a deny. Suppressing the resume instead would strand the siblings,
+    /// which is the bug #978 exists to prevent; so the cancellation is what
+    /// narrows, to the expiries that release nothing.
+    ///
+    /// Asserted on the **error text**, not the status: only `finish_expiry`
+    /// writes that sentence, so the assertion cannot race whatever the spawned
+    /// resume goes on to do to the row.
+    #[tokio::test]
+    async fn an_expiry_that_releases_the_run_does_not_also_cancel_it() {
+        use crate::ports::runs::RunStatus;
+        use crate::ports::types::{ApprovalId, EventSeq};
+        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+        use std::sync::Arc;
+
+        let (rt, _home) = runtime_with_events().await;
+        let rt = Arc::new(rt);
+
+        rt.runs()
+            .create_run(
+                rt.id(),
+                crate::ports::runs::NewRun::for_task("run-released", "t-released", "ceo"),
+            )
+            .await
+            .unwrap();
+        rt.runs()
+            .begin_run(rt.id(), "run-released", EventSeq::new(1))
+            .await
+            .unwrap();
+        rt.runs()
+            .finish_run(
+                rt.id(),
+                "run-released",
+                crate::ports::runs::RunOutcome::new(RunStatus::WaitingApproval),
+            )
+            .await
+            .unwrap();
+
+        // The difference from the test above, and the whole point of it: a real
+        // `workflow-run:` continuation, armed and recorded as this approval's
+        // cycle. Expiry is now this turn's last outstanding decision, so
+        // `retire_approval` releases the run instead of leaving it stranded.
+        let turn = crate::runtime::workflow_resume::workflow_turn_key("run-released");
+        rt.continuations.arm(&turn);
+
+        let approval = ApprovalId::new("appr-released");
+        let mut effect = extend_test_effect();
+        effect.run_id = Some("run-released".to_string());
+        rt.approval_gate
+            .rehydrate(approval.clone(), effect.clone(), 0);
+        rt.journal
+            .record_parked(
+                &approval,
+                &effect,
+                0,
+                TaskLink::Unlinked,
+                ApprovalConversation::default(),
+                Some(turn.clone()),
+            )
+            .await
+            .unwrap();
+
+        let expired = rt.sweep_expired_approvals().await.unwrap();
+        assert!(
+            expired.contains(&approval),
+            "the sweep must find the epoch-0 park: {expired:?}"
+        );
+
+        let row = rt
+            .runs()
+            .get_run(rt.id(), "run-released")
+            .await
+            .unwrap()
+            .expect("the run row survives the sweep");
+        assert_ne!(
+            row.error.as_deref(),
+            Some("the approval this run was waiting on expired and defaulted to denied"),
+            "a released run settles through its resume; the expiry must not settle it too"
         );
     }
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2266,9 +2266,11 @@ impl CompanyRuntime {
         // the same badge behind.
         let unanswered = self.unanswered_blocker(id);
         let is_blocker = self.is_blocker(id);
+        let waiting_run = self.parked_workflow_run(id);
         self.retire_approval(id, ExpiryReason::Ttl, now_millis())
             .await?;
-        self.finish_expiry(id, is_blocker, unanswered).await;
+        self.finish_expiry(id, is_blocker, unanswered, waiting_run)
+            .await;
         Ok(())
     }
 
@@ -4646,8 +4648,12 @@ impl CompanyRuntime {
             // as blockers, not ordinary approvals, even though unanswered
             // returns None for them.
             let is_blocker = self.is_blocker(id);
+            // Issue B-012: and which workflow run was waiting on it, for the
+            // same before-the-retirement reason as the two above.
+            let waiting_run = self.parked_workflow_run(id);
             self.retire_approval(id, ExpiryReason::Ttl, now).await?;
-            self.finish_expiry(id, is_blocker, unanswered).await;
+            self.finish_expiry(id, is_blocker, unanswered, waiting_run)
+                .await;
         }
         Ok(expired)
     }
@@ -4679,7 +4685,45 @@ impl CompanyRuntime {
         id: &ApprovalId,
         was_blocker: bool,
         unanswered: Option<(String, String)>,
+        waiting_run: Option<String>,
     ) {
+        // **The run that was waiting stops claiming it still is** (issue B-012).
+        //
+        // A workflow that parks on a gate is recorded `WaitingApproval` — the
+        // run is settled, nothing is executing, and that status is the row's
+        // account of why it stopped. Expiry retired the approval and removed it
+        // from the pending set, but nothing ever revisited the row, so it went
+        // on naming an approval no sweep will see again: the Observatory showed
+        // a run waiting for a decision that had already defaulted, and the
+        // approvals list showed nothing to decide. Two screens, no way to tell
+        // which was lying.
+        //
+        // `Cancelled` — "the attempt was cancelled before it could settle" — is
+        // what a default-deny leaves behind. Not `Declined`, which is reserved
+        // for work refused *by design* by the compiler or a step; here the
+        // decision was made by the clock and nobody chose it. Not `Failed`:
+        // nothing errored.
+        //
+        // Best-effort and last, like everything else here: a row that cannot be
+        // written must not undo a default-deny that already happened.
+        if let Some(run_id) = waiting_run {
+            let outcome =
+                crate::ports::runs::RunOutcome::new(crate::ports::runs::RunStatus::Cancelled)
+                    .with_error(
+                        "the approval this run was waiting on expired and defaulted to denied",
+                    );
+            if let Err(err) = self.runs().finish_run(&self.id, &run_id, outcome).await {
+                tracing::warn!(
+                    company = %self.id,
+                    approval = %id,
+                    run = %run_id,
+                    %err,
+                    "[approval] expired, but the waiting run's row could not be settled; \
+                     it will keep reporting `waiting_approval`"
+                );
+            }
+        }
+
         let mut card_returned = false;
         if let Some((task_id, question)) = unanswered {
             match crate::runtime::advance::return_expired_blocker_card(
@@ -4745,6 +4789,17 @@ impl CompanyRuntime {
         };
         let prefix = format!("{}.", crate::ports::blockers::BLOCKER_EFFECT_PREFIX);
         pending.effect.kind.starts_with(&prefix)
+    }
+
+    /// The workflow run this approval parked, read **before** the retirement
+    /// for the reason its two siblings are (issue B-012).
+    ///
+    /// `workflow_run_of` needs the pending entry, and retiring is what removes
+    /// it — so after `retire_approval` there is no way back to which run was
+    /// waiting, exactly as there is no way back to what was being asked.
+    fn parked_workflow_run(&self, id: &ApprovalId) -> Option<String> {
+        let pending = self.journal.pending().into_iter().find(|p| &p.id == id)?;
+        workflow_run_of(&pending)
     }
 
     fn unanswered_blocker(&self, id: &ApprovalId) -> Option<(String, String)> {
@@ -8178,6 +8233,88 @@ mod tests {
             .await
             .unwrap();
         approval
+    }
+
+    /// **B-012.** A workflow run parked on a gate stops claiming it is waiting
+    /// once that approval expires.
+    ///
+    /// A parked run is recorded `WaitingApproval` — settled, nothing executing,
+    /// and the status is the row's account of *why* it stopped. Expiry retired
+    /// the approval and dropped it from the pending set, but nothing revisited
+    /// the row, so it went on naming an approval no sweep would see again: the
+    /// Observatory showed a run awaiting a decision while the approvals list
+    /// showed nothing to decide, and neither screen was wrong about its own
+    /// data.
+    #[tokio::test]
+    async fn an_expired_approval_settles_the_workflow_run_that_was_waiting_on_it() {
+        use crate::ports::runs::RunStatus;
+        use crate::ports::types::{ApprovalId, EventSeq};
+        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+        use std::sync::Arc;
+
+        let (rt, _home) = runtime_with_events().await;
+        let rt = Arc::new(rt);
+
+        // A run parked on a gate: begun, then settled as `WaitingApproval` —
+        // exactly the shape `finish_run` leaves behind for a workflow park.
+        rt.runs()
+            .create_run(
+                rt.id(),
+                crate::ports::runs::NewRun::for_task("run-parked", "t-parked", "ceo"),
+            )
+            .await
+            .unwrap();
+        rt.runs()
+            .begin_run(rt.id(), "run-parked", EventSeq::new(1))
+            .await
+            .unwrap();
+        rt.runs()
+            .finish_run(
+                rt.id(),
+                "run-parked",
+                crate::ports::runs::RunOutcome::new(RunStatus::WaitingApproval),
+            )
+            .await
+            .unwrap();
+
+        // The approval that run is waiting on. `Unlinked` + a `run_id` is what
+        // `workflow_run_of` requires to call this a workflow park rather than a
+        // task attempt — the two share an id space, so both terms are needed.
+        let approval = ApprovalId::new("appr-b012");
+        let mut effect = extend_test_effect();
+        effect.run_id = Some("run-parked".to_string());
+        rt.approval_gate
+            .rehydrate(approval.clone(), effect.clone(), 0);
+        rt.journal
+            .record_parked(
+                &approval,
+                &effect,
+                0,
+                TaskLink::Unlinked,
+                ApprovalConversation::default(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Parked at epoch 0 — unambiguously past any TTL.
+        let expired = rt.sweep_expired_approvals().await.unwrap();
+        assert!(
+            expired.contains(&approval),
+            "the sweep must find the epoch-0 park: {expired:?}"
+        );
+
+        let row = rt
+            .runs()
+            .get_run(rt.id(), "run-parked")
+            .await
+            .unwrap()
+            .expect("the run row survives the sweep");
+        assert_eq!(
+            row.status,
+            RunStatus::Cancelled,
+            "a default-denied gate leaves the run cancelled, not still waiting"
+        );
     }
 
     /// Issue #1865 (Codex review on PR #1883): a late resolve that discovers

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2267,7 +2267,7 @@ impl CompanyRuntime {
         // the same badge behind.
         let unanswered = self.unanswered_blocker(id);
         let is_blocker = self.is_blocker(id);
-        let waiting_run = self.parked_workflow_run(id);
+        let waiting_runs = self.parked_workflow_attempts(id).await;
         let released = self
             .retire_approval(id, ExpiryReason::Ttl, now_millis())
             .await?;
@@ -2275,7 +2275,7 @@ impl CompanyRuntime {
             id,
             is_blocker,
             unanswered,
-            waiting_run.filter(|_| !released),
+            if released { Vec::new() } else { waiting_runs },
         )
         .await;
         Ok(())
@@ -4657,13 +4657,13 @@ impl CompanyRuntime {
             let is_blocker = self.is_blocker(id);
             // Issue B-012: and which workflow run was waiting on it, for the
             // same before-the-retirement reason as the two above.
-            let waiting_run = self.parked_workflow_run(id);
+            let waiting_runs = self.parked_workflow_attempts(id).await;
             let released = self.retire_approval(id, ExpiryReason::Ttl, now).await?;
             self.finish_expiry(
                 id,
                 is_blocker,
                 unanswered,
-                waiting_run.filter(|_| !released),
+                if released { Vec::new() } else { waiting_runs },
             )
             .await;
         }
@@ -4697,7 +4697,7 @@ impl CompanyRuntime {
         id: &ApprovalId,
         was_blocker: bool,
         unanswered: Option<(String, String)>,
-        waiting_run: Option<String>,
+        waiting_runs: Vec<String>,
     ) {
         // **The run that was waiting stops claiming it still is** (issue B-012).
         //
@@ -4727,7 +4727,7 @@ impl CompanyRuntime {
         //
         // Best-effort and last, like everything else here: a row that cannot be
         // written must not undo a default-deny that already happened.
-        if let Some(run_id) = waiting_run {
+        for run_id in waiting_runs {
             let outcome =
                 crate::ports::runs::RunOutcome::new(crate::ports::runs::RunStatus::Cancelled)
                     .with_error(
@@ -4812,15 +4812,63 @@ impl CompanyRuntime {
         pending.effect.kind.starts_with(&prefix)
     }
 
-    /// The workflow run this approval parked, read **before** the retirement
-    /// for the reason its two siblings are (issue B-012).
+    /// The **attempt rows** this approval left recorded `WaitingApproval`, read
+    /// **before** the retirement for the reason its two siblings are (B-012).
     ///
     /// `workflow_run_of` needs the pending entry, and retiring is what removes
     /// it — so after `retire_approval` there is no way back to which run was
     /// waiting, exactly as there is no way back to what was being asked.
-    fn parked_workflow_run(&self, id: &ApprovalId) -> Option<String> {
-        let pending = self.journal.pending().into_iter().find(|p| &p.id == id)?;
-        workflow_run_of(&pending)
+    ///
+    /// # Why this resolves rather than settling `Effect::run_id` directly
+    ///
+    /// Codex on the B-012 PR. `Effect::run_id` on a workflow gate is the
+    /// **lineage** id — `workflow_resume::workflow_turn_key` mints this run's
+    /// resume key straight from it — while `RunStore` rows are per-node
+    /// *attempts* minted under `generate_id()` and merely *linked* to the
+    /// lineage (`NewRun::for_workflow_node`, `src/workflows/caps/mod.rs`).
+    /// `RunFilter::for_workflow_run` being a filter rather than a key is the
+    /// same fact from the other side. Handing the lineage id to `finish_run`
+    /// therefore names no row at all: it answers `NotFound`, the settle is
+    /// swallowed as best-effort, and the attempt goes on reading
+    /// `WaitingApproval` — which is precisely the bug B-012 is about.
+    ///
+    /// Narrowed to the parked **node**, not every `WaitingApproval` attempt in
+    /// the lineage: a graph can park two nodes on two gates, and only one of
+    /// them expired. Without a node to match, nothing is settled — a run left
+    /// stale is the bug, but cancelling a sibling node still waiting on a live
+    /// decision would be a worse one.
+    async fn parked_workflow_attempts(&self, id: &ApprovalId) -> Vec<String> {
+        let Some(pending) = self.journal.pending().into_iter().find(|p| &p.id == id) else {
+            return Vec::new();
+        };
+        let Some(lineage) = workflow_run_of(&pending) else {
+            return Vec::new();
+        };
+        let Some(node) = crate::runtime::workflow_resume::gate_node_id(&pending.effect) else {
+            return Vec::new();
+        };
+        let node = node.to_string();
+        let filter = crate::ports::runs::RunFilter {
+            workflow_run_id: Some(lineage),
+            statuses: vec![crate::ports::runs::RunStatus::WaitingApproval],
+            ..Default::default()
+        };
+        match self.runs().list_runs(&self.id, &filter).await {
+            Ok(rows) => rows
+                .into_iter()
+                .filter(|row| row.node_id.as_deref() == Some(node.as_str()))
+                .map(|row| row.id)
+                .collect(),
+            Err(err) => {
+                tracing::warn!(
+                    company = %self.id,
+                    approval = %id,
+                    %err,
+                    "[approval] could not resolve the attempts waiting on an expiring approval"
+                );
+                Vec::new()
+            }
+        }
     }
 
     fn unanswered_blocker(&self, id: &ApprovalId) -> Option<(String, String)> {
@@ -8243,6 +8291,74 @@ mod tests {
         }
     }
 
+    /// A workflow gate parked on a node of `lineage`, in the shape production
+    /// actually leaves behind (Codex on the B-012 PR).
+    ///
+    /// The two halves that matter are the two that were wrong when this was
+    /// hand-rolled: `Effect::run_id` is the **lineage** id, and the
+    /// `WaitingApproval` row is a separately-minted *attempt* linked to it by
+    /// `NewRun::for_workflow_node`. A fixture that gives the row the lineage's
+    /// own id proves only that the fixture works.
+    ///
+    /// Returns the attempt row's id — the row the expiry has to find.
+    async fn park_workflow_gate(
+        rt: &std::sync::Arc<crate::company::runtime::CompanyRuntime>,
+        approval: &crate::ports::types::ApprovalId,
+        lineage: &str,
+        node: &str,
+        at_millis: u64,
+        cycle: Option<String>,
+    ) -> String {
+        use crate::ports::runs::RunStatus;
+        use crate::ports::types::EventSeq;
+        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+
+        let attempt = crate::ports::generate_id();
+        rt.runs()
+            .create_run(
+                rt.id(),
+                crate::ports::NewRun::for_workflow_node(attempt.clone(), lineage, node, "ceo"),
+            )
+            .await
+            .unwrap();
+        rt.runs()
+            .begin_run(rt.id(), &attempt, EventSeq::new(1))
+            .await
+            .unwrap();
+        rt.runs()
+            .finish_run(
+                rt.id(),
+                &attempt,
+                crate::ports::runs::RunOutcome::new(RunStatus::WaitingApproval),
+            )
+            .await
+            .unwrap();
+
+        let effect = crate::runtime::workflow_resume::gate_effect(
+            "wf-demo",
+            node,
+            &serde_json::json!({}),
+            lineage,
+            &[],
+            &[],
+            None,
+        );
+        rt.approval_gate
+            .rehydrate(approval.clone(), effect.clone(), at_millis);
+        rt.journal
+            .record_parked(
+                approval,
+                &effect,
+                at_millis,
+                TaskLink::Unlinked,
+                ApprovalConversation::default(),
+                cycle,
+            )
+            .await
+            .unwrap();
+        attempt
+    }
+
     /// Seeds one parked approval into BOTH the live gate and the durable journal
     /// under a fixed id at `at_millis`, exactly as a real park leaves them — the
     /// gate answers "is this live?" for extend/sweep, the journal projects the
@@ -8285,56 +8401,18 @@ mod tests {
     #[tokio::test]
     async fn an_expired_approval_settles_the_workflow_run_that_was_waiting_on_it() {
         use crate::ports::runs::RunStatus;
-        use crate::ports::types::{ApprovalId, EventSeq};
-        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+        use crate::ports::types::ApprovalId;
         use std::sync::Arc;
 
         let (rt, _home) = runtime_with_events().await;
         let rt = Arc::new(rt);
 
-        // A run parked on a gate: begun, then settled as `WaitingApproval` —
-        // exactly the shape `finish_run` leaves behind for a workflow park.
-        rt.runs()
-            .create_run(
-                rt.id(),
-                crate::ports::runs::NewRun::for_task("run-parked", "t-parked", "ceo"),
-            )
-            .await
-            .unwrap();
-        rt.runs()
-            .begin_run(rt.id(), "run-parked", EventSeq::new(1))
-            .await
-            .unwrap();
-        rt.runs()
-            .finish_run(
-                rt.id(),
-                "run-parked",
-                crate::ports::runs::RunOutcome::new(RunStatus::WaitingApproval),
-            )
-            .await
-            .unwrap();
-
-        // The approval that run is waiting on. `Unlinked` + a `run_id` is what
-        // `workflow_run_of` requires to call this a workflow park rather than a
-        // task attempt — the two share an id space, so both terms are needed.
+        // A workflow node parked on a gate: an attempt row settled
+        // `WaitingApproval` and linked to the lineage, plus the gate itself
+        // carrying that lineage. Parked at epoch 0 — past any TTL.
         let approval = ApprovalId::new("appr-b012");
-        let mut effect = extend_test_effect();
-        effect.run_id = Some("run-parked".to_string());
-        rt.approval_gate
-            .rehydrate(approval.clone(), effect.clone(), 0);
-        rt.journal
-            .record_parked(
-                &approval,
-                &effect,
-                0,
-                TaskLink::Unlinked,
-                ApprovalConversation::default(),
-                None,
-            )
-            .await
-            .unwrap();
+        let attempt = park_workflow_gate(&rt, &approval, "wr-b012", "solve", 0, None).await;
 
-        // Parked at epoch 0 — unambiguously past any TTL.
         let expired = rt.sweep_expired_approvals().await.unwrap();
         assert!(
             expired.contains(&approval),
@@ -8343,14 +8421,73 @@ mod tests {
 
         let row = rt
             .runs()
-            .get_run(rt.id(), "run-parked")
+            .get_run(rt.id(), &attempt)
             .await
             .unwrap()
-            .expect("the run row survives the sweep");
+            .expect("the attempt row survives the sweep");
         assert_eq!(
             row.status,
             RunStatus::Cancelled,
-            "a default-denied gate leaves the run cancelled, not still waiting"
+            "a default-denied gate leaves the attempt cancelled, not still waiting"
+        );
+    }
+
+    /// **The narrowing** the settle above is scoped by. One expiry must not
+    /// cancel a *sibling* node still waiting on a live decision.
+    ///
+    /// A graph can park two nodes on two gates, and `RunFilter` can only ask
+    /// for the lineage — so "every `WaitingApproval` attempt of this run" is
+    /// the obvious query and the wrong one. The node is read off the gate's own
+    /// payload (`gate_node_id`) to close that gap.
+    #[tokio::test]
+    async fn an_expiry_leaves_a_sibling_node_still_waiting_on_a_live_gate() {
+        use crate::ports::runs::RunStatus;
+        use crate::ports::types::ApprovalId;
+        use std::sync::Arc;
+
+        let (rt, _home) = runtime_with_events().await;
+        let rt = Arc::new(rt);
+
+        // Same lineage, two nodes: one parked at epoch 0 (past any TTL), one
+        // parked now (nowhere near it).
+        let expiring = ApprovalId::new("appr-expiring");
+        let attempt_expiring =
+            park_workflow_gate(&rt, &expiring, "wr-two-gates", "solve", 0, None).await;
+        let live = ApprovalId::new("appr-live");
+        let attempt_live = park_workflow_gate(
+            &rt,
+            &live,
+            "wr-two-gates",
+            "review",
+            crate::ports::now_millis(),
+            None,
+        )
+        .await;
+
+        let expired = rt.sweep_expired_approvals().await.unwrap();
+        assert!(
+            expired.contains(&expiring) && !expired.contains(&live),
+            "only the epoch-0 park expires: {expired:?}"
+        );
+
+        let settled = rt
+            .runs()
+            .get_run(rt.id(), &attempt_expiring)
+            .await
+            .unwrap()
+            .expect("the expired node's attempt survives");
+        assert_eq!(settled.status, RunStatus::Cancelled);
+
+        let sibling = rt
+            .runs()
+            .get_run(rt.id(), &attempt_live)
+            .await
+            .unwrap()
+            .expect("the sibling's attempt survives");
+        assert_eq!(
+            sibling.status,
+            RunStatus::WaitingApproval,
+            "the sibling node is still waiting on a decision nobody has made"
         );
     }
 
@@ -8372,57 +8509,29 @@ mod tests {
     /// resume goes on to do to the row.
     #[tokio::test]
     async fn an_expiry_that_releases_the_run_does_not_also_cancel_it() {
-        use crate::ports::runs::RunStatus;
-        use crate::ports::types::{ApprovalId, EventSeq};
-        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+        use crate::ports::types::ApprovalId;
         use std::sync::Arc;
 
         let (rt, _home) = runtime_with_events().await;
         let rt = Arc::new(rt);
 
-        rt.runs()
-            .create_run(
-                rt.id(),
-                crate::ports::runs::NewRun::for_task("run-released", "t-released", "ceo"),
-            )
-            .await
-            .unwrap();
-        rt.runs()
-            .begin_run(rt.id(), "run-released", EventSeq::new(1))
-            .await
-            .unwrap();
-        rt.runs()
-            .finish_run(
-                rt.id(),
-                "run-released",
-                crate::ports::runs::RunOutcome::new(RunStatus::WaitingApproval),
-            )
-            .await
-            .unwrap();
-
         // The difference from the test above, and the whole point of it: a real
         // `workflow-run:` continuation, armed and recorded as this approval's
         // cycle. Expiry is now this turn's last outstanding decision, so
         // `retire_approval` releases the run instead of leaving it stranded.
-        let turn = crate::runtime::workflow_resume::workflow_turn_key("run-released");
+        let turn = crate::runtime::workflow_resume::workflow_turn_key("wr-released");
         rt.continuations.arm(&turn);
 
         let approval = ApprovalId::new("appr-released");
-        let mut effect = extend_test_effect();
-        effect.run_id = Some("run-released".to_string());
-        rt.approval_gate
-            .rehydrate(approval.clone(), effect.clone(), 0);
-        rt.journal
-            .record_parked(
-                &approval,
-                &effect,
-                0,
-                TaskLink::Unlinked,
-                ApprovalConversation::default(),
-                Some(turn.clone()),
-            )
-            .await
-            .unwrap();
+        let attempt = park_workflow_gate(
+            &rt,
+            &approval,
+            "wr-released",
+            "solve",
+            0,
+            Some(turn.clone()),
+        )
+        .await;
 
         let expired = rt.sweep_expired_approvals().await.unwrap();
         assert!(
@@ -8432,10 +8541,10 @@ mod tests {
 
         let row = rt
             .runs()
-            .get_run(rt.id(), "run-released")
+            .get_run(rt.id(), &attempt)
             .await
             .unwrap()
-            .expect("the run row survives the sweep");
+            .expect("the attempt row survives the sweep");
         assert_ne!(
             row.error.as_deref(),
             Some("the approval this run was waiting on expired and defaulted to denied"),

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -8606,7 +8606,7 @@ mod tests {
                 rt.id(),
                 &attempt,
                 RunOutcome::new(RunStatus::WaitingApproval)
-                    .with_usage(usage.clone())
+                    .with_usage(usage)
                     .with_step_count(7),
             )
             .await

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -4819,35 +4819,54 @@ impl CompanyRuntime {
     /// it — so after `retire_approval` there is no way back to which run was
     /// waiting, exactly as there is no way back to what was being asked.
     ///
-    /// # Why this resolves rather than settling `Effect::run_id` directly
+    /// # Why the cycle, and not `Effect::run_id` or the effect kind
     ///
-    /// Codex on the B-012 PR. `Effect::run_id` on a workflow gate is the
-    /// **lineage** id — `workflow_resume::workflow_turn_key` mints this run's
-    /// resume key straight from it — while `RunStore` rows are per-node
-    /// *attempts* minted under `generate_id()` and merely *linked* to the
-    /// lineage (`NewRun::for_workflow_node`, `src/workflows/caps/mod.rs`).
-    /// `RunFilter::for_workflow_run` being a filter rather than a key is the
-    /// same fact from the other side. Handing the lineage id to `finish_run`
-    /// therefore names no row at all: it answers `NotFound`, the settle is
-    /// swallowed as best-effort, and the attempt goes on reading
-    /// `WaitingApproval` — which is precisely the bug B-012 is about.
+    /// Two Codex findings, in sequence, both about reaching for the wrong
+    /// handle. `Effect::run_id` on a `workflow.approve` gate is the **lineage**
+    /// id, while `RunStore` rows are per-node *attempts* minted under
+    /// `generate_id()` and merely linked to it (`NewRun::for_workflow_node`), so
+    /// handing it to `finish_run` names no row at all. And the path that
+    /// actually leaves an attempt reading `WaitingApproval` is not that gate: it
+    /// is a **gated tool call** inside a workflow agent node
+    /// (`caps::park_gated_calls` → the `!parked.is_empty()` settle), parked with
+    /// `ApprovalPolicy::effect_for`'s own effect — whose `kind` is the tool name
+    /// and whose `run_id` is `None`. So on the real path neither the kind test
+    /// nor `workflow_run_of` can say anything, and a fix keyed on either is a
+    /// no-op that a fixture combining a gate effect with a hand-made attempt row
+    /// will nonetheless report as working.
     ///
-    /// Narrowed to the parked **node**, not every `WaitingApproval` attempt in
-    /// the lineage: a graph can park two nodes on two gates, and only one of
-    /// them expired. Without a node to match, nothing is settled — a run left
-    /// stale is the bug, but cancelling a sibling node still waiting on a live
-    /// decision would be a worse one.
+    /// The **cycle recorded at park time** is the one correlation that survives
+    /// both shapes, so it is what this reads:
+    ///
+    /// * `workflow-node:{run}:{node}` — a blocked node's gated calls. The real
+    ///   case, and it names the run and the node outright.
+    /// * `workflow-run:{run}` — a run-level gate, whose node is on its own
+    ///   payload (`gate_node_id`).
+    ///
+    /// Narrowed to that node, never "every `WaitingApproval` attempt in the
+    /// lineage": a graph can park two nodes on two gates and only one expired.
+    /// Anything whose node cannot be resolved settles nothing — a stale row is
+    /// the bug, but cancelling a sibling still waiting on a live decision would
+    /// be a worse one.
     async fn parked_workflow_attempts(&self, id: &ApprovalId) -> Vec<String> {
+        use crate::runtime::workflow_resume::{gate_node_id, run_and_node_from_node_turn};
+
         let Some(pending) = self.journal.pending().into_iter().find(|p| &p.id == id) else {
             return Vec::new();
         };
-        let Some(lineage) = workflow_run_of(&pending) else {
+        let cycle = self.journal.approval_cycle(id).flatten();
+        let resolved = cycle
+            .as_deref()
+            .and_then(run_and_node_from_node_turn)
+            .map(|(run, node)| (run.to_string(), node.to_string()))
+            .or_else(|| {
+                let run = workflow_run_of(&pending)?;
+                let node = gate_node_id(&pending.effect)?;
+                Some((run, node.to_string()))
+            });
+        let Some((lineage, node)) = resolved else {
             return Vec::new();
         };
-        let Some(node) = crate::runtime::workflow_resume::gate_node_id(&pending.effect) else {
-            return Vec::new();
-        };
-        let node = node.to_string();
         let filter = crate::ports::runs::RunFilter {
             workflow_run_id: Some(lineage),
             statuses: vec![crate::ports::runs::RunStatus::WaitingApproval],
@@ -8291,26 +8310,28 @@ mod tests {
         }
     }
 
-    /// A workflow gate parked on a node of `lineage`, in the shape production
-    /// actually leaves behind (Codex on the B-012 PR).
+    /// A **gated tool call** parked by a workflow agent node, in the shape
+    /// production actually creates (Codex on the B-012 PR, second round).
     ///
-    /// The two halves that matter are the two that were wrong when this was
-    /// hand-rolled: `Effect::run_id` is the **lineage** id, and the
-    /// `WaitingApproval` row is a separately-minted *attempt* linked to it by
-    /// `NewRun::for_workflow_node`. A fixture that gives the row the lineage's
-    /// own id proves only that the fixture works.
+    /// This is the path that leaves an attempt reading `WaitingApproval`:
+    /// `caps::park_gated_calls` journals `ApprovalPolicy::effect_for`'s effect —
+    /// `kind` is the **tool name**, `run_id` is `None` — under the node's
+    /// `workflow-node:{run}:{node}` cycle, and the node then settles its attempt
+    /// `WaitingApproval`. The earlier fixture here paired a `gate_effect` with a
+    /// hand-made attempt row, a combination no parking path produces, and so
+    /// reported a fix that could not fire in production as working.
     ///
     /// Returns the attempt row's id — the row the expiry has to find.
-    async fn park_workflow_gate(
+    async fn park_gated_node_call(
         rt: &std::sync::Arc<crate::company::runtime::CompanyRuntime>,
         approval: &crate::ports::types::ApprovalId,
         lineage: &str,
         node: &str,
         at_millis: u64,
-        cycle: Option<String>,
+        arm_continuation: bool,
     ) -> String {
         use crate::ports::runs::RunStatus;
-        use crate::ports::types::EventSeq;
+        use crate::ports::types::{Effect, EffectGroup, EventSeq};
         use crate::runtime::journal::{ApprovalConversation, TaskLink};
 
         let attempt = crate::ports::generate_id();
@@ -8334,15 +8355,22 @@ mod tests {
             .await
             .unwrap();
 
-        let effect = crate::runtime::workflow_resume::gate_effect(
-            "wf-demo",
-            node,
-            &serde_json::json!({}),
-            lineage,
-            &[],
-            &[],
-            None,
-        );
+        // `effect_for`'s shape, field for field: the tool's own name as the
+        // kind, the agent stamped, and **no** `run_id`.
+        let effect = Effect {
+            kind: "workspace.write".into(),
+            group: EffectGroup::Other,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::json!({ "path": "README.md" }),
+            agent: Some("ceo".into()),
+            run_id: None,
+        };
+        let node_turn = crate::runtime::workflow_resume::workflow_node_turn_key(lineage, node);
+        if arm_continuation {
+            rt.continuations.arm(&node_turn);
+        }
         rt.approval_gate
             .rehydrate(approval.clone(), effect.clone(), at_millis);
         rt.journal
@@ -8352,7 +8380,7 @@ mod tests {
                 at_millis,
                 TaskLink::Unlinked,
                 ApprovalConversation::default(),
-                cycle,
+                Some(node_turn),
             )
             .await
             .unwrap();
@@ -8411,7 +8439,7 @@ mod tests {
         // `WaitingApproval` and linked to the lineage, plus the gate itself
         // carrying that lineage. Parked at epoch 0 — past any TTL.
         let approval = ApprovalId::new("appr-b012");
-        let attempt = park_workflow_gate(&rt, &approval, "wr-b012", "solve", 0, None).await;
+        let attempt = park_gated_node_call(&rt, &approval, "wr-b012", "solve", 0, false).await;
 
         let expired = rt.sweep_expired_approvals().await.unwrap();
         assert!(
@@ -8452,15 +8480,15 @@ mod tests {
         // parked now (nowhere near it).
         let expiring = ApprovalId::new("appr-expiring");
         let attempt_expiring =
-            park_workflow_gate(&rt, &expiring, "wr-two-gates", "solve", 0, None).await;
+            park_gated_node_call(&rt, &expiring, "wr-two-gates", "solve", 0, false).await;
         let live = ApprovalId::new("appr-live");
-        let attempt_live = park_workflow_gate(
+        let attempt_live = park_gated_node_call(
             &rt,
             &live,
             "wr-two-gates",
             "review",
             crate::ports::now_millis(),
-            None,
+            false,
         )
         .await;
 
@@ -8492,46 +8520,60 @@ mod tests {
     }
 
     /// **The other half of B-012** (CodeRabbit on the B-012 PR). An expiry that
-    /// *releases* the run must not also cancel it.
+    /// *releases* the node must not also cancel its attempt.
     ///
-    /// `retire_approval` deliberately resumes a workflow run whose last
-    /// outstanding gate expired — "a workflow run releases even on an empty
-    /// batch … so its approved siblings are not stranded" (issue #978) — and it
-    /// **spawns** that resume rather than awaiting it. The first cut of B-012
-    /// cancelled the row unconditionally, which both raced the resume and
-    /// cancelled a run that was legitimately continuing with the expiry banked
-    /// as a deny. Suppressing the resume instead would strand the siblings,
+    /// `retire_approval` deliberately continues work whose last outstanding
+    /// decision expired — "a workflow run releases even on an empty batch … so
+    /// its approved siblings are not stranded" (issue #978) — and it **spawns**
+    /// that continuation rather than awaiting it. The first cut of B-012
+    /// cancelled the attempt unconditionally, which both raced the spawn and
+    /// cancelled work that was legitimately continuing with the expiry banked as
+    /// a deny. Suppressing the continuation instead would strand the siblings,
     /// which is the bug #978 exists to prevent; so the cancellation is what
     /// narrows, to the expiries that release nothing.
     ///
+    /// The scenario is the one that makes a node's batch non-empty, because an
+    /// expiry alone never does (`ContinuationQueue::decide` banks no event for
+    /// one): **two** gated calls on one node, one answered by the operator and
+    /// one left to expire. That is also exactly when the siblings #978 protects
+    /// exist at all.
+    ///
     /// Asserted on the **error text**, not the status: only `finish_expiry`
     /// writes that sentence, so the assertion cannot race whatever the spawned
-    /// resume goes on to do to the row.
+    /// continuation goes on to do to the row.
     #[tokio::test]
     async fn an_expiry_that_releases_the_run_does_not_also_cancel_it() {
-        use crate::ports::types::ApprovalId;
+        use crate::ports::types::{Actor, ActorKind, ApprovalId, Verdict};
         use std::sync::Arc;
 
         let (rt, _home) = runtime_with_events().await;
         let rt = Arc::new(rt);
 
-        // The difference from the test above, and the whole point of it: a real
-        // `workflow-run:` continuation, armed and recorded as this approval's
-        // cycle. Expiry is now this turn's last outstanding decision, so
-        // `retire_approval` releases the run instead of leaving it stranded.
-        let turn = crate::runtime::workflow_resume::workflow_turn_key("wr-released");
-        rt.continuations.arm(&turn);
-
         let approval = ApprovalId::new("appr-released");
-        let attempt = park_workflow_gate(
-            &rt,
-            &approval,
-            "wr-released",
-            "solve",
-            0,
-            Some(turn.clone()),
-        )
-        .await;
+        let attempt = park_gated_node_call(&rt, &approval, "wr-released", "solve", 0, true).await;
+
+        // The node's *second* gated call, answered by the operator before the
+        // first expires. Its banked event is what makes the released batch
+        // non-empty, and so what makes this node continue rather than strand.
+        let node_turn =
+            crate::runtime::workflow_resume::workflow_node_turn_key("wr-released", "solve");
+        rt.continuations.arm(&node_turn);
+        assert!(
+            rt.continuations
+                .decide(
+                    &node_turn,
+                    Some(CompanyEvent::ApprovalResolved {
+                        approval_id: ApprovalId::new("appr-answered"),
+                        verdict: Verdict::Approve,
+                        by: Actor {
+                            kind: ActorKind::Operator,
+                            id: "operator".into(),
+                        },
+                    }),
+                )
+                .is_none(),
+            "the node is still blocked on the gate that has not expired yet"
+        );
 
         let expired = rt.sweep_expired_approvals().await.unwrap();
         assert!(
@@ -8548,7 +8590,7 @@ mod tests {
         assert_ne!(
             row.error.as_deref(),
             Some("the approval this run was waiting on expired and defaulted to denied"),
-            "a released run settles through its resume; the expiry must not settle it too"
+            "a released node continues through its own resume; the expiry must not settle it too"
         );
     }
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1632,7 +1632,6 @@ impl CompanyRuntime {
     pub(crate) async fn unpark_blocker(self: &Arc<Self>, id: &ApprovalId) -> Result<()> {
         self.retire_approval(id, ExpiryReason::CardUnwritable, now_millis())
             .await
-            .map(|_released| ())
     }
 
     /// Thin `&self` wrapper around
@@ -2268,16 +2267,10 @@ impl CompanyRuntime {
         let unanswered = self.unanswered_blocker(id);
         let is_blocker = self.is_blocker(id);
         let waiting_runs = self.parked_workflow_attempts(id).await;
-        let released = self
-            .retire_approval(id, ExpiryReason::Ttl, now_millis())
+        self.retire_approval(id, ExpiryReason::Ttl, now_millis())
             .await?;
-        self.finish_expiry(
-            id,
-            is_blocker,
-            unanswered,
-            if released { Vec::new() } else { waiting_runs },
-        )
-        .await;
+        self.finish_expiry(id, is_blocker, unanswered, waiting_runs)
+            .await;
         Ok(())
     }
 
@@ -4658,14 +4651,9 @@ impl CompanyRuntime {
             // Issue B-012: and which workflow run was waiting on it, for the
             // same before-the-retirement reason as the two above.
             let waiting_runs = self.parked_workflow_attempts(id).await;
-            let released = self.retire_approval(id, ExpiryReason::Ttl, now).await?;
-            self.finish_expiry(
-                id,
-                is_blocker,
-                unanswered,
-                if released { Vec::new() } else { waiting_runs },
-            )
-            .await;
+            self.retire_approval(id, ExpiryReason::Ttl, now).await?;
+            self.finish_expiry(id, is_blocker, unanswered, waiting_runs)
+                .await;
         }
         Ok(expired)
     }
@@ -4697,7 +4685,7 @@ impl CompanyRuntime {
         id: &ApprovalId,
         was_blocker: bool,
         unanswered: Option<(String, String)>,
-        waiting_runs: Vec<String>,
+        waiting_runs: Vec<crate::ports::runs::RunRecord>,
     ) {
         // **The run that was waiting stops claiming it still is** (issue B-012).
         //
@@ -4716,23 +4704,35 @@ impl CompanyRuntime {
         // decision was made by the clock and nobody chose it. Not `Failed`:
         // nothing errored.
         //
-        // **Only when the expiry released nothing** (CodeRabbit on this PR).
-        // `retire_approval` deliberately resumes a workflow run whose *last*
-        // outstanding gate expired — "a workflow run releases even on an empty
-        // batch … so its approved siblings are not stranded" — and that resume
-        // is spawned, not awaited. Cancelling unconditionally would race it,
-        // and would cancel a run that is legitimately continuing with the
-        // expiry banked as a deny. The caller passes `None` in that case, so
-        // this settles exactly the rows nothing else will ever revisit.
+        // **Whether or not the expiry released a continuation** (Codex on this
+        // PR, third round). It is tempting to skip this when something was
+        // released — a node whose *other* gated call the operator approved does
+        // continue — but the continuation runs as a **new attempt**:
+        // `RunAttempts` is an in-memory map built fresh per run
+        // (`workflows/runner.rs`) and `caps` mints every attempt under
+        // `generate_id()`. Nothing ever writes this row again. So skipping it
+        // left exactly the stale `WaitingApproval` this issue exists to remove,
+        // and — because the continuation cannot touch this id — there was never
+        // a race here to avoid in the first place. This attempt stopped at a
+        // gate that defaulted to denied, which is true either way.
+        //
+        // **Usage is carried, not reset** (Codex, same round). `finish_run`
+        // assigns `run.usage` and `run.step_count` from the outcome
+        // (`ports/runs.rs`), and `RunOutcome::new` zeroes both — so settling
+        // from a bare outcome would silently erase the tokens and cost this
+        // attempt really did spend, on a row the billing surfaces read.
         //
         // Best-effort and last, like everything else here: a row that cannot be
         // written must not undo a default-deny that already happened.
-        for run_id in waiting_runs {
+        for row in waiting_runs {
+            let run_id = row.id;
             let outcome =
                 crate::ports::runs::RunOutcome::new(crate::ports::runs::RunStatus::Cancelled)
                     .with_error(
-                        "the approval this run was waiting on expired and defaulted to denied",
-                    );
+                        "the approval this attempt was waiting on expired and defaulted to denied",
+                    )
+                    .with_usage(row.usage)
+                    .with_step_count(row.step_count);
             if let Err(err) = self.runs().finish_run(&self.id, &run_id, outcome).await {
                 tracing::warn!(
                     company = %self.id,
@@ -4848,7 +4848,10 @@ impl CompanyRuntime {
     /// Anything whose node cannot be resolved settles nothing — a stale row is
     /// the bug, but cancelling a sibling still waiting on a live decision would
     /// be a worse one.
-    async fn parked_workflow_attempts(&self, id: &ApprovalId) -> Vec<String> {
+    async fn parked_workflow_attempts(
+        &self,
+        id: &ApprovalId,
+    ) -> Vec<crate::ports::runs::RunRecord> {
         use crate::runtime::workflow_resume::{gate_node_id, run_and_node_from_node_turn};
 
         let Some(pending) = self.journal.pending().into_iter().find(|p| &p.id == id) else {
@@ -4876,7 +4879,6 @@ impl CompanyRuntime {
             Ok(rows) => rows
                 .into_iter()
                 .filter(|row| row.node_id.as_deref() == Some(node.as_str()))
-                .map(|row| row.id)
                 .collect(),
             Err(err) => {
                 tracing::warn!(
@@ -5010,19 +5012,12 @@ impl CompanyRuntime {
     /// records `Deny`. That is the safety property the whole change rests on:
     /// an approval disappearing from the queue must never read as one that was
     /// granted.
-    /// Returns whether this retirement **released a continuation** — a turn or
-    /// workflow run that was waiting on the approval and has now been told.
-    ///
-    /// The caller needs to know, because a released workflow run goes on to
-    /// settle itself and must not be marked cancelled underneath the resume
-    /// this spawns (CodeRabbit on the B-012 PR). Only an expiry that releases
-    /// nothing leaves a row nobody will ever revisit.
     async fn retire_approval(
         self: &Arc<Self>,
         id: &ApprovalId,
         reason: ExpiryReason,
         at_millis: u64,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         let explicit_request = self
             .approval_gate
             .take_expired_effect(id)
@@ -5058,15 +5053,9 @@ impl CompanyRuntime {
                         by,
                     },
                 ))));
-                // Released: the asking agent's continuation is queued and its
-                // settled verdict spawned, so this run has been told and will
-                // settle itself. Cancelling it here would race that (CodeRabbit
-                // on the B-012 PR). The error arm above deliberately falls
-                // through instead — nothing was queued, so nothing was told.
-                return Ok(true);
+                return Ok(());
             }
         }
-        let mut released_continuation = false;
         // Issue #469: releasing the turn this approval was blocking, and
         // running its continuation when this expiry was the last thing it
         // waited on. Spawned rather than awaited: the continuation is a full
@@ -5089,9 +5078,6 @@ impl CompanyRuntime {
                 // siblings are not stranded. A brain turn with nothing to
                 // report owes no cycle, exactly as before.
                 if workflow_run || !batch.is_empty() {
-                    // Told to the caller: a released run settles itself, and
-                    // must not be cancelled underneath this resume.
-                    released_continuation = true;
                     let rt = Arc::clone(self);
                     let released = id.clone();
                     let turn = turn.clone();
@@ -5133,7 +5119,7 @@ impl CompanyRuntime {
                 "approval expiry journaled but its event-log entry failed",
             );
         }
-        Ok(released_continuation)
+        Ok(())
     }
 
     /// Expires every single-use grant the agent never redeemed, and tells the
@@ -8519,30 +8505,23 @@ mod tests {
         );
     }
 
-    /// **The other half of B-012** (CodeRabbit on the B-012 PR). An expiry that
-    /// *releases* the node must not also cancel its attempt.
+    /// **An expiry settles its attempt even when it releases a continuation**
+    /// (Codex on the B-012 PR, third round).
     ///
-    /// `retire_approval` deliberately continues work whose last outstanding
-    /// decision expired — "a workflow run releases even on an empty batch … so
-    /// its approved siblings are not stranded" (issue #978) — and it **spawns**
-    /// that continuation rather than awaiting it. The first cut of B-012
-    /// cancelled the attempt unconditionally, which both raced the spawn and
-    /// cancelled work that was legitimately continuing with the expiry banked as
-    /// a deny. Suppressing the continuation instead would strand the siblings,
-    /// which is the bug #978 exists to prevent; so the cancellation is what
-    /// narrows, to the expiries that release nothing.
+    /// The tempting reading is that a released node is "still going" and must
+    /// not be settled. It is not: a continuation runs as a **new** attempt —
+    /// `RunAttempts` is rebuilt per run and `caps` mints every attempt under
+    /// `generate_id()` — so nothing ever writes this row again. Skipping it left
+    /// exactly the stale `WaitingApproval` this issue exists to remove, and the
+    /// earlier version of this test could not see that, because it asserted only
+    /// that the cancellation *error* was absent and never looked at the status.
     ///
-    /// The scenario is the one that makes a node's batch non-empty, because an
+    /// The scenario is the one that makes a node's batch non-empty, since an
     /// expiry alone never does (`ContinuationQueue::decide` banks no event for
-    /// one): **two** gated calls on one node, one answered by the operator and
-    /// one left to expire. That is also exactly when the siblings #978 protects
-    /// exist at all.
-    ///
-    /// Asserted on the **error text**, not the status: only `finish_expiry`
-    /// writes that sentence, so the assertion cannot race whatever the spawned
-    /// continuation goes on to do to the row.
+    /// one): two gated calls on one node, one answered and one expired.
     #[tokio::test]
-    async fn an_expiry_that_releases_the_run_does_not_also_cancel_it() {
+    async fn an_expiry_settles_its_attempt_even_when_it_releases_a_continuation() {
+        use crate::ports::runs::RunStatus;
         use crate::ports::types::{Actor, ActorKind, ApprovalId, Verdict};
         use std::sync::Arc;
 
@@ -8554,7 +8533,7 @@ mod tests {
 
         // The node's *second* gated call, answered by the operator before the
         // first expires. Its banked event is what makes the released batch
-        // non-empty, and so what makes this node continue rather than strand.
+        // non-empty, and so what makes this node continue at all.
         let node_turn =
             crate::runtime::workflow_resume::workflow_node_turn_key("wr-released", "solve");
         rt.continuations.arm(&node_turn);
@@ -8587,11 +8566,66 @@ mod tests {
             .await
             .unwrap()
             .expect("the attempt row survives the sweep");
-        assert_ne!(
-            row.error.as_deref(),
-            Some("the approval this run was waiting on expired and defaulted to denied"),
-            "a released node continues through its own resume; the expiry must not settle it too"
+        assert_eq!(
+            row.status,
+            RunStatus::Cancelled,
+            "the released continuation runs as a NEW attempt, so this row is nobody else's \
+             to settle and must not be left reading `WaitingApproval`"
         );
+    }
+
+    /// **A settle that only changes status must not erase what the attempt
+    /// spent** (Codex on the B-012 PR, third round).
+    ///
+    /// `RunStore::finish_run` assigns `usage` and `step_count` from the outcome
+    /// rather than merging, and `RunOutcome::new` zeroes both — so cancelling an
+    /// expired attempt from a bare outcome silently wipes the tokens and cost it
+    /// really did spend, on a row the billing surfaces read.
+    #[tokio::test]
+    async fn settling_an_expired_attempt_keeps_the_usage_it_recorded() {
+        use crate::ports::runs::{RunOutcome, RunStatus};
+        use crate::ports::types::{ApprovalId, TokenUsage};
+        use std::sync::Arc;
+
+        let (rt, _home) = runtime_with_events().await;
+        let rt = Arc::new(rt);
+
+        let approval = ApprovalId::new("appr-usage");
+        let attempt = park_gated_node_call(&rt, &approval, "wr-usage", "solve", 0, false).await;
+
+        // What the attempt spent before it parked. Re-settled onto the parked
+        // row exactly as a real turn's trace fold would leave it.
+        let usage = TokenUsage {
+            input: 1_200,
+            output: 340,
+            cached_input: 0,
+            cost_usd: 0.042,
+        };
+        rt.runs()
+            .finish_run(
+                rt.id(),
+                &attempt,
+                RunOutcome::new(RunStatus::WaitingApproval)
+                    .with_usage(usage.clone())
+                    .with_step_count(7),
+            )
+            .await
+            .unwrap();
+
+        rt.sweep_expired_approvals().await.unwrap();
+
+        let row = rt
+            .runs()
+            .get_run(rt.id(), &attempt)
+            .await
+            .unwrap()
+            .expect("the attempt row survives the sweep");
+        assert_eq!(row.status, RunStatus::Cancelled);
+        assert_eq!(
+            row.usage, usage,
+            "the expiry changed the status; it must not have erased the spend"
+        );
+        assert_eq!(row.step_count, 7, "nor the trace it recorded");
     }
 
     /// Issue #1865 (Codex review on PR #1883): a late resolve that discovers

--- a/src/ports/runs.rs
+++ b/src/ports/runs.rs
@@ -490,6 +490,29 @@ impl RunOutcome {
         self.error = Some(error.into());
         self
     }
+
+    /// Carries an attempt's already-recorded usage into this settle.
+    ///
+    /// [`RunStore::finish_run`] **assigns** `usage` and `step_count` from the
+    /// outcome rather than merging them, and [`RunOutcome::new`] zeroes both. So
+    /// a settle that only means to change a row's *status* — an expiry
+    /// cancelling an attempt that was waiting on it, a reaper closing an
+    /// interrupted one — silently erases the tokens and cost that attempt
+    /// really did spend unless it carries them back (Codex, B-012 review).
+    /// Paired with [`with_step_count`](Self::with_step_count) for the same
+    /// reason.
+    pub fn with_usage(mut self, usage: TokenUsage) -> Self {
+        self.usage = usage;
+        self
+    }
+
+    /// Carries an attempt's already-recorded step count into this settle.
+    ///
+    /// See [`with_usage`](Self::with_usage) — same assignment, same erasure.
+    pub fn with_step_count(mut self, step_count: u32) -> Self {
+        self.step_count = step_count;
+        self
+    }
 }
 
 /// Which runs [`RunStore::list_runs`] should return.

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -229,6 +229,28 @@ pub fn is_node_turn(turn: &str) -> bool {
         .is_some_and(|rest| !rest.is_empty())
 }
 
+/// The `(run, node)` behind a key minted by [`workflow_node_turn_key`], or
+/// `None` for any other turn key (B-012, Codex review).
+///
+/// # Why this parses what `is_node_turn` deliberately does not
+///
+/// Routing a released batch only ever needed the prefix test, so nothing pulled
+/// the halves back out. Settling the attempt an *expired* gated call left behind
+/// does need them, and this key is the only place they survive: a gated tool
+/// call is parked with `ApprovalPolicy::effect_for`'s own effect, whose `kind`
+/// is the tool name and whose `run_id` is `None` — so neither the effect kind
+/// nor `Effect::run_id` can name the run or the node, and the cycle recorded at
+/// park time is the durable correlation.
+///
+/// Split on the **first** separator after the prefix: run ids are generated ids
+/// with no `:` in them, while a node id is a graph-authored string that may well
+/// contain one.
+pub fn run_and_node_from_node_turn(turn: &str) -> Option<(&str, &str)> {
+    let rest = turn.strip_prefix(WORKFLOW_NODE_TURN_PREFIX)?;
+    let (run_id, node_id) = rest.split_once(':')?;
+    (!run_id.is_empty() && !node_id.is_empty()).then_some((run_id, node_id))
+}
+
 /// The payload key holding the workflow whose run paused.
 pub const PAYLOAD_WORKFLOW_ID: &str = "workflow_id";
 /// The payload key holding the gate node awaiting sign-off.


### PR DESCRIPTION
## Summary

**B-012 (p0).** Three screens told three different stories about one parked
approval — and the approval itself vanished without the founder deciding it. The
Observatory showed a run awaiting a decision, the approvals list showed nothing
to decide, and neither was wrong about its own data.

## The run was never hung

That was my first assumption and it is incorrect. A workflow that parks on a
gate is recorded `WaitingApproval` — the run is *settled*, nothing is executing,
and that status is the row's account of **why** it stopped.
`workflow_resume.rs` says so directly:

> "A denied or TTL-expired approval never reaches `perform_effect` at all, and
> since the paused run is already settled, 'nothing runs' is the complete
> outcome — no task to cancel, no connection to close."

What was missing is smaller and stranger: expiry retired the approval and
removed it from the pending set, and **nothing ever revisited the row**. So the
run went on naming an approval no sweep would ever see again. Default
`approval_ttl_hours = 24`, and after that the disagreement is permanent.

## The fix

Not a resume — finishing the row that expiry orphaned.

- **`parked_workflow_run` reads the waiting run before `retire_approval`.** The
  sweeper already pre-reads two things for exactly this reason: retiring is what
  removes the pending entry, and afterwards there is no way back to which run was
  waiting, just as there is no way back to what was being asked. This is a third
  pre-read in the same place, for the same reason.
- **Threaded through the shared `finish_expiry`**, so the sweeper and the
  late-resolve path (`retire_if_expired`) leave identical state. That is the
  property the CodeRabbit review on #1905 established for the *card* — the two
  paths had disagreed and were unified. The **run** was never brought in; this
  brings it in.
- **`Cancelled`**, deliberately. "The attempt was cancelled before it could
  settle" is what a default-deny leaves behind. Not `Declined`, which is
  documented as work refused *by design* by the compiler or a step — here the
  clock decided and nobody chose it. Not `Failed`: nothing errored.

Best-effort and last, matching the rest of `finish_expiry`: a row that cannot be
written must not undo a default-deny that already happened, so that path logs
and leaves the row reporting what it reported before.

## Verification

- The new test is confirmed to **fail** with the fix reverted, reproducing the
  bug verbatim: `left: WaitingApproval, right: Cancelled`.
- `cargo test --locked` — 4505 passed
- `cargo test --locked --features openhuman --tests`
- `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Note

The PDF listed this cause as "not determined from the UI". It is determined now,
and it is narrower than the report suggests — nothing is stuck or leaking, one
row simply outlives the fact it points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed approval expiration handling for workflows that are automatically resumed.
  - Expired approvals no longer incorrectly cancel workflows after their continuation has been released.
  - Prevented unrelated workflow steps from being cancelled when an approval expires.
  - Expired and interrupted attempts now retain their recorded usage and step-count information when settled.
  - Improved consistency across approval expiration paths, preventing workflows from becoming stuck or receiving an incorrect cancelled status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->