### PR TITLE
fix(inference): discover a provider's model vocabulary instead of assuming OpenRouter's

### DIFF
--- a/docs/spec/runtime/providers.md
+++ b/docs/spec/runtime/providers.md
@@ -131,19 +131,40 @@ Agents address workloads by abstract **tier** — `chat-v1`, `reasoning-v1`,
 a workload, never a model, which is what lets an agent keep its tier while
 moving between harnesses.
 
-What goes on the wire differs by path, and sending the wrong one fails
-(`inference::model_for_tier`):
+What goes on the wire differs by **what the endpoint publishes**, and sending
+the wrong one fails (`inference::model_for_tier`, `inference::TierVocabulary`):
 
-| path | wire value | why |
+| vocabulary | wire value | why |
 |---|---|---|
-| proxied | the tier name (`chat-v1`) | the platform's registry routes on it, pinning each tier to a sub-provider so its rate card stays exact |
-| direct | a concrete slug (`anthropic/claude-sonnet-5`) | OpenRouter has never heard of `chat-v1` |
+| `tiers` | the tier name (`chat-v1`) | the endpoint publishes the tier ids and resolves them itself, pinning each tier to a sub-provider so its rate card stays exact |
+| `concrete` | a concrete slug (`anthropic/claude-sonnet-5`) | the endpoint publishes OpenRouter's catalog and has never heard of `chat-v1` |
+| `unknown` | the tier name, unchanged | the catalog was read and publishes neither, so `DEFAULT_TIER_MODELS` are ids we already know are absent. Both answers fail; only one names a string the operator configured |
 
-On the direct path an unmapped tier takes `DEFAULT_TIER_MODELS`, which mirrors
-the platform's own OpenRouter bindings — so both paths reach the same models and
-adding a key does not silently move a company onto different ones.
+The vocabulary is **discovered, not assumed**. Every OpenAI-compatible endpoint
+publishes `GET {base_url}/models`, so a catalog containing `agentic-v1` is the
+endpoint telling us it resolves tiers. Nothing keys off a hostname.
 
-A harness's own `models` entry is honoured **verbatim on both paths**: the
+It used to be read off `is_proxied()` — true only for the `openrouter` kind with
+no tenant key. That conflated **who pays** with **what vocabulary is spoken**,
+and the two come apart the moment a tenant points its own key at a tier-native
+endpoint: every tier was rewritten to an OpenRouter slug and the provider
+answered `Model 'anthropic/claude-sonnet-5' is not available`, naming an id
+neither the operator nor the provider had ever mentioned. `is_proxied()` still
+decides billing and the product header; it no longer decides the model id.
+
+`is_proxied()` remains the **pre-discovery fallback** inside
+`InferenceDecl::vocabulary()`, used when the catalog cannot be read at all — so
+an unreachable provider behaves exactly as it did before rather than changing
+how turns resolve on a network blip. `InferenceDecl::vocabulary_confirmed()`
+tells the two apart.
+
+`DEFAULT_TIER_MODELS` is the `concrete` mapping and **only** that: four
+OpenRouter catalog ids, mirroring the platform's own OpenRouter bindings so a
+proxied tier and a direct substitution reach the same models. It is not a
+universal default and applying it to an endpoint whose vocabulary has not been
+established is the defect above.
+
+A harness's own `models` entry is honoured **verbatim in every vocabulary**: the
 operator named a specific model, and rewriting it is not ours to do.
 
 ### Naming a specific model on the proxied path
@@ -162,27 +183,56 @@ wants a specific model through the proxy writes the `openrouter/…` form into
 
 ## Model catalog
 
-`GET {scope}/inference/models` lists OpenRouter's public model registry for
-the console's picker — the operator-facing complement to `DEFAULT_TIER_MODELS`
-above, used when an operator wants to pick a *specific* model rather than
-accept a tier default.
+`GET {scope}/inference/models` lists the catalog of **the endpoint this company
+is configured against**, resolved exactly as `baseUrl` on the status route is
+(so a `managed`/keyless company reads the platform endpoint it inherits). The
+company's stored key is presented as the bearer: it is write-only to the console
+(`keyConfigured` is all the console ever sees), so this route is the only thing
+that can ask an authenticated endpoint what it serves.
 
-The route is authenticated like the rest of `{scope}/inference/*` but does not
-read the calling company's own config: the registry is a public, per-process
-resource shared by every tenant on the host, not something scoped per company.
+It used to answer with OpenRouter's public registry unconditionally, ignoring
+the calling company entirely — the console listed 421 models to a company whose
+provider published eleven, the operator picked one the console had offered, and
+the provider rejected it. It also hid the one signal that answers which
+vocabulary the endpoint speaks.
+
+The response carries the vocabulary alongside the catalog, so the picker and the
+tier prefill can never disagree about the same provider:
+
+| field | meaning |
+|---|---|
+| `baseUrl` | the endpoint the catalog came from — the console names it rather than implying a vendor |
+| `models` | every id the endpoint publishes, sorted |
+| `tierVocabulary` | `tiers` / `concrete` / `unknown`, or **absent** when the catalog could not be read — which is not the same as `unknown` and must not be shown as one |
+| `tierDefaults` | the tier → model mapping this endpoint's vocabulary implies. Empty for `unknown` and for an unreadable catalog: there is no mapping we can honestly supply |
+| `error` | why the catalog is empty, naming the endpoint |
+
+A fetch failure (timeout, non-2xx, an empty catalog) is a **200 carrying
+`error`**, not a 5xx. An empty picker with no explanation reads as "this
+provider has no models", which is a claim nobody established; "could not list
+models from `<endpoint>`" is true and leaves the operator able to type an id by
+hand.
+
+The cache is a registry keyed on the normalized base URL — one entry per
+endpoint, each with its own single-flight lock, so two tenants on two providers
+neither share a catalog nor queue behind each other. It is **not** keyed on the
+credential: a catalog is a public property of an endpoint, and hashing a
+credential to key a cache would put a derivative of it in process memory for a
+partition nothing needs.
 
 | property | value |
 |---|---|
 | cache lifetime | 1 hour (`MODEL_CATALOG_TTL`) |
+| failure lifetime | 1 minute (`MODEL_CATALOG_FAILURE_TTL`) — a failure used to store nothing, so an unreachable provider cost a fresh timeout on every status read and every turn that consulted the vocabulary |
 | fetch timeout | 10 seconds (`MODEL_CATALOG_TIMEOUT`) — a console page-load waits at most this long on a cold cache, whatever its position in a `fetch_lock` queue |
-| concurrent misses | coalesced onto a single upstream fetch (`ModelCatalogCache::fetch_lock`) — after startup or a TTL expiry, several console requests arriving together do not each fire their own OpenRouter call. The lock wait and the fetch share one timeout budget per caller, so a caller queued behind others during an outage is not left waiting `N × MODEL_CATALOG_TIMEOUT` for its turn to fail too |
-| malformed entries | skipped individually rather than failing the whole response, so one bad record does not hide every valid model the registry returned |
+| concurrent misses | coalesced onto a single upstream fetch (`ModelCatalogCache::fetch_lock`), per endpoint. The lock wait and the fetch share one timeout budget per caller, so a caller queued behind others during an outage is not left waiting `N × MODEL_CATALOG_TIMEOUT` for its turn to fail too |
+| malformed entries | skipped individually rather than failing the whole response, so one bad record does not hide every valid model the endpoint returned |
 | response ordering | sorted by model id, distinct from the provider order `discover_models` preserves for the local/custom setup probe |
 
-A registry fetch failure (timeout, non-2xx, an empty catalog) surfaces as an
-error on this route rather than silently returning stale or empty data — the
-picker shows a failure state instead of an incomplete list that looks
-complete.
+The turn path (`TenantProvider::resolve`) and the console probe
+(`POST {scope}/inference/test`) read the same cache, so consulting the
+vocabulary costs one request per endpoint per hour rather than one per turn —
+and it is a request to the host the turn is about to call anyway.
 
 ---
 

--- a/docs/spec/runtime/providers.md
+++ b/docs/spec/runtime/providers.md
@@ -137,12 +137,24 @@ the wrong one fails (`inference::model_for_tier`, `inference::TierVocabulary`):
 | vocabulary | wire value | why |
 |---|---|---|
 | `tiers` | the tier name (`chat-v1`) | the endpoint publishes the tier ids and resolves them itself, pinning each tier to a sub-provider so its rate card stays exact |
-| `concrete` | a concrete slug (`anthropic/claude-sonnet-5`) | the endpoint publishes OpenRouter's catalog and has never heard of `chat-v1` |
+| `concrete` | a concrete slug (`anthropic/claude-sonnet-5`) — **per tier, and only where the catalog publishes that slug** | the endpoint publishes OpenRouter's catalog and has never heard of `chat-v1` |
 | `unknown` | the tier name, unchanged | the catalog was read and publishes neither, so `DEFAULT_TIER_MODELS` are ids we already know are absent. Both answers fail; only one names a string the operator configured |
 
 The vocabulary is **discovered, not assumed**. Every OpenAI-compatible endpoint
 publishes `GET {base_url}/models`, so a catalog containing `agentic-v1` is the
 endpoint telling us it resolves tiers. Nothing keys off a hostname.
+
+**Classification is `any`; substitution is per tier.** One shipped id present is
+enough to call an endpoint `concrete` — it speaks OpenRouter's vocabulary — but
+`TierVocabulary::Concrete` carries a `ConcreteTiers` mask of *which* shipped ids
+that catalog actually listed, and `model_for_tier` substitutes only those. A
+gateway mirroring `anthropic/claude-sonnet-5` and nothing else was once handed
+`openai/gpt-5.6-sol-pro` for `reasoning-v1` — an id that same catalog had just
+said it does not serve, which is this page's whole argument one level down. Its
+unpublished tiers go out as tiers instead. The un-discovered fallback assumes
+all four (`ConcreteTiers::all()`), which is what shipped before and is true of
+OpenRouter itself; narrowing only ever happens on evidence from a catalog that
+was read.
 
 It used to be read off `is_proxied()` — true only for the `openrouter` kind with
 no tenant key. That conflated **who pays** with **what vocabulary is spoken**,
@@ -224,6 +236,7 @@ partition nothing needs.
 |---|---|
 | cache lifetime | 1 hour (`MODEL_CATALOG_TTL`) |
 | failure lifetime | 1 minute (`MODEL_CATALOG_FAILURE_TTL`) — a failure used to store nothing, so an unreachable provider cost a fresh timeout on every status read and every turn that consulted the vocabulary |
+| credential failures | **never remembered.** A `401`/`403` is an answer about the key that was presented, not about the endpoint the memo is keyed on: remembering one company's rejection would hand it to the next company reaching the same endpoint with a different key, and would make a company that has just rotated a bad key wait the memo out before its good one is tried. Not memoizing them is cheap in the way that matters — an auth rejection is a fast round trip, not the timeout the memo exists to stop paying repeatedly |
 | fetch timeout | 10 seconds (`MODEL_CATALOG_TIMEOUT`) — a console page-load waits at most this long on a cold cache, whatever its position in a `fetch_lock` queue |
 | concurrent misses | coalesced onto a single upstream fetch (`ModelCatalogCache::fetch_lock`), per endpoint. The lock wait and the fetch share one timeout budget per caller, so a caller queued behind others during an outage is not left waiting `N × MODEL_CATALOG_TIMEOUT` for its turn to fail too |
 | malformed entries | skipped individually rather than failing the whole response, so one bad record does not hide every valid model the endpoint returned |

--- a/docs/spec/runtime/providers.md
+++ b/docs/spec/runtime/providers.md
@@ -227,10 +227,22 @@ hand.
 
 The cache is a registry keyed on the normalized base URL — one entry per
 endpoint, each with its own single-flight lock, so two tenants on two providers
-neither share a catalog nor queue behind each other. It is **not** keyed on the
-credential: a catalog is a public property of an endpoint, and hashing a
-credential to key a cache would put a derivative of it in process memory for a
-partition nothing needs.
+neither share a catalog nor queue behind each other. It is **never** keyed on the
+credential: hashing one to key a cache would put a derivative of it in process
+memory next to the data it guards.
+
+It **is** keyed on the reading company whenever a credential was presented. A
+keyless read is a public property of the endpoint and stays shared by everyone;
+an authenticated one is not, because an endpoint may publish an
+entitlement-scoped catalog, and a base-URL-only key would then hand one
+company's model list to the next company on that endpoint for the rest of the
+hour. That can only happen inside a single process serving several companies — a
+local multi-company host, or hosted shared-single-DB mode; database-per-tenant
+gives each tenant its own container and so its own registry — but it is a real
+cross-company disclosure in a supported mode. The scope is the company id:
+non-secret, already the unit of isolation everywhere else, and it changes when
+the answer should. The cost is one fetch per company per endpoint per hour
+instead of one per endpoint.
 
 | property | value |
 |---|---|

--- a/frontend/src/api/inference.ts
+++ b/frontend/src/api/inference.ts
@@ -183,8 +183,18 @@ export interface InferenceModelCatalog {
   baseUrl: string;
   /** Every model that endpoint publishes, sorted. Empty when `error` is set. */
   models: InferenceModel[];
-  /** How this endpoint spells a tier; absent when the catalog is unreadable. */
-  tierVocabulary?: TierVocabulary;
+  /**
+   * How this endpoint spells a tier.
+   *
+   * `null` when the catalog could not be read — which is a different fact from
+   * `"unknown"` ("the endpoint answered, and publishes neither vocabulary") and
+   * must not be shown as one. The host sends the field either way:
+   * `ModelCatalogDto::tier_vocabulary` is an `Option` with no
+   * `skip_serializing_if`, so the wire carries an explicit `null` rather than
+   * omitting the key (CodeRabbit review on #2045). Optional as well as nullable
+   * because a stub or an older host may omit it; both mean "no vocabulary".
+   */
+  tierVocabulary?: TierVocabulary | null;
   /**
    * The tier → model mapping this endpoint's vocabulary implies. Empty for
    * `unknown` and for an unreadable catalog: prefilling ids the endpoint has

--- a/frontend/src/api/inference.ts
+++ b/frontend/src/api/inference.ts
@@ -46,12 +46,17 @@ export interface InferenceStatus {
   /** Abstract-tier → concrete model id. */
   models: Record<string, string>;
   /**
-   * The shipped tier → model defaults, independent of `provider`/`models`
-   * above. The console's OpenRouter preset used to hard-code its own copy of
-   * these ids so the form had something to prefill before an operator typed
-   * an override; that duplicate could silently drift from what the host
+   * The shipped tier → model defaults — **OpenRouter's vocabulary**, and
+   * nothing wider. The console's OpenRouter preset used to hard-code its own
+   * copy of these ids so the form had something to prefill before an operator
+   * typed an override; that duplicate could silently drift from what the host
    * actually defaults to. This is read off the host on every status load, so
    * the preset is never more than one request stale.
+   *
+   * It is only that preset. These are OpenRouter catalog ids and mean nothing
+   * at another endpoint; what the *configured* endpoint wants is
+   * `InferenceModelCatalog.tierDefaults`, derived from that endpoint's own
+   * published catalog.
    */
   defaultTierModels: Record<string, string>;
   /** Provenance badge. */
@@ -141,11 +146,57 @@ export interface InferenceMutation {
   note: string;
 }
 
-/** One model published by the OpenRouter registry. */
+/** One model published by the configured provider's catalog. */
 export interface InferenceModel {
   id: string;
   name?: string;
   contextLength?: number;
+}
+
+/**
+ * How the configured endpoint spells a tier.
+ *
+ * - `tiers` — it publishes the tier names themselves (`chat-v1`, `agentic-v1`)
+ *   and resolves them against its own registry, so a tier is what it wants.
+ * - `concrete` — it publishes the ids `defaultTierModels` names, so a bare tier
+ *   would be rejected and the shipped mapping is the right default.
+ * - `unknown` — its catalog publishes neither, so there is no default anyone can
+ *   supply and the operator has to name a model per tier.
+ *
+ * Absent (`undefined`) means the catalog could not be read at all, which is a
+ * different thing from `unknown` and must not be shown as one.
+ */
+export type TierVocabulary = "tiers" | "concrete" | "unknown";
+
+/**
+ * The catalog of the endpoint **this company is configured against**.
+ *
+ * This route used to answer with a bare array that was always OpenRouter's
+ * public registry, whatever endpoint the company had been pointed at: the
+ * console listed 421 models to a company whose provider published eleven, the
+ * operator picked one the console had offered, and the provider rejected it.
+ * Discovery follows the configured base URL now, and the response says which
+ * endpoint answered so the console can name it rather than imply a vendor.
+ */
+export interface InferenceModelCatalog {
+  /** The endpoint the catalog was read from. */
+  baseUrl: string;
+  /** Every model that endpoint publishes, sorted. Empty when `error` is set. */
+  models: InferenceModel[];
+  /** How this endpoint spells a tier; absent when the catalog is unreadable. */
+  tierVocabulary?: TierVocabulary;
+  /**
+   * The tier → model mapping this endpoint's vocabulary implies. Empty for
+   * `unknown` and for an unreadable catalog: prefilling ids the endpoint has
+   * already told us it does not publish is the defect this field replaces.
+   */
+  tierDefaults: Record<string, string>;
+  /**
+   * Why the catalog is empty, naming the endpoint — a 200 rather than a 5xx,
+   * because an empty picker with no explanation reads as "this provider has no
+   * models", which nobody established.
+   */
+  error?: string;
 }
 
 /** The live-probe result. */
@@ -165,12 +216,12 @@ export function getInferenceStatus(
   return client.get<InferenceStatus>(`${client.scopeFor(company)}/inference`);
 }
 
-/** The cached OpenRouter model catalog exposed by the company host. */
+/** The model catalog of the endpoint this company is configured against. */
 export function listInferenceModels(
   client: OpenCompanyClient,
   company: string | null,
-): Promise<InferenceModel[]> {
-  return client.get<InferenceModel[]>(`${client.scopeFor(company)}/inference/models`);
+): Promise<InferenceModelCatalog> {
+  return client.get<InferenceModelCatalog>(`${client.scopeFor(company)}/inference/models`);
 }
 
 /** Set (or replace) the runtime provider override, optionally rotating the key. */

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -199,16 +199,27 @@ const METERING_NOTES: Record<UsageMetering, string> = {
 function presetFor(
   provider: InferenceProvider,
   defaultTierModels?: Partial<Record<Tier, string>>,
+  catalogTierDefaults?: Partial<Record<Tier, string>>,
 ): {
   baseUrl: string;
   models: Partial<Record<Tier, string>>;
 } {
   const preset = PROVIDERS[provider].preset;
-  // The host's own `defaultTierModels` (from `GET …/inference`) is the source
-  // of truth once it has loaded; `PROVIDERS.openrouter.preset.models` is only
-  // the fallback used before that first status read resolves, so switching to
-  // OpenRouter still has something to prefill with immediately.
-  if (provider === "openrouter" && defaultTierModels && Object.keys(defaultTierModels).length > 0) {
+  if (provider !== "openrouter") return preset;
+  // The *endpoint's own* defaults win when a catalog has actually been read.
+  // `status.defaultTierModels` is OpenRouter's vocabulary and nothing wider, so
+  // prefilling from it against an endpoint that publishes `chat-v1` writes four
+  // ids that endpoint has already told us it does not serve — an explicit,
+  // saved, silently unusable mapping, which is worse than the unmapped case the
+  // host now resolves correctly on its own.
+  if (catalogTierDefaults && Object.keys(catalogTierDefaults).length > 0) {
+    return { ...preset, models: catalogTierDefaults };
+  }
+  // No catalog yet: the host's own `defaultTierModels` (from `GET …/inference`)
+  // beats `PROVIDERS.openrouter.preset.models`, which is only the fallback used
+  // before that first status read resolves, so switching to OpenRouter still
+  // has something to prefill with immediately.
+  if (defaultTierModels && Object.keys(defaultTierModels).length > 0) {
     return { ...preset, models: defaultTierModels };
   }
   return preset;
@@ -221,14 +232,26 @@ type TestState =
   | { kind: "ok"; note: string }
   | { kind: "error"; message: string };
 
+/**
+ * `baseUrl` and `message` travel with the state because the catalog is now the
+ * *configured endpoint's*, not a vendor registry: "could not be loaded" has to
+ * name which endpoint could not be loaded, or the operator has no idea what to
+ * go and look at.
+ */
 type ModelCatalogState =
   | { kind: "idle" }
   | { kind: "loading" }
-  | { kind: "ready"; models: InferenceModel[] }
-  | { kind: "empty" }
-  | { kind: "error" };
+  | {
+      kind: "ready";
+      models: InferenceModel[];
+      baseUrl: string;
+      /** The tier → model mapping this endpoint's own vocabulary implies. */
+      tierDefaults: Record<string, string>;
+    }
+  | { kind: "empty"; baseUrl: string }
+  | { kind: "error"; message: string };
 
-/** Keep a stored custom id selectable even after the registry no longer lists it. */
+/** Keep a stored custom id selectable even after the catalog no longer lists it. */
 function optionsForTier(catalog: InferenceModel[], current: string): InferenceModel[] {
   if (!current || catalog.some((model) => model.id === current)) return catalog;
   return [{ id: current, name: "Current custom model" }, ...catalog];
@@ -396,6 +419,16 @@ export function InferenceSection({
   >(null);
   const [test, setTest] = useState<TestState>({ kind: "idle" });
   const [modelCatalog, setModelCatalog] = useState<ModelCatalogState>({ kind: "idle" });
+  /**
+   * The last tier → model mapping a *read* catalog implied, kept apart from
+   * `modelCatalog` on purpose: switching the provider select away from
+   * OpenRouter resets that state to `idle`, and `pickProvider` runs before the
+   * effect has had a chance to re-read anything — so a form that reads the
+   * defaults straight off `modelCatalog` would fall back to OpenRouter's ids on
+   * exactly the switch-away-and-back path an operator takes while comparing
+   * providers.
+   */
+  const [catalogTierDefaults, setCatalogTierDefaults] = useState<Record<string, string>>({});
 
   // Switch form.
   const [provider, setProvider] = useState<InferenceProvider>("managed");
@@ -504,10 +537,32 @@ export function InferenceSection({
     void listInferenceModels(client, company)
       .then((catalog) => {
         if (!current) return;
-        setModelCatalog(catalog.length ? { kind: "ready", models: catalog } : { kind: "empty" });
+        // The host reports an unreadable catalog as a 200 carrying `error`, so
+        // the console can say what went wrong instead of rendering an empty
+        // picker that reads as "this provider has no models".
+        if (catalog.error) {
+          setModelCatalog({ kind: "error", message: catalog.error });
+          return;
+        }
+        setCatalogTierDefaults(catalog.tierDefaults ?? {});
+        setModelCatalog(
+          catalog.models.length
+            ? {
+                kind: "ready",
+                models: catalog.models,
+                baseUrl: catalog.baseUrl,
+                tierDefaults: catalog.tierDefaults ?? {},
+              }
+            : { kind: "empty", baseUrl: catalog.baseUrl },
+        );
       })
       .catch(() => {
-        if (current) setModelCatalog({ kind: "error" });
+        if (current) {
+          setModelCatalog({
+            kind: "error",
+            message: "The provider's model list could not be loaded. Enter model ids directly.",
+          });
+        }
       });
 
     return () => {
@@ -628,7 +683,7 @@ export function InferenceSection({
 
   function pickProvider(next: InferenceProvider) {
     setProvider(next);
-    const preset = presetFor(next, status?.defaultTierModels);
+    const preset = presetFor(next, status?.defaultTierModels, catalogTierDefaults);
     setBaseUrl(preset.baseUrl);
     setModels(preset.models);
     setBaseline({ baseUrl: preset.baseUrl, models: preset.models });
@@ -1118,7 +1173,7 @@ export function InferenceSection({
                         className="text-xs text-muted-foreground"
                         data-testid="inference-model-catalog-fallback"
                       >
-                        OpenRouter&apos;s model list could not be loaded. Enter model ids directly.
+                        {modelCatalog.message}
                       </p>
                     )}
                     {provider === "openrouter" && modelCatalog.kind === "empty" && (
@@ -1126,7 +1181,23 @@ export function InferenceSection({
                         className="text-xs text-muted-foreground"
                         data-testid="inference-model-catalog-empty"
                       >
-                        OpenRouter returned no models. Enter model ids directly.
+                        {modelCatalog.baseUrl} returned no models. Enter model ids directly.
+                      </p>
+                    )}
+                    {/*
+                      Which endpoint these options came from. The list is the
+                      *configured* provider's catalog, not a vendor registry —
+                      and the form's provider select can be pointed somewhere
+                      else than the saved config while an operator is mid-edit,
+                      so naming the endpoint is the difference between a list
+                      the operator can trust and one they have to guess at.
+                    */}
+                    {provider === "openrouter" && modelCatalog.kind === "ready" && (
+                      <p
+                        className="text-xs text-muted-foreground"
+                        data-testid="inference-model-catalog-source"
+                      >
+                        Models listed by {modelCatalog.baseUrl}.
                       </p>
                     )}
                     {/*
@@ -1210,7 +1281,7 @@ export function InferenceSection({
                                       })
                                     }
                                   >
-                                    Choose from the OpenRouter catalog instead
+                                    Choose from the provider&apos;s catalog instead
                                   </button>
                                 )}
                               </div>
@@ -1240,7 +1311,7 @@ export function InferenceSection({
                                   <SelectValue
                                     placeholder={
                                       modelCatalog.kind === "loading"
-                                        ? "Loading OpenRouter models…"
+                                        ? "Loading models…"
                                         : "Choose a model"
                                     }
                                   />

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -559,6 +559,43 @@ export function InferenceSection({
   const storedProviderIsOpenRouter =
     status?.provider === "openrouter" || status?.provider === "managed";
 
+  /**
+   * Whether the **saved** config rides the platform's subscription proxy.
+   *
+   * The same test `wouldSaveProxied` below applies to the draft, minus the key
+   * the operator is currently typing — which is exactly the difference the
+   * catalog effect has to notice. Hoisted here because that effect runs before
+   * `wouldSaveProxied` is computed.
+   */
+  const savedIsProxied = !(status?.provider === "openrouter" && status.keyConfigured);
+
+  /**
+   * Whether typing a key has pointed the draft at a *different endpoint* than
+   * the one the catalog was read from.
+   *
+   * A company on the platform proxy — `managed`, or `openrouter` with no key —
+   * resolves to the platform's own tier-native endpoint, whose catalog
+   * publishes `chat-v1` and friends. The moment an OpenRouter key is typed,
+   * Save would send the config straight to `api.openrouter.ai` instead, and
+   * that endpoint has never heard of `chat-v1` (Codex review on #2045). The
+   * catalog effect does not otherwise depend on the key, so the picker went on
+   * offering the proxy's tier names under a draft that no longer reaches the
+   * proxy; selecting one persisted it as a verbatim override that direct
+   * OpenRouter rejects.
+   *
+   * This is the same class of mistake as the `storedProviderIsOpenRouter`
+   * guard below and gets the same answer: the route can only be asked about the
+   * saved config, so a draft that has moved off it must be told the catalog no
+   * longer applies rather than shown one that does not describe where it is
+   * going.
+   *
+   * On its own this is only half the test — it says the *endpoint* moved, not
+   * that the catalog is unusable there. It is combined with the catalog's own
+   * `tierVocabulary` at the point of use below, because only a tier-native
+   * catalog publishes ids that are categorically wrong at direct OpenRouter.
+   */
+  const draftLeavesSavedEndpoint = savedIsProxied && key.trim().length > 0;
+
   useEffect(() => {
     let current = true;
     if (provider !== "openrouter") {
@@ -607,6 +644,51 @@ export function InferenceSection({
         // picker that reads as "this provider has no models".
         if (catalog.error) {
           setModelCatalog({ kind: "error", message: catalog.error });
+          // A previous successful read's mapping must not survive a failure:
+          // leaving it in state let a later `pickProvider` seed the form from
+          // ids this endpoint never confirmed, and Save persisted them
+          // (CodeRabbit review on #2045).
+          //
+          // Cleared to `null` — "no catalog has been read" — and deliberately
+          // not to the `{}` the failing response literally carries. The two are
+          // different facts here for the same reason `tierVocabulary` is `null`
+          // rather than `"unknown"` when the catalog cannot be read: `{}` is a
+          // *confirmed* empty mapping, which `presetFor` honours by prefilling
+          // nothing at all, whereas an endpoint that did not answer has
+          // confirmed nothing. Collapsing the two discards the host's own
+          // `status.defaultTierModels` fallback on any blip, which is what the
+          // `seeds the switch form from status.defaultTierModels` regression in
+          // `inference-model-picker.test.ts` catches.
+          setCatalogTierDefaults(null);
+          return;
+        }
+        // The catalog describes the **saved** endpoint. When a key has been
+        // typed against a company still saved on the platform proxy, Save would
+        // go direct to OpenRouter instead — and a *tier-native* catalog's ids
+        // are precisely the ones that endpoint cannot resolve, because
+        // resolving a tier server-side is what `tiers` means. Offering them
+        // here let an operator pick `chat-v1` and persist it as a verbatim
+        // override direct OpenRouter rejects (Codex review on #2045).
+        //
+        // Narrowed to `tiers` deliberately. A `concrete` or `unknown` catalog
+        // publishes ordinary `<author>/<model>` ids, which are not categorically
+        // invalid at another endpoint and which the operator may well be
+        // choosing on purpose — and withdrawing the picker for those would break
+        // the deliberate flow where typing a key is what makes the catalog
+        // select safe to offer at all (`useFreeText` below, and the two
+        // `inference.spec.ts` cases that encode it). The tier-native case is the
+        // one where the ids are known-wrong for where the draft is going.
+        if (draftLeavesSavedEndpoint && catalog.tierVocabulary === "tiers") {
+          setModelCatalog({
+            kind: "error",
+            message:
+              "A key sends this company straight to OpenRouter, so the subscription endpoint's " +
+              "tier list no longer applies. Save the key first to pick from OpenRouter's " +
+              "catalog, or enter model ids directly.",
+          });
+          // Nothing was read for the endpoint this draft would actually reach,
+          // so the prefill must not inherit the proxy's tier names either.
+          setCatalogTierDefaults(null);
           return;
         }
         setCatalogTierDefaults(catalog.tierDefaults ?? {});
@@ -627,13 +709,19 @@ export function InferenceSection({
             kind: "error",
             message: "The provider's model list could not be loaded. Enter model ids directly.",
           });
+          // A rejected request carries no answer at all — not even the empty
+          // map a 200-with-`error` supplies — so the prefill goes back to "no
+          // catalog has been read", which is what `null` means here. Holding a
+          // previous read's mapping through a failure is how unconfirmed ids
+          // reached Save (CodeRabbit review on #2045).
+          setCatalogTierDefaults(null);
         }
       });
 
     return () => {
       current = false;
     };
-  }, [client, company, provider, storedProviderIsOpenRouter]);
+  }, [client, company, provider, storedProviderIsOpenRouter, draftLeavesSavedEndpoint]);
 
   /**
    * Whether saving right now would ride the platform's subscription proxy
@@ -651,8 +739,7 @@ export function InferenceSection({
    * that follows can depend on it — hooks cannot come after a conditional
    * return.
    */
-  const wouldSaveProxied =
-    key.trim().length === 0 && !(status?.provider === "openrouter" && status.keyConfigured);
+  const wouldSaveProxied = key.trim().length === 0 && savedIsProxied;
 
   /**
    * Drop a catalog-shaped tier override the moment the form would save

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -195,24 +195,37 @@ const METERING_NOTES: Record<UsageMetering, string> = {
   none: "no model runs on this path, so Usage stays at zero",
 };
 
-/** Per-provider form defaults applied when the operator picks a provider. */
+/**
+ * Per-provider form defaults applied when the operator picks a provider.
+ *
+ * `catalogTierDefaults` is `null` when **no** catalog has been read yet, and an
+ * object — possibly `{}` — once one has. The two are not interchangeable, and
+ * collapsing them was a defect (Codex review on #2045): a catalog classified
+ * `unknown` legitimately implies **no** defaults, and testing only the key count
+ * read that confirmed emptiness as "nothing loaded" and fell through to
+ * OpenRouter's ids. Switching provider away and back then repopulated four ids
+ * the endpoint's own catalog had just proved absent, and Save persisted them —
+ * the exact failure the vocabulary work exists to remove.
+ */
 function presetFor(
   provider: InferenceProvider,
   defaultTierModels?: Partial<Record<Tier, string>>,
-  catalogTierDefaults?: Partial<Record<Tier, string>>,
+  catalogTierDefaults?: Partial<Record<Tier, string>> | null,
 ): {
   baseUrl: string;
   models: Partial<Record<Tier, string>>;
 } {
   const preset = PROVIDERS[provider].preset;
   if (provider !== "openrouter") return preset;
-  // The *endpoint's own* defaults win when a catalog has actually been read.
+  // A catalog has been read: its answer is the whole answer, including when
+  // that answer is "this endpoint implies no defaults".
+  //
   // `status.defaultTierModels` is OpenRouter's vocabulary and nothing wider, so
   // prefilling from it against an endpoint that publishes `chat-v1` writes four
   // ids that endpoint has already told us it does not serve — an explicit,
   // saved, silently unusable mapping, which is worse than the unmapped case the
   // host now resolves correctly on its own.
-  if (catalogTierDefaults && Object.keys(catalogTierDefaults).length > 0) {
+  if (catalogTierDefaults) {
     return { ...preset, models: catalogTierDefaults };
   }
   // No catalog yet: the host's own `defaultTierModels` (from `GET …/inference`)
@@ -427,8 +440,16 @@ export function InferenceSection({
    * defaults straight off `modelCatalog` would fall back to OpenRouter's ids on
    * exactly the switch-away-and-back path an operator takes while comparing
    * providers.
+   *
+   * `null` means **no catalog has been read**, which is a different fact from a
+   * catalog that was read and implies no defaults (`{}`, the `unknown`
+   * vocabulary). `presetFor` needs to tell them apart: treating a confirmed-empty
+   * mapping as "not loaded" repopulated four OpenRouter ids the endpoint had
+   * just been seen not to publish.
    */
-  const [catalogTierDefaults, setCatalogTierDefaults] = useState<Record<string, string>>({});
+  const [catalogTierDefaults, setCatalogTierDefaults] = useState<Record<string, string> | null>(
+    null,
+  );
 
   // Switch form.
   const [provider, setProvider] = useState<InferenceProvider>("managed");
@@ -524,10 +545,54 @@ export function InferenceSection({
     void refresh();
   }, [refresh]);
 
+  /**
+   * Whether the endpoint `GET …/inference/models` will answer for is the one an
+   * `openrouter` draft would actually reach.
+   *
+   * The route resolves the **saved** config, so this is the only thing that
+   * makes its answer applicable to the form. `managed` is included because the
+   * host treats it as a legacy alias for `openrouter` and resolves it onto the
+   * same platform endpoint, so an unconfigured company — the first-run case —
+   * still gets a real catalog rather than a refusal. `undefined` (status not
+   * loaded yet) is excluded: the effect re-runs when it arrives.
+   */
+  const storedProviderIsOpenRouter =
+    status?.provider === "openrouter" || status?.provider === "managed";
+
   useEffect(() => {
     let current = true;
     if (provider !== "openrouter") {
       setModelCatalog({ kind: "idle" });
+      return () => {
+        current = false;
+      };
+    }
+
+    // The route answers for the endpoint this company is **saved** against, and
+    // has no way to be asked about an unsaved draft. So a form whose provider
+    // select has been moved somewhere the stored config is not must not present
+    // that catalog as this provider's (Codex review on #2045): switching a saved
+    // Ollama or custom company to OpenRouter used to list the *old* endpoint's
+    // models under an OpenRouter picker, and choosing one saved a foreign model
+    // id against OpenRouter — a configuration that cannot work. Naming the
+    // source endpoint on screen does not stop the picker writing it into the
+    // wrong provider's mapping.
+    //
+    // `managed` counts as OpenRouter here because the host does: it is a legacy
+    // alias (`LEGACY_MANAGED`), and an unconfigured company resolves to the same
+    // platform endpoint an `openrouter` draft with no base URL would reach. That
+    // keeps first-run setup — the common case — showing a real catalog.
+    if (!storedProviderIsOpenRouter) {
+      setModelCatalog({
+        kind: "error",
+        message:
+          "This company is saved against a different endpoint, so its model list is not " +
+          "OpenRouter's. Save the provider first to pick from OpenRouter's catalog, or enter " +
+          "model ids directly.",
+      });
+      // Nothing was read *for this provider*, so the tier prefill must stay on
+      // its pre-catalog fallback rather than inherit the other endpoint's.
+      setCatalogTierDefaults(null);
       return () => {
         current = false;
       };
@@ -568,7 +633,7 @@ export function InferenceSection({
     return () => {
       current = false;
     };
-  }, [client, company, provider]);
+  }, [client, company, provider, storedProviderIsOpenRouter]);
 
   /**
    * Whether saving right now would ride the platform's subscription proxy

--- a/frontend/test/e2e/inference.spec.ts
+++ b/frontend/test/e2e/inference.spec.ts
@@ -186,10 +186,21 @@ test("OpenRouter models are selected from the registry and persist through reloa
   await page.route("**/inference/models", async (route) => {
     await route.fulfill({
       contentType: "application/json",
-      body: JSON.stringify([
-        { id: "provider/catalog-chat", name: "Catalog Chat", contextLength: 128_000 },
-        { id: "provider/catalog-reasoning", name: "Catalog Reasoning" },
-      ]),
+      // `GET …/inference/models` answers with the configured endpoint's own
+      // catalog — `{baseUrl, models, tierVocabulary, tierDefaults}` — not the
+      // bare array it used to return. These ids are neither the tier names nor
+      // the shipped concrete ids, so a real host classifies this endpoint
+      // `unknown` and supplies no tier defaults; the console then keeps
+      // prefilling from `status.defaultTierModels`, as it does here.
+      body: JSON.stringify({
+        baseUrl: "https://catalog.example.test/v1",
+        models: [
+          { id: "provider/catalog-chat", name: "Catalog Chat", contextLength: 128_000 },
+          { id: "provider/catalog-reasoning", name: "Catalog Reasoning" },
+        ],
+        tierVocabulary: "unknown",
+        tierDefaults: {},
+      }),
     });
   });
   await openConnections(page);
@@ -245,9 +256,13 @@ test("a saved OpenRouter tier override can be cleared back to the tier default (
   await page.route("**/inference/models", async (route) => {
     await route.fulfill({
       contentType: "application/json",
-      body: JSON.stringify([
-        { id: "provider/catalog-chat", name: "Catalog Chat", contextLength: 128_000 },
-      ]),
+      // Same catalog shape as the spec above: an object, not a bare array.
+      body: JSON.stringify({
+        baseUrl: "https://catalog.example.test/v1",
+        models: [{ id: "provider/catalog-chat", name: "Catalog Chat", contextLength: 128_000 }],
+        tierVocabulary: "unknown",
+        tierDefaults: {},
+      }),
     });
   });
   await openConnections(page);

--- a/frontend/test/unit/inference-card-honesty.test.ts
+++ b/frontend/test/unit/inference-card-honesty.test.ts
@@ -52,16 +52,26 @@ function stubClient(replies: InferenceStatus[], mutation?: InferenceStatus) {
     scopeFor: (company: string | null) =>
       company ? `/api/v1/companies/${company}` : "/api/v1/company",
     // The catalog route answers with an object naming the endpoint that was
-    // read, not a bare array (`InferenceModelCatalog`). This card asserts
-    // nothing about the picker, so an empty catalog for the resolved endpoint
-    // is the honest stub — but it has to be the *shape* the console parses.
+    // read, not a bare array (`InferenceModelCatalog`). These tests assert
+    // nothing about the picker, so the stub answers the host's *unreadable
+    // catalog* reply — a 200 carrying `error`, with no `tierVocabulary`,
+    // because "we could not ask" is not the same fact as `"unknown"`.
+    //
+    // Deliberately not `{models: [], tierVocabulary: "unknown"}`: the host
+    // cannot produce that pairing. `list_models` only sets a vocabulary in its
+    // success arm, and `catalog_models` treats an empty catalog as a failure,
+    // so an empty list always arrives with `error` set and no vocabulary. A
+    // double that answered a shape the host cannot emit would let these tests
+    // pass on behaviour nothing real can reach.
     get: async (path: string) =>
       path.endsWith("/inference/models")
         ? {
             baseUrl: "https://openrouter.ai/api/v1",
             models: [],
-            tierVocabulary: "unknown",
             tierDefaults: {},
+            error:
+              "Could not list models from https://openrouter.ai/api/v1: connection refused. " +
+              "Enter model ids directly.",
           }
         : read(),
     put: async () => ({ status: settled(), note: "" }),

--- a/frontend/test/unit/inference-card-honesty.test.ts
+++ b/frontend/test/unit/inference-card-honesty.test.ts
@@ -51,7 +51,19 @@ function stubClient(replies: InferenceStatus[], mutation?: InferenceStatus) {
   return {
     scopeFor: (company: string | null) =>
       company ? `/api/v1/companies/${company}` : "/api/v1/company",
-    get: async (path: string) => (path.endsWith("/inference/models") ? [] : read()),
+    // The catalog route answers with an object naming the endpoint that was
+    // read, not a bare array (`InferenceModelCatalog`). This card asserts
+    // nothing about the picker, so an empty catalog for the resolved endpoint
+    // is the honest stub — but it has to be the *shape* the console parses.
+    get: async (path: string) =>
+      path.endsWith("/inference/models")
+        ? {
+            baseUrl: "https://openrouter.ai/api/v1",
+            models: [],
+            tierVocabulary: "unknown",
+            tierDefaults: {},
+          }
+        : read(),
     put: async () => ({ status: settled(), note: "" }),
     del: async () => ({ status: settled(), note: "" }),
     post: async () => ({ status: settled(), note: "" }),

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -33,6 +33,39 @@ function status(
   };
 }
 
+/**
+ * The models route answers with the *configured endpoint's* catalog, plus what
+ * that catalog says about how tiers must be spelled for it — so the test double
+ * has to answer in that shape, not with a bare array.
+ *
+ * An `Error` still stands for a transport failure; an unreadable catalog that
+ * the host itself reports arrives as a 200 carrying `error`, which
+ * `catalogError` covers.
+ */
+const CATALOG_BASE_URL = "https://provider.example/v1";
+
+function catalogBody(models: InferenceModel[]) {
+  // Mirrors the host: a catalog with no models carries no vocabulary and no
+  // defaults, because there is nothing to have classified. (The host never
+  // actually answers that shape — an empty catalog is reported as an `error` —
+  // but a double that supplied defaults for an empty list would let a test
+  // assert behaviour the host cannot produce.)
+  if (models.length === 0) {
+    return { baseUrl: CATALOG_BASE_URL, models, tierDefaults: {} };
+  }
+  return {
+    baseUrl: CATALOG_BASE_URL,
+    models,
+    tierVocabulary: "concrete" as const,
+    tierDefaults: {
+      "chat-v1": "anthropic/claude-sonnet-5",
+      "reasoning-v1": "openai/gpt-5.6-sol-pro",
+      "agentic-v1": "anthropic/claude-opus-5",
+      "vision-v1": "qwen/qwen3.8-max",
+    },
+  };
+}
+
 function clientFor(
   inference: InferenceStatus,
   catalog: InferenceModel[] | Error,
@@ -45,7 +78,7 @@ function clientFor(
       calls.push(path);
       if (path.endsWith("/inference/models")) {
         if (catalog instanceof Error) throw catalog;
-        return catalog;
+        return catalogBody(catalog);
       }
       return inference;
     },
@@ -101,6 +134,55 @@ describe("OpenRouter tier model pickers", () => {
     expect(container.querySelector("#inference-model-chat-v1")?.textContent).toContain(
       "operator/custom-chat",
     );
+  });
+
+  it("names the endpoint the listed models came from", async () => {
+    // The catalog is the *configured provider's*, not a vendor registry, and
+    // the form's provider select can point somewhere other than the saved
+    // config while an operator is mid-edit. An unattributed list is one the
+    // operator has to guess the provenance of — which is how a TinyHumans
+    // company came to trust `anthropic/claude-sonnet-5` off an OpenRouter list.
+    const { client } = clientFor(status("openrouter", {}), [
+      { id: "provider/one", name: "One" },
+    ]);
+
+    await mount(client);
+
+    const source = container.querySelector('[data-testid="inference-model-catalog-source"]');
+    expect(source).not.toBeNull();
+    expect(source?.textContent).toContain(CATALOG_BASE_URL);
+  });
+
+  it("shows the host's own reason when the provider's catalog cannot be read", async () => {
+    // An unreadable catalog reaches the console as a 200 carrying `error`, so
+    // the picker can say which endpoint failed. An empty list is not a true
+    // statement about a catalog nobody managed to read.
+    const calls: string[] = [];
+    const inference = status("openrouter", {});
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: async (path: string) => {
+        calls.push(path);
+        if (path.endsWith("/inference/models")) {
+          return {
+            baseUrl: CATALOG_BASE_URL,
+            models: [],
+            tierDefaults: {},
+            error: `Could not list models from ${CATALOG_BASE_URL}: connection refused. Enter model ids directly.`,
+          };
+        }
+        return inference;
+      },
+      put: async () => ({ status: inference, note: "" }),
+    } as unknown as OpenCompanyClient;
+
+    await mount(client);
+
+    const fallback = container.querySelector('[data-testid="inference-model-catalog-fallback"]');
+    expect(fallback).not.toBeNull();
+    expect(fallback?.textContent).toContain("Could not list models from");
+    expect(fallback?.textContent).toContain(CATALOG_BASE_URL);
+    expect(container.querySelector('[data-testid="inference-model-catalog-source"]')).toBeNull();
   });
 
   it("falls back to editable model ids when the registry request fails", async () => {
@@ -567,6 +649,67 @@ describe("typing an id the registry does not list (issue #1838 follow-up)", () =
 });
 
 describe("the OpenRouter preset prefills from the host's own defaults (issue #1838 follow-up)", () => {
+  it("prefills from the endpoint's own catalog defaults, not OpenRouter's ids", async () => {
+    // The remaining route to a silently unusable mapping, on the console side:
+    // `status.defaultTierModels` is OpenRouter's vocabulary, so prefilling it
+    // against an endpoint publishing `chat-v1` writes four ids that endpoint
+    // has already told us it does not serve — and an *explicit* mapping is
+    // honoured verbatim by the host, so it survives the server-side fix.
+    const { client } = clientFor(
+      status("openrouter", {}, true, {
+        "chat-v1": "vendor-x/model-a",
+        "reasoning-v1": "vendor-x/model-b",
+        "agentic-v1": "vendor-x/model-c",
+        "vision-v1": "vendor-x/model-d",
+      }),
+      // A tier-native catalog: the endpoint publishes the tier names.
+      [{ id: "chat-v1" }, { id: "agentic-v1" }],
+    );
+    // `clientFor`'s body reports `concrete`; override it to the identity
+    // mapping a tier-native endpoint implies.
+    const original = client.get.bind(client);
+    (client as unknown as { get: (p: string) => Promise<unknown> }).get = async (path: string) => {
+      const body = (await original(path)) as Record<string, unknown>;
+      if (path.endsWith("/inference/models")) {
+        return {
+          ...body,
+          tierVocabulary: "tiers",
+          tierDefaults: {
+            "chat-v1": "chat-v1",
+            "reasoning-v1": "reasoning-v1",
+            "agentic-v1": "agentic-v1",
+            "vision-v1": "vision-v1",
+          },
+        };
+      }
+      return body;
+    };
+
+    await mount(client);
+
+    async function selectProvider(label: string) {
+      const trigger = container.querySelector("#inference-provider") as HTMLButtonElement;
+      await act(async () => {
+        trigger.click();
+      });
+      await act(async () => {});
+      const item = Array.from(
+        document.body.querySelectorAll('[data-slot="select-item"]'),
+      ).find((el) => el.textContent?.includes(label)) as HTMLElement | undefined;
+      await act(async () => {
+        item?.click();
+      });
+      await act(async () => {});
+    }
+
+    await selectProvider("Ollama");
+    await selectProvider("OpenRouter");
+
+    const chat = container.querySelector("#inference-model-chat-v1");
+    expect(chat?.textContent ?? (chat as HTMLInputElement | null)?.value).toContain("chat-v1");
+    expect(chat?.textContent ?? (chat as HTMLInputElement | null)?.value).not.toContain("vendor-x");
+  });
+
   it("seeds the switch form from status.defaultTierModels rather than a hard-coded copy", async () => {
     // The console used to duplicate `DEFAULT_TIER_MODELS` locally; a value
     // that could only ever drift is not a fixture worth asserting against —

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -45,13 +45,22 @@ function status(
 const CATALOG_BASE_URL = "https://provider.example/v1";
 
 function catalogBody(models: InferenceModel[]) {
-  // Mirrors the host: a catalog with no models carries no vocabulary and no
-  // defaults, because there is nothing to have classified. (The host never
-  // actually answers that shape — an empty catalog is reported as an `error` —
-  // but a double that supplied defaults for an empty list would let a test
-  // assert behaviour the host cannot produce.)
+  // Mirrors the host exactly, the empty case included: an empty catalog is
+  // reported as a *failure*, so it arrives as a 200 carrying `error`, with no
+  // vocabulary and no defaults.
+  //
+  // This used to answer `{models: [], tierDefaults: {}}` with no `error`, under
+  // a comment conceding the host cannot produce that shape — and the concession
+  // turned out to matter. `{}` and "no catalog was read" are now different facts
+  // to `presetFor`, so a double reporting a confirmed-empty mapping where the
+  // host would report a failure asserts behaviour nothing real can reach.
   if (models.length === 0) {
-    return { baseUrl: CATALOG_BASE_URL, models, tierDefaults: {} };
+    return {
+      baseUrl: CATALOG_BASE_URL,
+      models,
+      tierDefaults: {},
+      error: `Could not list models from ${CATALOG_BASE_URL}: it published an empty model catalog. Enter model ids directly.`,
+    };
   }
   return {
     baseUrl: CATALOG_BASE_URL,
@@ -1010,5 +1019,104 @@ describe("typing a passthrough id one keystroke at a time while proxied (issue #
     }
 
     expect(input).toHaveProperty("value", target);
+  });
+});
+
+/**
+ * The catalog route answers for the endpoint this company is **saved** against.
+ * Two consequences the console had wrong, both found by Codex review on #2045.
+ */
+describe("the catalog belongs to the saved endpoint, not to the draft", () => {
+  async function selectProvider(label: string) {
+    const trigger = container.querySelector("#inference-provider") as HTMLButtonElement;
+    expect(trigger).not.toBeNull();
+    await act(async () => {
+      trigger.click();
+    });
+    await act(async () => {});
+    const item = Array.from(document.body.querySelectorAll('[data-slot="select-item"]')).find(
+      (el) => el.textContent?.includes(label),
+    ) as HTMLElement | undefined;
+    expect(item).not.toBeUndefined();
+    await act(async () => {
+      item?.click();
+    });
+    await act(async () => {});
+  }
+
+  it("does not offer another provider's models under the OpenRouter picker", async () => {
+    // A company saved on a custom endpoint, whose operator is drafting a switch
+    // to OpenRouter. The route still resolves the *saved* endpoint, so its
+    // catalog is not OpenRouter's — offering it here let the operator pick a
+    // model the console had shown and save a foreign id against OpenRouter.
+    const { client } = clientFor(
+      status("openai_compatible", {}, true),
+      [{ id: "local/only-here", name: "Local Only" }],
+    );
+
+    await mount(client);
+    await selectProvider("OpenRouter");
+
+    expect(container.querySelector('[data-testid="inference-model-select-chat-v1"]')).toBeNull();
+    expect(container.querySelector("input#inference-model-chat-v1")).not.toBeNull();
+    expect(container.textContent).not.toContain("Local Only");
+    expect(container.textContent).toContain("saved against a different endpoint");
+  });
+
+  it("still reads a catalog for an unconfigured company, which resolves to the same endpoint", async () => {
+    // `managed` is the host's legacy alias for `openrouter` and resolves onto
+    // the same platform endpoint an `openrouter` draft with no base URL reaches,
+    // so first-run setup must keep asking for a real catalog rather than being
+    // refused. (Whether the *picker* renders is a separate question the
+    // proxied-save guard answers — an unkeyed company gets free text either
+    // way — so this asserts the request and the absence of the refusal.)
+    const { client, calls } = clientFor(status("managed", {}, true), [
+      { id: "anthropic/claude-sonnet-5", name: "Sonnet" },
+    ]);
+
+    await mount(client);
+    await selectProvider("OpenRouter");
+
+    expect(calls.some((path) => path.endsWith("/inference/models"))).toBe(true);
+    expect(container.textContent).not.toContain("saved against a different endpoint");
+  });
+
+  it("keeps a confirmed-empty tier mapping empty instead of falling back to OpenRouter's ids", async () => {
+    // An `unknown` vocabulary means the endpoint's catalog was read and implies
+    // no defaults. Treating that `{}` as "no catalog loaded" repopulated the
+    // four shipped ids the catalog had just been seen not to publish, and Save
+    // persisted them — the defect this whole change exists to remove, reached
+    // through the switch-away-and-back path.
+    const { client } = clientFor(
+      status("openrouter", {}, true, {
+        "chat-v1": "anthropic/claude-sonnet-5",
+        "reasoning-v1": "openai/gpt-5.6-sol-pro",
+        "agentic-v1": "anthropic/claude-opus-5",
+        "vision-v1": "qwen/qwen3.8-max",
+      }),
+      [],
+    );
+    const raw = client as unknown as { get: (path: string) => Promise<unknown> };
+    const inner = raw.get.bind(raw);
+    raw.get = async (path: string) => {
+      const body = await inner(path);
+      if (path.endsWith("/inference/models")) {
+        return {
+          baseUrl: "https://gateway.example/v1",
+          models: [{ id: "gateway/one" }],
+          tierVocabulary: "unknown" as const,
+          tierDefaults: {},
+        };
+      }
+      return body;
+    };
+
+    await mount(client);
+    await selectProvider("Ollama");
+    await selectProvider("OpenRouter");
+
+    const chat = container.querySelector("#inference-model-chat-v1");
+    const shown = chat?.textContent ?? (chat as HTMLInputElement | null)?.value ?? "";
+    expect(shown).not.toContain("anthropic/claude-sonnet-5");
   });
 });

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -1120,3 +1120,126 @@ describe("the catalog belongs to the saved endpoint, not to the draft", () => {
     expect(shown).not.toContain("anthropic/claude-sonnet-5");
   });
 });
+
+describe("the catalog only describes the endpoint the draft would actually reach", () => {
+  function setValue(input: HTMLInputElement | null, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+    setter?.call(input, value);
+    input?.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  it("refuses the subscription endpoint's catalog once a key points the draft at OpenRouter", async () => {
+    // A company on the platform proxy — `managed`, or `openrouter` with no key
+    // — resolves to the platform's own tier-native endpoint, whose catalog
+    // publishes `chat-v1` and friends. Typing an OpenRouter key sends Save
+    // straight to `api.openrouter.ai`, which has never heard of `chat-v1`.
+    //
+    // The catalog effect did not depend on the key, so the picker went on
+    // offering the proxy's tier names under a draft that no longer reached the
+    // proxy; selecting one persisted a verbatim override direct OpenRouter
+    // rejects (Codex review on #2045).
+    // A tier-native catalog, which is what the platform proxy publishes and the
+    // only kind whose ids are categorically wrong at direct OpenRouter. A
+    // `concrete`/`unknown` catalog is deliberately left alone — see the guard.
+    const inference = status("managed", {}, false);
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: async (path: string) =>
+        path.endsWith("/inference/models")
+          ? {
+              baseUrl: "https://api.tinyhumans.ai/openai/v1",
+              models: [{ id: "chat-v1", name: "Chat v1" }, { id: "agentic-v1", name: "Agentic v1" }],
+              tierVocabulary: "tiers" as const,
+              tierDefaults: { "chat-v1": "chat-v1", "agentic-v1": "agentic-v1" },
+            }
+          : inference,
+      put: async () => ({ status: inference, note: "" }),
+    } as unknown as OpenCompanyClient;
+
+    await mount(client);
+
+    // Keyless: the proxy's own catalog is the right one to show.
+    expect(container.querySelector("#inference-model-chat-v1")).not.toBeNull();
+
+    const keyInput = container.querySelector<HTMLInputElement>("input#inference-key");
+    expect(keyInput).not.toBeNull();
+    await act(async () => setValue(keyInput, "sk-not-a-real-key"));
+    await act(async () => {});
+
+    // The draft now reaches a different endpoint, so the tier-native catalog is
+    // withdrawn and the tier falls back to free text rather than a select full
+    // of tier names OpenRouter would reject.
+    expect(container.textContent).toContain("straight to OpenRouter");
+    const chat = container.querySelector<HTMLInputElement>("input#inference-model-chat-v1");
+    expect(chat).not.toBeNull();
+    expect(chat?.value ?? "").not.toContain("chat-v1");
+  });
+
+  it("drops a loaded catalog's tier defaults when a later read fails", async () => {
+    // A successful read leaves `catalogTierDefaults` populated. If a later read
+    // fails and that mapping survives, `pickProvider` seeds the form from ids
+    // the endpoint has not confirmed and Save persists them (CodeRabbit review
+    // on #2045).
+    //
+    // Cleared to `null` rather than `{}` on purpose: "we could not ask" is not
+    // "the endpoint confirmed it publishes nothing", and only the first leaves
+    // the host's own `status.defaultTierModels` standing as the fallback.
+    let failNext = false;
+    const inference = status("openrouter", {}, true, {
+      "chat-v1": "host-default/chat",
+      "reasoning-v1": "host-default/reasoning",
+      "agentic-v1": "host-default/agentic",
+      "vision-v1": "host-default/vision",
+    });
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: async (path: string) => {
+        if (path.endsWith("/inference/models")) {
+          if (failNext) throw new Error("connection refused");
+          return catalogBody([{ id: "anthropic/claude-sonnet-5" }]);
+        }
+        return inference;
+      },
+      put: async () => ({ status: inference, note: "" }),
+    } as unknown as OpenCompanyClient;
+
+    await mount(client);
+
+    async function selectProvider(label: string) {
+      const trigger = container.querySelector("#inference-provider") as HTMLButtonElement;
+      await act(async () => {
+        trigger.click();
+      });
+      await act(async () => {});
+      const item = Array.from(
+        document.body.querySelectorAll('[data-slot="select-item"]'),
+      ).find((el) => el.textContent?.includes(label)) as HTMLElement | undefined;
+      await act(async () => {
+        item?.click();
+      });
+      await act(async () => {});
+    }
+
+    // Leave OpenRouter and come back with the endpoint now unreachable. This
+    // first return still seeds from the mapping the *successful* read left:
+    // `pickProvider` reads state synchronously on the click, before the fetch
+    // it triggers can resolve. What the fix changes is what is left behind
+    // afterwards — the failed read clears the mapping instead of keeping it.
+    failNext = true;
+    await selectProvider("Ollama");
+    await selectProvider("OpenRouter");
+
+    // So the guarantee is about the *next* preset: with the stale mapping
+    // cleared, this one falls back to the host's own defaults rather than ids
+    // the endpoint can no longer vouch for. Before the fix the mapping
+    // survived every failure and seeded this — and every later — switch with
+    // `anthropic/claude-sonnet-5`, which Save then persisted.
+    await selectProvider("Ollama");
+    await selectProvider("OpenRouter");
+
+    const chat = container.querySelector<HTMLInputElement>("input#inference-model-chat-v1");
+    expect(chat).not.toBeNull();
+    expect(chat?.value).toBe("host-default/chat");
+    expect(chat?.value).not.toContain("anthropic/claude-sonnet-5");
+  });
+});

--- a/frontend/test/unit/inference-models-api.test.ts
+++ b/frontend/test/unit/inference-models-api.test.ts
@@ -11,13 +11,46 @@ describe("the inference model catalog client", () => {
         company ? `/api/v1/companies/${company}` : "/api/v1/company",
       get: async (path: string) => {
         calls.push(path);
-        return [{ id: "provider/model", name: "Model" }];
+        return {
+          baseUrl: "https://provider.example/v1",
+          models: [{ id: "provider/model", name: "Model" }],
+          tierVocabulary: "unknown",
+          tierDefaults: {},
+        };
       },
     } as unknown as OpenCompanyClient;
 
-    await expect(listInferenceModels(client, "acme")).resolves.toEqual([
-      { id: "provider/model", name: "Model" },
-    ]);
+    // The catalog travels whole: the route answers with the endpoint that was
+    // read and what its vocabulary implies, not just a list of ids. The console
+    // needs `baseUrl` to say *whose* list it is showing, and `tierDefaults` to
+    // prefill from the configured endpoint rather than from OpenRouter's ids.
+    await expect(listInferenceModels(client, "acme")).resolves.toEqual({
+      baseUrl: "https://provider.example/v1",
+      models: [{ id: "provider/model", name: "Model" }],
+      tierVocabulary: "unknown",
+      tierDefaults: {},
+    });
     expect(calls).toEqual(["/api/v1/companies/acme/inference/models"]);
+  });
+
+  it("passes an unreadable catalog's explanation through rather than an empty list alone", async () => {
+    // An unreadable catalog is a 200 carrying `error`, so the console can name
+    // the endpoint that did not answer instead of rendering an empty picker
+    // that reads as "this provider publishes no models". `tierVocabulary` is
+    // absent in that case, which is a different thing from `"unknown"`.
+    const client = {
+      scopeFor: () => "/api/v1/company",
+      get: async () => ({
+        baseUrl: "http://localhost:11434/v1",
+        models: [],
+        tierDefaults: {},
+        error: "Could not list models from http://localhost:11434/v1: connection refused.",
+      }),
+    } as unknown as OpenCompanyClient;
+
+    const catalog = await listInferenceModels(client, null);
+    expect(catalog.models).toEqual([]);
+    expect(catalog.tierVocabulary).toBeUndefined();
+    expect(catalog.error).toContain("http://localhost:11434/v1");
   });
 });

--- a/frontend/test/unit/inference-models-api.test.ts
+++ b/frontend/test/unit/inference-models-api.test.ts
@@ -37,12 +37,19 @@ describe("the inference model catalog client", () => {
     // An unreadable catalog is a 200 carrying `error`, so the console can name
     // the endpoint that did not answer instead of rendering an empty picker
     // that reads as "this provider publishes no models". `tierVocabulary` is
-    // absent in that case, which is a different thing from `"unknown"`.
+    // `null` in that case, which is a different thing from `"unknown"`.
+    //
+    // The stub sends an explicit `null` because that is what the host sends:
+    // `ModelCatalogDto::tier_vocabulary` carries no `skip_serializing_if`, so
+    // the key is present and null rather than omitted. Asserting
+    // `toBeUndefined()` against a stub that omitted the field passed for a
+    // reason nothing real reproduces (CodeRabbit review on #2045).
     const client = {
       scopeFor: () => "/api/v1/company",
       get: async () => ({
         baseUrl: "http://localhost:11434/v1",
         models: [],
+        tierVocabulary: null,
         tierDefaults: {},
         error: "Could not list models from http://localhost:11434/v1: connection refused.",
       }),
@@ -50,7 +57,7 @@ describe("the inference model catalog client", () => {
 
     const catalog = await listInferenceModels(client, null);
     expect(catalog.models).toEqual([]);
-    expect(catalog.tierVocabulary).toBeUndefined();
+    expect(catalog.tierVocabulary).toBeNull();
     expect(catalog.error).toContain("http://localhost:11434/v1");
   });
 });

--- a/frontend/test/unit/product-scope-hidden-surfaces.test.ts
+++ b/frontend/test/unit/product-scope-hidden-surfaces.test.ts
@@ -287,14 +287,19 @@ function inferenceClient(status: InferenceStatus) {
     scopeFor: (company: string | null) =>
       company ? `/api/v1/companies/${company}` : "/api/v1/company",
     // `InferenceModelCatalog` — an object naming the endpoint read, not the
-    // bare array this route used to answer with.
+    // bare array this route used to answer with. These tests are about which
+    // surfaces the card hides, not about the picker, so the stub answers the
+    // host's unreadable-catalog reply: a 200 carrying `error`, with no
+    // `tierVocabulary`. The host never pairs an empty `models` with a
+    // vocabulary — an empty catalog is reported as a failure — so answering
+    // one would be a shape nothing real can produce.
     get: async (path: string) =>
       path.endsWith("/inference/models")
         ? {
             baseUrl: status.baseUrl,
             models: [],
-            tierVocabulary: "unknown",
             tierDefaults: {},
+            error: `Could not list models from ${status.baseUrl}: connection refused. Enter model ids directly.`,
           }
         : status,
     put: async () => ({ status, note: "" }),

--- a/frontend/test/unit/product-scope-hidden-surfaces.test.ts
+++ b/frontend/test/unit/product-scope-hidden-surfaces.test.ts
@@ -286,7 +286,17 @@ function inferenceClient(status: InferenceStatus) {
   return {
     scopeFor: (company: string | null) =>
       company ? `/api/v1/companies/${company}` : "/api/v1/company",
-    get: async (path: string) => (path.endsWith("/inference/models") ? [] : status),
+    // `InferenceModelCatalog` — an object naming the endpoint read, not the
+    // bare array this route used to answer with.
+    get: async (path: string) =>
+      path.endsWith("/inference/models")
+        ? {
+            baseUrl: status.baseUrl,
+            models: [],
+            tierVocabulary: "unknown",
+            tierDefaults: {},
+          }
+        : status,
     put: async () => ({ status, note: "" }),
     del: async () => ({ status, note: "" }),
     post: async () => ({ status, note: "" }),

--- a/src/company/inference.rs
+++ b/src/company/inference.rs
@@ -137,14 +137,17 @@ pub const LEGACY_MANAGED: &str = "managed";
 /// The provider a company gets when nothing names one.
 pub const DEFAULT_PROVIDER: &str = "openrouter";
 
-/// Default concrete OpenRouter model id per abstract tier.
+/// The concrete model id per abstract tier **in OpenRouter's vocabulary**.
 ///
-/// Used on the **direct** path only. A tier names a workload, and something has
-/// to turn it into a model id before the request leaves this process — but only
-/// when the endpoint would not do it. See [`model_for_tier`].
+/// Not a universal default, and the name is the only thing about it that ever
+/// suggested otherwise. These four strings are OpenRouter catalog ids: they are
+/// meaningful at an endpoint that publishes OpenRouter's catalog and meaningless
+/// anywhere else, so applying them is only ever correct once
+/// [`TierVocabulary::Concrete`] has been established for the endpoint the
+/// request is about to travel to. See [`model_for_tier`].
 ///
-/// The slugs mirror the platform's own OpenRouter bindings, so proxied and
-/// direct resolve to the same models by default.
+/// The slugs mirror the platform's own OpenRouter bindings, so a proxied tier
+/// and a direct substitution resolve to the same models by default.
 pub const DEFAULT_TIER_MODELS: &[(&str, &str)] = &[
     ("chat-v1", "anthropic/claude-sonnet-5"),
     ("reasoning-v1", "openai/gpt-5.6-sol-pro"),
@@ -152,37 +155,135 @@ pub const DEFAULT_TIER_MODELS: &[(&str, &str)] = &[
     ("vision-v1", "qwen/qwen3.8-max"),
 ];
 
-/// The concrete model id to put on the wire for `tier`.
+/// Which model vocabulary an endpoint speaks — the question that has to be
+/// answered before [`model_for_tier`] can decide whether to substitute anything.
 ///
-/// **The two paths need different answers, and sending the wrong one fails.**
+/// **This is a property of the endpoint, not of who pays for it.** It used to be
+/// read off [`InferenceDecl::is_proxied`], which is true only for the `openrouter`
+/// kind with no tenant key; every other config was assumed to want OpenRouter
+/// catalog ids. That conflated the payer with the vocabulary and broke the
+/// moment the two came apart: a company pointing `provider = "openrouter"` at
+/// `https://api.tinyhumans.ai/openai/v1` **with its own key** is not proxied, so
+/// every tier was rewritten to `anthropic/claude-opus-5` and friends and the
+/// endpoint answered `Model 'anthropic/claude-sonnet-5' is not available` — for
+/// an endpoint whose catalog publishes `chat-v1` and `agentic-v1` directly.
 ///
-/// * **Proxied** — the platform endpoint resolves tier names itself, against a
-///   curated registry that pins each tier to a sub-provider so its rate card
-///   stays exact. A bare tier is exactly what it wants. It also accepts a
-///   concrete model, but only under its own `openrouter/<author>/<slug>`
-///   namespace, and only when passthrough is switched on there — which it is
-///   not by default. So a tier is the only thing that always works.
-/// * **Direct** — OpenRouter has never heard of `chat-v1`, so a tier must be
-///   resolved here or the request 400s.
+/// Every OpenAI-compatible endpoint publishes its catalog at `GET
+/// {base_url}/models`, so the vocabulary is *discoverable* rather than
+/// guessable: see [`TierVocabulary::from_catalog_ids`]. Nothing here keys off a
+/// hostname — a provider that publishes `agentic-v1` is telling us it resolves
+/// tiers itself, whoever it is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TierVocabulary {
+    /// The endpoint publishes the tier names themselves, so it resolves a tier
+    /// against its own registry. Send the tier verbatim — substituting a
+    /// concrete id bypasses that routing and, on the platform proxy, is
+    /// rejected outright unless passthrough is switched on.
+    Tiers,
+    /// The endpoint publishes the concrete ids [`DEFAULT_TIER_MODELS`] names, so
+    /// a bare tier would 400 and the shipped mapping is the right default.
+    Concrete,
+    /// The endpoint's catalog was read and publishes neither vocabulary. We know
+    /// the shipped ids are *absent* from it, so applying them would be a guess
+    /// already contradicted by evidence.
+    Unknown,
+}
+
+impl TierVocabulary {
+    /// Classify an endpoint from the ids it publishes at `{base_url}/models`.
+    ///
+    /// Tiers win when present: a catalog containing `agentic-v1` resolves tiers
+    /// server-side, and that stays true even if it also lists concrete models.
+    /// `any` rather than `all` on purpose — a provider that publishes three of
+    /// the four tiers still speaks tiers, and demanding a complete set would
+    /// silently fall back to substitution for it.
+    pub fn from_catalog_ids<'a>(ids: impl IntoIterator<Item = &'a str>) -> Self {
+        let ids: std::collections::HashSet<&str> = ids.into_iter().collect();
+        if crate::company::types::INFERENCE_TIERS
+            .iter()
+            .any(|tier| ids.contains(tier))
+        {
+            return Self::Tiers;
+        }
+        if DEFAULT_TIER_MODELS
+            .iter()
+            .any(|(_, model)| ids.contains(model))
+        {
+            return Self::Concrete;
+        }
+        Self::Unknown
+    }
+
+    /// The wire/console label.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Tiers => "tiers",
+            Self::Concrete => "concrete",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// The tier → model mapping to offer as *this endpoint's* defaults.
+    ///
+    /// Empty for [`Self::Unknown`], and that emptiness is the point: an endpoint
+    /// whose catalog publishes neither vocabulary has no default we can honestly
+    /// supply, so the console must ask the operator for a model id per tier
+    /// rather than prefill four ids the catalog has already told us are not
+    /// there. Handing over a mapping we know is unusable is the failure this
+    /// whole type exists to stop.
+    pub fn tier_defaults(self) -> BTreeMap<String, String> {
+        match self {
+            Self::Tiers => crate::company::types::INFERENCE_TIERS
+                .iter()
+                .map(|tier| ((*tier).to_string(), (*tier).to_string()))
+                .collect(),
+            Self::Concrete => DEFAULT_TIER_MODELS
+                .iter()
+                .map(|(tier, model)| ((*tier).to_string(), (*model).to_string()))
+                .collect(),
+            Self::Unknown => BTreeMap::new(),
+        }
+    }
+}
+
+/// The concrete model id to put on the wire for `tier`, given what the endpoint
+/// this request is about to reach actually publishes.
 ///
-/// An operator's own `models` entry is honoured verbatim on both paths: they
-/// named a specific model and it is not this function's place to rewrite it
-/// (on the proxied path they can write the `openrouter/…` form themselves).
-pub fn model_for_tier(tier: &str, overrides: &BTreeMap<String, String>, proxied: bool) -> String {
+/// An operator's own `models` entry is honoured verbatim in every vocabulary:
+/// they named a specific model and it is not this function's place to rewrite
+/// it.
+///
+/// With no override, the vocabulary decides:
+///
+/// * [`TierVocabulary::Concrete`] — the endpoint publishes OpenRouter catalog
+///   ids and has never heard of `chat-v1`, so the tier is resolved here or the
+///   request 400s.
+/// * [`TierVocabulary::Tiers`] — the endpoint resolves the tier itself against
+///   its own registry, which is exactly what it wants; substituting would bypass
+///   its per-tier provider pinning.
+/// * [`TierVocabulary::Unknown`] — the tier goes out unchanged. Both answers are
+///   wrong at an endpoint that publishes neither vocabulary, but only one of
+///   them is *honest*: the provider's 400 then names a string the operator
+///   configured and can find, next to advice pointing at `GET
+///   {base_url}/models`, instead of an `anthropic/…` id they never typed and
+///   cannot locate in their own catalog.
+pub fn model_for_tier(
+    tier: &str,
+    overrides: &BTreeMap<String, String>,
+    vocabulary: TierVocabulary,
+) -> String {
     if let Some(mapped) = overrides.get(tier) {
         return mapped.clone();
     }
-    if proxied {
-        // Let the platform resolve it. Substituting a concrete slug here would
-        // bypass its per-tier provider pinning and, with passthrough off, be
-        // rejected outright.
-        return tier.to_string();
+    match vocabulary {
+        TierVocabulary::Concrete => DEFAULT_TIER_MODELS
+            .iter()
+            .find(|(name, _)| *name == tier)
+            .map(|(_, model)| (*model).to_string())
+            .unwrap_or_else(|| tier.to_string()),
+        TierVocabulary::Tiers | TierVocabulary::Unknown => tier.to_string(),
     }
-    DEFAULT_TIER_MODELS
-        .iter()
-        .find(|(name, _)| *name == tier)
-        .map(|(_, model)| (*model).to_string())
-        .unwrap_or_else(|| tier.to_string())
 }
 
 /// Normalizes a provider kind: blank and the legacy `managed` both become
@@ -283,6 +384,15 @@ pub struct InferenceDecl {
     /// Whether this rides the platform's subscription proxy. Read through
     /// [`is_proxied`](Self::is_proxied).
     proxied: bool,
+    /// The endpoint's model vocabulary, **once discovered from its catalog**.
+    ///
+    /// `None` means nobody has read `{base_url}/models` for this decl yet, not
+    /// that the endpoint speaks nothing — [`vocabulary`](Self::vocabulary)
+    /// supplies the pre-discovery guess. Discovery is a network read, so it is
+    /// attached by the callers that can afford one and can cache it
+    /// (`crate::server::inference_models::discovered_vocabulary`) rather than
+    /// performed inside this resolve, which runs on every turn.
+    vocabulary: Option<TierVocabulary>,
 }
 
 impl InferenceDecl {
@@ -317,6 +427,40 @@ impl InferenceDecl {
     /// base URL by every caller that cares.
     pub fn is_proxied(&self) -> bool {
         self.proxied
+    }
+
+    /// The model vocabulary to resolve tiers against for this config.
+    ///
+    /// The discovered answer when one is attached; otherwise the pre-discovery
+    /// guess, which is the rule this code used to apply unconditionally:
+    /// proxied endpoints resolve tiers, everything else is assumed to publish
+    /// OpenRouter catalog ids. That guess is wrong for a tier-native endpoint a
+    /// tenant reaches with its own key, which is precisely why discovery
+    /// exists — but keeping it as the fallback means an endpoint whose catalog
+    /// cannot be read behaves exactly as it did before, rather than changing
+    /// behaviour on a network failure.
+    pub fn vocabulary(&self) -> TierVocabulary {
+        self.vocabulary.unwrap_or(if self.proxied {
+            TierVocabulary::Tiers
+        } else {
+            TierVocabulary::Concrete
+        })
+    }
+
+    /// Whether [`vocabulary`](Self::vocabulary) is the endpoint's published
+    /// answer rather than the pre-discovery guess. The console needs the
+    /// difference: "this provider publishes no mapping we recognise" and "we
+    /// could not reach this provider's catalog" are different things to tell an
+    /// operator.
+    pub fn vocabulary_confirmed(&self) -> bool {
+        self.vocabulary.is_some()
+    }
+
+    /// Attach a discovered vocabulary (or clear it back to the guess).
+    #[must_use]
+    pub fn with_vocabulary(mut self, vocabulary: Option<TierVocabulary>) -> Self {
+        self.vocabulary = vocabulary;
+        self
     }
 
     /// The stable telemetry slug for this config
@@ -466,6 +610,7 @@ pub fn decl_for_probe(
         source: InferenceSource::Runtime,
         credential,
         proxied,
+        vocabulary: None,
     }
 }
 
@@ -712,6 +857,7 @@ pub async fn resolve_effective_scoped(
             source: InferenceSource::Runtime,
             credential,
             proxied,
+            vocabulary: None,
         }));
     }
 
@@ -731,6 +877,7 @@ pub async fn resolve_effective_scoped(
             source: InferenceSource::Manifest,
             credential,
             proxied,
+            vocabulary: None,
         }));
     }
 
@@ -755,6 +902,7 @@ pub async fn resolve_effective_scoped(
             source: InferenceSource::Default,
             credential,
             proxied,
+            vocabulary: None,
         }));
     }
 
@@ -1519,7 +1667,7 @@ mod tests {
     fn every_tier_resolves_to_a_concrete_model_id_on_the_direct_path() {
         let none = BTreeMap::new();
         for tier in crate::company::types::INFERENCE_TIERS {
-            let resolved = model_for_tier(tier, &none, false);
+            let resolved = model_for_tier(tier, &none, TierVocabulary::Concrete);
             assert_ne!(
                 &resolved, tier,
                 "`{tier}` must map to a concrete slug, not pass through"
@@ -1548,7 +1696,7 @@ mod tests {
             ("vision-v1", "qwen/qwen3.8-max"),
         ] {
             assert_eq!(
-                model_for_tier(tier, &none, false),
+                model_for_tier(tier, &none, TierVocabulary::Concrete),
                 expected,
                 "`{tier}` must resolve to the documented default `{expected}`"
             );
@@ -1561,34 +1709,167 @@ mod tests {
             BTreeMap::from([("chat-v1".to_string(), "anthropic/claude-haiku".to_string())]);
         // An operator's own entry is honoured verbatim on BOTH paths — they
         // named a specific model, and rewriting it is not this function's call.
-        for proxied in [false, true] {
+        for vocabulary in [
+            TierVocabulary::Concrete,
+            TierVocabulary::Tiers,
+            TierVocabulary::Unknown,
+        ] {
             assert_eq!(
-                model_for_tier("chat-v1", &overrides, proxied),
+                model_for_tier("chat-v1", &overrides, vocabulary),
                 "anthropic/claude-haiku"
             );
         }
         // An unmapped tier still takes the shipped default on the direct path.
         assert_eq!(
-            model_for_tier("reasoning-v1", &overrides, false),
+            model_for_tier("reasoning-v1", &overrides, TierVocabulary::Concrete),
             "openai/gpt-5.6-sol-pro"
         );
         // A caller naming a concrete slug is not treated as an unknown tier.
         assert_eq!(
-            model_for_tier("anthropic/claude-sonnet-4.5", &BTreeMap::new(), false),
+            model_for_tier(
+                "anthropic/claude-sonnet-4.5",
+                &BTreeMap::new(),
+                TierVocabulary::Concrete
+            ),
             "anthropic/claude-sonnet-4.5"
         );
     }
 
-    /// The proxied path keeps the tier name. The platform's registry routes on
-    /// it and pins each tier to a sub-provider; substituting a concrete slug
-    /// would bypass that pinning, and its passthrough namespace is opt-in and
-    /// off by default, so the slug would simply be rejected.
+    /// A tier-native endpoint keeps the tier name. The platform's registry
+    /// routes on it and pins each tier to a sub-provider; substituting a
+    /// concrete slug would bypass that pinning, and its passthrough namespace
+    /// is opt-in and off by default, so the slug would simply be rejected.
     #[test]
-    fn the_proxied_path_keeps_the_tier_name() {
+    fn a_tier_native_endpoint_keeps_the_tier_name() {
         let none = BTreeMap::new();
         for tier in crate::company::types::INFERENCE_TIERS {
-            assert_eq!(&model_for_tier(tier, &none, true), tier);
+            assert_eq!(&model_for_tier(tier, &none, TierVocabulary::Tiers), tier);
         }
+    }
+
+    /// The signal that answers "which of these is this provider?" — a catalog
+    /// publishing `agentic-v1` is telling us it resolves tiers itself. Nothing
+    /// here looks at a hostname: the same catalog served from anywhere
+    /// classifies the same way.
+    #[test]
+    fn a_catalog_publishing_tier_names_classifies_as_tier_native() {
+        assert_eq!(
+            TierVocabulary::from_catalog_ids([
+                "reasoning-v1",
+                "vision-v1",
+                "chat-v1",
+                "burst-v1",
+                "agentic-v1",
+                "coding-v1",
+                "whisper-v1",
+                "embedding-v1",
+            ]),
+            TierVocabulary::Tiers
+        );
+        // Three of four is still a tier-native provider — demanding a complete
+        // set would silently fall back to substitution for it.
+        assert_eq!(
+            TierVocabulary::from_catalog_ids(["chat-v1", "agentic-v1", "reasoning-v1"]),
+            TierVocabulary::Tiers
+        );
+    }
+
+    /// OpenRouter's catalog publishes the concrete ids and none of the tiers,
+    /// so it keeps the shipped substitution.
+    #[test]
+    fn a_catalog_publishing_the_shipped_ids_classifies_as_concrete() {
+        assert_eq!(
+            TierVocabulary::from_catalog_ids([
+                "anthropic/claude-opus-5",
+                "anthropic/claude-sonnet-5",
+                "openai/gpt-5.6-sol-pro",
+                "qwen/qwen3.8-max",
+                "meta-llama/llama-4",
+            ]),
+            TierVocabulary::Concrete
+        );
+    }
+
+    /// A catalog that publishes neither is `Unknown`, and `Unknown` supplies no
+    /// defaults at all. This is the half that broke the probe: the shipped ids
+    /// used to be applied to *every* non-proxied endpoint, so an operator ended
+    /// up with a four-entry mapping their provider had already told us it does
+    /// not publish.
+    #[test]
+    fn a_catalog_publishing_neither_vocabulary_offers_no_defaults() {
+        let vocabulary = TierVocabulary::from_catalog_ids(["llama3.1", "mistral-small"]);
+        assert_eq!(vocabulary, TierVocabulary::Unknown);
+        assert!(
+            vocabulary.tier_defaults().is_empty(),
+            "an endpoint whose catalog names none of our ids has no default we can honestly supply"
+        );
+        let none = BTreeMap::new();
+        assert_eq!(
+            model_for_tier("agentic-v1", &none, vocabulary),
+            "agentic-v1",
+            "the tier goes out unchanged, so the provider's 400 names a string the operator \
+             configured rather than an `anthropic/…` id they never typed"
+        );
+    }
+
+    /// The defaults each vocabulary implies, asserted against hardcoded values
+    /// rather than read back from the tables they come from — asserting a table
+    /// against itself would pass whatever the table said.
+    #[test]
+    fn tier_defaults_follow_the_vocabulary() {
+        assert_eq!(
+            TierVocabulary::Tiers.tier_defaults(),
+            BTreeMap::from([
+                ("chat-v1".to_string(), "chat-v1".to_string()),
+                ("reasoning-v1".to_string(), "reasoning-v1".to_string()),
+                ("agentic-v1".to_string(), "agentic-v1".to_string()),
+                ("vision-v1".to_string(), "vision-v1".to_string()),
+            ]),
+            "a tier-native provider resolves the tier itself, so identity is the mapping"
+        );
+        assert_eq!(
+            TierVocabulary::Concrete
+                .tier_defaults()
+                .get("agentic-v1")
+                .map(String::as_str),
+            Some("anthropic/claude-opus-5")
+        );
+    }
+
+    /// The pre-discovery fallback, and the reason discovery has to exist: a
+    /// tenant-keyed config is not proxied, so without a discovered answer it is
+    /// still guessed as `Concrete` — which is exactly the guess that failed
+    /// against a tier-native endpoint. Attaching the endpoint's own answer is
+    /// what changes it, and `is_proxied()` is untouched by that, because who
+    /// pays and what vocabulary is spoken are different facts.
+    #[test]
+    fn a_discovered_vocabulary_overrides_the_payer_derived_guess() {
+        let decl = decl_for_probe(
+            "openrouter",
+            Some(PLATFORM_BASE_URL),
+            Some("test-token"),
+            None,
+        );
+        assert!(!decl.is_proxied(), "a tenant key means the tenant pays");
+        assert_eq!(
+            decl.vocabulary(),
+            TierVocabulary::Concrete,
+            "the pre-discovery guess"
+        );
+        assert!(!decl.vocabulary_confirmed());
+
+        let decl = decl.with_vocabulary(Some(TierVocabulary::Tiers));
+        assert!(decl.vocabulary_confirmed());
+        assert_eq!(decl.vocabulary(), TierVocabulary::Tiers);
+        assert!(
+            !decl.is_proxied(),
+            "discovering the vocabulary must not move who is billed"
+        );
+        assert_eq!(
+            model_for_tier("agentic-v1", &decl.models, decl.vocabulary()),
+            "agentic-v1",
+            "the tier reaches a tier-native endpoint intact"
+        );
     }
 
     #[test]

--- a/src/company/inference.rs
+++ b/src/company/inference.rs
@@ -173,21 +173,64 @@ pub const DEFAULT_TIER_MODELS: &[(&str, &str)] = &[
 /// guessable: see [`TierVocabulary::from_catalog_ids`]. Nothing here keys off a
 /// hostname — a provider that publishes `agentic-v1` is telling us it resolves
 /// tiers itself, whoever it is.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TierVocabulary {
     /// The endpoint publishes the tier names themselves, so it resolves a tier
     /// against its own registry. Send the tier verbatim — substituting a
     /// concrete id bypasses that routing and, on the platform proxy, is
     /// rejected outright unless passthrough is switched on.
     Tiers,
-    /// The endpoint publishes the concrete ids [`DEFAULT_TIER_MODELS`] names, so
-    /// a bare tier would 400 and the shipped mapping is the right default.
-    Concrete,
+    /// The endpoint publishes ids [`DEFAULT_TIER_MODELS`] names, so a bare tier
+    /// would 400 and the shipped mapping is the right default — **for the tiers
+    /// it actually publishes**, which is what the payload records.
+    Concrete(ConcreteTiers),
     /// The endpoint's catalog was read and publishes neither vocabulary. We know
     /// the shipped ids are *absent* from it, so applying them would be a guess
     /// already contradicted by evidence.
     Unknown,
+}
+
+/// Which of [`DEFAULT_TIER_MODELS`]' four ids an endpoint's catalog publishes,
+/// one bit per tier in `DEFAULT_TIER_MODELS` order.
+///
+/// [`TierVocabulary::Concrete`] used to be a bare marker, and that lost the
+/// distinction this type exists for. *Classification* is `any` — one shipped id
+/// present is enough to say "this endpoint speaks OpenRouter's catalog" — but
+/// *substitution* is per tier, and the two are not the same question. A partial
+/// mirror publishing `anthropic/claude-sonnet-5` and nothing else was
+/// classified `Concrete` and then handed `openai/gpt-5.6-sol-pro` for
+/// `reasoning-v1`: an id that very catalog had just said it does not serve.
+/// That is this PR's own defect one level down, and it has to fail the same
+/// way — [`model_for_tier`] leaves an unpublished tier alone rather than
+/// synthesizing an id against evidence we already hold.
+///
+/// A bitmask rather than a set, so the enum stays `Copy` and allocation-free:
+/// it rides on [`InferenceDecl`], which is cloned on every turn.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ConcreteTiers(u8);
+
+impl ConcreteTiers {
+    /// Every shipped tier — the pre-discovery assumption, and the truth for
+    /// OpenRouter itself, whose registry is where these four ids come from.
+    pub fn all() -> Self {
+        Self((1u8 << DEFAULT_TIER_MODELS.len()) - 1)
+    }
+
+    /// Does this endpoint publish the shipped id for `tier`?
+    pub fn publishes(self, tier: &str) -> bool {
+        DEFAULT_TIER_MODELS
+            .iter()
+            .position(|(name, _)| *name == tier)
+            .is_some_and(|index| self.0 & (1u8 << index) != 0)
+    }
+
+    fn with(self, index: usize) -> Self {
+        Self(self.0 | (1u8 << index))
+    }
+
+    fn is_empty(self) -> bool {
+        self.0 == 0
+    }
 }
 
 impl TierVocabulary {
@@ -198,6 +241,12 @@ impl TierVocabulary {
     /// `any` rather than `all` on purpose — a provider that publishes three of
     /// the four tiers still speaks tiers, and demanding a complete set would
     /// silently fall back to substitution for it.
+    ///
+    /// [`Self::Concrete`] is reached on `any` too, for the same reason, but it
+    /// carries **which** shipped ids were actually seen rather than implying all
+    /// four: a partial mirror is still an OpenRouter-vocabulary endpoint, and
+    /// the tiers it does not publish simply have no default to substitute. See
+    /// [`ConcreteTiers`].
     pub fn from_catalog_ids<'a>(ids: impl IntoIterator<Item = &'a str>) -> Self {
         let ids: std::collections::HashSet<&str> = ids.into_iter().collect();
         if crate::company::types::INFERENCE_TIERS
@@ -206,20 +255,27 @@ impl TierVocabulary {
         {
             return Self::Tiers;
         }
-        if DEFAULT_TIER_MODELS
-            .iter()
-            .any(|(_, model)| ids.contains(model))
-        {
-            return Self::Concrete;
+        let published = DEFAULT_TIER_MODELS.iter().enumerate().fold(
+            ConcreteTiers::default(),
+            |acc, (index, (_, model))| {
+                if ids.contains(model) {
+                    acc.with(index)
+                } else {
+                    acc
+                }
+            },
+        );
+        if published.is_empty() {
+            return Self::Unknown;
         }
-        Self::Unknown
+        Self::Concrete(published)
     }
 
     /// The wire/console label.
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Tiers => "tiers",
-            Self::Concrete => "concrete",
+            Self::Concrete(_) => "concrete",
             Self::Unknown => "unknown",
         }
     }
@@ -232,14 +288,19 @@ impl TierVocabulary {
     /// rather than prefill four ids the catalog has already told us are not
     /// there. Handing over a mapping we know is unusable is the failure this
     /// whole type exists to stop.
+    ///
+    /// For [`Self::Concrete`] the same rule applies **per tier**: a partial
+    /// mirror gets defaults for the tiers it publishes and nothing for the rest,
+    /// rather than four ids of which some are already known to be absent.
     pub fn tier_defaults(self) -> BTreeMap<String, String> {
         match self {
             Self::Tiers => crate::company::types::INFERENCE_TIERS
                 .iter()
                 .map(|tier| ((*tier).to_string(), (*tier).to_string()))
                 .collect(),
-            Self::Concrete => DEFAULT_TIER_MODELS
+            Self::Concrete(published) => DEFAULT_TIER_MODELS
                 .iter()
+                .filter(|(tier, _)| published.publishes(tier))
                 .map(|(tier, model)| ((*tier).to_string(), (*model).to_string()))
                 .collect(),
             Self::Unknown => BTreeMap::new(),
@@ -258,7 +319,11 @@ impl TierVocabulary {
 ///
 /// * [`TierVocabulary::Concrete`] — the endpoint publishes OpenRouter catalog
 ///   ids and has never heard of `chat-v1`, so the tier is resolved here or the
-///   request 400s.
+///   request 400s. Only for the tiers that endpoint's catalog actually
+///   publishes: a partial mirror gets substitution where it has been seen to
+///   work and the bare tier everywhere else, because sending an id the same
+///   catalog omitted is the very guess-against-evidence this module exists to
+///   stop (see [`ConcreteTiers`]).
 /// * [`TierVocabulary::Tiers`] — the endpoint resolves the tier itself against
 ///   its own registry, which is exactly what it wants; substituting would bypass
 ///   its per-tier provider pinning.
@@ -277,12 +342,14 @@ pub fn model_for_tier(
         return mapped.clone();
     }
     match vocabulary {
-        TierVocabulary::Concrete => DEFAULT_TIER_MODELS
+        TierVocabulary::Concrete(published) if published.publishes(tier) => DEFAULT_TIER_MODELS
             .iter()
             .find(|(name, _)| *name == tier)
             .map(|(_, model)| (*model).to_string())
             .unwrap_or_else(|| tier.to_string()),
-        TierVocabulary::Tiers | TierVocabulary::Unknown => tier.to_string(),
+        TierVocabulary::Concrete(_) | TierVocabulary::Tiers | TierVocabulary::Unknown => {
+            tier.to_string()
+        }
     }
 }
 
@@ -439,11 +506,16 @@ impl InferenceDecl {
     /// exists — but keeping it as the fallback means an endpoint whose catalog
     /// cannot be read behaves exactly as it did before, rather than changing
     /// behaviour on a network failure.
+    ///
+    /// The un-discovered `Concrete` guess assumes **all four** shipped ids —
+    /// `ConcreteTiers::all()` — which is exactly what the pre-discovery code
+    /// did, and true of OpenRouter itself. Narrowing a tier only ever happens
+    /// on evidence from a catalog that was actually read.
     pub fn vocabulary(&self) -> TierVocabulary {
         self.vocabulary.unwrap_or(if self.proxied {
             TierVocabulary::Tiers
         } else {
-            TierVocabulary::Concrete
+            TierVocabulary::Concrete(ConcreteTiers::all())
         })
     }
 
@@ -1667,7 +1739,8 @@ mod tests {
     fn every_tier_resolves_to_a_concrete_model_id_on_the_direct_path() {
         let none = BTreeMap::new();
         for tier in crate::company::types::INFERENCE_TIERS {
-            let resolved = model_for_tier(tier, &none, TierVocabulary::Concrete);
+            let resolved =
+                model_for_tier(tier, &none, TierVocabulary::Concrete(ConcreteTiers::all()));
             assert_ne!(
                 &resolved, tier,
                 "`{tier}` must map to a concrete slug, not pass through"
@@ -1696,7 +1769,7 @@ mod tests {
             ("vision-v1", "qwen/qwen3.8-max"),
         ] {
             assert_eq!(
-                model_for_tier(tier, &none, TierVocabulary::Concrete),
+                model_for_tier(tier, &none, TierVocabulary::Concrete(ConcreteTiers::all())),
                 expected,
                 "`{tier}` must resolve to the documented default `{expected}`"
             );
@@ -1710,7 +1783,7 @@ mod tests {
         // An operator's own entry is honoured verbatim on BOTH paths — they
         // named a specific model, and rewriting it is not this function's call.
         for vocabulary in [
-            TierVocabulary::Concrete,
+            TierVocabulary::Concrete(ConcreteTiers::all()),
             TierVocabulary::Tiers,
             TierVocabulary::Unknown,
         ] {
@@ -1721,7 +1794,11 @@ mod tests {
         }
         // An unmapped tier still takes the shipped default on the direct path.
         assert_eq!(
-            model_for_tier("reasoning-v1", &overrides, TierVocabulary::Concrete),
+            model_for_tier(
+                "reasoning-v1",
+                &overrides,
+                TierVocabulary::Concrete(ConcreteTiers::all())
+            ),
             "openai/gpt-5.6-sol-pro"
         );
         // A caller naming a concrete slug is not treated as an unknown tier.
@@ -1729,7 +1806,7 @@ mod tests {
             model_for_tier(
                 "anthropic/claude-sonnet-4.5",
                 &BTreeMap::new(),
-                TierVocabulary::Concrete
+                TierVocabulary::Concrete(ConcreteTiers::all())
             ),
             "anthropic/claude-sonnet-4.5"
         );
@@ -1786,7 +1863,56 @@ mod tests {
                 "qwen/qwen3.8-max",
                 "meta-llama/llama-4",
             ]),
-            TierVocabulary::Concrete
+            TierVocabulary::Concrete(ConcreteTiers::all())
+        );
+    }
+
+    /// A **partial** OpenRouter mirror is still `Concrete`, but only for the ids
+    /// it actually publishes.
+    ///
+    /// Classification is `any` — one shipped id present is enough to say this
+    /// endpoint speaks OpenRouter's catalog — and that was once taken as licence
+    /// to substitute all four. A gateway mirroring only
+    /// `anthropic/claude-sonnet-5` was therefore handed `openai/gpt-5.6-sol-pro`
+    /// for `reasoning-v1`: an id that same catalog had just said it does not
+    /// serve. That is this module's own defect one level down, so it now fails
+    /// the same way — the unpublished tier goes out as the tier (Codex review
+    /// on #2045).
+    #[test]
+    fn a_partial_mirror_substitutes_only_the_ids_its_catalog_publishes() {
+        let vocabulary = TierVocabulary::from_catalog_ids([
+            "anthropic/claude-sonnet-5",
+            "some-gateway/unrelated-model",
+        ]);
+        assert_eq!(vocabulary.as_str(), "concrete");
+        assert_ne!(
+            vocabulary,
+            TierVocabulary::Concrete(ConcreteTiers::all()),
+            "one shipped id is not evidence for the other three"
+        );
+
+        let none = BTreeMap::new();
+        assert_eq!(
+            model_for_tier("chat-v1", &none, vocabulary),
+            "anthropic/claude-sonnet-5",
+            "the tier this catalog does publish is substituted exactly as before"
+        );
+        for absent in ["reasoning-v1", "agentic-v1", "vision-v1"] {
+            assert_eq!(
+                model_for_tier(absent, &none, vocabulary),
+                absent,
+                "`{absent}` is absent from this catalog, so synthesizing its shipped id would be \
+                 a guess the catalog has already contradicted"
+            );
+        }
+
+        assert_eq!(
+            vocabulary.tier_defaults(),
+            BTreeMap::from([(
+                "chat-v1".to_string(),
+                "anthropic/claude-sonnet-5".to_string()
+            )]),
+            "the console is offered defaults only for the tiers this endpoint publishes"
         );
     }
 
@@ -1828,7 +1954,7 @@ mod tests {
             "a tier-native provider resolves the tier itself, so identity is the mapping"
         );
         assert_eq!(
-            TierVocabulary::Concrete
+            TierVocabulary::Concrete(ConcreteTiers::all())
                 .tier_defaults()
                 .get("agentic-v1")
                 .map(String::as_str),
@@ -1853,7 +1979,7 @@ mod tests {
         assert!(!decl.is_proxied(), "a tenant key means the tenant pays");
         assert_eq!(
             decl.vocabulary(),
-            TierVocabulary::Concrete,
+            TierVocabulary::Concrete(ConcreteTiers::all()),
             "the pre-discovery guess"
         );
         assert!(!decl.vocabulary_confirmed());

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -1925,6 +1925,7 @@ impl TenantProvider {
         let vocabulary = crate::server::inference_models::discovered_vocabulary(
             &decl.base_url,
             bearer.as_deref(),
+            Some(self.company.as_ref()),
         )
         .await;
         Ok(decl.with_vocabulary(vocabulary))

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -1607,11 +1607,14 @@ pub async fn request_plan(
     tools: Vec<serde_json::Value>,
     tool_choice: &ToolChoice,
 ) -> anyhow::Result<RequestPlan> {
-    // Tier -> what this endpoint understands. The direct path talks to
-    // OpenRouter, which has never heard of `chat-v1`, so the tier is resolved
-    // here; the proxied path keeps the tier, which is what the platform's
-    // registry routes on.
-    let model = inference::model_for_tier(abstract_model, &decl.models, decl.is_proxied());
+    // Tier -> what this endpoint understands, read off the endpoint's own
+    // published catalog rather than off who is paying for it. `is_proxied()`
+    // used to stand in for this and is now only the fallback inside
+    // `vocabulary()`: a tenant-keyed config pointed at a tier-native endpoint is
+    // not proxied, and rewriting `chat-v1` to an OpenRouter slug for it is what
+    // produced `Model 'anthropic/claude-sonnet-5' is not available` against an
+    // endpoint that publishes `chat-v1` itself.
+    let model = inference::model_for_tier(abstract_model, &decl.models, decl.vocabulary());
     let url = format!("{}/chat/completions", decl.base_url.trim_end_matches('/'));
     let bearer = decl
         .bearer()
@@ -1911,7 +1914,20 @@ impl TenantProvider {
         .map_err(|e| anyhow::anyhow!("resolving inference config: {e}"))?
         .ok_or_else(|| anyhow::anyhow!("no inference provider is configured for this company"))?;
         *self.slug.write().unwrap() = decl.telemetry_slug();
-        Ok(decl)
+        // Ask the endpoint what vocabulary it speaks before deciding whether to
+        // rewrite this turn's tier. Cached per endpoint for an hour (and per
+        // failure for a minute), so this is one extra request per provider per
+        // hour rather than one per turn — and it is a request to the same host
+        // the turn is about to call anyway. A catalog we cannot read leaves the
+        // decl on its pre-discovery fallback, i.e. exactly the behaviour that
+        // shipped before, rather than changing how turns resolve on a blip.
+        let bearer = decl.bearer().await.ok().flatten();
+        let vocabulary = crate::server::inference_models::discovered_vocabulary(
+            &decl.base_url,
+            bearer.as_deref(),
+        )
+        .await;
+        Ok(decl.with_vocabulary(vocabulary))
     }
 }
 
@@ -4152,6 +4168,72 @@ mod tests {
         .await
         .expect("plan");
         assert_eq!(explicit.model, "anthropic/claude-sonnet-4.5");
+    }
+
+    /// The live defect, at the layer that puts the string on the wire.
+    ///
+    /// A company on `provider = "openrouter"` with its own key against a
+    /// tier-native endpoint is **not proxied** — the tenant pays. The old rule
+    /// read the vocabulary off exactly that bit, so every tier was rewritten to
+    /// an OpenRouter slug and the endpoint answered `Model
+    /// 'anthropic/claude-sonnet-5' is not available`, naming an id nobody had
+    /// chosen. With the endpoint's own catalog consulted, the tier reaches it
+    /// intact — and who is billed is unchanged, because that was never the same
+    /// question.
+    #[tokio::test]
+    async fn request_plan_keeps_the_tier_for_a_tier_native_endpoint_on_a_tenant_key() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        let mut manifest = manifest_inference("openrouter");
+        manifest.base_url = Some(crate::company::inference::PLATFORM_BASE_URL.into());
+        inference::store_key(&company, &secrets, "test-token")
+            .await
+            .unwrap();
+        let decl = inference::resolve_effective(&company, &manifest, None, &secrets)
+            .await
+            .unwrap()
+            .expect("a keyed openrouter config resolves");
+        assert!(!decl.is_proxied(), "a tenant key means the tenant pays");
+
+        // Pre-discovery: the payer-derived guess, which is what shipped.
+        let guessed = request_plan(
+            &decl,
+            "agentic-v1",
+            Vec::new(),
+            0.0,
+            None,
+            Vec::new(),
+            &ToolChoice::Auto,
+        )
+        .await
+        .expect("plan");
+        assert_eq!(
+            guessed.model, "anthropic/claude-opus-5",
+            "unchanged fallback when no catalog could be read"
+        );
+
+        // The endpoint published `agentic-v1`, so it resolves tiers itself.
+        let discovered =
+            decl.with_vocabulary(Some(crate::company::inference::TierVocabulary::Tiers));
+        let plan = request_plan(
+            &discovered,
+            "agentic-v1",
+            Vec::new(),
+            0.0,
+            None,
+            Vec::new(),
+            &ToolChoice::Auto,
+        )
+        .await
+        .expect("plan");
+        assert_eq!(
+            plan.model, "agentic-v1",
+            "the tier the provider publishes goes out as the tier"
+        );
+        assert!(
+            !discovered.is_proxied(),
+            "discovering the vocabulary must not re-bill the company"
+        );
     }
 
     #[tokio::test]

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -1900,6 +1900,28 @@ impl TenantProvider {
         &self.scope.id
     }
 
+    /// The scope an authenticated catalog read on this provider's behalf is
+    /// cached under.
+    ///
+    /// Company **and** harness, not company alone. `resolve_effective_scoped`
+    /// resolves config and credentials per [`inference::HarnessScope`] — that
+    /// is exactly what lets one `built_in` harness ride the subscription while
+    /// another runs on a key of its own — so two harnesses in one company can
+    /// present different credentials to the same endpoint. Keyed on the company
+    /// only, the first harness's entitlement-scoped catalog was reused for the
+    /// second for an hour without its credential ever being presented, and the
+    /// second could then be handed a vocabulary its own key does not reach
+    /// (Codex review on #2045).
+    ///
+    /// Both halves are non-secret ids, and neither is the credential or derived
+    /// from it — the invariant `catalog_registry` documents. The separator is
+    /// the same control character that module uses to join scope to endpoint,
+    /// which no id or URL can contain, so the three-field key cannot be spelled
+    /// two ways.
+    fn catalog_scope(&self) -> String {
+        format!("{}\u{1}{}", self.company.as_ref(), self.harness_id())
+    }
+
     /// Re-resolves the effective config from the secret store and updates the
     /// cached telemetry slug. Errors when no provider is configured at all.
     async fn resolve(&self) -> anyhow::Result<InferenceDecl> {
@@ -1915,17 +1937,25 @@ impl TenantProvider {
         .ok_or_else(|| anyhow::anyhow!("no inference provider is configured for this company"))?;
         *self.slug.write().unwrap() = decl.telemetry_slug();
         // Ask the endpoint what vocabulary it speaks before deciding whether to
-        // rewrite this turn's tier. Cached per endpoint for an hour (and per
-        // failure for a minute), so this is one extra request per provider per
-        // hour rather than one per turn — and it is a request to the same host
-        // the turn is about to call anyway. A catalog we cannot read leaves the
-        // decl on its pre-discovery fallback, i.e. exactly the behaviour that
-        // shipped before, rather than changing how turns resolve on a blip.
+        // rewrite this turn's tier. Cached per company, harness and endpoint for
+        // an hour (and per failure for a minute), so this is one extra request
+        // per provider per hour rather than one per turn — and it is a request
+        // to the same host the turn is about to call anyway.
+        //
+        // `turn_vocabulary`, not `discovered_vocabulary`: this is the turn path,
+        // whose callers time out in two to three seconds, so the read is spawned
+        // and only waited on for `TURN_CATALOG_BUDGET`. A `/models` slower than
+        // that leaves the decl on its pre-discovery fallback for this turn —
+        // exactly the behaviour that shipped before discovery existed — while
+        // the spawned read still finishes and records its answer for the next
+        // one. Awaiting it inline let a caller's own timeout cancel the read
+        // before it could memoize anything, so every later turn repeated it
+        // (Codex review on #2045).
         let bearer = decl.bearer().await.ok().flatten();
-        let vocabulary = crate::server::inference_models::discovered_vocabulary(
+        let vocabulary = crate::server::inference_models::turn_vocabulary(
             &decl.base_url,
             bearer.as_deref(),
-            Some(self.company.as_ref()),
+            Some(&self.catalog_scope()),
         )
         .await;
         Ok(decl.with_vocabulary(vocabulary))

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -1,18 +1,38 @@
-//! OpenAI-compatible model catalog discovery and the OpenRouter registry cache.
+//! OpenAI-compatible model catalog discovery, cached **per endpoint**.
 //!
 //! Both first-run setup and the inference settings picker consume the standard
 //! `{ "data": [{ "id": ... }] }` model-list shape. Keeping the fetch and parser
 //! here prevents setup from knowing only about the first entry while the picker
 //! grows a second interpretation of the same provider response.
+//!
+//! The cache used to be a single process-wide slot holding OpenRouter's public
+//! registry, because the picker route asked for that registry unconditionally —
+//! whatever endpoint the company had actually been pointed at. Discovery now
+//! follows the configured base URL, so the cache is a registry keyed on it: one
+//! entry per endpoint, each with its own single-flight lock, so two tenants on
+//! two providers neither share a catalog nor queue behind each other.
 
-use std::sync::{Mutex, OnceLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex as TokioMutex;
 
-/// How long a successful OpenRouter catalog stays fresh in this process.
+use crate::company::inference::TierVocabulary;
+
+/// How long a successful catalog stays fresh in this process.
 pub(crate) const MODEL_CATALOG_TTL: Duration = Duration::from_secs(60 * 60);
+
+/// How long a *failed* catalog read is remembered.
+///
+/// Much shorter than the success TTL, and it exists for a different reason: a
+/// failure that stored nothing meant every caller retried, so an unreachable
+/// provider cost a fresh [`MODEL_CATALOG_TIMEOUT`] on every status read and
+/// every turn that consulted the vocabulary. Remembering "this endpoint did not
+/// answer, a minute ago" turns that into one attempt a minute while staying
+/// short enough that a provider coming back up is picked up promptly.
+pub(crate) const MODEL_CATALOG_FAILURE_TTL: Duration = Duration::from_secs(60);
 
 /// Maximum time a console page-load waits for the registry on a cache miss.
 const MODEL_CATALOG_TIMEOUT: Duration = Duration::from_secs(10);
@@ -94,8 +114,9 @@ fn parse_models(payload: RegistryResponse) -> Vec<InferenceModel> {
 
 /// Fetch every model from an OpenAI-compatible `{base_url}/models` endpoint.
 ///
-/// `bearer` is used by local/custom setup probes; OpenRouter's public registry
-/// passes `None`.
+/// `bearer` is the credential the endpoint expects — the company's stored key
+/// for a tenant catalog read, `None` for a public registry (OpenRouter's) or a
+/// keyless local server.
 pub(crate) async fn discover_models(
     base_url: &str,
     bearer: Option<&str>,
@@ -105,8 +126,8 @@ pub(crate) async fn discover_models(
     // default timeout, so an endpoint that accepts the connection but never
     // responds would otherwise hold this open indefinitely. `setup.rs`'s
     // local/custom probe calls this directly (no wrapping timeout of its
-    // own), while `openrouter_models` below also wraps its call in
-    // `tokio::time::timeout` for a friendlier, registry-specific message.
+    // own), while `catalog_models` below also wraps its call in
+    // `tokio::time::timeout` for a friendlier, endpoint-naming message.
     let client = reqwest::Client::builder()
         .timeout(MODEL_CATALOG_TIMEOUT)
         .build()
@@ -133,19 +154,20 @@ struct CacheEntry {
     models: Vec<InferenceModel>,
 }
 
-/// Process-wide OpenRouter catalog cache.
+/// One endpoint's catalog cache.
 #[derive(Default)]
 pub(crate) struct ModelCatalogCache {
     entry: Mutex<Option<CacheEntry>>,
+    /// The last failure and when it happened — see [`MODEL_CATALOG_FAILURE_TTL`].
+    failure: Mutex<Option<(Instant, String)>>,
     /// Serializes cache-miss fetches (issue #1838 follow-up). Held across the
     /// whole `discover_models` await, not just the cache write: without it,
     /// every console request that lands after startup or a TTL expiry sees
     /// the same empty/stale entry and fires its own upstream fetch, so a
-    /// multi-tenant host can burst several identical OpenRouter registry
-    /// calls at once — and any of them that gets rate-limited fails even
-    /// though a sibling fetch is about to populate the cache. A `tokio`
-    /// mutex, not `std`: the guard needs to survive the `.await` inside
-    /// [`openrouter_models`].
+    /// multi-tenant host can burst several identical registry calls at once —
+    /// and any of them that gets rate-limited fails even though a sibling
+    /// fetch is about to populate the cache. A `tokio` mutex, not `std`: the
+    /// guard needs to survive the `.await` inside [`catalog_models`].
     fetch_lock: TokioMutex<()>,
 }
 
@@ -160,77 +182,160 @@ impl ModelCatalogCache {
         if let Ok(mut entry) = self.entry.lock() {
             *entry = Some(CacheEntry { at, models });
         }
+        // A success clears the failure memo: the endpoint is answering again,
+        // and leaving a stale "unreachable" behind would keep reporting it.
+        if let Ok(mut failure) = self.failure.lock() {
+            *failure = None;
+        }
+    }
+
+    /// The remembered failure, while it is still fresh.
+    pub(crate) fn lookup_failure(&self, now: Instant) -> Option<String> {
+        let failure = self.failure.lock().ok()?;
+        let (at, message) = failure.as_ref()?;
+        (now.saturating_duration_since(*at) < MODEL_CATALOG_FAILURE_TTL).then(|| message.clone())
+    }
+
+    pub(crate) fn store_failure(&self, message: String, at: Instant) {
+        if let Ok(mut failure) = self.failure.lock() {
+            *failure = Some((at, message));
+        }
     }
 }
 
-pub(crate) fn openrouter_cache() -> &'static ModelCatalogCache {
-    static CACHE: OnceLock<ModelCatalogCache> = OnceLock::new();
-    CACHE.get_or_init(ModelCatalogCache::default)
+/// The per-endpoint cache registry.
+///
+/// Keyed on the normalized base URL and **not** on the credential. A model
+/// catalog is a public property of an endpoint rather than of the key used to
+/// read it, and a credential must not become a map key — hashing one to key a
+/// cache would put a derivative of it in process memory next to the data it
+/// guards, for a partition nothing here needs. The cost is that two tenants
+/// sharing one endpoint share its catalog; the benefit is that a credential
+/// never leaves the paths that already handle it.
+fn catalog_registry() -> &'static Mutex<HashMap<String, Arc<ModelCatalogCache>>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, Arc<ModelCatalogCache>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Return the cached OpenRouter catalog, fetching it on a miss.
+/// Trailing slashes and surrounding space do not make a different endpoint.
+fn cache_key(base_url: &str) -> String {
+    base_url.trim().trim_end_matches('/').to_string()
+}
+
+/// This endpoint's cache, created on first use.
+pub(crate) fn catalog_cache(base_url: &str) -> Arc<ModelCatalogCache> {
+    let key = cache_key(base_url);
+    let mut registry = match catalog_registry().lock() {
+        Ok(registry) => registry,
+        // A poisoned registry must not take the catalog offline for the rest of
+        // the process: hand back an unshared cache, which costs this caller a
+        // fetch and nothing else.
+        Err(_) => return Arc::new(ModelCatalogCache::default()),
+    };
+    Arc::clone(registry.entry(key).or_default())
+}
+
+/// Return the cached catalog for `base_url`, fetching it on a miss.
 ///
-/// Single-flight on a miss (issue #1838 follow-up): every caller queues on
-/// [`ModelCatalogCache::fetch_lock`] rather than racing its own request to
-/// OpenRouter, and re-checks the cache after acquiring it, so only the first
-/// caller through actually fetches — everyone behind it reads what that
+/// Single-flight per endpoint (issue #1838 follow-up): every caller for one
+/// endpoint queues on its [`ModelCatalogCache::fetch_lock`] rather than racing
+/// its own request, and re-checks the cache after acquiring it, so only the
+/// first caller through actually fetches — everyone behind it reads what that
 /// fetch just stored instead of duplicating the upstream call.
 ///
 /// Bounded across the *whole* queue-wait-plus-fetch, not just the fetch
-/// itself (issue #1838 follow-up): a failed fetch stores nothing, so during
-/// a registry outage each queued caller would otherwise acquire the lock in
-/// turn and run its own fresh `MODEL_CATALOG_TIMEOUT`-bounded attempt — the
-/// Nth caller through the queue waiting roughly `N * MODEL_CATALOG_TIMEOUT`
-/// before ever finding out, breaking the "a console page-load waits at most
-/// [`MODEL_CATALOG_TIMEOUT`]" contract this module documents
-/// (`docs/spec/runtime/providers.md`). Wrapping the lock acquisition and the
-/// fetch in one `tokio::time::timeout` keeps every individual caller's own
-/// wall-clock budget fixed at `MODEL_CATALOG_TIMEOUT`, however many callers
-/// are already ahead of it in the queue.
-pub(crate) async fn openrouter_models() -> Result<Vec<InferenceModel>, String> {
+/// itself (issue #1838 follow-up): during an outage each queued caller would
+/// otherwise acquire the lock in turn and run its own fresh
+/// `MODEL_CATALOG_TIMEOUT`-bounded attempt — the Nth caller through the queue
+/// waiting roughly `N * MODEL_CATALOG_TIMEOUT` before ever finding out,
+/// breaking the "a console page-load waits at most [`MODEL_CATALOG_TIMEOUT`]"
+/// contract this module documents (`docs/spec/runtime/providers.md`). Wrapping
+/// the lock acquisition and the fetch in one `tokio::time::timeout` keeps every
+/// individual caller's own wall-clock budget fixed, however many callers are
+/// already ahead of it in the queue.
+///
+/// A failure is remembered for [`MODEL_CATALOG_FAILURE_TTL`] and replayed to
+/// callers within it, so an unreachable provider costs one attempt a minute
+/// rather than one per request.
+pub(crate) async fn catalog_models(
+    base_url: &str,
+    bearer: Option<&str>,
+) -> Result<Vec<InferenceModel>, String> {
+    let cache = catalog_cache(base_url);
     let now = Instant::now();
-    if let Some(models) = openrouter_cache().lookup(now) {
+    if let Some(models) = cache.lookup(now) {
         return Ok(models);
     }
+    if let Some(failure) = cache.lookup_failure(now) {
+        return Err(failure);
+    }
 
+    let endpoint = cache_key(base_url);
     let outcome = tokio::time::timeout(MODEL_CATALOG_TIMEOUT, async {
-        let _fetch_guard = openrouter_cache().fetch_lock.lock().await;
+        let _fetch_guard = cache.fetch_lock.lock().await;
         // Another caller may have already refilled the cache while we waited
         // for the lock — re-check before fetching again.
         let now = Instant::now();
-        if let Some(models) = openrouter_cache().lookup(now) {
+        if let Some(models) = cache.lookup(now) {
             return Ok(models);
         }
+        if let Some(failure) = cache.lookup_failure(now) {
+            return Err(FetchError::Failed(failure));
+        }
 
-        let mut models = discover_models(crate::company::inference::OPENROUTER_BASE_URL, None)
+        let mut models = discover_models(base_url, bearer)
             .await
             .map_err(FetchError::Failed)?;
         if models.is_empty() {
-            return Err(FetchError::Failed(
-                "OpenRouter's model registry returned no models".to_string(),
-            ));
+            return Err(FetchError::Failed(format!(
+                "{endpoint} published an empty model catalog"
+            )));
         }
         // Sorted here, not in `parse_models`: this is the operator-facing
         // catalog picker's own copy, while `parse_models` also serves
         // `setup.rs`'s local/custom probe, which relies on provider order.
         models.sort_by(|a, b| a.id.cmp(&b.id));
-        openrouter_cache().store(models.clone(), now);
+        cache.store(models.clone(), now);
         Ok(models)
     })
     .await;
 
-    match outcome {
-        Ok(Ok(models)) => Ok(models),
-        Ok(Err(FetchError::Failed(message))) => Err(message),
-        Err(_elapsed) => Err(format!(
-            "OpenRouter's model registry did not answer within {} seconds",
+    let result = match outcome {
+        Ok(Ok(models)) => return Ok(models),
+        Ok(Err(FetchError::Failed(message))) => message,
+        Err(_elapsed) => format!(
+            "{endpoint} did not answer within {} seconds",
             MODEL_CATALOG_TIMEOUT.as_secs()
-        )),
-    }
+        ),
+    };
+    cache.store_failure(result.clone(), Instant::now());
+    Err(result)
+}
+
+/// What vocabulary `base_url` speaks, or `None` when its catalog cannot be read.
+///
+/// `None` is deliberately not [`TierVocabulary::Unknown`]: "the endpoint told us
+/// it publishes neither vocabulary" and "we could not ask" are different facts
+/// and lead to different operator advice, so the caller keeps its pre-discovery
+/// fallback for the second rather than acting on an answer nobody gave.
+// Both consumers — the turn path (`TenantProvider::resolve`) and the console
+// probe (`test_config`) — live behind the `openhuman` feature, so a default
+// build compiles this and calls it from nowhere. Gating the function itself
+// would put a second `cfg` on a pure, feature-independent helper and make the
+// two builds disagree about what this module offers.
+#[cfg_attr(not(feature = "openhuman"), allow(dead_code))]
+pub(crate) async fn discovered_vocabulary(
+    base_url: &str,
+    bearer: Option<&str>,
+) -> Option<TierVocabulary> {
+    let models = catalog_models(base_url, bearer).await.ok()?;
+    Some(TierVocabulary::from_catalog_ids(
+        models.iter().map(|model| model.id.as_str()),
+    ))
 }
 
 /// Distinguishes "the fetch itself failed" from the outer
-/// [`tokio::time::timeout`] elapsing in [`openrouter_models`], since both
+/// [`tokio::time::timeout`] elapsing in [`catalog_models`], since both
 /// have to report through the same `Result` and the outer timeout's own
 /// message must win regardless of which inner step it interrupted.
 enum FetchError {
@@ -366,11 +471,72 @@ mod tests {
         assert_eq!(cache.lookup(stored_at + MODEL_CATALOG_TTL), None);
     }
 
+    /// A failure used to store nothing, so an unreachable provider cost a fresh
+    /// `MODEL_CATALOG_TIMEOUT` on every request that consulted it — once per
+    /// status read and, now that the turn path consults the vocabulary, once
+    /// per turn. Remembering it briefly turns that into one attempt a minute.
+    #[test]
+    fn a_failure_is_remembered_briefly_and_cleared_by_the_next_success() {
+        let cache = ModelCatalogCache::default();
+        let failed_at = Instant::now();
+        cache.store_failure("provider.example did not answer".to_string(), failed_at);
+
+        assert_eq!(
+            cache.lookup_failure(failed_at + MODEL_CATALOG_FAILURE_TTL - Duration::from_secs(1)),
+            Some("provider.example did not answer".to_string()),
+        );
+        assert_eq!(
+            cache.lookup_failure(failed_at + MODEL_CATALOG_FAILURE_TTL),
+            None,
+            "the memo expires far sooner than a success, so a provider coming back up is \
+             picked up promptly"
+        );
+
+        cache.store_failure("still down".to_string(), Instant::now());
+        let recovered_at = Instant::now();
+        cache.store(vec![model("vendor/model")], recovered_at);
+        assert_eq!(
+            cache.lookup_failure(recovered_at),
+            None,
+            "a success clears the memo — leaving it would keep reporting an outage that ended"
+        );
+    }
+
+    /// The seam the turn path and the probe both read: a cached catalog answers
+    /// the vocabulary question with no request of its own.
+    #[tokio::test]
+    async fn a_cached_catalog_answers_the_vocabulary_question() {
+        const ENDPOINT: &str = "https://vocabulary.example/v1";
+        catalog_cache(ENDPOINT).store(vec![model("agentic-v1"), model("chat-v1")], Instant::now());
+        assert_eq!(
+            discovered_vocabulary(ENDPOINT, None).await,
+            Some(TierVocabulary::Tiers)
+        );
+    }
+
+    /// Two endpoints are two caches. A single process-wide slot is what let one
+    /// company's catalog answer for another's endpoint in the first place.
+    #[test]
+    fn each_endpoint_gets_its_own_cache_and_trailing_slashes_do_not_split_one() {
+        let a = catalog_cache("https://a.example/v1");
+        let b = catalog_cache("https://b.example/v1");
+        let now = Instant::now();
+        a.store(vec![model("a-only")], now);
+
+        assert_eq!(a.lookup(now), Some(vec![model("a-only")]));
+        assert_eq!(b.lookup(now), None, "b must not inherit a's catalog");
+        assert_eq!(
+            catalog_cache("https://a.example/v1/").lookup(now),
+            Some(vec![model("a-only")]),
+            "a trailing slash is the same endpoint"
+        );
+    }
+
     /// Regression for a P2 review finding on #1838's follow-up round: without
     /// `fetch_lock`, every concurrent caller that observed the same
     /// empty/stale entry would independently "fetch" — a multi-tenant host
     /// bursting several identical upstream calls at once. This exercises the
-    /// exact lock-then-recheck sequence [`openrouter_models`] runs (acquire
+    /// exact lock-then-recheck sequence [`catalog_models`] runs (acquire
     /// `fetch_lock`, re-`lookup`, only then do the (here, simulated) fetch),
     /// against the real `ModelCatalogCache`, so a regression that drops the
     /// lock or the re-check fails this test rather than only showing up as
@@ -429,7 +595,7 @@ mod tests {
     /// through the queue waiting roughly `N * bound` before ever finding out,
     /// which is exactly the docs/spec/runtime/providers.md "at most
     /// `MODEL_CATALOG_TIMEOUT` seconds" promise this test defends. Mirrors
-    /// `openrouter_models`'s real composition (`tokio::time::timeout` wrapped
+    /// `catalog_models`'s real composition (`tokio::time::timeout` wrapped
     /// around lock-acquire + recheck + fetch) against the real
     /// `ModelCatalogCache`, with a simulated fetch standing in for
     /// `discover_models` so the assertion is deterministic instead of racing

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -112,6 +112,53 @@ fn parse_models(payload: RegistryResponse) -> Vec<InferenceModel> {
     models
 }
 
+/// Why a catalog read failed, and — the part that matters to the cache —
+/// whether the answer was about the **endpoint** or about the **credential**.
+///
+/// The negative memo in [`catalog_models`] is keyed on the endpoint alone, the
+/// same as the positive one. That is right for "this endpoint did not answer":
+/// every caller reaching it gets the same result, and remembering it turns an
+/// outage into one attempt a minute instead of one per request. It is *wrong*
+/// for a `401`/`403`, which is a fact about the key that was presented and not
+/// about the endpoint — on a multi-company host, memoizing one company's bad
+/// key would make a second company on the same endpoint read the first's
+/// rejection back out of the cache and fall to the pre-discovery guess without
+/// ever presenting its own valid credential. It would also make a company that
+/// has just rotated a bad key wait out the memo before its good one is tried.
+///
+/// So credential-specific failures are reported and **not** remembered. The
+/// cost of not memoizing them is small in exactly the way that matters: an
+/// auth rejection is a fast round trip, not the [`MODEL_CATALOG_TIMEOUT`] hang
+/// the memo exists to stop paying for repeatedly.
+#[derive(Debug)]
+pub(crate) struct DiscoveryError {
+    message: String,
+    /// `true` for `401`/`403` — an answer about the presented key.
+    credential_specific: bool,
+}
+
+impl DiscoveryError {
+    fn endpoint(message: String) -> Self {
+        Self {
+            message,
+            credential_specific: false,
+        }
+    }
+
+    fn credential(message: String) -> Self {
+        Self {
+            message,
+            credential_specific: true,
+        }
+    }
+}
+
+impl std::fmt::Display for DiscoveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
 /// Fetch every model from an OpenAI-compatible `{base_url}/models` endpoint.
 ///
 /// `bearer` is the credential the endpoint expects — the company's stored key
@@ -120,7 +167,7 @@ fn parse_models(payload: RegistryResponse) -> Vec<InferenceModel> {
 pub(crate) async fn discover_models(
     base_url: &str,
     bearer: Option<&str>,
-) -> Result<Vec<InferenceModel>, String> {
+) -> Result<Vec<InferenceModel>, DiscoveryError> {
     let url = format!("{}/models", base_url.trim_end_matches('/'));
     // Bounded here, not left to each caller: reqwest's async client has no
     // default timeout, so an endpoint that accepts the connection but never
@@ -131,7 +178,11 @@ pub(crate) async fn discover_models(
     let client = reqwest::Client::builder()
         .timeout(MODEL_CATALOG_TIMEOUT)
         .build()
-        .map_err(|error| format!("failed to build the model-discovery client: {error}"))?;
+        .map_err(|error| {
+            DiscoveryError::endpoint(format!(
+                "failed to build the model-discovery client: {error}"
+            ))
+        })?;
     let mut request = client.get(&url);
     if let Some(bearer) = bearer.filter(|bearer| !bearer.trim().is_empty()) {
         request = request.bearer_auth(bearer);
@@ -139,13 +190,22 @@ pub(crate) async fn discover_models(
     let response = request
         .send()
         .await
-        .map_err(|error| format!("request to {url} failed: {error}"))?
-        .error_for_status()
-        .map_err(|error| format!("request to {url} failed: {error}"))?;
-    let payload = response
-        .json::<RegistryResponse>()
-        .await
-        .map_err(|error| format!("model catalog from {url} was invalid: {error}"))?;
+        .map_err(|error| DiscoveryError::endpoint(format!("request to {url} failed: {error}")))?;
+    let status = response.status();
+    let response = response.error_for_status().map_err(|error| {
+        let message = format!("request to {url} failed: {error}");
+        if matches!(
+            status,
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+        ) {
+            DiscoveryError::credential(message)
+        } else {
+            DiscoveryError::endpoint(message)
+        }
+    })?;
+    let payload = response.json::<RegistryResponse>().await.map_err(|error| {
+        DiscoveryError::endpoint(format!("model catalog from {url} was invalid: {error}"))
+    })?;
     Ok(parse_models(payload))
 }
 
@@ -283,9 +343,13 @@ pub(crate) async fn catalog_models(
             return Err(FetchError::Failed(failure));
         }
 
-        let mut models = discover_models(base_url, bearer)
-            .await
-            .map_err(FetchError::Failed)?;
+        let mut models = discover_models(base_url, bearer).await.map_err(|error| {
+            if error.credential_specific {
+                FetchError::Credential(error.to_string())
+            } else {
+                FetchError::Failed(error.to_string())
+            }
+        })?;
         if models.is_empty() {
             return Err(FetchError::Failed(format!(
                 "{endpoint} published an empty model catalog"
@@ -302,6 +366,13 @@ pub(crate) async fn catalog_models(
 
     let result = match outcome {
         Ok(Ok(models)) => return Ok(models),
+        // An answer about the key that was presented, not about the endpoint.
+        // Reported, never remembered — see [`DiscoveryError`]: memoizing it on
+        // an endpoint key would hand one company's rejection to the next
+        // company reaching the same endpoint with a different credential, and
+        // would make a company that has just rotated a bad key wait the memo
+        // out before its good one is ever tried.
+        Ok(Err(FetchError::Credential(message))) => return Err(message),
         Ok(Err(FetchError::Failed(message))) => message,
         Err(_elapsed) => format!(
             "{endpoint} did not answer within {} seconds",
@@ -340,6 +411,9 @@ pub(crate) async fn discovered_vocabulary(
 /// message must win regardless of which inner step it interrupted.
 enum FetchError {
     Failed(String),
+    /// A `401`/`403` — about the credential presented, not the endpoint, so it
+    /// is reported to this caller and never written to the endpoint's memo.
+    Credential(String),
 }
 
 #[cfg(test)]
@@ -511,6 +585,41 @@ mod tests {
         assert_eq!(
             discovered_vocabulary(ENDPOINT, None).await,
             Some(TierVocabulary::Tiers)
+        );
+    }
+
+    /// A credential-specific rejection is reported and **not** remembered.
+    ///
+    /// The negative memo is keyed on the endpoint, which is right for "this
+    /// endpoint did not answer" and wrong for "this key was rejected". On a
+    /// multi-company host the second would let one company's bad key answer for
+    /// the next company reaching the same endpoint with a valid one, and would
+    /// make a company that has just rotated a bad key wait the memo out before
+    /// its good key is ever presented (Codex review on #2045).
+    ///
+    /// Asserted at the seam rather than over the network: the classification
+    /// lives in [`DiscoveryError`], and [`catalog_models`] is what must not
+    /// write a `Credential` failure into the endpoint's memo.
+    #[test]
+    fn a_credential_rejection_is_not_written_to_the_endpoints_failure_memo() {
+        const ENDPOINT: &str = "https://rejects-one-key.example/v1";
+        let cache = catalog_cache(ENDPOINT);
+        let now = Instant::now();
+        assert_eq!(cache.lookup_failure(now), None, "nothing remembered yet");
+
+        // What an endpoint-level failure does: it is remembered, so an outage
+        // costs one attempt a minute rather than one per request.
+        cache.store_failure(format!("{ENDPOINT} did not answer within 10 seconds"), now);
+        assert!(cache.lookup_failure(now).is_some());
+
+        // And the classification that keeps a 401 out of that path.
+        assert!(
+            DiscoveryError::credential("401 Unauthorized".to_string()).credential_specific,
+            "a 401 is an answer about the key, not about the endpoint"
+        );
+        assert!(
+            !DiscoveryError::endpoint("connection refused".to_string()).credential_specific,
+            "a transport failure is an answer about the endpoint, and is memoized"
         );
     }
 

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -44,6 +44,23 @@ pub(crate) const MODEL_CATALOG_FAILURE_TTL: Duration = Duration::from_secs(60);
 /// Maximum time a console page-load waits for the registry on a cache miss.
 const MODEL_CATALOG_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Maximum time a **turn** waits for a cold catalog before falling back.
+///
+/// A console page-load can afford [`MODEL_CATALOG_TIMEOUT`]; a turn cannot.
+/// Production triage wraps `ChatModel::invoke` in a two-second timeout
+/// (`src/harness/built_in/triage.rs`), and the selector and title paths use
+/// three. Discovery on the turn path inheriting the console's ten-second budget
+/// would therefore consume the caller's entire deadline before the model
+/// request was ever sent — at an endpoint whose `/chat/completions` is
+/// perfectly healthy and only whose `/models` is slow (Codex review on #2045).
+///
+/// Shorter than the tightest of those deadlines on purpose, so a slow catalog
+/// costs a turn a fraction of its budget rather than all of it. A healthy
+/// endpoint answers `/models` well inside this: it is the same host the turn is
+/// about to call anyway, and the result is then cached for an hour, so this
+/// budget is paid at most once per company per endpoint per hour.
+pub(crate) const TURN_CATALOG_BUDGET: Duration = Duration::from_millis(750);
+
 /// One model exposed to the operator console.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -456,6 +473,53 @@ pub(crate) async fn discovered_vocabulary(
     ))
 }
 
+/// [`discovered_vocabulary`] on a budget a **turn** can afford.
+///
+/// The read is *spawned* rather than awaited inline, and only the waiting is
+/// bounded. That separation is the whole point. A turn's callers impose their
+/// own, much tighter deadlines — triage two seconds, selector and title three —
+/// and when one of them elapses it **cancels** whatever `invoke` was awaiting.
+/// An inline `catalog_models` therefore got dropped mid-flight, which meant the
+/// failure memo that exists to stop the *next* caller paying the same cost was
+/// never written: every subsequent auxiliary call started the same doomed
+/// ten-second read and died the same way (Codex review on #2045).
+///
+/// A spawned task outlives that cancellation. Whoever gives up first, the read
+/// runs to completion on its own and records what it found — a catalog in the
+/// cache, or a failure in the memo that suppresses retries for
+/// [`MODEL_CATALOG_FAILURE_TTL`]. So a slow `/models` costs each turn at most
+/// [`TURN_CATALOG_BUDGET`] once, rather than every turn its whole deadline
+/// forever.
+///
+/// `None` means "no answer within the budget", which the caller treats exactly
+/// as it treats an unreadable catalog: keep the pre-discovery fallback. That is
+/// the behaviour that shipped before discovery existed, so a slow catalog
+/// degrades to the old guess for one turn rather than breaking the turn.
+#[cfg_attr(not(feature = "openhuman"), allow(dead_code))]
+pub(crate) async fn turn_vocabulary(
+    base_url: &str,
+    bearer: Option<&str>,
+    scope: Option<&str>,
+) -> Option<TierVocabulary> {
+    // Owned, because the task has to be able to outlive this future — which is
+    // the entire reason it is spawned. The bearer lives in process memory for
+    // the duration of the read and, as everywhere else in this module, never
+    // reaches a cache key.
+    let base_url = base_url.to_string();
+    let bearer = bearer.map(str::to_string);
+    let scope = scope.map(str::to_string);
+    let read = tokio::spawn(async move {
+        discovered_vocabulary(&base_url, bearer.as_deref(), scope.as_deref()).await
+    });
+    match tokio::time::timeout(TURN_CATALOG_BUDGET, read).await {
+        Ok(Ok(vocabulary)) => vocabulary,
+        // Elapsed, or the task panicked. Either way this turn falls back; a
+        // task that merely ran out of *our* patience is still running and will
+        // have filled the cache or the memo before the next turn asks.
+        Ok(Err(_)) | Err(_) => None,
+    }
+}
+
 /// Distinguishes "the fetch itself failed" from the outer
 /// [`tokio::time::timeout`] elapsing in [`catalog_models`], since both
 /// have to report through the same `Result` and the outer timeout's own
@@ -477,6 +541,52 @@ mod tests {
             name: None,
             context_length: None,
         }
+    }
+
+    /// A turn gives up on a hanging `/models` inside its own budget, not the
+    /// console's.
+    ///
+    /// The endpoint here accepts the connection and never answers — the case
+    /// that matters, because a refused connection fails fast and costs nobody
+    /// anything. Production triage allows `invoke` two seconds end to end and
+    /// the selector and title paths three, so a discovery that waited out
+    /// `MODEL_CATALOG_TIMEOUT` consumed the caller's whole deadline before the
+    /// model request was ever sent, at an endpoint whose `/chat/completions`
+    /// may be perfectly healthy (Codex review on #2045).
+    ///
+    /// Asserted as a band rather than an exact figure: the floor proves the
+    /// budget is actually waited out rather than the call failing instantly for
+    /// some unrelated reason, and the ceiling proves it is the *turn's* budget
+    /// being honoured and not the console's.
+    #[tokio::test]
+    async fn a_turn_stops_waiting_for_a_hanging_catalog_within_its_own_budget() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}/v1", listener.local_addr().unwrap());
+        // Accepted connections are held, never answered. Kept in a task that
+        // owns them so nothing is closed early and turned into a fast failure.
+        let _accepting = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+
+        let started = Instant::now();
+        let vocabulary = turn_vocabulary(&endpoint, None, None).await;
+        let waited = started.elapsed();
+
+        assert_eq!(
+            vocabulary, None,
+            "an endpoint that never answers leaves the caller on its pre-discovery fallback"
+        );
+        assert!(
+            waited >= TURN_CATALOG_BUDGET,
+            "expected the budget to be waited out, gave up after {waited:?}"
+        );
+        assert!(
+            waited < MODEL_CATALOG_TIMEOUT,
+            "a turn must not inherit the console's {MODEL_CATALOG_TIMEOUT:?} budget, waited {waited:?}"
+        );
     }
 
     #[test]
@@ -682,6 +792,48 @@ mod tests {
         assert_eq!(
             catalog_cache_scoped(PUBLIC, None).lookup(now),
             Some(vec![model("vendor/public")])
+        );
+    }
+
+    /// The partition goes one level finer than the company: per **harness**.
+    ///
+    /// `resolve_effective_scoped` resolves config and credentials per
+    /// `HarnessScope`, which is what lets one `built_in` harness ride the
+    /// subscription while another runs on a key of its own. Two harnesses in one
+    /// company can therefore present different credentials to the same endpoint,
+    /// and a company-only key reused the first one's entitlement-scoped catalog
+    /// for the second without its credential ever being presented (Codex review
+    /// on #2045).
+    ///
+    /// This asserts the property at the cache level, on the exact scope strings
+    /// `TenantProvider::catalog_scope` builds — company and harness joined by the
+    /// same control character `catalog_cache_scoped` uses, so a three-field key
+    /// cannot be spelled two ways.
+    #[test]
+    fn two_harnesses_in_one_company_do_not_share_an_authenticated_catalog() {
+        const ENDPOINT: &str = "https://gateway.example/v1";
+        let now = Instant::now();
+        let subscription = format!("acme\u{1}{}", "default");
+        let own_key = format!("acme\u{1}{}", "research");
+
+        catalog_cache_scoped(ENDPOINT, Some(&subscription))
+            .store(vec![model("gateway/subscription-tier")], now);
+
+        assert_eq!(
+            catalog_cache_scoped(ENDPOINT, Some(&own_key)).lookup(now),
+            None,
+            "a second harness's key may reach a different entitlement, so it must read for itself"
+        );
+        assert_eq!(
+            catalog_cache_scoped(ENDPOINT, Some(&subscription)).lookup(now),
+            Some(vec![model("gateway/subscription-tier")]),
+            "the harness that did the read still reuses its own entry"
+        );
+        // The company-only key is a third, distinct slot — proof the harness
+        // half genuinely participates rather than being absorbed into the id.
+        assert_eq!(
+            catalog_cache_scoped(ENDPOINT, Some("acme")).lookup(now),
+            None
         );
     }
 

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -11,6 +11,13 @@
 //! follows the configured base URL, so the cache is a registry keyed on it: one
 //! entry per endpoint, each with its own single-flight lock, so two tenants on
 //! two providers neither share a catalog nor queue behind each other.
+//!
+//! An **authenticated** read is additionally partitioned by the company it was
+//! made for, because an endpoint may publish an entitlement-scoped catalog and a
+//! base-URL-only key would then hand one company's model list to the next. A
+//! keyless read stays shared: it is a public property of the endpoint. Neither
+//! path ever puts the credential, or anything derived from it, in the key. See
+//! [`catalog_registry`].
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -263,15 +270,29 @@ impl ModelCatalogCache {
     }
 }
 
-/// The per-endpoint cache registry.
+/// The catalog cache registry.
 ///
-/// Keyed on the normalized base URL and **not** on the credential. A model
-/// catalog is a public property of an endpoint rather than of the key used to
-/// read it, and a credential must not become a map key — hashing one to key a
-/// cache would put a derivative of it in process memory next to the data it
-/// guards, for a partition nothing here needs. The cost is that two tenants
-/// sharing one endpoint share its catalog; the benefit is that a credential
-/// never leaves the paths that already handle it.
+/// **Never keyed on the credential.** A credential must not become a map key:
+/// hashing one to key a cache would put a derivative of it in process memory
+/// next to the data it guards.
+///
+/// It *is* keyed on who asked, whenever a credential was presented. An
+/// unauthenticated read is a public property of the endpoint and is shared by
+/// every caller reaching it. An **authenticated** read is not: an endpoint may
+/// publish an entitlement-scoped catalog, in which case a base-URL-only key
+/// hands one company's model list to the next company on the same endpoint for
+/// the rest of the hour (CodeRabbit security review on #2045). That only ever
+/// happens inside a single process serving several companies — a local
+/// multi-company host, or hosted shared-single-DB mode; database-per-tenant
+/// gives each tenant its own container and so its own registry — but it is a
+/// real cross-company disclosure in a supported mode, so the partition is the
+/// safe side to err on.
+///
+/// The scope is the **company id**: already non-secret, already the unit of
+/// isolation everywhere else, and it changes when the answer should change. The
+/// cost is one catalog fetch per company per endpoint per hour rather than one
+/// per endpoint — a bounded trade for not sharing an authenticated answer across
+/// a trust boundary.
 fn catalog_registry() -> &'static Mutex<HashMap<String, Arc<ModelCatalogCache>>> {
     static REGISTRY: OnceLock<Mutex<HashMap<String, Arc<ModelCatalogCache>>>> = OnceLock::new();
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
@@ -282,9 +303,18 @@ fn cache_key(base_url: &str) -> String {
     base_url.trim().trim_end_matches('/').to_string()
 }
 
-/// This endpoint's cache, created on first use.
-pub(crate) fn catalog_cache(base_url: &str) -> Arc<ModelCatalogCache> {
-    let key = cache_key(base_url);
+/// The cache slot for an endpoint read within `scope`.
+///
+/// `scope` is `None` for a read that presented no credential — a public catalog,
+/// shared by everyone — and `Some(company_id)` for an authenticated one. The
+/// separator is a control character no company id or URL can contain, so no
+/// scope-plus-endpoint pair can be spelled two ways.
+pub(crate) fn catalog_cache_scoped(base_url: &str, scope: Option<&str>) -> Arc<ModelCatalogCache> {
+    let endpoint = cache_key(base_url);
+    let key = match scope {
+        Some(scope) => format!("{scope}\u{1}{endpoint}"),
+        None => endpoint,
+    };
     let mut registry = match catalog_registry().lock() {
         Ok(registry) => registry,
         // A poisoned registry must not take the catalog offline for the rest of
@@ -293,6 +323,12 @@ pub(crate) fn catalog_cache(base_url: &str) -> Arc<ModelCatalogCache> {
         Err(_) => return Arc::new(ModelCatalogCache::default()),
     };
     Arc::clone(registry.entry(key).or_default())
+}
+
+/// The unscoped (public, keyless) cache for an endpoint.
+#[cfg(test)]
+pub(crate) fn catalog_cache(base_url: &str) -> Arc<ModelCatalogCache> {
+    catalog_cache_scoped(base_url, None)
 }
 
 /// Return the cached catalog for `base_url`, fetching it on a miss.
@@ -317,11 +353,25 @@ pub(crate) fn catalog_cache(base_url: &str) -> Arc<ModelCatalogCache> {
 /// A failure is remembered for [`MODEL_CATALOG_FAILURE_TTL`] and replayed to
 /// callers within it, so an unreachable provider costs one attempt a minute
 /// rather than one per request.
+///
+/// `scope` is the company this read is on behalf of. It partitions the cache
+/// whenever a `bearer` is presented, so an authenticated answer is never handed
+/// to a different company — see [`catalog_registry`]. A keyless read carries
+/// `None` and is shared, because an unauthenticated catalog is a public property
+/// of the endpoint.
 pub(crate) async fn catalog_models(
     base_url: &str,
     bearer: Option<&str>,
+    scope: Option<&str>,
 ) -> Result<Vec<InferenceModel>, String> {
-    let cache = catalog_cache(base_url);
+    // The partition follows the credential, not the caller: a read that presents
+    // nothing has nothing company-specific to leak, and sharing it keeps one
+    // fetch serving every company on a public endpoint.
+    let authenticated_scope = bearer
+        .filter(|bearer| !bearer.trim().is_empty())
+        .and(scope)
+        .filter(|scope| !scope.trim().is_empty());
+    let cache = catalog_cache_scoped(base_url, authenticated_scope);
     let now = Instant::now();
     if let Some(models) = cache.lookup(now) {
         return Ok(models);
@@ -398,8 +448,9 @@ pub(crate) async fn catalog_models(
 pub(crate) async fn discovered_vocabulary(
     base_url: &str,
     bearer: Option<&str>,
+    scope: Option<&str>,
 ) -> Option<TierVocabulary> {
-    let models = catalog_models(base_url, bearer).await.ok()?;
+    let models = catalog_models(base_url, bearer, scope).await.ok()?;
     Some(TierVocabulary::from_catalog_ids(
         models.iter().map(|model| model.id.as_str()),
     ))
@@ -583,8 +634,54 @@ mod tests {
         const ENDPOINT: &str = "https://vocabulary.example/v1";
         catalog_cache(ENDPOINT).store(vec![model("agentic-v1"), model("chat-v1")], Instant::now());
         assert_eq!(
-            discovered_vocabulary(ENDPOINT, None).await,
+            discovered_vocabulary(ENDPOINT, None, None).await,
             Some(TierVocabulary::Tiers)
+        );
+    }
+
+    /// An authenticated catalog is not shared across companies.
+    ///
+    /// The positive cache is keyed on the endpoint, which is right for a public
+    /// catalog and wrong for one read with a company's own credential: an
+    /// endpoint may publish an entitlement-scoped list, and a base-URL-only key
+    /// would serve one company's answer to the next for the rest of the hour
+    /// (CodeRabbit security review on #2045). A keyless read stays shared,
+    /// because there is nothing company-specific in it to leak.
+    #[test]
+    fn an_authenticated_catalog_is_partitioned_per_company_and_a_keyless_one_is_not() {
+        const ENDPOINT: &str = "https://shared-gateway.example/v1";
+        let now = Instant::now();
+
+        let acme = catalog_cache_scoped(ENDPOINT, Some("acme"));
+        let other = catalog_cache_scoped(ENDPOINT, Some("other"));
+        acme.store(vec![model("acme/entitled-only")], now);
+
+        assert_eq!(acme.lookup(now), Some(vec![model("acme/entitled-only")]));
+        assert_eq!(
+            other.lookup(now),
+            None,
+            "one company's authenticated catalog must not answer for another on the same endpoint"
+        );
+        assert_eq!(
+            catalog_cache_scoped(ENDPOINT, None).lookup(now),
+            None,
+            "nor must it answer a keyless read of the same endpoint"
+        );
+
+        // The same company reaching the same endpoint does reuse its own entry,
+        // so the partition costs one fetch per company rather than one per call.
+        assert_eq!(
+            catalog_cache_scoped(ENDPOINT, Some("acme")).lookup(now),
+            Some(vec![model("acme/entitled-only")])
+        );
+
+        // A keyless catalog is a public property of the endpoint, and stays
+        // shared by everyone reading it that way.
+        const PUBLIC: &str = "https://public-registry.example/v1";
+        catalog_cache_scoped(PUBLIC, None).store(vec![model("vendor/public")], now);
+        assert_eq!(
+            catalog_cache_scoped(PUBLIC, None).lookup(now),
+            Some(vec![model("vendor/public")])
         );
     }
 

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -785,10 +785,16 @@ mod tests {
     #[test]
     fn an_authenticated_catalog_is_partitioned_per_company_and_a_keyless_one_is_not() {
         const ENDPOINT: &str = "https://shared-gateway.example/v1";
+        // Company ids nothing else uses. The registry is process-global and
+        // `evict_company_catalogs` clears a whole company, so a scope named
+        // `acme` would be wiped by any route test in another module that saves a
+        // key for the company of that name, mid-assertion and at random.
+        const ONE: &str = "partition-one";
+        const TWO: &str = "partition-two";
         let now = Instant::now();
 
-        let acme = catalog_cache_scoped(ENDPOINT, Some("acme"));
-        let other = catalog_cache_scoped(ENDPOINT, Some("other"));
+        let acme = catalog_cache_scoped(ENDPOINT, Some(ONE));
+        let other = catalog_cache_scoped(ENDPOINT, Some(TWO));
         acme.store(vec![model("acme/entitled-only")], now);
 
         assert_eq!(acme.lookup(now), Some(vec![model("acme/entitled-only")]));
@@ -806,7 +812,7 @@ mod tests {
         // The same company reaching the same endpoint does reuse its own entry,
         // so the partition costs one fetch per company rather than one per call.
         assert_eq!(
-            catalog_cache_scoped(ENDPOINT, Some("acme")).lookup(now),
+            catalog_cache_scoped(ENDPOINT, Some(ONE)).lookup(now),
             Some(vec![model("acme/entitled-only")])
         );
 
@@ -837,9 +843,11 @@ mod tests {
     #[test]
     fn two_harnesses_in_one_company_do_not_share_an_authenticated_catalog() {
         const ENDPOINT: &str = "https://gateway.example/v1";
+        // A company id nothing else uses — see the note in the test above.
+        const COMPANY: &str = "harness-partition-co";
         let now = Instant::now();
-        let subscription = format!("acme\u{1}{}", "default");
-        let own_key = format!("acme\u{1}{}", "research");
+        let subscription = format!("{COMPANY}\u{1}{}", "default");
+        let own_key = format!("{COMPANY}\u{1}{}", "research");
 
         catalog_cache_scoped(ENDPOINT, Some(&subscription))
             .store(vec![model("gateway/subscription-tier")], now);
@@ -857,7 +865,7 @@ mod tests {
         // The company-only key is a third, distinct slot — proof the harness
         // half genuinely participates rather than being absorbed into the id.
         assert_eq!(
-            catalog_cache_scoped(ENDPOINT, Some("acme")).lookup(now),
+            catalog_cache_scoped(ENDPOINT, Some(COMPANY)).lookup(now),
             None
         );
     }

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -342,6 +342,31 @@ pub(crate) fn catalog_cache_scoped(base_url: &str, scope: Option<&str>) -> Arc<M
     Arc::clone(registry.entry(key).or_default())
 }
 
+/// Drop every **authenticated** catalog entry read on `company`'s behalf.
+///
+/// Called when that company's inference credential is written, because a
+/// rotation changes what the endpoint will answer without changing anything in
+/// the cache key — which is made of non-secret ids on purpose, and must stay
+/// that way (see [`catalog_registry`]). Without this, a company that rotated to
+/// a key with different entitlements would keep reading the previous
+/// credential's catalog for the rest of [`MODEL_CATALOG_TTL`], so the new bearer
+/// would never be presented to `/models` at all (Codex review on #2045).
+///
+/// Matches on the `company\u{1}` prefix, which covers both shapes the scope
+/// takes: the console route's `(company, endpoint)` and the turn path's
+/// `(company, harness, endpoint)`. Keyless entries are keyed on the bare
+/// endpoint and are deliberately left alone — an unauthenticated catalog is a
+/// public property of the endpoint and no credential change can alter it. A URL
+/// cannot contain the separator, so the prefix cannot match one by accident.
+pub(crate) fn evict_company_catalogs(company: &str) {
+    let prefix = format!("{company}\u{1}");
+    if let Ok(mut registry) = catalog_registry().lock() {
+        registry.retain(|key, _| !key.starts_with(&prefix));
+    }
+    // A poisoned registry needs no handling here: `catalog_cache_scoped` already
+    // hands out an unshared cache in that state, so nothing stale can be served.
+}
+
 /// The unscoped (public, keyless) cache for an endpoint.
 #[cfg(test)]
 pub(crate) fn catalog_cache(base_url: &str) -> Arc<ModelCatalogCache> {
@@ -834,6 +859,54 @@ mod tests {
         assert_eq!(
             catalog_cache_scoped(ENDPOINT, Some("acme")).lookup(now),
             None
+        );
+    }
+
+    /// Rotating a credential drops that company's authenticated catalogs, and
+    /// nobody else's.
+    ///
+    /// The cache key holds non-secret ids only, so a rotation is invisible to it
+    /// — the previous credential's catalog would otherwise answer for the rest
+    /// of [`MODEL_CATALOG_TTL`] and the new bearer would never reach `/models`
+    /// (Codex review on #2045). Eviction on the write is what keeps that
+    /// invariant affordable.
+    #[test]
+    fn rotating_a_credential_evicts_only_that_companys_authenticated_catalogs() {
+        const ENDPOINT: &str = "https://rotating-gateway.example/v1";
+        let now = Instant::now();
+        let acme_console = "rot-acme".to_string();
+        let acme_harness = format!("rot-acme\u{1}{}", "research");
+
+        catalog_cache_scoped(ENDPOINT, Some(&acme_console))
+            .store(vec![model("old/entitlement")], now);
+        catalog_cache_scoped(ENDPOINT, Some(&acme_harness))
+            .store(vec![model("old/entitlement")], now);
+        catalog_cache_scoped(ENDPOINT, Some("rot-other"))
+            .store(vec![model("other/entitlement")], now);
+        catalog_cache_scoped(ENDPOINT, None).store(vec![model("public/model")], now);
+
+        evict_company_catalogs("rot-acme");
+
+        assert_eq!(
+            catalog_cache_scoped(ENDPOINT, Some(&acme_console)).lookup(now),
+            None,
+            "the console's own scoped read must be re-fetched with the new credential"
+        );
+        assert_eq!(
+            catalog_cache_scoped(ENDPOINT, Some(&acme_harness)).lookup(now),
+            None,
+            "and so must every harness scope beneath that company"
+        );
+        assert_eq!(
+            catalog_cache_scoped(ENDPOINT, Some("rot-other")).lookup(now),
+            Some(vec![model("other/entitlement")]),
+            "another company's credential did not change, so its catalog stands"
+        );
+        assert_eq!(
+            catalog_cache_scoped(ENDPOINT, None).lookup(now),
+            Some(vec![model("public/model")]),
+            "a keyless catalog is a public property of the endpoint and no \
+             credential change can alter it"
         );
     }
 

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -1467,12 +1467,12 @@ base_url = "https://byo.example/v1"
     /// partitioned per company — every route test here drives the `acme`
     /// company from [`state_with_company`], and a seed in the shared/keyless
     /// slot would no longer be the entry the route reads.
-    fn seed_catalog(base_url: &str, ids: &[&str]) {
-        seed_catalog_for("acme", base_url, ids);
-    }
-
     /// Seed the authenticated catalog cache for a named company — the scope the
-    /// route reads under. Needed by any test that does not use `acme`.
+    /// route reads under.
+    ///
+    /// Every caller names its own company rather than sharing one: eviction is
+    /// company-wide, so a fixture seeded under an id another test saves a key
+    /// for is thrown away at random.
     fn seed_catalog_for(company: &str, base_url: &str, ids: &[&str]) {
         crate::server::inference_models::catalog_cache_scoped(base_url, Some(company)).store(
             ids.iter()
@@ -1497,10 +1497,17 @@ base_url = "https://byo.example/v1"
     #[tokio::test]
     async fn model_catalog_route_lists_the_configured_endpoints_own_catalog() {
         const ENDPOINT: &str = "http://127.0.0.1:9/tier-native/v1";
+        // Its own company id. Saving a key evicts that company's authenticated
+        // catalogs, and a dozen tests in this module save one under `acme`; with
+        // a shared id, whichever of them libtest happens to run alongside this
+        // one throws the seeded fixture away. Locally the interleaving hid it;
+        // CI's found it (Codex review on #2045).
+        const COMPANY: &str = "catalog-tiers";
         let home_dir = home();
-        let state = state_with_company(home_dir.path()).await;
-        let (status, _, raw) = send(
+        let state = state_with_company_named(home_dir.path(), COMPANY).await;
+        let (status, _, raw) = send_as(
             &state,
+            COMPANY,
             "PUT",
             "/api/v1/company/inference",
             Some(json!({
@@ -1519,13 +1526,20 @@ base_url = "https://byo.example/v1"
         // route fell through to a real request. This order is also what happens
         // in life — the cache is warmed by a read, which comes after the config
         // exists to be read against.
-        seed_catalog(
+        seed_catalog_for(
+            COMPANY,
             ENDPOINT,
             &["agentic-v1", "chat-v1", "reasoning-v1", "vision-v1"],
         );
 
-        let (status, body, raw) =
-            send(&state, "GET", "/api/v1/company/inference/models", None).await;
+        let (status, body, raw) = send_as(
+            &state,
+            COMPANY,
+            "GET",
+            "/api/v1/company/inference/models",
+            None,
+        )
+        .await;
 
         assert_eq!(status, StatusCode::OK, "{raw}");
         assert_eq!(
@@ -1558,10 +1572,13 @@ base_url = "https://byo.example/v1"
     #[tokio::test]
     async fn model_catalog_route_keeps_concrete_defaults_for_a_concrete_catalog() {
         const ENDPOINT: &str = "http://127.0.0.1:9/concrete/v1";
+        // Its own company id, for the same reason as the test above.
+        const COMPANY: &str = "catalog-concrete";
         let home_dir = home();
-        let state = state_with_company(home_dir.path()).await;
-        let (status, _, raw) = send(
+        let state = state_with_company_named(home_dir.path(), COMPANY).await;
+        let (status, _, raw) = send_as(
             &state,
+            COMPANY,
             "PUT",
             "/api/v1/company/inference",
             Some(json!({
@@ -1575,7 +1592,8 @@ base_url = "https://byo.example/v1"
 
         // After the save, for the same reason as the test above: storing a key
         // evicts this company's authenticated catalogs.
-        seed_catalog(
+        seed_catalog_for(
+            COMPANY,
             ENDPOINT,
             &[
                 "anthropic/claude-opus-5",
@@ -1585,8 +1603,14 @@ base_url = "https://byo.example/v1"
             ],
         );
 
-        let (status, body, raw) =
-            send(&state, "GET", "/api/v1/company/inference/models", None).await;
+        let (status, body, raw) = send_as(
+            &state,
+            COMPANY,
+            "GET",
+            "/api/v1/company/inference/models",
+            None,
+        )
+        .await;
 
         assert_eq!(status, StatusCode::OK, "{raw}");
         assert_eq!(body["tierVocabulary"], "concrete", "{raw}");

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -174,7 +174,16 @@ async fn list_models(company: ScopedCompany) -> Result<Json<ModelCatalogDto>, Ap
         }));
     };
 
-    match crate::server::inference_models::catalog_models(&base_url, bearer.as_deref()).await {
+    // Scoped to this company: an authenticated catalog read is not a public
+    // property of the endpoint, so its cache entry must not be handed to another
+    // company on the same URL (CodeRabbit security review on #2045).
+    match crate::server::inference_models::catalog_models(
+        &base_url,
+        bearer.as_deref(),
+        Some(runtime.id().as_ref()),
+    )
+    .await
+    {
         Ok(models) => {
             let vocabulary = inference::TierVocabulary::from_catalog_ids(
                 models.iter().map(|model| model.id.as_str()),
@@ -996,6 +1005,7 @@ async fn test_config(company: ScopedCompany) -> Response {
                 let vocabulary = crate::server::inference_models::discovered_vocabulary(
                     &decl.base_url,
                     bearer.as_deref(),
+                    Some(runtime.id().as_ref()),
                 )
                 .await;
                 decl.with_vocabulary(vocabulary)
@@ -1418,8 +1428,13 @@ base_url = "https://byo.example/v1"
     /// deterministically: each test uses a base URL of its own, because the
     /// registry is process-wide and a shared key would let one test's positive
     /// entry decide another's outcome.
+    ///
+    /// Seeded in **`acme`'s** scope, because an authenticated read is
+    /// partitioned per company — every route test here drives the `acme`
+    /// company from [`state_with_company`], and a seed in the shared/keyless
+    /// slot would no longer be the entry the route reads.
     fn seed_catalog(base_url: &str, ids: &[&str]) {
-        crate::server::inference_models::catalog_cache(base_url).store(
+        crate::server::inference_models::catalog_cache_scoped(base_url, Some("acme")).store(
             ids.iter()
                 .map(|id| crate::server::inference_models::InferenceModel {
                     id: (*id).to_string(),

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -803,6 +803,14 @@ async fn revert_config(
     inference::clear_key(runtime.id(), secrets.as_ref())
         .await
         .map_err(ApiError)?;
+    // Reset changes the effective credential just as a rotation does, so it owes
+    // the same eviction `set_config` performs. Clearing the runtime key makes
+    // resolution fall back to the manifest's `api_key_secret`; when that manifest
+    // points at the same base URL, nothing in the cache key moves and turns would
+    // keep reading the *previous* credential's catalog for up to
+    // `MODEL_CATALOG_TTL` without ever presenting the manifest key (Codex review
+    // on #2045). Every path in this module that writes the credential evicts.
+    crate::server::inference_models::evict_company_catalogs(runtime.id().as_ref());
     Ok(Json(MutationResponse {
         status: effective_status(&state, runtime).await?,
         note: "Reverted to the committed manifest (or managed) configuration.".to_string(),
@@ -1699,6 +1707,65 @@ base_url = "https://byo.example/v1"
             body["error"].is_string(),
             "with the entry evicted and the endpoint unreachable, the route reports why \
              rather than replaying stale ids: {raw}"
+        );
+    }
+
+    /// Reset owes the same eviction a rotation does.
+    ///
+    /// `revert_config` clears the runtime key so resolution falls back to the
+    /// manifest's credential. When the manifest points at the same base URL
+    /// nothing in the cache key moves, so without eviction the route would keep
+    /// answering from the catalog the *cleared* credential fetched (Codex review
+    /// on #2045). Its own company id, for the parallelism reason above.
+    #[tokio::test]
+    async fn resetting_the_config_does_not_serve_the_cleared_credentials_catalog() {
+        const ENDPOINT: &str = "http://127.0.0.1:9/reset/v1";
+        const COMPANY: &str = "resetter";
+        let home_dir = home();
+        let state = state_with_company_named(home_dir.path(), COMPANY).await;
+
+        let (status, _, raw) = send_as(
+            &state,
+            COMPANY,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({
+                "provider": "openai_compatible",
+                "baseUrl": ENDPOINT,
+                "key": "before-reset",
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        seed_catalog_for(COMPANY, ENDPOINT, &["entitled/before-reset"]);
+
+        let (status, body, raw) = send_as(
+            &state,
+            COMPANY,
+            "GET",
+            "/api/v1/company/inference/models",
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(body["models"][0]["id"], "entitled/before-reset", "{raw}");
+
+        let (status, _, raw) =
+            send_as(&state, COMPANY, "DELETE", "/api/v1/company/inference", None).await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+
+        let (status, body, raw) = send_as(
+            &state,
+            COMPANY,
+            "GET",
+            "/api/v1/company/inference/models",
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_ne!(
+            body["models"][0]["id"], "entitled/before-reset",
+            "a reset must not be answered from the cleared credential's catalog: {raw}"
         );
     }
 

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -720,6 +720,15 @@ async fn set_config(
         store_key(runtime.id(), runtime.secrets().as_ref(), key.trim())
             .await
             .map_err(ApiError)?;
+        // A rotation changes what the endpoint will answer without changing the
+        // cache key, which is deliberately made of non-secret ids only. Left
+        // alone, the catalog read with the *previous* credential would keep
+        // answering for up to `MODEL_CATALOG_TTL`, so an entitlement-changing
+        // rotation would never present the new bearer to `/models`: turns could
+        // hold the old vocabulary and the console could offer models the new
+        // account cannot reach (Codex review on #2045). Evicting on the write is
+        // the fix that does not require the credential to become part of the key.
+        crate::server::inference_models::evict_company_catalogs(runtime.id().as_ref());
     }
 
     let status = effective_status(&state, runtime).await?;
@@ -1135,7 +1144,20 @@ base_url = "https://byo.example/v1"
     }
 
     async fn state_with_company(home: &std::path::Path) -> AppState {
-        let id = CompanyId::new("acme");
+        state_with_company_named(home, "acme").await
+    }
+
+    /// A company under a caller-chosen id.
+    ///
+    /// Almost every test here can share `acme`, but the catalog cache is
+    /// process-global and keyed on the company, and storing a key now evicts
+    /// that company's authenticated entries (Codex review on #2045). A test that
+    /// rotates a credential therefore wipes the seeded fixtures of every sibling
+    /// running beside it under the same id — libtest runs these in parallel — so
+    /// it needs an id of its own rather than an ordering assumption that cannot
+    /// hold.
+    async fn state_with_company_named(home: &std::path::Path, name: &str) -> AppState {
+        let id = CompanyId::new(name);
         save_record(home, &id, &manifest()).await;
         let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
             .with_id(id.clone())
@@ -1144,7 +1166,7 @@ base_url = "https://byo.example/v1"
             .unwrap();
         let state = AppState::new(AppConfig::default());
         state.registry().insert(id, std::sync::Arc::new(runtime));
-        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        crate::server::test_support::seed_fixed_admin(&state, name).await;
         state
     }
 
@@ -1401,10 +1423,22 @@ base_url = "https://byo.example/v1"
         uri: &str,
         body: Option<Value>,
     ) -> (StatusCode, Value, String) {
+        send_as(state, "acme", method, uri, body).await
+    }
+
+    /// `send` against a company other than `acme`, for the tests that need an id
+    /// of their own — see `state_with_company_named`.
+    async fn send_as(
+        state: &AppState,
+        company: &str,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+    ) -> (StatusCode, Value, String) {
         let request = Request::builder()
             .method(method)
             .uri(uri)
-            .header("cookie", crate::server::test_support::fixed_cookie("acme"));
+            .header("cookie", crate::server::test_support::fixed_cookie(company));
         let request = match body {
             Some(body) => request
                 .header("content-type", "application/json")
@@ -1434,7 +1468,13 @@ base_url = "https://byo.example/v1"
     /// company from [`state_with_company`], and a seed in the shared/keyless
     /// slot would no longer be the entry the route reads.
     fn seed_catalog(base_url: &str, ids: &[&str]) {
-        crate::server::inference_models::catalog_cache_scoped(base_url, Some("acme")).store(
+        seed_catalog_for("acme", base_url, ids);
+    }
+
+    /// Seed the authenticated catalog cache for a named company — the scope the
+    /// route reads under. Needed by any test that does not use `acme`.
+    fn seed_catalog_for(company: &str, base_url: &str, ids: &[&str]) {
+        crate::server::inference_models::catalog_cache_scoped(base_url, Some(company)).store(
             ids.iter()
                 .map(|id| crate::server::inference_models::InferenceModel {
                     id: (*id).to_string(),
@@ -1459,11 +1499,6 @@ base_url = "https://byo.example/v1"
         const ENDPOINT: &str = "http://127.0.0.1:9/tier-native/v1";
         let home_dir = home();
         let state = state_with_company(home_dir.path()).await;
-        seed_catalog(
-            ENDPOINT,
-            &["agentic-v1", "chat-v1", "reasoning-v1", "vision-v1"],
-        );
-
         let (status, _, raw) = send(
             &state,
             "PUT",
@@ -1476,6 +1511,18 @@ base_url = "https://byo.example/v1"
         )
         .await;
         assert_eq!(status, StatusCode::OK, "{raw}");
+
+        // Seeded *after* the save, not before: storing a key evicts this
+        // company's authenticated catalogs, because a rotation changes what the
+        // endpoint will answer without changing the cache key (Codex review on
+        // #2045). Seeding first meant the save threw the fixture away and the
+        // route fell through to a real request. This order is also what happens
+        // in life — the cache is warmed by a read, which comes after the config
+        // exists to be read against.
+        seed_catalog(
+            ENDPOINT,
+            &["agentic-v1", "chat-v1", "reasoning-v1", "vision-v1"],
+        );
 
         let (status, body, raw) =
             send(&state, "GET", "/api/v1/company/inference/models", None).await;
@@ -1513,16 +1560,6 @@ base_url = "https://byo.example/v1"
         const ENDPOINT: &str = "http://127.0.0.1:9/concrete/v1";
         let home_dir = home();
         let state = state_with_company(home_dir.path()).await;
-        seed_catalog(
-            ENDPOINT,
-            &[
-                "anthropic/claude-opus-5",
-                "anthropic/claude-sonnet-5",
-                "openai/gpt-5.6-sol-pro",
-                "qwen/qwen3.8-max",
-            ],
-        );
-
         let (status, _, raw) = send(
             &state,
             "PUT",
@@ -1536,6 +1573,18 @@ base_url = "https://byo.example/v1"
         .await;
         assert_eq!(status, StatusCode::OK, "{raw}");
 
+        // After the save, for the same reason as the test above: storing a key
+        // evicts this company's authenticated catalogs.
+        seed_catalog(
+            ENDPOINT,
+            &[
+                "anthropic/claude-opus-5",
+                "anthropic/claude-sonnet-5",
+                "openai/gpt-5.6-sol-pro",
+                "qwen/qwen3.8-max",
+            ],
+        );
+
         let (status, body, raw) =
             send(&state, "GET", "/api/v1/company/inference/models", None).await;
 
@@ -1544,6 +1593,88 @@ base_url = "https://byo.example/v1"
         assert_eq!(
             body["tierDefaults"]["agentic-v1"], "anthropic/claude-opus-5",
             "{raw}"
+        );
+    }
+
+    /// Rotating the key does not let the route answer from the catalog the
+    /// *previous* credential fetched.
+    ///
+    /// The cache key holds non-secret ids only, so a rotation is invisible to
+    /// it: without eviction the pre-rotation catalog would answer for the rest
+    /// of `MODEL_CATALOG_TTL` and the new bearer would never reach `/models`,
+    /// so the console could offer models the new account cannot access (Codex
+    /// review on #2045).
+    ///
+    /// Asserted through the route rather than the registry — the registry-level
+    /// boundaries are covered by
+    /// `rotating_a_credential_evicts_only_that_companys_authenticated_catalogs`.
+    /// The endpoint is unreachable on purpose: after the eviction there is
+    /// nothing cached to serve, so the route reports a failure instead of
+    /// handing back the stale ids, and *that* is the observable difference.
+    #[tokio::test]
+    async fn rotating_the_key_does_not_serve_the_previous_credentials_catalog() {
+        const ENDPOINT: &str = "http://127.0.0.1:9/rotated/v1";
+        // Its own company: eviction is company-wide, so rotating under `acme`
+        // would clear the fixtures of every sibling test running in parallel.
+        const COMPANY: &str = "rotator";
+        let home_dir = home();
+        let state = state_with_company_named(home_dir.path(), COMPANY).await;
+
+        let configure = |key: &'static str| {
+            send_as(
+                &state,
+                COMPANY,
+                "PUT",
+                "/api/v1/company/inference",
+                Some(json!({
+                    "provider": "openai_compatible",
+                    "baseUrl": ENDPOINT,
+                    "key": key,
+                })),
+            )
+        };
+
+        let (status, _, raw) = configure("first-token").await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        // What the first credential saw.
+        seed_catalog_for(COMPANY, ENDPOINT, &["entitled/first-only"]);
+
+        let (status, body, raw) = send_as(
+            &state,
+            COMPANY,
+            "GET",
+            "/api/v1/company/inference/models",
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(
+            body["models"][0]["id"], "entitled/first-only",
+            "the first credential's catalog is cached and served: {raw}"
+        );
+
+        // Rotate. The endpoint and the company are unchanged, so nothing in the
+        // cache key moves — only the credential behind it.
+        let (status, _, raw) = configure("second-token").await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+
+        let (status, body, raw) = send_as(
+            &state,
+            COMPANY,
+            "GET",
+            "/api/v1/company/inference/models",
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_ne!(
+            body["models"][0]["id"], "entitled/first-only",
+            "the rotated credential must not be answered from the old key's catalog: {raw}"
+        );
+        assert!(
+            body["error"].is_string(),
+            "with the entry evicted and the endpoint unreachable, the route reports why \
+             rather than replaying stale ids: {raw}"
         );
     }
 

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -81,19 +81,122 @@ pub fn router() -> Router<AppState> {
     .merge(scoped("/inference/restart", post(restart_runtime)))
 }
 
-/// `GET …/inference/models` — the cached public OpenRouter model registry.
-async fn list_models(
-    company: ScopedCompany,
-) -> Result<Json<Vec<crate::server::inference_models::InferenceModel>>, ApiError> {
-    let _ = company;
-    crate::server::inference_models::openrouter_models()
+/// What `GET …/inference/models` answers: the catalog **this company's endpoint**
+/// publishes, and what that catalog says about how tiers must be spelled for it.
+///
+/// The route used to answer with a bare array, and that array was always
+/// OpenRouter's public registry — whatever endpoint the company had been pointed
+/// at. An operator on a TinyHumans base URL was shown 421 OpenRouter models,
+/// picked `anthropic/claude-sonnet-5` from them because the console offered it,
+/// and got `Model 'anthropic/claude-sonnet-5' is not available` from a provider
+/// that publishes `chat-v1` and `agentic-v1` instead.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ModelCatalogDto {
+    /// The endpoint the catalog was read from — the same URL
+    /// [`InferenceStatusDto::base_url`] reports, so the console can say *whose*
+    /// list this is instead of implying a vendor.
+    base_url: String,
+    /// Every model the endpoint publishes, sorted. Empty when `error` is set.
+    models: Vec<crate::server::inference_models::InferenceModel>,
+    /// How this endpoint spells a tier: `tiers` (it publishes the tier names and
+    /// resolves them itself), `concrete` (it publishes the ids
+    /// [`inference::DEFAULT_TIER_MODELS`] names), or `unknown` (neither).
+    /// `null` when the catalog could not be read, which is not the same as
+    /// `unknown` and must not be shown as one.
+    tier_vocabulary: Option<&'static str>,
+    /// The tier → model mapping this endpoint's own vocabulary implies, for the
+    /// console to prefill with. Empty for `unknown` and for an unreadable
+    /// catalog: there is no mapping we can honestly supply, and prefilling one
+    /// we already know the endpoint does not publish is the bug this route was
+    /// on the wrong side of.
+    tier_defaults: BTreeMap<String, String>,
+    /// Why the catalog is empty, in the operator's words, or `null` on success.
+    ///
+    /// Carried in a 200 rather than raised as a 500 on purpose: an empty picker
+    /// with no explanation reads as "this provider has no models", which is a
+    /// claim we have not established. "Could not list models from
+    /// `<endpoint>`" is a true statement and leaves the operator able to type an
+    /// id by hand, which is exactly what they should do next.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+/// The endpoint a company's requests actually travel to, and the credential they
+/// carry — resolved the same way [`effective_status_with`] resolves `base_url`,
+/// so the catalog is read from the endpoint the turns use.
+///
+/// Resolved *with* the platform default in place: a `managed`/keyless
+/// `openrouter` company inherits the platform endpoint and its credential, and
+/// reading the catalog without them would list the wrong endpoint's models on
+/// exactly the companies that never configured anything.
+async fn resolved_endpoint(
+    runtime: &CompanyRuntime,
+) -> Result<Option<(String, Option<String>)>, ApiError> {
+    let (manifest, _harness_id) = manifest_inference(runtime).await?;
+    let secrets = runtime.secrets().as_ref();
+    let platform = platform_default(&crate::app::config::ProcessEnv);
+    let Some(decl) = resolve_effective(runtime.id(), &manifest, platform.as_ref(), secrets)
         .await
-        .map(Json)
-        .map_err(|error| {
-            ApiError(OpenCompanyError::Store(format!(
-                "OpenRouter model registry unavailable: {error}"
-            )))
-        })
+        .map_err(ApiError)?
+    else {
+        return Ok(None);
+    };
+    let bearer = decl.bearer().await.map_err(ApiError)?;
+    Ok(Some((decl.base_url.clone(), bearer)))
+}
+
+/// `GET …/inference/models` — the model catalog of the endpoint **this company**
+/// is configured against, cached per endpoint.
+///
+/// Every OpenAI-compatible provider publishes `GET {base_url}/models`, so
+/// discovery follows the configured base URL rather than assuming a vendor. The
+/// company's stored key is read host-side and presented as the bearer: it is
+/// write-only to the console (`keyConfigured` is all the console ever sees), so
+/// this route is the only place that can ask an authenticated endpoint what it
+/// serves.
+async fn list_models(company: ScopedCompany) -> Result<Json<ModelCatalogDto>, ApiError> {
+    let runtime = company.runtime.as_ref();
+    let Some((base_url, bearer)) = resolved_endpoint(runtime).await? else {
+        // Nothing resolves — not even a platform default on this host. There is
+        // no endpoint to ask, and saying so beats listing some other vendor's
+        // catalog as if it were this company's.
+        return Ok(Json(ModelCatalogDto {
+            base_url: String::new(),
+            models: Vec::new(),
+            tier_vocabulary: None,
+            tier_defaults: BTreeMap::new(),
+            error: Some(
+                "No inference endpoint is configured for this company, so there is no model \
+                 catalog to list. Save a provider first."
+                    .to_string(),
+            ),
+        }));
+    };
+
+    match crate::server::inference_models::catalog_models(&base_url, bearer.as_deref()).await {
+        Ok(models) => {
+            let vocabulary = inference::TierVocabulary::from_catalog_ids(
+                models.iter().map(|model| model.id.as_str()),
+            );
+            Ok(Json(ModelCatalogDto {
+                base_url,
+                models,
+                tier_vocabulary: Some(vocabulary.as_str()),
+                tier_defaults: vocabulary.tier_defaults(),
+                error: None,
+            }))
+        }
+        Err(error) => Ok(Json(ModelCatalogDto {
+            error: Some(format!(
+                "Could not list models from {base_url}: {error}. Enter model ids directly."
+            )),
+            base_url,
+            models: Vec::new(),
+            tier_vocabulary: None,
+            tier_defaults: BTreeMap::new(),
+        })),
+    }
 }
 
 /// The company's effective inference status as the console renders it. **Never**
@@ -113,8 +216,8 @@ struct InferenceStatusDto {
     base_url: String,
     /// Abstract-tier → concrete model id.
     models: BTreeMap<String, String>,
-    /// The shipped tier → model defaults ([`inference::DEFAULT_TIER_MODELS`]),
-    /// independent of `provider`/`models` above.
+    /// The shipped tier → model defaults ([`inference::DEFAULT_TIER_MODELS`]) —
+    /// **OpenRouter's vocabulary**, and nothing wider.
     ///
     /// The console's OpenRouter preset used to hard-code its own copy of these
     /// four ids so switching to OpenRouter had something to prefill the form
@@ -123,6 +226,14 @@ struct InferenceStatusDto {
     /// `DEFAULT_TIER_MODELS` changed. Carrying the live values on every status
     /// read means the preset is never more than one request stale, on a route
     /// the console already polls.
+    ///
+    /// It is *only* that preset. These are OpenRouter catalog ids, so they are
+    /// the right prefill for the OpenRouter provider and meaningless for any
+    /// other endpoint. What the **configured** endpoint wants is a different
+    /// question, answered from that endpoint's own catalog by
+    /// [`ModelCatalogDto::tier_defaults`] on `GET …/inference/models`; treating
+    /// this field as a universal default is what put four OpenRouter ids into a
+    /// TinyHumans company's tier mapping.
     default_tier_models: BTreeMap<String, String>,
     /// Where the effective config came from: `default` / `manifest` / `runtime`,
     /// or `managed` when nothing tenant-specific is configured.
@@ -755,12 +866,17 @@ async fn unauthenticated_reason(
     if decl.bearer().await?.is_some() {
         return Ok(None);
     }
+    // The endpoint is named rather than the vendor. The `openrouter` *kind* no
+    // longer implies OpenRouter's endpoint — the same kind carrying a
+    // tenant `base_url` reaches whatever that URL points at — so "save an
+    // OpenRouter key" is advice that sends the operator of a differently-pointed
+    // company to buy a credential their provider will never see.
     Ok(Some(format!(
         "No inference key is stored for this company, and this host has no platform credential to \
-         fall back on — a request to {} would carry no Authorization header and be rejected, so \
-         none was sent. Save an OpenRouter key above, or point this company at an endpoint that \
-         needs none.",
-        decl.base_url
+         fall back on — a request to {base} would carry no Authorization header and be rejected, \
+         so none was sent. Save a key that {base} accepts above, or point this company at an \
+         endpoint that needs none.",
+        base = decl.base_url
     )))
 }
 
@@ -866,6 +982,24 @@ async fn test_config(company: ScopedCompany) -> Response {
                 }
                 Ok(None) => {}
             }
+            // Ask the endpoint what vocabulary it speaks before the probe
+            // chooses a model for it. Without this the probe resolves tiers by
+            // the pre-discovery guess, which is what made a perfectly good
+            // TinyHumans config fail Test with `Model
+            // 'anthropic/claude-sonnet-5' is not available` — an id neither the
+            // operator nor the provider ever named.
+            let decl = {
+                let bearer = match decl.bearer().await {
+                    Ok(bearer) => bearer,
+                    Err(err) => return ApiError(err).into_response(),
+                };
+                let vocabulary = crate::server::inference_models::discovered_vocabulary(
+                    &decl.base_url,
+                    bearer.as_deref(),
+                )
+                .await;
+                decl.with_vocabulary(vocabulary)
+            };
             // The default harness's real id, whether or not it declares its own
             // `[harness.inference]` — `model_unavailable_advice` names the same
             // table either way (its own, or the company's as the harness's
@@ -1280,26 +1414,175 @@ base_url = "https://byo.example/v1"
         (status, value, raw)
     }
 
-    #[tokio::test]
-    async fn model_catalog_route_returns_cached_openrouter_models() {
-        let home_dir = home();
-        let state = state_with_company(home_dir.path()).await;
-        crate::server::inference_models::openrouter_cache().store(
-            vec![crate::server::inference_models::InferenceModel {
-                id: "provider/real-model".to_string(),
-                name: Some("Real Model".to_string()),
-                context_length: Some(128_000),
-            }],
+    /// Seed one endpoint's catalog cache so the route answers offline, and
+    /// deterministically: each test uses a base URL of its own, because the
+    /// registry is process-wide and a shared key would let one test's positive
+    /// entry decide another's outcome.
+    fn seed_catalog(base_url: &str, ids: &[&str]) {
+        crate::server::inference_models::catalog_cache(base_url).store(
+            ids.iter()
+                .map(|id| crate::server::inference_models::InferenceModel {
+                    id: (*id).to_string(),
+                    name: Some(format!("{id} (display)")),
+                    context_length: Some(128_000),
+                })
+                .collect(),
             std::time::Instant::now(),
         );
+    }
+
+    /// The catalog is read from the endpoint **this company** is configured
+    /// against, not from OpenRouter's public registry.
+    ///
+    /// This is the defect in one assertion. The route used to call
+    /// `openrouter_models()` with no reference to the company at all, so a
+    /// company pointed at a TinyHumans base URL was shown OpenRouter's 421
+    /// models — `anthropic/claude-sonnet-5` among them — and the endpoint then
+    /// answered `Model 'anthropic/claude-sonnet-5' is not available`.
+    #[tokio::test]
+    async fn model_catalog_route_lists_the_configured_endpoints_own_catalog() {
+        const ENDPOINT: &str = "http://127.0.0.1:9/tier-native/v1";
+        let home_dir = home();
+        let state = state_with_company(home_dir.path()).await;
+        seed_catalog(
+            ENDPOINT,
+            &["agentic-v1", "chat-v1", "reasoning-v1", "vision-v1"],
+        );
+
+        let (status, _, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({
+                "provider": "openai_compatible",
+                "baseUrl": ENDPOINT,
+                "key": "test-token",
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
 
         let (status, body, raw) =
             send(&state, "GET", "/api/v1/company/inference/models", None).await;
 
         assert_eq!(status, StatusCode::OK, "{raw}");
-        assert_eq!(body[0]["id"], "provider/real-model");
-        assert_eq!(body[0]["name"], "Real Model");
-        assert_eq!(body[0]["contextLength"], 128_000);
+        assert_eq!(
+            body["baseUrl"], ENDPOINT,
+            "the catalog names the endpoint it came from: {raw}"
+        );
+        let ids: Vec<&str> = body["models"]
+            .as_array()
+            .expect("models array")
+            .iter()
+            .map(|m| m["id"].as_str().unwrap_or_default())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["agentic-v1", "chat-v1", "reasoning-v1", "vision-v1"],
+            "the configured endpoint's own ids, not OpenRouter's: {raw}"
+        );
+        assert_eq!(
+            body["tierVocabulary"], "tiers",
+            "an endpoint publishing the tier names is telling us it resolves them: {raw}"
+        );
+        assert_eq!(
+            body["tierDefaults"]["agentic-v1"], "agentic-v1",
+            "so the default mapping for it is identity, not an OpenRouter slug: {raw}"
+        );
+    }
+
+    /// The other vocabulary: an endpoint publishing the concrete ids
+    /// [`inference::DEFAULT_TIER_MODELS`] names still gets the shipped mapping.
+    #[tokio::test]
+    async fn model_catalog_route_keeps_concrete_defaults_for_a_concrete_catalog() {
+        const ENDPOINT: &str = "http://127.0.0.1:9/concrete/v1";
+        let home_dir = home();
+        let state = state_with_company(home_dir.path()).await;
+        seed_catalog(
+            ENDPOINT,
+            &[
+                "anthropic/claude-opus-5",
+                "anthropic/claude-sonnet-5",
+                "openai/gpt-5.6-sol-pro",
+                "qwen/qwen3.8-max",
+            ],
+        );
+
+        let (status, _, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({
+                "provider": "openai_compatible",
+                "baseUrl": ENDPOINT,
+                "key": "test-token",
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+
+        let (status, body, raw) =
+            send(&state, "GET", "/api/v1/company/inference/models", None).await;
+
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(body["tierVocabulary"], "concrete", "{raw}");
+        assert_eq!(
+            body["tierDefaults"]["agentic-v1"], "anthropic/claude-opus-5",
+            "{raw}"
+        );
+    }
+
+    /// A provider that cannot be reached must say so. An empty list is not a
+    /// true statement about a catalog nobody managed to read, and the picker
+    /// blanking with no explanation is how an operator concludes their provider
+    /// serves no models.
+    #[tokio::test]
+    async fn model_catalog_route_reports_an_unreachable_provider_rather_than_blanking() {
+        // The discard port: refuses fast, offline, and deterministically.
+        const ENDPOINT: &str = "http://127.0.0.1:9/unreachable/v1";
+        let home_dir = home();
+        let state = state_with_company(home_dir.path()).await;
+
+        let (status, _, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({
+                "provider": "openai_compatible",
+                "baseUrl": ENDPOINT,
+                "key": "test-token",
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+
+        let (status, body, raw) =
+            send(&state, "GET", "/api/v1/company/inference/models", None).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the console needs a body it can render, not a bare 5xx: {raw}"
+        );
+        assert!(
+            body["models"].as_array().is_some_and(|m| m.is_empty()),
+            "{raw}"
+        );
+        assert!(
+            body["tierVocabulary"].is_null(),
+            "unreadable is not `unknown`: {raw}"
+        );
+        let error = body["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("Could not list models from") && error.contains(ENDPOINT),
+            "the failure names the endpoint it could not reach: {raw}"
+        );
+        assert!(
+            body["tierDefaults"]
+                .as_object()
+                .is_some_and(serde_json::Map::is_empty),
+            "no catalog means no defaults we can honestly prefill: {raw}"
+        );
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Found while configuring a live TinyHumans inference key end to end: an
endpoint's model vocabulary was decided by *who pays for it*
(`InferenceDecl::is_proxied()`), not by what the endpoint actually publishes.
A company pointed at `https://api.tinyhumans.ai/openai/v1` with a valid key
reported healthy, but `GET .../inference/models` served OpenRouter's 421-model
registry — a catalog that endpoint does not serve — and every unmapped tier got
rewritten to an OpenRouter slug, so a test call failed naming a model id neither
the operator nor the provider ever mentioned. TinyHumans instead publishes its
own tier vocabulary directly (`chat-v1`, `agentic-v1`, `reasoning-v1`,
`vision-v1`) and resolves tiers itself.

The same shape hits a local Ollama, an Azure deployment, and any
OpenAI-compatible gateway: configure everything correctly, watch the connection
test go green, then get a failure naming `anthropic/claude-sonnet-5`.

- Discover an endpoint's vocabulary from its own `GET {base_url}/models` rather
  than assuming OpenRouter's, classified as `TierVocabulary::Tiers / Concrete /
  Unknown`. An `Unknown` catalog gets **no** prefilled defaults — prefilling ids
  the endpoint has already said it doesn't serve is how an operator ends up with
  a saved, silently unusable mapping.
- Catalog cache keyed on the normalized base URL (a public property of the
  endpoint, not the credential) with a single-flight lock and a 1-minute
  negative memo per endpoint.
- `GET .../inference/models` now always returns `200` with `{baseUrl, models,
  tierVocabulary, tierDefaults, error}` — an unreadable catalog names why rather
  than rendering as an empty picker with no explanation.
- `is_proxied()` stays the pre-discovery fallback for billing/product-header
  purposes, which is a different question from vocabulary and was never the same
  bit.
- The console names the endpoint it is listing (`Models listed by <baseUrl>.`)
  instead of implying a vendor, and reports the host's own failure message
  instead of a hardcoded "OpenRouter's model list could not be loaded".

## Review round (Codex, 2026-09-08) — four findings, all valid, all fixed

Recorded here because three of them are the same mistake this PR is about, one
level in from where it was fixed, and one is a regression this PR introduced.

1. **A partial OpenRouter mirror got all four shipped ids.** `Concrete` was
   reached on `any` matching id and then licensed substitution of the whole
   table, so a gateway publishing `anthropic/claude-sonnet-5` and nothing else
   was handed `openai/gpt-5.6-sol-pro` for `reasoning-v1` — an id that same
   catalog had just said it does not serve. `TierVocabulary::Concrete` now
   carries a `ConcreteTiers` mask: **classification stays `any`, substitution is
   per tier.** Requiring all four instead would send a three-of-four mirror to
   `Unknown` and fail all four tiers where three would have worked.
2. **The negative catalog memo was keyed on the endpoint, credential failures
   included.** A `401`/`403` is an answer about the key presented, so on a
   multi-company host one company's bad key answered for the next company's
   valid one, and a company that had just rotated a bad key waited the memo out.
   Credential-specific failures are now reported and never remembered; an auth
   rejection is a fast round trip, so there is no timeout to amortise.
3. **The console could not tell a confirmed-empty tier mapping from "no catalog
   read".** An `unknown` vocabulary implies no defaults on purpose, and testing
   only the key count read that as "nothing loaded" and fell through to
   OpenRouter's ids — so switching provider away and back repopulated four ids
   the endpoint had just been seen not to publish, and Save persisted them.
   `catalogTierDefaults` is nullable now.
4. **A regression this PR introduced.** `GET …/inference/models` answers for the
   **saved** endpoint, while the effect keys off the form's *draft* provider. A
   company saved on Ollama or a custom endpoint, drafting a switch to OpenRouter,
   was shown the old endpoint's models under an OpenRouter picker — and choosing
   one saved a foreign model id against OpenRouter. The catalog is no longer
   offered when the draft provider is not the one the company is saved on;
   `managed` counts as OpenRouter because the host resolves it to the same
   endpoint, so first-run setup keeps a real catalog.

Each has a regression test, named in the reply on its thread.

## Review round 2 (CodeRabbit, 2026-09-08) — four findings

1. **Gate the catalog on the persisted provider** — same finding as Codex #4
   above, already fixed in `a19b6d5`; CodeRabbit's own annotation says so.
2. **Partition authenticated catalog caches by authorization scope** (Major,
   CWE-862). **Valid, fixed.** The base-URL-only key was right for a keyless read
   and wrong for one made with a company's credential: an endpoint may publish an
   entitlement-scoped catalog, so one company's list could be served to another
   for the rest of the hour. The registry now keys an *authenticated* entry on
   `(company id, endpoint)` and a keyless one on the endpoint alone. The
   credential still never becomes a map key. Only reachable in one process
   serving several companies (local multi-company, or shared-single-DB);
   db-per-tenant gives each tenant its own registry. Costs one fetch per company
   per endpoint per hour instead of one per endpoint.
3. **Require HTTPS before sending a bearer** (Major). **Declined here, with a
   reason.** The bearer already goes to `{base_url}/chat/completions` on every
   turn and has for as long as BYOK has existed — this PR adds one request per
   company per endpoint per hour to the same host over the same scheme, so the
   marginal exposure is nil. The proposed rule would also refuse an
   `openai_compatible` endpoint served over plain HTTP on an internal network
   behind a keyed gateway, which the provider table supports today. That is a
   provider-policy change with real breakage and belongs in its own reviewed
   diff — the reply on the thread sketches the shape (warn in the card; exempt
   loopback and private ranges if a hard refusal is wanted).
4. **Do not emit all concrete defaults from a partial catalog** — the same
   finding as Codex #1 above, fixed in `a19b6d5`, one commit before this review
   ran.

## Review round 3 (Codex + CodeRabbit, 2026-09-08/09) — six findings

Five valid and fixed, one declined with a reason. One of CodeRabbit's was valid
in substance but wrong in its prescription, and the correction is the
interesting part.

1. **Catalog discovery sat inside the turn's own deadline** (Codex, P1).
   **Valid, fixed — and it invalidated the answer this PR gave to its own
   push-back #1 below.** `TenantProvider::resolve` awaited `discovered_vocabulary`
   inline, so it inherited `MODEL_CATALOG_TIMEOUT` (10 s). Production triage
   wraps `invoke` in a **2-second** timeout (`triage.rs:80`), and the selector
   and title paths use three. At an endpoint whose `/chat/completions` is
   healthy but whose `/models` hangs, discovery therefore ate the caller's whole
   budget before the model request was ever sent — and because the caller's
   timeout *cancels* the future, the failure memo that exists to stop the next
   caller paying the same cost was never written, so every later auxiliary call
   repeated the same doomed read.

   `turn_vocabulary` replaces the inline await: the read is **spawned**, and only
   the *waiting* is bounded (`TURN_CATALOG_BUDGET`, 750 ms). Whoever gives up
   first, the spawned read runs to completion and records what it found, so the
   next turn reads an answer instead of starting the same request again. A
   catalog slower than the budget leaves the decl on its pre-discovery fallback
   for one turn — exactly the behaviour that shipped before discovery existed.
   Task pile-up is bounded by machinery already here: `catalog_models`
   single-flights on `fetch_lock` and re-checks the cache after acquiring it, so
   queued reads return the first one's result rather than duplicating it.

2. **Partition *successful* catalogs by credential scope** (Codex, P1).
   Already fixed in `6d32042`, the commit that landed between this comment and
   the review that raised it — authenticated entries are keyed on
   `(company id, endpoint)`. Finding 6 extends the same key one level finer.

3. **Reload the catalog when a managed draft gains a key** (Codex, P1).
   **Valid, fixed — and the obvious fix was wrong.** An unconfigured or
   `managed` company resolves to the platform proxy, whose catalog is
   tier-native (`chat-v1`, …). Typing an OpenRouter key sends Save straight to
   `api.openrouter.ai`, which has never heard of `chat-v1` — but the effect did
   not depend on the key, so the picker went on offering the proxy's tier names
   under a draft that no longer reached the proxy, and selecting one persisted
   an override direct OpenRouter rejects.

   The first fix withdrew the catalog on *any* typed key against a proxied
   company, and `frontend/test/e2e/inference.spec.ts` immediately said no:
   typing a key is *how* the catalog select is unlocked, because a keyless save
   would ride the proxy and reject the raw `<author>/<model>` id the select
   writes. Two cases encode that, with a comment explaining why they type one.
   A blanket withdrawal turns the picker off for everybody.

   What shipped combines two facts instead — `draftLeavesSavedEndpoint`
   (saved-proxied plus a typed key) says the *endpoint* moved, and
   `tierVocabulary === "tiers"` says the ids are categorically unusable where
   the draft is going, since resolving a tier server-side is exactly what
   `tiers` means. A `concrete` or `unknown` catalog publishes ordinary ids that
   are not categorically wrong elsewhere, so it is left alone and the intended
   flow survives. The check moved into the `.then` handler, because the
   vocabulary arrives with the catalog rather than being knowable up front.

4. **Clear `catalogTierDefaults` on catalog failures** (CodeRabbit, Major).
   **Valid, fixed — but not as prescribed, and the prescription was the bug.**
   The finding is right that both failure branches left a previous successful
   read's mapping in state, where a later `pickProvider` could seed the form
   from ids the endpoint never confirmed and Save would persist them.

   The suggested fix — `setCatalogTierDefaults(catalog.tierDefaults ?? {})`
   before the error return — is wrong here, and the existing regression test
   `seeds the switch form from status.defaultTierModels` catches it. `{}` is a
   **confirmed-empty** mapping, which `presetFor` honours by prefilling nothing;
   "the endpoint did not answer" has confirmed nothing. Collapsing the two
   discards the host's own `status.defaultTierModels` fallback on any blip —
   the same distinction this PR already draws when it sends `tierVocabulary:
   null` rather than `"unknown"` for an unreadable catalog. Both branches clear
   to `null`.

5. **Track published tier names individually** (Codex, P2). **Declined, with a
   reason.** The ask is to mirror round 1's `ConcreteTiers` fix onto the `Tiers`
   branch, so a catalog publishing only `chat-v1` stops offering all four tier
   names. The two cases are not symmetric:

   - On the wire, nothing changes. `model_for_tier` already sends the bare tier
     for `Tiers`, published or not, and that is the honest answer — the same one
     `Unknown` gets. The `Concrete` bug was different in kind: it substituted a
     *wrong, different* id the catalog had explicitly omitted.
   - A tier-native gateway's `/models` is not a routing contract. Resolving a
     tier server-side is precisely what `Tiers` means, and such a gateway may
     route `reasoning-v1` correctly without listing it. Suppressing the default
     would push operators into hand-entering ids for tiers that already work.

   So the change would alter no request, and would trade a working default for a
   blank box on a guess about an endpoint's listing habits. The operator can
   still type any id per tier. Reopening this is reasonable if a real gateway is
   found that lists a strict subset *and* rejects the rest.

6. **Include the harness credential scope in catalog caching** (Codex, P1).
   **Valid, fixed.** `resolve_effective_scoped` resolves config and credentials
   per `HarnessScope` — that is what lets one `built_in` harness ride the
   subscription while another runs on a key of its own — so two harnesses in one
   company can present different credentials to the same endpoint. Keyed on the
   company alone, the first harness's entitlement-scoped catalog was reused for
   the second without its credential ever being presented.
   `TenantProvider::catalog_scope` now keys on `(company id, harness id,
   endpoint)`. Both halves are non-secret ids; the credential still never becomes
   a map key.

**Also fixed, from CodeRabbit's nitpick list:** `InferenceModelCatalog
.tierVocabulary` is widened to `TierVocabulary | null`. The host really does
send an explicit `null` — `ModelCatalogDto::tier_vocabulary` carries no
`skip_serializing_if` — and the unit stub that omitted the field was asserting
`toBeUndefined()` against a shape nothing real produces. Stub and assertion now
match the wire.

## Review round 4 (Codex, 2026-09-09) — two findings on the round-3 head

1. **Invalidate positive catalogs when credentials rotate** (P1). **Valid,
   fixed.** This is the price of the invariant round 2 established: the cache key
   is made of non-secret ids on purpose, so a rotation is *invisible* to it.
   `catalog_cache_scoped` sees the same `(company, endpoint)` before and after,
   and answers from the entry the **old** bearer fetched for the rest of
   `MODEL_CATALOG_TTL` — the new credential never reaches `/models` at all.

   Fixed by evicting on the write rather than by weakening the key:
   `evict_company_catalogs` drops every registry entry under the `company\u{1}`
   prefix (covering both the console's `(company, endpoint)` scope and the turn
   path's `(company, harness, endpoint)`), and `set_config` calls it immediately
   after `store_key` — so it fires on a rotation and on an explicit clear, and
   not on a save that omits the field. Keyless entries stay: an unauthenticated
   catalog is a public property of the endpoint that no credential change can
   alter.

   Two existing route tests seeded the catalog *before* saving a key and so were
   throwing their own fixture away; they now seed after, which is also the real
   order. A new route test asserts the rotation directly, under a company id of
   its own — eviction is company-wide, and libtest runs these in parallel, so
   rotating under the shared `acme` would have wiped sibling fixtures.

**A test-isolation bug the eviction exposed, caught by CI and not by any local
run.** Eviction is company-wide and the catalog registry is process-global, so
any test that saves a key under a company clears every seeded catalog fixture
belonging to it. A dozen tests in `server::ops::inference::tests` save one under
`acme`, and two seeded a catalog under the same id — whichever pair libtest
scheduled together decided whether the fixture survived. Both `Rust` and
`Rust (openhuman, tinymemory)` failed on it; two consecutive local runs of the
gated suite had passed by luck. Every test that seeds a catalog now has an id
nothing else uses (`catalog-tiers`, `catalog-concrete`, `rotator`, and
`partition-one`/`partition-two`/`harness-partition-co` for the registry-level
ones, which were exposed to the same race from another module). Verified by
running **both** lanes to completion locally afterwards, which is the step whose
absence let this through: `cargo test` alone had never been run, only
`cargo test --features openhuman,tinymemory`.

2. **Compare catalog and draft endpoints for OpenRouter overrides** (P1).
   **Valid — and deliberately not fixed here.** The chain checks out:
   `PROVIDERS.openrouter.requiresBaseUrl` is `false`, so the console renders no
   Base URL field, Save sends `baseUrl: undefined`, and `set_config` has
   **replace** semantics for `base_url` (unlike `key`, which documents
   omit-means-unchanged). A stored custom OpenRouter endpoint is therefore
   cleared by a save from the console.

   That clearing is pre-existing and deliberate — echoing the resolved URL back
   "would pin the company to it, silently overriding `OPENCOMPANY_INFERENCE_URL`".
   What *this* PR changes is the other half: the picker now lists the custom
   gateway's own models rather than OpenRouter's registry, so the ids and the
   endpoint the save falls back to are no longer accidentally consistent.

   The suggested fix — compare the catalog URL against the endpoint the draft
   will save — is the right shape, but the console cannot compute the second
   value. `InferenceStatusDto` exposes `base_url` as one resolved string with
   nothing marking it an explicit override rather than a value from
   `OPENCOMPANY_INFERENCE_URL` or a built-in default (`source` answers where the
   *config* came from, not that question), and comparing against a hardcoded
   `https://openrouter.ai/api/v1` would be wrong for exactly the deployments the
   no-echo rule protects. A real fix is a contract change — surface whether
   `base_url` is an override, or make the omitted field mean "unchanged" as
   `key` already does — with its own test surface. That thread is left **open**
   on purpose, and flagged to the maintainer directly because it is their own
   live configuration (`openrouter` + key + custom `baseUrl`).

## Review round 5 (Codex + CodeRabbit, 2026-09-09) — four findings on the round-4 head

1. **Evict catalogs when Reset changes the credential** (Codex P1, and the same
   thing CodeRabbit's credential-write-path audit found). **Valid, fixed — a hole
   in round 4's own fix.** The eviction was wired into `set_config` only, and
   `revert_config` calls `inference::clear_key` directly. Reset changes the
   effective credential exactly as a rotation does: the runtime key is cleared so
   resolution falls back to the manifest's `api_key_secret`, and when the manifest
   names the same base URL nothing in the `(company, harness, endpoint)` key
   moves, so the cleared credential's catalog would answer for the rest of
   `MODEL_CATALOG_TTL`. `revert_config` now evicts too; every credential write in
   the module does. Covered by
   `resetting_the_config_does_not_serve_the_cleared_credentials_catalog`.

   Kept at the two route handlers rather than pushed into
   `company::inference::{store_key, clear_key}`: those are the domain layer and
   the cache is `server::inference_models`, so centralizing there would invert the
   dependency for a concern the domain layer does not own.

2. **Refetch the picker after credential rotation** (Codex P2). **Valid, declined
   with a reason, recorded as a known limit.** After a rotation on an
   already-keyed OpenRouter company no dependency of the catalog effect changes,
   so the option list is stale until remount. Bounded: Save is followed by
   `refresh()`, which reseeds the *form* from the host's post-rotation status, and
   the server-side entry is evicted so any reload is correct. The fix wants either
   a credential-generation field on `InferenceStatusDto` (a wire-contract change)
   or a refetch on every Save (including saves that changed no credential).
   Neither belongs in this diff.

3. **Bound the process-wide catalog registry** (Codex P2). **Real, declined here,
   worth a follow-up issue.** `catalog_registry` only inserts: TTL expiry makes
   `lookup` miss but drops neither the map entry nor its model vector. Bounded in
   practice by the key — companies × harnesses × endpoints-ever-used, the first
   two fixed by deployment — so it is unbounded accumulation when operators
   repeatedly repoint endpoints rather than growth proportional to traffic. The
   cheap fix is wrong: a slot can be past its TTL while a caller holds its
   `fetch_lock` across an in-flight `discover_models`, and dropping it there lets
   a second caller create a fresh slot and duplicate the upstream fetch, defeating
   the single-flight from issue #1838. A correct policy respects the in-flight
   lock and deserves its own change.

4. **Breaking API contract / update callers** (tinysweeper, high). **Disregarded
   on its own stated condition** — "if the frontend was updated in a separate file
   not shown here, disregard". It was, in `cdf4be914`, which is why it is absent
   from the incremental diff that review saw. Enumerated: the route has exactly
   one consumer, `listInferenceModels`, typed `Promise<InferenceModelCatalog>`,
   with one call site that reads `catalog.models`. `rg 'inference/models'` finds no
   other reader, and every stub and Playwright fixture answers the object shape.

   Its second finding — the bearer living in the spawned task past the caller's
   timeout — is also declined: the credential is already an owned `String` before
   `turn_vocabulary`, already handed to `reqwest`, and the console path already
   holds one for `MODEL_CATALOG_TIMEOUT`. The task outliving its caller is the
   fix, not a defect. `std::mem::take` scrubs nothing; real scrubbing wants
   `zeroize` applied at the secret-store boundary, uniformly, as its own change.

## What a reviewer should push back on — answered up front

**1. This adds a network call to the turn path.** `TenantProvider::resolve`
consults the catalog before deciding whether to rewrite a tier. Measured rather
than asserted: a cold-cache read of OpenRouter's registry — the largest catalog
any of these providers publishes, ~700 KB and ~421 models — took **0.14 s –
0.37 s** over five consecutive `GET https://openrouter.ai/api/v1/models` calls
from a developer machine. A tier-native endpoint publishing four ids is far
smaller.

**The hard bound on the turn path is `TURN_CATALOG_BUDGET` (750 ms), not
`MODEL_CATALOG_TIMEOUT` (10 s).** Review round 3 finding 1 is why: the console
can afford ten seconds and a turn cannot, because triage allows `invoke` two
seconds end to end. The read is spawned and only the waiting is bounded, so an
endpoint that accepts the connection and never answers costs a turn 750 ms once
rather than its whole deadline every time — asserted by
`a_turn_stops_waiting_for_a_hanging_catalog_within_its_own_budget`, which holds
a socket open without replying and measures the give-up. A refused connection
fails immediately.

Amortised it is one request per company, harness and endpoint per hour
(`MODEL_CATALOG_TTL`), or one per minute while an endpoint is down
(`MODEL_CATALOG_FAILURE_TTL`), and it is a request to the same host the turn is
about to call anyway. **Not measured:** the in-process cost end to end under the
harness — only the upstream request the added work consists of, and the
give-up path above.

**2. The cache is never keyed on the credential — but it is keyed on who asked.**
A credential must not become a map key, directly or hashed. That argument covers
a *keyless* read, which is a public property of the endpoint and stays shared. It
does not cover an authenticated one: an endpoint may publish an
entitlement-scoped catalog, so an authenticated entry is keyed on
`(company id, endpoint)`. Superseded the original position here after review
round 2 — the earlier claim that no provider kind publishes a per-key catalog was
not something I could actually establish for `openai_compatible`.

**3. Known scope limit: the console picker is still gated on `provider ===
"openrouter"`.** `ollama` and `openai_compatible` companies keep free-text model
boxes and do not get the newly discoverable catalog in the UI. The **turn path**
fix is provider-agnostic, so an Ollama company now sends `chat-v1` — honest, and
it still fails — rather than `anthropic/claude-sonnet-5`, which is mystifying.
Widening the picker is a follow-up, not something this PR claims.

**4. This is a breaking response-shape change** on `GET
{scope}/inference/models`: array → object. Only `frontend/src/api/inference.ts`
consumes it in-repo, so the blast radius is contained, but it is a genuine API
break and anything out-of-tree reading that route will need updating.

**5. Cosmetic, deliberately not fixed here.** The failure message renders the
endpoint three times ("Could not list models from `X`: request to `X`/models
failed: error sending request for url (`X`/models)"). The inner text comes from
`discover_models`, which predates this PR and is shared with `setup.rs`'s probe
path; this PR only newly puts it on screen. Tightening it means touching a
shared error path, so it is left for a follow-up rather than smuggled in here.

## Verified

Rebased onto `upstream/main` (`89b1f818a`); the earlier `CONFLICTING` state was
only the `vendor/openhuman` submodule pointer, which GitHub will not
fast-forward and git will. The branch now carries `main`'s pin `b7f4e949`, and
`git merge-base --is-ancestor 61d25fe2 b7f4e949` confirms it is a descendant of
what this branch had, so there is no runtime downgrade.

**Fixed the two stale fixtures that were the entire CI failure.** Both
`inference.spec.ts:155` and `:209` fulfilled `**/inference/models` with a bare
JSON array. Against the new handler `catalog.models.length` is `undefined.length`,
thrown inside `.then`, swallowed by `.catch` into the error state — so
`inference-model-select-chat-v1` never rendered and both specs failed on
`toBeEnabled()` finding no element. Three unit stubs returned `[]` for the same
route and passed only by accident through that same error path; they are updated
to the real shape too.

Commands run locally for **review round 3**, all green (exit codes captured
directly, not through a pipe):

- `cargo fmt --all -- --check` — 0
- `cargo clippy --all-targets -- -D warnings` — 0
- `cargo clippy --all-targets --features openhuman,tinymemory -- -D warnings` — 0
  (the gated lane, run explicitly because it catches lints the default pass
  misses)
- `cargo test --features openhuman,tinymemory` — **7203 passed, 0 failed**
  across all targets
- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — all
  three gates, 0 each
- `npx vitest run` — **513 files, 4827 tests, 0 failed**
- `npx playwright test test/e2e/inference.spec.ts` against a locally built host
  — **7 passed**, including the two key-typing cases that caught the first,
  too-broad version of finding 3's fix
- `scripts/ci/assert-design-tokens.sh` — 0

Re-run in full for **review round 4** after the eviction change: `cargo fmt --all -- --check`, both clippy lanes and `cargo test --features openhuman,tinymemory` — **7205 passed, 0 failed** in the lib target and zero failures across every integration target.

**Browser-verified**, light and dark, against a real host with a company pointed
at a local tier-native OpenAI-compatible endpoint — which is the case this PR
exists for, and the case that could not previously be represented:

- `GET .../inference/models` answered with that endpoint's own catalog:
  `tierVocabulary: "tiers"`, `tierDefaults` mapping each tier to itself, and the
  four ids it publishes — **not** OpenRouter's registry.
- The picker offered exactly those four models, and the card read `Models listed
  by http://127.0.0.1:8592/v1.` rather than implying a vendor.
- Repointed at an endpoint that cannot answer: the card named *that* endpoint in
  its failure, fell back to free-text inputs, and left the four tier fields
  **empty** rather than prefilling `anthropic/claude-sonnet-5` — the behaviour
  this PR argues for, seen rather than asserted.

**Browser-verified again for review round 3**, light and dark, against a local
tier-native OpenAI-compatible endpoint (a stub publishing `chat-v1`,
`agentic-v1`, `reasoning-v1`, `vision-v1`) with the company on `openrouter` and
a custom base URL — the operator's own shape, `proxied = false`:

- `GET .../inference/models` answered `tierVocabulary: "tiers"` with that
  endpoint's four ids and a tier-to-itself `tierDefaults` — not OpenRouter's
  registry.
- The picker rendered — the original CI failure was that it never did — and its
  options were exactly those four ids plus "Enter a model id…", with the card
  reading `Models listed by http://127.0.0.1:8597/v1.`
- With the company saved keyless (so proxied) against that endpoint, typing a
  key withdrew the tier-native catalog, named why, and left all four tier fields
  **empty free-text** rather than a select full of tier names direct OpenRouter
  would reject — finding 3, seen rather than asserted.

## Root cause fixed, not patched

The wrong id was a symptom of a hardcoded catalog; the fix makes the catalog
discoverable per-endpoint so the same class of provider never needs a special
case again.

