### PR TITLE
fix(console): stop offering a member Settings controls their role cannot use

### DIFF
--- a/frontend/src/components/admin-only-notice.tsx
+++ b/frontend/src/components/admin-only-notice.tsx
@@ -1,0 +1,49 @@
+import { Info } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+/**
+ * Why a surface is read-only for the person looking at it.
+ *
+ * Rendered instead of — never alongside — the controls it explains. A page that
+ * shows this and still offers an enabled Save has said two things and meant the
+ * worse one.
+ *
+ * # What belongs in `title` and `children`
+ *
+ * `title` names the refusal from the viewer's side ("Only an admin can change
+ * this company's model"), and `children` says *why the company draws the line
+ * there*, then what the viewer can still do. The reason is the part that stops
+ * this reading as an apology: a search provider decides whose retention policy
+ * every teammate's query lands under, and someone told that will ask the right
+ * admin for the right thing instead of assuming the page is broken.
+ *
+ * Do not write "you do not have permission" and stop. That is the sentence this
+ * component exists to replace.
+ */
+export function AdminOnlyNotice({
+  title,
+  children,
+  testId,
+}: {
+  /** The refusal, in the viewer's language. */
+  title: string;
+  /** Why the line is drawn here, and what the viewer can still do. */
+  children: React.ReactNode;
+  /**
+   * Stable hook for the E2E spec that drives a real member through these pages.
+   *
+   * Each page keeps its own id rather than sharing one: the spec walks several
+   * pages in a single context, and a shared id could not tell "the page I am on
+   * explains itself" apart from "some page did".
+   */
+  testId: string;
+}) {
+  return (
+    <Alert data-testid={testId}>
+      <Info className="size-4" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>{children}</AlertDescription>
+    </Alert>
+  );
+}

--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -762,13 +762,11 @@ export function SmtpCard({ client, company, canManage }: Props) {
             <Loader2 className="size-4 animate-spin" /> Loading email settings…
           </p>
         ) : !canManage ? (
-          /* The whole form is withheld, not disabled — every field on it is
-             part of one credential, and the last of them is a password. Both
-             writes behind it (`save` and even `test`, which sends through the
-             stored configuration) are `AdminScopedCompany`, so there is nothing
-             here a member could do with the boxes except fill them in and be
-             refused. What remains is the fact a member has a reason to want:
-             whether this company can send mail at all. */
+          // The mutations are withheld (`save`, `test`, and the password
+          // field), not the routing: `GET …/smtp` is member-readable and
+          // never carries a password by construction (`docs/modules/server/
+          // authority.md`), so a member keeps the same read the admin form
+          // shows them, just not editable.
           <>
             <AdminOnlyNotice
               testId="smtp-read-only"
@@ -777,11 +775,30 @@ export function SmtpCard({ client, company, canManage }: Props) {
               These are the credentials for the company&rsquo;s own outbound mail
               server, so an admin holds them.
             </AdminOnlyNotice>
-            <p className="text-sm text-muted-foreground" data-testid="smtp-member-summary">
-              {status?.configured
-                ? "An outbound mail server is configured for this company."
-                : "No outbound mail server is configured, so this company sends on the host's default."}
-            </p>
+            {status?.configured ? (
+              <div className="grid gap-4 sm:grid-cols-2" data-testid="smtp-routing">
+                <ReadOnlyField label="SMTP host" id="smtp-host" value={status.host} />
+                <div className="grid grid-cols-2 gap-3">
+                  <ReadOnlyField
+                    label="Port"
+                    id="smtp-port"
+                    value={status.port === undefined ? undefined : String(status.port)}
+                  />
+                  <ReadOnlyField
+                    label="Security"
+                    id="smtp-security"
+                    value={status.security ? SECURITY_LABELS[status.security] : undefined}
+                  />
+                </div>
+                <ReadOnlyField label="Username" id="smtp-username" value={status.username} />
+                <ReadOnlyField label="From name" id="smtp-from-name" value={status.from_name} />
+                <ReadOnlyField label="From email" id="smtp-from-email" value={status.from_email} />
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground" data-testid="smtp-member-summary">
+                No outbound mail server is configured, so this company sends on the host's default.
+              </p>
+            )}
           </>
         ) : (
           <>
@@ -923,6 +940,18 @@ function Field({
       <Label htmlFor={id}>{label}</Label>
       {children}
       {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+/** A field a member reads but cannot edit. Same `id` an editable form uses for it. */
+function ReadOnlyField({ label, id, value }: { label: string; id: string; value?: string }) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <p id={id} data-testid={id} className="text-sm">
+        {value || <span className="text-muted-foreground">Not set</span>}
+      </p>
     </div>
   );
 }

--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -3,6 +3,7 @@ import { Check, Copy, Globe, Loader2, Mail, ShieldAlert, TriangleAlert, X } from
 import { toast } from "sonner";
 
 import { ApiError } from "@/api/types";
+import { AdminOnlyNotice } from "@/components/admin-only-notice";
 import type { OpenCompanyClient } from "@/api/client";
 import {
   clearDomain,
@@ -39,6 +40,15 @@ import { cn } from "@/lib/utils";
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * Whether this viewer may change the company's mail identity.
+   *
+   * `PUT …/domain` and the SMTP writes are `AdminScopedCompany`. The reads are
+   * not, and neither is `POST …/domain/verify` — re-checking DNS for a domain
+   * only an admin could have set changes nothing a member could not already
+   * read — so a member keeps the whole card except the controls that write.
+   */
+  canManage: boolean;
 }
 
 const SECURITY_LABELS: Record<SmtpSecurity, string> = {
@@ -295,7 +305,7 @@ function SmtpPreview() {
  * directly and pinning the guarantee that matters here: every field is read
  * from and written to the host, and none of it is cached in the browser.
  */
-export function DomainCard({ client, company }: Props) {
+export function DomainCard({ client, company, canManage }: Props) {
   const [status, setStatus] = useState<DomainStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -387,6 +397,16 @@ export function DomainCard({ client, company }: Props) {
         <CardDescription>Send and receive on your own domain instead of the default.</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        {!canManage && (
+          <AdminOnlyNotice
+            testId="domain-read-only"
+            title="Only an admin can change this company's domain"
+          >
+            The domain is how this company signs its outgoing mail, so it is the
+            company&rsquo;s identity rather than any one member&rsquo;s. You can see
+            what is configured and re-check the DNS records.
+          </AdminOnlyNotice>
+        )}
         {loadError ? (
           <Alert variant="destructive" data-testid="domain-load-error">
             <TriangleAlert className="size-4" />
@@ -397,6 +417,11 @@ export function DomainCard({ client, company }: Props) {
             <Loader2 className="size-4 animate-spin" /> Loading domain…
           </p>
         ) : !configured ? (
+          !canManage ? (
+            <p className="text-sm text-muted-foreground">
+              No custom domain is configured, so this company sends on the default one.
+            </p>
+          ) : (
           <div className="flex flex-col gap-2 sm:flex-row">
             <Input
               value={draft}
@@ -419,6 +444,7 @@ export function DomainCard({ client, company }: Props) {
               Add domain
             </Button>
           </div>
+          )
         ) : (
           <>
             <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border p-3">
@@ -439,15 +465,17 @@ export function DomainCard({ client, company }: Props) {
                     <span className="size-1.5 rounded-full bg-status-blocked" /> Pending
                   </Badge>
                 )}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={busy}
-                  onClick={() => void remove()}
-                  data-testid="domain-remove"
-                >
-                  Remove
-                </Button>
+                {canManage && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() => void remove()}
+                    data-testid="domain-remove"
+                  >
+                    Remove
+                  </Button>
+                )}
               </div>
             </div>
 
@@ -599,7 +627,7 @@ function CopyCell({ value }: { value: string }) {
  * write-only three ways, and `test/unit/domain-settings-host-backed.test.ts`
  * is what holds that property while nothing renders the card.
  */
-export function SmtpCard({ client, company }: Props) {
+export function SmtpCard({ client, company, canManage }: Props) {
   const [status, setStatus] = useState<SmtpStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -733,6 +761,28 @@ export function SmtpCard({ client, company }: Props) {
           <p className="flex items-center gap-2 text-sm text-muted-foreground">
             <Loader2 className="size-4 animate-spin" /> Loading email settings…
           </p>
+        ) : !canManage ? (
+          /* The whole form is withheld, not disabled — every field on it is
+             part of one credential, and the last of them is a password. Both
+             writes behind it (`save` and even `test`, which sends through the
+             stored configuration) are `AdminScopedCompany`, so there is nothing
+             here a member could do with the boxes except fill them in and be
+             refused. What remains is the fact a member has a reason to want:
+             whether this company can send mail at all. */
+          <>
+            <AdminOnlyNotice
+              testId="smtp-read-only"
+              title="Only an admin can change how this company sends mail"
+            >
+              These are the credentials for the company&rsquo;s own outbound mail
+              server, so an admin holds them.
+            </AdminOnlyNotice>
+            <p className="text-sm text-muted-foreground" data-testid="smtp-member-summary">
+              {status?.configured
+                ? "An outbound mail server is configured for this company."
+                : "No outbound mail server is configured, so this company sends on the host's default."}
+            </p>
+          </>
         ) : (
           <>
             <div className="grid gap-4 sm:grid-cols-2">

--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -12,6 +12,7 @@ import {
   setPolicy,
 } from "@/api/policy";
 import { listWorkflowToolSlugs } from "@/api/workflows";
+import { AdminOnlyNotice } from "@/components/admin-only-notice";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -261,6 +262,18 @@ export function gatedBy(list: string[], target: string): boolean {
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * Whether this viewer may change the policy.
+   *
+   * Both writes behind this card call `require_admin`, so `false` renders the
+   * tiers and the deadline as a statement of what the company's policy IS,
+   * with nothing on the card that offers to change it.
+   *
+   * Required, and deliberately not defaulted, for the reason `GrantNamespace`
+   * gives: a caller that has not worked out the viewer's role must not get an
+   * enabled control by omission.
+   */
+  canManage: boolean;
 }
 
 /**
@@ -286,7 +299,7 @@ interface Props {
  *   edits, but editing `[policy]` in `company.toml` clears it. An operator who
  *   cannot see that would be surprised by a redeploy.
  */
-export function PolicySettings({ client, company }: Props) {
+export function PolicySettings({ client, company, canManage }: Props) {
   const [status, setStatus] = useState<PolicyStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -948,6 +961,16 @@ export function PolicySettings({ client, company }: Props) {
           </div>
         ) : (
           <>
+            {!canManage && (
+              <AdminOnlyNotice
+                testId="policy-read-only"
+                title="Only an admin can change this company's approval policy"
+              >
+                The tier decides how much every teammate here may do without asking
+                first, so it is the company&rsquo;s to set rather than any one
+                member&rsquo;s. You can see which tier is in force.
+              </AdminOnlyNotice>
+            )}
             <div className="rounded-md border border-status-blocked/30 bg-status-blocked-soft p-3 text-xs text-muted-foreground">
               Policy-based approval prompts are disabled. Teammates ask through{" "}
               <code>request_approval</code>; read-only mode and the emergency stop still
@@ -973,7 +996,7 @@ export function PolicySettings({ client, company }: Props) {
                       tierButtons.current[index] = el;
                     }}
                     type="button"
-                    disabled={saving}
+                    disabled={saving || !canManage}
                     onClick={() => chooseTier(tier)}
                     role="radio"
                     aria-checked={active}
@@ -1061,14 +1084,16 @@ export function PolicySettings({ client, company }: Props) {
                   step="1"
                   inputMode="numeric"
                   value={draftDeadline}
-                  disabled={saving}
+                  disabled={saving || !canManage}
                   className="max-w-32"
                   onChange={(event) => setDraftDeadline(event.target.value)}
                 />
                 <span className="text-sm text-muted-foreground">hours</span>
-                <Button size="sm" disabled={saving} onClick={() => void saveDeadline()}>
-                  Save deadline
-                </Button>
+                {canManage && (
+                  <Button size="sm" disabled={saving} onClick={() => void saveDeadline()}>
+                    Save deadline
+                  </Button>
+                )}
               </div>
             </div>
 
@@ -1142,16 +1167,18 @@ export function PolicySettings({ client, company }: Props) {
                   <code>[policy]</code> in <code>company.toml</code> clears it —
                   version control wins when it speaks.
                 </p>
-                <Button
-                  ref={resetButtonRef}
-                  size="sm"
-                  variant="outline"
-                  disabled={saving}
-                  onClick={() => requestReset()}
-                >
-                  <RotateCcw className="mr-1 h-3 w-3" />
-                  Use the manifest's policy
-                </Button>
+                {canManage && (
+                  <Button
+                    ref={resetButtonRef}
+                    size="sm"
+                    variant="outline"
+                    disabled={saving}
+                    onClick={() => requestReset()}
+                  >
+                    <RotateCcw className="mr-1 h-3 w-3" />
+                    Use the manifest&apos;s policy
+                  </Button>
+                )}
               </div>
             )}
             <AlertDialog

--- a/frontend/src/hooks/use-can-manage.ts
+++ b/frontend/src/hooks/use-can-manage.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+import { me as fetchMe } from "@/api/auth";
+import type { OpenCompanyClient } from "@/api/client";
+
+/**
+ * Whether the signed-in viewer may administer this company.
+ *
+ * Courtesy, never enforcement: every write behind an admin-only control answers
+ * `403 only an admin can do that` whatever this returns. What it decides is
+ * whether the console *offers* the control at all.
+ *
+ * # Why this is a hook and not eight copies of an effect
+ *
+ * It was eight copies of an effect. Ten, counting the surfaces outside Settings.
+ * Each one resolved the role correctly — and resolving it was never the part
+ * that went wrong. Two pages resolved it and then wired the answer into one
+ * sub-component while their own credential form, Save and Disconnect went on
+ * rendering enabled for a member; two more never asked at all. A page could be
+ * half-gated because "know the role" and "use the role" were separate acts, and
+ * nothing connected them.
+ *
+ * One definition does not by itself close that gap — a caller can still ignore
+ * what it returns. What it does is make the gate cheap enough that there is no
+ * reason to reach for half of it, and put the question in one place where the
+ * answer, and this warning, are read together.
+ *
+ * # Why it fails closed
+ *
+ * `false` until the read answers, and `false` if it never does. An unresolved
+ * role must not render an enabled button: the cost of being briefly wrong that
+ * way is an admin seeing a read-only notice for one round trip, and the cost of
+ * being wrong the other way is inviting someone to paste a live credential into
+ * a form that can only refuse it.
+ *
+ * A host with no user plane, or a signed-out console, lands here too. Both are
+ * non-admin for this purpose.
+ */
+export function useCanManage(client: OpenCompanyClient, company: string | null): boolean {
+  const [canManage, setCanManage] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    // Re-closed on every company change, not just on the first read: carrying a
+    // previous company's `true` across the switch would offer an admin's
+    // controls on a company this person may only be a member of.
+    setCanManage(false);
+    void (async () => {
+      let admin = false;
+      try {
+        admin = (await fetchMe(client, company)).role === "admin";
+      } catch {
+        // No user plane on this host, or not signed in.
+      }
+      if (live) setCanManage(admin);
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
+
+  return canManage;
+}

--- a/frontend/src/hooks/use-can-manage.ts
+++ b/frontend/src/hooks/use-can-manage.ts
@@ -42,6 +42,29 @@ import type { OpenCompanyClient } from "@/api/client";
  * resolves at all — even to a member — still decides the answer here too.
  */
 export function useCanManage(client: OpenCompanyClient, company: string | null): boolean {
+  return useResolvedManage(client, company, client.carriesPlatformBearer);
+}
+
+/**
+ * Whether the signed-in viewer may set this company's policy — `PUT …/policy`
+ * (`set_policy`, `policy.rs`), which calls `require_admin` straight off the
+ * request headers rather than going through `AdminScopedCompany`. That
+ * resolves only a human session and refuses a bearer with no session behind
+ * it as unauthenticated, unlike the hosting/search/domain/SMTP writes
+ * {@link useCanManage} gates, which `AdminScopedCompany` admits the platform
+ * bearer for directly. Offering the policy controls to a bearer-only client
+ * would invite a request `require_admin` can only 401.
+ */
+export function useCanManagePolicy(client: OpenCompanyClient, company: string | null): boolean {
+  return useResolvedManage(client, company, false);
+}
+
+/** Shared resolution: a confirmed human admin session, or `bearerDefault` when none resolves. */
+function useResolvedManage(
+  client: OpenCompanyClient,
+  company: string | null,
+  bearerDefault: boolean,
+): boolean {
   const [canManage, setCanManage] = useState(false);
 
   useEffect(() => {
@@ -51,19 +74,19 @@ export function useCanManage(client: OpenCompanyClient, company: string | null):
     // controls on a company this person may only be a member of.
     setCanManage(false);
     void (async () => {
-      let manage = client.carriesPlatformBearer;
+      let manage = bearerDefault;
       try {
         manage = (await fetchMe(client, company)).role === "admin";
       } catch {
-        // No session to resolve — `manage` keeps the platform-bearer default
-        // above, which is what the backend itself falls back to.
+        // No session to resolve — `manage` keeps the bearer default above,
+        // which is what the backend itself falls back to for this route.
       }
       if (live) setCanManage(manage);
     })();
     return () => {
       live = false;
     };
-  }, [client, company]);
+  }, [client, company, bearerDefault]);
 
   return canManage;
 }

--- a/frontend/src/hooks/use-can-manage.ts
+++ b/frontend/src/hooks/use-can-manage.ts
@@ -70,20 +70,23 @@ function provesNoSession(err: unknown): boolean {
   return err instanceof ApiError && err.status === 401 && err.fromHost;
 }
 
+interface Resolved {
+  client: OpenCompanyClient;
+  company: string | null;
+  bearerDefault: boolean;
+  manage: boolean;
+}
+
 /** Shared resolution: a confirmed human admin session, or `bearerDefault` only when the read proves no session exists. */
 function useResolvedManage(
   client: OpenCompanyClient,
   company: string | null,
   bearerDefault: boolean,
 ): boolean {
-  const [canManage, setCanManage] = useState(false);
+  const [resolved, setResolved] = useState<Resolved | null>(null);
 
   useEffect(() => {
     let live = true;
-    // Re-closed on every company change, not just on the first read: carrying a
-    // previous company's `true` across the switch would offer an admin's
-    // controls on a company this person may only be a member of.
-    setCanManage(false);
     void (async () => {
       let manage = bearerDefault;
       try {
@@ -91,12 +94,17 @@ function useResolvedManage(
       } catch (err) {
         manage = provesNoSession(err) ? bearerDefault : false;
       }
-      if (live) setCanManage(manage);
+      if (live) setResolved({ client, company, bearerDefault, manage });
     })();
     return () => {
       live = false;
     };
   }, [client, company, bearerDefault]);
 
-  return canManage;
+  const current =
+    resolved !== null &&
+    resolved.client === client &&
+    resolved.company === company &&
+    resolved.bearerDefault === bearerDefault;
+  return current ? resolved.manage : false;
 }

--- a/frontend/src/hooks/use-can-manage.ts
+++ b/frontend/src/hooks/use-can-manage.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import { me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
 
 /**
  * Whether the signed-in viewer may administer this company.
@@ -40,6 +41,11 @@ import type { OpenCompanyClient } from "@/api/client";
  * hide a control the backend has already agreed to run. `resolve_principal`
  * prefers a session over the bearer when both are present, so a session that
  * resolves at all — even to a member — still decides the answer here too.
+ *
+ * The bearer default only stands in for a read that came back proving no
+ * session exists (`/auth/me`'s own 401). A timeout, a 5xx, or anything else
+ * that merely failed to answer stays closed — it hasn't shown the backend
+ * would refuse a session, only that this particular read didn't get one.
  */
 export function useCanManage(client: OpenCompanyClient, company: string | null): boolean {
   return useResolvedManage(client, company, client.carriesPlatformBearer);
@@ -59,7 +65,12 @@ export function useCanManagePolicy(client: OpenCompanyClient, company: string | 
   return useResolvedManage(client, company, false);
 }
 
-/** Shared resolution: a confirmed human admin session, or `bearerDefault` when none resolves. */
+/** Whether `err` is `/auth/me` answering its documented no-session 401, rather than a transport or server failure that merely didn't resolve one. */
+function provesNoSession(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 401 && err.fromHost;
+}
+
+/** Shared resolution: a confirmed human admin session, or `bearerDefault` only when the read proves no session exists. */
 function useResolvedManage(
   client: OpenCompanyClient,
   company: string | null,
@@ -77,9 +88,8 @@ function useResolvedManage(
       let manage = bearerDefault;
       try {
         manage = (await fetchMe(client, company)).role === "admin";
-      } catch {
-        // No session to resolve — `manage` keeps the bearer default above,
-        // which is what the backend itself falls back to for this route.
+      } catch (err) {
+        manage = provesNoSession(err) ? bearerDefault : false;
       }
       if (live) setCanManage(manage);
     })();

--- a/frontend/src/hooks/use-can-manage.ts
+++ b/frontend/src/hooks/use-can-manage.ts
@@ -33,8 +33,13 @@ import type { OpenCompanyClient } from "@/api/client";
  * being wrong the other way is inviting someone to paste a live credential into
  * a form that can only refuse it.
  *
- * A host with no user plane, or a signed-out console, lands here too. Both are
- * non-admin for this purpose.
+ * A host with no user plane, or a signed-out console, lands here too — with one
+ * exception. `AdminScopedCompany` (`scope.rs`) admits the platform bearer
+ * ({@link OpenCompanyClient.carriesPlatformBearer}) directly, with no session
+ * behind it to resolve; failing this hook closed against that principal would
+ * hide a control the backend has already agreed to run. `resolve_principal`
+ * prefers a session over the bearer when both are present, so a session that
+ * resolves at all — even to a member — still decides the answer here too.
  */
 export function useCanManage(client: OpenCompanyClient, company: string | null): boolean {
   const [canManage, setCanManage] = useState(false);
@@ -46,13 +51,14 @@ export function useCanManage(client: OpenCompanyClient, company: string | null):
     // controls on a company this person may only be a member of.
     setCanManage(false);
     void (async () => {
-      let admin = false;
+      let manage = client.carriesPlatformBearer;
       try {
-        admin = (await fetchMe(client, company)).role === "admin";
+        manage = (await fetchMe(client, company)).role === "admin";
       } catch {
-        // No user plane on this host, or not signed in.
+        // No session to resolve — `manage` keeps the platform-bearer default
+        // above, which is what the backend itself falls back to.
       }
-      if (live) setCanManage(admin);
+      if (live) setCanManage(manage);
     })();
     return () => {
       live = false;

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -8,11 +8,12 @@ import {
   saveHosting,
   type HostingStatus,
 } from "@/api/hosting";
-import { me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
+import { AdminOnlyNotice } from "@/components/admin-only-notice";
 import { PageHeader } from "@/components/page-header";
 import { cn } from "@/lib/utils";
 import { SETTINGS_FIELD_COLUMN } from "@/views/settings-pages";
+import { useCanManage } from "@/hooks/use-can-manage";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { GrantNamespace } from "@/components/grant-namespace";
 import { Badge } from "@/components/ui/badge";
@@ -77,15 +78,12 @@ export function HostingView({ client, company }: Props) {
   const [status, setStatus] = useState<HostingStatus | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  // Whether this viewer may widen the company's tool grants (issue #1796).
+  // Whether this viewer may change what this company deploys through.
   //
-  // Resolved the way `OAuthView` resolves the same question, and defaulted
-  // CLOSED for the same reason: every write behind the control is admin-only,
-  // so an unresolved role must not render an enabled button. Courtesy, not
-  // enforcement — the host refuses a non-admin's `PUT` whatever this says. What
-  // it prevents is offering an operator an action whose only possible outcome
-  // is a 403 toast, which on this page would replace one dead end with another.
-  const [canManage, setCanManage] = useState(false);
+  // Governs the whole page, not just the grant control: `PUT …/hosting` and
+  // `DELETE …/hosting/key` are both `AdminScopedCompany`, so for a member the
+  // token field, Save and Disconnect could each only ever produce a refusal.
+  const canManage = useCanManage(client, company);
 
   const [apiKey, setApiKey] = useState("");
   const [team, setTeam] = useState("");
@@ -106,22 +104,6 @@ export function HostingView({ client, company }: Props) {
     } catch (err) {
       setLoadError(reason(err));
     }
-  }, [client, company]);
-
-  useEffect(() => {
-    let live = true;
-    void (async () => {
-      let admin = false;
-      try {
-        admin = (await fetchMe(client, company)).role === "admin";
-      } catch {
-        // No user plane on this host, or not signed in — treat as non-admin.
-      }
-      if (live) setCanManage(admin);
-    })();
-    return () => {
-      live = false;
-    };
   }, [client, company]);
 
   useEffect(() => {
@@ -221,6 +203,17 @@ export function HostingView({ client, company }: Props) {
       {header}
       <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto px-4 py-6">
 
+        {!canManage && (
+          <AdminOnlyNotice
+            testId="hosting-read-only"
+            title="Only an admin can change where this company deploys"
+          >
+            This token deploys the company&rsquo;s files to the public internet under its
+            own account, and a database provisioned through it is a bill that account
+            pays &mdash; so an admin holds it. You can see what is connected.
+          </AdminOnlyNotice>
+        )}
+
         {/* The two problems this form cannot fix, said before the form so an
           operator does not fill it in and wonder why nothing happened. */}
         {!status.inBuild ? (
@@ -267,24 +260,26 @@ export function HostingView({ client, company }: Props) {
             </div>
 
             <div className={cn("grid gap-4 sm:grid-cols-2", SETTINGS_FIELD_COLUMN)}>
-              <div className="space-y-2">
-                <Label htmlFor="hosting-key">API token</Label>
-                <Input
-                  id="hosting-key"
-                  data-testid="hosting-api-key"
-                  type="password"
-                  autoComplete="off"
-                  placeholder={
-                    status.apiKeyConfigured ? "Configured — type to replace" : "vercel_…"
-                  }
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
-                />
-                <p className="text-xs text-muted-foreground">
-                  Create one at vercel.com → Account Settings → Tokens. Stored
-                  write-only: it is never shown again, here or anywhere else.
-                </p>
-              </div>
+              {canManage ? (
+                <div className="space-y-2">
+                  <Label htmlFor="hosting-key">API token</Label>
+                  <Input
+                    id="hosting-key"
+                    data-testid="hosting-api-key"
+                    type="password"
+                    autoComplete="off"
+                    placeholder={
+                      status.apiKeyConfigured ? "Configured — type to replace" : "vercel_…"
+                    }
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Create one at vercel.com → Account Settings → Tokens. Stored
+                    write-only: it is never shown again, here or anywhere else.
+                  </p>
+                </div>
+              ) : null}
 
               <div className="space-y-2">
                 <Label htmlFor="hosting-team">Team (optional)</Label>
@@ -293,6 +288,7 @@ export function HostingView({ client, company }: Props) {
                   data-testid="hosting-team"
                   placeholder="team_…"
                   value={team}
+                  disabled={!canManage}
                   onChange={(e) => setTeam(e.target.value)}
                 />
                 <p className="text-xs text-muted-foreground">
@@ -303,11 +299,13 @@ export function HostingView({ client, company }: Props) {
             </div>
 
             <div className="flex items-center gap-2">
-              <Button onClick={() => void onSave()} disabled={busy} data-testid="hosting-save">
-                {busy ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
-                Save
-              </Button>
-              {status.apiKeyConfigured ? (
+              {canManage ? (
+                <Button onClick={() => void onSave()} disabled={busy} data-testid="hosting-save">
+                  {busy ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                  Save
+                </Button>
+              ) : null}
+              {canManage && status.apiKeyConfigured ? (
                 <AlertDialog>
                   <AlertDialogTrigger
                     render={

--- a/frontend/src/views/InferenceView.tsx
+++ b/frontend/src/views/InferenceView.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useState } from "react";
-import { Info } from "lucide-react";
-
-import { me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
+import { AdminOnlyNotice } from "@/components/admin-only-notice";
 import { PageHeader } from "@/components/page-header";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useCanManage } from "@/hooks/use-can-manage";
 import { InferenceSection } from "@/views/connections/InferenceSection";
 
 interface Props {
@@ -26,25 +23,8 @@ interface Props {
  */
 export function InferenceView({ client, company }: Props) {
   // Changing the model or the key changes what every teammate's turn costs, so
-  // it is an admin's (issue #403). Courtesy only — the host answers 403 whatever
-  // this says.
-  const [canManage, setCanManage] = useState(false);
-
-  useEffect(() => {
-    let live = true;
-    void (async () => {
-      let admin = false;
-      try {
-        admin = (await fetchMe(client, company)).role === "admin";
-      } catch {
-        // No user plane on this host, or not signed in — treat as non-admin.
-      }
-      if (live) setCanManage(admin);
-    })();
-    return () => {
-      live = false;
-    };
-  }, [client, company]);
+  // it is an admin's.
+  const canManage = useCanManage(client, company);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -59,14 +39,13 @@ export function InferenceView({ client, company }: Props) {
       />
       <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto px-4 py-6">
         {!canManage && (
-          <Alert data-testid="inference-read-only">
-            <Info className="size-4" />
-            <AlertTitle>Only an admin can change this company&apos;s model</AlertTitle>
-            <AlertDescription>
-              The model and its key decide what every teammate&apos;s turn costs, so an admin sets
-              them. You can see what is configured.
-            </AlertDescription>
-          </Alert>
+          <AdminOnlyNotice
+            testId="inference-read-only"
+            title="Only an admin can change this company's model"
+          >
+            The model and its key decide what every teammate&apos;s turn costs, so an admin sets
+            them. You can see what is configured.
+          </AdminOnlyNotice>
         )}
 
         <InferenceSection client={client} company={company} canManage={canManage} />

--- a/frontend/src/views/SearchView.tsx
+++ b/frontend/src/views/SearchView.tsx
@@ -3,11 +3,12 @@ import { Check, Loader2, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 
 import { clearSearch, getSearch, saveSearch, type SearchStatus } from "@/api/search";
-import { me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
+import { AdminOnlyNotice } from "@/components/admin-only-notice";
 import { PageHeader } from "@/components/page-header";
 import { cn } from "@/lib/utils";
 import { SETTINGS_FIELD_COLUMN } from "@/views/settings-pages";
+import { useCanManage } from "@/hooks/use-can-manage";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { GrantNamespace } from "@/components/grant-namespace";
 import { Badge } from "@/components/ui/badge";
@@ -92,15 +93,13 @@ export function SearchView({ client, company }: Props) {
   const [status, setStatus] = useState<SearchStatus | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  // Whether this viewer may widen the company's tool grants (issue #1796).
+  // Whether this viewer may change where this company's teammates search.
   //
-  // Resolved the way `OAuthView` resolves the same question, and defaulted
-  // CLOSED for the same reason: every write behind the control is admin-only,
-  // so an unresolved role must not render an enabled button. Courtesy, not
-  // enforcement — the host refuses a non-admin's `PUT` whatever this says. What
-  // it prevents is offering an operator an action whose only possible outcome
-  // is a 403 toast, which on this page would replace one dead end with another.
-  const [canManage, setCanManage] = useState(false);
+  // Governs the whole page, not just the grant control: `PUT …/search` and
+  // `DELETE …/search/key` are both `AdminScopedCompany`. The footnote at the
+  // bottom of this page has always said the choice is an administrator's; until
+  // this gate existed, the page said that under an enabled provider picker.
+  const canManage = useCanManage(client, company);
 
   const [provider, setProvider] = useState("managed");
   const [apiKey, setApiKey] = useState("");
@@ -122,22 +121,6 @@ export function SearchView({ client, company }: Props) {
     } catch (err) {
       setLoadError(reason(err));
     }
-  }, [client, company]);
-
-  useEffect(() => {
-    let live = true;
-    void (async () => {
-      let admin = false;
-      try {
-        admin = (await fetchMe(client, company)).role === "admin";
-      } catch {
-        // No user plane on this host, or not signed in — treat as non-admin.
-      }
-      if (live) setCanManage(admin);
-    })();
-    return () => {
-      live = false;
-    };
   }, [client, company]);
 
   useEffect(() => {
@@ -252,6 +235,19 @@ export function SearchView({ client, company }: Props) {
       {header}
       <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto px-4 py-6">
 
+        {!canManage && (
+          <AdminOnlyNotice
+            testId="search-read-only"
+            title="Only an admin can change where this company searches"
+          >
+            Whatever a teammate types into a search reaches the provider selected
+            here, under that provider&rsquo;s own retention policy &mdash; and the
+            calls are billed to whichever account the key belongs to. Both are the
+            company&rsquo;s to decide, so an admin decides them. You can see which
+            index answers today.
+          </AdminOnlyNotice>
+        )}
+
         {!status.inBuild ? (
           <Alert data-testid="search-not-in-build">
             <TriangleAlert className="size-4" />
@@ -304,6 +300,7 @@ export function SearchView({ client, company }: Props) {
                   value={provider}
                   onValueChange={(v) => v && setProvider(String(v))}
                   items={labels}
+                  disabled={!canManage}
                 >
                   <SelectTrigger id="search-provider" data-testid="search-provider">
                     <SelectValue />
@@ -321,7 +318,10 @@ export function SearchView({ client, company }: Props) {
                 </p>
               </div>
 
-              {byo && provider !== "searxng" ? (
+              {/* Withheld from a member, not disabled — the same rule the API
+                token follows on the Hosting page. A disabled password box is
+                still somewhere to aim a paste. */}
+              {canManage && byo && provider !== "searxng" ? (
                 <div className="space-y-2">
                   <Label htmlFor="search-key">API key</Label>
                   <Input
@@ -350,6 +350,7 @@ export function SearchView({ client, company }: Props) {
                     data-testid="search-endpoint"
                     placeholder="https://searx.example.com"
                     value={endpoint}
+                    disabled={!canManage}
                     onChange={(e) => setEndpoint(e.target.value)}
                   />
                   <p className="text-xs text-muted-foreground">
@@ -361,11 +362,13 @@ export function SearchView({ client, company }: Props) {
             </div>
 
             <div className="flex items-center gap-2">
-              <Button onClick={() => void onSave()} disabled={busy} data-testid="search-save">
-                {busy ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
-                Save
-              </Button>
-              {status.provider !== "managed" ? (
+              {canManage ? (
+                <Button onClick={() => void onSave()} disabled={busy} data-testid="search-save">
+                  {busy ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                  Save
+                </Button>
+              ) : null}
+              {canManage && status.provider !== "managed" ? (
                 <Button
                   variant="outline"
                   onClick={() => void onClear()}

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -48,7 +48,7 @@ import type { CompanyFeed } from "@/hooks/use-company";
 import { withHostParam } from "@/hooks/use-host-route";
 import { restartTour } from "@/tour/state";
 import { preloadTour } from "@/tour/TourController";
-import { useCanManage } from "@/hooks/use-can-manage";
+import { useCanManage, useCanManagePolicy } from "@/hooks/use-can-manage";
 import { useLocalScope } from "@/connections/ConnectionContext";
 import { forgetSession } from "@/connections/registry";
 import type { ConnectionId } from "@/connections/types";
@@ -83,13 +83,15 @@ export function SettingsView({ client, company, feed, onFlag, onResetCompany }: 
   const scope = useLocalScope();
   const { status } = feed;
   const scoped = company ?? client.defaultCompany;
-  // Approvals and Domain are `require_admin` / `AdminScopedCompany` writes.
-  //
-  // Not passed to Lifecycle: `pause` and `resume` take `CompanyAuth` and never
-  // ask for a role, so a member's Pause genuinely stops the company. Hiding it
+  // Domain/SMTP are `AdminScopedCompany`, which admits the platform bearer;
+  // Policy is `require_admin` off the request headers, which does not — so
+  // it needs its own narrower gate rather than sharing this one. Neither is
+  // passed to Lifecycle: `pause` and `resume` take `CompanyAuth` and never ask
+  // for a role, so a member's Pause genuinely stops the company. Hiding it
   // here would make this page lie in the other direction — the missing guard is
   // the host's to add, and this gate should follow it rather than lead it.
   const canManage = useCanManage(client, company);
+  const canManagePolicy = useCanManagePolicy(client, company);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -119,7 +121,7 @@ export function SettingsView({ client, company, feed, onFlag, onResetCompany }: 
         {/* Approvals: the autonomy tier and the always-ask list (issue #562).
             High in the page on purpose — an operator who comes to settings
             because they are drowning in approval cards is here for this. */}
-        <PolicySettings client={client} company={company} canManage={canManage} />
+        <PolicySettings client={client} company={company} canManage={canManagePolicy} />
 
         {/* Connection */}
         <Card>

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -48,6 +48,7 @@ import type { CompanyFeed } from "@/hooks/use-company";
 import { withHostParam } from "@/hooks/use-host-route";
 import { restartTour } from "@/tour/state";
 import { preloadTour } from "@/tour/TourController";
+import { useCanManage } from "@/hooks/use-can-manage";
 import { useLocalScope } from "@/connections/ConnectionContext";
 import { forgetSession } from "@/connections/registry";
 import type { ConnectionId } from "@/connections/types";
@@ -82,6 +83,13 @@ export function SettingsView({ client, company, feed, onFlag, onResetCompany }: 
   const scope = useLocalScope();
   const { status } = feed;
   const scoped = company ?? client.defaultCompany;
+  // Approvals and Domain are `require_admin` / `AdminScopedCompany` writes.
+  //
+  // Not passed to Lifecycle: `pause` and `resume` take `CompanyAuth` and never
+  // ask for a role, so a member's Pause genuinely stops the company. Hiding it
+  // here would make this page lie in the other direction — the missing guard is
+  // the host's to add, and this gate should follow it rather than lead it.
+  const canManage = useCanManage(client, company);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -111,7 +119,7 @@ export function SettingsView({ client, company, feed, onFlag, onResetCompany }: 
         {/* Approvals: the autonomy tier and the always-ask list (issue #562).
             High in the page on purpose — an operator who comes to settings
             because they are drowning in approval cards is here for this. */}
-        <PolicySettings client={client} company={company} />
+        <PolicySettings client={client} company={company} canManage={canManage} />
 
         {/* Connection */}
         <Card>
@@ -193,7 +201,12 @@ export function SettingsView({ client, company, feed, onFlag, onResetCompany }: 
             remount a company switch would carry a credential typed for one
             company into another company's Save. `SettingsSection` remounts
             `BillingView`/`HostingView` for exactly this reason. */}
-        <DomainSettings key={company ?? "self"} client={client} company={company} />
+        <DomainSettings
+          key={company ?? "self"}
+          client={client}
+          company={company}
+          canManage={canManage}
+        />
 
         {/* Appearance.
 

--- a/frontend/test/e2e/settings-authority.spec.ts
+++ b/frontend/test/e2e/settings-authority.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The Settings pages must not offer a member controls the host refuses.
+ *
+ * `connections-authority.spec.ts` is this spec's older half, and covers the
+ * three pages that existed when issue #403 was fixed: Apps, MCP and Inference.
+ * Hosting, Search, and the Approvals and Domain cards on General arrived later
+ * and never joined it — which is why each of them shipped rendering a member an
+ * enabled Save. A page that gains a credential form after the spec was written
+ * does not fail it; it is simply not in it. So this file walks the Settings
+ * section by page, and is the thing to extend when a page is added.
+ *
+ * The host is the boundary either way: `PUT …/hosting`, `PUT …/search`,
+ * `PUT …/domain` and the SMTP writes are `AdminScopedCompany`, and
+ * `PUT …/policy` calls `require_admin`, so each answers a member
+ * `403 only an admin can do that` whatever the console renders. What this spec
+ * covers is that the console does not *invite* the refusal — which matters most
+ * where the invitation is a password box, because a member learns they are not
+ * allowed only after a live credential has left their password manager.
+ *
+ * Lifecycle is deliberately not asserted here. `POST …/{id}/pause` takes
+ * `CompanyAuth` and never resolves a role, so a member's Pause genuinely stops
+ * the company; asserting the button away would encode a guard that does not
+ * exist. When the host grows one, add the case here alongside it.
+ *
+ * Drives a real browser against a live host, like the rest of this directory,
+ * and is not a merge gate (the Playwright config declares no `webServer`).
+ *
+ * The suite's shared storage state is the harness **admin**. The member half
+ * signs in separately through the same magic-link flow the product uses, in its
+ * own browser context, so both roles are exercised against one host.
+ */
+
+type Page = import("@playwright/test").Page;
+type APIRequestContext = import("@playwright/test").APIRequestContext;
+
+const MEMBER_EMAIL = "member-settings@example.test";
+
+// The first-run tour offers itself once per browser context and then records
+// `skipped` in that context's localStorage. These tests visit four settings
+// pages within one context, so waiting for the dismiss button on every visit
+// burns a full `waitFor` timeout on the pages after the first, where the tour
+// can no longer appear. Key the dismissal by page object so only the first
+// visit in each context waits on it.
+const tourDismissed = new WeakMap<Page, boolean>();
+
+async function openSettingsPage(page: Page, sub: string) {
+  await page.goto(`/#/settings/${sub}`);
+  if (tourDismissed.has(page)) return;
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await skip
+    .waitFor({ state: "visible", timeout: 10_000 })
+    .then(() => skip.click())
+    .catch(() => {
+      /* already seen in this context — nothing to dismiss */
+    });
+  tourDismissed.set(page, true);
+}
+
+/**
+ * Invites `MEMBER_EMAIL` as a member and redeems a login code for `context`.
+ *
+ * Idempotent on the invite: a re-run hits `409 already a member`, which is a
+ * success for our purposes — the address can sign in either way.
+ */
+async function signInAsMember(admin: APIRequestContext, context: APIRequestContext) {
+  const invited = await admin.post("/api/v1/company/users/invites", {
+    data: { email: MEMBER_EMAIL, role: "member" },
+  });
+  expect(
+    invited.ok() || invited.status() === 409,
+    `inviting ${MEMBER_EMAIL} failed: ${invited.status()} ${await invited.text()}`,
+  ).toBeTruthy();
+
+  const requested = await context.post("/api/v1/company/auth/request", {
+    data: { email: MEMBER_EMAIL },
+  });
+  const devCode = (await requested.json())?.dev_code as string | undefined;
+  expect(
+    devCode,
+    "no dev_code came back — the host must bind loopback with no mail transport " +
+      "configured for the member half of this spec to sign in",
+  ).toBeTruthy();
+
+  const verified = await context.post("/api/v1/company/auth/verify", {
+    data: { code: devCode },
+  });
+  expect(verified.ok(), `member sign-in failed: ${await verified.text()}`).toBeTruthy();
+  expect((await verified.json()).role).toBe("member");
+}
+
+test("a member sees what Settings holds but is offered nothing that changes it", async ({
+  page,
+  browser,
+}) => {
+  const memberContext = await browser.newContext({ storageState: undefined });
+  try {
+    await signInAsMember(page.request, memberContext.request);
+    const memberPage = await memberContext.newPage();
+
+    // ---- Hosting: where this company's sites go live ------------------------
+    await openSettingsPage(memberPage, "hosting");
+    await expect(memberPage.getByTestId("hosting-read-only")).toBeVisible({ timeout: 30_000 });
+
+    // The assertion that matters most: no credential field anywhere. A member
+    // must never be handed somewhere to paste a deployment token.
+    await expect(memberPage.getByTestId("hosting-api-key")).toHaveCount(0);
+    await expect(memberPage.getByTestId("hosting-save")).toHaveCount(0);
+    await expect(memberPage.getByTestId("hosting-clear")).toHaveCount(0);
+
+    // The read survives — what the company deploys through explains why a
+    // teammate can deploy at all.
+    await expect(memberPage.getByRole("heading", { name: "Hosting" })).toBeVisible();
+
+    // ---- Search: whose index answers a teammate, under whose retention ------
+    await openSettingsPage(memberPage, "search");
+    await expect(memberPage.getByTestId("search-read-only")).toBeVisible({ timeout: 30_000 });
+    await expect(memberPage.getByTestId("search-api-key")).toHaveCount(0);
+    await expect(memberPage.getByTestId("search-save")).toHaveCount(0);
+    await expect(memberPage.getByTestId("search-clear")).toHaveCount(0);
+
+    // The provider stays visible and inert. This page's own footnote says the
+    // choice is an administrator's; it used to print that under a live picker.
+    const provider = memberPage.getByTestId("search-provider");
+    await expect(provider).toBeVisible();
+    await expect(provider).toBeDisabled();
+
+    // ---- General: approvals, domain, outbound mail --------------------------
+    await openSettingsPage(memberPage, "general");
+    await expect(memberPage.getByTestId("policy-read-only")).toBeVisible({ timeout: 30_000 });
+    // The tiers stay readable — which one is in force decides what this
+    // member's teammates may do without asking — but none of them is a choice.
+    await expect(memberPage.getByTestId("policy-tier-full")).toBeDisabled();
+
+    await expect(memberPage.getByTestId("domain-read-only")).toBeVisible();
+    await expect(memberPage.getByTestId("domain-remove")).toHaveCount(0);
+    await expect(memberPage.getByTestId("domain-input")).toHaveCount(0);
+
+    await expect(memberPage.getByTestId("smtp-read-only")).toBeVisible();
+    await expect(memberPage.getByTestId("smtp-save")).toHaveCount(0);
+    await expect(memberPage.getByTestId("smtp-password")).toHaveCount(0);
+
+    // ---- Usage: read-only for everyone, and unchanged by any of this --------
+    // `GET …/usage` is `ScopedCompany`, and the page carries no admin control
+    // at all, so a member gets the whole thing. Asserted rather than assumed:
+    // the risk when adding role gates is over-correcting into a member losing
+    // a page that was always theirs.
+    await openSettingsPage(memberPage, "usage");
+    await expect(memberPage.getByRole("heading", { name: "Usage" })).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(memberPage.getByRole("combobox", { name: "Usage date range" })).toBeEnabled();
+  } finally {
+    await memberContext.close();
+  }
+});
+
+test("an admin is still offered every Settings control", async ({ page }) => {
+  // The control for the spec above: each assertion there is only worth having
+  // if the admin path still renders what the member's does not.
+  await openSettingsPage(page, "hosting");
+  await expect(page.getByTestId("hosting-read-only")).toHaveCount(0);
+  await expect(page.getByTestId("hosting-api-key")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("hosting-save")).toBeVisible();
+
+  await openSettingsPage(page, "search");
+  await expect(page.getByTestId("search-read-only")).toHaveCount(0);
+  await expect(page.getByTestId("search-provider")).toBeEnabled({ timeout: 30_000 });
+  await expect(page.getByTestId("search-save")).toBeVisible();
+
+  await openSettingsPage(page, "general");
+  await expect(page.getByTestId("policy-read-only")).toHaveCount(0);
+  await expect(page.getByTestId("policy-tier-full")).toBeEnabled({ timeout: 30_000 });
+  await expect(page.getByTestId("domain-read-only")).toHaveCount(0);
+  await expect(page.getByTestId("smtp-read-only")).toHaveCount(0);
+  await expect(page.getByTestId("smtp-save")).toBeVisible();
+});

--- a/frontend/test/e2e/settings-authority.spec.ts
+++ b/frontend/test/e2e/settings-authority.spec.ts
@@ -30,6 +30,22 @@ import { expect, test } from "@playwright/test";
  * The suite's shared storage state is the harness **admin**. The member half
  * signs in separately through the same magic-link flow the product uses, in its
  * own browser context, so both roles are exercised against one host.
+ *
+ * A third principal — the platform bearer (`?token=` / `VITE_OC_TOKEN`) with no
+ * human session behind it — is covered at the API layer by the test below
+ * rather than through the browser. `AdminScopedCompany` (`scope.rs`) admits
+ * that principal directly for exactly the mutations this page and Search gate,
+ * so `useCanManage` has to grant it the same controls a member never sees; but
+ * driving it through an actual page load hits an unrelated, pre-existing gap —
+ * `client.onUnauthorized` (`api/client.ts`) flips the *whole* connection to
+ * "unauthenticated" on the first 401 from any non-`/auth/` route, and several
+ * app-shell routes a bearer has no session to answer for (`/presence`,
+ * `/notifications`, `/chat/mentionables`) 401 within the first second of any
+ * page load — bouncing the console back to the login screen out from under
+ * whatever page was open, Settings included. That is a separate defect in the
+ * connection registry, not in `useCanManage`, and fixing it is a larger change
+ * than this file's scope; the case below asserts the same ground truth
+ * `useCanManage` reads without depending on a page surviving that race.
  */
 
 type Page = import("@playwright/test").Page;
@@ -175,4 +191,55 @@ test("an admin is still offered every Settings control", async ({ page }) => {
   await expect(page.getByTestId("domain-read-only")).toHaveCount(0);
   await expect(page.getByTestId("smtp-read-only")).toHaveCount(0);
   await expect(page.getByTestId("smtp-save")).toBeVisible();
+});
+
+/**
+ * `OPENCOMPANY_PLATFORM_TOKEN` this host was started with, if any — the
+ * shared-secret credential `AdminScopedCompany` admits directly, with no
+ * session behind it. Not configured by default: `host.sh` starts from an empty
+ * environment and only forwards names listed in `PW_HOST_PASSTHROUGH` (see its
+ * own header comment), so exercising this case needs both set on the run:
+ *
+ *   OPENCOMPANY_PLATFORM_TOKEN=<secret> PW_HOST_PASSTHROUGH=OPENCOMPANY_PLATFORM_TOKEN npm run e2e
+ *
+ * Skipped rather than failed when absent — the same way the suite treats every
+ * fixture it does not manage (`COMPOSIO`, `LIVE_BRAIN`). A run against a host
+ * nobody configured a bearer for has nothing to prove wrong.
+ */
+const PLATFORM_TOKEN = process.env.OPENCOMPANY_PLATFORM_TOKEN;
+
+test("a platform bearer with no human session gets what AdminScopedCompany already grants it", async ({
+  browser,
+}) => {
+  test.skip(
+    !PLATFORM_TOKEN,
+    "needs OPENCOMPANY_PLATFORM_TOKEN forwarded via PW_HOST_PASSTHROUGH — see the comment above.",
+  );
+  const bearerContext = await browser.newContext({ storageState: undefined });
+  try {
+    const bearer = bearerContext.request;
+    const headers = { authorization: `Bearer ${PLATFORM_TOKEN}` };
+
+    // The premise `useCanManage` now has to recognise: no session behind this
+    // bearer at all.
+    const me = await bearer.get("/api/v1/company/auth/me", { headers });
+    expect(me.status()).toBe(401);
+
+    // Proves the same authority `useCanManage` grants without writing a real
+    // credential: `AdminScopedCompany` (`scope.rs`) runs before the handler
+    // body, so an unsupported provider — refused by `put_hosting` itself,
+    // before it ever calls `write_all` — only reaches that refusal if the
+    // bearer already cleared the authority check. A principal `useCanManage`
+    // should have refused would 401/403 here instead, never 400. `PW_BASE_URL`
+    // can point this run at a real company, so nothing here may touch whatever
+    // hosting credential it actually has stored.
+    const probe = await bearer.put("/api/v1/company/hosting", {
+      headers,
+      data: { provider: "not-a-real-provider" },
+    });
+    expect(probe.status()).toBe(400);
+    expect((await probe.json()).code).toBe("invalid_request");
+  } finally {
+    await bearerContext.close();
+  }
 });

--- a/frontend/test/e2e/settings-authority.spec.ts
+++ b/frontend/test/e2e/settings-authority.spec.ts
@@ -5,11 +5,19 @@ import { expect, test } from "@playwright/test";
  *
  * `connections-authority.spec.ts` is this spec's older half, and covers the
  * three pages that existed when issue #403 was fixed: Apps, MCP and Inference.
- * Hosting, Search, and the Approvals and Domain cards on General arrived later
- * and never joined it — which is why each of them shipped rendering a member an
- * enabled Save. A page that gains a credential form after the spec was written
- * does not fail it; it is simply not in it. So this file walks the Settings
- * section by page, and is the thing to extend when a page is added.
+ * Hosting, Search, and the Approvals card on General arrived later and never
+ * joined it — which is why each of them shipped rendering a member an enabled
+ * Save. A page that gains a credential form after the spec was written does
+ * not fail it; it is simply not in it. So this file walks the Settings section
+ * by page, and is the thing to extend when a page is added.
+ *
+ * Domain and SMTP are not among those pages right now: #2131 gated both cards
+ * on General to a static `ComingSoon` preview for every role, with no form,
+ * button, or handler in either — so there is nothing on screen for a role gate
+ * to protect until that gate lifts. `useCanManage` still authorizes
+ * `PUT …/domain` and the SMTP writes the same as `PUT …/hosting` and
+ * `PUT …/search`; the case for them belongs back here alongside `DomainCard`
+ * and `SmtpCard` once #2131 remounts the real forms.
  *
  * The host is the boundary either way: `PUT …/hosting`, `PUT …/search`,
  * `PUT …/domain` and the SMTP writes are `AdminScopedCompany`, and
@@ -142,20 +150,17 @@ test("a member sees what Settings holds but is offered nothing that changes it",
     await expect(provider).toBeVisible();
     await expect(provider).toBeDisabled();
 
-    // ---- General: approvals, domain, outbound mail --------------------------
+    // ---- General: approvals --------------------------------------------------
     await openSettingsPage(memberPage, "general");
     await expect(memberPage.getByTestId("policy-read-only")).toBeVisible({ timeout: 30_000 });
     // The tiers stay readable — which one is in force decides what this
     // member's teammates may do without asking — but none of them is a choice.
     await expect(memberPage.getByTestId("policy-tier-full")).toBeDisabled();
 
-    await expect(memberPage.getByTestId("domain-read-only")).toBeVisible();
-    await expect(memberPage.getByTestId("domain-remove")).toHaveCount(0);
-    await expect(memberPage.getByTestId("domain-input")).toHaveCount(0);
-
-    await expect(memberPage.getByTestId("smtp-read-only")).toBeVisible();
-    await expect(memberPage.getByTestId("smtp-save")).toHaveCount(0);
-    await expect(memberPage.getByTestId("smtp-password")).toHaveCount(0);
+    // Domain and SMTP assertions retired with the surface: #2131 gated both
+    // cards to a static `ComingSoon` preview for every role, so `useCanManage`
+    // has nothing left to authorize there. Return them here when that gate
+    // lifts and the real `DomainCard`/`SmtpCard` mount again.
 
     // ---- Usage: read-only for everyone, and unchanged by any of this --------
     // `GET …/usage` is `ScopedCompany`, and the page carries no admin control
@@ -188,9 +193,8 @@ test("an admin is still offered every Settings control", async ({ page }) => {
   await openSettingsPage(page, "general");
   await expect(page.getByTestId("policy-read-only")).toHaveCount(0);
   await expect(page.getByTestId("policy-tier-full")).toBeEnabled({ timeout: 30_000 });
-  await expect(page.getByTestId("domain-read-only")).toHaveCount(0);
-  await expect(page.getByTestId("smtp-read-only")).toHaveCount(0);
-  await expect(page.getByTestId("smtp-save")).toBeVisible();
+  // Domain and SMTP assertions retired with the surface — see the matching
+  // note in the member test above.
 });
 
 /**

--- a/frontend/test/unit/autonomy-readers.test.ts
+++ b/frontend/test/unit/autonomy-readers.test.ts
@@ -118,7 +118,7 @@ describe("a policy written on the settings page", () => {
   function Both({ api, seen }: { api: OpenCompanyClient; seen: string[] }): ReactNode {
     const status = useAutonomy(api, "acme");
     seen.push(status?.mode ?? "unknown");
-    return createElement(PolicySettings, { client: api, company: "acme" });
+    return createElement(PolicySettings, { client: api, company: "acme", canManage: true });
   }
 
   async function mount(api: OpenCompanyClient, seen: string[]) {

--- a/frontend/test/unit/credential-clear-confirm.test.ts
+++ b/frontend/test/unit/credential-clear-confirm.test.ts
@@ -33,8 +33,20 @@ const { HostingView } = await import("@/views/HostingView");
 let container: HTMLDivElement;
 let root: Root;
 
+/**
+ * A client that answers `/auth/me` as an admin.
+ *
+ * The role is stated rather than left to a stub with no `get`: `HostingView`
+ * withholds Disconnect from a non-admin, and an unanswerable `/auth/me` reads
+ * as non-admin. A fixture that did not say would be asserting a member's view
+ * of a confirmation flow only an admin can reach.
+ */
 function client(): OpenCompanyClient {
-  return { scopeFor: () => "/api/v1/company" } as unknown as OpenCompanyClient;
+  return {
+    scopeFor: () => "/api/v1/company",
+    get: () =>
+      Promise.resolve({ id: "u1", email: "a@b.c", role: "admin", company: "acme" }),
+  } as unknown as OpenCompanyClient;
 }
 
 function button(label: string): HTMLButtonElement {

--- a/frontend/test/unit/domain-settings-host-backed.test.ts
+++ b/frontend/test/unit/domain-settings-host-backed.test.ts
@@ -124,8 +124,8 @@ async function show(client: OpenCompanyClient) {
   await act(async () => {
     root.render(
       createElement(Fragment, null, [
-        createElement(DomainCard, { key: "domain", client, company: "acme" }),
-        createElement(SmtpCard, { key: "smtp", client, company: "acme" }),
+        createElement(DomainCard, { key: "domain", client, company: "acme", canManage: true }),
+        createElement(SmtpCard, { key: "smtp", client, company: "acme", canManage: true }),
       ]),
     );
   });

--- a/frontend/test/unit/policy-always-ask-vocabulary.test.ts
+++ b/frontend/test/unit/policy-always-ask-vocabulary.test.ts
@@ -651,6 +651,49 @@ describe("policy tier changes", () => {
     expect(document.body.textContent).toContain("Give teammates more autonomy?");
     expect(toasts.error).toHaveBeenCalled();
   });
+
+  it("disables every tier control for a member and states why", async () => {
+    const client = makeClient();
+    await act(async () => {
+      root.render(
+        createElement(PolicySettings, { client, company: "acme", canManage: false }),
+      );
+    });
+
+    expect(container.textContent).toContain(
+      "Only an admin can change this company's approval policy",
+    );
+
+    const radios = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="radio"]'),
+    );
+    expect(radios.length).toBeGreaterThan(0);
+    expect(radios.every((radio) => radio.disabled)).toBe(true);
+
+    const full = radios.find((radio) => radio.textContent?.includes("Full"));
+    await act(async () => {
+      full?.click();
+    });
+    expect(document.body.textContent).not.toContain("Give teammates more autonomy?");
+    expect((client.put as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it("withholds the deadline save control from a member", async () => {
+    const client = makeClient();
+    await act(async () => {
+      root.render(
+        createElement(PolicySettings, { client, company: "acme", canManage: false }),
+      );
+    });
+
+    const buttons = Array.from(container.querySelectorAll("button")).map(
+      (button) => button.textContent,
+    );
+    expect(buttons).not.toContain("Save deadline");
+    expect(
+      container.querySelector<HTMLInputElement>("#approval-deadline")?.disabled,
+    ).toBe(true);
+  });
 });
 
 describe("alwaysApproveGates", () => {

--- a/frontend/test/unit/policy-always-ask-vocabulary.test.ts
+++ b/frontend/test/unit/policy-always-ask-vocabulary.test.ts
@@ -137,7 +137,7 @@ afterEach(async () => {
 
 async function mount(client: OpenCompanyClient) {
   await act(async () => {
-    root.render(createElement(PolicySettings, { client, company: "acme" }));
+    root.render(createElement(PolicySettings, { client, company: "acme", canManage: true }));
   });
 }
 

--- a/frontend/test/unit/policy-tier-autonomy.test.ts
+++ b/frontend/test/unit/policy-tier-autonomy.test.ts
@@ -111,7 +111,7 @@ afterEach(async () => {
 
 async function mount(client: OpenCompanyClient) {
   await act(async () => {
-    root.render(createElement(PolicySettings, { client, company: "acme" }));
+    root.render(createElement(PolicySettings, { client, company: "acme", canManage: true }));
     await Promise.resolve();
   });
 }
@@ -291,7 +291,7 @@ describe("changing the autonomy tier", () => {
     // choice was reviewed against "acme"'s policy and must not apply to the
     // new one.
     await act(async () => {
-      root.render(createElement(PolicySettings, { client, company: "other" }));
+      root.render(createElement(PolicySettings, { client, company: "other", canManage: true }));
       await Promise.resolve();
     });
     expect(document.querySelector("[data-testid=policy-tier-confirm]")).toBeNull();
@@ -314,7 +314,7 @@ describe("changing the autonomy tier", () => {
 
     // The scope moves to another company while the PUT is in flight.
     await act(async () => {
-      root.render(createElement(PolicySettings, { client, company: "other" }));
+      root.render(createElement(PolicySettings, { client, company: "other", canManage: true }));
       await Promise.resolve();
     });
 
@@ -638,7 +638,7 @@ describe("loading the policy", () => {
       },
     } as unknown as OpenCompanyClient;
     await act(async () => {
-      root.render(createElement(PolicySettings, { client: failing, company: "other" }));
+      root.render(createElement(PolicySettings, { client: failing, company: "other", canManage: true }));
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -664,12 +664,12 @@ describe("loading the policy", () => {
     } as unknown as OpenCompanyClient;
 
     await act(async () => {
-      root.render(createElement(PolicySettings, { client, company: "acme" }));
+      root.render(createElement(PolicySettings, { client, company: "acme", canManage: true }));
       await Promise.resolve();
     });
     // Move to another company while "acme"'s read is still in flight.
     await act(async () => {
-      root.render(createElement(PolicySettings, { client, company: "other" }));
+      root.render(createElement(PolicySettings, { client, company: "other", canManage: true }));
       await Promise.resolve();
     });
 
@@ -713,7 +713,7 @@ describe("loading the policy", () => {
     } as unknown as OpenCompanyClient;
 
     await act(async () => {
-      root.render(createElement(PolicySettings, { client, company: "acme" }));
+      root.render(createElement(PolicySettings, { client, company: "acme", canManage: true }));
       await Promise.resolve();
     });
     await act(async () => {
@@ -726,7 +726,7 @@ describe("loading the policy", () => {
 
     // The operator switches companies while the save is still pending.
     await act(async () => {
-      root.render(createElement(PolicySettings, { client, company: "other" }));
+      root.render(createElement(PolicySettings, { client, company: "other", canManage: true }));
       await Promise.resolve();
     });
 
@@ -770,7 +770,7 @@ describe("loading the policy", () => {
     } as unknown as OpenCompanyClient;
 
     await act(async () => {
-      root.render(createElement(PolicySettings, { client, company: "acme" }));
+      root.render(createElement(PolicySettings, { client, company: "acme", canManage: true }));
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -783,7 +783,7 @@ describe("loading the policy", () => {
         .click();
     });
     await act(async () => {
-      root.render(createElement(PolicySettings, { client, company: "other" }));
+      root.render(createElement(PolicySettings, { client, company: "other", canManage: true }));
       await Promise.resolve();
     });
 

--- a/frontend/test/unit/policy-tier-autonomy.test.ts
+++ b/frontend/test/unit/policy-tier-autonomy.test.ts
@@ -621,6 +621,50 @@ describe("changing the spend cap", () => {
   });
 });
 
+describe("the operator's role", () => {
+  it("disables every tier control for a member and states why", async () => {
+    const { client, put } = makeClient(status("supervised"));
+    await act(async () => {
+      root.render(
+        createElement(PolicySettings, { client, company: "acme", canManage: false }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain(
+      "Only an admin can change this company's approval policy",
+    );
+
+    const full = container.querySelector<HTMLButtonElement>(
+      "[data-testid=policy-tier-full]",
+    )!;
+    expect(full.disabled).toBe(true);
+
+    await act(async () => {
+      full.click();
+    });
+    expect(document.querySelector("[data-testid=policy-tier-confirm]")).toBeNull();
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("withholds the manifest-reset control from a member even when overridden", async () => {
+    const { client, del } = makeClient(overridden("readonly", "full"));
+    await act(async () => {
+      root.render(
+        createElement(PolicySettings, { client, company: "acme", canManage: false }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(
+      [...container.querySelectorAll("button")].some((button) =>
+        button.textContent?.includes("manifest's policy"),
+      ),
+    ).toBe(false);
+    expect(del).not.toHaveBeenCalled();
+  });
+});
+
 describe("loading the policy", () => {
   it("clears the previous company's policy when a company-switch read fails", async () => {
     const { client } = makeClient(status("supervised"));

--- a/frontend/test/unit/settings-admin-only-controls.test.ts
+++ b/frontend/test/unit/settings-admin-only-controls.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { HostingView } from "@/views/HostingView";
+import { SearchView } from "@/views/SearchView";
+
+/**
+ * Settings must not offer a member a control whose only outcome is a refusal.
+ *
+ * Every write behind these two pages is `AdminScopedCompany`, so a member's
+ * Save answers `403 only an admin can do that`. Both pages already resolved the
+ * viewer's role before this suite existed — and wired the answer into the tool-
+ * grant banner alone, leaving the credential field, Save and Disconnect
+ * rendering enabled. Knowing the role and using it were separate acts, and the
+ * pages did the first.
+ *
+ * The assertion that matters most is the credential field's absence rather than
+ * its disabled-ness. A disabled password box is still somewhere to aim a paste,
+ * and a member who pastes a live key learns they were not allowed only after
+ * the key has left their password manager.
+ */
+
+const HOSTING = {
+  apiKeyConfigured: true,
+  provider: "vercel",
+  team: "team_abc",
+  granted: true,
+  inBuild: true,
+  supportedProviders: ["vercel"],
+};
+
+const SEARCH = {
+  provider: "brave",
+  effectiveProvider: "brave",
+  endpoint: null,
+  apiKeyConfigured: true,
+  needsApiKey: false,
+  needsEndpoint: false,
+  granted: true,
+  inBuild: true,
+  supportedProviders: ["managed", "brave", "searxng"],
+};
+
+/** A client answering the page's own read, and `/auth/me` as `role`. */
+function clientAs(role: "admin" | "member", answer: unknown): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: (path: string) =>
+      path.endsWith("/auth/me")
+        ? Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme", hasPassword: true })
+        : Promise.resolve(answer),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(element: React.ReactElement) {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("Settings → Hosting, by role", () => {
+  it("offers a member no credential field, no Save and no Disconnect", async () => {
+    const client = clientAs("member", HOSTING);
+    await show(createElement(HostingView, { client, company: "acme" }));
+
+    expect(at("hosting-api-key")).toBeNull();
+    expect(at("hosting-save")).toBeNull();
+    expect(at("hosting-clear")).toBeNull();
+  });
+
+  it("tells a member why, rather than leaving the page silently plainer", async () => {
+    // Withholding the controls without saying so would trade a dishonest
+    // button for a missing one: the member would go looking for a control that
+    // is not theirs and conclude the page is broken.
+    const client = clientAs("member", HOSTING);
+    await show(createElement(HostingView, { client, company: "acme" }));
+
+    const notice = at("hosting-read-only");
+    expect(notice).not.toBeNull();
+    expect(notice?.textContent).toContain("Only an admin");
+  });
+
+  it("still shows a member what is connected", async () => {
+    // The read is not admin-only, and a member has a reason to want it: it is
+    // what explains why a teammate can deploy at all.
+    const client = clientAs("member", HOSTING);
+    await show(createElement(HostingView, { client, company: "acme" }));
+
+    expect(at("hosting-connected")).not.toBeNull();
+    expect(at("hosting-team")).not.toBeNull();
+  });
+
+  it("offers an admin the whole form and no notice", async () => {
+    // The control. Every assertion above is only worth having if the admin
+    // path still renders what the member's does not.
+    const client = clientAs("admin", HOSTING);
+    await show(createElement(HostingView, { client, company: "acme" }));
+
+    expect(at("hosting-read-only")).toBeNull();
+    expect(at("hosting-api-key")).not.toBeNull();
+    expect(at("hosting-save")).not.toBeNull();
+    expect(at("hosting-clear")).not.toBeNull();
+  });
+});
+
+describe("Settings → Search, by role", () => {
+  it("offers a member no key field and no way to change the provider", async () => {
+    const client = clientAs("member", SEARCH);
+    await show(createElement(SearchView, { client, company: "acme" }));
+
+    expect(at("search-api-key")).toBeNull();
+    expect(at("search-save")).toBeNull();
+    expect(at("search-clear")).toBeNull();
+  });
+
+  it("leaves the provider picker visible to a member but not operable", async () => {
+    // Which index answers a teammate's search is worth reading even when it is
+    // not yours to change — the page's own footnote is about exactly that.
+    const client = clientAs("member", SEARCH);
+    await show(createElement(SearchView, { client, company: "acme" }));
+
+    const picker = at("search-provider");
+    expect(picker).not.toBeNull();
+    expect(picker?.hasAttribute("disabled") || picker?.getAttribute("aria-disabled") === "true").toBe(
+      true,
+    );
+  });
+
+  it("states the rule the page's own footnote has always asserted", async () => {
+    // The page has always ended with "the choice is an administrator's and not
+    // a teammate's". Until this gate existed it printed that under an enabled
+    // picker and an enabled Save.
+    const client = clientAs("member", SEARCH);
+    await show(createElement(SearchView, { client, company: "acme" }));
+
+    const notice = at("search-read-only");
+    expect(notice).not.toBeNull();
+    expect(notice?.textContent).toContain("Only an admin");
+    // The footnote's own characters, typographic apostrophe included — this is
+    // the sentence the page was printing under an enabled picker.
+    expect(container.textContent).toContain("an administrator’s and not a teammate’s");
+  });
+
+  it("offers an admin the whole form and no notice", async () => {
+    const client = clientAs("admin", SEARCH);
+    await show(createElement(SearchView, { client, company: "acme" }));
+
+    expect(at("search-read-only")).toBeNull();
+    expect(at("search-api-key")).not.toBeNull();
+    expect(at("search-save")).not.toBeNull();
+    expect(at("search-clear")).not.toBeNull();
+  });
+});

--- a/frontend/test/unit/settings-coming-soon.test.ts
+++ b/frontend/test/unit/settings-coming-soon.test.ts
@@ -79,7 +79,7 @@ afterEach(() => {
 
 async function show(client: OpenCompanyClient) {
   await act(async () => {
-    root.render(createElement(DomainSettings, { client, company: "acme" }));
+    root.render(createElement(DomainSettings, { client, company: "acme", canManage: true }));
   });
 }
 

--- a/frontend/test/unit/settings-general-admin-only.test.ts
+++ b/frontend/test/unit/settings-general-admin-only.test.ts
@@ -4,6 +4,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import { DomainSettings } from "@/components/domain-settings";
 import { PolicySettings } from "@/components/policy-settings";
@@ -81,7 +82,9 @@ function clientAs(
  */
 function bearerClient(): OpenCompanyClient {
   const get = (path: string) => {
-    if (path.endsWith("/auth/me")) return Promise.reject(new Error("401 unauthorized"));
+    if (path.endsWith("/auth/me")) {
+      return Promise.reject(new ApiError(401, "unauthorized", "not signed in", true));
+    }
     if (path.endsWith("/policy")) return Promise.resolve(POLICY);
     if (path.endsWith("/domain")) return Promise.resolve(DOMAIN);
     if (path.endsWith("/smtp")) return Promise.resolve(SMTP);

--- a/frontend/test/unit/settings-general-admin-only.test.ts
+++ b/frontend/test/unit/settings-general-admin-only.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenCompanyClient } from "@/api/client";
 import { DomainSettings } from "@/components/domain-settings";
 import { PolicySettings } from "@/components/policy-settings";
+import { useCanManage, useCanManagePolicy } from "@/hooks/use-can-manage";
 
 /**
  * The two admin-only cards on Settings → General, by role.
@@ -39,17 +40,29 @@ const POLICY = {
 };
 
 const DOMAIN = { domain: "mail.acme.test", verified: true, records: [], checks: [] };
-const SMTP = { configured: true, host: "smtp.acme.test", port: 587, security: "starttls" };
+const SMTP = {
+  configured: true,
+  host: "smtp.acme.test",
+  port: 587,
+  security: "starttls",
+  username: "apikey",
+  from_name: "Acme",
+  from_email: "hello@acme.test",
+};
+const SMTP_UNCONFIGURED = { configured: false };
 
 /** A client answering every read this pair makes, with `/auth/me` as `role`. */
-function clientAs(role: "admin" | "member"): OpenCompanyClient {
+function clientAs(
+  role: "admin" | "member",
+  overrides: { smtp?: unknown } = {},
+): OpenCompanyClient {
   const get = (path: string) => {
     if (path.endsWith("/auth/me")) {
       return Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme" });
     }
     if (path.endsWith("/policy")) return Promise.resolve(POLICY);
     if (path.endsWith("/domain")) return Promise.resolve(DOMAIN);
-    if (path.endsWith("/smtp")) return Promise.resolve(SMTP);
+    if (path.endsWith("/smtp")) return Promise.resolve(overrides.smtp ?? SMTP);
     // The policy card also reads the wired tool slugs, to offer them as
     // suggestions on the always-ask box. An empty set is the shape a host with
     // no wired tools sends, and it degrades to a plain input.
@@ -60,6 +73,43 @@ function clientAs(role: "admin" | "member"): OpenCompanyClient {
     get,
     defaultCompany: "acme",
   } as unknown as OpenCompanyClient;
+}
+
+/**
+ * The platform bearer (`?token=` / `VITE_OC_TOKEN`), with no human session
+ * behind it — `carriesPlatformBearer: true` and every `/auth/me` refused.
+ */
+function bearerClient(): OpenCompanyClient {
+  const get = (path: string) => {
+    if (path.endsWith("/auth/me")) return Promise.reject(new Error("401 unauthorized"));
+    if (path.endsWith("/policy")) return Promise.resolve(POLICY);
+    if (path.endsWith("/domain")) return Promise.resolve(DOMAIN);
+    if (path.endsWith("/smtp")) return Promise.resolve(SMTP);
+    return Promise.resolve({ slugs: [] });
+  };
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    carriesPlatformBearer: true,
+    get,
+    defaultCompany: "acme",
+  } as unknown as OpenCompanyClient;
+}
+
+/**
+ * Wires the two hooks exactly as `SettingsView` does — Policy off
+ * {@link useCanManagePolicy}, Domain/SMTP off the broader {@link useCanManage}
+ * — so a mismatch between what a principal is granted and what each card is
+ * told can only pass if the wiring, not just each hook in isolation, is right.
+ */
+function SettingsGeneralSlice({ client }: { client: OpenCompanyClient }) {
+  const canManage = useCanManage(client, "acme");
+  const canManagePolicy = useCanManagePolicy(client, "acme");
+  return createElement(
+    "div",
+    null,
+    createElement(PolicySettings, { client, company: "acme", canManage: canManagePolicy }),
+    createElement(DomainSettings, { client, company: "acme", canManage }),
+  );
 }
 
 let container: HTMLDivElement;
@@ -135,11 +185,30 @@ describe("Settings → General → Domain and SMTP, by role", () => {
 
     expect(at("domain-remove")).toBeNull();
     expect(at("domain-input")).toBeNull();
-    // The whole SMTP form goes, password included: it is one credential, and
-    // the last field on it is a secret.
+    // The mutations go — password, Save, and Test, since all three are
+    // `AdminScopedCompany` — but the routing itself is member-readable
+    // (`GET …/smtp`), so it stays on screen.
     expect(at("smtp-save")).toBeNull();
     expect(at("smtp-password")).toBeNull();
-    expect(at("smtp-member-summary")).not.toBeNull();
+    expect(at("smtp-host")?.textContent).toBe("smtp.acme.test");
+    expect(at("smtp-port")?.textContent).toBe("587");
+    expect(at("smtp-security")?.textContent).toBe("STARTTLS");
+    expect(at("smtp-username")?.textContent).toBe("apikey");
+    expect(at("smtp-from-name")?.textContent).toBe("Acme");
+    expect(at("smtp-from-email")?.textContent).toBe("hello@acme.test");
+  });
+
+  it("falls back to the plain summary for a member when nothing is configured", async () => {
+    await show(
+      createElement(DomainSettings, {
+        client: clientAs("member", { smtp: SMTP_UNCONFIGURED }),
+        company: "acme",
+        canManage: false,
+      }),
+    );
+
+    expect(at("smtp-routing")).toBeNull();
+    expect(at("smtp-member-summary")?.textContent).toContain("No outbound mail server");
   });
 
   it("tells a member why both cards are read-only", async () => {
@@ -183,5 +252,22 @@ describe("Settings → General → Domain and SMTP, by role", () => {
     expect(at("smtp-read-only")).toBeNull();
     expect(at("domain-remove")).not.toBeNull();
     expect(at("smtp-save")).not.toBeNull();
+  });
+});
+
+describe("Settings → General, a platform bearer with no human session", () => {
+  it("gets Domain/SMTP management but not the policy controls", async () => {
+    await show(createElement(SettingsGeneralSlice, { client: bearerClient() }));
+
+    // `AdminScopedCompany` (`scope.rs`) admits the bearer directly.
+    expect(at("domain-read-only")).toBeNull();
+    expect(at("smtp-read-only")).toBeNull();
+    expect(at("domain-remove")).not.toBeNull();
+    expect(at("smtp-save")).not.toBeNull();
+
+    // `set_policy` calls `require_admin` off the request headers and refuses
+    // a bearer with no session behind it as unauthenticated.
+    expect(at("policy-read-only")).not.toBeNull();
+    expect(at("policy-tier-full")?.hasAttribute("disabled")).toBe(true);
   });
 });

--- a/frontend/test/unit/settings-general-admin-only.test.ts
+++ b/frontend/test/unit/settings-general-admin-only.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { DomainSettings } from "@/components/domain-settings";
+import { PolicySettings } from "@/components/policy-settings";
+
+/**
+ * The two admin-only cards on Settings → General, by role.
+ *
+ * Neither asked the viewer's role at all before this: the autonomy tiers were
+ * clickable, the domain box typable and the SMTP password field offered, while
+ * `PUT …/policy` calls `require_admin` and `PUT …/domain` and the SMTP writes
+ * are `AdminScopedCompany`. Every one of them answers a member with
+ * `403 only an admin can do that`.
+ *
+ * Lifecycle is deliberately absent from this file. `pause` and `resume` take
+ * `CompanyAuth` and never ask for a role, so a member's Pause really does stop
+ * the company — a console gate there would be a second lie, not a fix. The
+ * missing guard is the host's.
+ */
+
+const POLICY = {
+  mode: "full",
+  manifestMode: "auto",
+  overridden: true,
+  setBy: "someone@acme.test",
+  alwaysApprove: [],
+  approvalDeadlineHours: 24,
+  tiers: [
+    { value: "readonly", label: "Read-only", description: "Look, change nothing." },
+    { value: "supervised", label: "Supervised", description: "Conservative." },
+    { value: "auto", label: "Auto", description: "Balanced." },
+    { value: "full", label: "Full", description: "Broadest." },
+  ],
+};
+
+const DOMAIN = { domain: "mail.acme.test", verified: true, records: [], checks: [] };
+const SMTP = { configured: true, host: "smtp.acme.test", port: 587, security: "starttls" };
+
+/** A client answering every read this pair makes, with `/auth/me` as `role`. */
+function clientAs(role: "admin" | "member"): OpenCompanyClient {
+  const get = (path: string) => {
+    if (path.endsWith("/auth/me")) {
+      return Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme" });
+    }
+    if (path.endsWith("/policy")) return Promise.resolve(POLICY);
+    if (path.endsWith("/domain")) return Promise.resolve(DOMAIN);
+    if (path.endsWith("/smtp")) return Promise.resolve(SMTP);
+    // The policy card also reads the wired tool slugs, to offer them as
+    // suggestions on the always-ask box. An empty set is the shape a host with
+    // no wired tools sends, and it degrades to a plain input.
+    return Promise.resolve({ slugs: [] });
+  };
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get,
+    defaultCompany: "acme",
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(element: React.ReactElement) {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("Settings → General → Approvals, by role", () => {
+  it("leaves a member the tiers to read but not to pick", async () => {
+    await show(
+      createElement(PolicySettings, {
+        client: clientAs("member"),
+        company: "acme",
+        canManage: false,
+      }),
+    );
+
+    // Every tier is still shown — which tier the company is on is worth
+    // knowing to a member, because it decides what their teammates may do.
+    const full = at("policy-tier-full");
+    expect(full).not.toBeNull();
+    expect(full?.hasAttribute("disabled")).toBe(true);
+
+    const notice = at("policy-read-only");
+    expect(notice).not.toBeNull();
+    expect(notice?.textContent).toContain("Only an admin");
+  });
+
+  it("leaves an admin every tier live and shows no notice", async () => {
+    await show(
+      createElement(PolicySettings, {
+        client: clientAs("admin"),
+        company: "acme",
+        canManage: true,
+      }),
+    );
+
+    expect(at("policy-read-only")).toBeNull();
+    expect(at("policy-tier-full")?.hasAttribute("disabled")).toBe(false);
+  });
+});
+
+describe("Settings → General → Domain and SMTP, by role", () => {
+  it("offers a member no domain write and no SMTP credential field", async () => {
+    await show(
+      createElement(DomainSettings, {
+        client: clientAs("member"),
+        company: "acme",
+        canManage: false,
+      }),
+    );
+
+    expect(at("domain-remove")).toBeNull();
+    expect(at("domain-input")).toBeNull();
+    // The whole SMTP form goes, password included: it is one credential, and
+    // the last field on it is a secret.
+    expect(at("smtp-save")).toBeNull();
+    expect(at("smtp-password")).toBeNull();
+    expect(at("smtp-member-summary")).not.toBeNull();
+  });
+
+  it("tells a member why both cards are read-only", async () => {
+    await show(
+      createElement(DomainSettings, {
+        client: clientAs("member"),
+        company: "acme",
+        canManage: false,
+      }),
+    );
+
+    expect(at("domain-read-only")?.textContent).toContain("Only an admin");
+    expect(at("smtp-read-only")?.textContent).toContain("Only an admin");
+  });
+
+  it("still lets a member re-check DNS, which the host allows", async () => {
+    // `POST …/domain/verify` is `ScopedCompany` on purpose — it re-reads DNS
+    // for a domain only an admin could have set and changes nothing a member
+    // could not already read. Withholding it would over-correct.
+    await show(
+      createElement(DomainSettings, {
+        client: clientAs("member"),
+        company: "acme",
+        canManage: false,
+      }),
+    );
+
+    expect(at("domain-verify")).not.toBeNull();
+  });
+
+  it("offers an admin both forms and no notice", async () => {
+    await show(
+      createElement(DomainSettings, {
+        client: clientAs("admin"),
+        company: "acme",
+        canManage: true,
+      }),
+    );
+
+    expect(at("domain-read-only")).toBeNull();
+    expect(at("smtp-read-only")).toBeNull();
+    expect(at("domain-remove")).not.toBeNull();
+    expect(at("smtp-save")).not.toBeNull();
+  });
+});

--- a/frontend/test/unit/settings-general-admin-only.test.ts
+++ b/frontend/test/unit/settings-general-admin-only.test.ts
@@ -1,14 +1,29 @@
 // @vitest-environment jsdom
 
-import { act, createElement } from "react";
+import { act, createElement, Fragment } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
-import { DomainSettings } from "@/components/domain-settings";
+import { DomainCard, SmtpCard } from "@/components/domain-settings";
 import { PolicySettings } from "@/components/policy-settings";
 import { useCanManage, useCanManagePolicy } from "@/hooks/use-can-manage";
+
+/**
+ * `DomainCard`/`SmtpCard` directly, not `DomainSettings` — both are gated as
+ * coming soon (issue #2131) and `DomainSettings` renders static previews in
+ * their place. The role-gating this file pins still has to hold for the
+ * release that switches the two cards back on, so it is exercised at the
+ * level it belongs to, the same way `domain-settings-host-backed.test.ts`
+ * does. `settings-coming-soon.test.ts` covers the gate itself.
+ */
+function DomainAndSmtp({ client, company, canManage }: { client: OpenCompanyClient; company: string; canManage: boolean }) {
+  return createElement(Fragment, null, [
+    createElement(DomainCard, { key: "domain", client, company, canManage }),
+    createElement(SmtpCard, { key: "smtp", client, company, canManage }),
+  ]);
+}
 
 /**
  * The two admin-only cards on Settings → General, by role.
@@ -111,7 +126,7 @@ function SettingsGeneralSlice({ client }: { client: OpenCompanyClient }) {
     "div",
     null,
     createElement(PolicySettings, { client, company: "acme", canManage: canManagePolicy }),
-    createElement(DomainSettings, { client, company: "acme", canManage }),
+    createElement(DomainAndSmtp, { client, company: "acme", canManage }),
   );
 }
 
@@ -179,7 +194,7 @@ describe("Settings → General → Approvals, by role", () => {
 describe("Settings → General → Domain and SMTP, by role", () => {
   it("offers a member no domain write and no SMTP credential field", async () => {
     await show(
-      createElement(DomainSettings, {
+      createElement(DomainAndSmtp, {
         client: clientAs("member"),
         company: "acme",
         canManage: false,
@@ -203,7 +218,7 @@ describe("Settings → General → Domain and SMTP, by role", () => {
 
   it("falls back to the plain summary for a member when nothing is configured", async () => {
     await show(
-      createElement(DomainSettings, {
+      createElement(DomainAndSmtp, {
         client: clientAs("member", { smtp: SMTP_UNCONFIGURED }),
         company: "acme",
         canManage: false,
@@ -216,7 +231,7 @@ describe("Settings → General → Domain and SMTP, by role", () => {
 
   it("tells a member why both cards are read-only", async () => {
     await show(
-      createElement(DomainSettings, {
+      createElement(DomainAndSmtp, {
         client: clientAs("member"),
         company: "acme",
         canManage: false,
@@ -232,7 +247,7 @@ describe("Settings → General → Domain and SMTP, by role", () => {
     // for a domain only an admin could have set and changes nothing a member
     // could not already read. Withholding it would over-correct.
     await show(
-      createElement(DomainSettings, {
+      createElement(DomainAndSmtp, {
         client: clientAs("member"),
         company: "acme",
         canManage: false,
@@ -244,7 +259,7 @@ describe("Settings → General → Domain and SMTP, by role", () => {
 
   it("offers an admin both forms and no notice", async () => {
     await show(
-      createElement(DomainSettings, {
+      createElement(DomainAndSmtp, {
         client: clientAs("admin"),
         company: "acme",
         canManage: true,

--- a/frontend/test/unit/use-can-manage-platform-bearer.test.ts
+++ b/frontend/test/unit/use-can-manage-platform-bearer.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { HostingView } from "@/views/HostingView";
+
+/**
+ * `AdminScopedCompany` (`scope.rs`) admits the platform bearer directly, with
+ * no session behind it — but `resolve_principal` prefers a session over the
+ * bearer whenever one resolves. `useCanManage` has to land on the same
+ * answer: grant the bearer-only case, and still refuse a member whose session
+ * resolves, even on a client that also carries a bearer.
+ */
+
+const HOSTING = {
+  apiKeyConfigured: true,
+  provider: "vercel",
+  team: "team_abc",
+  granted: true,
+  inBuild: true,
+  supportedProviders: ["vercel"],
+};
+
+function clientAs(opts: {
+  platformBearer: boolean;
+  me: "admin" | "member" | "none";
+}): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    carriesPlatformBearer: opts.platformBearer,
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return opts.me === "none"
+          ? Promise.reject(new Error("401 unauthorized"))
+          : Promise.resolve({
+              id: "u1",
+              email: "a@b.c",
+              role: opts.me,
+              company: "acme",
+              hasPassword: true,
+            });
+      }
+      return Promise.resolve(HOSTING);
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(element: React.ReactElement) {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("useCanManage, platform bearer vs member session", () => {
+  it("offers the platform bearer the whole form when there is no /auth/me user", async () => {
+    const client = clientAs({ platformBearer: true, me: "none" });
+    await show(createElement(HostingView, { client, company: "acme" }));
+
+    expect(at("hosting-read-only")).toBeNull();
+    expect(at("hosting-api-key")).not.toBeNull();
+    expect(at("hosting-save")).not.toBeNull();
+  });
+
+  it("still refuses a member session, even on a client that also carries a platform bearer", async () => {
+    const client = clientAs({ platformBearer: true, me: "member" });
+    await show(createElement(HostingView, { client, company: "acme" }));
+
+    expect(at("hosting-api-key")).toBeNull();
+    expect(at("hosting-save")).toBeNull();
+    expect(at("hosting-read-only")).not.toBeNull();
+  });
+
+  it("fails closed with no bearer and no session", async () => {
+    const client = clientAs({ platformBearer: false, me: "none" });
+    await show(createElement(HostingView, { client, company: "acme" }));
+
+    expect(at("hosting-api-key")).toBeNull();
+    expect(at("hosting-save")).toBeNull();
+    expect(at("hosting-read-only")).not.toBeNull();
+  });
+});

--- a/frontend/test/unit/use-can-manage-platform-bearer.test.ts
+++ b/frontend/test/unit/use-can-manage-platform-bearer.test.ts
@@ -4,6 +4,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import { HostingView } from "@/views/HostingView";
 
@@ -12,7 +13,9 @@ import { HostingView } from "@/views/HostingView";
  * no session behind it — but `resolve_principal` prefers a session over the
  * bearer whenever one resolves. `useCanManage` has to land on the same
  * answer: grant the bearer-only case, and still refuse a member whose session
- * resolves, even on a client that also carries a bearer.
+ * resolves, even on a client that also carries a bearer. A read that merely
+ * failed to resolve a session — a timeout, a 5xx — is a third case: it must
+ * not be treated as proof there is none.
  */
 
 const HOSTING = {
@@ -26,22 +29,26 @@ const HOSTING = {
 
 function clientAs(opts: {
   platformBearer: boolean;
-  me: "admin" | "member" | "none";
+  me: "admin" | "member" | "none" | "unreachable";
 }): OpenCompanyClient {
   return {
     scopeFor: () => "/api/v1/companies/acme",
     carriesPlatformBearer: opts.platformBearer,
     get: (path: string) => {
       if (path.endsWith("/auth/me")) {
-        return opts.me === "none"
-          ? Promise.reject(new Error("401 unauthorized"))
-          : Promise.resolve({
-              id: "u1",
-              email: "a@b.c",
-              role: opts.me,
-              company: "acme",
-              hasPassword: true,
-            });
+        if (opts.me === "none") {
+          return Promise.reject(new ApiError(401, "unauthorized", "not signed in", true));
+        }
+        if (opts.me === "unreachable") {
+          return Promise.reject(new ApiError(0, "network_error", "cannot reach the company host"));
+        }
+        return Promise.resolve({
+          id: "u1",
+          email: "a@b.c",
+          role: opts.me,
+          company: "acme",
+          hasPassword: true,
+        });
       }
       return Promise.resolve(HOSTING);
     },
@@ -95,6 +102,15 @@ describe("useCanManage, platform bearer vs member session", () => {
 
   it("fails closed with no bearer and no session", async () => {
     const client = clientAs({ platformBearer: false, me: "none" });
+    await show(createElement(HostingView, { client, company: "acme" }));
+
+    expect(at("hosting-api-key")).toBeNull();
+    expect(at("hosting-save")).toBeNull();
+    expect(at("hosting-read-only")).not.toBeNull();
+  });
+
+  it("fails closed on a platform bearer when /auth/me merely couldn't be reached", async () => {
+    const client = clientAs({ platformBearer: true, me: "unreachable" });
     await show(createElement(HostingView, { client, company: "acme" }));
 
     expect(at("hosting-api-key")).toBeNull();


### PR DESCRIPTION
## Summary

Settings handed a member live administrative controls and let them find out only
after submitting.

Signed in as a real `role: member`:

- **Hosting** rendered the API-token box, the Team box and **Save**, all enabled.
- **Search** opened the provider dropdown, accepted a switch to Brave, and
  offered an API-key password box — directly beneath its own footer explaining
  *"the reason the choice is an administrator's and not a teammate's"*.

The refusal itself was never silent: every attempt raised a toast carrying the
host's own words, `only an admin can do that`. The defect is the enabled
control, not a swallowed error — and it matters because on Hosting and Search
you learn the rule only after a live credential has left your password manager.

The cause was not three pages. The role read
`(await fetchMe(...)).role === "admin"` had been copy-pasted into **ten**
components. Resolving the role was never what broke; *using* it was. Hosting and
Search resolved it and wired it into the tool-grant banner alone, while Policy
and Domain never asked at all. Knowing the role and acting on it were separate
acts with nothing connecting them.

Replaced with one `useCanManage` hook, failing closed, and one `AdminOnlyNotice`
for the reason. On `PolicySettings` and `DomainSettings` the `canManage` prop is
**required and undefaulted**, so the compiler enumerated all eleven render sites
— including a hosting fixture that answered no `/auth/me` at all.

Credential fields are **withheld rather than disabled**: a disabled password box
is still somewhere to aim a paste. Reads stay — the Team box, the provider name,
the tier list, and Verify DNS, which is deliberately open to members.

### Review round 2

Three follow-ups from the first round, one of them a hazard:

- The opt-in bearer test in `settings-authority.spec.ts` PUT a real credential
  into `hosting`, and `GET .../hosting` is write-only, so a run against a
  caller-supplied host had no way back. It now proves the same
  `AdminScopedCompany` authority with an unsupported provider, refused before
  the handler ever writes anything.
- `useCanManage` correctly admits the platform bearer for the
  `AdminScopedCompany` writes it gates, but `SettingsView` was passing that
  same value to `PolicySettings`, and `set_policy` calls `require_admin`
  directly — a human-session-only check the bearer 401s against. Policy now
  reads a separate `useCanManagePolicy` hook that never falls back to the
  bearer default; Domain/SMTP keep the broader one.
- The SMTP card's member view had collapsed to a single
  configured/not-configured sentence, discarding the host, port, security,
  username and From identity that `GET .../smtp` already returns to a member
  by design (non-secret routing, no password field). It now renders that
  routing read-only, matching the domain card's DNS table beside it.

### Review round 3

Two more follow-ups on `useCanManage`, both about the same catch block:

- The bearer fallback treated *any* `/auth/me` failure as proof of no
  session — a timeout or a 5xx reads as "signed out" and grants the
  platform-bearer default just as readily as the documented no-session
  401 does. Once connectivity recovers the backend still prefers a real
  session and refuses the write, so this only ever bought a misleading
  control, never a working one. The catch now checks that the failure is
  specifically `/auth/me`'s own 401 (an `ApiError` with `status === 401`
  and `fromHost`) before falling back; anything else resolves to `false`.
- `SettingsView` and `InferenceView` stay mounted across a company
  switch, so `useCanManage`'s state could carry a previous company's
  `true` into the render before its own effect reset it. The hook now
  stores the resolved answer alongside the inputs it was resolved for and
  only returns it when those inputs still match the current render — a
  stale answer for a different company can no longer render even for one
  pass.

A `tinysweeper/commits` flag on the e2e spec's
`process.env.OPENCOMPANY_PLATFORM_TOKEN` line is a false positive: that
line is an env-var read, not a literal, and has been since it was first
added — the actual literal the rule caught (the destructive PUT's
`apiKey`) was already removed in round 2. The check scans this PR's
commit history rather than its current tree, so the historical commit
before that removal keeps tripping it regardless of what head reads now.

## API Or Behavior Changes

Console only; no route or payload changes.

A member now sees a stated reason in place of controls their role cannot use, on
Hosting, Search, and — found during the audit rather than reported — **General →
Approvals** and **General → Domain/SMTP**, both of which were ungated behind an
`AdminScopedCompany` backend.

Audited and left alone as already correct: Inference (moved onto the shared hook
with no behaviour change), People, Skills, Usage, Observatory, and the read-only
items under General.

**Not gated here, deliberately:** company Pause. A member can genuinely still
pause the company, because the route does not check a role. Hiding a button that
works would make the page lie in the other direction. That guard belongs on the
server and is addressed separately; once it lands, gating this control is one
line, as `canManage` is already resolved in `SettingsView`.

## Tests

- `npm run typecheck` / `:unit` / `:e2e` — 0 / 0 / 0
- `npx vitest run` — 0, 481 files, 4455 tests (no flake this run; the
  documented `client.post is not a function` debounce-timer flake from an
  unrelated file has shown up on some earlier rounds)
- `cargo fmt --all -- --check` — 0
- `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings` — 0
- Playwright `settings-authority.spec.ts` — 3/3 against a live host

### Review round 4

Restored non-admin (`canManage: false`) coverage on `PolicySettings` that a
required-prop migration had quietly dropped: every render site in
`policy-tier-autonomy.test.ts` and `policy-always-ask-vocabulary.test.ts` had
been hardcoded to `canManage: true` to keep existing assertions passing, so
the member path — every tier control disabled, the deadline-save and
manifest-reset buttons withheld, the admin-only notice shown — was no longer
exercised in either file. Added one `canManage: false` case per file's main
describe block plus a second case pinning the deadline/reset controls, kept
the existing `canManage: true` cases as the contrasting control, and proved
the new cases fail if the `!canManage` gates are stripped from
`policy-settings.tsx` (verified locally, reverted, re-confirmed green).

Inspected every other `PolicySettings` render site the same migration
touched: `autonomy-readers.test.ts` also hardcodes `canManage: true`, but
correctly — that suite proves a write on the settings card propagates to the
title-row reader, which only an admin fixture can exercise at all.
`settings-general-admin-only.test.ts` already wires both roles (one hook-driven,
one contrasting `true`/`false` pair) and needed no change.

### Review round 3

New unit case: a platform bearer whose `/auth/me` rejects with a non-401
`ApiError` (network error / 5xx) now renders `hosting-read-only`, not the
credential form — fails against the pre-round-3 tree, passes after. Existing
bearer-grant, member-refusal and admin cases (`use-can-manage-platform-bearer.test.ts`,
`settings-general-admin-only.test.ts`) still pass unchanged.

Rebased onto `upstream/main` (through the Composio BYOK merge) with no
conflicts, including on `policy-settings.tsx`, which a sibling PR touched
concurrently. Full console lane re-run post-rebase, not a subset.

Also driven against a locally built host (own port, own
`OPENCOMPANY_DATA_DIR`, no other worktree's process): signed in as the real
harness admin and a freshly invited member through the dev-code login flow
and read the on-screen state for both, before and after writing a real SMTP
configuration.

- **Admin** — Hosting still shows the API token field and Save; General
  still shows live approval tiers, an editable domain card, and an SMTP form
  with Save/Test connection.
- **Member, Hosting** — "Only an admin can change where this company
  deploys" — no API token field, no Save.
- **Member, Search** — "Only an admin can change where this company
  searches" — provider shown, not editable.
- **Member, General** — "Only an admin can change this company's approval
  policy", "Only an admin can change this company's domain", "Only an admin
  can change how this company sends mail". Before any SMTP write, the SMTP
  card falls back to "No outbound mail server is configured, so this company
  sends on the host's default." After the admin session wrote one, the same
  member session (reloaded) rendered the routing read-only: "SMTP host:
  smtp.browsercheck.test", "Port: 587", "Security: STARTTLS", "Username:
  apikey", "From name: Browser Check Co", "From email:
  hello@browsercheck.test" — no password field, no Save, no Test connection.

Round 2 was also driven against a locally built host (own port, own
`OPENCOMPANY_DATA_DIR`, rebuilt console bundle): signed in as the real admin
and a real invited member through the magic-link flow and read the on-screen
state for each. Admin still gets an editable SMTP form with Save/Test and
live approval tiers. The member's SMTP card, once a real configuration was
written, showed "SMTP host: smtp.review-e2e.test", "Port: 2525", "Security:
SSL / TLS", "Username: review-apikey", "From name: Review Co", "From email:
hello@review-e2e.test" — read-only, no password field, no Save, no Test
connection. The platform-bearer case stays API-only, for the pre-existing
`client.onUnauthorized` reason above: `PUT .../domain` 200s for the bearer,
`PUT .../policy` 401s for the same bearer, and the hosting probe now returns
`400 invalid_request` without touching whatever key is actually stored.

Proved red first: with the source stashed, 5 of 8 Hosting/Search cases and 3 of 6
General cases fail against the old code — exactly the member-facing ones. The
admin cases pass both before and after, which is what makes them a control. For
the end-to-end spec the console was rebuilt from pre-change source: the member
test fails, the admin test passes.

Existing fixtures were also updated to state which role each one exercises, so a
future reader can see what a passing test is actually asserting.

One unrelated observation: `connections-authority.spec.ts` fails 2/2 on this rig,
on a `not.toContain("token")` assertion and a first-run tour overlay intercepting
a tab click. Identical error signatures appear on a pre-change build, so it is
pre-existing and rig-shaped rather than a regression from this work.

### Platform bearer (`?token=` / `VITE_OC_TOKEN`)

`AdminScopedCompany` (`scope.rs`) admits this principal directly when no
session resolves — `resolve_principal` prefers a session whenever one does,
even a member's. `useCanManage` failed closed against it anyway, hiding a
control the backend had already agreed to run. Fixed by defaulting to
`client.carriesPlatformBearer` when `/auth/me` cannot resolve; a resolving
session, member or admin, still decides the answer.

Verified against a locally built host with `OPENCOMPANY_PLATFORM_TOKEN` set:
`/auth/me` 401s for the bearer, `PUT .../hosting` (`AdminScopedCompany`) 200s
and stores, and the same call with only a member's session cookie still 403s.
A component test renders the real `HostingView` for both the bearer-only and
member-with-a-co-present-bearer cases. A new, opt-in `settings-authority.spec.ts`
case exercises the same ground truth at the API layer against a managed e2e
host (`OPENCOMPANY_PLATFORM_TOKEN` forwarded via `PW_HOST_PASSTHROUGH`),
skipped when unset — and now proves it without writing a real credential (see
Round 2 above).

`set_policy` is the one write on this page `AdminScopedCompany` does not
cover: it calls `require_admin` straight off the request headers, which
resolves only a human session and 401s a bearer with none. `useCanManage`
still grants the bearer for Domain/SMTP; Policy now reads
`useCanManagePolicy`, which resolves the same human-session check but never
falls back to the bearer default. A component test wires both hooks through
`SettingsView`'s own composition and asserts the bearer gets Domain/SMTP
management with a read-only Policy card.

Not driven through the browser: `client.onUnauthorized` flips the whole
connection to `unauthenticated` on the first 401 from any non-`/auth/` route,
and several app-shell routes a bearer has no session to answer for
(`/presence`, `/notifications`, `/chat/mentionables`) 401 within the first
second of any page load, bouncing the console to the login screen regardless
of which page was open. That's a separate, pre-existing gap in the connection
registry, not in this hook — worth its own fix, out of scope here.

## Documentation

`useCanManage` and `AdminOnlyNotice` carry the rule in one place, replacing ten
copies of an inline role comparison.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added role-based access controls across Hosting, Search, Inference, Domain, SMTP, and Policy settings.
  - Members see read-only views and admin-only notices, with editing controls and sensitive credentials hidden or disabled.
  - Administrators retain full management controls.
  - Platform-authorized access can manage domain, SMTP, and hosting settings; policy changes remain restricted to human administrators.
  - Spend-cap amounts are now displayed in currency format.

- **Tests**
  - Added coverage for member, administrator, and platform-authorized access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

