### PR TITLE
docs: correct the Cortex record — the driver was written, and works

### DIFF
--- a/docs/spec/runtime/memory-engine-cortex-driver.md
+++ b/docs/spec/runtime/memory-engine-cortex-driver.md
@@ -60,9 +60,19 @@ wraps records in a JSON envelope inside `content` (`Bound::put` calls
 `encode(record)`), so that is the shape it uses anyway — but a scan-per-read is
 slow and still non-atomic.
 
-Both rest on a `forget` that reported `deleted.events: 2` for a selector naming
-one event id. That is a lot of correctness risk to absorb for something an
-upstream `on_conflict: replace` would remove entirely.
+Only the first rests on `forget`, and that matters, because `forget` is where our
+worst scare came from: a call reporting `deleted.events: 2` for a selector naming
+one event id. That turned out to be our own malformed request rather than an
+engine defect — the record's Phase 1 acceptance notes set out exactly which layer
+refuses what — but an emulation that deletes the previous event on every
+overwrite puts that call on the write path of every store, which is a lot of
+blast radius to accept for something an upstream `on_conflict: replace` would
+remove entirely.
+
+The envelope-and-fold path does not delete anything. It appends the new event and
+lets the fold prefer the newest per key, so the previous version stays on disk and
+is simply not returned. That is the path the shipped driver takes, and it is why
+its `forget` is confined to `delete`, where a caller asked for removal.
 
 The reproduction is recorded at
 [cortexdb-releases#3](https://github.com/cortexdbai/cortexdb-releases/issues/3)

--- a/docs/spec/runtime/memory-engine-cortex-driver.md
+++ b/docs/spec/runtime/memory-engine-cortex-driver.md
@@ -1,0 +1,116 @@
+# Writing a driver against CortexDB v0.9.8
+
+Companion to [`memory-engine-cortex.md`](memory-engine-cortex.md), which asks
+whether we should host Cortex at all. This one assumes that question is still
+open and answers a narrower one: what a `MemoryProvider` driver has to do to
+speak to CortexDB v0.9.8, and what that costs at every call.
+
+Split out of the design record when it outgrew the 500-line cap. The record kept
+the decision; this kept the mechanics behind it.
+
+The driver these notes describe is merged as
+[tinymemory#128](https://github.com/tinyhumansai/tinymemory/pull/128) and is
+deliberately unregistered — see the record's phased plan.
+
+## The upsert gap, and what it costs to work around
+
+This is the finding that decides the phasing, and it is not about capability
+breadth — it is that the two data models disagree.
+
+`Memory::store` is an **idempotent upsert keyed by `(namespace, key)`**: storing
+twice at one key replaces the previous content "rather than erroring or creating
+a duplicate". The conformance suite asserts it directly
+(`assert_upsert_replaces_rather_than_duplicates`) — write `first`, write
+`second`, expect one row holding `second`. `memory-engine.md` makes that suite
+the thing that retired the unproven-remote flag, so passing it is not optional.
+
+CortexDB is an append-only event log. Measured against the deployment:
+
+| Attempt | Result |
+|---|---|
+| Same key, different content | `409 IDEMPOTENCY_CONFLICT` — "idempotency key reused with a different body" |
+| Same key, identical content | `202`, `replayed_from_idempotency: true` |
+| Update route | none — `/v1/events` and `/v1/events/{id}` are GET-only, `/v1/experience` POST-only |
+| Forget, then rewrite the key | forget succeeds, rewrite still `409` — **and the scope is left holding nothing** |
+| Carry our own key in the envelope | `422` — closed schema, and `/v1/events` has no metadata filter regardless |
+
+The idempotency ledger is independent of the event store and survives
+`/v1/forget`, so delete-then-rewrite loses the original *and* refuses the
+replacement. It is strictly worse than not attempting it.
+
+**The engine can already do this; the HTTP surface cannot express it.** The
+embedded adapter that #1568 removed (`tinymemory-tinycortex`) forwards `store`
+straight through to the engine's own implementation, and that crate runs the
+*full* conformance suite over `TinycortexProvider`
+(`tests/full_provider_conformance.rs`) — including
+`assert_upsert_replaces_rather_than_duplicates`. The engine core therefore
+passes the exact assertion the hosted API fails.
+
+That makes the upstream ask narrow and concrete: expose over HTTP what the
+engine already implements and is already conformance-tested against, rather than
+add a capability. It also suggests the gap is an API-surface oversight rather
+than a deliberate design position.
+
+Two emulations exist, and neither is comfortable. A driver can keep an
+**external index** of `(namespace, key) → event_id`, writing with fresh
+idempotency keys and forgetting the prior event on overwrite — which makes the
+driver stateful, carrying a database of its own. Or it can put the key in an
+**in-content envelope** and resolve it with a client-side scan; the host already
+wraps records in a JSON envelope inside `content` (`Bound::put` calls
+`encode(record)`), so that is the shape it uses anyway — but a scan-per-read is
+slow and still non-atomic.
+
+Both rest on a `forget` that reported `deleted.events: 2` for a selector naming
+one event id. That is a lot of correctness risk to absorb for something an
+upstream `on_conflict: replace` would remove entirely.
+
+The reproduction is recorded at
+[cortexdb-releases#3](https://github.com/cortexdbai/cortexdb-releases/issues/3)
+— closed there, like #1 and #2, because that tracker is scoped to packaging, and
+being raised with CortexDB directly instead.
+
+**This was written as blocking Phase 1. It is not.** The driver appends every
+write under a fresh idempotency key — which the engine always accepts — carrying
+the logical key inside the payload, and folds to newest-per-key on read.
+Replacement is reconstructed on the read side rather than performed on the write
+side, and the conformance suite passes that way against a live v0.9.8.
+
+The price is paid on every call, and it is the real input to the decision:
+
+- **keyed reads are a scan.** `/v1/events` has no metadata filter, so `get` and
+  `list` fetch the scope and fold it — a walk growing with everything the
+  namespace has held.
+- **writes cost seconds, not milliseconds.** `/v1/experience` answers
+  `202 captured` and indexes after, so the driver waits for its own record to be
+  readable: 1–4s to the listing, a second more to ranked recall.
+- **superseded values reach `recall`, and this one is not merely a cost.** The
+  fold removes them from keyed reads and cannot remove them from recall — the one
+  path Cortex was wanted for. A caller can be handed a value `get` would never
+  return. Whether that breaks the contract or is permitted backend-defined
+  behaviour is unsettled, and **the conformance suite does not decide it**:
+  `assert_upsert_replaces_rather_than_duplicates` reads back through `list` and
+  never calls `recall`, so passing it says nothing about this axis. Treat the
+  green suite as coverage that stops short here, not as proof.
+
+None of the three is a defect in the driver; each is the cost of emulating
+replacement on an engine that does not offer it. But **an upsert alone would only
+remove the third.** `on_conflict: "replace"` is our proposed ask, not a documented
+CortexDB option, and even if it shipped: keyed reads still scan, because that
+needs a metadata filter on `/v1/events`; writes still wait, because that needs a
+readiness signal the engine does not expose. Three asks, not one.
+
+## What building it taught us
+
+Five engine behaviours surfaced only against a running instance, and each one
+produced a driver that passed every offline test and was wrong in production —
+the conformance double and the driver were written from the same documentation,
+so they agreed with each other rather than with the service. The catalogue lives
+in `cortex.rs`'s module docs, beside the code that has to cope with each one,
+which is where it stays current.
+
+The generalisable part belongs here: **a double written from a vendor's
+documentation cannot tell you the vendor's documentation is wrong.** The lane
+that found these runs the same conformance suite against a live engine
+(`tests/live_remote_engines.rs`), and it is worth pointing at every hosted engine
+we bind, not just this one — which is the argument #1968 was opened to settle.
+

--- a/docs/spec/runtime/memory-engine-cortex.md
+++ b/docs/spec/runtime/memory-engine-cortex.md
@@ -50,8 +50,9 @@ question, and the recommendation follows from them.
    reachable.** `(namespace, key)` replacement cannot be expressed against an
    append-only log with immutable keys. It can be *reconstructed*: append every
    write under a fresh idempotency key carrying the logical key, and fold to
-   newest-per-key on read. That driver exists and passes. Its cost — its own
-   section below — is what should decide this, not impossibility.
+   newest-per-key on read. That driver exists and passes. Its cost — set out in
+   [the driver notes](memory-engine-cortex-driver.md) — is what should decide
+   this, not impossibility.
 
 ## The isolation choice collapses
 
@@ -159,98 +160,21 @@ claim against a structure. Tracked as
 probe of the mandatory families is proposed in
 [#1973](https://github.com/tinyhumansai/opencompany/pull/1973).
 
-## The upsert gap, and what it costs to work around
+## The upsert gap, and the driver mechanics
 
-This is the finding that decides the phasing, and it is not about capability
-breadth — it is that the two data models disagree.
+The contract's `(namespace, key)` upsert has no direct mapping onto an
+append-only log, and reconstructing it is most of what a driver does. That
+argument, the measured table of failed direct mappings, what the workaround costs
+at every call, and the engine behaviours that only appear against a running
+instance are in
+[`memory-engine-cortex-driver.md`](memory-engine-cortex-driver.md).
 
-`Memory::store` is an **idempotent upsert keyed by `(namespace, key)`**: storing
-twice at one key replaces the previous content "rather than erroring or creating
-a duplicate". The conformance suite asserts it directly
-(`assert_upsert_replaces_rather_than_duplicates`) — write `first`, write
-`second`, expect one row holding `second`. `memory-engine.md` makes that suite
-the thing that retired the unproven-remote flag, so passing it is not optional.
-
-CortexDB is an append-only event log. Measured against the deployment:
-
-| Attempt | Result |
-|---|---|
-| Same key, different content | `409 IDEMPOTENCY_CONFLICT` — "idempotency key reused with a different body" |
-| Same key, identical content | `202`, `replayed_from_idempotency: true` |
-| Update route | none — `/v1/events` and `/v1/events/{id}` are GET-only, `/v1/experience` POST-only |
-| Forget, then rewrite the key | forget succeeds, rewrite still `409` — **and the scope is left holding nothing** |
-| Carry our own key in the envelope | `422` — closed schema, and `/v1/events` has no metadata filter regardless |
-
-The idempotency ledger is independent of the event store and survives
-`/v1/forget`, so delete-then-rewrite loses the original *and* refuses the
-replacement. It is strictly worse than not attempting it.
-
-**The engine can already do this; the HTTP surface cannot express it.** The
-embedded adapter that #1568 removed (`tinymemory-tinycortex`) forwards `store`
-straight through to the engine's own implementation, and that crate runs the
-*full* conformance suite over `TinycortexProvider`
-(`tests/full_provider_conformance.rs`) — including
-`assert_upsert_replaces_rather_than_duplicates`. The engine core therefore
-passes the exact assertion the hosted API fails.
-
-That makes the upstream ask narrow and concrete: expose over HTTP what the
-engine already implements and is already conformance-tested against, rather than
-add a capability. It also suggests the gap is an API-surface oversight rather
-than a deliberate design position.
-
-Two emulations exist, and neither is comfortable. A driver can keep an
-**external index** of `(namespace, key) → event_id`, writing with fresh
-idempotency keys and forgetting the prior event on overwrite — which makes the
-driver stateful, carrying a database of its own. Or it can put the key in an
-**in-content envelope** and resolve it with a client-side scan; the host already
-wraps records in a JSON envelope inside `content` (`Bound::put` calls
-`encode(record)`), so that is the shape it uses anyway — but a scan-per-read is
-slow and still non-atomic.
-
-Both rest on a `forget` that reported `deleted.events: 2` for a selector naming
-one event id. That is a lot of correctness risk to absorb for something an
-upstream `on_conflict: replace` would remove entirely.
-
-The reproduction is recorded at
-[cortexdb-releases#3](https://github.com/cortexdbai/cortexdb-releases/issues/3)
-— closed there, like #1 and #2, because that tracker is scoped to packaging, and
-being raised with CortexDB directly instead.
-
-**This was written as blocking Phase 1. It is not.** The driver appends every
-write under a fresh idempotency key — which the engine always accepts — carrying
-the logical key inside the payload, and folds to newest-per-key on read.
-Replacement is reconstructed on the read side rather than performed on the write
-side, and the conformance suite passes that way against a live v0.9.8.
-
-The price is paid on every call, and it is the real input to the decision:
-
-- **keyed reads are a scan.** `/v1/events` has no metadata filter, so `get` and
-  `list` fetch the scope and fold it — a walk growing with everything the
-  namespace has held.
-- **writes cost seconds, not milliseconds.** `/v1/experience` answers
-  `202 captured` and indexes after, so the driver waits for its own record to be
-  readable: 1–4s to the listing, a second more to ranked recall.
-- **superseded values stay in the ranking corpus.** The fold removes them from
-  keyed reads, not from recall — the one path Cortex was wanted for.
-
-All three disappear the day the engine grows `on_conflict: "replace"`. None is a
-correctness defect in the driver; each is the cost of emulating replacement on an
-engine that does not offer it.
-
-## What building it taught us
-
-Five engine behaviours surfaced only against a running instance, and each one
-produced a driver that passed every offline test and was wrong in production —
-the conformance double and the driver were written from the same documentation,
-so they agreed with each other rather than with the service. The catalogue lives
-in `cortex.rs`'s module docs, beside the code that has to cope with each one,
-which is where it stays current.
-
-The generalisable part belongs here: **a double written from a vendor's
-documentation cannot tell you the vendor's documentation is wrong.** The lane
-that found these runs the same conformance suite against a live engine
-(`tests/live_remote_engines.rs`), and it is worth pointing at every hosted engine
-we bind, not just this one — which is the argument #1968 was opened to settle.
+Two conclusions from it are load-bearing here. **A conformant driver is
+reachable** — appending under a fresh idempotency key and folding to
+newest-per-key on read passes the suite against a live engine. And **an upsert
+alone would not make Cortex cheap**: keyed reads would still scan and writes
+would still wait, because those need a metadata filter and a readiness signal
+that are separate asks.
 
 ## Belief revision is not reachable
 
@@ -435,18 +359,30 @@ Acceptance, against the list this record set before the work started:
   through `provides()`, which is a fixed-body structural check — the lever is a
   probe or a conformance case (#1968, #1973);
 - **key-exact deletion**, verified — and the `deleted.events: 2` alarm above was
-  ours, not the engine's. That request named `selector.event_ids`, which is not a
-  schema field, alongside `confirm_all: true`; an unrecognised selector field
-  deserialises as an *empty* selector, meaning the whole scope, which
-  `confirm_all` then authorises. The real field is `selector.memory_ids`, and
-  deletion with it is exact (`requested: 1, matched: 1, deleted: 1`). Two
-  interlocks refuse the mistake on its own, which is why it was never destructive
-  in practice. The driver names `memory_ids` and never sends `confirm_all`.
+  ours. Being precise about what was blocked and by whom, since only one of these
+  is a guardrail:
 
-One operational note for whoever starts Phase 1: `cortex` is clean as a *driver
-id* in the registry, but `OPENCOMPANY_MEMORY=cortex` remains a hard boot refusal
-as a **mode** value, left over from #1568. The driver is selected with
-`OPENCOMPANY_MEMORY=remote` plus `OPENCOMPANY_MEMORY_DRIVER=cortex`.
+  | Request | Enforced by | Result |
+  |---|---|---|
+  | `event_ids` (not a schema field) **+ `confirm_all: true`** | nothing | **the scope was wiped** — observed, not simulated |
+  | `event_ids` alone | engine | `422 EMPTY_SELECTOR_WITHOUT_CONFIRMATION` |
+  | `memory_ids` + `confirm_all: true` | engine | `400 AMBIGUOUS_SELECTOR_CONFIRM_ALL` |
+  | `memory_ids` alone | — | exact: `requested: 1, matched: 1, deleted: 1` |
+
+  An unrecognised selector field deserialises as an *empty* selector, meaning the
+  whole scope. The engine refuses that on its own, but it cannot refuse it when
+  `confirm_all` is also present, because that combination is a valid wipe request.
+  So the only thing standing between a typo and a destroyed tenant is driver-side:
+  it names `memory_ids` and never sends `confirm_all` anywhere.
+
+Two operational notes for whoever registers it. `cortex` is clean as a *driver
+id*, but `OPENCOMPANY_MEMORY=cortex` remains a hard boot refusal as a **mode**
+value, left over from #1568. And the selection recipe below does **not** work
+today: `SUPPORTED_REMOTE_DRIVERS` holds only `supermemory`, `mem0` and `cognee`,
+and `remote_provider()` rejects every other id, so
+`OPENCOMPANY_MEMORY=remote` plus `OPENCOMPANY_MEMORY_DRIVER=cortex` is a boot
+refusal until registration lands. It is the target configuration, not a usable
+one.
 
 **Phase 2 — provisioning.** Per-tenant instance lifecycle through
 opencompany-manager: create, inject `OPENCOMPANY_MEMORY_*` alongside the existing

--- a/docs/spec/runtime/memory-engine-cortex.md
+++ b/docs/spec/runtime/memory-engine-cortex.md
@@ -25,12 +25,17 @@ question, and the recommendation follows from them.
    **closed-source**, distributed only as prebuilt artifacts (`cortexdbai/cortexdb-releases`,
    Docker Hub `cortexdb/cortexdb`). Whatever we build treats it as an opaque
    upstream binary we cannot patch.
-2. **The self-hosted build cannot issue per-tenant credentials.** Under
-   `CORTEX_DEPLOYMENT_PRESET=cloud_shared_saas` the PASETO minter answers
-   `NOT_CONFIGURED`; its keypair generator is not in the distribution; and the
-   bundled `PRODUCTION_DEPLOYMENT.md` describes `CORTEX_API_KEY` as the
-   bootstrap key for the *default* tenant, with real per-tenant keys coming from
-   Cortex's own hosted key store.
+2. **The server does not issue per-tenant credentials, and the issuer it expects
+   is not obtainable.** Under `CORTEX_DEPLOYMENT_PRESET=cloud_shared_saas` the
+   PASETO minter answers `NOT_CONFIGURED`, its keypair generator is absent, and
+   `PRODUCTION_DEPLOYMENT.md` calls `CORTEX_API_KEY` the bootstrap key for the
+   *default* tenant. By design, not omission: the vendor's [deployment
+   profiles](https://cortexdb.ai/docs/enterprise/deployment-profiles) say every
+   production preset "expect[s] token issuance from an external OIDC provider or
+   the separate `cortex-auth-ref` issuer" — but that issuer is absent from the
+   v0.9.8 assets with no public repository, and no contract is given for the OIDC
+   alternative. Not impossible; unspecified and unobtainable, which for planning
+   is the same place.
 3. **The derived fact and belief tier does not work.** Facts, Beliefs and
    Understanding stay empty with the extraction and enrichment routers enabled
    and reporting healthy; only Events and Episodes hold data. These are Cortex
@@ -40,12 +45,11 @@ question, and the recommendation follows from them.
 4. **Retrieval quality is real, and comes from embeddings alone.** Ranked recall
    over the Events layer is good and needs no LLM lanes at all.
 5. **The contract's upsert has no direct mapping, but a conformant driver is
-   still reachable.** `(namespace, key)` replacement cannot be expressed against
-   an append-only log whose keys are immutable. It can be *reconstructed*: append
-   every write under a fresh idempotency key carrying the logical key in the
-   payload, and fold the log to newest-per-key on read. That driver exists and
-   passes. What it costs is the subject of its own section below — and the cost,
-   not the impossibility, is what should decide this.
+   reachable.** `(namespace, key)` replacement cannot be expressed against an
+   append-only log with immutable keys. It can be *reconstructed*: append every
+   write under a fresh idempotency key carrying the logical key, and fold to
+   newest-per-key on read. That driver exists and passes. Its cost — its own
+   section below — is what should decide this, not impossibility.
 
 ## The isolation choice collapses
 
@@ -57,7 +61,7 @@ removes the middle option:
 |---|---|---|
 | One shared instance, one bootstrap credential | Namespace-only — the **weak** tier | Yes |
 | **One instance per tenant**, own key and own data dir | Credential *and* storage isolation | **Yes** |
-| Shared instance, real per-tenant credentials | Strong | **No** — needs Cortex's hosted key store |
+| Shared instance, real per-tenant credentials | Strong | **Not today** — needs an issuer we cannot obtain (finding 2) |
 
 `memory-engine.md` is unambiguous about why the weak tier is not acceptable as a
 default: with a hosted engine "the namespace string is the only thing separating
@@ -212,22 +216,20 @@ being raised with CortexDB directly instead.
 
 **This was written as blocking Phase 1. It is not.** The driver appends every
 write under a fresh idempotency key — which the engine always accepts — carrying
-the logical key inside the payload, and folds the log down to newest-per-key on
-read. Replacement is reconstructed on the read side rather than performed on the
-write side, and the full conformance suite passes that way against a live
-v0.9.8.
+the logical key inside the payload, and folds to newest-per-key on read.
+Replacement is reconstructed on the read side rather than performed on the write
+side, and the conformance suite passes that way against a live v0.9.8.
 
 The price is paid on every call, and it is the real input to the decision:
 
 - **keyed reads are a scan.** `/v1/events` has no metadata filter, so `get` and
-  `list` fetch the scope and fold it — a walk that grows with everything the
-  namespace has ever held.
+  `list` fetch the scope and fold it — a walk growing with everything the
+  namespace has held.
 - **writes cost seconds, not milliseconds.** `/v1/experience` answers
-  `202 captured` and indexes afterwards, so the driver waits for its own record
-  to become readable: 1–4s to the listing, about a second more to ranked recall.
+  `202 captured` and indexes after, so the driver waits for its own record to be
+  readable: 1–4s to the listing, a second more to ranked recall.
 - **superseded values stay in the ranking corpus.** The fold removes them from
-  keyed reads, not from recall — the one path Cortex was wanted for. A caller can
-  see through `recall` a value `get` would never return.
+  keyed reads, not from recall — the one path Cortex was wanted for.
 
 All three disappear the day the engine grows `on_conflict: "replace"`. None is a
 correctness defect in the driver; each is the cost of emulating replacement on an
@@ -235,30 +237,26 @@ engine that does not offer it.
 
 ## What building it taught us
 
-Five engine behaviours surfaced only against a running instance. Each produced a
-driver that passed every offline test and was wrong in production — the
-conformance double and the driver were written from the same documentation, so
-they agreed with each other rather than with the service. These are properties of
-the engine, not of our adapter; whoever revisits this will meet them again.
+Five engine behaviours surfaced only against a running instance, each producing a
+driver that passed every offline test and was wrong in production — the double
+and the driver were written from the same documentation, so they agreed with each
+other rather than with the service. The three that bear on a decision are below;
+the full list, including the duplicated listing and the silently-ignored query
+parameters, is in `cortex.rs`'s module docs, which is where it stays current.
 
 1. **The two read paths return different bytes for the same event.**
    `/v1/events` returns content as stored; `/v1/recall` renders it with the
    speaker prefixed (`[user] {...}`). A driver storing structured content lists
-   perfectly and **searches to nothing** — every hit fails to parse and is
-   dropped, which looks exactly like an empty index.
-2. **The listing emits every record twice**, and `limit` counts the duplicates,
-   so a page of 200 carries about 100 distinct events.
-3. **Unknown query parameters are ignored, not refused** — a wrong paging
-   parameter re-serves page one instead of erroring.
-4. **No readiness signal exists.** `/v1/experience/status` never advances past
+   perfectly and **searches to nothing** — hits fail to parse and are dropped,
+   which looks exactly like an empty index.
+2. **No readiness signal exists.** `/v1/experience/status` never advances past
    `captured`, and the `lifecycle_stream` URL the write returns connects and
    emits nothing. Read-after-write means polling.
-5. **A namespace segment may contain `:` and a scope id may not.** The contract
+3. **A namespace segment may contain `:` and a scope id may not.** The contract
    addresses a *section* with it (`conversation:thread-8f21`); Cortex's grammar
-   separates `type:id`. Refusing makes whole sections unstorable; collapsing it
+   separates `type:id`. Refusing makes sections unstorable; collapsing it
    re-addresses the namespace out of its section, so `namespaces()` reports a
-   scope nobody enumerating that section can find. The driver encodes it
-   reversibly.
+   scope nobody enumerating it can find. The driver encodes it reversibly.
 
 ## Belief revision is not reachable
 
@@ -346,8 +344,8 @@ host-side, because Cortex does not provide them:
 
 **Deliberately incomplete.** #1936 asked for HA, backup/restore and an upgrade
 path alongside sizing. They are absent by decision, not oversight: they describe
-operating a deployment this record recommends against. They belong with the
-Phase 0 topology decision, if it goes the other way.
+operating a deployment this record recommends against, and belong with the Phase
+0 topology decision if it goes the other way.
 
 Per-instance footprint is the open number. The binary's own config lint projects
 **~18 GiB steady-state RAM** on a 3.9 GiB box, and that estimate did not move
@@ -428,11 +426,10 @@ append-only event log is its own problem rather than a line of glue. What Phase 
 leaves out is Cortex's derived fact and belief tier, which no host port reads and
 which Phase 4 revisits.
 
-Merged as [tinymemory#128](https://github.com/tinyhumansai/tinymemory/pull/128),
-with a live-engine test lane — a double written from the same documentation as
-the driver agrees with the driver, not with the service. It is deliberately not
-registered: `SUPPORTED_REMOTE_DRIVERS` and `remote_provider()` are untouched, so
-nothing here can select it. Registering it is a decision, not a task.
+Merged as [tinymemory#128](https://github.com/tinyhumansai/tinymemory/pull/128)
+with a live-engine test lane, and deliberately not registered:
+`SUPPORTED_REMOTE_DRIVERS` and `remote_provider()` are untouched, so nothing here
+can select it. Registering it is a decision, not a task.
 
 Acceptance, against the list this record set before the work started:
 
@@ -476,6 +473,10 @@ not.
 
 - Does CortexDB agree with our reading of clause 2? Worth confirming in writing
   when we contact them, though the text is not ambiguous.
+- What does a self-hosted deployment use for per-tenant token issuance — is
+  `cortex-auth-ref` published, or is an external OIDC provider expected, against
+  what contract? This is what would unblock the strong isolation tier, though the
+  derived-layer finding is the one that decides adoption.
 - What is the true per-instance memory floor, from Cortex rather than the lint?
 - Will the two filed defects be accepted? The release tracker is scoped to
   binary/packaging issues, with source bugs directed to Cortex Cloud support —

--- a/docs/spec/runtime/memory-engine-cortex.md
+++ b/docs/spec/runtime/memory-engine-cortex.md
@@ -343,9 +343,8 @@ host-side, because Cortex does not provide them:
 ## Infrastructure
 
 **Deliberately incomplete.** #1936 asked for HA, backup/restore and an upgrade
-path alongside sizing. They are absent by decision, not oversight: they describe
-operating a deployment this record recommends against, and belong with the Phase
-0 topology decision if it goes the other way.
+path alongside sizing. They are absent by decision: they describe operating a
+deployment this record recommends against, and belong with the Phase 0 decision.
 
 Per-instance footprint is the open number. The binary's own config lint projects
 **~18 GiB steady-state RAM** on a 3.9 GiB box, and that estimate did not move

--- a/docs/spec/runtime/memory-engine-cortex.md
+++ b/docs/spec/runtime/memory-engine-cortex.md
@@ -358,8 +358,8 @@ Acceptance, against the list this record set before the work started:
   provisioned empty instance probing clean. Note this cannot be expressed
   through `provides()`, which is a fixed-body structural check — the lever is a
   probe or a conformance case (#1968, #1973);
-- **key-exact deletion**, verified — and the `deleted.events: 2` alarm above was
-  ours. Being precise about what was blocked and by whom, since only one of these
+- **key-exact deletion**, verified — and the `deleted.events: 2` alarm (see the
+  [driver notes](memory-engine-cortex-driver.md)) was ours. Being precise about what was blocked and by whom, since only one of these
   is a guardrail:
 
   | Request | Enforced by | Result |

--- a/docs/spec/runtime/memory-engine-cortex.md
+++ b/docs/spec/runtime/memory-engine-cortex.md
@@ -25,17 +25,19 @@ question, and the recommendation follows from them.
    **closed-source**, distributed only as prebuilt artifacts (`cortexdbai/cortexdb-releases`,
    Docker Hub `cortexdb/cortexdb`). Whatever we build treats it as an opaque
    upstream binary we cannot patch.
-2. **The server does not issue per-tenant credentials, and the issuer it expects
-   is not obtainable.** Under `CORTEX_DEPLOYMENT_PRESET=cloud_shared_saas` the
-   PASETO minter answers `NOT_CONFIGURED`, its keypair generator is absent, and
-   `PRODUCTION_DEPLOYMENT.md` calls `CORTEX_API_KEY` the bootstrap key for the
-   *default* tenant. By design, not omission: the vendor's [deployment
-   profiles](https://cortexdb.ai/docs/enterprise/deployment-profiles) say every
-   production preset "expect[s] token issuance from an external OIDC provider or
-   the separate `cortex-auth-ref` issuer" — but that issuer is absent from the
-   v0.9.8 assets with no public repository, and no contract is given for the OIDC
-   alternative. Not impossible; unspecified and unobtainable, which for planning
-   is the same place.
+2. **The one token minter a self-hosted operator can reach does not confine a
+   token to its scope.** `POST /v1/auth/tokens` answers `NOT_CONFIGURED` by
+   default, but `CORTEX_V1_MINTER_ENABLE=1` turns it on and it mints correctly
+   — `subject`, `scope`, TTL, capability narrowing, and working revocation. The
+   scope does not hold. A token minted *for* scope A, pointed at scope B: `POST
+   /v1/recall` is refused `403 POLICY_DENIED`, but `GET /v1/events?scope=B`
+   returns B's records and `POST /v1/experience` into B is accepted. Reproduced
+   three times, including with narrowed `capabilities`. The vendor documents
+   this minter as dev-only (a minted token reports `tenant: dev`) and says
+   production presets expect an external OIDC provider or the separate
+   `cortex-auth-ref` issuer — which is absent from the v0.9.8 assets, has no
+   public repository, and no published contract. So the reachable minter does
+   not isolate, and the isolating one is not reachable.
 3. **The derived fact and belief tier does not work.** Facts, Beliefs and
    Understanding stay empty with the extraction and enrichment routers enabled
    and reporting healthy; only Events and Episodes hold data. These are Cortex
@@ -61,7 +63,7 @@ removes the middle option:
 |---|---|---|
 | One shared instance, one bootstrap credential | Namespace-only — the **weak** tier | Yes |
 | **One instance per tenant**, own key and own data dir | Credential *and* storage isolation | **Yes** |
-| Shared instance, real per-tenant credentials | Strong | **Not today** — needs an issuer we cannot obtain (finding 2) |
+| Shared instance, real per-tenant credentials | Strong | **No** — the reachable minter does not confine a token to its scope (finding 2) |
 
 `memory-engine.md` is unambiguous about why the weak tier is not acceptable as a
 default: with a hosted engine "the namespace string is the only thing separating
@@ -237,26 +239,18 @@ engine that does not offer it.
 
 ## What building it taught us
 
-Five engine behaviours surfaced only against a running instance, each producing a
-driver that passed every offline test and was wrong in production — the double
-and the driver were written from the same documentation, so they agreed with each
-other rather than with the service. The three that bear on a decision are below;
-the full list, including the duplicated listing and the silently-ignored query
-parameters, is in `cortex.rs`'s module docs, which is where it stays current.
+Five engine behaviours surfaced only against a running instance, and each one
+produced a driver that passed every offline test and was wrong in production —
+the conformance double and the driver were written from the same documentation,
+so they agreed with each other rather than with the service. The catalogue lives
+in `cortex.rs`'s module docs, beside the code that has to cope with each one,
+which is where it stays current.
 
-1. **The two read paths return different bytes for the same event.**
-   `/v1/events` returns content as stored; `/v1/recall` renders it with the
-   speaker prefixed (`[user] {...}`). A driver storing structured content lists
-   perfectly and **searches to nothing** — hits fail to parse and are dropped,
-   which looks exactly like an empty index.
-2. **No readiness signal exists.** `/v1/experience/status` never advances past
-   `captured`, and the `lifecycle_stream` URL the write returns connects and
-   emits nothing. Read-after-write means polling.
-3. **A namespace segment may contain `:` and a scope id may not.** The contract
-   addresses a *section* with it (`conversation:thread-8f21`); Cortex's grammar
-   separates `type:id`. Refusing makes sections unstorable; collapsing it
-   re-addresses the namespace out of its section, so `namespaces()` reports a
-   scope nobody enumerating it can find. The driver encodes it reversibly.
+The generalisable part belongs here: **a double written from a vendor's
+documentation cannot tell you the vendor's documentation is wrong.** The lane
+that found these runs the same conformance suite against a live engine
+(`tests/live_remote_engines.rs`), and it is worth pointing at every hosted engine
+we bind, not just this one — which is the argument #1968 was opened to settle.
 
 ## Belief revision is not reachable
 
@@ -472,10 +466,11 @@ not.
 
 - Does CortexDB agree with our reading of clause 2? Worth confirming in writing
   when we contact them, though the text is not ambiguous.
-- What does a self-hosted deployment use for per-tenant token issuance — is
-  `cortex-auth-ref` published, or is an external OIDC provider expected, against
-  what contract? This is what would unblock the strong isolation tier, though the
-  derived-layer finding is the one that decides adoption.
+- Is the v1 minter's `scope` advisory rather than enforcing, or is the gap in
+  finding 2 a defect? And what should a self-hosted multi-tenant deployment use
+  instead — is `cortex-auth-ref` published, or is an external OIDC provider
+  expected, against what contract? This decides whether the strong isolation tier
+  is reachable at all, though the derived-layer finding still decides adoption.
 - What is the true per-instance memory floor, from Cortex rather than the lint?
 - Will the two filed defects be accepted? The release tracker is scoped to
   binary/packaging issues, with source bugs directed to Cortex Cloud support —

--- a/docs/spec/runtime/memory-engine-cortex.md
+++ b/docs/spec/runtime/memory-engine-cortex.md
@@ -7,7 +7,12 @@ let tenants bind to it through the `remote` seam, on equal footing with
 
 Companion to [`memory-engine.md`](memory-engine.md), which specifies the seam this
 would bind through. **That document describes what ships; this one describes a
-proposal and the measurements behind it.** Nothing here is implemented.
+proposal and the measurements behind it.**
+
+Nothing here is wired into OpenCompany. A driver exists —
+[tinymemory#128](https://github.com/tinyhumansai/tinymemory/pull/128), passing the
+contract against a live CortexDB — and is deliberately unregistered. Binding it
+is the decision this record informs, and it has not been taken.
 
 ## Findings first
 
@@ -34,9 +39,13 @@ question, and the recommendation follows from them.
    bind-time failure.
 4. **Retrieval quality is real, and comes from embeddings alone.** Ranked recall
    over the Events layer is good and needs no LLM lanes at all.
-5. **A conformant driver cannot be written against v0.9.8 at all.** The contract's
-   `(namespace, key)` upsert has no expressible mapping onto an append-only event
-   log whose keys are immutable. This blocks Phase 1 outright.
+5. **The contract's upsert has no direct mapping, but a conformant driver is
+   still reachable.** `(namespace, key)` replacement cannot be expressed against
+   an append-only log whose keys are immutable. It can be *reconstructed*: append
+   every write under a fresh idempotency key carrying the logical key in the
+   payload, and fold the log to newest-per-key on read. That driver exists and
+   passes. What it costs is the subject of its own section below — and the cost,
+   not the impossibility, is what should decide this.
 
 ## The isolation choice collapses
 
@@ -144,7 +153,7 @@ claim against a structure. Tracked as
 probe of the mandatory families is proposed in
 [#1973](https://github.com/tinyhumansai/opencompany/pull/1973).
 
-## A conformant driver cannot be written against v0.9.8
+## The upsert gap, and what it costs to work around
 
 This is the finding that decides the phasing, and it is not about capability
 breadth — it is that the two data models disagree.
@@ -200,7 +209,56 @@ The reproduction is recorded at
 [cortexdb-releases#3](https://github.com/cortexdbai/cortexdb-releases/issues/3)
 — closed there, like #1 and #2, because that tracker is scoped to packaging, and
 being raised with CortexDB directly instead.
-**Phase 1 is blocked on their answer, not on our effort.**
+
+**This was written as blocking Phase 1. It is not.** The driver appends every
+write under a fresh idempotency key — which the engine always accepts — carrying
+the logical key inside the payload, and folds the log down to newest-per-key on
+read. Replacement is reconstructed on the read side rather than performed on the
+write side, and the full conformance suite passes that way against a live
+v0.9.8.
+
+The price is paid on every call, and it is the real input to the decision:
+
+- **keyed reads are a scan.** `/v1/events` has no metadata filter, so `get` and
+  `list` fetch the scope and fold it — a walk that grows with everything the
+  namespace has ever held.
+- **writes cost seconds, not milliseconds.** `/v1/experience` answers
+  `202 captured` and indexes afterwards, so the driver waits for its own record
+  to become readable: 1–4s to the listing, about a second more to ranked recall.
+- **superseded values stay in the ranking corpus.** The fold removes them from
+  keyed reads, not from recall — the one path Cortex was wanted for. A caller can
+  see through `recall` a value `get` would never return.
+
+All three disappear the day the engine grows `on_conflict: "replace"`. None is a
+correctness defect in the driver; each is the cost of emulating replacement on an
+engine that does not offer it.
+
+## What building it taught us
+
+Five engine behaviours surfaced only against a running instance. Each produced a
+driver that passed every offline test and was wrong in production — the
+conformance double and the driver were written from the same documentation, so
+they agreed with each other rather than with the service. These are properties of
+the engine, not of our adapter; whoever revisits this will meet them again.
+
+1. **The two read paths return different bytes for the same event.**
+   `/v1/events` returns content as stored; `/v1/recall` renders it with the
+   speaker prefixed (`[user] {...}`). A driver storing structured content lists
+   perfectly and **searches to nothing** — every hit fails to parse and is
+   dropped, which looks exactly like an empty index.
+2. **The listing emits every record twice**, and `limit` counts the duplicates,
+   so a page of 200 carries about 100 distinct events.
+3. **Unknown query parameters are ignored, not refused** — a wrong paging
+   parameter re-serves page one instead of erroring.
+4. **No readiness signal exists.** `/v1/experience/status` never advances past
+   `captured`, and the `lifecycle_stream` URL the write returns connects and
+   emits nothing. Read-after-write means polling.
+5. **A namespace segment may contain `:` and a scope id may not.** The contract
+   addresses a *section* with it (`conversation:thread-8f21`); Cortex's grammar
+   separates `type:id`. Refusing makes whole sections unstorable; collapsing it
+   re-addresses the namespace out of its section, so `namespaces()` reports a
+   scope nobody enumerating that section can find. The driver encodes it
+   reversibly.
 
 ## Belief revision is not reachable
 
@@ -286,6 +344,11 @@ host-side, because Cortex does not provide them:
 
 ## Infrastructure
 
+**Deliberately incomplete.** #1936 asked for HA, backup/restore and an upgrade
+path alongside sizing. They are absent by decision, not oversight: they describe
+operating a deployment this record recommends against. They belong with the
+Phase 0 topology decision, if it goes the other way.
+
 Per-instance footprint is the open number. The binary's own config lint projects
 **~18 GiB steady-state RAM** on a 3.9 GiB box, and that estimate did not move
 under any remediation it suggests — probed across `CORTEX_VECTOR_RESIDENT_MAX`
@@ -348,7 +411,7 @@ and cloud-hosted offerings at sales@cortexdb.ai — neither is required here.
 explicitly and write down why. Licensing is settled (clause 2 permits it); what
 remains is the topology decision, which gates everything below.
 
-**Phase 1 — the driver. Currently blocked upstream.**
+**Phase 1 — the driver. Done, and unbound.**
 A `cortex` driver over `tinymemory-api` implementing the mandatory three —
 `Core`, `Recall` and `Portability`. All three are non-negotiable:
 `MemoryProvider` declares them as supertraits
@@ -361,12 +424,17 @@ whole of what `MemoryStore`, `ContextStore` and `FactStore` need, since all
 three are host ports over the same `Bound` helper and no driver advertises or
 withholds them individually. `Portability` is not optional scope to defer,
 though: it is what Phase 3 runs migration over, and implementing it against an
-append-only event log is its own problem rather than a line of glue. What Phase 1 leaves out is Cortex's derived fact and belief tier,
-which no host port reads and which Phase 4 revisits. This cannot start until
-CortexDB offers a way to replace a value at a key
-([cortexdb-releases#3](https://github.com/cortexdbai/cortexdb-releases/issues/3));
-without it the driver fails a mandatory conformance assertion no amount of
-adapter work can satisfy. Acceptance, once unblocked:
+append-only event log is its own problem rather than a line of glue. What Phase 1
+leaves out is Cortex's derived fact and belief tier, which no host port reads and
+which Phase 4 revisits.
+
+Merged as [tinymemory#128](https://github.com/tinyhumansai/tinymemory/pull/128),
+with a live-engine test lane — a double written from the same documentation as
+the driver agrees with the driver, not with the service. It is deliberately not
+registered: `SUPPORTED_REMOTE_DRIVERS` and `remote_provider()` are untouched, so
+nothing here can select it. Registering it is a decision, not a task.
+
+Acceptance, against the list this record set before the work started:
 
 - the full driver conformance suite (tinymemory#18 §E1);
 - failure-path tests for error mapping and malformed responses, as the existing
@@ -376,11 +444,14 @@ adapter work can satisfy. Acceptance, once unblocked:
   provisioned empty instance probing clean. Note this cannot be expressed
   through `provides()`, which is a fixed-body structural check — the lever is a
   probe or a conformance case (#1968, #1973);
-- **key-exact deletion**, verified. `Bound::forget`, `evict`'s
-  archive-then-delete loop and `delete_label` all require it, and an
-  over-deleting `forget` destroys tenant memory even with upsert working — the
-  observed `deleted.events: 2` for a one-id selector is disqualifying on its own
-  until explained.
+- **key-exact deletion**, verified — and the `deleted.events: 2` alarm above was
+  ours, not the engine's. That request named `selector.event_ids`, which is not a
+  schema field, alongside `confirm_all: true`; an unrecognised selector field
+  deserialises as an *empty* selector, meaning the whole scope, which
+  `confirm_all` then authorises. The real field is `selector.memory_ids`, and
+  deletion with it is exact (`requested: 1, matched: 1, deleted: 1`). Two
+  interlocks refuse the mistake on its own, which is why it was never destructive
+  in practice. The driver names `memory_ids` and never sends `confirm_all`.
 
 One operational note for whoever starts Phase 1: `cortex` is clean as a *driver
 id* in the registry, but `OPENCOMPANY_MEMORY=cortex` remains a hard boot refusal
@@ -410,8 +481,11 @@ not.
   binary/packaging issues, with source bugs directed to Cortex Cloud support —
   so a self-hosted deployment's support path is itself unproven.
 - Is there an undocumented prerequisite for fact extraction that we missed?
-- Will Cortex add an upsert path? Without one, the only route is a stateful
-  driver carrying its own key index — is that acceptable, or disqualifying?
+- Will Cortex add an upsert path? **Answered enough to decide on.** No stateful
+  key index is needed — append-and-fold works and passes. The question is no
+  longer whether a driver is possible but whether its cost is worth paying: a
+  scan per keyed read, seconds per write, and superseded values left in the
+  ranking corpus.
 - Is the embedded engine a fallback? `tinymemory-tinycortex` still exists and
   still passes the full suite, so it is technically viable today with no
   upstream dependency. #1568's PR body records only the mechanical removal and
@@ -419,6 +493,8 @@ not.
 - Self-hosted deployments have no support channel we can reach: the public
   tracker is packaging-only and Cortex Cloud support presumes a customer
   relationship. Worth settling when we contact them about the upsert gap.
-- If Facts and Beliefs stay unreachable, does Cortex still beat `supermemory` /
-  `mem0` / `cognee` on retrieval alone — and is that enough to justify running
-  one instance per tenant?
+- If Facts and Beliefs stay unreachable, does Cortex beat `supermemory` / `mem0`
+  / `cognee` on retrieval alone? **No.** Its ranked recall is vector search over
+  the event log — confirmed on a fresh scope queried before any derived layer had
+  built — which is what all three incumbents already provide through this seam,
+  without a scan per read or a multi-second write.

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -30,7 +30,9 @@ Whether Cortex could return as a *hosted* engine under `remote` — the opposite
 question from #1568 — is investigated in
 [`memory-engine-cortex.md`](memory-engine-cortex.md), which records what a
 deployed CortexDB instance actually provides. Nothing there is implemented; it
-is a design record with open decisions.
+is a design record with open decisions. A companion,
+[`memory-engine-cortex-driver.md`](memory-engine-cortex-driver.md), records what a
+driver against v0.9.8 has to do and what each call costs.
 
 ## Choosing a hosted engine (`remote`)
 


### PR DESCRIPTION
## Summary

`docs/spec/runtime/memory-engine-cortex.md` says a conformant driver **cannot** be
written against CortexDB v0.9.8, and that Phase 1 is blocked upstream. Both were
true when it was written and are wrong now — wrong in the direction that costs
somebody a week, because a reader would conclude the work cannot start when it is
finished and merged as tinyhumansai/tinymemory#128.

The upsert gap is real; it is not a wall. Appending every write under a fresh
idempotency key carrying the logical key in the payload, then folding the log to
newest-per-key on read, reconstructs replacement on the read side and passes the
full conformance suite against a live engine. This PR replaces the impossibility
claim with what the workaround actually costs — a scan per keyed read, seconds
per write, and superseded values left in the ranking corpus — because the cost is
what should decide this, and it points at the same recommendation from firmer
ground.

Documentation only. No code, no behaviour, no new architecture — mostly
corrections and deletions.

## Related issue

#1936. Does not close it: the remaining deliverable is a topology decision, not a
document.

## API or behavior changes

None.

## What changed

- **Finding 5 and its section.** "A conformant driver cannot be written" → the
  gap and its price. The measured table of failed direct mappings stays; it is
  still why the workaround is necessary.
- **Phase 1: blocked → done, and unbound.** With the point that matters for
  review: `SUPPORTED_REMOTE_DRIVERS` and `remote_provider()` are untouched, so
  nothing here can select the driver. Registering it is a decision, not a task.
- **The `deleted.events: 2` alarm was ours.** This record called it
  "disqualifying on its own until explained". The explanation is that the request
  named `selector.event_ids`, which is not a schema field, alongside
  `confirm_all: true` — an unrecognised selector field deserialises as an *empty*
  selector, meaning the whole scope, which `confirm_all` then authorises. With
  `selector.memory_ids` deletion is exact, and two engine interlocks refuse that
  mistake on its own. I would rather this correction be in the record than have
  someone inherit a phantom defect.
- **Two open questions answered** instead of left hanging. Ranked recall is
  vector search over the event log — confirmed on a fresh scope queried before
  any derived layer had built — so on retrieval alone Cortex does not beat the
  drivers we already ship.
- **New: the five engine behaviours that only surfaced against a running
  instance.** Each produced a driver that passed every offline test and was wrong
  in production, because the conformance double and the driver were both written
  from the same documentation and agreed with each other rather than with the
  service. They are properties of the engine, so whoever revisits this meets them
  again.
- **Infrastructure stays incomplete and now says so.** #1936 asked for HA,
  backup/restore and an upgrade path. They describe operating a deployment this
  record recommends against, so they wait on the Phase 0 topology decision. An
  explicit gap beats a plan written to fill a checkbox.

## Validation

- [x] `bash scripts/ci/assert-md-line-cap.sh` — passes (the file lands at 500,
      which is why several passages are tighter than a first draft; the cap is
      the one I added in #1975, so it would have been poor form to trip it)
- [x] Every stale claim confirmed gone by grep: "Nothing here is implemented",
      "cannot be written against v0.9.8", "Currently blocked upstream", "blocked
      on their answer", "This blocks Phase 1 outright", "disqualifying on its
      own"
- [x] `memory-engine.md`'s link to this file still resolves

No Rust touched, so the Rust lanes are unaffected.

## Tests

None — documentation. The claims it now makes are the ones tinymemory#128's test
suite and live lane already assert; this PR stops the spec contradicting them.

## Documentation

This *is* the documentation change.

## Checklist

- [x] The change is focused on one logical change
- [x] No new `#[allow(...)]`, `#[ignore]`, or relaxed lints
- [x] No secrets, tokens, or `.env` contents in the diff or the description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated runtime memory documentation with the Cortex driver’s live conformance status and unregistered state.
  - Clarified that the reachable token minter does not enforce scope isolation.
  - Added driver guidance covering append-and-fold reconstruction, scan-based reads, delayed write visibility, and stale recalled values.
  - Documented exact deletion behavior and resolved the prior deletion alarm.
  - Marked Phase 1 complete and refreshed infrastructure details, acceptance criteria, and open questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->