### PR TITLE
fix(ledger): refuse a row missing a field the ledger declares required

### DIFF
--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -272,6 +272,15 @@ const EMPTY_DECIDING: ReadonlyMap<string, Verdict> = new Map();
 const EMPTY_DECIDED: Readonly<Record<string, DecidedApproval>> = {};
 const EMPTY_FAILED: Record<string, string> = {};
 
+/**
+ * How many faults the alert states outright before the rest go behind "more".
+ *
+ * Enough that the usual case — one row, one reason — is simply readable, and
+ * few enough that a batch of them cannot grow the alert past the content it
+ * sits under (issue #1347).
+ */
+const FAULTS_STATED = 3;
+
 /** The task ledger is operated as a board; declared ledgers are read as rows. */
 export function defaultLedgerMode(
   ledger: LedgerSummary | null,
@@ -1114,31 +1123,44 @@ export function LedgersView({
                 </p>
               )}
 
-              {/* One row, not one per fault (issue #1347).
-                  
-                  A ledger whose rows are written by agents produces faults in
-                  batches — a required field one pass forgot is missing from
-                  every row that pass wrote — so this was seven full-width
-                  alerts, 364px of the same sentence with a different id in it,
-                  stacked below the board and out-weighing the content they are
-                  about. The count is the whole headline; the ids are what you
-                  open when you go looking. */}
+              {/* One alert, not one per fault (issue #1347): a ledger whose
+                  rows are written by agents produces faults in batches, and
+                  seven full-width alerts was 364px of the same sentence with a
+                  different id in it, out-weighing the content they are about.
+
+                  The count alone was not enough, though. Every fault the host
+                  sends already names the row and what is wrong with it — the
+                  same sentence the workspace's rendered copy prints — and
+                  behind a closed disclosure the screen said only that some row
+                  somewhere could not be read, which is not something anybody
+                  can act on. So the first few are stated outright and the
+                  bound moves to the list rather than to the alert. */}
               {read?.faults && read.faults.length > 0 && (
                 <Alert data-testid="ledger-faults">
                   <AlertTriangle className="size-4" />
                   <AlertDescription>
-                    <details>
-                      <summary className="w-fit cursor-pointer select-none">
-                        {read.faults.length === 1
-                          ? "1 row could not be read"
-                          : `${read.faults.length} rows could not be read`}
-                      </summary>
-                      <ul className="mt-2 space-y-1">
-                        {read.faults.map((fault) => (
-                          <li key={fault}>{inlineCode(fault)}</li>
-                        ))}
-                      </ul>
-                    </details>
+                    <p>
+                      {read.faults.length === 1
+                        ? "1 row could not be read"
+                        : `${read.faults.length} rows could not be read`}
+                    </p>
+                    <ul className="mt-2 space-y-1">
+                      {read.faults.slice(0, FAULTS_STATED).map((fault) => (
+                        <li key={fault}>{inlineCode(fault)}</li>
+                      ))}
+                    </ul>
+                    {read.faults.length > FAULTS_STATED && (
+                      <details className="mt-1">
+                        <summary className="w-fit cursor-pointer select-none">
+                          {read.faults.length - FAULTS_STATED} more
+                        </summary>
+                        <ul className="mt-2 space-y-1">
+                          {read.faults.slice(FAULTS_STATED).map((fault) => (
+                            <li key={fault}>{inlineCode(fault)}</li>
+                          ))}
+                        </ul>
+                      </details>
+                    )}
                   </AlertDescription>
                 </Alert>
               )}

--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -366,6 +366,26 @@ export function LedgersView({
   );
 
   /**
+   * The open list's summary, preferring the copy that came back with the rows
+   * on screen.
+   *
+   * `useLedgerNav` reads once per company and again only when a list is
+   * declared or retired — never when a row is recorded — so its `open` count
+   * is the number this list held when the screen was first opened. Record a
+   * risk and the row appears while the count beside the title still says zero,
+   * because the two came from different requests.
+   *
+   * The read that fetched the rows carries a summary counted over the very
+   * fold those rows came out of, so it is the one number that cannot disagree
+   * with what is rendered beneath it. The slug guard keeps a read still in
+   * flight for the previous list from being counted against this one.
+   */
+  const counted = useMemo(
+    () => (read?.ledger.slug === ledger?.slug ? (read?.ledger ?? ledger) : ledger),
+    [read, ledger],
+  );
+
+  /**
    * Columns or rows.
    *
    * The task ledger is operated as a board; declared ledgers read as rows
@@ -789,7 +809,7 @@ export function LedgersView({
                         the same ambiguity `filteredEmptyNotice` exists to
                         rule out elsewhere in this file. */}
                     <span className="text-xs text-muted-foreground">
-                      {held.open}
+                      {held.slug === counted?.slug ? counted.open : held.open}
                     </span>
                   </DropdownMenuItem>
                 ))}
@@ -822,12 +842,13 @@ export function LedgersView({
            that changes, and the one the switcher already shows for every
            *other* list while saying nothing about the open one. */
         trailing={
-          ledger && (
+          counted && (
             <span
-              title={`${ledger.open} open`}
+              data-testid="ledger-open-count"
+              title={`${counted.open} open`}
               className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium tabular-nums text-muted-foreground"
             >
-              {ledger.open}
+              {counted.open}
             </span>
           )
         }

--- a/frontend/test/e2e/ledger-required-field.spec.ts
+++ b/frontend/test/e2e/ledger-required-field.spec.ts
@@ -1,0 +1,222 @@
+import { expect, test } from "@playwright/test";
+
+const API = "/api/v1/company";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const seen = JSON.stringify({ skipped: true, seenAt: Date.now() });
+    for (const key of [
+      "oc-tour:single",
+      "oc-tour:e2e-harness-co",
+      "oc-tour:null",
+    ]) {
+      window.localStorage.setItem(key, seen);
+    }
+  });
+});
+
+/** A list shape, with `evidence` required or not. */
+function declaration(slug: string, evidenceRequired: boolean) {
+  return {
+    slug,
+    title: `E2E required ${slug}`,
+    purpose: "A list used to check its required-field contract.",
+    derived: `derived/${slug}.md`,
+    fields: [
+      { name: "id", role: "id" },
+      { name: "finding", role: "title", required: true },
+      { name: "status", role: "status", required: true },
+      {
+        name: "evidence",
+        role: "prose",
+        required: evidenceRequired,
+        description: "What actually happened, concretely.",
+      },
+    ],
+    statuses: [{ name: "noted", label: "Noted" }],
+    checks: ["required-field", "known-status"],
+  };
+}
+
+/**
+ * The write and the read agree about what a row must carry.
+ *
+ * The list declares `evidence` required. Before this, the write took a row
+ * without one and answered 200, and every read then reported that same row as
+ * one that could not be read — so the rendered file listed it twice, once as a
+ * row and once as a fault about itself. The refusal below is that contradiction
+ * closed at the only place that can close it: the write.
+ */
+test("a row missing a required field is refused, and a complete one reads back clean", async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(120_000);
+
+  const marker = Date.now();
+  const slug = `e2e-required-${marker}`;
+  const declared = await request.post(`${API}/ledgers`, {
+    data: declaration(slug, true),
+  });
+  expect(declared.ok()).toBeTruthy();
+
+  try {
+    const refused = await request.post(`${API}/ledgers/${slug}/entries`, {
+      data: {
+        id: "missing-evidence",
+        status: "noted",
+        fields: { finding: "a row with no evidence field" },
+      },
+    });
+    expect(refused.status()).toBe(400);
+    // The refusal names the field and carries its description, so whoever
+    // filled the row in wrong learns what belongs there without a second call.
+    const body = await refused.text();
+    expect(body).toContain("evidence");
+    expect(body).toContain("What actually happened");
+
+    // Refused means nothing landed — not stored-and-complained-about.
+    const afterRefusal = await (
+      await request.get(`${API}/ledgers/${slug}/entries`)
+    ).json();
+    expect(afterRefusal.entries).toHaveLength(0);
+    expect(afterRefusal.faults ?? []).toHaveLength(0);
+
+    // An amendment carries only what changes: the row already holds the
+    // evidence, so moving its status must not be refused for not repeating it.
+    const opened = await request.post(`${API}/ledgers/${slug}/entries`, {
+      data: {
+        id: "complete",
+        status: "noted",
+        fields: { finding: "a complete row", evidence: "it happened twice" },
+      },
+    });
+    expect(opened.ok()).toBeTruthy();
+    const amended = await request.post(`${API}/ledgers/${slug}/entries`, {
+      data: { id: "complete", status: "noted" },
+    });
+    expect(amended.ok()).toBeTruthy();
+
+    await page.goto(`/#/ledgers/${slug}`);
+    await expect(page.getByTestId("ledger-entry-complete")).toBeVisible({
+      timeout: 15_000,
+    });
+    // The contract, on screen: a list holding only rows the write accepted
+    // reports nothing unreadable.
+    await expect(page.getByTestId("ledger-faults")).toHaveCount(0);
+  } finally {
+    await request.delete(`${API}/ledgers/${slug}?purge=true`);
+  }
+});
+
+/**
+ * A row that predates the requirement is named, not merely counted.
+ *
+ * The write refusing new ones does not empty the fault surface: a list amended
+ * to require a field it did not before still holds rows written under the older
+ * shape, and those are reported rather than hidden. Editing a list is a retire
+ * (which keeps the rows) and a re-declare, which is what this reproduces.
+ *
+ * The console used to answer that with "1 row could not be read" and nothing
+ * else — the row and the reason were behind a closed disclosure, while the
+ * workspace's rendered copy printed both. A fault nobody can act on is a fault
+ * nobody acts on.
+ */
+test("the board names the row that could not be read and why", async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(120_000);
+
+  const marker = Date.now();
+  const slug = `e2e-legacy-${marker}`;
+  const declared = await request.post(`${API}/ledgers`, {
+    data: declaration(slug, false),
+  });
+  expect(declared.ok()).toBeTruthy();
+
+  try {
+    const legacy = await request.post(`${API}/ledgers/${slug}/entries`, {
+      data: {
+        id: "predates-the-rule",
+        status: "noted",
+        fields: { finding: "written before evidence was required" },
+      },
+    });
+    expect(legacy.ok()).toBeTruthy();
+
+    // Retire without `purge`, so the rows survive the shape change.
+    expect((await request.delete(`${API}/ledgers/${slug}`)).ok()).toBeTruthy();
+    const redeclared = await request.post(`${API}/ledgers`, {
+      data: declaration(slug, true),
+    });
+    expect(redeclared.ok()).toBeTruthy();
+
+    await page.goto(`/#/ledgers/${slug}`);
+    const faults = page.getByTestId("ledger-faults");
+    await expect(faults).toBeVisible({ timeout: 15_000 });
+    await expect(faults).toContainText("1 row could not be read");
+
+    // Asserted on the *rendered* text, not on `textContent`: the reason this
+    // was reported at all is that the row and the fault sat inside a closed
+    // `<details>`, and a collapsed disclosure still carries its text content.
+    // `toContainText` would therefore have passed against the very bug this
+    // pins. What has to be true is that a reader sees it without opening
+    // anything.
+    await expect(
+      faults.getByText("predates-the-rule", { exact: false }),
+    ).toBeVisible();
+    const stated = await faults.innerText();
+    expect(stated).toContain("predates-the-rule");
+    expect(stated).toContain("evidence");
+  } finally {
+    await request.delete(`${API}/ledgers/${slug}?purge=true`);
+  }
+});
+
+/**
+ * The count beside the list's name is counted over the rows on screen.
+ *
+ * It used to come from the sidebar's own read, which happens once per company
+ * and again only when a list is declared or retired — never when a row is
+ * recorded. So a list opened while empty went on saying zero with a live row
+ * rendered underneath it, until a full page reload.
+ */
+test("the open count follows a row recorded after the screen was opened", async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(120_000);
+
+  const marker = Date.now();
+  const slug = `e2e-count-${marker}`;
+  const declared = await request.post(`${API}/ledgers`, {
+    data: declaration(slug, true),
+  });
+  expect(declared.ok()).toBeTruthy();
+
+  try {
+    await page.goto(`/#/ledgers/${slug}`);
+    const count = page.getByTestId("ledger-open-count");
+    await expect(count).toHaveText("0", { timeout: 15_000 });
+
+    const recorded = await request.post(`${API}/ledgers/${slug}/entries`, {
+      data: {
+        id: "live-row",
+        status: "noted",
+        fields: { finding: "a live row", evidence: "it happened" },
+      },
+    });
+    expect(recorded.ok()).toBeTruthy();
+
+    await page.getByRole("button", { name: /refresh/i }).first().click();
+    await expect(page.getByTestId("ledger-entry-live-row")).toBeVisible({
+      timeout: 15_000,
+    });
+    // The row is on screen, so the count beside the title cannot still say
+    // there is nothing here.
+    await expect(count).toHaveText("1");
+  } finally {
+    await request.delete(`${API}/ledgers/${slug}?purge=true`);
+  }
+});

--- a/frontend/test/e2e/ledger-required-field.spec.ts
+++ b/frontend/test/e2e/ledger-required-field.spec.ts
@@ -220,3 +220,108 @@ test("the open count follows a row recorded after the screen was opened", async 
     await request.delete(`${API}/ledgers/${slug}?purge=true`);
   }
 });
+
+/**
+ * The count beside the list's name describes the rows rendered under it.
+ *
+ * `read_ledger` used to answer with a count from a second, independent fold
+ * of the ledger — taken separately from the one that produced the rows in
+ * the same response. A write landing between the two could flip a row's
+ * status after the rows were read but before the count was, so the badge
+ * disagreed with what the screen actually showed beside it. This checks the
+ * agreement against the DOM itself — counting the rows Playwright can see,
+ * not a second value pulled from another request — after a write and after
+ * a close, which is where a stale or independently-folded count would show.
+ */
+test("the open count agrees with the rows the screen actually shows", async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(120_000);
+
+  const marker = Date.now();
+  const slug = `e2e-count-agree-${marker}`;
+  const declared = await request.post(`${API}/ledgers`, {
+    data: {
+      slug,
+      title: `E2E count agree ${marker}`,
+      purpose: "A list used to check the badge against the rows it counts.",
+      derived: `derived/${slug}.md`,
+      fields: [
+        { name: "id", role: "id" },
+        { name: "risk", role: "title" },
+        { name: "status", role: "status" },
+        { name: "reason", role: "prose" },
+      ],
+      statuses: [
+        { name: "open" },
+        { name: "closed", closed: true, needs_reason: true },
+      ],
+    },
+  });
+  expect(declared.ok()).toBeTruthy();
+
+  try {
+    const recordRow = (id: string, risk: string) =>
+      request.post(`${API}/ledgers/${slug}/entries`, {
+        data: { id, status: "open", fields: { risk } },
+      });
+    expect((await recordRow("r1", "first")).ok()).toBeTruthy();
+    expect((await recordRow("r2", "second")).ok()).toBeTruthy();
+
+    await page.goto(`/#/ledgers/${slug}`);
+    // A company that has not yet cleared the first-run activation funnel
+    // gates the whole shell behind it (`OnboardingGate`); dismiss the same
+    // way an operator would, if it is showing.
+    const gateSkip = page.getByTestId("gate-skip");
+    try {
+      await gateSkip.waitFor({ state: "visible", timeout: 5_000 });
+      await gateSkip.click();
+    } catch {
+      // Not showing — the company already cleared activation.
+    }
+
+    const count = page.getByTestId("ledger-open-count");
+    await expect(page.getByTestId("ledger-entry-r2")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // The invariant: the badge equals however many rows the DOM itself
+    // renders as not-closed — never a fixed number asserted independently
+    // of what is actually on screen.
+    const assertBadgeMatchesRows = async () => {
+      const statuses = await page
+        .getByTestId("ledger-entry-status")
+        .allTextContents();
+      const openRows = statuses.filter(
+        (text) => !text.trim().startsWith("Closed"),
+      ).length;
+      await expect(count).toHaveText(String(openRows));
+    };
+    await assertBadgeMatchesRows();
+    await expect(count).toHaveText("2");
+
+    // Record a third row live: the badge must move with the rows.
+    expect((await recordRow("r3", "third")).ok()).toBeTruthy();
+    await page.getByRole("button", { name: /refresh/i }).first().click();
+    await expect(page.getByTestId("ledger-entry-r3")).toBeVisible({
+      timeout: 15_000,
+    });
+    await assertBadgeMatchesRows();
+    await expect(count).toHaveText("3");
+
+    // Close one: the badge must drop with the row, not lag behind it.
+    const closed = await request.post(`${API}/ledgers/${slug}/entries`, {
+      data: { id: "r1", status: "closed", reason: "resolved" },
+    });
+    expect(closed.ok()).toBeTruthy();
+    await page.getByRole("button", { name: /refresh/i }).first().click();
+    await expect(
+      page.getByTestId("ledger-entry-r1").getByTestId("ledger-entry-status"),
+    ).toHaveText("Closed", { timeout: 15_000 });
+    await assertBadgeMatchesRows();
+    await expect(count).toHaveText("2");
+  } finally {
+    await request.delete(`${API}/ledgers/${slug}?purge=true`);
+  }
+});

--- a/src/company/ledgers.rs
+++ b/src/company/ledgers.rs
@@ -16,6 +16,13 @@
 //!   written with no reason is refused at the write rather than reported at the
 //!   read, because a row that closed silently is worth nothing to whoever picks
 //!   it up next and by then the person who knew has moved on.
+//! * **A required field is required at the write.** A ledger that declares the
+//!   `required-field` check refuses a row that would land without one, for the
+//!   same reason: the reader already calls such a row unreadable, so accepting
+//!   it stores something every surface then reports as a fault — the row
+//!   rendered twice, once as itself and once under *rows that could not be
+//!   read*. The check runs against the merged row, so amending one that already
+//!   carries the field is not refused for declining to repeat it.
 //! * **The derived file follows the write.** Every mutation re-renders and
 //!   republishes, so `derived/` is never a stale copy of something.
 
@@ -26,8 +33,9 @@ use crate::Result;
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ledger::{
-    AuthorKind, Entries, LedgerAuthor, LedgerEvent, LedgerSource, LedgerSpec, MAX_FIELD_CHARS,
-    Order, REASON_FIELD, Registry, budget, derived, engine, native, parse_order,
+    AuthorKind, Check, Entries, Field, FieldRole, LedgerAuthor, LedgerEvent, LedgerSource,
+    LedgerSpec, MAX_FIELD_CHARS, Order, REASON_FIELD, Registry, budget, derived, engine, native,
+    parse_order,
 };
 use crate::ports::now_millis;
 
@@ -271,8 +279,9 @@ pub async fn read(ctx: &Ledgers, spec: &LedgerSpec, query: &Query) -> Result<Rea
 /// Returns [`OpenCompanyError::InvalidRequest`] when the ledger is native (its
 /// rows are written by the surface that owns them), when the author may not
 /// write it, when the event names no entry, when it sets a status the ledger
-/// does not declare, or when it closes a row into a status that demands a
-/// reason without giving one.
+/// does not declare, when it closes a row into a status that demands a reason
+/// without giving one, or when it would leave the row without a field the
+/// ledger requires.
 pub async fn record(
     ctx: &Ledgers,
     spec: &LedgerSpec,
@@ -348,6 +357,15 @@ pub async fn record(
                     )));
                 }
             }
+        }
+    }
+
+    if spec.checks.contains(&Check::RequiredField) {
+        let missing = missing_required(ctx, spec, id, &fields).await?;
+        if !missing.is_empty() {
+            return Err(OpenCompanyError::InvalidRequest(missing_required_message(
+                spec, id, &missing,
+            )));
         }
     }
 
@@ -543,6 +561,70 @@ fn refuse_non_human(author: &LedgerAuthor, what: &str) -> Result<()> {
          can erase the record of what it did is one whose record means nothing. Close the row \
          instead — it keeps the reason."
     )))
+}
+
+/// The fields `spec` requires that would still be empty once this event lands.
+///
+/// Resolved against the **merged** row, not against the event: every write is a
+/// merge, so an amendment that only moves a status must not be refused for
+/// declining to repeat a field the row already carries. The stored row is read
+/// only when the event leaves one of them unfilled, so the common write — one
+/// that carries them — costs nothing extra.
+///
+/// The id is skipped for the reason [`engine::fold`]'s own check skips it: it
+/// lives beside the fields rather than inside them, and is already refused
+/// empty above.
+async fn missing_required(
+    ctx: &Ledgers,
+    spec: &LedgerSpec,
+    id: &str,
+    fields: &BTreeMap<String, Option<String>>,
+) -> Result<Vec<Field>> {
+    let unfilled: Vec<&Field> = spec
+        .fields
+        .iter()
+        .filter(|field| field.required && field.role != FieldRole::Id)
+        .filter(|field| !fields.get(&field.name).is_some_and(Option::is_some))
+        .collect();
+    if unfilled.is_empty() {
+        return Ok(Vec::new());
+    }
+    let stored = entries(ctx, spec).await?;
+    let held = stored.find(id);
+    Ok(unfilled
+        .into_iter()
+        // Naming a field with no value clears it, whatever the row held.
+        .filter(|field| {
+            fields.contains_key(&field.name)
+                || held.is_none_or(|entry| entry.get(&field.name).trim().is_empty())
+        })
+        .cloned()
+        .collect())
+}
+
+/// The refusal a missing required field earns.
+///
+/// Worded as the reader's own fault sentence, so the write and the read say the
+/// same thing about the same row, and carrying each field's description — which
+/// is written to tell whoever fills it in what belongs there.
+fn missing_required_message(spec: &LedgerSpec, id: &str, missing: &[Field]) -> String {
+    let named = missing
+        .iter()
+        .map(|field| {
+            if field.description.trim().is_empty() {
+                format!("`{}`", field.name)
+            } else {
+                format!("`{}` ({})", field.name, field.description.trim())
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "`{id}` has no {named}, which `{}` requires. Stored without it, the row reads back as one \
+         that could not be read — so it is refused here rather than kept and complained about on \
+         every read.",
+        spec.slug
+    )
 }
 
 /// Trims and caps every value, dropping keys that are only whitespace.

--- a/src/company/ledgers.rs
+++ b/src/company/ledgers.rs
@@ -25,9 +25,19 @@
 //!   carries the field is not refused for declining to repeat it.
 //! * **The derived file follows the write.** Every mutation re-renders and
 //!   republishes, so `derived/` is never a stale copy of something.
+//! * **A write and a purge on the same ledger never interleave.** Checking a
+//!   required field or a close reason reads the stored row first and only
+//!   then appends; a purge landing in that gap would remove the very events
+//!   the check just relied on, so the append that follows would recreate the
+//!   row without them and still report success. [`record`], [`delete_entry`]
+//!   and [`retire`] all take [`ledger_lock`] for one company's one ledger
+//!   before touching the store, so the two paths queue behind each other
+//!   instead of racing.
 
-use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, LazyLock, Mutex as StdMutex};
+
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::Result;
 use crate::company::runtime::CompanyRuntime;
@@ -38,6 +48,49 @@ use crate::ledger::{
     parse_order,
 };
 use crate::ports::now_millis;
+use crate::ports::types::CompanyId;
+
+/// One company's one ledger, by slug — the key a write lock is scoped to.
+type LedgerKey = (CompanyId, String);
+
+/// A registry of per-[`LedgerKey`] async locks, one per every distinct ledger
+/// a write has touched.
+struct LedgerLocks {
+    inner: StdMutex<HashMap<LedgerKey, Arc<AsyncMutex<()>>>>,
+}
+
+impl LedgerLocks {
+    fn get(&self, company: &CompanyId, slug: &str) -> Arc<AsyncMutex<()>> {
+        let mut locks = self.inner.lock().expect("ledger-write-lock map poisoned");
+        locks
+            .entry((company.clone(), slug.to_string()))
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    }
+}
+
+/// Every write's lock, shared by every [`Ledgers`] instance in the process.
+///
+/// A `static` rather than a field: two `Ledgers` built over the same company
+/// (one per request, per the routes) must meet on the same lock, which only
+/// something the process shares — not something each instance constructs —
+/// can guarantee. Mirrors the precedent `FS_WRITE_LOCKS` set for the
+/// filesystem store, deliberately including its scope: in-process only, so a
+/// second process over the same data directory is outside its reach and
+/// relies on the store's own write atomicity instead.
+static LEDGER_WRITE_LOCKS: LazyLock<LedgerLocks> = LazyLock::new(|| LedgerLocks {
+    inner: StdMutex::new(HashMap::new()),
+});
+
+/// The write lock for one company's one ledger.
+///
+/// Held across a check-then-append (or a purge) so the two never observe each
+/// other's half-done state. Scoped to `(company, slug)` rather than to the
+/// whole store, so writes to unrelated ledgers — or unrelated companies —
+/// never queue behind each other.
+fn ledger_lock(company: &CompanyId, slug: &str) -> Arc<AsyncMutex<()>> {
+    LEDGER_WRITE_LOCKS.get(company, slug)
+}
 
 /// Everything a ledger operation needs, without a whole [`CompanyRuntime`].
 ///
@@ -322,6 +375,9 @@ pub async fn record(
         ));
     }
 
+    let lock = ledger_lock(&ctx.company, &spec.slug);
+    let _guard = lock.lock().await;
+
     let fields = normalize_fields(fields);
     if let Some(field) = spec.status_field()
         && let Some(Some(status)) = fields.get(&field.name)
@@ -499,6 +555,8 @@ pub async fn retire(ctx: &Ledgers, author: &LedgerAuthor, slug: &str, purge: boo
     }
     ctx.ledgers.delete_spec(&ctx.company, &spec.slug).await?;
     if purge {
+        let lock = ledger_lock(&ctx.company, &spec.slug);
+        let _guard = lock.lock().await;
         ctx.ledgers.purge_ledger(&ctx.company, &spec.slug).await?;
     }
     Ok(())
@@ -527,6 +585,8 @@ pub async fn delete_entry(
             spec.slug, spec.written_by
         )));
     }
+    let lock = ledger_lock(&ctx.company, &spec.slug);
+    let _guard = lock.lock().await;
     let removed = ctx
         .ledgers
         .purge_entry(&ctx.company, &spec.slug, id.trim())

--- a/src/company/ledgers.rs
+++ b/src/company/ledgers.rs
@@ -199,6 +199,12 @@ pub struct Read {
     pub matched: usize,
     /// What the declared checks found on the whole ledger.
     pub faults: Vec<String>,
+    /// Rows not in a closed status, counted over the same fold `entries` came
+    /// from — never a second, independent fold that could observe a write
+    /// landing between the two.
+    pub open: usize,
+    /// Rows in one, counted over that same fold.
+    pub closed: usize,
 }
 
 /// What a read is narrowed by.
@@ -261,10 +267,14 @@ pub async fn read(ctx: &Ledgers, spec: &LedgerSpec, query: &Query) -> Result<Rea
         .unwrap_or(budget::DEFAULT_READ_LIMIT)
         .clamp(1, budget::MAX_READ_LIMIT);
     rows.truncate(limit);
+    let open = folded.open_count(spec);
+    let closed = folded.closed_count(spec);
     Ok(Read {
         entries: rows,
         matched,
         faults: folded.faults,
+        open,
+        closed,
     })
 }
 

--- a/src/company/ledgers_test.rs
+++ b/src/company/ledgers_test.rs
@@ -136,6 +136,81 @@ async fn recording_again_amends_the_same_row() {
     assert_eq!(read.entries[0].get("risk"), "second");
 }
 
+/// #2048 review: `read_ledger` used to fold the ledger once for its rows and
+/// again, independently, inside `summary()` for the open/closed count sent
+/// alongside them. A write landing in the gap between those two folds could
+/// flip a row's status after the rows were read but before the count was, so
+/// the response shipped a badge that disagreed with the rows beside it.
+///
+/// This reproduces that gap deterministically — recording a close at exactly
+/// the point the old handler's second, independent fold used to run — rather
+/// than relying on scheduler luck to land a race. It shows two things: a
+/// second fold at that point genuinely disagrees with the rows already
+/// returned (the defect is real, not hypothetical), and `read`'s own
+/// `open`/`closed` — computed from the very fold that produced `entries`,
+/// never a later one — hold steady across the write instead.
+#[tokio::test]
+async fn a_second_independent_fold_would_disagree_with_the_rows_read_already_returned() {
+    let (ctx, _runtime, _home) = ledgers().await;
+    let spec = define(&ctx, &hazards()).await.expect("declared");
+    record(
+        &ctx,
+        &spec,
+        &agent(),
+        "r1",
+        fields(&[("risk", "a"), ("status", "open")]),
+    )
+    .await
+    .expect("recorded");
+
+    // One fold, as the fixed `read` performs it: rows and counts share a
+    // single snapshot, so both describe the ledger as of the same instant.
+    let read = read(&ctx, &spec, &Query::default()).await.expect("read");
+    assert_eq!(read.entries.len(), 1);
+    assert_eq!(read.open, 1);
+    assert_eq!(read.closed, 0);
+
+    // The write that used to land in the window between the rows' fold and
+    // the count's second, independent fold.
+    record(
+        &ctx,
+        &spec,
+        &agent(),
+        "r1",
+        fields(&[("status", "closed"), ("reason", "handled")]),
+    )
+    .await
+    .expect("closed");
+
+    // A second, independent fold taken right here — what `summary()` used to
+    // run after `read()` already returned — now disagrees with the rows
+    // `read` already handed back above: this is the exact mismatch a
+    // two-fold response would have shipped to the console.
+    let refolded = entries(&ctx, &spec).await.expect("entries");
+    assert_eq!(
+        refolded.open_count(&spec),
+        0,
+        "the row already closed by the time a second fold ran"
+    );
+    assert_ne!(
+        refolded.open_count(&spec),
+        read.open,
+        "a second, independent fold disagrees with the snapshot `read` already returned"
+    );
+
+    // `read`'s own numbers, by contrast, are unaffected by the write that
+    // came after it: they were taken from one snapshot and remain
+    // internally consistent with the rows in that same `read`.
+    assert_eq!(
+        read.open,
+        read.entries
+            .iter()
+            .filter(|entry| !spec.is_closed(&entry.status(&spec)))
+            .count()
+    );
+    assert_eq!(read.closed, 0);
+}
+
 /// Refused at the **write**, not reported at the read: by the time somebody
 /// reads it, the person who knew why has moved on.
 #[tokio::test]

--- a/src/company/ledgers_test.rs
+++ b/src/company/ledgers_test.rs
@@ -569,6 +569,163 @@ async fn a_blank_value_clears_the_field() {
     assert_eq!(cleared.get("risk"), "");
 }
 
+/// A ledger shaped like the global `learnings`: it declares the check *and*
+/// marks a prose field required, which is the pair `hazards` deliberately
+/// lacks.
+fn findings() -> serde_json::Value {
+    json!({
+        "slug": "findings",
+        "title": "Findings",
+        "purpose": "What we found out.",
+        "derived": "derived/findings.md",
+        "fields": [
+            { "name": "id", "role": "id", "required": true },
+            { "name": "finding", "role": "title", "required": true },
+            { "name": "status", "role": "status", "required": true },
+            { "name": "evidence", "role": "prose", "required": true,
+              "description": "What actually happened, concretely." },
+            { "name": "reason", "role": "prose" }
+        ],
+        "statuses": [
+            { "name": "noted" },
+            { "name": "adopted", "closed": true, "needs_reason": true }
+        ],
+        "sections": [
+            { "heading": "Noted", "statuses": ["noted"], "order": "recent" }
+        ],
+        "checks": ["required-field", "known-status", "closed-needs-reason"]
+    })
+}
+
+/// The write half of the contract the read half already stated. A row landing
+/// without a field the ledger requires is refused, rather than stored and then
+/// reported unreadable by every surface that opens the ledger.
+#[tokio::test]
+async fn a_row_missing_a_required_field_is_refused_at_the_write() {
+    let (ctx, _runtime, _home) = ledgers().await;
+    let spec = define(&ctx, &findings()).await.expect("declared");
+    let error = record(
+        &ctx,
+        &spec,
+        &agent(),
+        "f1",
+        fields(&[("finding", "a row with no evidence"), ("status", "noted")]),
+    )
+    .await
+    .expect_err("no evidence");
+    let message = format!("{error}");
+    assert!(message.contains("evidence"), "{message}");
+    assert!(message.contains("f1"), "{message}");
+    // The description is what tells whoever filled it in wrong what belongs
+    // there, so the refusal carries it.
+    assert!(message.contains("What actually happened"), "{message}");
+
+    // Nothing was stored: a refused write must not leave the row behind.
+    let read = read(&ctx, &spec, &Query::default()).await.expect("read");
+    assert!(read.entries.is_empty(), "{:?}", read.entries);
+}
+
+/// The whole point, stated as one assertion: what the write accepts, the read
+/// reads back clean. Before this, a row could be recorded and then reported by
+/// the same ledger as one that could not be read.
+#[tokio::test]
+async fn what_the_write_accepts_the_read_reports_no_fault_on() {
+    let (ctx, _runtime, _home) = ledgers().await;
+    let spec = define(&ctx, &findings()).await.expect("declared");
+    record(
+        &ctx,
+        &spec,
+        &agent(),
+        "f1",
+        fields(&[
+            ("finding", "the vendor is slow"),
+            ("status", "noted"),
+            ("evidence", "three late deliveries in a row"),
+        ]),
+    )
+    .await
+    .expect("recorded");
+    let read = read(&ctx, &spec, &Query::default()).await.expect("read");
+    assert_eq!(read.entries.len(), 1);
+    assert!(read.faults.is_empty(), "{:?}", read.faults);
+}
+
+/// Every write is a merge, so the check runs against the merged row. Moving a
+/// row's status must not be refused for declining to repeat what it holds.
+#[tokio::test]
+async fn an_amendment_need_not_repeat_a_required_field_the_row_holds() {
+    let (ctx, _runtime, _home) = ledgers().await;
+    let spec = define(&ctx, &findings()).await.expect("declared");
+    record(
+        &ctx,
+        &spec,
+        &agent(),
+        "f1",
+        fields(&[
+            ("finding", "the vendor is slow"),
+            ("status", "noted"),
+            ("evidence", "three late deliveries"),
+        ]),
+    )
+    .await
+    .expect("recorded");
+    let amended = record(&ctx, &spec, &agent(), "f1", fields(&[("status", "noted")]))
+        .await
+        .expect("an amendment carries only what changes");
+    assert_eq!(amended.events, 2);
+
+    close(
+        &ctx,
+        &spec,
+        &agent(),
+        "f1",
+        "adopted",
+        "folded into the standard",
+    )
+    .await
+    .expect("closing carries neither the title nor the evidence again");
+}
+
+/// Clearing one is the same loss as never writing it, and a merge is the only
+/// way to express a clear — so it is refused on the same ground.
+#[tokio::test]
+async fn clearing_a_required_field_is_refused() {
+    let (ctx, _runtime, _home) = ledgers().await;
+    let spec = define(&ctx, &findings()).await.expect("declared");
+    record(
+        &ctx,
+        &spec,
+        &agent(),
+        "f1",
+        fields(&[
+            ("finding", "the vendor is slow"),
+            ("status", "noted"),
+            ("evidence", "three late deliveries"),
+        ]),
+    )
+    .await
+    .expect("recorded");
+    let error = record(&ctx, &spec, &agent(), "f1", fields(&[("evidence", "  ")]))
+        .await
+        .expect_err("cleared");
+    assert!(format!("{error}").contains("evidence"), "{error}");
+}
+
+/// The write refuses exactly what the read would fault, and no more: a ledger
+/// that does not declare the check is not silently held to it.
+#[tokio::test]
+async fn a_ledger_that_does_not_declare_the_check_is_not_held_to_it() {
+    let (ctx, _runtime, _home) = ledgers().await;
+    let mut document = findings();
+    document["slug"] = json!("loose");
+    document["derived"] = json!("derived/loose.md");
+    document["checks"] = json!(["known-status"]);
+    let spec = define(&ctx, &document).await.expect("declared");
+    record(&ctx, &spec, &agent(), "f1", fields(&[("status", "noted")]))
+        .await
+        .expect("no required-field check, so nothing to enforce");
+}
+
 /// The briefing is what a turn carries: every ledger named, every open row
 /// identified, and the call that fetches the rest on each one.
 #[tokio::test]

--- a/src/company/ledgers_test.rs
+++ b/src/company/ledgers_test.rs
@@ -1,12 +1,16 @@
 //! The rules only one code path enforces.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde_json::json;
+use tokio::sync::Notify;
 
 use super::*;
 use crate::company::runtime::CompanyRuntime;
 use crate::ledger::LedgerAuthor;
+use crate::ports::ledgers::LedgerStore;
 use crate::ports::types::CompanyId;
 
 /// The context under test, plus the runtime and home it borrows from.
@@ -784,6 +788,141 @@ async fn clearing_a_required_field_is_refused() {
         .await
         .expect_err("cleared");
     assert!(format!("{error}").contains("evidence"), "{error}");
+}
+
+/// A [`LedgerStore`] that pauses inside `events` exactly once, after the read
+/// has already happened, so a test can hold a caller mid-check while another
+/// task mutates the store underneath it.
+struct PausingStore {
+    inner: Arc<dyn LedgerStore>,
+    armed: Arc<AtomicBool>,
+    paused: Arc<Notify>,
+    resume: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl LedgerStore for PausingStore {
+    async fn list_specs(&self, company: &CompanyId) -> Result<Vec<LedgerSpec>> {
+        self.inner.list_specs(company).await
+    }
+
+    async fn put_spec(&self, company: &CompanyId, spec: &LedgerSpec) -> Result<()> {
+        self.inner.put_spec(company, spec).await
+    }
+
+    async fn delete_spec(&self, company: &CompanyId, slug: &str) -> Result<bool> {
+        self.inner.delete_spec(company, slug).await
+    }
+
+    async fn append(&self, company: &CompanyId, event: &LedgerEvent) -> Result<()> {
+        self.inner.append(company, event).await
+    }
+
+    async fn events(&self, company: &CompanyId, ledger: &str) -> Result<Vec<LedgerEvent>> {
+        let read = self.inner.events(company, ledger).await;
+        if self.armed.swap(false, Ordering::SeqCst) {
+            self.paused.notify_one();
+            self.resume.notified().await;
+        }
+        read
+    }
+
+    async fn purge_entry(&self, company: &CompanyId, ledger: &str, entry: &str) -> Result<bool> {
+        self.inner.purge_entry(company, ledger, entry).await
+    }
+
+    async fn purge_ledger(&self, company: &CompanyId, ledger: &str) -> Result<bool> {
+        self.inner.purge_ledger(company, ledger).await
+    }
+}
+
+/// The required-field check reads the stored row, then the write appends. A
+/// purge landing in that gap used to remove the earlier events the check had
+/// just relied on, so the append that followed recreated the row with only
+/// its own partial fields — reporting success on exactly the row the check
+/// exists to keep out.
+///
+/// [`PausingStore`] holds the amendment inside that exact gap — after its
+/// required-field check has read the row, before it appends — so the purge
+/// gets a deterministic window to land in, rather than relying on real
+/// thread timing to hit a gap this narrow. The lock under test still does
+/// its own real work here: it is what makes the purge task block instead of
+/// running in that window once the fix is in place.
+#[tokio::test]
+async fn a_purge_racing_the_required_field_check_cannot_recreate_a_row_missing_it() {
+    let (runtime, _home) = runtime().await;
+
+    let armed = Arc::new(AtomicBool::new(false));
+    let paused = Arc::new(Notify::new());
+    let resume = Arc::new(Notify::new());
+    let store: Arc<dyn LedgerStore> = Arc::new(PausingStore {
+        inner: runtime.ledgers().clone(),
+        armed: armed.clone(),
+        paused: paused.clone(),
+        resume: resume.clone(),
+    });
+    let ctx = Ledgers::new(runtime.id().clone(), store);
+
+    let spec = define(&ctx, &findings()).await.expect("declared");
+    record(
+        &ctx,
+        &spec,
+        &agent(),
+        "f1",
+        fields(&[
+            ("finding", "the vendor is slow"),
+            ("status", "noted"),
+            ("evidence", "three late deliveries"),
+        ]),
+    )
+    .await
+    .expect("recorded");
+
+    // Seeding is done: arm the pause for the amendment's own read.
+    armed.store(true, Ordering::SeqCst);
+
+    let amend_ctx = ctx.clone();
+    let amend_spec = spec.clone();
+    let amender = tokio::spawn(async move {
+        record(
+            &amend_ctx,
+            &amend_spec,
+            &agent(),
+            "f1",
+            fields(&[("status", "noted")]),
+        )
+        .await
+    });
+
+    paused.notified().await;
+
+    let purge_ctx = ctx.clone();
+    let purge_spec = spec.clone();
+    let purger =
+        tokio::spawn(async move { delete_entry(&purge_ctx, &purge_spec, &person(), "f1").await });
+
+    // Under the fix the purge blocks on the same lock the amendment is
+    // holding; this just gives it the chance to run first when it is not
+    // blocked, which is the whole bug.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    resume.notify_one();
+
+    let amend_result = tokio::time::timeout(std::time::Duration::from_secs(5), amender)
+        .await
+        .expect("amendment did not finish")
+        .expect("amendment task panicked");
+    let purge_result = tokio::time::timeout(std::time::Duration::from_secs(5), purger)
+        .await
+        .expect("purge did not finish")
+        .expect("purge task panicked");
+    purge_result.expect("purge does not error");
+
+    if let Ok(entry) = amend_result {
+        assert!(
+            !entry.get("evidence").trim().is_empty(),
+            "amendment reported success on a row missing a required field: {entry:?}"
+        );
+    }
 }
 
 /// The write refuses exactly what the read would fault, and no more: a ledger

--- a/src/harness/built_in/ledger_tools.rs
+++ b/src/harness/built_in/ledger_tools.rs
@@ -470,7 +470,9 @@ impl Tool for RecordEntry {
          ledger holds. USE FOR putting something durable where the company will find it again, \
          instead of leaving it in a reply or a note. Reusing an existing `id` MERGES into that row \
          rather than opening a second one, so amending a row and moving it back to the top of the \
-         list are both this call. Fill the fields `list_ledgers` names for that ledger."
+         list are both this call. Fill the fields `list_ledgers` names for that ledger: a new row \
+         must carry every one it marks required, and is REFUSED without them; an amendment need \
+         only carry what changes, because the row keeps the rest."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/src/ledger/spec.rs
+++ b/src/ledger/spec.rs
@@ -105,7 +105,14 @@ pub struct Field {
     /// A short line saying what belongs here, shown to whoever writes the row.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
-    /// Whether an entry missing this field is a reported fault.
+    /// Whether an entry must carry this field.
+    ///
+    /// Enforced at the write by [`crate::company::ledgers::record`] and
+    /// reported at the read by [`Check::RequiredField`] — both only when the
+    /// spec declares that check. The read half still matters after the write
+    /// half exists: a ledger amended to require a field it did not before has
+    /// rows that predate the requirement, and those are reported rather than
+    /// hidden.
     #[serde(default)]
     pub required: bool,
 }

--- a/src/server/ops/ledgers.rs
+++ b/src/server/ops/ledgers.rs
@@ -256,9 +256,14 @@ async fn human_label(scope: &ScopedCompany, actor_id: &str) -> String {
     }
 }
 
-async fn summary(ctx: &ledgers::Ledgers, spec: &LedgerSpec) -> Result<LedgerSummary, ApiError> {
-    let entries = ledgers::entries(ctx, spec).await?;
-    Ok(LedgerSummary {
+/// Builds the wire summary from counts the caller already folded.
+///
+/// Every other field comes straight off `spec`, so this does no I/O of its
+/// own — a caller that already holds `open`/`closed` from the fold behind the
+/// rows it is sending alongside should call this rather than [`summary`],
+/// which folds again and can observe a write the rows' fold did not.
+fn summary_from_counts(spec: &LedgerSpec, open: usize, closed: usize) -> LedgerSummary {
+    LedgerSummary {
         slug: spec.slug.clone(),
         title: spec.title.clone(),
         purpose: spec.purpose.clone(),
@@ -270,9 +275,18 @@ async fn summary(ctx: &ledgers::Ledgers, spec: &LedgerSpec) -> Result<LedgerSumm
         statuses: spec.statuses.iter().map(LedgerStatusDto::from).collect(),
         sections: spec.sections.clone(),
         writers: spec.writers.clone(),
-        open: entries.open_count(spec),
-        closed: entries.closed_count(spec),
-    })
+        open,
+        closed,
+    }
+}
+
+async fn summary(ctx: &ledgers::Ledgers, spec: &LedgerSpec) -> Result<LedgerSummary, ApiError> {
+    let entries = ledgers::entries(ctx, spec).await?;
+    Ok(summary_from_counts(
+        spec,
+        entries.open_count(spec),
+        entries.closed_count(spec),
+    ))
 }
 
 async fn list_ledgers(scope: ScopedCompany) -> Result<Json<LedgerList>, ApiError> {
@@ -318,7 +332,7 @@ async fn read_ledger(
     )
     .await?;
     Ok(Json(LedgerRead {
-        ledger: summary(&ctx(&scope), spec).await?,
+        ledger: summary_from_counts(spec, read.open, read.closed),
         entries: read.entries.iter().map(|e| EntryRow::of(e, spec)).collect(),
         matched: read.matched,
         faults: read.faults,

--- a/src/server/ops/ledgers_test.rs
+++ b/src/server/ops/ledgers_test.rs
@@ -328,6 +328,81 @@ async fn closing_without_a_reason_is_a_400_that_says_so() {
     assert_eq!(status, StatusCode::OK);
 }
 
+/// The shape the global `learnings` ledger has: a required prose field and the
+/// check that reports it.
+fn findings() -> Value {
+    json!({
+        "slug": "findings",
+        "title": "Findings",
+        "purpose": "What we found out.",
+        "derived": "derived/findings.md",
+        "fields": [
+            { "name": "id", "role": "id", "required": true },
+            { "name": "finding", "role": "title", "required": true },
+            { "name": "status", "role": "status", "required": true },
+            { "name": "evidence", "role": "prose", "required": true },
+            { "name": "reason", "role": "prose" }
+        ],
+        "statuses": [
+            { "name": "noted" },
+            { "name": "adopted", "closed": true, "needs_reason": true }
+        ],
+        "checks": ["required-field", "known-status", "closed-needs-reason"]
+    })
+}
+
+/// The route half of the write/read contract: a row the ledger would report as
+/// unreadable is refused with a 400 that names the field, rather than accepted
+/// with a 200 and then listed under the read's faults.
+#[tokio::test]
+async fn a_row_missing_a_required_field_is_a_400_rather_than_a_fault_on_read() {
+    let (state, _home) = state().await;
+    send(&state, "POST", "/api/v1/company/ledgers", Some(findings())).await;
+
+    let (status, body) = send(
+        &state,
+        "POST",
+        "/api/v1/company/ledgers/findings/entries",
+        Some(json!({
+            "id": "L-BAD-1",
+            "status": "noted",
+            "fields": { "finding": "a row with no evidence field" }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        format!("{body}").contains("evidence"),
+        "the refusal must name the field: {body}"
+    );
+
+    // Refused means nothing landed — so the read has neither the row nor a
+    // fault about it, which is the contradiction this closes.
+    let (status, body) = send(
+        &state,
+        "GET",
+        "/api/v1/company/ledgers/findings/entries",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["entries"].as_array().map(Vec::len), Some(0), "{body}");
+    assert!(body["faults"].is_null(), "{body}");
+
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/ledgers/findings/entries",
+        Some(json!({
+            "id": "L-BAD-1",
+            "status": "noted",
+            "fields": { "finding": "a row with evidence", "evidence": "it happened three times" }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+}
+
 /// The board is readable through the surface and not writable by it.
 #[tokio::test]
 async fn the_board_cannot_be_written_through_the_ledger_routes() {

--- a/src/server/ops/ledgers_test.rs
+++ b/src/server/ops/ledgers_test.rs
@@ -220,10 +220,9 @@ async fn the_read_count_never_disagrees_with_its_own_rows_under_a_racing_write()
         };
 
         let read_state = state.clone();
-        let reader =
-            tokio::spawn(
-                async move { send(&read_state, "GET", "/api/v1/company/ledgers/hazards", None).await },
-            );
+        let reader = tokio::spawn(async move {
+            send(&read_state, "GET", "/api/v1/company/ledgers/hazards", None).await
+        });
 
         let write_state = state.clone();
         let writer = tokio::spawn(async move {

--- a/src/server/ops/ledgers_test.rs
+++ b/src/server/ops/ledgers_test.rs
@@ -199,7 +199,15 @@ async fn a_ledger_round_trips_under_both_scope_forms() {
 /// must equal what the rows in that same response actually say — not merely
 /// most of the time. This does not assert the fix's code shape; it holds the
 /// invariant a two-fold response can violate under a real race.
-#[tokio::test]
+///
+/// Needs real OS-thread concurrency to land the write inside the narrow
+/// window between the two folds the old handler had: on the default
+/// current-thread runtime the pair never actually overlaps and the race
+/// never reproduces. Confirmed against the pre-fix handler (reintroducing
+/// `summary(&ctx, spec).await?` in place of `summary_from_counts`) that this
+/// fails within the first ~15 rounds; against the fix, 300 rounds passed
+/// clean across repeated runs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn the_read_count_never_disagrees_with_its_own_rows_under_a_racing_write() {
     let (state, _home) = state().await;
     send(&state, "POST", "/api/v1/company/ledgers", Some(hazards())).await;
@@ -211,7 +219,7 @@ async fn the_read_count_never_disagrees_with_its_own_rows_under_a_racing_write()
     )
     .await;
 
-    for round in 0..40 {
+    for round in 0..80 {
         // Alternate direction so the race is attempted flipping each way.
         let write_body = if round % 2 == 0 {
             json!({ "id": "r1", "status": "closed", "reason": "handled" })

--- a/src/server/ops/ledgers_test.rs
+++ b/src/server/ops/ledgers_test.rs
@@ -188,6 +188,74 @@ async fn a_ledger_round_trips_under_both_scope_forms() {
     assert_eq!(read["entries"][0]["id"], "vendor-slip");
 }
 
+/// `read_ledger` used to build `ledger.open`/`ledger.closed` from a second,
+/// independent fold (inside `summary`) after already folding once for the
+/// rows. A write landing between the two could flip a row's status after the
+/// first fold but before the second, so the count disagreed with the rows it
+/// was displayed beside — an open row on screen while the badge already
+/// counted it closed, until the next refresh.
+///
+/// Racing a read against a status flip, every response's `open`/`closed`
+/// must equal what the rows in that same response actually say — not merely
+/// most of the time. This does not assert the fix's code shape; it holds the
+/// invariant a two-fold response can violate under a real race.
+#[tokio::test]
+async fn the_read_count_never_disagrees_with_its_own_rows_under_a_racing_write() {
+    let (state, _home) = state().await;
+    send(&state, "POST", "/api/v1/company/ledgers", Some(hazards())).await;
+    send(
+        &state,
+        "POST",
+        "/api/v1/company/ledgers/hazards/entries",
+        Some(json!({ "id": "r1", "fields": { "risk": "a" }, "status": "open" })),
+    )
+    .await;
+
+    for round in 0..40 {
+        // Alternate direction so the race is attempted flipping each way.
+        let write_body = if round % 2 == 0 {
+            json!({ "id": "r1", "status": "closed", "reason": "handled" })
+        } else {
+            json!({ "id": "r1", "status": "open" })
+        };
+
+        let read_state = state.clone();
+        let reader =
+            tokio::spawn(
+                async move { send(&read_state, "GET", "/api/v1/company/ledgers/hazards", None).await },
+            );
+
+        let write_state = state.clone();
+        let writer = tokio::spawn(async move {
+            send(
+                &write_state,
+                "POST",
+                "/api/v1/company/ledgers/hazards/entries",
+                Some(write_body),
+            )
+            .await
+        });
+
+        let (read_result, write_result) = tokio::join!(reader, writer);
+        let (read_status, read_body) = read_result.unwrap();
+        assert_eq!(read_status, StatusCode::OK, "round {round}: {read_body}");
+        let (write_status, write_body) = write_result.unwrap();
+        assert_eq!(write_status, StatusCode::OK, "round {round}: {write_body}");
+
+        let rows = read_body["entries"].as_array().expect("entries array");
+        let open_rows = rows.iter().filter(|row| row["closed"] == false).count();
+        let closed_rows = rows.iter().filter(|row| row["closed"] == true).count();
+        assert_eq!(
+            read_body["ledger"]["open"], open_rows,
+            "round {round}: open count disagrees with the rows beside it: {read_body}"
+        );
+        assert_eq!(
+            read_body["ledger"]["closed"], closed_rows,
+            "round {round}: closed count disagrees with the rows beside it: {read_body}"
+        );
+    }
+}
+
 /// **The wire regression, pinned.** `StatusSpec::needs_reason` used to
 /// serialize snake_case like every other declaration field, but the console
 /// reads `LedgerStatus.needsReason` — camelCase, matching `LedgerSummary`'s


### PR DESCRIPTION
## Summary

A ledger accepted rows it then reported as unreadable.

`learnings` declares `evidence` required. Posting a row without it returned
`HTTP 200` and persisted the row. Reading it back returned

```
faults: ["`L-BAD-1` has no `evidence`, which this ledger requires"]
```

and the rendered file listed that same row **twice** — once as an ordinary entry
under `## Noted`, and again under `## Rows that could not be read`.

The contract is declared in `Field.required` and the spec's `checks`, and was
enforced only in `engine::fold`, on the read. Nothing on the write path knew the
requirement existed.

The sweep converged on one function rather than three: `company::ledgers::record`
is the only non-test caller of `LedgerStore::append`, and the HTTP route, the
`record_entry` tool and `close_entry` all reach it. `src/server/ops/ledgers.rs`
needed no change — the route was never the bug.

The write now refuses with 400 rather than recording a flagged row. This module
already refuses a reason-less close and an undeclared status at the write, with
the argument spelled out in its own module docs; a missing required field is the
same argument. No caller outside tests depended on the permissive behaviour.

Two details the check gets right deliberately:

- it runs against the **merged** row, so an amendment carrying only a status is
  not refused for failing to repeat `evidence`;
- it is gated on the spec actually declaring the requirement, so the write
  refuses exactly what the read would fault, and no more.

Two console defects on the same surface are fixed alongside, because they are
what made the first one survivable in practice.

**The fault text was present but hidden.** The board rendered
`1 row could not be read` and buried the row and reason inside a closed
`<details>`. It now states them outright, keeping the single-alert constraint by
bounding the list rather than collapsing it.

**The ledger badge did not track writes.** The count came from `useLedgerNav`,
which re-reads on declare and retire but never on a row write — so a live
watched risk rendered underneath a badge reading `0`, correcting only on a full
reload. It now reads the summary that already arrives with the rows.

## API Or Behavior Changes

`POST .../ledgers/{slug}/entries` and the `record_entry` tool now return 400
naming the missing field and its description, where they previously returned 200
and stored a row that could not be read back.

The read-side fault check is retained and is not dead: a list amended to require
a field its existing rows predate still faults them.

## Tests

- `cargo fmt --all -- --check` — 0
- `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings` — 0
- `cargo test --locked --features openhuman --lib` — 0, 6806 passed, 0 failed, 3 ignored
- `npm run typecheck` / `:unit` / `:e2e` — 0 / 0 / 0
- `npx vitest run` — 0, 470 files, 4381 tests, identical to the pre-change baseline
- Playwright `ledger-required-field.spec.ts` — 3/3 against a real host

Every new assertion was proved red against the unfixed code: the two service
tests and the route test failed with 200s, and both console specs failed.

One correction worth recording. The fault assertion initially passed against the
*unfixed* console, because Playwright's `toContainText` reads text inside a
collapsed `<details>`. It was tightened to `toBeVisible` / `innerText`, which is
the only form that actually pins the defect.

Verified live: the original request now returns 400 naming the field; a complete
row returns 200; an amendment carrying only a status returns 200; a close
carrying only a reason returns 200; clearing a required field returns 400; the
rendered file lists the row once with no fault section. In the browser the fault
reads `1 row could not be read / old-row has no evidence, which this ledger
requires`, and the badge tracks `1 -> 2`.

The agent tool with a live model is covered by the service tests plus the
tool-description change rather than by execution: it calls `ledgers::record`
directly and returns the refusal verbatim, so driving a real turn would be
testing the model, not the contract.

### Review follow-up: the badge count could disagree with its own rows

`GET .../ledgers/{slug}` folded the ledger once for the rows and again,
independently, inside `summary()` for the `open`/`closed` count sent
alongside them. A write landing in the gap between the two folds could flip a
row's status after the rows were read but before the count was, so the badge
could disagree with the rows rendered beneath it.

`ledgers::read` now folds once and returns `open`/`closed` computed from the
same fold that produced the rows; the route builds the summary from those
counts instead of re-folding.

- `cargo fmt --all -- --check` — 0
- `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings` — 0
- `cargo test --locked --features openhuman --lib` — 0, 6815 passed, 0 failed, 3 ignored
- `npm run typecheck` / `:unit` / `:e2e` — 0 / 0 / 0
- `npx vitest run` — 0, 472 files, 4391 tests
- Playwright `ledger-required-field.spec.ts` — 4/4 against a real host

Two Rust regression tests. One is deterministic: it folds once for the rows
(as the fix does), records a write at the point the old handler's second fold
used to run, then folds again independently and shows that second fold
disagreeing with the rows the first one already returned — confirmed against
the pre-fix handler that this reproduces every time. The other races a read
against a status flip under real OS-thread concurrency (the default
current-thread runtime never lands the write inside the gap and never
reproduces the race); confirmed it fails within the first ~15 rounds against
the pre-fix handler and passes clean over 300 rounds against the fix.

Verified live against a local build: recording a row and closing one each
updated the badge and the visible rows together, in both directions, with no
reload; the legacy-row fault from the read-side check stayed fully readable
on screen without expanding anything. The Playwright spec now pins the badge
against the rows the DOM actually renders, not a value from a second request,
after a write and after a close.

### Review follow-up: a purge racing the required-field check could recreate a row missing it

`missing_required` reads the stored row, then `record` appends. A purge
(`delete_entry`, or `retire` with `purge: true`) landing in that gap removed
the events the check had just relied on, so the append that followed
recreated the row with only its own partial fields — reporting success on
exactly the row the check exists to keep out. The same gap exists around the
close-reason check.

`record`, `delete_entry` and `retire` now take one process-wide lock scoped
to `(company, ledger slug)` before touching the store, held across the
check-then-append (or the purge), so a write and a purge on the same ledger
queue behind each other instead of racing. Kept the fix at this module rather
than pushing an atomic op into the store: `LedgerStore` has three
implementations (fs, sqlite, mongodb) with no shared transaction primitive,
and expressing "validate against current state, then append" atomically
across all three would mean duplicating the required-field logic into each
backend instead of leaving it the one place this module's own docs already
say it belongs.

- `cargo fmt --all -- --check` — 0
- `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings` — 0
- `cargo test --locked --features openhuman --lib` — 0, 6848 passed, 0 failed, 3 ignored
- `npm run typecheck` / `:unit` / `:e2e` — 0 / 0 / 0
- `npx vitest run` — 0, 477 files, 4423 tests (first run threw one unrelated unhandled
  error from a stray `WorkflowCreateDialog` debounce timer after its test had already
  passed; a clean re-run showed 0 errors)

One Rust regression test, deterministic rather than timing-based: a
`LedgerStore` decorator holds the amendment's required-field read open after
it returns, so a concurrent `delete_entry` gets an exact window to purge in
before the read is allowed to resolve — no reliance on real thread scheduling
to land inside a gap this narrow. Confirmed against the pre-fix handler that
this reproduces the exact defect every time: the amendment reports success
with the row's evidence field silently empty. Passes clean with the lock in
place, where the purge instead blocks until the amendment's write completes.

## Documentation

The `record_entry` tool description now states that required fields are enforced
at the write, so an agent is told the rule before it is refused by it.

