### PR TITLE
feat(workflows): ask one peer before escalating a sufficiency gap to a human (#1866)

### DIFF
--- a/docs/spec/runtime/workflow-vocabulary.md
+++ b/docs/spec/runtime/workflow-vocabulary.md
@@ -417,9 +417,28 @@ taxonomy; and `halt_benign` settles the attempt and node as `Declined`, meaning
 the work was intentionally unnecessary rather than failed. A failed, blank, or
 otherwise insufficient output is never allowed to become `halt_benign`.
 
-The peer rung depends on #1859's board-read capability. Until that capability is
-present it is recorded as skipped; the judge does not broadcast to the roster,
-and an exhausted recovery ladder escalates the missing information instead.
+The three rungs run in order and each runs only when every rung above it found
+nothing. The first two are local reads — the company fact store, then workspace
+context. The third puts the question to **one** roster peer, never a broadcast:
+the teammate whose role, description or name shares the most terms with the
+question, chosen by the same term extraction the fact rung queries with. The
+node's own agent is excluded, ties keep roster order, and a question no role
+matches skips the rung rather than picking arbitrarily.
+
+That peer runs exactly one background turn under its own wall-clock bound, and
+its reply enters the evidence tagged `peer <id> (<role>):` so the
+re-verification judge and the operator's blocker card both see where the answer
+came from. The consultation is metered as that peer's own turn, not as a
+`JudgeCall`, so a node's judge metering still describes only its judge calls.
+It carries no authority: anything the consulted peer stages — a hand-off, a
+card, a publish — is discarded rather than executed for this run, no attempt is
+settled for it, and it fires at most once per node attempt even when the peer
+is the orchestrator and runs a nested graph. The rung is skipped when the
+plan-level token ceiling is already spent, and a peer that answers with nothing,
+fails or overruns its bound leaves the ladder empty — recovery never degrades
+into advancing anyway. An exhausted ladder escalates the missing information as
+before, with each rung's outcome recorded on the blocker.
+
 Workflows without `verify` take the legacy path and spend no judge call.
 
 ## The engine-only kinds OpenCompany rejects

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1192,7 +1192,11 @@ impl HarnessAgentRunner {
     ///
     /// The consultation runs inside this run's own delegation and
     /// publish-refusal scopes, and everything it stages there is discarded
-    /// before the next node's drain could execute it.
+    /// before the next node's drain could execute it. Its approval requests get
+    /// a scope of their own instead: unclaimed pushes fall into the bucket the
+    /// chat cycle drains, which would put a card the consulted peer asked for
+    /// in front of the operator as if their own turn had raised it. The claim
+    /// discards that bucket on drop.
     ///
     /// The nested scopes must stay `Box::pin`ed: `TaskLocalFuture` holds its
     /// inner future inline, and an agent turn inside three of them unboxed
@@ -1211,6 +1215,10 @@ impl HarnessAgentRunner {
             record: &self.record,
             exclude_agent: agent_ref,
         };
+        let approval_claim = self
+            .deps
+            .approval_requests
+            .claim(ApprovalScope::Run(format!("{}::consult", self.run_id)));
         let ladder = Box::pin(async {
             let recovered = crate::workflows::judge::ask_around(
                 &self.deps,
@@ -1224,6 +1232,7 @@ impl HarnessAgentRunner {
         });
         let ladder = Box::pin(self.publish_refusal_claim.scoped(ladder));
         let ladder = Box::pin(self.board_claim.scoped(ladder));
+        let ladder = Box::pin(approval_claim.scoped(ladder));
         PEER_CONSULT_ACTIVE.scope((), ladder).await
     }
 
@@ -1241,7 +1250,8 @@ impl HarnessAgentRunner {
             .len();
         let publishes = self.deps.pending_publishes.drain().len();
         let refused_publishes = self.deps.pending_publishes.drain_refusals().len();
-        let total = delegations + refused_delegations + publishes + refused_publishes;
+        let approvals = self.deps.approval_requests.queued();
+        let total = delegations + refused_delegations + publishes + refused_publishes + approvals;
         if total > 0 {
             tracing::info!(
                 company = %self.company,
@@ -1251,6 +1261,7 @@ impl HarnessAgentRunner {
                 refused_delegations,
                 publishes,
                 refused_publishes,
+                approvals,
                 "workflow agent node: discarded the board writes a peer consultation staged; a \
                  consultation carries no authority to act for this run"
             );
@@ -9056,6 +9067,21 @@ mod tests {
                     });
                 deps.pending_publishes
                     .push_refusal("consultation-note.md".to_string());
+                deps.approval_requests
+                    .push(crate::harness::policy::ApprovalRequest {
+                        tool: "send_email".to_string(),
+                        reason: "the consulted peer tried a gated tool".to_string(),
+                        effect: crate::ports::types::Effect {
+                            kind: "email.send".to_string(),
+                            group: crate::ports::types::EffectGroup::Other,
+                            amount_usd: None,
+                            established_thread: false,
+                            first_time_counterparty: false,
+                            payload: json!({ "to": "someone@example.com" }),
+                            agent: Some("cfo".to_string()),
+                            run_id: None,
+                        },
+                    });
             }
             Ok(crate::harness::TurnOutcome {
                 reply: self.peer_reply.to_string(),
@@ -9334,6 +9360,7 @@ mod tests {
             ])
             .await;
         let (deps, _journal) = crate::workflows::gated_tool_turn_test::deps(base_url, dir.path());
+        let queues = deps.clone();
         let turn = Arc::new(ConsultedPeerTurn::staging(
             "The renewal date is March 1st.",
             deps.clone(),
@@ -9368,6 +9395,12 @@ mod tests {
         assert!(
             notices.take().is_empty(),
             "no operator notice may be raised for work a consultation only staged"
+        );
+        assert_eq!(
+            queues.approval_requests.queued(),
+            0,
+            "a consultation must not leave an approval card for the operator's next chat cycle \
+             to drain as if the operator had asked for it"
         );
     }
 

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -99,6 +99,18 @@ pub(crate) use self::upstream::DEFAULT_UPSTREAM_BUDGET_CHARS;
 // (`WORKFLOW_TOOL_CATALOG`) is what callers ground and validate against, and the
 // slug table is now only its in-module pinning cross-check.
 
+tokio::task_local! {
+    /// Set for the span of a peer consultation. A consulted orchestrator can
+    /// run a whole graph, whose nodes reach this same recover path, so the
+    /// "one peer turn" bound holds down the stack only while this is read.
+    static PEER_CONSULT_ACTIVE: ();
+}
+
+/// Whether a peer consultation is already running on this task.
+fn peer_consult_active() -> bool {
+    PEER_CONSULT_ACTIVE.try_with(|_| ()).is_ok()
+}
+
 /// The four effectful capability slots [`build_capabilities`] chooses by mode:
 /// `tool_call`, `http_request`, `state`, and the optional `agent` runner. The
 /// dry and live branches each build one of these; the read-only `resolver` and
@@ -1176,6 +1188,75 @@ impl HarnessAgentRunner {
     /// Nothing here returns a `Result`. The turn already happened and its output is
     /// valid; a store hiccup must not discard it. Same stance
     /// [`park_gated_calls`](Self::park_gated_calls) takes, arrived at the same way.
+    /// Runs the bounded recovery ladder for this node, lending it the peer rung.
+    ///
+    /// The consultation runs inside this run's own delegation and
+    /// publish-refusal scopes, and everything it stages there is discarded
+    /// before the next node's drain could execute it.
+    ///
+    /// The nested scopes must stay `Box::pin`ed: `TaskLocalFuture` holds its
+    /// inner future inline, and an agent turn inside three of them unboxed
+    /// overflows the thread's stack.
+    async fn recover_context(
+        &self,
+        question: &str,
+        agent_ref: &str,
+    ) -> crate::workflows::judge::RecoveryResult {
+        if peer_consult_active() {
+            return crate::workflows::judge::ask_around(&self.deps, &self.company, question, None)
+                .await;
+        }
+        let consult = crate::workflows::judge::PeerConsult {
+            turn: self.turn.as_ref(),
+            record: &self.record,
+            exclude_agent: agent_ref,
+        };
+        let ladder = Box::pin(async {
+            let recovered = crate::workflows::judge::ask_around(
+                &self.deps,
+                &self.company,
+                question,
+                Some(consult),
+            )
+            .await;
+            self.discard_consultation_writes();
+            recovered
+        });
+        let ladder = Box::pin(self.publish_refusal_claim.scoped(ladder));
+        let ladder = Box::pin(self.board_claim.scoped(ladder));
+        PEER_CONSULT_ACTIVE.scope((), ladder).await
+    }
+
+    /// Throws away every board write and staged publish a peer consultation
+    /// left behind: a consultation was asked a question, not given authority.
+    ///
+    /// Runs inside the run's own scopes, so the delegation drains empty this
+    /// run's bucket and no other claimant's.
+    fn discard_consultation_writes(&self) {
+        let delegations = self.deps.delegations.drain(MAX_DELEGATIONS_PER_TURN).len();
+        let refused_delegations = self
+            .deps
+            .delegations
+            .drain_refusals(MAX_DELEGATIONS_PER_TURN)
+            .len();
+        let publishes = self.deps.pending_publishes.drain().len();
+        let refused_publishes = self.deps.pending_publishes.drain_refusals().len();
+        let total = delegations + refused_delegations + publishes + refused_publishes;
+        if total > 0 {
+            tracing::info!(
+                company = %self.company,
+                workflow = %self.workflow_id,
+                run_id = %self.run_id,
+                delegations,
+                refused_delegations,
+                publishes,
+                refused_publishes,
+                "workflow agent node: discarded the board writes a peer consultation staged; a \
+                 consultation carries no authority to act for this run"
+            );
+        }
+    }
+
     async fn drain_board_writes(&self) {
         let queue = &self.deps.delegations;
 
@@ -2805,9 +2886,7 @@ impl HarnessAgentRunner {
                 }
                 crate::workflows::judge::SufficiencyVerdict::Recover => {
                     let question = criteria.unwrap_or(&instruction);
-                    let recovered =
-                        crate::workflows::judge::ask_around(&self.deps, &self.company, question)
-                            .await;
+                    let recovered = self.recover_context(question, agent_ref).await;
                     let recovered_and_sufficient = match &recovered.evidence {
                         Some(evidence) => {
                             let verified = crate::workflows::judge::augment_with_recovery(
@@ -8873,5 +8952,622 @@ mod tests {
                  already armed by the time the approval gate's park() runs"
             );
         }
+    }
+
+    // ── the recovery ladder's peer rung ──────────────────────────────────────
+
+    /// The fixture roster plus one teammate whose role and description match a
+    /// question about a customer's renewal, so [`pick_peer`] has somebody to
+    /// choose. The node itself runs as `researcher`, which is deliberately not
+    /// on the roster.
+    fn record_with_peer() -> CompanyRecord {
+        let mut record = crate::workflows::gated_tool_turn_test::record();
+        record.manifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\n[[agent]]\nid = \"cfo\"\nrole = \"Chief Financial \
+             Officer\"\ndescription = \"Owns renewal contracts and customer pricing\"\n",
+        )
+        .expect("manifest parses");
+        record
+    }
+
+    /// A [`RunTurn`] whose node turn refuses for want of a fact, and whose peer
+    /// consultation answers with `peer_reply` — optionally staging board work
+    /// on the way, standing in for a consulted teammate whose tools wrote.
+    struct ConsultedPeerTurn {
+        peer_reply: &'static str,
+        consults: std::sync::atomic::AtomicUsize,
+        node_turns: std::sync::atomic::AtomicUsize,
+        stage: Option<HarnessDeps>,
+    }
+
+    impl ConsultedPeerTurn {
+        fn new(peer_reply: &'static str) -> Self {
+            Self {
+                peer_reply,
+                consults: std::sync::atomic::AtomicUsize::new(0),
+                node_turns: std::sync::atomic::AtomicUsize::new(0),
+                stage: None,
+            }
+        }
+
+        fn staging(peer_reply: &'static str, deps: HarnessDeps) -> Self {
+            Self {
+                stage: Some(deps),
+                ..Self::new(peer_reply)
+            }
+        }
+
+        fn consults(&self) -> usize {
+            self.consults.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl RunTurn for ConsultedPeerTurn {
+        async fn run(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _chat: crate::runtime::delegation::ChatTarget<'_>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            unreachable!("workflow agent nodes route through run_background_workflow")
+        }
+
+        async fn run_steered(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _control: &crate::company::steer::SteerControl,
+            _chat: crate::runtime::delegation::ChatTarget<'_>,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            unreachable!("workflow agent nodes route through run_background_workflow")
+        }
+
+        async fn run_steered_background(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _control: &crate::company::steer::SteerControl,
+            _chat: crate::runtime::delegation::ChatTarget<'_>,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            unreachable!("workflow agent nodes route through run_background_workflow")
+        }
+
+        async fn run_background(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            self.consults
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if let Some(deps) = self.stage.as_ref() {
+                deps.delegations
+                    .push(crate::harness::orchestrator::Delegation::SpawnTask {
+                        title: "Chase the renewal paperwork".to_string(),
+                        note: None,
+                        assignee: None,
+                    });
+                deps.pending_publishes
+                    .push_refusal("consultation-note.md".to_string());
+            }
+            Ok(crate::harness::TurnOutcome {
+                reply: self.peer_reply.to_string(),
+                steps: Vec::new(),
+                hit_iteration_cap: false,
+                abnormal_stop: None,
+                halted_for_spend: None,
+                budget_paused: None,
+            })
+        }
+
+        async fn run_background_workflow(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+            _workflow_run_id: &str,
+            _node_id: &str,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            self.node_turns
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(crate::harness::TurnOutcome {
+                reply: "I cannot draft the email without the customer's renewal date.".to_string(),
+                steps: Vec::new(),
+                hit_iteration_cap: false,
+                abnormal_stop: None,
+                halted_for_spend: None,
+                budget_paused: None,
+            })
+        }
+    }
+
+    /// The verify node every peer-rung test below drives.
+    fn verify_node() -> Value {
+        json!({
+            "node_id": "draft",
+            "prompt": "Draft the customer email.",
+            "verify": { "criteria": "must include the customer's renewal date" }
+        })
+    }
+
+    /// Builds a runner over `turn` with the peer-bearing roster, handing back
+    /// the run-scoped collectors a test asserts on.
+    #[allow(clippy::type_complexity)]
+    fn peer_runner(
+        turn: Arc<dyn RunTurn>,
+        deps: HarnessDeps,
+        run_id: &str,
+        runs: Option<Arc<dyn crate::ports::RunStore>>,
+    ) -> (
+        HarnessAgentRunner,
+        RunBlocks,
+        RunBoard,
+        RunNotices,
+        RunArtifacts,
+    ) {
+        let board_claim = Arc::new(deps.delegations.claim_board(run_id.to_string()));
+        let publish_refusal_claim = Arc::new(
+            deps.pending_publishes
+                .claim_refusals_for_run(run_id.to_string()),
+        );
+        let blocks = RunBlocks::default();
+        let board = RunBoard::default();
+        let notices = RunNotices::default();
+        let artifacts = RunArtifacts::default();
+        let mut runner = HarnessAgentRunner::new(
+            turn,
+            deps,
+            record_with_peer(),
+            CompanyId::new("acme"),
+            format!("wf-{run_id}"),
+            run_id.to_string(),
+            None,
+            Value::Null,
+            crate::ports::types::StartedBy::Operator,
+            notices.clone(),
+            board.clone(),
+            blocks.clone(),
+            RunCappedNodes::default(),
+            RunApprovals::default(),
+            artifacts.clone(),
+            board_claim,
+            publish_refusal_claim,
+        );
+        if let Some(runs) = runs {
+            runner = runner.with_runs(Some(runs), None, RunAttempts::default());
+        }
+        (runner, blocks, board, notices, artifacts)
+    }
+
+    /// The rung's reason to exist: an information gap the fact store and the
+    /// workspace cannot close is put to one roster peer, and an answer the
+    /// re-verification judge accepts ships as the node's output carrying its
+    /// provenance.
+    #[tokio::test]
+    async fn a_peer_answer_the_judge_accepts_ships_the_recovered_context_block() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-accepted-")
+            .tempdir()
+            .expect("tempdir");
+        let (base_url, script) =
+            crate::workflows::gated_tool_turn_test::spawn_script_recording(vec![
+                crate::workflows::gated_tool_turn_test::Turn::Say("{\"verdict\":\"recover\"}"),
+                crate::workflows::gated_tool_turn_test::Turn::Say("{\"verdict\":\"continue\"}"),
+            ])
+            .await;
+        let (deps, _journal) = crate::workflows::gated_tool_turn_test::deps(base_url, dir.path());
+        let turn = Arc::new(ConsultedPeerTurn::new("The renewal date is March 1st."));
+        let (runner, blocks, _board, _notices, _artifacts) =
+            peer_runner(turn.clone(), deps, "run-1866-peer-ok", None);
+
+        let (_value, outcome) = runner
+            .run_turn("researcher", verify_node())
+            .await
+            .expect("an answered consultation the judge accepts must let the node ship");
+
+        assert_eq!(turn.consults(), 1, "exactly one peer turn is spent");
+        assert!(
+            outcome
+                .reply
+                .contains("peer cfo (Chief Financial Officer): The renewal date is March 1st."),
+            "the shipped reply must carry the peer's answer and its provenance: {}",
+            outcome.reply
+        );
+        assert!(
+            outcome.reply.contains("Recovered company context:"),
+            "the shipped reply must be the augmented text: {}",
+            outcome.reply
+        );
+        let seen = script.seen.lock().expect("seen");
+        assert_eq!(seen.len(), 2, "one judge call, then one re-verification");
+        assert!(
+            seen[1].to_string().contains("peer cfo"),
+            "the re-verification judge must see the peer's answer, not the bare refusal"
+        );
+        assert!(
+            blocks.take().is_empty(),
+            "an accepted recovery blocks nobody"
+        );
+    }
+
+    /// A peer answer is not privileged: the second judge still gets to refuse
+    /// it, and when it does the operator gets an Information blocker whose
+    /// recovery log names the peer that was asked.
+    #[tokio::test]
+    async fn a_peer_answer_the_judge_rejects_parks_an_information_blocker() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-rejected-")
+            .tempdir()
+            .expect("tempdir");
+        let (base_url, _script) =
+            crate::workflows::gated_tool_turn_test::spawn_script_recording(vec![
+                crate::workflows::gated_tool_turn_test::Turn::Say("{\"verdict\":\"recover\"}"),
+                crate::workflows::gated_tool_turn_test::Turn::Say("{\"verdict\":\"retry\"}"),
+            ])
+            .await;
+        let (deps, _journal) = crate::workflows::gated_tool_turn_test::deps(base_url, dir.path());
+        let runs: Arc<dyn crate::ports::RunStore> =
+            Arc::new(crate::store::FsOps::new(dir.path().to_path_buf()));
+        let turn = Arc::new(ConsultedPeerTurn::new("I do not have that date either."));
+        let (runner, blocks, _board, _notices, _artifacts) = peer_runner(
+            turn.clone(),
+            deps,
+            "run-1866-peer-blocked",
+            Some(runs.clone()),
+        );
+
+        let err = runner
+            .run_turn("researcher", verify_node())
+            .await
+            .expect_err("an unclosed information gap must not advance downstream");
+        let EngineError::Capability(message) = err else {
+            panic!("expected a capability error");
+        };
+        assert!(
+            message.contains("peer: cfo answered"),
+            "the operator's blocker must say the peer was asked and answered: {message}"
+        );
+        assert_eq!(turn.consults(), 1);
+        assert_eq!(
+            blocks.take().len(),
+            1,
+            "the gap is parked as one blocked node"
+        );
+        let attempts = runs
+            .list_runs(
+                &CompanyId::new("acme"),
+                &crate::ports::RunFilter::for_workflow_run("run-1866-peer-blocked".to_string()),
+            )
+            .await
+            .expect("list attempts");
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(
+            attempts[0].status,
+            crate::ports::RunStatus::Blocked,
+            "an information gap is blocked on a person, not failed"
+        );
+    }
+
+    /// The deterministic check outranks the peer. An answer the judge accepts
+    /// still has to satisfy the node's declared postcondition, and when it does
+    /// not the attempt fails rather than shipping.
+    #[tokio::test]
+    async fn a_peer_answer_the_judge_accepts_still_fails_its_postcondition() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-postcondition-")
+            .tempdir()
+            .expect("tempdir");
+        let (base_url, _script) =
+            crate::workflows::gated_tool_turn_test::spawn_script_recording(vec![
+                crate::workflows::gated_tool_turn_test::Turn::Say("{\"verdict\":\"recover\"}"),
+                crate::workflows::gated_tool_turn_test::Turn::Say("{\"verdict\":\"continue\"}"),
+            ])
+            .await;
+        let (deps, _journal) = crate::workflows::gated_tool_turn_test::deps(base_url, dir.path());
+        let runs: Arc<dyn crate::ports::RunStore> =
+            Arc::new(crate::store::FsOps::new(dir.path().to_path_buf()));
+        let turn = Arc::new(ConsultedPeerTurn::new("The renewal date is March 1st."));
+        let (runner, blocks, _board, _notices, _artifacts) = peer_runner(
+            turn.clone(),
+            deps,
+            "run-1866-peer-postcondition",
+            Some(runs.clone()),
+        );
+
+        let err = runner
+            .run_turn(
+                "researcher",
+                json!({
+                    "node_id": "draft",
+                    "prompt": "Draft the customer email.",
+                    "verify": { "criteria": "must include the customer's renewal date" },
+                    "postcondition": { "require": "field_present", "field": "items" }
+                }),
+            )
+            .await
+            .expect_err("a recovered reply must still clear the deterministic check");
+        let EngineError::Capability(message) = err else {
+            panic!("expected a capability error");
+        };
+        assert!(
+            message.contains("items"),
+            "the halt must name what the recovered output was missing: {message}"
+        );
+        assert!(
+            blocks.take().is_empty(),
+            "a failed postcondition asks nobody for anything"
+        );
+        let attempts = runs
+            .list_runs(
+                &CompanyId::new("acme"),
+                &crate::ports::RunFilter::for_workflow_run(
+                    "run-1866-peer-postcondition".to_string(),
+                ),
+            )
+            .await
+            .expect("list attempts");
+        assert_eq!(attempts[0].status, crate::ports::RunStatus::Failed);
+    }
+
+    /// A consultation was asked a question, not given authority. Whatever the
+    /// consulted peer staged on the shared board and publish queues is thrown
+    /// away, so the *next* node's drain — the path that would otherwise execute
+    /// it and attribute it to this run — finds nothing.
+    #[tokio::test]
+    async fn a_consultation_that_stages_board_work_leaves_nothing_behind() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-no-authority-")
+            .tempdir()
+            .expect("tempdir");
+        let (base_url, _script) =
+            crate::workflows::gated_tool_turn_test::spawn_script_recording(vec![
+                crate::workflows::gated_tool_turn_test::Turn::Say("{\"verdict\":\"recover\"}"),
+                crate::workflows::gated_tool_turn_test::Turn::Say("{\"verdict\":\"continue\"}"),
+            ])
+            .await;
+        let (deps, _journal) = crate::workflows::gated_tool_turn_test::deps(base_url, dir.path());
+        let turn = Arc::new(ConsultedPeerTurn::staging(
+            "The renewal date is March 1st.",
+            deps.clone(),
+        ));
+        let (runner, blocks, board, notices, _artifacts) =
+            peer_runner(turn.clone(), deps, "run-1866-peer-authority", None);
+
+        runner
+            .run_turn("researcher", verify_node())
+            .await
+            .expect("the consultation answered, so the node ships");
+        assert_eq!(turn.consults(), 1);
+
+        // The node that runs next is what would execute a leaked staging: its
+        // own post-turn drain reads the same queues.
+        runner
+            .run_turn(
+                "researcher",
+                json!({ "node_id": "next", "prompt": "carry on" }),
+            )
+            .await
+            .expect("a plain node runs");
+
+        assert!(
+            board.take().is_empty(),
+            "a consultation must open no card on the run's board"
+        );
+        assert!(
+            blocks.take().is_empty(),
+            "a consultation settles nothing and blocks nobody"
+        );
+        assert!(
+            notices.take().is_empty(),
+            "no operator notice may be raised for work a consultation only staged"
+        );
+    }
+
+    /// A consulted peer may be the orchestrator, which can run a whole workflow
+    /// — whose nodes reach this same recover path. The rung must fire once down
+    /// the whole stack, not once per nested node.
+    #[tokio::test]
+    async fn a_consultation_cannot_re_enter_the_recovery_ladder() {
+        struct ReentrantPeerTurn {
+            consults: std::sync::atomic::AtomicUsize,
+            node_turns: std::sync::atomic::AtomicUsize,
+            runner: std::sync::OnceLock<Arc<HarnessAgentRunner>>,
+        }
+
+        #[async_trait]
+        impl RunTurn for ReentrantPeerTurn {
+            async fn run(
+                &self,
+                _company: &CompanyId,
+                _agent_id: &str,
+                _message: &str,
+                _chat: crate::runtime::delegation::ChatTarget<'_>,
+            ) -> crate::Result<crate::harness::TurnOutcome> {
+                unreachable!("nodes route through run_background_workflow")
+            }
+
+            async fn run_steered(
+                &self,
+                _company: &CompanyId,
+                _agent_id: &str,
+                _message: &str,
+                _control: &crate::company::steer::SteerControl,
+                _chat: crate::runtime::delegation::ChatTarget<'_>,
+                _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+            ) -> crate::Result<crate::harness::TurnOutcome> {
+                unreachable!("nodes route through run_background_workflow")
+            }
+
+            async fn run_steered_background(
+                &self,
+                _company: &CompanyId,
+                _agent_id: &str,
+                _message: &str,
+                _control: &crate::company::steer::SteerControl,
+                _chat: crate::runtime::delegation::ChatTarget<'_>,
+                _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+            ) -> crate::Result<crate::harness::TurnOutcome> {
+                unreachable!("nodes route through run_background_workflow")
+            }
+
+            async fn run_background(
+                &self,
+                _company: &CompanyId,
+                _agent_id: &str,
+                _message: &str,
+                _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+            ) -> crate::Result<crate::harness::TurnOutcome> {
+                self.consults
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // The consulted peer runs a nested graph node, which reaches
+                // the same recover path.
+                let runner = self.runner.get().expect("runner wired").clone();
+                let _ = Box::pin(runner.run_turn("researcher", verify_node())).await;
+                Ok(crate::harness::TurnOutcome {
+                    reply: String::new(),
+                    steps: Vec::new(),
+                    hit_iteration_cap: false,
+                    abnormal_stop: None,
+                    halted_for_spend: None,
+                    budget_paused: None,
+                })
+            }
+
+            async fn run_background_workflow(
+                &self,
+                _company: &CompanyId,
+                _agent_id: &str,
+                _message: &str,
+                _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+                _workflow_run_id: &str,
+                _node_id: &str,
+            ) -> crate::Result<crate::harness::TurnOutcome> {
+                self.node_turns
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(crate::harness::TurnOutcome {
+                    reply: "I cannot draft the email without the customer's renewal date."
+                        .to_string(),
+                    steps: Vec::new(),
+                    hit_iteration_cap: false,
+                    abnormal_stop: None,
+                    halted_for_spend: None,
+                    budget_paused: None,
+                })
+            }
+        }
+
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-reentrant-")
+            .tempdir()
+            .expect("tempdir");
+        let (base_url, _script) =
+            crate::workflows::gated_tool_turn_test::spawn_script_recording(vec![
+                crate::workflows::gated_tool_turn_test::Turn::Say("{\"verdict\":\"recover\"}"),
+                crate::workflows::gated_tool_turn_test::Turn::Say("{\"verdict\":\"recover\"}"),
+            ])
+            .await;
+        let (deps, _journal) = crate::workflows::gated_tool_turn_test::deps(base_url, dir.path());
+        let turn = Arc::new(ReentrantPeerTurn {
+            consults: std::sync::atomic::AtomicUsize::new(0),
+            node_turns: std::sync::atomic::AtomicUsize::new(0),
+            runner: std::sync::OnceLock::new(),
+        });
+        let (runner, _blocks, _board, _notices, _artifacts) =
+            peer_runner(turn.clone(), deps, "run-1866-peer-reentrant", None);
+        let runner = Arc::new(runner);
+        turn.runner.set(runner.clone()).ok().expect("wire runner");
+
+        let _ = runner.run_turn("researcher", verify_node()).await;
+
+        assert_eq!(
+            turn.node_turns.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "the nested node did run, so the re-entrancy this guards against was reached"
+        );
+        assert_eq!(
+            turn.consults.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the peer rung must fire once down the whole stack, not once per nested node"
+        );
+    }
+
+    /// The whole gate is opt-in: a node with no `verify` spends no judge call
+    /// and asks no peer, exactly as it did before any of this existed.
+    #[tokio::test]
+    async fn a_node_with_no_verify_calls_neither_judge_nor_peer() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-optin-")
+            .tempdir()
+            .expect("tempdir");
+        let (base_url, script) =
+            crate::workflows::gated_tool_turn_test::spawn_script_recording(Vec::new()).await;
+        let (deps, _journal) = crate::workflows::gated_tool_turn_test::deps(base_url, dir.path());
+        let turn = Arc::new(ConsultedPeerTurn::new("should never be reached"));
+        let (runner, _blocks, _board, _notices, _artifacts) =
+            peer_runner(turn.clone(), deps, "run-1866-peer-optin", None);
+
+        runner
+            .run_turn("researcher", json!({ "node_id": "plain", "prompt": "go" }))
+            .await
+            .expect("an unverified node runs as it always did");
+
+        assert!(
+            script.seen.lock().expect("seen").is_empty(),
+            "no judge call for a node that declared no criteria"
+        );
+        assert_eq!(turn.consults(), 0, "and therefore no peer turn either");
+    }
+
+    /// `escalate` is a different arm from `recover` and must never touch the
+    /// ladder: an infrastructure or human gap is not something a teammate can
+    /// answer, so spending a peer turn on it would be pure cost. Held by
+    /// construction; pinned so a refactor that folded the arms together fails.
+    #[tokio::test]
+    async fn an_escalate_verdict_never_enters_the_recovery_ladder() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-escalate-")
+            .tempdir()
+            .expect("tempdir");
+        let (base_url, script) =
+            crate::workflows::gated_tool_turn_test::spawn_script_recording(vec![
+                crate::workflows::gated_tool_turn_test::Turn::Say(
+                    "{\"verdict\":\"escalate\",\"gap\":\"infrastructure\"}",
+                ),
+            ])
+            .await;
+        let (deps, _journal) = crate::workflows::gated_tool_turn_test::deps(base_url, dir.path());
+        let turn = Arc::new(ConsultedPeerTurn::new("should never be reached"));
+        let (runner, _blocks, _board, _notices, _artifacts) =
+            peer_runner(turn.clone(), deps, "run-1866-peer-escalate", None);
+
+        let err = runner
+            .run_turn("researcher", verify_node())
+            .await
+            .expect_err("an escalated gap halts the node");
+        let EngineError::Capability(message) = err else {
+            panic!("expected a capability error");
+        };
+        assert!(
+            message.contains("after semantic verification"),
+            "the escalate arm's own message, not the recovery arm's: {message}"
+        );
+        assert!(
+            !message.contains("recovery tried"),
+            "an escalated gap must not report a recovery ladder it never ran: {message}"
+        );
+        assert_eq!(turn.consults(), 0, "no peer turn on the escalate arm");
+        assert_eq!(
+            script.seen.lock().expect("seen").len(),
+            1,
+            "one judge call and no re-verification"
+        );
     }
 }

--- a/src/workflows/judge.rs
+++ b/src/workflows/judge.rs
@@ -9,9 +9,14 @@ use tinyinference::model::{ModelRequest, ModelResponse};
 use crate::harness::HarnessDeps;
 use crate::harness::build::model_for_tier;
 use crate::ports::blockers::BlockerKind;
-use crate::ports::types::{CompanyId, TokenUsage};
+use crate::ports::types::{CompanyId, CompanyRecord, TokenUsage};
+use crate::runtime::delegation::RunTurn;
 
 const JUDGE_TIMEOUT: Duration = Duration::from_secs(30);
+/// The wall-clock bound on the single peer turn the last recovery rung spends.
+/// Wider than [`JUDGE_TIMEOUT`] because a peer runs a full tool-using turn, not
+/// a one-shot completion; a consultation that overruns it yields no evidence.
+const PEER_TIMEOUT: Duration = Duration::from_secs(120);
 const MAX_OUTPUT_TOKENS: u32 = 256;
 const MAX_QUERY_CHARS: usize = 800;
 const MAX_RECOVERY_ITEMS: usize = 3;
@@ -274,9 +279,143 @@ fn focus_terms(question: &str) -> Vec<String> {
     terms
 }
 
-/// Bounded fact → workspace → one-peer recovery. The peer rung is explicitly
-/// unavailable until #1859 lands; it is skipped, never broadcast to the roster.
-pub async fn ask_around(deps: &HarnessDeps, company: &CompanyId, question: &str) -> RecoveryResult {
+/// What a workflow node lends the last recovery rung so it can put the question
+/// to a teammate: the turn seam a peer runs on, the roster it is chosen from,
+/// and the node's own agent, which is never its own peer.
+pub struct PeerConsult<'a> {
+    pub turn: &'a dyn RunTurn,
+    pub record: &'a CompanyRecord,
+    pub exclude_agent: &'a str,
+}
+
+/// How the one peer consultation ended, so `ask_around` can log each outcome
+/// distinctly rather than collapsing "nobody knew" into "nobody was asked".
+enum PeerOutcome {
+    Answered {
+        id: String,
+        role: String,
+        answer: String,
+    },
+    Empty {
+        id: String,
+    },
+    Failed {
+        id: String,
+        error: String,
+    },
+    TimedOut {
+        id: String,
+    },
+    NoRoleMatched,
+    CeilingReached,
+}
+
+/// The roster entry whose role, description or name shares the most
+/// [`focus_terms`] with the question, or `None` when none shares any.
+///
+/// Pure and model-free: selecting a peer must not itself cost a model call.
+/// Ties keep roster order, so one roster and question always pick one peer.
+fn pick_peer(
+    record: &CompanyRecord,
+    question: &str,
+    exclude_agent: &str,
+) -> Option<crate::company::Agent> {
+    let terms = focus_terms(question);
+    if terms.is_empty() {
+        return None;
+    }
+    let mut best: Option<(usize, crate::company::Agent)> = None;
+    for agent in record.effective_agents() {
+        if agent.id == exclude_agent {
+            continue;
+        }
+        let haystack = format!(
+            "{} {} {}",
+            agent.role,
+            agent.description.as_deref().unwrap_or_default(),
+            agent.name.as_deref().unwrap_or_default()
+        )
+        .to_lowercase();
+        let score = terms
+            .iter()
+            .filter(|term| haystack.contains(term.as_str()))
+            .count();
+        if score > 0 && best.as_ref().is_none_or(|(top, _)| score > *top) {
+            best = Some((score, agent));
+        }
+    }
+    best.map(|(_, agent)| agent)
+}
+
+fn peer_prompt(question: &str) -> String {
+    format!(
+        "A workflow step cannot finish because it is missing company information. Answer from \
+         what you already know, in a few sentences. If you do not know, reply with nothing at \
+         all.\n\n{question}"
+    )
+}
+
+/// Puts the question to exactly one peer, under [`PEER_TIMEOUT`], through
+/// `run_background` — a consultation is not a workflow node and must not be
+/// tagged as one on the console's run trace.
+async fn consult_peer(
+    deps: &HarnessDeps,
+    company: &CompanyId,
+    question: &str,
+    consult: &PeerConsult<'_>,
+) -> PeerOutcome {
+    if crate::harness::HarnessPool::total_ceiling_spent(company, deps).await {
+        tracing::info!(
+            company = %company,
+            "[capability-budget] total token ceiling reached; skipping the peer recovery rung \
+             (no model call)"
+        );
+        return PeerOutcome::CeilingReached;
+    }
+    let Some(peer) = pick_peer(consult.record, question, consult.exclude_agent) else {
+        return PeerOutcome::NoRoleMatched;
+    };
+    let ask = peer_prompt(question);
+    match tokio::time::timeout(
+        PEER_TIMEOUT,
+        consult.turn.run_background(company, &peer.id, &ask, None),
+    )
+    .await
+    {
+        Ok(Ok(outcome)) => {
+            let answer = cap(&outcome.reply, MAX_RECOVERY_CHARS);
+            if answer.is_empty() {
+                PeerOutcome::Empty { id: peer.id }
+            } else {
+                PeerOutcome::Answered {
+                    id: peer.id,
+                    role: peer.role,
+                    answer,
+                }
+            }
+        }
+        Ok(Err(err)) => PeerOutcome::Failed {
+            id: peer.id,
+            error: err.to_string(),
+        },
+        Err(_) => PeerOutcome::TimedOut { id: peer.id },
+    }
+}
+
+/// Bounded fact → workspace → one-peer recovery, in that order, each rung run
+/// only when every rung above it found nothing.
+///
+/// The first two rungs are local reads. The third spends one turn on exactly
+/// one roster peer chosen by [`pick_peer`] and bounded by [`PEER_TIMEOUT`] —
+/// never a broadcast; `consult = None` skips it. Each rung's outcome is
+/// recorded in [`RecoveryResult::log`], which reaches the operator's blocker
+/// card when the ladder ends empty.
+pub async fn ask_around(
+    deps: &HarnessDeps,
+    company: &CompanyId,
+    question: &str,
+    consult: Option<PeerConsult<'_>>,
+) -> RecoveryResult {
     let query = cap(question, MAX_QUERY_CHARS);
     let mut evidence = Vec::new();
     let mut log = Vec::new();
@@ -329,7 +468,26 @@ pub async fn ask_around(deps: &HarnessDeps, company: &CompanyId, question: &str)
     }
 
     if evidence.is_empty() {
-        log.push("peer: skipped; board read capability #1859 is unavailable".to_string());
+        match consult {
+            None => log.push("peer: skipped; no consultation handle".to_string()),
+            Some(consult) => match consult_peer(deps, company, &query, &consult).await {
+                PeerOutcome::Answered { id, role, answer } => {
+                    evidence.push(format!("peer {id} ({role}): {answer}"));
+                    log.push(format!("peer: {id} answered"));
+                }
+                PeerOutcome::Empty { id } => log.push(format!("peer: {id} had no answer")),
+                PeerOutcome::Failed { id, error } => {
+                    log.push(format!("peer: {id} could not answer ({error})"));
+                }
+                PeerOutcome::TimedOut { id } => log.push(format!("peer: {id} timed out")),
+                PeerOutcome::NoRoleMatched => {
+                    log.push("peer: skipped; no role matched the question".to_string());
+                }
+                PeerOutcome::CeilingReached => {
+                    log.push("peer: skipped; token ceiling reached".to_string());
+                }
+            },
+        }
     } else {
         log.push("peer: skipped after local match".to_string());
     }
@@ -602,6 +760,7 @@ mod tests {
             &deps,
             &CompanyId::new("acme"),
             "The answer must include the renewal date",
+            None,
         )
         .await;
 
@@ -722,6 +881,577 @@ mod tests {
             verdict,
             SufficiencyVerdict::Retry,
             "a budget-refused verify must not be accepted as sufficient"
+        );
+    }
+
+    // ── the recovery ladder's peer rung ──────────────────────────────────────
+
+    /// A roster built from `[[agent]]` blocks, on the fixture record so every
+    /// other field keeps the shape the rest of these tests use.
+    fn roster(agents: &str) -> CompanyRecord {
+        let mut record = crate::workflows::gated_tool_turn_test::record();
+        record.manifest =
+            toml::from_str(&format!("[company]\nname = \"Acme\"\n\n{agents}\n")).expect("manifest");
+        record
+    }
+
+    /// `support` is listed FIRST and scores lower than `cfo`, so a scoring
+    /// regression that fell back to "the first roster entry that matches at all"
+    /// is visible rather than accidentally right.
+    const THREE_DESKS: &str = r#"
+[[agent]]
+id = "support"
+role = "Support Lead"
+description = "Handles renewal reminders for customers"
+
+[[agent]]
+id = "cfo"
+role = "Chief Financial Officer"
+description = "Owns pricing and renewal contracts"
+
+[[agent]]
+id = "designer"
+role = "Brand Designer"
+description = "Owns the visual identity"
+"#;
+
+    #[test]
+    fn pick_peer_picks_the_role_that_shares_most_terms_with_the_question() {
+        let record = roster(THREE_DESKS);
+        let peer = pick_peer(
+            &record,
+            "The answer must include the renewal pricing",
+            "researcher",
+        )
+        .expect("a roster role shares terms with this question");
+        assert_eq!(
+            peer.id, "cfo",
+            "the highest-scoring role must be chosen, not the first that matches at all"
+        );
+    }
+
+    #[test]
+    fn pick_peer_never_picks_the_nodes_own_agent() {
+        let record = roster(THREE_DESKS);
+        let peer = pick_peer(
+            &record,
+            "The answer must include the renewal pricing",
+            "cfo",
+        )
+        .expect("another role still matches once the node's own agent is excluded");
+        assert_eq!(
+            peer.id, "support",
+            "the node's own agent must be excluded even when it scores highest"
+        );
+    }
+
+    #[test]
+    fn pick_peer_keeps_roster_order_on_a_tie() {
+        let record = roster(
+            r#"
+[[agent]]
+id = "first"
+role = "Renewal Desk"
+
+[[agent]]
+id = "second"
+role = "Renewal Team"
+"#,
+        );
+        for _ in 0..8 {
+            let peer = pick_peer(&record, "the renewal date", "researcher").expect("a tie matches");
+            assert_eq!(
+                peer.id, "first",
+                "a tie must resolve to roster order, identically on every call"
+            );
+        }
+    }
+
+    #[test]
+    fn pick_peer_returns_none_when_no_role_matches() {
+        let record = roster(THREE_DESKS);
+        assert!(
+            pick_peer(&record, "the warehouse forklift inspection", "researcher").is_none(),
+            "a question no role shares a term with must pick nobody rather than pick arbitrarily"
+        );
+    }
+
+    #[test]
+    fn pick_peer_ignores_retired_agents() {
+        let mut record = roster(THREE_DESKS);
+        record.overlay_retired_agents = vec!["cfo".to_string()];
+        let peer = pick_peer(
+            &record,
+            "The answer must include the renewal pricing",
+            "researcher",
+        )
+        .expect("a live role still matches");
+        assert_eq!(
+            peer.id, "support",
+            "a retired teammate must never be consulted"
+        );
+    }
+
+    /// A [`FactStore`] that records every query and matches nothing, so a test
+    /// can read exactly which queries the fact rung sent.
+    #[derive(Default)]
+    struct RecordingFactStore {
+        queries: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::ports::FactStore for RecordingFactStore {
+        async fn list(
+            &self,
+            _company: &CompanyId,
+            query: Option<&str>,
+            _kind: Option<crate::ports::FactKind>,
+        ) -> crate::Result<Vec<crate::ports::FactRecord>> {
+            self.queries
+                .lock()
+                .expect("queries")
+                .push(query.unwrap_or_default().to_string());
+            Ok(Vec::new())
+        }
+
+        async fn upsert(
+            &self,
+            _company: &CompanyId,
+            _fact: &crate::ports::FactRecord,
+        ) -> crate::Result<()> {
+            unreachable!("not exercised by this test")
+        }
+
+        async fn delete(&self, _company: &CompanyId, _id: &str) -> crate::Result<bool> {
+            unreachable!("not exercised by this test")
+        }
+    }
+
+    /// The two rungs must read the question the same way. If the fact rung's
+    /// term extraction and the peer rung's scoring vocabulary ever drift apart,
+    /// a question could reach a fact the peer scoring cannot see (or the
+    /// reverse) and the ladder would disagree with itself about its own
+    /// subject. Both sides are asserted against the same `focus_terms` call.
+    #[tokio::test]
+    async fn the_fact_rung_and_the_peer_rung_read_the_question_the_same_way() {
+        let question = "The answer must include the renewal pricing for the enterprise account";
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-term-parity-")
+            .tempdir()
+            .expect("tempdir");
+        let (mut deps, _journal) =
+            crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+        let facts = std::sync::Arc::new(RecordingFactStore::default());
+        deps.facts = Some(facts.clone());
+
+        let _ = ask_around(&deps, &CompanyId::new("acme"), question, None).await;
+
+        let sent = facts.queries.lock().expect("queries").clone();
+        let terms = focus_terms(question);
+        assert_eq!(
+            sent.first().map(String::as_str),
+            Some(question),
+            "the fact rung still asks the whole sentence first"
+        );
+        assert_eq!(
+            sent[1..],
+            terms[..],
+            "the fact rung's focused queries must be exactly `focus_terms`"
+        );
+
+        for term in &terms {
+            let record = roster(&format!(
+                "[[agent]]\nid = \"peer\"\nrole = \"Desk\"\ndescription = \"{term}\"\n"
+            ));
+            assert!(
+                pick_peer(&record, question, "researcher").is_some(),
+                "a role described by the focused term {term:?} must be reachable by the peer rung"
+            );
+        }
+        for dropped in ["answer", "must", "include", "the", "for"] {
+            let record = roster(&format!(
+                "[[agent]]\nid = \"peer\"\nrole = \"Desk\"\ndescription = \"{dropped}\"\n"
+            ));
+            assert!(
+                pick_peer(&record, question, "researcher").is_none(),
+                "a word the fact rung drops must not select a peer either: {dropped:?}"
+            );
+        }
+    }
+
+    /// A [`RunTurn`] that answers a peer consultation with a canned reply, and
+    /// counts the two dispatch seams separately so a regression that routed a
+    /// consultation through `run_background_workflow` — which tags live frames
+    /// with a run/node id and renders the consultation as a node — is visible.
+    struct PeerStub {
+        reply: &'static str,
+        fail: bool,
+        stall: bool,
+        background_calls: std::sync::atomic::AtomicUsize,
+        workflow_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl PeerStub {
+        fn answering(reply: &'static str) -> Self {
+            Self {
+                reply,
+                fail: false,
+                stall: false,
+                background_calls: std::sync::atomic::AtomicUsize::new(0),
+                workflow_calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                fail: true,
+                ..Self::answering("")
+            }
+        }
+
+        fn stalling() -> Self {
+            Self {
+                stall: true,
+                ..Self::answering("")
+            }
+        }
+
+        fn background(&self) -> usize {
+            self.background_calls
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl RunTurn for PeerStub {
+        async fn run(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _chat: crate::runtime::delegation::ChatTarget<'_>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            unreachable!("a consultation routes through run_background")
+        }
+
+        async fn run_steered(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _control: &crate::company::steer::SteerControl,
+            _chat: crate::runtime::delegation::ChatTarget<'_>,
+            _run_sink: Option<std::sync::Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            unreachable!("a consultation routes through run_background")
+        }
+
+        async fn run_steered_background(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _control: &crate::company::steer::SteerControl,
+            _chat: crate::runtime::delegation::ChatTarget<'_>,
+            _run_sink: Option<std::sync::Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            unreachable!("a consultation routes through run_background")
+        }
+
+        async fn run_background(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _run_sink: Option<std::sync::Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            self.background_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if self.stall {
+                tokio::time::sleep(PEER_TIMEOUT * 4).await;
+            }
+            if self.fail {
+                return Err(crate::OpenCompanyError::Store(
+                    "the peer's harness is down".to_string(),
+                ));
+            }
+            Ok(crate::harness::TurnOutcome {
+                reply: self.reply.to_string(),
+                steps: Vec::new(),
+                hit_iteration_cap: false,
+                abnormal_stop: None,
+                halted_for_spend: None,
+                budget_paused: None,
+            })
+        }
+
+        async fn run_background_workflow(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _run_sink: Option<std::sync::Arc<crate::harness::run_trace::RunTraceSink>>,
+            _workflow_run_id: &str,
+            _node_id: &str,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            self.workflow_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(crate::harness::TurnOutcome {
+                reply: self.reply.to_string(),
+                steps: Vec::new(),
+                hit_iteration_cap: false,
+                abnormal_stop: None,
+                halted_for_spend: None,
+                budget_paused: None,
+            })
+        }
+    }
+
+    /// Drives `ask_around`'s peer rung against `stub`, with no fact store and an
+    /// empty workspace, so the first two rungs are guaranteed to find nothing.
+    async fn ladder_with_peer(
+        dir: &std::path::Path,
+        stub: &PeerStub,
+        record: &CompanyRecord,
+        question: &str,
+    ) -> RecoveryResult {
+        let (deps, _journal) = crate::workflows::gated_tool_turn_test::deps(String::new(), dir);
+        ask_around(
+            &deps,
+            &CompanyId::new("acme"),
+            question,
+            Some(PeerConsult {
+                turn: stub,
+                record,
+                exclude_agent: "researcher",
+            }),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn a_peer_answer_lands_as_provenance_tagged_evidence() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-answer-")
+            .tempdir()
+            .expect("tempdir");
+        let stub = PeerStub::answering("Enterprise renewals are priced at 12% uplift.");
+        let record = roster(THREE_DESKS);
+        let result = ladder_with_peer(
+            dir.path(),
+            &stub,
+            &record,
+            "The answer must include the renewal pricing",
+        )
+        .await;
+
+        let evidence = result.evidence.expect("the peer answered");
+        assert_eq!(
+            evidence,
+            "peer cfo (Chief Financial Officer): Enterprise renewals are priced at 12% uplift.",
+            "the answer must carry its provenance into the judge's input and the blocker card"
+        );
+        assert!(
+            result.log.contains("peer: cfo answered"),
+            "the recovery log must say who answered: {}",
+            result.log
+        );
+        assert_eq!(stub.background(), 1, "exactly one peer turn is spent");
+        assert_eq!(
+            stub.workflow_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a consultation is not a node and must not route through the workflow-tagged seam"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_peer_with_no_answer_leaves_the_ladder_empty() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-empty-")
+            .tempdir()
+            .expect("tempdir");
+        let stub = PeerStub::answering("   ");
+        let record = roster(THREE_DESKS);
+        let result = ladder_with_peer(
+            dir.path(),
+            &stub,
+            &record,
+            "The answer must include the renewal pricing",
+        )
+        .await;
+
+        assert_eq!(result.evidence, None, "an empty reply is not evidence");
+        assert!(
+            result.log.contains("peer: cfo had no answer"),
+            "the log must distinguish an empty answer from nobody being asked: {}",
+            result.log
+        );
+        assert_eq!(stub.background(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_failed_peer_turn_leaves_the_ladder_empty() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-fail-")
+            .tempdir()
+            .expect("tempdir");
+        let stub = PeerStub::failing();
+        let record = roster(THREE_DESKS);
+        let result = ladder_with_peer(
+            dir.path(),
+            &stub,
+            &record,
+            "The answer must include the renewal pricing",
+        )
+        .await;
+
+        assert_eq!(result.evidence, None, "a failed turn is not evidence");
+        assert!(
+            result.log.contains("peer: cfo could not answer"),
+            "the log must name the failure rather than report a clean miss: {}",
+            result.log
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_peer_turn_that_overruns_its_bound_times_out() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-timeout-")
+            .tempdir()
+            .expect("tempdir");
+        let stub = PeerStub::stalling();
+        let record = roster(THREE_DESKS);
+        let result = ladder_with_peer(
+            dir.path(),
+            &stub,
+            &record,
+            "The answer must include the renewal pricing",
+        )
+        .await;
+
+        assert_eq!(result.evidence, None, "a timed-out turn is not evidence");
+        assert!(
+            result.log.contains("peer: cfo timed out"),
+            "an unbounded peer turn is the failure this rung must not have: {}",
+            result.log
+        );
+    }
+
+    #[tokio::test]
+    async fn a_question_no_role_matches_asks_nobody() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-nomatch-")
+            .tempdir()
+            .expect("tempdir");
+        let stub = PeerStub::answering("should never be reached");
+        let record = roster(THREE_DESKS);
+        let result = ladder_with_peer(
+            dir.path(),
+            &stub,
+            &record,
+            "the warehouse forklift inspection",
+        )
+        .await;
+
+        assert_eq!(result.evidence, None);
+        assert_eq!(
+            stub.background(),
+            0,
+            "no role matched, so no turn may be spent"
+        );
+        assert!(
+            result.log.contains("peer: skipped; no role matched"),
+            "{}",
+            result.log
+        );
+    }
+
+    #[tokio::test]
+    async fn a_spent_total_ceiling_never_asks_a_peer() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-ceiling-")
+            .tempdir()
+            .expect("tempdir");
+        let (mut deps, _journal) =
+            crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+        deps.plan = Some(crate::harness::capability_budget::CapabilityPlan {
+            period: crate::harness::capability_budget::BudgetPeriod::Daily,
+            budgets: Default::default(),
+            total_budget: Some(1_000),
+        });
+        deps.meter = Some(std::sync::Arc::new(ExhaustedMeter));
+        let stub = PeerStub::answering("should never be reached");
+        let record = roster(THREE_DESKS);
+
+        let result = ask_around(
+            &deps,
+            &CompanyId::new("acme"),
+            "The answer must include the renewal pricing",
+            Some(PeerConsult {
+                turn: &stub,
+                record: &record,
+                exclude_agent: "researcher",
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            stub.background(),
+            0,
+            "a company past its token ceiling must not pay for a peer turn"
+        );
+        assert_eq!(result.evidence, None);
+        assert!(
+            result.log.contains("peer: skipped; token ceiling reached"),
+            "{}",
+            result.log
+        );
+    }
+
+    #[tokio::test]
+    async fn a_fact_match_never_asks_a_peer() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1866-peer-last-")
+            .tempdir()
+            .expect("tempdir");
+        let (mut deps, _journal) =
+            crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+        deps.facts = Some(std::sync::Arc::new(ExactMatchFactStore {
+            matches: "renewal",
+            fact: crate::ports::FactRecord {
+                id: "f1".to_string(),
+                kind: crate::ports::FactKind::Fact,
+                title: "Renewal pricing".to_string(),
+                body: "Enterprise renewals carry a 12% uplift.".to_string(),
+                source: "test".to_string(),
+                updated_at_millis: 0,
+            },
+        }));
+        let stub = PeerStub::answering("should never be reached");
+        let record = roster(THREE_DESKS);
+
+        let result = ask_around(
+            &deps,
+            &CompanyId::new("acme"),
+            "The answer must include the renewal pricing",
+            Some(PeerConsult {
+                turn: &stub,
+                record: &record,
+                exclude_agent: "researcher",
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            stub.background(),
+            0,
+            "the peer rung is last; a local answer must add no always-on turn cost"
+        );
+        assert!(
+            result.log.contains("peer: skipped after local match"),
+            "{}",
+            result.log
         );
     }
 }


### PR DESCRIPTION
## Summary

The sufficiency gate's recovery ladder shipped with two of its three rungs. `ask_around` queries the fact store, then the workspace — and the third was a bare log line:

```rust
log.push("peer: skipped; board read capability #1859 is unavailable".to_string());
```

So an information gap the company could answer escalated straight to a human Information blocker with `peer: skipped` in the log, without anyone being asked. #1859 has since merged (#1951), leaving that marker stale.

This builds the rung: pick one roster peer whose role actually matches the question, ask it once under a bound, and fold the answer into the evidence with its provenance attached.

Closes #1866

## API Or Behavior Changes

- `ask_around` takes `Option<PeerConsult>`; the `if evidence.is_empty()` short-circuit and the `"peer: skipped after local match"` line are unchanged, so a local hit still costs no turn.
- `pick_peer` is **pure and model-free**: it scores `effective_agents()` by case-insensitive `focus_terms(question)` hits across role + description + name, excludes the node's own agent, keeps roster order on a tie, and returns `None` on an all-zero score. Selection is never a second model call. It reuses `focus_terms` so the fact rung and the peer rung cannot drift on what the question is about.
- `consult_peer` prechecks the same spend ceiling `judge_sufficiency` uses, then runs **exactly one** `RunTurn::run_background` (not `run_background_workflow` — that tags live frames with a run/node id and the console would render a consultation as a node) under `PEER_TIMEOUT`, capped at `MAX_RECOVERY_CHARS`. Answers land as `peer {id} ({role}): {answer}`, and that prefix survives into the re-verification judge's input and the operator's blocker card. Each outcome — answered / empty / failed / timed out / no role matched / ceiling reached — gets its own log line.
- **A consultation carries no authority.** It runs under the run's own delegation and publish-refusal scopes and its own `ApprovalScope::Run("<run>::consult")`, and everything it stages is discarded: delegations, publish refusals, and approval requests. It settles no attempt row and pushes nothing onto the run's blocks.
- Fires at most once per node attempt, guarded by a task-local so a consulted orchestrator running a nested graph cannot re-enter the ladder.
- Metered as the peer's own turn, not as a `JudgeCall`.

**One deliberate design choice worth a reviewer's eye.** The consultation could have run in a throwaway scope, which would make a leak structurally impossible — and would also make the discard **untestable**, since removing it would change nothing observable. It runs in the run's own scope instead, so `discard_consultation_writes` is load-bearing and provable. The test below is what that buys.

**An honest limit on the premise.** #1951 wired `list_tasks` / `read_task` / `read_run` only inside the `if is_orchestrator` branch of `build.rs`; the sibling branch is pinned by `a_member_with_delegates_to_gets_exactly_the_two_hand_off_tools`. So #1859 unblocked this rung **probabilistically, not structurally**: ask the orchestrator and you may get a real answer; ask a role-matched marketing peer about a stalled run and it is as blind as before. Widening that belt is a policy decision — `consequence.rs` classes these reads `Reach::Nothing`, which argues for it — and is deliberately **not** in this PR. Tracked as #2031.

## Tests

Run unpiped, exit codes captured. Note `pub mod workflows` is behind the `openhuman` feature — a plain `cargo check` compiles none of this and passes vacuously.

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --features openhuman`
- [x] `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings`
- [x] `cargo test --lib --features openhuman -- workflows::` — 612 passed
- [x] `cargo test --lib --features openhuman -- harness::` — 1555 passed

N/A: `cargo build --all-targets` and full `cargo test` — the gated `--all-targets` clippy covers the build, and an unscoped `--lib` run has OOM'd in this workspace; the two affected scopes are run in full above.

20 new tests. The current behaviour was recorded first, and it is the blocker message this PR removes:

```
facts: unavailable; workspace: 0 match(es); peer: skipped; board read capability #1859 is unavailable
```

Red proofs across five rounds — selection, bounds, provenance, the caps invariants, and the headline. The two that matter most:

```
a_consultation_that_stages_board_work_leaves_nothing_behind:
  a consultation must open no card on the run's board
a_consultation_cannot_re_enter_the_recovery_ladder:
  the peer rung must fire once down the whole stack, not once per nested node
    left: 3   right: 2
```

The no-authority test stages a delegation, a publish refusal **and an approval request** from the consulted peer, then runs a *second, plain node on the same runner* — the path that would execute a leak and attribute it to this run — and asserts the board, blocks and notices are all empty.

That approval leg was found late, during a rebase review, and is the reason this PR is worth reading carefully: `ApprovalRequestQueue::push` is not claim-gated, so an unclaimed push files into `Unscoped` and `drain` folds it into the chat cycle's bucket. A consulted peer that reached a gated tool left **an approval card in front of the operator, attributed to a chat turn they never started**. Proved with `left: 1, right: 0`, fixed with the dedicated scope, and shipped as its own commit.

Also pinned: an exhausted ceiling and a fact-store hit each leave the stub's call count at **zero**, proving the rung is genuinely last and adds no always-on cost; and the `escalate` arm never enters the ladder.

**Not done**: no Playwright spec — this rung has no UI surface a browser can drive, and inventing one would be theatre. No live-model run; every path is stubbed. `PEER_TIMEOUT` is a judgement (4× the judge's, since a peer runs a full tool-using turn), not a measurement — worth an opinion. One back-compat test has no red proof, stated rather than papered over.

## Documentation

`docs/spec/runtime/workflow-vocabulary.md` — the rung, its bounds, that it runs only when both local rungs found nothing, and that it is metered as the peer's own turn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recovery can now consult a relevant roster peer when a workflow node needs assistance.
  - Peer responses are recorded with clear attribution and used to re-check the workflow’s postconditions.
  - Consultations are bounded, run at most once per attempt, and respect available token limits.
  - Unsuccessful, empty, or timed-out consultations continue through the existing escalation path.

- **Bug Fixes**
  - Prevented consultation work from creating unintended board changes, approvals, or published results.
  - Prevented nested consultations from repeatedly triggering one another.

- **Documentation**
  - Updated the runtime workflow vocabulary to describe peer consultation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->