### PR TITLE
fix(console): one rule for rendering money, so the same number reads the same everywhere

### DIFF
--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -37,6 +37,7 @@ import { Label } from "@/components/ui/label";
 // waiting for its 30s poll. Not a cycle: `use-autonomy` imports only
 // `@/api/policy` and `@/lib/visible-poll`.
 import { applyAutonomy } from "@/hooks/use-autonomy";
+import { usd } from "@/lib/money";
 import { cn } from "@/lib/utils";
 
 /**
@@ -1203,8 +1204,8 @@ export function PolicySettings({ client, company }: Props) {
                       <>
                         {status.autoApproveUnderUsd === null
                           ? "Today every spend asks first."
-                          : `Today spend under $${status.autoApproveUnderUsd} asks nothing.`}{" "}
-                        {`Raising the cap to ${pendingCapRaise} lets qualifying spends under the new cap pass without asking; the daily budget still stops spending after its limit.`}
+                          : `Today spend under ${usd(status.autoApproveUnderUsd)} asks nothing.`}{" "}
+                        {`Raising the cap to ${usd(pendingCapRaise)} lets qualifying spends under the new cap pass without asking; the daily budget still stops spending after its limit.`}
                       </>
                     ) : resetAwaitingConfirmation ? (
                       <>
@@ -1294,7 +1295,7 @@ export function PolicySettings({ client, company }: Props) {
                     }}
                   >
                     {pendingCapRaise !== null
-                      ? `Raise cap to $${pendingCapRaise}`
+                      ? `Raise cap to ${usd(pendingCapRaise)}`
                       : resetAwaitingConfirmation
                         ? "Revert and give more autonomy"
                         : AUTONOMY_CONFIRM_ACTION}

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -10,6 +10,7 @@ import type {
 } from "@/api/workflows";
 // Issue #981: the one definition of "this report did not go out", shared with
 // the run drawer, the history rows and the host itself.
+import { usd } from "@/lib/money";
 import { undeliveredCount } from "@/views/workflows/run-health";
 
 /**
@@ -1250,7 +1251,7 @@ export function handleEvent(
       break;
     case "payment_received":
       toast.success("Payment received", {
-        description: `$${event.amountUsd.toFixed(2)} — ${event.memo}`,
+        description: `${usd(event.amountUsd)} — ${event.memo}`,
       });
       break;
     // Issue #228. A run that went fine is not an attention signal — toasting

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -2,6 +2,7 @@
 // never exposes runtime internals ("agent graph", "tier", "dispatch", "cycle",
 // "checkpoint", "A2A"). Everything a person sees goes through this layer.
 
+import { usd } from "./money";
 import type { TaskApprovalStatus } from "../api/tasks";
 import type {
   ApprovalSummary,
@@ -870,8 +871,9 @@ function renderValue(value: unknown): string {
   return JSON.stringify(value) ?? String(value);
 }
 
-export function money(usd: number): string {
-  return usd.toLocaleString(undefined, { style: "currency", currency: "USD" });
+/** An effect's dollar amount, rendered like every other real-money figure. */
+export function money(amountUsd: number): string {
+  return usd(amountUsd);
 }
 
 /** Feedback categories, phrased the way an operator would think about them. */

--- a/frontend/src/lib/money.ts
+++ b/frontend/src/lib/money.ts
@@ -32,10 +32,11 @@ const ZERO = "$0.00";
  *
  * Mirrors the rounding `Intl` applies rather than testing a hand-picked
  * threshold, so the bound and the rendered string can never disagree about
- * which side of a cent a value falls on.
+ * which side of a cent a value falls on. Decided from the magnitude, so a
+ * debit and its matching credit land on the same side of the boundary.
  */
 function roundsToZero(amount: number): boolean {
-  return Math.round(amount * 100) === 0;
+  return Math.round(Math.abs(amount) * 100) === 0;
 }
 
 /**

--- a/frontend/src/lib/money.ts
+++ b/frontend/src/lib/money.ts
@@ -1,0 +1,63 @@
+/**
+ * The one renderer for a real-money USD amount held as a dollar float.
+ *
+ * Cent precision, always — a tile and the rows beneath it read the same number
+ * because they run the same formatter, not because two call sites happen to
+ * agree on an option. An amount too small to show at that precision reads as a
+ * bound rather than as zero, so a non-zero total never renders as free.
+ *
+ * Sibling formatters, deliberately not merged into this one:
+ * - `lib/cost.ts` — LLM token cost, which is legitimately sub-cent and carries
+ *   its own four-digit line precision. Same floor vocabulary as here.
+ * - `views/finance/money.ts` — integer minor units in an arbitrary currency,
+ *   where the digit count is asked of `Intl` per currency.
+ */
+
+/** Cent precision, pinned at both ends so a whole amount still shows `.00`. */
+const CENT_DIGITS = {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+} as const;
+
+/** The smallest amount cent precision can state. */
+const CENT = "$0.01";
+
+/** Nothing, stated exactly. Also the answer for `-0`. */
+const ZERO = "$0.00";
+
+/**
+ * Whether cent precision would render `amount` as zero.
+ *
+ * Mirrors the rounding `Intl` applies rather than testing a hand-picked
+ * threshold, so the bound and the rendered string can never disagree about
+ * which side of a cent a value falls on.
+ */
+function roundsToZero(amount: number): boolean {
+  return Math.round(amount * 100) === 0;
+}
+
+/**
+ * Renders a USD dollar float at cent precision.
+ *
+ * `—` for a value that is not a number, `$0.00` for exactly nothing, and a
+ * bound (`<$0.01`, or `>-$0.01` below zero) for an amount that is not nothing
+ * but is smaller than a cent.
+ */
+export function usd(amount: number): string {
+  if (!Number.isFinite(amount)) return "—";
+  if (amount === 0) return ZERO;
+  if (roundsToZero(amount)) return amount < 0 ? `>-${CENT}` : `<${CENT}`;
+  return amount.toLocaleString("en-US", CENT_DIGITS);
+}
+
+/**
+ * Renders the size of an amount, leaving the sign to the caller.
+ *
+ * For the two places that pair their own `+`/`−` glyph with a figure — a
+ * transaction row and the net tile — where `usd`'s own minus would double up.
+ */
+export function usdMagnitude(amount: number): string {
+  return usd(Math.abs(amount));
+}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -52,6 +52,7 @@ import {
   reportAddMember,
   type AddMemberOutcome,
 } from "@/lib/member-feedback";
+import { usd } from "@/lib/money";
 import { fromDto, newMember, type TeamMember } from "@/lib/team";
 import { personAvatar, personName } from "@/lib/person";
 import { useAskerNames } from "@/components/approval-card";
@@ -735,7 +736,7 @@ export function ChatView({
       // Update the one card from the host's answer rather than refetching the
       // roster: the response IS the new state, so a refetch could only disagree.
       setMembers((ms) => ms.map((m) => (m.id === member.id ? { ...m, ...fromDto(row) } : m)));
-      toast.success(cap === null ? "Daily cap removed." : `Daily cap set to $${cap.toFixed(2)}.`);
+      toast.success(cap === null ? "Daily cap removed." : `Daily cap set to ${usd(cap)}.`);
     } catch (error) {
       toast.error(budgetError(error, "Couldn't change the daily cap."));
     }

--- a/frontend/src/views/FinancesView.tsx
+++ b/frontend/src/views/FinancesView.tsx
@@ -143,6 +143,11 @@ export function FinancesView({ client, company }: Props) {
                   ? "Spending is capped at $0.00 this month."
                   : `${usd(data.spentUsd)} of ${usd(budgetUsd)} used · ${usd(budgetUsd - data.spentUsd)} left`}
             </CardDescription>
+            <CardDescription data-testid="monthly-budget-origin">
+              This cap is read from the company manifest's <code>[budget]</code>{" "}
+              section and cannot be changed here. To limit spending from the
+              console, set a daily cap on each teammate's page.
+            </CardDescription>
           </CardHeader>
           {hasBudget && (
             <CardContent className="space-y-2">

--- a/frontend/src/views/FinancesView.tsx
+++ b/frontend/src/views/FinancesView.tsx
@@ -1,7 +1,3 @@
-// Issue #302: unmounted from the console — hidden, not retired. The host's
-// finances routes, economy state and tests are unchanged; re-listing "finances"
-// in `app-shell.tsx`'s `View`/`NAV` (behind a `lazy()` import, as it was)
-// brings this surface back. Do not delete it as dead code.
 import { useEffect, useState } from "react";
 import { Bar, BarChart, LabelList, XAxis, YAxis } from "recharts";
 import { ArrowDownLeft, ArrowUpRight, CircleAlert, Coins, PiggyBank, TrendingUp, Wallet } from "lucide-react";
@@ -21,16 +17,9 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
+import { usd, usdMagnitude } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { PageHeader } from "@/components/page-header";
-
-function usd(n: number, maxFrac = 2): string {
-  return (n === 0 ? 0 : n).toLocaleString(undefined, {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: maxFrac,
-  });
-}
 
 /* The brand leads slot 1, and the token already themes itself — see the note
    in UsageView on why the hex pair this replaced was a liability. */
@@ -132,12 +121,12 @@ export function FinancesView({ client, company }: Props) {
         {/* KPIs */}
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <Kpi icon={Wallet} label="Wallet balance" value={usd(data.balanceUsd)} hint="Ledger balance" />
-          <Kpi icon={TrendingUp} label="Revenue" value={usd(data.revenueUsd, 0)} hint="This month" />
-          <Kpi icon={Coins} label="Spend" value={usd(data.spentUsd, 0)} hint={budgetUsd === null ? "This month" : `of ${usd(budgetUsd, 0)} budget`} />
+          <Kpi icon={TrendingUp} label="Revenue" value={usd(data.revenueUsd)} hint="This month" />
+          <Kpi icon={Coins} label="Spend" value={usd(data.spentUsd)} hint={budgetUsd === null ? "This month" : `of ${usd(budgetUsd)} budget`} />
           <Kpi
             icon={PiggyBank}
             label="Net"
-            value={`${netSign}${usd(Math.abs(data.netUsd), 0)}`}
+            value={`${netSign}${usdMagnitude(data.netUsd)}`}
             hint="Revenue − spend"
             valueClass={data.netUsd > 0 ? "text-status-done-text" : data.netUsd < 0 ? "text-status-failed-text" : undefined}
           />
@@ -152,7 +141,7 @@ export function FinancesView({ client, company }: Props) {
                 ? "No monthly budget is set."
                 : budgetUsd === 0
                   ? "Spending is capped at $0.00 this month."
-                  : `${usd(data.spentUsd, 0)} of ${usd(budgetUsd, 0)} used · ${usd(budgetUsd - data.spentUsd, 0)} left`}
+                  : `${usd(data.spentUsd)} of ${usd(budgetUsd)} used · ${usd(budgetUsd - data.spentUsd)} left`}
             </CardDescription>
           </CardHeader>
           {hasBudget && (
@@ -183,9 +172,9 @@ export function FinancesView({ client, company }: Props) {
                   <BarChart data={data.byCategory} layout="vertical" margin={{ left: 8, right: 48 }}>
                     <XAxis type="number" dataKey="amount" hide />
                     <YAxis type="category" dataKey="category" tickLine={false} axisLine={false} width={110} />
-                    <ChartTooltip content={<ChartTooltipContent formatter={(v) => usd(Number(v), 0)} />} />
+                    <ChartTooltip content={<ChartTooltipContent formatter={(v) => usd(Number(v))} />} />
                     <Bar dataKey="amount" fill="var(--color-amount)" radius={4}>
-                      <LabelList dataKey="amount" position="right" className="fill-muted-foreground" formatter={(v) => usd(Number(v ?? 0), 0)} />
+                      <LabelList dataKey="amount" position="right" className="fill-muted-foreground" formatter={(v) => usd(Number(v ?? 0))} />
                     </Bar>
                   </BarChart>
                 </ChartContainer>
@@ -224,7 +213,7 @@ export function FinancesView({ client, company }: Props) {
                         </div>
                         <span className={cn("shrink-0 text-sm font-medium tabular-nums", inflow ? "text-status-done-text" : "text-foreground")}>
                           {inflow ? "+" : "−"}
-                          {usd(t.amountUsd)}
+                          {usdMagnitude(t.amountUsd)}
                         </span>
                       </li>
                     );

--- a/frontend/src/views/TaskPlanBrief.tsx
+++ b/frontend/src/views/TaskPlanBrief.tsx
@@ -42,6 +42,7 @@ import {
 
 import type { PrereqStatus, Prerequisite, TaskPlan } from "@/api/tasks";
 import { Button } from "@/components/ui/button";
+import { usd } from "@/lib/money";
 import { cn } from "@/lib/utils";
 
 /**
@@ -409,7 +410,7 @@ function Estimates({ step }: { step: TaskPlan["steps"][number] }) {
     );
   }
   if (typeof step.estimatedCostUsd === "number") {
-    parts.push(`~$${step.estimatedCostUsd.toFixed(2)}`);
+    parts.push(`~${usd(step.estimatedCostUsd)}`);
   }
   if (parts.length === 0) return null;
   return (

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -41,6 +41,7 @@ import {
   reportAddMember,
   type MissedStep,
 } from "@/lib/member-feedback";
+import { usd } from "@/lib/money";
 import { fromDto, newMember, roleSubtitle, type TeamMember } from "@/lib/team";
 import { workloadByAssignee, type Workload } from "@/lib/team-workload";
 import { personName } from "@/lib/person";
@@ -900,7 +901,6 @@ function DailyBudgetLine({
 
   const spent = member.spentTodayUsd ?? 0;
   const overBudget = spent >= cap;
-  const usd = (n: number) => `$${n.toFixed(2)}`;
   return (
     <div className="space-y-0.5">
       <p

--- a/frontend/src/views/chat/MembersPane.tsx
+++ b/frontend/src/views/chat/MembersPane.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { PresenceStatus } from "@/lib/awareness";
+import { usd } from "@/lib/money";
 import { roleSubtitle, type TeamMember } from "@/lib/team";
 import { cn } from "@/lib/utils";
 import { PresenceDot } from "@/views/chat/PresenceDot";
@@ -431,7 +432,6 @@ function DailyBudgetLine({ member, setByLabel }: { member: TeamMember; setByLabe
 
   const spent = member.spentTodayUsd ?? 0;
   const overBudget = spent >= cap;
-  const usd = (n: number) => `$${n.toFixed(2)}`;
   return (
     <span className="block">
       <span

--- a/frontend/src/views/observatory/AttemptCard.tsx
+++ b/frontend/src/views/observatory/AttemptCard.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
+import { formatUsdCost } from "@/lib/cost";
 import { cn } from "@/lib/utils";
 import { formatDuration, relativeTime } from "@/views/workflows/run-health";
 import { stepTotal, type ObservatoryRun } from "@/api/observatory";
@@ -142,7 +143,7 @@ export function AttemptCard({ run, nowMs, turn, focusStep, onOpen }: Props) {
         )}
         {run.usage.costUsd > 0 && (
           <span className="text-muted-foreground hidden shrink-0 text-xs tabular-nums sm:inline">
-            ${run.usage.costUsd.toFixed(3)}
+            {formatUsdCost({ amountUsd: run.usage.costUsd }, "line")}
           </span>
         )}
       </button>

--- a/frontend/src/views/observatory/ObservatoryView.tsx
+++ b/frontend/src/views/observatory/ObservatoryView.tsx
@@ -32,6 +32,7 @@ import { classifyLoadFailure } from "@/lib/section-load";
 import { startVisiblePolling } from "@/lib/visible-poll";
 import { cn } from "@/lib/utils";
 import { formatDuration, relativeTime } from "@/views/workflows/run-health";
+import { formatUsdCost } from "@/lib/cost";
 import { AnalyticsLens } from "./AnalyticsLens";
 import { AttemptCard } from "./AttemptCard";
 import { WaterfallLens } from "./WaterfallLens";
@@ -329,7 +330,7 @@ export function ObservatoryView({ client, company, runId, eventTick }: Props) {
             <span>
               <dt className="inline">cost</dt>{" "}
               <dd className="text-foreground inline tabular-nums">
-                ${summary.costUsd.toFixed(3)}
+                {formatUsdCost({ amountUsd: summary.costUsd }, "line") ?? "$0.00"}
               </dd>
             </span>
           </dl>

--- a/frontend/src/views/team/AgentDetailView.tsx
+++ b/frontend/src/views/team/AgentDetailView.tsx
@@ -1855,9 +1855,17 @@ function Budget({
     >
       <div className="space-y-1 text-sm" data-testid="agent-budget">
         {capped ? (
-          <p className="text-muted-foreground">
-            {usd(cap)}/day · {usd(agent.spentTodayUsd ?? 0)} spent today
-          </p>
+          <>
+            <p className="text-muted-foreground">
+              {usd(cap)}/day · {usd(agent.spentTodayUsd ?? 0)} spent today
+            </p>
+            <p className="text-xs text-muted-foreground" data-testid="agent-budget-scope">
+              Spent today counts everything this teammate has spent since 00:00
+              UTC — chat turns and metered searches included, not only the
+              attempts listed above. This is the total the cap is enforced
+              against.
+            </p>
+          </>
         ) : (
           <p className="text-muted-foreground">No daily cap — this teammate spends freely.</p>
         )}

--- a/frontend/src/views/team/AgentDetailView.tsx
+++ b/frontend/src/views/team/AgentDetailView.tsx
@@ -74,6 +74,7 @@ import { FieldCopilot } from "@/views/team/FieldCopilot";
 import { fetchBoardColumns } from "@/lib/board-columns";
 import { avatarRef } from "@/lib/avatar";
 import { AvatarPicker } from "@/components/avatar-picker";
+import { usd } from "@/lib/money";
 import { personName } from "@/lib/person";
 import { roleSubtitle, toneFor } from "@/lib/team";
 import { workloadByAssignee, type Workload } from "@/lib/team-workload";
@@ -496,7 +497,7 @@ export function AgentDetailView({
             }
           : held,
       );
-      toast.success(cap === null ? "Daily cap removed." : `Daily cap set to $${cap.toFixed(2)}.`);
+      toast.success(cap === null ? "Daily cap removed." : `Daily cap set to ${usd(cap)}.`);
     } catch (error) {
       toast.error(budgetError(error, "Couldn't change the daily cap."));
     }
@@ -1255,8 +1256,7 @@ function FactLine({
       )}
       {capped && (
         <span data-testid="agent-spend">
-          Today ${(agent.spentTodayUsd ?? 0).toFixed(2)} of $
-          {(agent.budgetUsdDaily ?? 0).toFixed(2)}
+          Today {usd(agent.spentTodayUsd ?? 0)} of {usd(agent.budgetUsdDaily ?? 0)}
         </span>
       )}
     </div>
@@ -1840,7 +1840,6 @@ function Budget({
   // An override exists (someone set this deliberately), as opposed to the cap
   // simply coming from the company's own definition.
   const overridden = agent.budgetSetBy !== undefined;
-  const usd = (n: number) => `$${n.toFixed(2)}`;
   return (
     <Section
       title="Budget"

--- a/frontend/src/views/team/AgentRuns.tsx
+++ b/frontend/src/views/team/AgentRuns.tsx
@@ -511,9 +511,14 @@ function RunTotals({ runs }: { runs: RunSummary[] }) {
       {/* Cost is settled-only, like the token figures it sits beside — a live
           attempt contributes nothing until it settles. Rendered as "—" rather
           than "$0.00" when the whole page is unsettled, because a zero here
-          would read as free work rather than as unbilled-so-far. */}
+          would read as free work rather than as unbilled-so-far.
+
+          The label names the page because this is not the teammate's spend:
+          it counts only attempts listed here, and only ones that ran as a
+          tracked attempt. The daily cap is enforced against a different, wider
+          total — see the Budget section. */}
       <Stat
-        label="Cost"
+        label="Cost on this page"
         value={
           totals.costUsd > 0
             ? (formatUsdCost({ amountUsd: totals.costUsd }, "total") ?? "—")

--- a/frontend/test/e2e/finance-number-agreement.spec.ts
+++ b/frontend/test/e2e/finance-number-agreement.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { clearLedger, ledgerPath, seedLedger, subDollarMonth } from "./ledger";
+import { clearLedger, halfCentDebit, ledgerPath, seedLedger, subDollarMonth } from "./ledger";
 
 /**
  * The Finance overview must tell one story about money.
@@ -74,6 +74,50 @@ test.describe("Finance number agreement", () => {
     await expect(budget).toBeVisible();
     await expect(budget).toContainText("company manifest");
     await expect(budget).toContainText("cannot be changed here");
+  });
+});
+
+/**
+ * The wallet balance tile is the one call site that hands `usd` a raw signed
+ * float below a cent — a transaction row's amount and the net tile's amount
+ * are both `abs`'d before they reach it. A boundary bug in the shared
+ * formatter that only misfires on a negative value would pass every other
+ * surface on this page and still ship, which is exactly what happened.
+ */
+test.describe("negative half-cent agreement", () => {
+  test.skip(
+    !SEEDED,
+    "needs a host this suite brought up, so the ledger can be seeded on its disk (unset PW_BASE_URL)",
+  );
+
+  test.beforeEach(async () => {
+    clearLedger();
+    seedLedger(halfCentDebit());
+  });
+
+  test.afterEach(async () => {
+    clearLedger();
+  });
+
+  test("renders a negative half-cent debit at the same magnitude on the wallet tile, the net tile, and the transaction row", async ({
+    page,
+  }) => {
+    await page.goto("/#/finances/overview");
+    await expect(page.getByText("Recent transactions")).toBeVisible();
+
+    // Exact text, not `toContainText` — a bound like `>-$0.01` also *contains*
+    // the substring `-$0.01`, so a loose match cannot fail on the bug this
+    // pins: the wallet tile stating the sub-cent bound instead of the amount.
+    const walletLabel = page.locator("div").filter({ hasText: /^Wallet balance$/ }).first();
+    const walletTile = page.locator("div.space-y-2").filter({ has: walletLabel }).first();
+    await expect(walletTile.locator(".text-2xl")).toHaveText("-$0.01");
+
+    const netLabel = page.locator("div").filter({ hasText: /^Net$/ }).first();
+    const netTile = page.locator("div.space-y-2").filter({ has: netLabel }).first();
+    await expect(netTile.locator(".text-2xl")).toHaveText("−$0.01");
+
+    const row = page.locator("li").filter({ hasText: "Half-cent debit" });
+    await expect(row).toContainText("−$0.01");
   });
 });
 

--- a/frontend/test/e2e/finance-number-agreement.spec.ts
+++ b/frontend/test/e2e/finance-number-agreement.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test";
+
+import { clearLedger, ledgerPath, seedLedger, subDollarMonth } from "./ledger";
+
+/**
+ * The Finance overview must tell one story about money.
+ *
+ * `spentUsd` is the sum of the magnitudes of the same negative ledger entries
+ * the transaction list renders, so the tile and the rows are two renderings of
+ * one number. They disagreed: the tile formatted to whole dollars while the rows
+ * formatted to cents, so this month's $0.163 of real spend read as "Spend $0"
+ * directly above a list of three outflows.
+ *
+ * Driven against a real host with a real seeded ledger rather than a stubbed
+ * response, because the unit test already proves the component and what was
+ * missing was any proof the *host's own projection* and the console agree. The
+ * suite could not seed a spend at all before this — see `./ledger.ts`.
+ *
+ * Like the rest of `test/e2e`, this needs a running host and is not a CI merge
+ * gate; `npm run typecheck:e2e` compiles it, `npm run e2e` runs it.
+ */
+
+const SEEDED = ledgerPath() !== null;
+
+test.describe("Finance number agreement", () => {
+  test.skip(
+    !SEEDED,
+    "needs a host this suite brought up, so the ledger can be seeded on its disk (unset PW_BASE_URL)",
+  );
+
+  test.beforeEach(async () => {
+    clearLedger();
+    seedLedger(subDollarMonth());
+  });
+
+  test.afterEach(async () => {
+    clearLedger();
+  });
+
+  test("states this month's sub-dollar spend as the amount the rows total", async ({
+    page,
+  }) => {
+    await page.goto("/#/finances/overview");
+    await expect(page.getByText("Recent transactions")).toBeVisible();
+
+    // The three seeded outflows, at the precision they were recorded in.
+    await expect(page.getByText("Model turn — drafting reply")).toBeVisible();
+    await expect(page.getByText("−$0.12")).toBeVisible();
+    await expect(page.getByText("−$0.04")).toBeVisible();
+
+    // $0.12 + $0.04 + $0.003 = $0.163, which is sixteen cents — not "$0".
+    const spend = page.locator("div").filter({ hasText: /^Spend$/ }).first();
+    const tile = page.locator("div.space-y-2").filter({ has: spend }).first();
+    await expect(tile).toContainText("$0.16");
+    await expect(tile).not.toContainText(/\$0(?!\.)/);
+  });
+
+  test("never reports a spend smaller than a cent as nothing", async ({ page }) => {
+    await page.goto("/#/finances/overview");
+    await expect(page.getByText("Spend by category")).toBeVisible();
+
+    // The metered search is $0.003 — real money, below cent precision. It is
+    // its own category, so the chart states it as a bound, not as zero.
+    await expect(page.getByText("<$0.01").first()).toBeVisible();
+    await expect(page.getByText("Metered web search")).toBeVisible();
+  });
+
+  test("says where the monthly budget comes from rather than only that it is unset", async ({
+    page,
+  }) => {
+    await page.goto("/#/finances/overview");
+
+    const budget = page.getByTestId("monthly-budget-origin");
+    await expect(budget).toBeVisible();
+    await expect(budget).toContainText("company manifest");
+    await expect(budget).toContainText("cannot be changed here");
+  });
+});
+
+/**
+ * The spend-approval threshold is inert on this build, and the console says so.
+ *
+ * Pinned rather than fixed: `ManifestApprovalGate` is constructed
+ * `with_policy_hitl_disabled`, and `evaluate` returns `Allow` above the tier
+ * match and above the cap comparison, so `autoApproveUnderUsd` governs nothing
+ * at runtime on either the native or the harness path. Enabling this control
+ * would persist a number that changes no behaviour, which is worse than a
+ * control that admits it is off. If policy HITL is ever turned on, this test
+ * fails and is the reminder to wire the control in the same change.
+ */
+test("the spend-approval threshold stays disabled while policy HITL is off", async ({
+  page,
+}) => {
+  await page.goto("/#/settings/approvals");
+
+  const cap = page.locator("#spend-cap");
+  await expect(cap).toBeVisible();
+  await expect(cap).toBeDisabled();
+  await expect(page.getByText("Spend approval threshold (inactive)")).toBeVisible();
+
+  // The deadline control right beside it is live, so this is a deliberate
+  // refusal rather than a page that failed to load.
+  await expect(page.locator("#approval-deadline")).toBeEnabled();
+});

--- a/frontend/test/e2e/ledger.ts
+++ b/frontend/test/e2e/ledger.ts
@@ -104,3 +104,23 @@ export function subDollarMonth(now = Date.now()): SeedEntry[] {
     },
   ];
 }
+
+/**
+ * A single outflow at exactly half a cent, negative.
+ *
+ * `balance_usd` (`finances_from`) is the bookkeeping sum across the whole
+ * ledger, passed to `usd` as a raw signed float rather than pre-`abs`'d —
+ * unlike a transaction row's `amount_usd`, which the host already sends
+ * non-negative. That is the one call site where a sign/magnitude boundary bug
+ * in the shared formatter reaches the screen.
+ */
+export function halfCentDebit(now = Date.now()): SeedEntry[] {
+  return [
+    {
+      atMillis: now - 60_000,
+      kind: "inference.spend",
+      amountUsd: -0.005,
+      memo: "Half-cent debit",
+    },
+  ];
+}

--- a/frontend/test/e2e/ledger.ts
+++ b/frontend/test/e2e/ledger.ts
@@ -1,0 +1,106 @@
+import { appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+import { MANAGED_HOST_HOME } from "./host-identity";
+
+/**
+ * Seeding for the company's financial ledger.
+ *
+ * The Finance surface folds `ledger.jsonl` and nothing else, and nothing in this
+ * suite could put a line in it — the ledger fills from the inference cost hook,
+ * which needs a real billed turn. So every Finance assertion until now ran
+ * against an empty ledger, where the tile and the transaction list agree because
+ * both are zero. That is the gap that let a whole-dollar tile ship over a
+ * cent-precision list.
+ *
+ * This writes the same file the cost hook appends to, in the same shape
+ * (`LedgerEntry` in `src/ports/types.rs`), so the host reads it through its own
+ * projection with no test-only route in the way. `GET …/finances` loads the
+ * record per request, so a seed lands on the next navigation.
+ */
+
+/** The harness company's id, as the host registers `companies/e2e_harness`. */
+export const HARNESS_COMPANY_ID = "e2e-harness-co";
+
+/** One line of `ledger.jsonl`. Outflows are negative, inflows positive. */
+export interface SeedEntry {
+  atMillis: number;
+  kind: string;
+  amountUsd: number;
+  memo: string;
+}
+
+/**
+ * Where this run's ledger lives, or `null` when the suite did not bring the
+ * host up and so cannot reach its disk (`PW_BASE_URL`).
+ */
+export function ledgerPath(companyId = HARNESS_COMPANY_ID): string | null {
+  if (!MANAGED_HOST_HOME) return null;
+  return join(MANAGED_HOST_HOME, "companies", companyId, "ledger.jsonl");
+}
+
+/** Appends entries to the company ledger. Returns false when unreachable. */
+export function seedLedger(
+  entries: SeedEntry[],
+  companyId = HARNESS_COMPANY_ID,
+): boolean {
+  const path = ledgerPath(companyId);
+  if (!path) return false;
+  mkdirSync(join(MANAGED_HOST_HOME!, "companies", companyId), { recursive: true });
+  const lines = entries
+    .map((e) =>
+      JSON.stringify({
+        at_millis: e.atMillis,
+        kind: e.kind,
+        amount_usd: e.amountUsd,
+        memo: e.memo,
+      }),
+    )
+    .join("\n");
+  appendFileSync(path, lines + "\n");
+  return true;
+}
+
+/**
+ * Removes the seeded ledger.
+ *
+ * The whole file, because this suite is the only thing that writes it on an
+ * offline harness host — a surgical removal would need to re-read and rewrite
+ * append-only data the host may be holding open.
+ */
+export function clearLedger(companyId = HARNESS_COMPANY_ID): void {
+  const path = ledgerPath(companyId);
+  if (!path) return;
+  rmSync(path, { force: true });
+}
+
+/**
+ * This month's spend as a handful of realistic lines, totalling $0.163.
+ *
+ * The amounts are the point. $0.12 and $0.04 are ordinary sub-dollar inference
+ * turns; $0.003 is a metered search, which is real spend smaller than a cent.
+ * Together they are the case a whole-dollar tile reported as "$0" while the list
+ * beneath it showed three outflows.
+ */
+export function subDollarMonth(now = Date.now()): SeedEntry[] {
+  return [
+    {
+      atMillis: now - 3_600_000,
+      kind: "inference.spend",
+      amountUsd: -0.12,
+      memo: "Model turn — drafting reply",
+    },
+    {
+      atMillis: now - 1_800_000,
+      kind: "inference.spend",
+      amountUsd: -0.04,
+      memo: "Model turn — summarising thread",
+    },
+    {
+      atMillis: now - 900_000,
+      kind: "tools.search",
+      amountUsd: -0.003,
+      memo: "Metered web search",
+    },
+  ];
+}

--- a/frontend/test/unit/finances-number-agreement.test.ts
+++ b/frontend/test/unit/finances-number-agreement.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { FinancesDto } from "@/api/types";
+import { FinancesView } from "@/views/FinancesView";
+
+/**
+ * The Finance overview folds one ledger: `spentUsd` is the sum of the same
+ * negative entries the transaction list renders, so the tile and the rows are
+ * two views of one number and may never disagree about its size.
+ *
+ * A spend of $0.16 read as "$0" above a list of this month's spending is the
+ * failure being pinned. Both halves are checked from one render, because a
+ * formatter agreeing with itself in isolation is what the two-formatter version
+ * also did.
+ */
+
+/** This month's only spend: sixteen cents, in one transaction. */
+const SUB_DOLLAR_SPEND: FinancesDto = {
+  balanceUsd: -0.16,
+  budgetUsd: null,
+  spentUsd: 0.16,
+  revenueUsd: 0,
+  netUsd: -0.16,
+  byCategory: [{ category: "Inference", amount: 0.16 }],
+  transactions: [
+    {
+      id: "tx-0",
+      date: "2026-09-02",
+      description: "Inference spend",
+      category: "Inference",
+      amountUsd: 0.16,
+      direction: "out",
+    },
+  ],
+};
+
+/** A spend too small for cent precision, which is still not nothing. */
+const SUB_CENT_SPEND: FinancesDto = {
+  ...SUB_DOLLAR_SPEND,
+  balanceUsd: -0.004,
+  spentUsd: 0.004,
+  netUsd: -0.004,
+  byCategory: [{ category: "Inference", amount: 0.004 }],
+  transactions: [{ ...SUB_DOLLAR_SPEND.transactions[0]!, amountUsd: 0.004 }],
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render(finances: FinancesDto): Promise<void> {
+  const client = {
+    finances: vi.fn(() => Promise.resolve(finances)),
+  } as unknown as OpenCompanyClient;
+  await act(async () => {
+    root.render(createElement(FinancesView, { client, company: "acme" }));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** The text of the tile whose label is `label`. */
+function tile(label: string): string {
+  const heading = [...container.querySelectorAll("span")].find(
+    (node) => node.textContent === label,
+  );
+  expect(heading, `no tile labelled "${label}"`).toBeDefined();
+  return heading!.closest("div.space-y-2")?.textContent ?? "";
+}
+
+describe("Finance overview number agreement", () => {
+  it("states this month's sub-dollar spend as the same amount the rows total", async () => {
+    await render(SUB_DOLLAR_SPEND);
+
+    expect(tile("Spend")).toContain("$0.16");
+    expect(tile("Wallet balance")).toContain("$0.16");
+    // The defect: a whole-dollar tile over a cent-precision list.
+    expect(tile("Spend")).not.toMatch(/\$0(?!\.)/);
+    expect(container.textContent).toContain("−$0.16");
+  });
+
+  it("never renders a non-zero spend as nothing", async () => {
+    await render(SUB_CENT_SPEND);
+
+    expect(tile("Spend")).toContain("<$0.01");
+    expect(tile("Spend")).not.toContain("$0.00");
+    expect(tile("Spend")).not.toMatch(/\$0(?!\.)/);
+  });
+
+  it("rounds no amount up past the rows it summarises", async () => {
+    // Half a dollar is the case a whole-dollar tile rounds to "$1" while the
+    // one transaction under it says fifty cents.
+    await render({
+      ...SUB_DOLLAR_SPEND,
+      balanceUsd: -0.5,
+      spentUsd: 0.5,
+      netUsd: -0.5,
+      byCategory: [{ category: "Inference", amount: 0.5 }],
+      transactions: [{ ...SUB_DOLLAR_SPEND.transactions[0]!, amountUsd: 0.5 }],
+    });
+
+    expect(tile("Spend")).toContain("$0.50");
+    expect(tile("Spend")).not.toContain("$1");
+    expect(container.textContent).toContain("−$0.50");
+  });
+
+  it("states the budget and what is left at the precision the spend is stated in", async () => {
+    await render({ ...SUB_DOLLAR_SPEND, budgetUsd: 10 });
+
+    const budget = container.textContent ?? "";
+    expect(budget).toContain("$0.16 of $10.00 used");
+    expect(budget).toContain("$9.84 left");
+  });
+});

--- a/frontend/test/unit/finances-number-agreement.test.ts
+++ b/frontend/test/unit/finances-number-agreement.test.ts
@@ -128,3 +128,22 @@ describe("Finance overview number agreement", () => {
     expect(budget).toContain("$9.84 left");
   });
 });
+
+describe("Monthly budget card", () => {
+  it("says where the cap comes from, so an absent one does not read as a missing control", async () => {
+    await render(SUB_DOLLAR_SPEND);
+
+    const origin = container.querySelector('[data-testid="monthly-budget-origin"]');
+    expect(origin?.textContent).toContain("company manifest");
+    expect(origin?.textContent).toContain("cannot be changed here");
+    expect(origin?.textContent).toContain("daily cap on each teammate's page");
+  });
+
+  it("keeps saying so once a cap exists, since the console still cannot change it", async () => {
+    await render({ ...SUB_DOLLAR_SPEND, budgetUsd: 10 });
+
+    expect(
+      container.querySelector('[data-testid="monthly-budget-origin"]')?.textContent,
+    ).toContain("company manifest");
+  });
+});

--- a/frontend/test/unit/finances-view-empty-state.test.ts
+++ b/frontend/test/unit/finances-view-empty-state.test.ts
@@ -64,7 +64,7 @@ describe("FinancesView empty data", () => {
     expect(container.textContent).not.toContain("Available USDC");
 
     const net = container.querySelectorAll<HTMLElement>(".text-2xl")[3];
-    expect(net?.textContent).toBe("$0");
+    expect(net?.textContent).toBe("$0.00");
     expect(net?.className).not.toContain("text-status-done-text");
   });
 

--- a/frontend/test/unit/money-usd.test.ts
+++ b/frontend/test/unit/money-usd.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { usd, usdMagnitude } from "@/lib/money";
+
+/**
+ * The boundaries that separate an honest figure from a misleading one: the
+ * amounts that a whole-dollar formatter reports as `$0` or `$1` while the rows
+ * beneath it say sixteen cents or fifty.
+ */
+describe("usd", () => {
+  it("states nothing as nothing, at cent precision", () => {
+    expect(usd(0)).toBe("$0.00");
+    expect(usd(-0)).toBe("$0.00");
+  });
+
+  it("bounds an amount too small to state rather than calling it zero", () => {
+    expect(usd(0.004)).toBe("<$0.01");
+    expect(usd(0.0001)).toBe("<$0.01");
+    expect(usd(-0.004)).toBe(">-$0.01");
+  });
+
+  it("keeps sub-dollar spend at the precision it was recorded in", () => {
+    expect(usd(0.16)).toBe("$0.16");
+    expect(usd(0.5)).toBe("$0.50");
+    expect(usd(0.999)).toBe("$1.00");
+    expect(usd(0.005)).toBe("$0.01");
+  });
+
+  it("groups a large amount without dropping its cents", () => {
+    expect(usd(12345.678)).toBe("$12,345.68");
+    expect(usd(1000000)).toBe("$1,000,000.00");
+  });
+
+  it("carries a sign on a real debit", () => {
+    expect(usd(-0.16)).toBe("-$0.16");
+    expect(usd(-1234.5)).toBe("-$1,234.50");
+  });
+
+  it("refuses to render a number it does not have", () => {
+    expect(usd(Number.NaN)).toBe("—");
+    expect(usd(Number.POSITIVE_INFINITY)).toBe("—");
+  });
+});
+
+describe("usdMagnitude", () => {
+  it("drops the sign for a caller that renders its own", () => {
+    expect(usdMagnitude(-0.16)).toBe("$0.16");
+    expect(usdMagnitude(0.16)).toBe("$0.16");
+    expect(usdMagnitude(-0)).toBe("$0.00");
+  });
+
+  it("keeps the sub-cent bound", () => {
+    expect(usdMagnitude(-0.004)).toBe("<$0.01");
+  });
+});
+
+/**
+ * The property that makes a tile and the list under it agree: one amount, one
+ * rendering, whichever side of the screen asks for it.
+ */
+describe("agreement", () => {
+  it("renders one amount identically for every caller", () => {
+    for (const amount of [0, 0.004, 0.16, 0.5, 0.999, 42, 12345.678]) {
+      expect(usd(amount)).toBe(usd(amount));
+      expect(usdMagnitude(amount)).toBe(usd(Math.abs(amount)));
+    }
+  });
+
+  it("never renders a positive amount as free", () => {
+    for (const amount of [0.0001, 0.004, 0.0049, 0.005, 0.16]) {
+      expect(usd(amount)).not.toBe("$0.00");
+      expect(usd(amount)).not.toBe("$0");
+    }
+  });
+});

--- a/frontend/test/unit/money-usd.test.ts
+++ b/frontend/test/unit/money-usd.test.ts
@@ -26,6 +26,14 @@ describe("usd", () => {
     expect(usd(0.005)).toBe("$0.01");
   });
 
+  it("decides the zero boundary the same way on either side of zero", () => {
+    expect(usd(-0.005)).toBe("-$0.01");
+    expect(usd(0.005)).toBe("$0.01");
+    expect(usd(-0.004)).toBe(">-$0.01");
+    expect(usd(-0.0049)).toBe(">-$0.01");
+    expect(usd(-0)).toBe("$0.00");
+  });
+
   it("groups a large amount without dropping its cents", () => {
     expect(usd(12345.678)).toBe("$12,345.68");
     expect(usd(1000000)).toBe("$1,000,000.00");
@@ -70,6 +78,15 @@ describe("agreement", () => {
     for (const amount of [0.0001, 0.004, 0.0049, 0.005, 0.16]) {
       expect(usd(amount)).not.toBe("$0.00");
       expect(usd(amount)).not.toBe("$0");
+    }
+  });
+
+  it("never disagrees with usdMagnitude about the same magnitude", () => {
+    const magnitude = (rendered: string): string =>
+      rendered.startsWith(">-") ? `<${rendered.slice(2)}` : rendered.startsWith("-") ? rendered.slice(1) : rendered;
+
+    for (const amount of [-0.005, 0.005, -0.004, -0.0049, -0, 0.16, 0.5, 42, 12345.678]) {
+      expect(magnitude(usd(amount))).toBe(usdMagnitude(amount));
     }
   });
 });


### PR DESCRIPTION
## Summary

Finance contradicted itself about money on a single screen. One render showed

```
Spend  $0  of $10 budget
...
Inference spend · −$0.16
```

Both figures come from the same data: `finances_from` computes `spentUsd` as the
sum of the magnitudes of the very ledger entries the transaction list renders.
The tile and the rows were two renderings of one number, and they disagreed
because `FinancesView`'s private `usd(n, maxFrac)` was called with `maxFrac=0`
for Spend, Revenue, Net and budget, and `maxFrac=2` for the balance and the rows.

A worse case sat behind the reported one: `0.5` rendered as **`$1`** in the tile
above `$0.50` in the row — rounding up, and overstating what the company had
spent.

The console had **no shared money formatter**; five independent implementations
had grown, and the same `costUsd` was rendered with three different digit counts
in three places. `lib/cost.ts` already carried the correct rule for token cost —
never make positive spend look free, floor at `<$0.01` — so that rule was
promoted rather than a second vocabulary invented. `frontend/src/lib/money.ts`:
cent precision always, `$0.00` only for exactly zero, `<$0.01` (or `>-$0.01`)
for a non-zero sub-cent amount, and an em dash for a non-finite one. The
sub-cent test compares against Intl's own rounding rather than a guessed
threshold, so the bound and the rendering cannot drift apart.

Thirteen sites now use it: every Finance tile, the budget card, chart labels and
tooltip, the transaction rows, four byte-identical private `usd()` clones in the
team and agent views, inline `toFixed(2)` calls in chat and events, `language.ts`,
three bare interpolations in policy settings that printed `$0.1` for ten cents
and a bare `0.16` with no currency marker, and two hardcoded `.toFixed(3)` calls
in the observatory that printed `$0.000` for a real cost.

Left alone deliberately: `lib/cost.ts` (correct, and token cost is legitimately
sub-cent), `views/finance/money.ts` (integer minor units, multi-currency, a
different unit domain), wallet balances (opaque provider strings by design), a
chart axis tick formatter (generated gridline values, not measured data), and
static copy describing the input value zero rather than a measurement.

Two further reports on this screen were investigated and are **not** presentation
bugs:

**The monthly budget cannot be set because no write path exists** — not at the
route, mutation or tool layer. `manifest.budget.monthly_usd` is read-only at
runtime and a hosted tenant has no `company.toml`. The only runtime-settable
budget is the per-agent daily cap. The card now says where the number lives and
which control actually exists; adding the write path is a design change, not a
formatting one.

**A teammate's two spend figures are two different quantities.** "Spent today" is
every usage sample since 00:00 UTC — the total the cap is genuinely enforced
against. The run list's cost is at most fifty settled, run-attributed rows of any
date. A metered web search files no `run_id`, so it counts against the cap and
can never appear in that list. Different quantities over different windows; the
disclosure is fixed, but the founder still cannot itemise the enforced total, and
no label can fix that.

## API Or Behavior Changes

Console only. Money reads consistently to the cent across Finance, team, agent,
chat, events, policy and observatory surfaces. A non-zero amount below a cent
renders `<$0.01` instead of `$0`, `$0.000` or `$1`.

## Tests

- `npm run typecheck` / `:unit` / `:e2e` — 0 / 0 / 0
- `npx vitest run` — 0, 474 files, 4409 tests, 0 errors
- `cargo fmt --all -- --check` — 0
- `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings` — 0
- `cargo test --locked --features openhuman --lib` — 0, 6800 passed, 0 failed
- Playwright — 5/5 against a real host, verified red against the pre-change view

Formatter unit tests cover 0, 0.004, 0.16, 0.5, 0.999 and a large value, plus
negatives and non-finite input. A component regression test was proved red first,
4/4 failing on the unmodified view.

One pre-existing assertion expected the net tile to be exactly `"$0"`. It pinned
the defective format rather than the negative-zero behaviour its own docblock
describes, so it was corrected to `"$0.00"`.

The end-to-end harness could not seed a spend at all — `ledger.jsonl` fills only
from the inference cost hook — so every Finance assertion had been running
against an empty ledger, where the tile and the rows agree **because both are
zero**. That gap is why this shipped. `test/e2e/ledger.ts` now writes the same
file the cost hook appends to, in the host's own `LedgerEntry` shape, with no
test-only route.

Driven live with a seeded `spentUsd: 0.163`: Spend `$0.16`, balance `-$0.16`,
rows `−$0.12` / `−$0.04` / `−<$0.01`, and a `<$0.01` category total.

Note for reviewers: a full `vitest run` on a clean base can exit 1 with
`client.post is not a function` unhandled errors from a workflow-dialog debounce
timer. It is load-dependent and pre-existing; the final run here was clean.

**Review finding — negative half-cent boundary.** `roundsToZero` compared
`Math.round(amount * 100)` to `0`, but `Math.round(-0.5)` is `-0` in JS and
`-0 === 0`, so `usd(-0.005)` took the sub-cent-bound branch (`>-$0.01`)
instead of the amount `Intl.NumberFormat` itself rounds it to (`-$0.01`),
while `usdMagnitude(-0.005)` — which `abs`s first and never hit the tie —
already said `$0.01`. Confirmed directly: `Math.round(-0.5)` is `-0`;
`usd(-0.005)` was `>-$0.01`; `usdMagnitude(-0.005)` was `$0.01`; Intl's own
`(-0.005).toLocaleString(...)` is `-$0.01`. Fixed by rounding the absolute
value, so the boundary is decided by magnitude and a debit and its matching
credit land on the same side of it. Added `usd(-0.005)`/`usd(-0.0049)` cases
to the boundary test and a table-driven check that `usd` and `usdMagnitude`
never disagree about a value's magnitude, proved red against the unfixed
`roundsToZero` first.

Also validated live: booted the worktree's own managed e2e host (own
derived port, own data dir under `target/e2e/data`), seeded a single
`-$0.005` ledger entry through `test/e2e/ledger.ts`'s new `halfCentDebit()`,
and read the actual rendered page. Pre-fix the Wallet balance tile showed
`>-$0.01` while the Net tile and the transaction row both showed `−$0.01`
for the same entry — the exact on-screen disagreement the finding
describes, since the wallet tile is the one surface that hands `usd` a raw
signed amount rather than an already-`abs`'d one. Post-fix all three read
`-$0.01` / `−$0.01` / `−$0.01`. Pinned as a committed Playwright case
(`negative half-cent agreement`) in `finance-number-agreement.spec.ts`, with
an exact-text assertion on the wallet tile so a bound like `>-$0.01` cannot
pass by substring match against `-$0.01`.

## Documentation

`frontend/src/lib/money.ts` documents the single rule and why sub-cent amounts
floor rather than round. A stale header comment in `FinancesView` claiming the
view was unmounted from the console was removed — it is mounted as Finance →
Overview.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent USD formatting across spending, budgets, transactions, estimates, notifications, and observatory cost displays.
  * Small non-zero amounts now show clear bounds such as `<$0.01`, while negative amounts preserve their magnitude and sign.
  * Added explanations for monthly budget origins and daily spend totals.

* **Bug Fixes**
  * Improved agreement between finance summary tiles and transaction rows, including sub-dollar and negative amounts.

* **Tests**
  * Added unit and end-to-end coverage for currency formatting, ledger scenarios, budget messaging, and policy controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->