### PR TITLE
fix(policy): park a Hire with an unknown amount or no configured cap (#2037)

### DIFF
--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -575,9 +575,10 @@ impl ManifestApprovalGate {
     ///
     /// It is the supervised checkpoint taxonomy read as a question about the
     /// past rather than the future: signing, publishing, touching identity,
-    /// spending at or over the cap, first contact with a counterparty. Those
-    /// are the effects `evaluate_supervised` refuses to wave through, and they
-    /// are refused precisely because they cannot be taken back.
+    /// spending or engaging anything but a known amount under a configured
+    /// cap, first contact with a counterparty. Those are the effects
+    /// `evaluate_supervised` refuses to wave through, and they are refused
+    /// precisely because they cannot be taken back.
     ///
     /// Deliberately **mode-independent**. A `full`-mode company executes every
     /// one of these without ever parking it, which is exactly the case this
@@ -646,13 +647,14 @@ impl ManifestApprovalGate {
     /// tiers.
     ///
     /// The **native** taxonomy has no such calls to wave through. Every group
-    /// [`evaluate_supervised`](Self::evaluate_supervised) parks — spend at or
-    /// over the cap, a message to a counterparty nobody has talked to, a
-    /// signature, a publish, an identity change, an engagement over the cap — is
-    /// by definition something that leaves the company or spends money, which is
-    /// the exact line `auto` says it stops at. The only inside-the-company
-    /// native bucket is [`EffectGroup::Other`], and `supervised` already allows
-    /// it. So there is nothing for `auto` to loosen here, and the honest
+    /// [`evaluate_supervised`](Self::evaluate_supervised) parks — a spend not
+    /// known to be under the cap, a message to a counterparty nobody has talked
+    /// to, a signature, a publish, an identity change, an engagement on those
+    /// same cap terms — is by definition something that leaves the company or
+    /// spends money, which is the exact line `auto` says it stops at. The only
+    /// inside-the-company native bucket is [`EffectGroup::Other`], and
+    /// `supervised` already allows it. So there is nothing for `auto` to loosen
+    /// here, and the honest
     /// implementation is one that says so.
     ///
     /// # Why not the stricter reading
@@ -689,14 +691,25 @@ impl ManifestApprovalGate {
         Self::evaluate_supervised_with_policy(&policy, effect)
     }
 
+    /// The one cap comparison both money groups read (issue #2037).
+    ///
+    /// True only when the amount and the cap are **both** known and the amount
+    /// is strictly under: an unstated amount and an unconfigured cap are not
+    /// evidence of a small number, so neither is under anything.
+    fn under_cap(amount: Option<f64>, cap: Option<f64>) -> bool {
+        matches!((amount, cap), (Some(amount), Some(cap)) if amount < cap)
+    }
+
     fn evaluate_supervised_with_cap(effect: &Effect, cap: Option<f64>) -> PolicyDecision {
         match effect.group() {
-            // Spend under the cap (strict `<`) is auto-allowed; at/over the cap,
-            // with no cap, or with an unknown amount, it parks.
-            EffectGroup::Spend => match (effect.amount_usd(), cap) {
-                (Some(amount), Some(cap)) if amount < cap => PolicyDecision::Allow,
-                _ => PolicyDecision::RequireApproval,
-            },
+            // Spend under the cap is auto-allowed; anything else parks.
+            EffectGroup::Spend => {
+                if Self::under_cap(effect.amount_usd(), cap) {
+                    PolicyDecision::Allow
+                } else {
+                    PolicyDecision::RequireApproval
+                }
+            }
             // First message to a new counterparty parks; established threads pass.
             EffectGroup::Send => {
                 if effect.is_established_thread() && !effect.is_first_time_counterparty() {
@@ -709,16 +722,14 @@ impl ManifestApprovalGate {
             EffectGroup::Sign | EffectGroup::Publish | EffectGroup::Identity => {
                 PolicyDecision::RequireApproval
             }
-            // Hiring parks for a first-time counterparty or at/over the cap.
+            // Hiring is auto-allowed under the cap, and only for a
+            // counterparty this company has dealt with before.
             EffectGroup::Hire => {
-                let over_cap = matches!(
-                    (effect.amount_usd(), cap),
-                    (Some(amount), Some(cap)) if amount >= cap
-                );
-                if effect.is_first_time_counterparty() || over_cap {
-                    PolicyDecision::RequireApproval
-                } else {
+                if Self::under_cap(effect.amount_usd(), cap) && !effect.is_first_time_counterparty()
+                {
                     PolicyDecision::Allow
+                } else {
+                    PolicyDecision::RequireApproval
                 }
             }
             EffectGroup::Other => PolicyDecision::Allow,
@@ -1032,6 +1043,93 @@ mod test {
         let mut cheap = effect("a2a.engage", EffectGroup::Hire);
         cheap.amount_usd = Some(10.0);
         assert_eq!(decide(&gate, &cheap).await, PolicyDecision::Allow);
+    }
+
+    /// Issue #2037: the two money gates read the **same** two inputs — an
+    /// amount that may be unknown, and a cap that may not be configured — so
+    /// they must not disagree about what those shapes mean.
+    ///
+    /// `Spend` has always failed closed on the omitting shapes and says so in a
+    /// comment. `Hire` computed its `over_cap` as `(Some, Some) if amount >=
+    /// cap`, which is `false` whenever *either* input is absent — so an unknown
+    /// amount and an unconfigured cap both read as "under the cap", and a paid
+    /// engagement of an established counterparty was waved straight through.
+    ///
+    /// Walked as one table across both groups, so neither arm can be relaxed on
+    /// its own again. Absence of information is not evidence of a small number.
+    #[tokio::test]
+    async fn the_money_gates_agree_on_every_cap_shape() {
+        let shapes: &[(&str, Option<f64>, Option<f64>, PolicyDecision)] = &[
+            (
+                "under a configured cap",
+                Some(10.0),
+                Some(100.0),
+                PolicyDecision::Allow,
+            ),
+            (
+                "exactly at a configured cap",
+                Some(100.0),
+                Some(100.0),
+                PolicyDecision::RequireApproval,
+            ),
+            (
+                "over a configured cap",
+                Some(250.0),
+                Some(100.0),
+                PolicyDecision::RequireApproval,
+            ),
+            (
+                "an unknown amount under a configured cap",
+                None,
+                Some(100.0),
+                PolicyDecision::RequireApproval,
+            ),
+            (
+                "a known amount with no cap configured",
+                Some(10.0),
+                None,
+                PolicyDecision::RequireApproval,
+            ),
+            (
+                "an unknown amount with no cap configured",
+                None,
+                None,
+                PolicyDecision::RequireApproval,
+            ),
+        ];
+
+        let mut checked = 0;
+        for (group, kind) in [
+            (EffectGroup::Spend, "x402.spend"),
+            (EffectGroup::Hire, "a2a.engage"),
+        ] {
+            for (label, amount, cap, expected) in shapes {
+                let gate = ManifestApprovalGate::new(policy("supervised", *cap));
+                // An established counterparty throughout: the cap is the only
+                // thing under test here, and first contact is asserted
+                // separately below.
+                let mut eff = effect(kind, group);
+                eff.amount_usd = *amount;
+                assert_eq!(decide(&gate, &eff).await, *expected, "{group:?}: {label}");
+                checked += 1;
+            }
+        }
+        assert_eq!(checked, 2 * shapes.len(), "the walk skipped a shape");
+    }
+
+    /// First contact stays an independent reason to park, orthogonal to the cap
+    /// (issue #2037).
+    ///
+    /// An engagement can be small, known, and comfortably under a configured
+    /// cap and still be the first time this company has ever paid this
+    /// counterparty. Folding the two reasons into one cap check would lose it.
+    #[tokio::test]
+    async fn supervised_hire_parks_first_contact_even_under_the_cap() {
+        let gate = ManifestApprovalGate::new(policy("supervised", Some(100.0)));
+        let mut first = effect("a2a.engage", EffectGroup::Hire);
+        first.amount_usd = Some(10.0);
+        first.first_time_counterparty = true;
+        assert_eq!(decide(&gate, &first).await, PolicyDecision::RequireApproval);
     }
 
     // -----------------------------------------------------------------------
@@ -1515,6 +1613,40 @@ mod test {
             let mut cold = effect("email.send", EffectGroup::Send);
             cold.first_time_counterparty = true;
             assert!(gate.is_irreversible(&cold), "{mode}: first contact");
+
+            // Hire: the same cap, read the same way — plus first contact.
+            let mut cheap_hire = effect("a2a.engage", EffectGroup::Hire);
+            cheap_hire.amount_usd = Some(99.0);
+            assert!(!gate.is_irreversible(&cheap_hire), "{mode}: under the cap");
+            let mut at_cap_hire = effect("a2a.engage", EffectGroup::Hire);
+            at_cap_hire.amount_usd = Some(100.0);
+            assert!(gate.is_irreversible(&at_cap_hire), "{mode}: at the cap");
+            let mut first_hire = effect("a2a.engage", EffectGroup::Hire);
+            first_hire.amount_usd = Some(10.0);
+            first_hire.first_time_counterparty = true;
+            assert!(gate.is_irreversible(&first_hire), "{mode}: first contact");
+
+            // Issue #2037: the shapes that omit one of the two inputs, for both
+            // money groups. An engagement whose price nobody stated, and one in
+            // a company that configured no cap, are irreversible for the same
+            // reason a spend is — and they are the shapes the retry dialog lost,
+            // because `record_executed` files nothing for a reversible effect.
+            let uncapped = ManifestApprovalGate::new(policy(mode, None));
+            for (label, group, kind) in [
+                ("a spend", EffectGroup::Spend, "x402.spend"),
+                ("an engagement", EffectGroup::Hire, "a2a.engage"),
+            ] {
+                assert!(
+                    gate.is_irreversible(&effect(kind, group)),
+                    "{mode}: {label} of unknown amount",
+                );
+                let mut known = effect(kind, group);
+                known.amount_usd = Some(10.0);
+                assert!(
+                    uncapped.is_irreversible(&known),
+                    "{mode}: {label} with no cap configured",
+                );
+            }
 
             // A read changes nothing and warns about nothing.
             assert!(

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -2892,6 +2892,75 @@ mod test {
         assert_eq!(reloaded.irreversible_effects("t-1").len(), 1);
     }
 
+    /// Issue #2037, the second half of it: what the gate calls irreversible is
+    /// the only thing that ever reaches the retry warning.
+    ///
+    /// [`State::index_executed`] files nothing for a reversible effect, so a
+    /// gate that waves a paid engagement through does not merely skip the
+    /// approval — it erases the engagement from the card's history, and Retry
+    /// re-runs it with no warning at all. The two halves are one bug and this
+    /// pins the join.
+    ///
+    /// The flag is **derived from a real gate** rather than hand-stamped
+    /// `irreversible: true` like [`executed`] does. A hand-stamped fixture
+    /// tests the index and stays green through exactly the regression this is
+    /// here for: the shape under test is an engagement of an established
+    /// counterparty, with no amount stated, in a company that configured no
+    /// cap — the shape that used to read as "under the cap".
+    #[tokio::test]
+    async fn an_engagement_the_gate_calls_irreversible_reaches_the_retry_warning() {
+        use crate::company::Policy;
+        use crate::policy::ManifestApprovalGate;
+
+        let gate = ManifestApprovalGate::new(Policy {
+            mode: "supervised".into(),
+            always_approve: Vec::new(),
+            auto_approve_under_usd: None,
+            approval_ttl_hours: None,
+        });
+
+        let engagement = Effect {
+            kind: "a2a.engage".into(),
+            group: EffectGroup::Hire,
+            ..effect()
+        };
+        assert!(
+            gate.is_irreversible(&engagement),
+            "an engagement of unstated value in a company with no cap is not \
+             something a person can take back",
+        );
+
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+        journal
+            .record_executed(
+                "cyc:0",
+                ExecutedEffect {
+                    kind: engagement.kind.clone(),
+                    amount_usd: engagement.amount_usd,
+                    task_id: Some("t-1".into()),
+                    at_millis: now_millis(),
+                    irreversible: gate.is_irreversible(&engagement),
+                },
+            )
+            .await
+            .unwrap();
+
+        let named = journal.irreversible_effects("t-1");
+        assert_eq!(
+            named.len(),
+            1,
+            "the card's retry dialog has nothing to warn about",
+        );
+        assert_eq!(named[0].kind, "a2a.engage");
+
+        // And it survives a restart, which is where the dialog usually reads it.
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        assert_eq!(reloaded.irreversible_effects("t-1").len(), 1);
+    }
+
     /// **Issue #726**: a journal over a non-filesystem store replays exactly
     /// what the same records replay over a file — and survives the loss of the
     /// bundle directory, which is the whole point.


### PR DESCRIPTION
## Summary

A paid engagement could be entered **without an approval**, and afterwards re-run from the card with **no irreversibility warning**.

`Spend` and `Hire` sit a few lines apart in `evaluate_supervised_with_cap`, take the same two inputs, and defaulted opposite ways. `Spend` fails closed and says so in its comment. `Hire` computed `over_cap` as `(Some(amount), Some(cap)) if amount >= cap` — `false` whenever the amount was unknown **or** no cap was configured — and fell through to `Allow`.

The second half: `is_irreversible` *is* `evaluate_supervised(...) == RequireApproval`, so that same `Allow` made the engagement report itself reversible. `index_executed`'s `if !effect.irreversible { return; }` then dropped the record, the card never entered `irreversible_by_task`, and Retry had nothing to warn about.

Both halves observed on unmodified source. The gate:

```
MISMATCH Hire: an unknown amount under a configured cap  -> got Allow, want RequireApproval
MISMATCH Hire: a known amount with no cap configured     -> got Allow, want RequireApproval
MISMATCH Hire: an unknown amount with no cap configured  -> got Allow, want RequireApproval
```

Exactly three shapes, all `Hire`; all six `Spend` shapes already passed. And the consequence, for an established-counterparty `a2a.engage` with `amount_usd: None` and cap `None`:

```
TODAY: irreversible_effects("t-1") = [] (len 0)
```

Closes #2037

## API Or Behavior Changes

One private helper both arms now reach `Allow` through:

```rust
fn under_cap(amount: Option<f64>, cap: Option<f64>) -> bool {
    matches!((amount, cap), (Some(amount), Some(cap)) if amount < cap)
}
```

`Hire` becomes `under_cap(...) && !is_first_time_counterparty()`. First contact stays an independent reason to park — orthogonal to the cap.

**Boundary preserved exactly**: strict `<`, so at the cap parks. `Spend` allowed on `amount < cap` and `Hire` parked on `amount >= cap` are the same line; nothing moved by one comparison, and `supervised_spend_cap_is_strict` plus the at-cap legs of the new table pin it.

Two doc paragraphs on `is_irreversible` and `evaluate_auto` said "at or over the cap"; they now say "not known to be under the cap", because that is the rule.

### Blast radius — this is a real behaviour change, and it is broad

**The default cap is `None`, and nothing supplies one.** `Policy::default()` leaves `auto_approve_under_usd: None`, the serde attribute is a bare `#[serde(default)]`, and provisioning writes only `PROVISIONED_POLICY_MODE` into a new manifest. One fixture in the tree sets a cap. So "no cap configured" is the **common** case — every company that has not used the console policy override.

It is worse than the cap alone implies: `effect_from_frame` lifts `amountUsd` and `firstTimeCounterparty` with `None` / `.unwrap_or(false)` when absent, so a bare `hire.*` payload arrives as *established counterparty, unknown amount* — the defect's exact shape by default, cap or no cap.

Where the change lands:
- **Approval decisions** change for `supervised` and `auto` only (`auto` delegates to `supervised`, and is the tier new companies get). `full` and `readonly` are untouched.
- **`is_irreversible` is mode-independent by design**, so the journal/Retry half changes in **every** mode — including `full`, which is the mode that warning exists for.
- Two production call sites, both in `runtime/cycle.rs`: the effect-execution stamp, and `consumed_grant_effect` for a redeemed tool grant — so the harness tool path also gets the corrected warning, though its parking decision is made independently by `ApprovalPolicy::check` and is unaffected.

**Can `Hire` fire today?** By construction yes; I could not confirm it does. `effect_group_for` classifies any kind with a `hire` or `engage` segment, and no literal `hire.*` kind is emitted anywhere in this repo — the emitter is the medulla brain, outside this tree. `undeclared_group` also maps a tool name containing `hire`/`contract`, which is the MCP/dynamic route. So the fix is right regardless, and its urgency rests on a vocabulary not visible from here.

## Tests

All unpiped, exit codes read directly, no filter returning a zero count:

- [x] `cargo fmt --all -- --check` · `cargo check --all-targets`
- [x] `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings`
- [x] `cargo test --lib policy::gate::` 43 · `policy::` 155 · `--features openhuman policy::` 288
- [x] `runtime::journal::` 48 · `runtime::` 796 · `company::` 894 · `brain::` 72 · `workflows::` 146 · `server::` 1463

N/A: frontend gates — no frontend file is touched.

New coverage, aimed at the fixture bias that let this ship: `the_money_gates_agree_on_every_cap_shape` puts **both** groups through **all six** shapes in one table with a `checked` count, so a skipped shape fails; `irreversibility_follows_the_supervised_taxonomy_in_every_mode` gains `Hire` and both omitting shapes for both money groups — it previously iterated only `Sign`/`Publish`/`Identity`; and `an_engagement_the_gate_calls_irreversible_reaches_the_retry_warning` derives `irreversible` from a **real gate** rather than the hand-stamped fixture, asserting the index is populated and survives a reload.

Red proofs, verbatim:

```
the_money_gates_agree_on_every_cap_shape:
  assertion `left == right` failed: Hire: an unknown amount under a configured cap
    left: Allow   right: RequireApproval

irreversibility_follows_the_supervised_taxonomy_in_every_mode:
  supervised: an engagement of unknown amount

an_engagement_the_gate_calls_irreversible_reaches_the_retry_warning:
  an engagement of unstated value in a company with no cap is not something a person can take back
```

Since a Rust assert masks everything after it, the arms were then reverted with the tests kept and the taxonomy loop instrumented to enumerate — six failing assertions across all three modes, none of them `Spend`. Source restored from a byte copy; gates re-run green after.

Stated rather than claimed: two new assertions **pass** on the unfixed code — `supervised_hire_parks_first_contact_even_under_the_cap` and the `Hire` under/at-cap legs. They guard against the refactor collapsing first-contact into the cap check, which is a real risk in this shape of change, but they are not evidence of the bug.

**No Playwright spec, deliberately.** The user-visible half is the Retry warning on `TaskEditDialog`, fed by `detail.irreversibleEffects`. Reaching it needs a real `Hire` effect committed against a card — an agent turn emitting a `hire`/`engage` kind, so an inference credential and a non-deterministic model decision. The suite's own precedent for this exact problem (`approval-timeout-honesty.spec.ts`) fakes the list; doing that here would assert the frontend renders a warning when handed one, which was never broken. The defect is the Rust gate deciding the flag, and the journal test covers that join.

## Documentation

No separate docs change — the corrected doc paragraphs on `is_irreversible` and `evaluate_auto` are the documentation, and the helper carries one line stating the invariant it enforces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Engagements with unknown amounts or no configured spending cap now require approval instead of being automatically allowed.
  * First-contact engagements are correctly held for approval regardless of spending-cap settings.
  * Irreversible engagement approvals now consistently trigger retry warnings and remain visible after journal reloads.
* **Consistency**
  * Hiring and spending decisions now apply the same amount and cap rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->