### PR TITLE
fix(console): give the Composio catalog read a deadline that outlasts the host's own (#2007)

### DIFF
--- a/frontend/src/api/composio.ts
+++ b/frontend/src/api/composio.ts
@@ -13,7 +13,7 @@
 // toolkit allowlist). Standalone functions over the shared client (mirrors
 // `api/inference.ts`), so no change to `OpenCompanyClient` is needed.
 
-import type { OpenCompanyClient } from "./client";
+import type { OpenCompanyClient, RequestOptions } from "./client";
 
 /**
  * Where this company's Composio credential comes from.
@@ -209,12 +209,41 @@ export interface ComposioConnection {
   defaultConnectionId?: string;
 }
 
-/** The company's Composio status. */
+/**
+ * The host's own budget for the upstream catalog fetch behind `GET …/composio`
+ * — `composio_toolkits::FETCH_TIMEOUT` in `src/server/ops/composio_toolkits.rs`.
+ *
+ * Declared here so {@link CATALOG_READ_TIMEOUT_MS} can be checked against it.
+ * A change on the host that is not mirrored here breaks the invariant test
+ * rather than the Apps page.
+ */
+export const SERVER_FETCH_TIMEOUT_MS = 5_000;
+
+/**
+ * How long the console waits on `GET …/composio` before giving up.
+ *
+ * Must strictly dominate {@link SERVER_FETCH_TIMEOUT_MS}: on a cold catalog the
+ * host spends up to that budget upstream and then answers with a flagged
+ * fallback, so a client deadline at or below it cancels the read at exactly the
+ * moment the host is about to explain itself, and the fallback can never be
+ * rendered. Below the client's default `GET` deadline, because this read blocks a
+ * view and wants a tighter bound than the shared default.
+ */
+export const CATALOG_READ_TIMEOUT_MS = 15_000;
+
+/**
+ * The company's Composio status.
+ *
+ * `options` reaches the client's own deadline and cancellation: this route
+ * fetches a live catalog from the platform, so a caller that blocks a view on
+ * it wants a bound of its own and a way to drop a superseded read.
+ */
 export function getComposioStatus(
   client: OpenCompanyClient,
   company: string | null,
+  options?: RequestOptions,
 ): Promise<ComposioStatus> {
-  return client.get<ComposioStatus>(`${client.scopeFor(company)}/composio`);
+  return client.get<ComposioStatus>(`${client.scopeFor(company)}/composio`, options);
 }
 
 /**

--- a/frontend/src/views/OAuthView.tsx
+++ b/frontend/src/views/OAuthView.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import {
+  CATALOG_READ_TIMEOUT_MS,
   disconnectComposioConnection,
   getComposioStatus,
   listComposioConnections,
@@ -38,22 +39,6 @@ interface Props {
 }
 
 type Load = "loading" | "ready" | "unavailable";
-
-/**
- * How long the Composio status probe may take before the grid stops waiting on
- * it. Mirrors the host's own `COMPOSIO_PROBE_TIMEOUT` on the connections read
- * path (`src/server/ops/connections_read.rs`) — the same argument applies on
- * this side of the wire: the answer it contributes is which route a tile takes,
- * and a page that paints honestly beats a page that never paints.
- */
-const COMPOSIO_PROBE_TIMEOUT_MS = 5_000;
-
-/**
- * The value the probe race resolves when the timeout wins (issue #1478). A
- * unique sentinel, so "the probe timed out" is distinguishable from "the probe
- * answered `null`" — the two are different facts and must render differently.
- */
-const PROBE_TIMED_OUT = Symbol("composio-probe-timed-out");
 
 /**
  * Apps: the third-party accounts this company signs in to and acts through.
@@ -129,11 +114,10 @@ export function OAuthView({ client, company }: Props) {
   // `reach` reads "Not available on this host" — so every tile would flash that
   // and then flip to Connect a moment later.
   const [reachSettled, setReachSettled] = useState(false);
-  // Whether the Composio probe LOST ITS RACE against the timeout (issue #1478).
-  // Distinct from `status === null`, which is also what a genuine "no Composio
-  // surface" answer sets — collapsing the two rendered a timed-out probe as a
-  // confident "this host has no providers to offer yet". A slow host is the
-  // common case here: the probe reaches an external catalog.
+  // Whether the Composio probe could not be answered at all. Distinct from
+  // `status === null`, which is also what a genuine "no Composio surface"
+  // answer sets — collapsing the two renders "we could not check" as a
+  // confident "this host has no providers to offer yet".
   const [probeFailed, setProbeFailed] = useState(false);
   // Poll timers for Composio sign-ins in flight, keyed by toolkit, so a company
   // switch or unmount cannot leave one running.
@@ -198,40 +182,31 @@ export function OAuthView({ client, company }: Props) {
   // there is no native arm to fall back to any more.
   useEffect(() => {
     let live = true;
+    const abort = new AbortController();
     setReachSettled(false);
     setProbeFailed(false);
     void (async () => {
       try {
-        // Bounded: the shared client has no abort or timeout, and the grid now
-        // waits on this call before painting — so a host that accepts the
-        // connection and never answers would hold the page on skeletons forever.
-        // The timeout resolves a distinct SENTINEL rather than `null`, because a
-        // null answer and a request that never answered are different facts: the
-        // former is "no Composio surface", the latter is "we could not check",
-        // and rendering the second as the first is the #1478 defect.
-        const probed = await Promise.race([
-          getComposioStatus(client, company),
-          new Promise<typeof PROBE_TIMED_OUT>((resolve) =>
-            window.setTimeout(() => resolve(PROBE_TIMED_OUT), COMPOSIO_PROBE_TIMEOUT_MS),
-          ),
-        ]);
+        // Bounded and cancellable through the client itself. The bound must
+        // outlast the host's own upstream-catalog budget, or a cold catalog is
+        // abandoned at exactly the moment the host is about to answer with its
+        // flagged fallback — and the grid renders "couldn't check" for a host
+        // that could have explained itself.
+        const probed = await getComposioStatus(client, company, {
+          timeoutMs: CATALOG_READ_TIMEOUT_MS,
+          signal: abort.signal,
+        });
         if (!live) return;
-        if (probed === PROBE_TIMED_OUT) {
-          // Could not check — say so downstream rather than assembling a
-          // confident empty state from a request that never answered.
-          setStatus(null);
-          setAttested(false);
-          setProbeFailed(true);
-        } else {
-          setStatus(probed);
-          setAttested(probed?.credentialSource === "attested");
-        }
+        setStatus(probed);
+        setAttested(probed?.credentialSource === "attested");
       } catch (err) {
-        // A 404 is the honest "no Composio surface on this host" (issue #822):
-        // leave the page in its no-route state. Anything else — a 5xx, an
-        // offline network, an expired session — is UNKNOWN, not absent, so it
-        // takes the same `probeFailed` path as the timeout above. Collapsing it
-        // to a confident empty catalog is the #1478 defect one level down.
+        // A read this page tore down itself — a company switch, an unmount —
+        // says nothing about the host, so it must not leave a warning behind.
+        if (err instanceof Error && err.name === "AbortError") return;
+        // A 404 is the honest "no Composio surface on this host": leave the
+        // page in its no-route state. Anything else — a 5xx, an offline
+        // network, an expired session, a host that did not answer in time — is
+        // UNKNOWN, not absent, and says so.
         if (live) {
           setStatus(null);
           setAttested(false);
@@ -243,6 +218,7 @@ export function OAuthView({ client, company }: Props) {
     })();
     return () => {
       live = false;
+      abort.abort();
     };
     // `credentialGeneration` is load-bearing, not decoration: this probe feeds
     // `reach.hasCredential` and `attested`, both of which are downstream of the

--- a/frontend/test/e2e/composio-backend.mjs
+++ b/frontend/test/e2e/composio-backend.mjs
@@ -27,7 +27,8 @@
 //   GET  /healthz     → readiness, for `playwright.config.ts`'s webServer wait
 //   GET  /__executes  → every execute body seen, oldest first
 //   POST /__delay     → how long the catalog route takes to answer
-//   POST /__reset     → forget them, restore the seed connections, clear the delay
+//   POST /__catalog   → which toolkits this backend publishes
+//   POST /__reset     → forget them, and restore the seed connections, catalog and delay
 //
 // # What it deliberately does not do
 //
@@ -96,6 +97,42 @@ let toolkitsDelayMs = 0;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * The catalog this backend publishes, as the seed serves it.
+ *
+ * A separate function rather than a constant for the same reason
+ * `seedConnections` is one: `POST /__catalog` replaces the live value, and a
+ * spec that did so must be able to hand the next spec the original back.
+ */
+const seedCatalog = () => [
+  {
+    slug: "gmail",
+    name: "Gmail",
+    enabled: true,
+    description: "Send and read email.",
+    categories: ["email"],
+  },
+  {
+    slug: "slack",
+    name: "Slack",
+    enabled: true,
+    description: "Post messages to channels.",
+    categories: ["communication"],
+  },
+];
+
+/**
+ * The catalog this backend publishes right now.
+ *
+ * Replaceable because a Composio *credential* is what decides which catalog a
+ * company gets: rotating a token can resolve a different Composio account, with
+ * a different set of integrations behind it. That is the entire reason the host
+ * evicts its cached catalog on a token write, and a spec cannot show the console
+ * picked up a re-read unless the answer it re-reads is distinguishable from the
+ * one it already had.
+ */
+let catalog = seedCatalog();
+
 /** Every `POST …/execute` body this process has seen, oldest first. */
 const executes = [];
 
@@ -130,6 +167,12 @@ const server = createServer(async (req, res) => {
     return res.end(JSON.stringify(executes));
   }
 
+  if (path === "/__catalog" && req.method === "POST") {
+    const body = await readBody(req);
+    catalog = Array.isArray(body.catalog) ? body.catalog : seedCatalog();
+    return ok(res, { catalog });
+  }
+
   if (path === "/__delay" && req.method === "POST") {
     const body = await readBody(req);
     toolkitsDelayMs = Number(body.toolkitsMs) || 0;
@@ -139,6 +182,7 @@ const server = createServer(async (req, res) => {
   if (path === "/__reset" && req.method === "POST") {
     executes.length = 0;
     toolkitsDelayMs = 0;
+    catalog = seedCatalog();
     // The connection list is state this server changes too. Resetting only the
     // execute log would leave a spec that disconnected an account deciding what
     // every later spec in the process sees — a failure that surfaces in a spec
@@ -150,23 +194,8 @@ const server = createServer(async (req, res) => {
   if (path === "/agent-integrations/composio/toolkits") {
     if (toolkitsDelayMs > 0) await sleep(toolkitsDelayMs);
     return ok(res, {
-      toolkits: ["gmail", "slack"],
-      catalog: [
-        {
-          slug: "gmail",
-          name: "Gmail",
-          enabled: true,
-          description: "Send and read email.",
-          categories: ["email"],
-        },
-        {
-          slug: "slack",
-          name: "Slack",
-          enabled: true,
-          description: "Post messages to channels.",
-          categories: ["communication"],
-        },
-      ],
+      toolkits: catalog.map((entry) => entry.slug),
+      catalog,
     });
   }
 

--- a/frontend/test/e2e/composio-backend.mjs
+++ b/frontend/test/e2e/composio-backend.mjs
@@ -26,7 +26,8 @@
 //
 //   GET  /healthz     → readiness, for `playwright.config.ts`'s webServer wait
 //   GET  /__executes  → every execute body seen, oldest first
-//   POST /__reset     → forget them, and restore the seed connection list
+//   POST /__delay     → how long the catalog route takes to answer
+//   POST /__reset     → forget them, restore the seed connections, clear the delay
 //
 // # What it deliberately does not do
 //
@@ -77,6 +78,24 @@ const seedConnections = () => [
 /** The connections this company holds right now. */
 let connections = seedConnections();
 
+/**
+ * How long the catalog route takes to answer, in milliseconds.
+ *
+ * The host bounds its own catalog fetch (`composio_toolkits::FETCH_TIMEOUT`) and
+ * degrades to a flagged fallback when that budget runs out. A spec about what
+ * the console does with a slow or degraded catalog has to be able to *produce*
+ * that state, and the only honest way is to make this route actually slow —
+ * scripting the host's answer instead would assert against a shape nobody
+ * proved the host still emits.
+ *
+ * Zero by default, so every existing spec is unaffected. Set through
+ * `POST /__delay`, cleared by `POST /__reset` along with everything else this
+ * process carries between specs.
+ */
+let toolkitsDelayMs = 0;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 /** Every `POST …/execute` body this process has seen, oldest first. */
 const executes = [];
 
@@ -111,8 +130,15 @@ const server = createServer(async (req, res) => {
     return res.end(JSON.stringify(executes));
   }
 
+  if (path === "/__delay" && req.method === "POST") {
+    const body = await readBody(req);
+    toolkitsDelayMs = Number(body.toolkitsMs) || 0;
+    return ok(res, { toolkitsMs: toolkitsDelayMs });
+  }
+
   if (path === "/__reset" && req.method === "POST") {
     executes.length = 0;
+    toolkitsDelayMs = 0;
     // The connection list is state this server changes too. Resetting only the
     // execute log would leave a spec that disconnected an account deciding what
     // every later spec in the process sees — a failure that surfaces in a spec
@@ -122,6 +148,7 @@ const server = createServer(async (req, res) => {
   }
 
   if (path === "/agent-integrations/composio/toolkits") {
+    if (toolkitsDelayMs > 0) await sleep(toolkitsDelayMs);
     return ok(res, {
       toolkits: ["gmail", "slack"],
       catalog: [

--- a/frontend/test/e2e/composio-catalog-deadline.spec.ts
+++ b/frontend/test/e2e/composio-catalog-deadline.spec.ts
@@ -1,0 +1,255 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { COMPOSIO, COMPOSIO_FIXTURE_URL, COMPOSIO_REASON } from "./capabilities";
+
+/**
+ * Issue #2007 — the Apps page painted "couldn't check" on a first visit and the
+ * whole catalog on the second.
+ *
+ * # The shape of it
+ *
+ * Two budgets, nested, and the same size. The console bounded `GET …/composio`
+ * at five seconds; the host bounds its own upstream catalog fetch at five
+ * seconds *inside* that call. So on a cold catalog the host spends its whole
+ * budget upstream, degrades to a flagged fallback, and starts writing an answer
+ * that explains itself — at exactly the moment the console stops listening. The
+ * abandoned request still completed server-side and filled a fifteen-minute
+ * cache, which is why the second visit worked. The reload in the report was a
+ * red herring: any visit inside that window would have done.
+ *
+ * # Why this needs a browser
+ *
+ * `test/unit/oauth-catalog-probe.test.ts` drives the same states against a
+ * scripted transport, and it is the faster gate. It cannot see the half that
+ * actually broke: that a REAL host, degrading for its own real reasons, has
+ * something to say — and that the console is still listening when it says it.
+ * The fallback notice is produced here by a genuinely slow upstream, not by a
+ * fixture asserting the shape somebody believed the host emits.
+ *
+ * # The two clocks, kept apart on purpose
+ *
+ * The host's degradation is caused by the **fixture's** catalog delay. The
+ * console's wait is caused by a **route delay in the browser**. Separating them
+ * is what makes these specs deterministic: the host's catalog cache is
+ * process-level with a fifteen-minute TTL, so a spec that tried to produce the
+ * console's wait by keeping the cache cold would pass or fail on what the spec
+ * before it happened to leave behind. Every spec here evicts that cache
+ * explicitly (setting the Composio token evicts it) and then states the
+ * console's latency itself.
+ */
+
+test.skip(!COMPOSIO || !COMPOSIO_FIXTURE_URL, COMPOSIO_REASON);
+
+/** The Composio bearer the company holds. The fixture checks no auth. */
+const TOKEN = "e2e-catalog-deadline-token";
+
+/**
+ * Longer than the host's own upstream budget (`FETCH_TIMEOUT`, five seconds),
+ * so the host gives up on the catalog and answers with its flagged fallback.
+ */
+const PAST_THE_HOSTS_BUDGET_MS = 20_000;
+
+/**
+ * How long the console's own read is made to take.
+ *
+ * A second past the budget the console used to hold, which is the window the
+ * defect lived in: long enough that the old five-second race had already fired,
+ * short enough that a healthy read is plainly what arrives.
+ */
+const CONSOLE_LATENCY_MS = 6_000;
+
+const PROBE_FAILED = "providers-probe-failed";
+const GRANT_UNKNOWN = "Couldn't check whether this company grants";
+
+/** How long the fixture's catalog route takes to answer. */
+async function setCatalogDelay(page: Page, toolkitsMs: number): Promise<void> {
+  const set = await page.request.post(`${COMPOSIO_FIXTURE_URL}/__delay`, {
+    data: { toolkitsMs },
+  });
+  expect(set.ok(), `the composio fixture refused /__delay: ${set.status()}`).toBeTruthy();
+}
+
+/**
+ * Give this company a Composio credential — and, in doing so, drop the host's
+ * cached catalog for it.
+ *
+ * The eviction is the point as much as the credential: a rotated token can
+ * resolve to a different Composio account, so the host drops the cached catalog
+ * on every token write. That makes this the one lever a spec has to guarantee
+ * the next catalog read is genuinely cold, short of restarting the host.
+ */
+async function setTokenAndEvictCatalog(page: Page): Promise<void> {
+  const set = await page.request.put("/api/v1/company/composio/token", {
+    data: { token: TOKEN },
+  });
+  expect(set.ok(), `setting the composio token failed: ${set.status()}`).toBeTruthy();
+}
+
+/**
+ * The status read, and only it.
+ *
+ * A predicate rather than a glob because the console addresses its host by
+ * whichever scope its connection carries — `/api/v1/company/…` in
+ * single-company mode, `/api/v1/companies/<id>/…` otherwise — and a pattern
+ * pinned to one of them silently matches nothing against the other. The `$`
+ * keeps `…/composio/connections` and `…/composio/token` out of it.
+ */
+const isComposioStatus = (url: URL) => /\/composio$/.test(url.pathname);
+
+/** Make the console's own status read take `ms`, whatever the host is doing. */
+async function delayTheConsolesRead(page: Page, ms: number): Promise<void> {
+  await page.route(isComposioStatus, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+    await route.continue();
+  });
+}
+
+/**
+ * The provider grid, and nothing else on the page.
+ *
+ * Scoped deliberately: "Gmail" also appears in the account-choice section
+ * below, which is fed by a different read and paints while the catalog is still
+ * in flight — an unscoped match there passes before the thing under test has
+ * happened.
+ */
+function providerGrid(page: Page) {
+  return page.locator("section", { has: page.getByRole("heading", { name: "Providers" }) });
+}
+
+async function openApps(page: Page): Promise<void> {
+  await page.goto("/#/connections/apps");
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await skip
+    .waitFor({ state: "visible", timeout: 10_000 })
+    .then(() => skip.click())
+    .catch(() => {
+      /* already dismissed in this context */
+    });
+  await expect(skip).toBeHidden({ timeout: 10_000 });
+  await expect(page.getByRole("heading", { name: "Providers" })).toBeVisible({ timeout: 60_000 });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.request.post(`${COMPOSIO_FIXTURE_URL}/__reset`);
+});
+
+test("a first visit paints the catalog the host sent, however long it took to send it", async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+  await setCatalogDelay(page, 0);
+  await setTokenAndEvictCatalog(page);
+  await delayTheConsolesRead(page, CONSOLE_LATENCY_MS);
+
+  await openApps(page);
+
+  // The catalog the fixture actually serves, on the FIRST visit — no reload,
+  // no warm cache.
+  const grid = providerGrid(page);
+  await expect(grid.getByText("Gmail", { exact: true })).toBeVisible({ timeout: 60_000 });
+  await expect(grid.getByText("Slack", { exact: true })).toBeVisible({ timeout: 60_000 });
+
+  // And neither warning. They were never two failures: abandoning the read
+  // nulled the whole status, so the catalog warning and the grant warning came
+  // from one abandoned request.
+  await expect(page.getByTestId(PROBE_FAILED)).toHaveCount(0);
+  await expect(page.getByText(GRANT_UNKNOWN)).toHaveCount(0);
+});
+
+test("a host that degraded gets to say so, instead of being cut off mid-sentence", async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+  // The upstream outlasts the host's own budget, so the host degrades for real:
+  // it serves its built-in starter list and marks it as one.
+  await setCatalogDelay(page, PAST_THE_HOSTS_BUDGET_MS);
+  await setTokenAndEvictCatalog(page);
+  await delayTheConsolesRead(page, CONSOLE_LATENCY_MS);
+
+  await openApps(page);
+
+  // The graceful degradation the inversion was hiding. "Couldn't check" and
+  // "here is a starter list, and here is why" are different things to tell an
+  // operator, and only one of them is true here.
+  await expect(providerGrid(page).getByText("could not be fetched")).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(page.getByTestId(PROBE_FAILED)).toHaveCount(0);
+});
+
+test("a host that never answers at all still gets the honest warning", async ({ page }) => {
+  test.setTimeout(120_000);
+  await setCatalogDelay(page, 0);
+  await setTokenAndEvictCatalog(page);
+  // Accepted and never answered — the state the console's own deadline exists
+  // for. Widening that deadline must not have removed the warning, only moved
+  // it off the path a healthy host takes. A handler returning a promise that
+  // never settles is what holds the request pending; one that merely returns
+  // lets Playwright continue it.
+  await page.route(isComposioStatus, () => new Promise<never>(() => {}));
+
+  await openApps(page);
+
+  await expect(page.getByTestId(PROBE_FAILED)).toBeVisible({ timeout: 60_000 });
+});
+
+test("rotating the credential re-reads the catalog instead of warning about it", async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+  await setCatalogDelay(page, 0);
+  await setTokenAndEvictCatalog(page);
+
+  await openApps(page);
+  const grid = providerGrid(page);
+  await expect(grid.getByText("Gmail", { exact: true })).toBeVisible({ timeout: 60_000 });
+
+  // A rotation re-probes by tearing the in-flight read down and starting
+  // another. That teardown now cancels the request rather than merely ignoring
+  // its answer, and a cancellation this page caused says nothing about the
+  // host — so it must leave no warning where a fresh catalog belongs.
+  const field = page.getByLabel(/Composio token/);
+  await field.fill(`${TOKEN}-rotated`);
+  await page.getByRole("button", { name: "Save token" }).click();
+  // The field is cleared only on a write the host accepted, so this is what
+  // separates "the rotation happened" from "the click did nothing and the
+  // assertions below re-read a page that never changed".
+  await expect(field).toHaveValue("", { timeout: 30_000 });
+
+  await expect(grid.getByText("Gmail", { exact: true })).toBeVisible({ timeout: 60_000 });
+  await expect(grid.getByText("Slack", { exact: true })).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByTestId(PROBE_FAILED)).toHaveCount(0);
+  await expect(page.getByText(GRANT_UNKNOWN)).toHaveCount(0);
+});
+
+/**
+ * Put the company back as this file found it: no Composio token, and a fixture
+ * that answers immediately.
+ *
+ * The suite runs serially against one host, and this file sorts among the other
+ * `composio-*` specs and before `connections-*`. A token left set hands those a
+ * credentialled company; a delay left set makes their catalog read take twenty
+ * seconds and fails them for this file's reasons.
+ */
+test.afterAll(async ({ playwright }, testInfo) => {
+  const request = await playwright.request.newContext({
+    baseURL: testInfo.project.use.baseURL,
+    storageState: testInfo.project.use.storageState as string | undefined,
+  });
+  try {
+    const undelayed = await request.post(`${COMPOSIO_FIXTURE_URL}/__delay`, {
+      data: { toolkitsMs: 0 },
+    });
+    expect(
+      undelayed.ok(),
+      `clearing the composio fixture delay failed: ${undelayed.status()}`,
+    ).toBeTruthy();
+    const cleared = await request.put("/api/v1/company/composio/token", { data: { token: "" } });
+    expect(
+      cleared.ok(),
+      `clearing the composio token failed: ${cleared.status()} ${await cleared.text()}`,
+    ).toBeTruthy();
+  } finally {
+    await request.dispose();
+  }
+});

--- a/frontend/test/e2e/composio-catalog-deadline.spec.ts
+++ b/frontend/test/e2e/composio-catalog-deadline.spec.ts
@@ -61,6 +61,31 @@ const CONSOLE_LATENCY_MS = 6_000;
 const PROBE_FAILED = "providers-probe-failed";
 const GRANT_UNKNOWN = "Couldn't check whether this company grants";
 
+/**
+ * A provider this company has NOT connected.
+ *
+ * Load-bearing, and the reason it is not Gmail or Slack: a connected provider
+ * gets a tile from the connection list alone, so it appears whether or not the
+ * catalog ever arrived. An assertion on one of those passes on a page whose
+ * catalog read failed — which is precisely the state under test. Only an
+ * unconnected provider proves the catalog reached the grid.
+ */
+const UNCONNECTED = {
+  slug: "notion",
+  name: "Notion",
+  enabled: true,
+  description: "Pages and databases.",
+  categories: ["productivity"],
+};
+
+/** Which toolkits the fixture publishes. */
+async function setCatalog(page: Page, entries: unknown[]): Promise<void> {
+  const set = await page.request.post(`${COMPOSIO_FIXTURE_URL}/__catalog`, {
+    data: { catalog: entries },
+  });
+  expect(set.ok(), `the composio fixture refused /__catalog: ${set.status()}`).toBeTruthy();
+}
+
 /** How long the fixture's catalog route takes to answer. */
 async function setCatalogDelay(page: Page, toolkitsMs: number): Promise<void> {
   const set = await page.request.post(`${COMPOSIO_FIXTURE_URL}/__delay`, {
@@ -138,16 +163,18 @@ test("a first visit paints the catalog the host sent, however long it took to se
 }) => {
   test.setTimeout(120_000);
   await setCatalogDelay(page, 0);
+  await setCatalog(page, [UNCONNECTED]);
   await setTokenAndEvictCatalog(page);
   await delayTheConsolesRead(page, CONSOLE_LATENCY_MS);
 
   await openApps(page);
 
   // The catalog the fixture actually serves, on the FIRST visit — no reload,
-  // no warm cache.
+  // no warm cache. Asserted on the unconnected provider: Gmail and Slack have
+  // tiles either way, so they cannot tell a catalog that arrived from one that
+  // was abandoned.
   const grid = providerGrid(page);
-  await expect(grid.getByText("Gmail", { exact: true })).toBeVisible({ timeout: 60_000 });
-  await expect(grid.getByText("Slack", { exact: true })).toBeVisible({ timeout: 60_000 });
+  await expect(grid.getByText(UNCONNECTED.name, { exact: true })).toBeVisible({ timeout: 60_000 });
 
   // And neither warning. They were never two failures: abandoning the read
   // nulled the whole status, so the catalog warning and the grant warning came
@@ -203,28 +230,41 @@ test("rotating the credential re-reads the catalog instead of warning about it",
   await openApps(page);
   const grid = providerGrid(page);
   await expect(grid.getByText("Gmail", { exact: true })).toBeVisible({ timeout: 60_000 });
+  // Nothing is showing it yet, which is what makes its arrival below evidence
+  // of a re-read rather than of a page that never changed.
+  await expect(grid.getByText(UNCONNECTED.name, { exact: true })).toHaveCount(0);
+
+  // A rotated token can resolve a different Composio account, so the catalog
+  // moves with the credential — that is why the host evicts its cached one on
+  // every token write, and it is the only way this spec can tell a re-read from
+  // a page that simply kept what it had.
+  await setCatalog(page, [UNCONNECTED]);
 
   // A rotation re-probes by tearing the in-flight read down and starting
   // another. That teardown now cancels the request rather than merely ignoring
   // its answer, and a cancellation this page caused says nothing about the
   // host — so it must leave no warning where a fresh catalog belongs.
+  const reread = page.waitForResponse(
+    (response) => isComposioStatus(new URL(response.url())) && response.status() === 200,
+  );
   const field = page.getByLabel(/Composio token/);
   await field.fill(`${TOKEN}-rotated`);
   await page.getByRole("button", { name: "Save token" }).click();
-  // The field is cleared only on a write the host accepted, so this is what
-  // separates "the rotation happened" from "the click did nothing and the
-  // assertions below re-read a page that never changed".
+  // The field is cleared only on a write the host accepted, so this separates
+  // "the rotation happened" from "the click did nothing".
   await expect(field).toHaveValue("", { timeout: 30_000 });
+  await reread;
 
-  await expect(grid.getByText("Gmail", { exact: true })).toBeVisible({ timeout: 60_000 });
-  await expect(grid.getByText("Slack", { exact: true })).toBeVisible({ timeout: 60_000 });
+  // The provider this company has not connected, so it can only have reached
+  // the grid through a catalog read AFTER the rotation.
+  await expect(grid.getByText(UNCONNECTED.name, { exact: true })).toBeVisible({ timeout: 60_000 });
   await expect(page.getByTestId(PROBE_FAILED)).toHaveCount(0);
   await expect(page.getByText(GRANT_UNKNOWN)).toHaveCount(0);
 });
 
 /**
  * Put the company back as this file found it: no Composio token, and a fixture
- * that answers immediately.
+ * that answers immediately and publishes what it seeds with.
  *
  * The suite runs serially against one host, and this file sorts among the other
  * `composio-*` specs and before `connections-*`. A token left set hands those a
@@ -243,6 +283,13 @@ test.afterAll(async ({ playwright }, testInfo) => {
     expect(
       undelayed.ok(),
       `clearing the composio fixture delay failed: ${undelayed.status()}`,
+    ).toBeTruthy();
+    // Back to the seed catalog: an empty body restores it, and the specs
+    // running after this file expect gmail and slack to be what is published.
+    const reseeded = await request.post(`${COMPOSIO_FIXTURE_URL}/__catalog`, { data: {} });
+    expect(
+      reseeded.ok(),
+      `restoring the composio fixture catalog failed: ${reseeded.status()}`,
     ).toBeTruthy();
     const cleared = await request.put("/api/v1/company/composio/token", { data: { token: "" } });
     expect(

--- a/frontend/test/unit/composio-catalog-deadline.test.ts
+++ b/frontend/test/unit/composio-catalog-deadline.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_REQUEST_TIMEOUT_MS, OpenCompanyClient } from "@/api/client";
+import {
+  CATALOG_READ_TIMEOUT_MS,
+  SERVER_FETCH_TIMEOUT_MS,
+  getComposioStatus,
+  type ComposioStatus,
+} from "@/api/composio";
+import type {
+  StreamHandlers,
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from "@/api/transport";
+import { ApiError } from "@/api/types";
+import { classifyLoadFailure } from "@/lib/section-load";
+
+/**
+ * The deadline on `GET …/composio`, and the ordering it has to keep.
+ *
+ * The console's budget for this read used to equal the host's own budget for
+ * the upstream catalog fetch *inside* it — two five-second bounds, nested. On a
+ * cold catalog the host spends up to its whole budget upstream and then answers
+ * with a flagged fallback, so the console gave up at exactly the moment the host
+ * was about to explain itself: the operator saw "couldn't check" on their first
+ * visit and a full catalog on their second, once the host's fifteen-minute cache
+ * was warm.
+ *
+ * These pin the ordering that makes that impossible, that a host answering past
+ * its own budget is still heard out, and that the three ways this read can fail
+ * stay three different facts.
+ */
+
+/** A transport whose reply the test stages, per URL, with an optional delay. */
+class DelayedTransport implements Transport {
+  readonly seen: TransportRequest[] = [];
+  readonly aborted: string[] = [];
+
+  constructor(
+    private readonly reply: (
+      req: TransportRequest,
+    ) => { delayMs?: number | null } & Partial<TransportResponse>,
+  ) {}
+
+  async request(req: TransportRequest): Promise<TransportResponse> {
+    this.seen.push(req);
+    const staged = this.reply(req);
+    if (staged.delayMs === null) await new Promise<never>(() => {});
+    if (staged.delayMs) {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, staged.delayMs!);
+        req.signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            this.aborted.push(req.url);
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          },
+          { once: true },
+        );
+      });
+    }
+    return {
+      status: staged.status ?? 200,
+      statusText: staged.statusText ?? "",
+      url: staged.url ?? req.url,
+      text: staged.text ?? "",
+      header: staged.header ?? (() => null),
+    };
+  }
+
+  subscribe(_url: string, _handlers: StreamHandlers): () => void {
+    return () => {};
+  }
+}
+
+function clientOn(transport: Transport): OpenCompanyClient {
+  return new OpenCompanyClient(
+    { baseUrl: "https://host.test", company: null, operatorToken: null, sessionHeader: null },
+    transport,
+  );
+}
+
+/** The degraded answer a host gives when its own catalog fetch ran out of time. */
+const DEGRADED: ComposioStatus = {
+  inBuild: true,
+  granted: true,
+  credentialSource: "company",
+  backendUrl: "https://api.example.test",
+  toolkits: [],
+  openMode: true,
+  effectiveToolkits: ["gmail"],
+  effectiveCatalog: [
+    { slug: "gmail", name: "Gmail", description: "", logo: null, categories: [] },
+  ],
+  catalogSource: "fallback",
+  catalogNotice: "the Composio backend did not answer within 5s",
+};
+
+describe("the catalog read's deadline", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("strictly dominates the host's own budget, and stays under the shared default", () => {
+    // The invariant, not the literals. Re-equalising the two — which is the
+    // state this issue was filed from — fails here first.
+    expect(SERVER_FETCH_TIMEOUT_MS).toBeLessThan(CATALOG_READ_TIMEOUT_MS);
+    expect(CATALOG_READ_TIMEOUT_MS).toBeLessThan(DEFAULT_REQUEST_TIMEOUT_MS);
+  });
+
+  it("hears out a host that answers past its own catalog budget", async () => {
+    // A second past the host's upstream budget: the shape of a cold catalog
+    // whose upstream ran long, where the host degrades gracefully and says so.
+    const answersAt = SERVER_FETCH_TIMEOUT_MS + 1_000;
+    const client = clientOn(
+      new DelayedTransport(() => ({ delayMs: answersAt, text: JSON.stringify(DEGRADED) })),
+    );
+
+    const read = getComposioStatus(client, null, { timeoutMs: CATALOG_READ_TIMEOUT_MS });
+    await vi.advanceTimersByTimeAsync(answersAt);
+
+    // The whole point: the host's own honesty marker reaches the console.
+    await expect(read).resolves.toMatchObject({
+      catalogSource: "fallback",
+      catalogNotice: "the Composio backend did not answer within 5s",
+    });
+  });
+
+  it("gives up at its own deadline and not a moment earlier", async () => {
+    const client = clientOn(new DelayedTransport(() => ({ delayMs: null })));
+
+    let settled = false;
+    const read = getComposioStatus(client, null, { timeoutMs: CATALOG_READ_TIMEOUT_MS }).catch(
+      (err: unknown) => {
+        settled = true;
+        return err;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(CATALOG_READ_TIMEOUT_MS - 1);
+    expect(settled, "a read must not be abandoned before its deadline").toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await read).toMatchObject({ status: 0, code: "timeout" });
+  });
+});
+
+describe("the three ways the catalog read can fail stay three facts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reads a 404 as a host with no Composio surface", async () => {
+    const client = clientOn(new DelayedTransport(() => ({ status: 404, text: "" })));
+
+    const err = await getComposioStatus(client, null).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(404);
+    expect(classifyLoadFailure(err)).toBe("unavailable");
+  });
+
+  it("reads a host that never answered as unknown, not absent", async () => {
+    const client = clientOn(new DelayedTransport(() => ({ delayMs: null })));
+
+    const read = getComposioStatus(client, null, { timeoutMs: CATALOG_READ_TIMEOUT_MS }).catch(
+      (e: unknown) => e,
+    );
+    await vi.advanceTimersByTimeAsync(CATALOG_READ_TIMEOUT_MS);
+
+    const err = await read;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).toMatchObject({ status: 0, code: "timeout" });
+    // The sentinel the hand-rolled race needed is gone; this is what carries
+    // "we could not check" now, and it must not read as "not served here".
+    expect(classifyLoadFailure(err)).toBe("error");
+  });
+
+  it("keeps a caller's own cancellation apart from both of them", async () => {
+    const transport = new DelayedTransport(() => ({ delayMs: 60_000 }));
+    const client = clientOn(transport);
+    const abort = new AbortController();
+
+    const read = getComposioStatus(client, null, {
+      timeoutMs: CATALOG_READ_TIMEOUT_MS,
+      signal: abort.signal,
+    }).catch((e: unknown) => e);
+    abort.abort();
+
+    const err = await read;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("AbortError");
+    expect(err).not.toBeInstanceOf(ApiError);
+    // And the socket is actually released, rather than the answer merely
+    // ignored when it eventually arrives.
+    expect(transport.aborted).toEqual(["https://host.test/api/v1/company/composio"]);
+  });
+});

--- a/frontend/test/unit/oauth-catalog-probe.test.ts
+++ b/frontend/test/unit/oauth-catalog-probe.test.ts
@@ -1,0 +1,264 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OpenCompanyClient } from "@/api/client";
+import { SERVER_FETCH_TIMEOUT_MS, type ComposioStatus } from "@/api/composio";
+import type {
+  StreamHandlers,
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from "@/api/transport";
+import { OAuthView } from "@/views/OAuthView";
+
+/**
+ * What the Apps page renders while the host is still reading a cold catalog.
+ *
+ * `composio-catalog-deadline.test.ts` pins the read. This pins the page, which
+ * is where the two warnings the operator actually saw were assembled — and
+ * where they turn out to be one failure: abandoning the read set the status to
+ * `null`, so the catalog warning and the "couldn't check the grant" warning
+ * both came from the same abandoned request rather than from two.
+ *
+ * A slow host is the case under test throughout. `SERVER_FETCH_TIMEOUT_MS` is
+ * what the host may spend upstream before it degrades, so an answer just past
+ * it is the ordinary cold-catalog shape, not a pathological one.
+ */
+
+/** The reply staged for one URL. `delayMs: null` never answers at all. */
+interface Staged extends Partial<TransportResponse> {
+  delayMs?: number | null;
+}
+
+class RoutedTransport implements Transport {
+  readonly aborted: string[] = [];
+
+  constructor(private readonly route: (path: string) => Staged) {}
+
+  async request(req: TransportRequest): Promise<TransportResponse> {
+    const staged = this.route(new URL(req.url).pathname);
+    if (staged.delayMs === null) {
+      await new Promise<never>((_, reject) => {
+        req.signal?.addEventListener(
+          "abort",
+          () => {
+            this.aborted.push(new URL(req.url).pathname);
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          },
+          { once: true },
+        );
+      });
+    }
+    if (staged.delayMs) {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, staged.delayMs!);
+        req.signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            this.aborted.push(new URL(req.url).pathname);
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          },
+          { once: true },
+        );
+      });
+    }
+    return {
+      status: staged.status ?? 200,
+      statusText: staged.statusText ?? "",
+      url: req.url,
+      text: staged.text ?? "",
+      header: () => null,
+    };
+  }
+
+  subscribe(_url: string, _handlers: StreamHandlers): () => void {
+    return () => {};
+  }
+}
+
+function status(overrides: Partial<ComposioStatus> = {}): ComposioStatus {
+  return {
+    inBuild: true,
+    granted: true,
+    credentialSource: "company",
+    backendUrl: "https://api.example.test",
+    toolkits: [],
+    openMode: true,
+    effectiveToolkits: ["gmail", "slack"],
+    effectiveCatalog: [
+      { slug: "gmail", name: "Gmail", description: "Send and read email.", logo: null, categories: ["email"] },
+      { slug: "slack", name: "Slack", description: "Post to channels.", logo: null, categories: ["communication"] },
+    ],
+    catalogSource: "backend",
+    catalogNotice: null,
+    ...overrides,
+  };
+}
+
+/** Gmail already connected, so the grant warning has something to warn about. */
+const CONNECTIONS = JSON.stringify([
+  { provider: "gmail", connected: true, via: ["composio"] },
+]);
+
+/**
+ * A host whose Composio status answers after `answersIn`, and which serves
+ * nothing else this page asks for.
+ *
+ * The 404 is deliberate rather than lazy: every other section on this page
+ * treats it as "not served here" and hides, which keeps the render down to the
+ * grid this test is about.
+ */
+function hostAnswering(composio: Staged, connections: string = CONNECTIONS): RoutedTransport {
+  return new RoutedTransport((path) => {
+    if (path.endsWith("/composio")) return composio;
+    if (path.endsWith("/composio/connections")) return { text: JSON.stringify([]) };
+    if (path.endsWith("/connections")) return { text: connections };
+    if (path.endsWith("/auth/me")) return { text: JSON.stringify({ role: "admin" }) };
+    return { status: 404, text: "" };
+  });
+}
+
+function clientOn(transport: Transport): OpenCompanyClient {
+  return new OpenCompanyClient(
+    { baseUrl: "https://host.test", company: null, operatorToken: null, sessionHeader: null },
+    transport,
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.useFakeTimers();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.useRealTimers();
+});
+
+async function mount(client: OpenCompanyClient, company: string | null = null) {
+  await act(async () => {
+    root.render(createElement(OAuthView, { client, company }));
+  });
+}
+
+/** Let `ms` of staged latency elapse, and React settle the state it produced. */
+async function elapse(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+const PROBE_FAILED = '[data-testid="providers-probe-failed"]';
+const NOT_GRANTED = '[data-testid="providers-not-granted"]';
+const GRANT_UNKNOWN = "Couldn't check whether this company grants";
+
+function text(): string {
+  return container.textContent ?? "";
+}
+
+describe("the Apps page against a host reading a cold catalog", () => {
+  it("waits for an answer that arrives past the host's own upstream budget", async () => {
+    const answersIn = SERVER_FETCH_TIMEOUT_MS + 1_000;
+    const client = clientOn(hostAnswering({ delayMs: answersIn, text: JSON.stringify(status()) }));
+
+    await mount(client);
+    await elapse(answersIn);
+
+    // The catalog the host actually sent, on the FIRST visit — no reload, no
+    // warm cache.
+    expect(text()).toContain("Gmail");
+    expect(text()).toContain("Slack");
+    // And neither warning. They were one failure: abandoning the read nulled
+    // the status, which is what produced both.
+    expect(container.querySelectorAll(PROBE_FAILED)).toHaveLength(0);
+    expect(text()).not.toContain(GRANT_UNKNOWN);
+  });
+
+  it("renders the host's own fallback notice when the host degraded", async () => {
+    const answersIn = SERVER_FETCH_TIMEOUT_MS + 1_000;
+    const notice = "the Composio backend did not answer within 5s";
+    const client = clientOn(
+      hostAnswering({
+        delayMs: answersIn,
+        text: JSON.stringify(status({ catalogSource: "fallback", catalogNotice: notice })),
+      }),
+    );
+
+    await mount(client);
+    await elapse(answersIn);
+
+    // The graceful degradation the inversion was hiding: the host explains
+    // itself, and the console shows what it said rather than "couldn't check".
+    expect(text()).toContain(notice);
+    expect(container.querySelectorAll(PROBE_FAILED)).toHaveLength(0);
+  });
+
+  it("keeps a false grant a false grant on a slow read", async () => {
+    const answersIn = SERVER_FETCH_TIMEOUT_MS + 1_000;
+    const client = clientOn(
+      hostAnswering({ delayMs: answersIn, text: JSON.stringify(status({ granted: false })) }),
+    );
+
+    await mount(client);
+    await elapse(answersIn);
+
+    // `granted` survives as a real boolean. Abandoning the read left it
+    // `undefined`, which renders as "we could not check" — the second warning
+    // in the report, and collateral of the first rather than a second failure.
+    expect(container.querySelectorAll(NOT_GRANTED)).toHaveLength(1);
+    expect(text()).not.toContain(GRANT_UNKNOWN);
+  });
+
+  it("still says so honestly about a host that never answers", async () => {
+    const client = clientOn(hostAnswering({ delayMs: null }));
+
+    await mount(client);
+    await elapse(60_000);
+
+    // The warning is not weakened — only moved off the healthy path.
+    expect(container.querySelectorAll(PROBE_FAILED)).toHaveLength(1);
+  });
+
+  it("reads a 404 as a host with no Composio surface, not as a failed check", async () => {
+    // Nothing connected, so the empty state is the one this host can honestly
+    // reach — the distinction is between "nothing here" and "could not check".
+    const client = clientOn(hostAnswering({ status: 404, text: "" }, "[]"));
+
+    await mount(client);
+    await elapse(1_000);
+
+    expect(container.querySelectorAll(PROBE_FAILED)).toHaveLength(0);
+    expect(container.querySelectorAll('[data-testid="providers-empty"]')).toHaveLength(1);
+  });
+
+  it("cancels a superseded read instead of ignoring it, and warns about neither", async () => {
+    const transport = hostAnswering({ delayMs: null });
+    const client = clientOn(transport);
+
+    await mount(client, "acme");
+    // A company switch while the first read is still open.
+    await act(async () => {
+      root.render(createElement(OAuthView, { client, company: "globex" }));
+    });
+    await elapse(1_000);
+
+    // The socket is released rather than left running for an answer nobody
+    // will read.
+    expect(transport.aborted).toContain("/api/v1/companies/acme/composio");
+    // And the cancellation says nothing about the host, so it leaves no
+    // warning behind for the company now on screen.
+    expect(container.querySelectorAll(PROBE_FAILED)).toHaveLength(0);
+    expect(text()).not.toContain(GRANT_UNKNOWN);
+  });
+});

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -144,14 +144,13 @@ async fn effective_toolkits(
 ///
 /// The cache is consulted before the (cfg-split) fetch and records the outcome
 /// either way, so a status poll during an outage costs a map lookup rather than
-/// another fetch timeout of waiting.
+/// another fetch timeout of waiting. Concurrent callers on a cold key share one
+/// fetch rather than each starting their own.
 async fn open_mode_toolkits(runtime: &CompanyRuntime) -> OpenModeToolkits {
     let key = catalog_cache_key(runtime);
-    if let Some(cached) = composio_toolkits::cache().lookup(&key, std::time::Instant::now()) {
-        return OpenModeToolkits::from_outcome(cached);
-    }
-    let outcome = fetch_catalog(runtime).await;
-    composio_toolkits::cache().store(&key, outcome.clone(), std::time::Instant::now());
+    let outcome = composio_toolkits::cache()
+        .get_or_fetch(&key, || fetch_catalog(runtime))
+        .await;
     OpenModeToolkits::from_outcome(outcome)
 }
 

--- a/src/server/ops/composio_toolkits.rs
+++ b/src/server/ops/composio_toolkits.rs
@@ -219,6 +219,32 @@ impl CacheEntry {
     }
 }
 
+/// What a catalog fetch produced: the entries, or a plain-language reason.
+type FetchOutcome = Result<Vec<CatalogEntry>, String>;
+
+/// A fetch running right now, and the key generation it began under.
+struct InFlight {
+    /// The key's generation when this fetch started. A fetch whose generation
+    /// is no longer current was dialled with a credential the company has since
+    /// replaced: it may still answer the callers already waiting on it, but it
+    /// may not be cached and no new caller may join it.
+    generation: u64,
+    tx: broadcast::Sender<FetchOutcome>,
+}
+
+/// The fetches in flight, and how many times each key has been evicted.
+///
+/// Behind one lock because every decision here reads them together: whether a
+/// caller may join a running fetch, and whether a finished one is still
+/// entitled to speak for its key. The generation counter outlives the cache
+/// entry it guards — it must, since its whole job is to describe fetches that
+/// started before an eviction — and costs one integer per company.
+#[derive(Default)]
+struct Flights {
+    running: HashMap<String, InFlight>,
+    generations: HashMap<String, u64>,
+}
+
 /// A process-level, per-company cache of the fetched catalog.
 ///
 /// Keyed per company rather than per backend URL even though the catalog is
@@ -227,29 +253,35 @@ impl CacheEntry {
 /// across tenants would let one company's outage mark another company's panel
 /// degraded. Entries are small (a hundred short strings) and bounded by the
 /// number of companies an instance hosts.
-/// What a catalog fetch produced: the entries, or a plain-language reason.
-type FetchOutcome = Result<Vec<CatalogEntry>, String>;
-
 #[derive(Default)]
 pub(crate) struct CatalogCache {
     entries: Mutex<HashMap<String, CacheEntry>>,
-    /// The fetches running right now, keyed the same way, so callers arriving
-    /// on a cold key wait on one rather than each starting their own.
-    in_flight: Mutex<HashMap<String, broadcast::Sender<FetchOutcome>>>,
+    flights: Mutex<Flights>,
 }
 
-/// Clears `key` from [`CatalogCache::in_flight`] however the leader's fetch
-/// ends. A panic or a dropped request future must not leave an entry behind
-/// that later callers would wait on forever.
-struct Flight<'a> {
+/// Releases a leader's slot however its fetch ends — a panic or a dropped
+/// request future included, so neither strands later callers on a fetch that
+/// will never answer.
+///
+/// Releases it only while it still holds THIS flight. Removing blindly by key
+/// lets a slow fetch finishing after an eviction delete the successor that
+/// replaced it, and the next caller then starts a third fetch instead of
+/// joining the second.
+struct FlightGuard<'a> {
     cache: &'a CatalogCache,
     key: &'a str,
+    generation: u64,
 }
 
-impl Drop for Flight<'_> {
+impl Drop for FlightGuard<'_> {
     fn drop(&mut self) {
-        if let Ok(mut flights) = self.cache.in_flight.lock() {
-            flights.remove(self.key);
+        if let Ok(mut flights) = self.cache.flights.lock()
+            && flights
+                .running
+                .get(self.key)
+                .is_some_and(|running| running.generation == self.generation)
+        {
+            flights.running.remove(self.key);
         }
     }
 }
@@ -280,20 +312,25 @@ impl CatalogCache {
             return cached;
         }
         let joined = {
-            let Ok(mut flights) = self.in_flight.lock() else {
+            let Ok(mut flights) = self.flights.lock() else {
                 return fetch().await;
             };
-            match flights.get(key) {
-                Some(tx) => Err(tx.subscribe()),
+            let generation = flights.generations.get(key).copied().unwrap_or(0);
+            match flights.running.get(key) {
+                Some(running) => Err(running.tx.subscribe()),
                 None => {
                     let (tx, _) = broadcast::channel(1);
-                    flights.insert(key.to_string(), tx.clone());
-                    Ok(tx)
+                    let running = InFlight {
+                        generation,
+                        tx: tx.clone(),
+                    };
+                    flights.running.insert(key.to_string(), running);
+                    Ok((tx, generation))
                 }
             }
         };
-        let tx = match joined {
-            Ok(tx) => tx,
+        let (tx, generation) = match joined {
+            Ok(led) => led,
             Err(mut rx) => {
                 return match rx.recv().await {
                     Ok(outcome) => outcome,
@@ -308,11 +345,33 @@ impl CatalogCache {
                 };
             }
         };
-        let _flight = Flight { cache: self, key };
+        let guard = FlightGuard {
+            cache: self,
+            key,
+            generation,
+        };
         let outcome = fetch().await;
-        self.store(key, outcome.clone(), Instant::now());
+        // Cached only while the credential it was dialled with is still the
+        // company's. An eviction during the fetch means this describes an
+        // account the company no longer reaches, and storing it would reinstate
+        // for a full TTL exactly what the eviction removed.
+        if self.is_current(key, generation) {
+            self.store(key, outcome.clone(), Instant::now());
+        }
+        drop(guard);
         let _ = tx.send(outcome.clone());
         outcome
+    }
+
+    /// Whether a fetch begun at `generation` still speaks for `key`.
+    ///
+    /// A poisoned map answers `false`: it cannot prove the answer is current,
+    /// and serving a superseded catalog is the failure this guards.
+    fn is_current(&self, key: &str, generation: u64) -> bool {
+        self.flights
+            .lock()
+            .map(|flights| flights.generations.get(key).copied().unwrap_or(0) == generation)
+            .unwrap_or(false)
     }
 
     /// The cached outcome for `key`, if one was recorded within its TTL of
@@ -335,15 +394,30 @@ impl CatalogCache {
         }
     }
 
-    /// Drop `key`'s entry so the next read re-fetches.
+    /// Drop `key`'s cached entry so the next read re-fetches, and retire every
+    /// fetch already in flight for it.
     ///
     /// Called when the company's credential changes: a rotated BYO token can
     /// resolve to a different Composio account, and continuing to serve the old
     /// account's catalog for up to [`CATALOG_TTL`] would be exactly the kind of
     /// stale-by-construction answer this issue is about.
+    ///
+    /// Retiring the in-flight fetches is what keeps that true once callers
+    /// share one. Dropping the cached entry alone leaves a fetch dialled with
+    /// the replaced credential free to be joined by the very next caller — the
+    /// status re-read the rotation itself performs is one — and free to store
+    /// its answer afterwards, reinstating the evicted catalog for a full TTL.
+    ///
+    /// The callers already waiting on such a fetch still receive its answer.
+    /// Their request predates the rotation, and without a shared flight each
+    /// would have had exactly this fetch of its own running.
     pub(crate) fn evict(&self, key: &str) {
         if let Ok(mut entries) = self.entries.lock() {
             entries.remove(key);
+        }
+        if let Ok(mut flights) = self.flights.lock() {
+            *flights.generations.entry(key.to_string()).or_default() += 1;
+            flights.running.remove(key);
         }
     }
 }
@@ -617,6 +691,110 @@ mod tests {
             fetches.load(Ordering::SeqCst),
             2,
             "an evicted key must re-fetch, not join a flight that has finished"
+        );
+    }
+
+    /// A rotation retires the fetch that was already running for the key.
+    ///
+    /// `evict` fires the moment a company's credential changes, and the same
+    /// request then re-reads the status. Once callers share a flight, dropping
+    /// only the cached entry leaves two ways for the replaced account's catalog
+    /// to survive the rotation: that re-read joins the fetch dialled with the
+    /// old credential, and that fetch afterwards stores its answer on top of the
+    /// eviction, serving it for a full TTL. Both halves are asserted — what the
+    /// post-rotation read receives, and what is left in the cache behind it.
+    #[tokio::test(start_paused = true)]
+    async fn an_eviction_retires_the_fetch_already_in_flight() {
+        let cache = CatalogCache::default();
+        let fetches = AtomicUsize::new(0);
+
+        // Dialled with the credential that is about to be replaced.
+        let stale = || async {
+            fetches.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            Ok(slugs(&["stale"]))
+        };
+
+        let rotation = async {
+            // Let the fetch above register itself and reach its await point.
+            tokio::task::yield_now().await;
+            cache.evict("k");
+            // The status re-read the rotation performs, under the new credential.
+            cache
+                .get_or_fetch("k", || async {
+                    fetches.fetch_add(1, Ordering::SeqCst);
+                    Ok(slugs(&["fresh"]))
+                })
+                .await
+        };
+
+        let (_retired, after) = tokio::join!(cache.get_or_fetch("k", stale), rotation);
+
+        assert_eq!(
+            after,
+            Ok(slugs(&["fresh"])),
+            "a read after a rotation must not be answered by a fetch dialled with the replaced credential"
+        );
+        assert_eq!(
+            cache.lookup("k", Instant::now()),
+            Some(Ok(slugs(&["fresh"]))),
+            "a fetch that began before the eviction must not reinstate what it removed"
+        );
+        assert_eq!(fetches.load(Ordering::SeqCst), 2);
+    }
+
+    /// A fetch finishing after an eviction does not release the fetch that
+    /// replaced it.
+    ///
+    /// The slot is keyed by company alone, so releasing it blindly lets a
+    /// straggler remove its own successor — and the next caller, finding no
+    /// flight, dials a third time for a list somebody is already fetching. The
+    /// answer the latecomer receives pins the other half: it must be the
+    /// successor's, never the retired fetch's.
+    #[tokio::test(start_paused = true)]
+    async fn a_straggler_does_not_release_its_successor() {
+        let cache = CatalogCache::default();
+        let fetches = AtomicUsize::new(0);
+
+        let straggler = || async {
+            fetches.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            Ok(slugs(&["stale"]))
+        };
+        let successor = || async {
+            fetches.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            Ok(slugs(&["fresh"]))
+        };
+        let third = || async {
+            fetches.fetch_add(1, Ordering::SeqCst);
+            Ok(slugs(&["third"]))
+        };
+
+        let rotate = async {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            cache.evict("k");
+            cache.get_or_fetch("k", successor).await
+        };
+        // Arrives after the straggler has finished, while the successor still runs.
+        let latecomer = async {
+            tokio::time::sleep(Duration::from_millis(60)).await;
+            cache.get_or_fetch("k", third).await
+        };
+
+        let (_retired, replaced, joined) =
+            tokio::join!(cache.get_or_fetch("k", straggler), rotate, latecomer);
+
+        assert_eq!(replaced, Ok(slugs(&["fresh"])));
+        assert_eq!(
+            joined,
+            Ok(slugs(&["fresh"])),
+            "a caller arriving after the rotation must get the successor's answer, not the retired fetch's"
+        );
+        assert_eq!(
+            fetches.load(Ordering::SeqCst),
+            2,
+            "the latecomer must join the fetch in flight rather than start a third"
         );
     }
 

--- a/src/server/ops/composio_toolkits.rs
+++ b/src/server/ops/composio_toolkits.rs
@@ -39,6 +39,8 @@ use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
+use tokio::sync::broadcast;
+
 use serde::Serialize;
 
 use crate::company::composio::CatalogEntry;
@@ -225,12 +227,94 @@ impl CacheEntry {
 /// across tenants would let one company's outage mark another company's panel
 /// degraded. Entries are small (a hundred short strings) and bounded by the
 /// number of companies an instance hosts.
+/// What a catalog fetch produced: the entries, or a plain-language reason.
+type FetchOutcome = Result<Vec<CatalogEntry>, String>;
+
 #[derive(Default)]
 pub(crate) struct CatalogCache {
     entries: Mutex<HashMap<String, CacheEntry>>,
+    /// The fetches running right now, keyed the same way, so callers arriving
+    /// on a cold key wait on one rather than each starting their own.
+    in_flight: Mutex<HashMap<String, broadcast::Sender<FetchOutcome>>>,
+}
+
+/// Clears `key` from [`CatalogCache::in_flight`] however the leader's fetch
+/// ends. A panic or a dropped request future must not leave an entry behind
+/// that later callers would wait on forever.
+struct Flight<'a> {
+    cache: &'a CatalogCache,
+    key: &'a str,
+}
+
+impl Drop for Flight<'_> {
+    fn drop(&mut self) {
+        if let Ok(mut flights) = self.cache.in_flight.lock() {
+            flights.remove(self.key);
+        }
+    }
 }
 
 impl CatalogCache {
+    /// The catalog for `key`: the cached outcome, the answer of a fetch already
+    /// running for the same key, or — for exactly one caller — `fetch`.
+    ///
+    /// The middle arm is what this adds. `GET …/composio` sits on a page-load
+    /// path the console asks more than once per paint, and on a cold key every
+    /// concurrent caller used to dial the backend for a list they were certain
+    /// to agree on, each paying the full [`FETCH_TIMEOUT`] before the page could
+    /// paint.
+    ///
+    /// Coalescing is an optimisation and never a correctness dependency: a
+    /// poisoned map, a leader that was cancelled, or a caller that arrives just
+    /// as one finishes all fall through to a fetch of their own.
+    pub(crate) async fn get_or_fetch<F, Fut>(
+        &self,
+        key: &str,
+        fetch: F,
+    ) -> Result<Vec<CatalogEntry>, String>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<Vec<CatalogEntry>, String>>,
+    {
+        if let Some(cached) = self.lookup(key, Instant::now()) {
+            return cached;
+        }
+        let joined = {
+            let Ok(mut flights) = self.in_flight.lock() else {
+                return fetch().await;
+            };
+            match flights.get(key) {
+                Some(tx) => Err(tx.subscribe()),
+                None => {
+                    let (tx, _) = broadcast::channel(1);
+                    flights.insert(key.to_string(), tx.clone());
+                    Ok(tx)
+                }
+            }
+        };
+        let tx = match joined {
+            Ok(tx) => tx,
+            Err(mut rx) => {
+                return match rx.recv().await {
+                    Ok(outcome) => outcome,
+                    // The leader went away without answering, or answered just
+                    // before this caller subscribed. Its result is in the cache
+                    // in the second case; in the first there is nothing to wait
+                    // for any more.
+                    Err(_) => match self.lookup(key, Instant::now()) {
+                        Some(outcome) => outcome,
+                        None => fetch().await,
+                    },
+                };
+            }
+        };
+        let _flight = Flight { cache: self, key };
+        let outcome = fetch().await;
+        self.store(key, outcome.clone(), Instant::now());
+        let _ = tx.send(outcome.clone());
+        outcome
+    }
+
     /// The cached outcome for `key`, if one was recorded within its TTL of
     /// `now`. An expired entry reads as a miss and is left for the next
     /// [`Self::store`] to overwrite.
@@ -280,6 +364,7 @@ pub(crate) fn cache_key(company: &crate::ports::types::CompanyId, backend_url: &
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Slug-only catalog entries — what a manifest list, a fallback list, or a
     /// backend predating the dynamic catalog yields.
@@ -400,6 +485,139 @@ mod tests {
         cache.store("k", Ok(slugs(&["gmail"])), at);
         cache.evict("k");
         assert_eq!(cache.lookup("k", at), None);
+    }
+
+    /// Two callers arriving on a cold key perform exactly ONE fetch, and both
+    /// get its answer.
+    ///
+    /// This is the page-load case: the console asks `GET …/composio` more than
+    /// once per paint, and before coalescing each ask dialled the backend for a
+    /// list they were certain to agree on. `join!` polls the first future to its
+    /// first await point before starting the second, so the second is guaranteed
+    /// to arrive while the first is still fetching.
+    #[tokio::test]
+    async fn two_cold_callers_share_one_fetch() {
+        let cache = CatalogCache::default();
+        let fetches = AtomicUsize::new(0);
+        let fetch = || async {
+            fetches.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            Ok(slugs(&["gmail"]))
+        };
+
+        let (first, second) = tokio::join!(
+            cache.get_or_fetch("k", fetch),
+            cache.get_or_fetch("k", fetch)
+        );
+
+        assert_eq!(
+            fetches.load(Ordering::SeqCst),
+            1,
+            "a second caller on a cold key must wait on the fetch in flight, not start another"
+        );
+        assert_eq!(first, Ok(slugs(&["gmail"])));
+        assert_eq!(second, first, "both callers get the same answer");
+        assert_eq!(
+            cache.lookup("k", Instant::now()),
+            Some(Ok(slugs(&["gmail"]))),
+            "the shared fetch still fills the cache"
+        );
+    }
+
+    /// A shared FAILURE is shared too — and cached under [`FAILURE_TTL`], so an
+    /// outage costs one fetch for every caller in the window rather than one
+    /// each.
+    #[tokio::test]
+    async fn two_cold_callers_share_one_failure() {
+        let cache = CatalogCache::default();
+        let fetches = AtomicUsize::new(0);
+        let fetch = || async {
+            fetches.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            Err("the Composio backend did not answer".to_string())
+        };
+
+        let (first, second) = tokio::join!(
+            cache.get_or_fetch("k", fetch),
+            cache.get_or_fetch("k", fetch)
+        );
+
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            first,
+            Err("the Composio backend did not answer".to_string())
+        );
+        assert_eq!(second, first);
+    }
+
+    /// A cached key never reaches the fetch at all — coalescing is added in
+    /// front of the cache, not in place of it.
+    #[tokio::test]
+    async fn a_cached_key_is_served_without_a_fetch() {
+        let cache = CatalogCache::default();
+        cache.store("k", Ok(slugs(&["slack"])), Instant::now());
+        let fetches = AtomicUsize::new(0);
+
+        let served = cache
+            .get_or_fetch("k", || async {
+                fetches.fetch_add(1, Ordering::SeqCst);
+                Ok(slugs(&["gmail"]))
+            })
+            .await;
+
+        assert_eq!(served, Ok(slugs(&["slack"])));
+        assert_eq!(fetches.load(Ordering::SeqCst), 0);
+    }
+
+    /// Two companies fetching at once do not coalesce onto each other: the
+    /// in-flight map is keyed exactly like the cache, so one tenant can never be
+    /// served another's catalog.
+    #[tokio::test]
+    async fn different_keys_do_not_share_a_fetch() {
+        let cache = CatalogCache::default();
+        let fetches = AtomicUsize::new(0);
+        let acme = || async {
+            fetches.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            Ok(slugs(&["gmail"]))
+        };
+        let globex = || async {
+            fetches.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            Ok(slugs(&["slack"]))
+        };
+
+        let (a, g) = tokio::join!(
+            cache.get_or_fetch("acme", acme),
+            cache.get_or_fetch("globex", globex)
+        );
+
+        assert_eq!(fetches.load(Ordering::SeqCst), 2);
+        assert_eq!(a, Ok(slugs(&["gmail"])));
+        assert_eq!(g, Ok(slugs(&["slack"])));
+    }
+
+    /// A key is released once its fetch is done, so the NEXT cold caller after
+    /// an eviction fetches rather than waiting on a flight that already ended.
+    #[tokio::test]
+    async fn a_finished_flight_is_released() {
+        let cache = CatalogCache::default();
+        let fetches = AtomicUsize::new(0);
+        let fetch = || async {
+            fetches.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            Ok(slugs(&["gmail"]))
+        };
+
+        assert_eq!(cache.get_or_fetch("k", fetch).await, Ok(slugs(&["gmail"])));
+        cache.evict("k");
+        assert_eq!(cache.get_or_fetch("k", fetch).await, Ok(slugs(&["gmail"])));
+
+        assert_eq!(
+            fetches.load(Ordering::SeqCst),
+            2,
+            "an evicted key must re-fetch, not join a flight that has finished"
+        );
     }
 
     /// Companies do not share an entry: one tenant's outage cannot mark another


### PR DESCRIPTION
## Summary

On the first visit to Connections → Apps the provider catalog times out and does not render — only already-connected providers appear, with two warnings. A reload fixes it.

The console's probe and the host handler it calls had **the same 5-second budget, nested**. `COMPOSIO_PROBE_TIMEOUT_MS` bounded the whole round trip, while `composio_toolkits::FETCH_TIMEOUT` is what that handler may spend *inside itself* on the upstream Composio fetch. The host's total is always `min(upstream, 5s) + ε`, so on a cold cache the browser stopped listening at the exact moment the handler was still legitimately working — and the handler's graceful degradation (`catalog_source: "fallback"` plus a notice naming the real reason) could never reach the page. The abandoned request still completed server-side and filled the 15-minute catalog cache, which is why the second load works.

**The hard refresh is a red herring.** Any reload inside the cache TTL would do; `Cmd+Shift+R` is not doing anything special.

**Both warnings are one failure.** On timeout the effect clears its status object, so `granted` becomes `undefined` and the grant-unknown copy renders as collateral. There is no second failing request.

Now the console's budget strictly dominates the host's, the hand-rolled race is replaced by the client's own cancelling deadline, and the host coalesces concurrent cold fetches.

Closes #2007

## API Or Behavior Changes

- `getComposioStatus` accepts `RequestOptions`. Two exported constants live beside it so the invariant is testable without React: `SERVER_FETCH_TIMEOUT_MS` (5s, mirroring the host's `FETCH_TIMEOUT`) and `CATALOG_READ_TIMEOUT_MS` (15s). The requirement is the **ordering** `server < client < DEFAULT_REQUEST_TIMEOUT_MS (30s)`, not the literals.
- The Apps probe drops its `Promise.race`, `window.setTimeout` and `PROBE_TIMED_OUT` sentinel for `getComposioStatus(client, company, { timeoutMs, signal })` with an `AbortController` wired to effect cleanup — so a company switch or unmount now **cancels** the read instead of merely ignoring it, and a caller-abort sets neither warning. The three error shapes stay distinct: 404 → no Composio surface, `ApiError(0, "timeout")` → probe failed, `AbortError` → neither.
- `CatalogCache` gains `get_or_fetch`: single-flight per key via `broadcast`, with a drop-guard so a panic or a cancelled request releases the key. Lookup/store TTLs and keying are unchanged. `evict` now does more than drop the cached entry — see below.
- A slow-but-successful host now costs up to 15s of skeleton before the honest warning, where it previously showed a false warning at 5s. A host that degrades still paints at ~5s — now *with* its own notice, which was previously unreachable.

**The single-flight introduced a bug, found in review, fixed here.** Sharing one fetch between callers quietly broke eviction. `evict` dropped the cached entry and nothing else, so a fetch dialled with the credential a company had just replaced stayed live in the shared-flight map — and the replaced account's catalog survived the rotation two ways: the status re-read the mutation performs in the same request joined that fetch, and the fetch then stored its answer on top of the eviction, where it was served for the full 15-minute TTL. A token rotation reported success and changed nothing. **Before the single-flight this could not happen**: a caller arriving after an eviction simply fetched afresh.

Each key now carries a generation, bumped by `evict`, which also clears the running slot. A fetch records the generation it began under, may be cached only while that is still current, and cannot be joined once retired. Callers already waiting on a retired fetch still receive its answer — their request predates the rotation, and without a shared flight each would have had exactly that fetch of its own running. The slot is also released only by the flight holding it; releasing blindly by key let a straggler finishing after an eviction delete the successor that replaced it, so the next caller dialled a third time for a list two callers were already waiting on.

**Not caused by #2014.** That PR's 30s default deadline can never fire ahead of a 5s race, and #2007 was filed roughly ten hours before it merged. #2014 is nonetheless the tool this fix uses: it built the real cancelling per-call deadline that makes the hand-rolled race obsolete.

## Tests

Run unpiped, exit codes captured:

- [x] `npm run typecheck` · `typecheck:unit` · `typecheck:e2e` · `npm run build`
- [x] `npx vitest run` — 4381 tests passed
- [x] `cargo fmt --all -- --check` · `cargo check --locked --all-targets` · `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,mcp,composio --all-targets -- -D warnings` — the changed Rust is `#[cfg(feature = "composio")]`-gated, so a gate without that feature compiles none of it
- [x] `cargo test --locked --features openhuman,mcp,composio --lib server::ops::composio_toolkits` — 16 passed
- [x] `scripts/ci/run-scoped-suite.sh "composio" openhuman,chargebee,paypal,composio composio` — 178 passed
- [x] `PW_COMPOSIO=1 npx playwright test composio-catalog-deadline` — 4 passed

N/A: `cargo build --all-targets` as a separate step — covered by the `--all-targets` clippy runs above.

**The suite could not express this bug.** The e2e fixture answered instantly, so nothing anywhere exercised "the host takes 5 seconds". This PR adds the delay knob (`POST /__delay {toolkitsMs}`, cleared by `__reset`) as part of the fix, then four specs: a first visit painting the catalog with neither warning; a degraded host rendering **its own** fallback notice — the path the inversion was hiding; a host that never answers still reaching the honest warning; and a credential rotation still re-reading cleanly.

Red proofs, each captured against the pre-fix source:

```
× strictly dominates the host's own budget… → expected 5000 to be less than 5000
× hears out a host that answers past its own catalog budget → rejected with ApiError … did not respond in time
× cancels a superseded read instead of ignoring it, and warns about neither
two_cold_callers_share_one_fetch ... FAILED  left: 2  right: 1
✘ a first visit paints the catalog the host sent…
    Locator: getByTestId('providers-probe-failed')   Expected: 0   Received: 1
```

That last one is the reported bug, reproduced on a real host.

The eviction defect above has its own two, each failing on the reviewed code with the retired catalog where the current one is required:

```
an_eviction_retires_the_fetch_already_in_flight ... FAILED
  a read after a rotation must not be answered by a fetch dialled with the replaced credential
  left: Ok([CatalogEntry { slug: "stale", … }])   right: Ok([CatalogEntry { slug: "fresh", … }])
a_straggler_does_not_release_its_successor ... FAILED
  left: Ok([CatalogEntry { slug: "stale", … }])   right: Ok([CatalogEntry { slug: "fresh", … }])
```

**Three false positives were found and fixed in the specs themselves.** A `page.route` pattern that matched nothing (the console addresses `/api/v1/companies/<co>/composio`), so two specs "passed" in 590ms having asserted nothing. A route handler that returned instead of holding the request open, so the stall never happened. And — found in review — two specs whose assertions a rotation or a failed catalog read leaves *unchanged*: Gmail and Slack are **connected**, so they get tiles from the connection list alone and appear even when the catalog never arrived. Both now assert on a provider this company has not connected, which can only reach the grid through a catalog the page actually read; the fixture takes its published catalog through `POST /__catalog`, so a rotation resolves a different set of integrations, which is what rotating a Composio token means. Each was then red-proofed on its own: the rotation spec fails with the re-probe trigger removed from the Apps effect, and the first spec now fails on that provider rather than on the warning beside it.

**Deliberately deferred**: lifting `ComposioSection`'s duplicate first-paint read. The single-flight removes its cost — a second round trip to our own host, no second upstream fetch — and that component owns the credential-rotation path, so the refactor carries real regression surface for no user-visible gain. Covered instead by an e2e that drives a rotation through the UI — which, as review pointed out, was asserting nothing a rotation could change when this deferral was first argued. It now is.

**Not verified**: the real 123-provider catalog (no live Composio credential here; the fixture serves two), and the two-loads-15-minutes-apart asymmetry — the only lever that evicts the host cache is a token write, and that same handler re-reads status in its response, so evicting and re-warming are welded into one request.

## Documentation

No separate docs change. The ordering invariant is documented at the constants and asserted by a test, which is the durable form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Composio catalog loading when responses are slow or unavailable.
  * Added clearer status handling for unavailable catalogs, failed requests, and timed-out requests.
  * Prevented stale warnings when switching companies or updating credentials.
  * Improved reliability when multiple requests load the same catalog simultaneously.

* **User Experience**
  * Catalogs remain available while slower background reads complete.
  * Canceled requests are handled cleanly when leaving the page or changing companies.
  * Rotating credentials now refreshes the catalog without leaving an incorrect warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
