### PR TITLE
fix(workflows): honest run-state — real spend on failure, contradictory panels, delete-orphaned runs

### DIFF
--- a/docs/modules/server/workflow-routes.md
+++ b/docs/modules/server/workflow-routes.md
@@ -105,6 +105,18 @@ from `GET …/workflows/runs`. The journal is append-only and shared with chat a
 audit, so there is no per-workflow table to cascade; and what a workflow *did*
 stays true after the workflow is gone. Retention is a separate design.
 
+**A run still in flight is stopped, after the durable delete (B-121).** Before
+this, delete tore down the schedule and the revisions and left an executing run
+uncontrollable — the only Stop button in the product lives on the workflow
+detail page the delete just removed. `200` now carries `{ "stoppedRuns": <n> }`,
+the count the post-delete sweep actually fired a stop at — **not** `204`, which
+had nowhere to carry it. `stoppedRuns: 0` is a completely ordinary answer (no
+run was in flight); a caller that only checked the status code before still
+sees success the same way. An older host predating this still answers `204`
+with no body — the console's own client treats an absent body as `stoppedRuns:
+0` rather than throwing, and any other caller doing a plain status check is
+unaffected either way.
+
 **No scheduler change is involved.** `WorkflowScheduler::tick` re-reads the
 company record and re-derives the schedule set from the overlay union every
 minute, so the tick *is* a continuous reconcile: a deleted workflow stops firing
@@ -138,9 +150,10 @@ curl -X PUT "$HOST/api/v1/company/workflows/weekly_digest" \
 }'
 # → 200 with the stored graph and a FRESH version; or 409 if it moved.
 
-# Remove it. 204 on success; past runs stay readable.
+# Remove it. Past runs stay readable; a run still in flight is stopped (B-121).
 curl -X DELETE "$HOST/api/v1/company/workflows/weekly_digest?expectedVersion=a60663c5…" \
      -H "Authorization: Bearer $TOKEN"
+# → 200 { "stoppedRuns": 0 }  — or a positive count if one was going.
 ```
 
 **In the console.** The Workflows view offers Edit and Delete side by side, both

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -375,6 +375,14 @@ export interface WorkflowRunResult {
    * delivery failure, because the nodes really did run.
    */
   verdict?: WorkflowRunVerdict;
+  /**
+   * Whether the operator stopped this run before it settled (Codex review, PR
+   * #2053). The host has sent this on every settled body since before #981;
+   * added to the type now because deriving a legacy fallback verdict — see
+   * {@link legacyRunVerdict} — needs it and a `WorkflowRunVerdict | undefined`
+   * host predating #981 still sends it.
+   */
+  cancelled?: boolean;
 }
 
 /**

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -1307,8 +1307,17 @@ export function updateWorkflow(
  * then truthfully stops nothing. `stoppedRuns` is the one place the real
  * answer lives; the console's delete flow reads it rather than its own
  * pre-request guess.
+ *
+ * **Tolerates an older host** (Codex review, PR #2053): before B-121 this
+ * route answered `204` with an empty body, and `OpenCompanyClient`'s generic
+ * request reader turns that into `undefined` rather than `{}`. Destructuring
+ * `stoppedRuns` straight off that would throw — after the host had already
+ * deleted the workflow — which would misreport a successful delete as a
+ * failure and leave the removed workflow selected until a reload. An absent
+ * response reads as `stoppedRuns: 0`, the only honest answer an old host that
+ * never ran a sweep at all can give.
  */
-export function deleteWorkflow(
+export async function deleteWorkflow(
   client: OpenCompanyClient,
   company: string | null,
   wid: string,
@@ -1317,9 +1326,10 @@ export function deleteWorkflow(
   const query = expectedVersion
     ? `?expectedVersion=${encodeURIComponent(expectedVersion)}`
     : "";
-  return client.del<{ stoppedRuns: number }>(
+  const body = await client.del<{ stoppedRuns: number } | undefined>(
     `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}${query}`,
   );
+  return { stoppedRuns: body?.stoppedRuns ?? 0 };
 }
 
 /**

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -1298,17 +1298,26 @@ export function updateWorkflow(
  * Follows the same runtime-vs-source contract as `deleteDesk`: a workflow
  * defined by a file in the company source tree cannot be removed from the
  * console and returns `409`; an unknown id is `404`.
+ *
+ * Resolves to how many in-flight runs the host's post-delete sweep actually
+ * stopped (CodeRabbit review, PR #2053) — **not** whether the caller was
+ * watching a run before it asked. Those can disagree with no race required: a
+ * long run can settle on its own in the seconds between the operator
+ * confirming the delete and this request reaching the host, and the sweep
+ * then truthfully stops nothing. `stoppedRuns` is the one place the real
+ * answer lives; the console's delete flow reads it rather than its own
+ * pre-request guess.
  */
 export function deleteWorkflow(
   client: OpenCompanyClient,
   company: string | null,
   wid: string,
   expectedVersion?: string | null,
-): Promise<void> {
+): Promise<{ stoppedRuns: number }> {
   const query = expectedVersion
     ? `?expectedVersion=${encodeURIComponent(expectedVersion)}`
     : "";
-  return client.del<void>(
+  return client.del<{ stoppedRuns: number }>(
     `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}${query}`,
   );
 }

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1683,7 +1683,12 @@ export function WorkflowsView({
   // If it changed underneath us the host refuses with a 409 and removes nothing,
   // and we surface that instead of quietly deleting a graph the operator never
   // saw.
-  const remove = useCallback(async () => {
+  //
+  // `stoppingARun` is what the confirmation just told the operator would
+  // happen (B-121), passed in rather than read here so the sentence they
+  // agreed to and the sentence they get back cannot come from two different
+  // readings of the run state.
+  const remove = useCallback(async (stoppingARun: boolean) => {
     if (!selectedId || !graph) return;
     const removedName = graph.name;
     setDeleting(true);
@@ -1712,7 +1717,16 @@ export function WorkflowsView({
       setResult(null);
       setSelectedNodeId(null);
       setConflict(null);
-      toast.success(`Deleted “${removedName}”.`);
+      // B-121: the run went with it, and saying so is the whole point of having
+      // warned. The host stops every run of a deleted workflow; before that it
+      // left them executing with the only Stop button in the product on the page
+      // this delete just unmounted.
+      setActiveRunId(null);
+      toast.success(
+        stoppingARun
+          ? `Deleted “${removedName}” and stopped the run in flight.`
+          : `Deleted “${removedName}”.`,
+      );
     } catch (e) {
       // A 409 is the one failure the operator can actually act on, and acting
       // on it means reloading — so it gets the persistent banner, not a toast.
@@ -2902,10 +2916,17 @@ export function WorkflowsView({
                         <AlertDialogTitle>Delete “{graph?.name ?? selectedId}”?</AlertDialogTitle>
                         {/* Say exactly what goes and what stays. "Stops its schedule"
                             is the consequence an operator most needs spelled out, and
-                            "past runs stay" stops them hesitating over losing history. */}
-                        <AlertDialogDescription>
-                          This removes the workflow and stops it running on its schedule. Past runs
-                          stay in the run history. This can&apos;t be undone.
+                            "past runs stay" stops them hesitating over losing history.
+
+                            B-121: and when a run is in flight, say THAT — it was
+                            the one consequence this dialog never mentioned, while
+                            being word for word the sentence an idle workflow gets.
+                            Deleting stops that run, which is a bigger thing to
+                            agree to than stopping a schedule. */}
+                        <AlertDialogDescription data-testid="workflow-delete-consequence">
+                          {watchingRun
+                            ? "A run of this workflow is going right now. Deleting it stops that run where it is — the steps it finished stay in the run history — and stops it running on its schedule. This can't be undone."
+                            : "This removes the workflow and stops it running on its schedule. Past runs stay in the run history. This can't be undone."}
                         </AlertDialogDescription>
                       </AlertDialogHeader>
                       <AlertDialogFooter>
@@ -2916,7 +2937,7 @@ export function WorkflowsView({
                             // dialog left mounted would re-render its title as
                             // `Delete “”?` over a backdrop nothing can click past.
                             setConfirmOpen(false);
-                            void remove();
+                            void remove(watchingRun);
                           }}
                           className="bg-destructive text-white hover:bg-destructive/90"
                           data-testid="workflow-delete-confirm"

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -135,7 +135,11 @@ import { CanvasShell } from "@/views/workflows/CanvasShell";
 import { approvalsForRun } from "@/views/workflows/run-approvals";
 // Issue #981: which nodes produced a report that never went out, so the canvas
 // card can say so beside the DONE badge instead of leaving it to a banner.
-import { settledRunNotice, undeliveredNodes } from "@/views/workflows/run-health";
+import {
+  legacyRunVerdict,
+  settledRunNotice,
+  undeliveredNodes,
+} from "@/views/workflows/run-health";
 import { NodeDetailPanel } from "@/views/workflows/NodeDetailPanel";
 import { type NodeOutputView, nodeOutputFor } from "@/views/workflows/run-output";
 
@@ -1563,9 +1567,12 @@ export function WorkflowsView({
           // one, so this used to say "nothing was sent" even over a dry run
           // that failed — the same false green B-039 fixed below for the
           // non-dry-run path, just for this one too. Success only for a
-          // clean run or a legacy host that sent no verdict at all.
-          if (res.verdict && res.verdict !== "ok") {
-            const settled = settledRunNotice(res.verdict);
+          // clean run — a legacy host that sent no verdict at all is read
+          // via `legacyRunVerdict` (Codex review, PR #2053) rather than
+          // assumed clean.
+          const verdict = res.verdict ?? legacyRunVerdict(res);
+          if (verdict !== "ok") {
+            const settled = settledRunNotice(verdict);
             toast[settled.tone](settled.message);
           } else {
             toast.success("Test run complete — nothing was sent.");
@@ -1575,7 +1582,14 @@ export function WorkflowsView({
           // This line used to be an unconditional "Workflow ran.", which a run
           // the operator had just STOPPED got too — so the same screen called
           // one run stopped and ran at the same time.
-          const settled = settledRunNotice(res.verdict);
+          //
+          // Codex review (PR #2053): `res.verdict` alone maps EVERY legacy
+          // host (predating issue #981, no `verdict` key on the wire) to the
+          // green fallback below, even one whose response shows it blocked,
+          // dropped a report, or was stopped — `legacyRunVerdict` derives the
+          // same reading `verdictOf` gives a history row from those other
+          // fields instead of assuming clean.
+          const settled = settledRunNotice(res.verdict ?? legacyRunVerdict(res));
           toast[settled.tone](settled.message);
         }
       }

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -135,7 +135,7 @@ import { CanvasShell } from "@/views/workflows/CanvasShell";
 import { approvalsForRun } from "@/views/workflows/run-approvals";
 // Issue #981: which nodes produced a report that never went out, so the canvas
 // card can say so beside the DONE badge instead of leaving it to a banner.
-import { undeliveredNodes } from "@/views/workflows/run-health";
+import { settledRunNotice, undeliveredNodes } from "@/views/workflows/run-health";
 import { NodeDetailPanel } from "@/views/workflows/NodeDetailPanel";
 import { type NodeOutputView, nodeOutputFor } from "@/views/workflows/run-output";
 
@@ -1557,8 +1557,15 @@ export function WorkflowsView({
             description:
               "Your test run executed real effects (teammate turns, tools, and any report delivery). Update the host to get true no-effect test runs.",
           });
+        } else if (dryRun) {
+          toast.success("Test run complete — nothing was sent.");
         } else {
-          toast.success(dryRun ? "Test run complete — nothing was sent." : "Workflow ran.");
+          // B-039: read the host's verdict rather than asserting a clean run.
+          // This line used to be an unconditional "Workflow ran.", which a run
+          // the operator had just STOPPED got too — so the same screen called
+          // one run stopped and ran at the same time.
+          const settled = settledRunNotice(res.verdict);
+          toast[settled.tone](settled.message);
         }
       }
       // A dry run journals NOTHING (#542), so there is no history row to pull

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1730,14 +1730,18 @@ export function WorkflowsView({
       setResult(null);
       setSelectedNodeId(null);
       setConflict(null);
-      // B-121: the run went with it, and saying so is the whole point of having
-      // warned. The host stops every run of a deleted workflow; before that it
-      // left them executing with the only Stop button in the product on the page
-      // this delete just unmounted.
+      // B-121: the run(s) went with it, and saying so is the whole point of
+      // having warned. The host stops EVERY run of a deleted workflow still
+      // in flight, not just the one this view happened to be watching — a
+      // manual run overlapping a scheduled one, or several manual triggers,
+      // are all live at once up to the company's concurrency ceiling (Codex
+      // review, PR #2053) — before that they were left executing with the
+      // only Stop button in the product on the page this delete just
+      // unmounted.
       setActiveRunId(null);
       toast.success(
         stoppedRuns > 0
-          ? `Deleted “${removedName}” and stopped the run in flight.`
+          ? `Deleted “${removedName}” and stopped ${stoppedRuns === 1 ? "the run" : `${stoppedRuns} runs`} in flight.`
           : `Deleted “${removedName}”.`,
       );
     } catch (e) {
@@ -2946,10 +2950,19 @@ export function WorkflowsView({
                             view's knowledge, decides that — see the toast below,
                             which reads the sweep's real count rather than this
                             guess), so the "nothing running" branch hedges rather
-                            than promising a fact this view cannot actually see. */}
+                            than promising a fact this view cannot actually see.
+
+                            Codex review (PR #2053), second round: manual and
+                            scheduled runs of the SAME workflow can overlap —
+                            the host admits several at once up to the company's
+                            concurrency ceiling — and the sweep stops every one
+                            of them, not just the one this view happens to be
+                            watching. "that run" (singular) undersold it; say
+                            "every run … still going" so the warning is accurate
+                            whether one is in flight or several. */}
                         <AlertDialogDescription data-testid="workflow-delete-consequence">
                           {watchingRun
-                            ? "A run of this workflow is going right now. Deleting it stops that run where it is — the steps it finished stay in the run history — and stops it running on its schedule. This can't be undone."
+                            ? "A run of this workflow is going right now. Deleting it stops every run of it still going — the steps each one finished stay in the run history — and stops it running on its schedule. This can't be undone."
                             : "This removes the workflow, stops it running on its schedule, and stops any run of it still going that hasn't shown up here yet. Past runs stay in the run history. This can't be undone."}
                         </AlertDialogDescription>
                       </AlertDialogHeader>

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -2935,11 +2935,22 @@ export function WorkflowsView({
                             the one consequence this dialog never mentioned, while
                             being word for word the sentence an idle workflow gets.
                             Deleting stops that run, which is a bigger thing to
-                            agree to than stopping a schedule. */}
+                            agree to than stopping a schedule.
+
+                            Codex review (PR #2053): `watchingRun` is this VIEW's
+                            own belief, current only as of its last history poll
+                            or SSE frame — a run a scheduler or another operator
+                            just started can be genuinely in flight server-side
+                            with nothing here having heard about it yet. Delete
+                            stops it either way (the host's own sweep, not this
+                            view's knowledge, decides that — see the toast below,
+                            which reads the sweep's real count rather than this
+                            guess), so the "nothing running" branch hedges rather
+                            than promising a fact this view cannot actually see. */}
                         <AlertDialogDescription data-testid="workflow-delete-consequence">
                           {watchingRun
                             ? "A run of this workflow is going right now. Deleting it stops that run where it is — the steps it finished stay in the run history — and stops it running on its schedule. This can't be undone."
-                            : "This removes the workflow and stops it running on its schedule. Past runs stay in the run history. This can't be undone."}
+                            : "This removes the workflow, stops it running on its schedule, and stops any run of it still going that hasn't shown up here yet. Past runs stay in the run history. This can't be undone."}
                         </AlertDialogDescription>
                       </AlertDialogHeader>
                       <AlertDialogFooter>

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1558,7 +1558,18 @@ export function WorkflowsView({
               "Your test run executed real effects (teammate turns, tools, and any report delivery). Update the host to get true no-effect test runs.",
           });
         } else if (dryRun) {
-          toast.success("Test run complete — nothing was sent.");
+          // CodeRabbit review (PR #2053): a dry run still drives the real
+          // engine (issue #542) and can fail or degrade exactly like a real
+          // one, so this used to say "nothing was sent" even over a dry run
+          // that failed — the same false green B-039 fixed below for the
+          // non-dry-run path, just for this one too. Success only for a
+          // clean run or a legacy host that sent no verdict at all.
+          if (res.verdict && res.verdict !== "ok") {
+            const settled = settledRunNotice(res.verdict);
+            toast[settled.tone](settled.message);
+          } else {
+            toast.success("Test run complete — nothing was sent.");
+          }
         } else {
           // B-039: read the host's verdict rather than asserting a clean run.
           // This line used to be an unconditional "Workflow ran.", which a run
@@ -1683,17 +1694,19 @@ export function WorkflowsView({
   // If it changed underneath us the host refuses with a 409 and removes nothing,
   // and we surface that instead of quietly deleting a graph the operator never
   // saw.
-  //
-  // `stoppingARun` is what the confirmation just told the operator would
-  // happen (B-121), passed in rather than read here so the sentence they
-  // agreed to and the sentence they get back cannot come from two different
-  // readings of the run state.
-  const remove = useCallback(async (stoppingARun: boolean) => {
+  const remove = useCallback(async () => {
     if (!selectedId || !graph) return;
     const removedName = graph.name;
     setDeleting(true);
     try {
-      await deleteWorkflow(client, company, selectedId, graph.version);
+      // CodeRabbit review (PR #2053): the confirmation dialog's "a run is
+      // going right now" is a pre-request guess (`watchingRun`, read where
+      // this is called) and the toast below reads the sweep's own count
+      // instead of that same guess — they can legitimately disagree with no
+      // race at all: a run this view was watching can settle on its own in
+      // the seconds between the operator confirming and this request
+      // reaching the host, and the sweep then truthfully stops nothing.
+      const { stoppedRuns } = await deleteWorkflow(client, company, selectedId, graph.version);
       // Drop it locally rather than re-listing: the host has confirmed, and a
       // re-list would flash an empty picker. A list request already in flight
       // predates this and would put the entry back — hence the bump.
@@ -1723,7 +1736,7 @@ export function WorkflowsView({
       // this delete just unmounted.
       setActiveRunId(null);
       toast.success(
-        stoppingARun
+        stoppedRuns > 0
           ? `Deleted “${removedName}” and stopped the run in flight.`
           : `Deleted “${removedName}”.`,
       );
@@ -2937,7 +2950,7 @@ export function WorkflowsView({
                             // dialog left mounted would re-render its title as
                             // `Delete “”?` over a backdrop nothing can click past.
                             setConfirmOpen(false);
-                            void remove(watchingRun);
+                            void remove();
                           }}
                           className="bg-destructive text-white hover:bg-destructive/90"
                           data-testid="workflow-delete-confirm"

--- a/frontend/src/views/workflows/RunResultPanel.tsx
+++ b/frontend/src/views/workflows/RunResultPanel.tsx
@@ -25,7 +25,11 @@ import { BlockedNodeApprovals } from "./BlockedNodeApprovals";
 import { DeliveryRows } from "./RunHistoryPanel";
 // Issue #596: the per-node parse is now shared with the durable run inspector
 // and the pre-publish approvals card, so it lives in `run-output.ts`.
-import { type NodeResult, parseRunNodes } from "./run-output";
+import {
+  type NodeResult,
+  noNodeResultsNotice,
+  parseRunNodes,
+} from "./run-output";
 // Issue #1002: which of the company's parked cards this run is held on.
 import { blockingApprovals, runApprovals, type RunApproval } from "./run-approvals";
 // Issue #981: the one rung for "this report did not go out", shared with the
@@ -124,6 +128,12 @@ export function RunResultPanel({
   const nodeResults = useMemo(
     () => parseRunNodes(result.output, graph),
     [result.output, graph],
+  );
+  // B-005 / B-039: why there are no cards, said in terms of how this run
+  // actually ended. `null` when there are cards.
+  const noResults = useMemo(
+    () => noNodeResultsNotice(nodeResults, result.output, result.verdict),
+    [nodeResults, result.output, result.verdict],
   );
   const deliveries = result.deliveries ?? [];
   const pendingDeliveryCount = deliveries.filter(
@@ -327,23 +337,25 @@ export function RunResultPanel({
           />
         )}
 
-        {nodeResults && nodeResults.length > 0 ? (
+        {noResults ? (
+          <p
+            className="mb-2 text-xs text-muted-foreground"
+            data-testid="workflow-run-no-node-results"
+          >
+            {noResults.message}
+          </p>
+        ) : (
           <div
             className="mb-2 space-y-2"
             data-testid="workflow-run-node-results"
           >
-            {nodeResults.map((n) => (
+            {(nodeResults ?? []).map((n) => (
               <NodeResultCard key={n.id} node={n} />
             ))}
           </div>
-        ) : (
-          <p className="mb-2 text-xs text-muted-foreground">
-            The run finished, but its output didn't match the expected node
-            shape — see the raw output below.
-          </p>
         )}
 
-        <details open={!nodeResults || nodeResults.length === 0}>
+        <details open={noResults?.showRaw ?? false}>
           <summary className="cursor-pointer text-xs text-muted-foreground">
             Show raw engine output
           </summary>

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -480,9 +480,15 @@ export function settledRunNotice(verdict: WorkflowRunVerdict | undefined): {
       };
     case "blocked":
     case "awaiting-approval":
+      // Not "before it can finish" (PR #2053 review): this run has already
+      // settled — the synchronous body only arrives once it has. Approving
+      // spawns a NEW run with no link back to this one (see `stranded`'s own
+      // comment above), so promising THIS run will finish is a claim the host
+      // never makes. "Parked" is the same word `parkedApprovalCount` and the
+      // card badges already use for the same state.
       return {
         tone: "info",
-        message: "The run is waiting on your approval before it can finish.",
+        message: "The run parked, waiting on your approval.",
       };
     case "stranded":
       return {

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -10,6 +10,7 @@
 import type {
   DeliveryReport,
   WorkflowRunOutcome,
+  WorkflowRunResult,
   WorkflowRunVerdict,
 } from "@/api/workflows";
 
@@ -370,6 +371,40 @@ export function verdictOf(run: WorkflowRunOutcome): WorkflowRunVerdict {
   // Legacy hosts may omit the verdict while still sending node statuses. An
   // error node under continue/route is degraded, not a clean run.
   if (run.nodes?.some((node) => node.status === "error")) return "degraded";
+  return "ok";
+}
+
+/**
+ * A legacy fallback verdict for a **settled run response** — the body
+ * `POST …/workflows/{wid}/run` answers with, not a history row — from a host
+ * predating issue #981 (Codex review, PR #2053): that response still carries
+ * `pendingApprovals`, `deliveries`, `blockedNodes`, `nodes` and `cancelled`,
+ * fields enough to say the run was NOT clean even with no `verdict` key on the
+ * wire. Reading only `res.verdict` maps every one of those non-clean legacy
+ * shapes to the green "Workflow ran." fallback — precisely the contradiction
+ * B-039 exists to close, just for an older host.
+ *
+ * A narrower {@link verdictOf}, because a `WorkflowRunResult` is a narrower
+ * shape than a `WorkflowRunOutcome`: it never carries `running` or `error` (a
+ * settled `200` is by construction neither — a failed run never reaches this
+ * body at all, it throws instead), so those arms are dropped; and it has no
+ * `strandedApprovals` for {@link isStranded} to read, since that reconciliation
+ * is a fact about a run somebody comes back to, not one microseconds old —
+ * the backend's own doc for this response enumerates its possible readings as
+ * exactly `stopped`, `blocked`, `undelivered`, `awaiting-approval`, `degraded`
+ * and `ok`, which is this ladder.
+ */
+export function legacyRunVerdict(res: WorkflowRunResult): WorkflowRunVerdict {
+  if (res.cancelled) return "stopped";
+  if ((res.blockedNodes?.length ?? 0) > 0) return "blocked";
+  if (undeliveredCount(res.deliveries ?? []) > 0) return "undelivered";
+  if (
+    (res.pendingApprovals?.length ?? 0) > 0 ||
+    pendingCount(res.deliveries ?? []) > 0
+  ) {
+    return "awaiting-approval";
+  }
+  if (res.nodes?.some((node) => node.status === "error")) return "degraded";
   return "ok";
 }
 

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -501,8 +501,20 @@ export function settledRunNotice(verdict: WorkflowRunVerdict | undefined): {
       // Reachable only from a host that settled a body while still calling the
       // run live. Say the true half rather than either terminal claim.
       return { tone: "info", message: "The workflow is still running." };
-    default:
+    case "ok":
+    case undefined:
+      // `undefined` is a host predating issue #981: it sends nothing to read,
+      // and the old sentence is the only honest one for it. `"ok"` is a real,
+      // checked success.
       return { tone: "success", message: "Workflow ran." };
+    default:
+      // CodeRabbit review (PR #2053): a word this console has never heard of.
+      // Unreachable through the closed `WorkflowRunVerdict` type above, but
+      // `verdict` is host-controlled at runtime — a host can grow an eighth
+      // word this build predates, the same case `verdictOf`'s own `in
+      // VERDICT_TONE` check exists to catch. Never paint an unrecognised word
+      // green; say only that the run is done, not that it went well.
+      return { tone: "info", message: "Workflow ran." };
   }
 }
 

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -444,6 +444,63 @@ export function runSummaryLine(
 }
 
 /**
+ * What to tell the operator the instant a run they pressed Run on settles
+ * (B-039).
+ *
+ * The console used to answer this with one line — `toast.success("Workflow
+ * ran.")` — for every run whose body came back, which is every run that did not
+ * throw. A run the operator had just **stopped** got it, so one screen said
+ * "stopped", "Workflow ran." and an output-shape error about a single run at
+ * once. So did a run that failed at its first node, and one parked on an
+ * approval.
+ *
+ * The reading comes from the host's `verdict` (issue #981), like every other
+ * reader of a run's outcome. `tone` is the sonner method to call, so a caller
+ * cannot pair a green tick with a red word.
+ *
+ * `undefined` — a host predating #981 — keeps the old sentence, deliberately.
+ * That host sends nothing to read, and the alternative is inventing a reading
+ * for it, which is the habit this exists to remove.
+ */
+export function settledRunNotice(verdict: WorkflowRunVerdict | undefined): {
+  tone: "success" | "info" | "error";
+  message: string;
+} {
+  switch (verdict) {
+    case "stopped":
+      // Idle, not red: a stop somebody asked for is not a fault — the same
+      // reading `VERDICT_TONE` gives it.
+      return { tone: "info", message: "Run stopped." };
+    case "failed":
+      return { tone: "error", message: "The workflow run failed." };
+    case "undelivered":
+      return {
+        tone: "error",
+        message: "The workflow ran, but a report did not go out.",
+      };
+    case "blocked":
+    case "awaiting-approval":
+      return {
+        tone: "info",
+        message: "The run is waiting on your approval before it can finish.",
+      };
+    case "stranded":
+      return {
+        tone: "info",
+        message: "The run stopped for an approval that is no longer in the queue.",
+      };
+    case "degraded":
+      return { tone: "info", message: "The workflow ran, with a step in error." };
+    case "running":
+      // Reachable only from a host that settled a body while still calling the
+      // run live. Say the true half rather than either terminal claim.
+      return { tone: "info", message: "The workflow is still running." };
+    default:
+      return { tone: "success", message: "Workflow ran." };
+  }
+}
+
+/**
  * A run that is still walking its graph.
  *
  * Its own reading, ahead of {@link runTone}: an in-flight run has not failed and

--- a/frontend/src/views/workflows/run-output.ts
+++ b/frontend/src/views/workflows/run-output.ts
@@ -12,7 +12,7 @@
 // Pure logic only (no JSX): callers render the returned `NodeResult` / message
 // list however they like (markdown, raw JSON behind a toggle).
 
-import type { WorkflowGraph } from "@/api/workflows";
+import type { WorkflowGraph, WorkflowRunVerdict } from "@/api/workflows";
 
 /** A single agent reply extracted from a node's `items[].json`. */
 export interface NodeMessage {
@@ -150,6 +150,97 @@ export function parseRunNodes(
   return orderedIds.map((id) =>
     parseSingleNode(id, nameById.get(id) ?? id, nodes[id]),
   );
+}
+
+/**
+ * Why the drawer has no per-node result cards to show, and whether the raw
+ * engine payload is worth putting in front of the operator (B-005, B-039).
+ *
+ * `null` when there ARE cards — the caller renders them and this says nothing.
+ */
+export interface NoNodeResultsNotice {
+  /** One sentence, true of how this run actually ended. */
+  message: string;
+  /**
+   * Whether to open the raw-engine-output disclosure unprompted.
+   *
+   * Only for a genuine shape fault. `{"nodes": {}}` and a `null` output are the
+   * *correct* payloads of a run that produced nothing, and showing an operator
+   * raw JSON as evidence of a problem they do not have is how B-005 came to
+   * report one panel saying two contradictory things about the same run.
+   */
+  showRaw: boolean;
+}
+
+/**
+ * What to say when a run produced no per-node cards.
+ *
+ * The drawer used to have one answer for this — "The run finished, but its
+ * output didn't match the expected node shape" — and it was wrong twice over
+ * for the two commonest ways to get here.
+ *
+ * *"The run finished"* is false for a run that parked on an approval (B-005)
+ * and for one an operator stopped (B-039); both are reported elsewhere in the
+ * same panel as exactly that, which is how one drawer came to describe one run
+ * two contradictory ways, one paragraph apart.
+ *
+ * *"didn't match the expected node shape"* is false for `{"nodes": {}}`, which
+ * is the shape a run that never reached a node correctly has, and for the
+ * `null` a stopped run carries. A shape fault is an output that is *present and
+ * wrong* — nothing else.
+ *
+ * So the reading comes from the host's own `verdict` (issue #981: the host owns
+ * what a run adds up to, and every other reader mirrors it rather than
+ * re-deriving it), and the shape fault is narrowed to the case that is actually
+ * one.
+ */
+export function noNodeResultsNotice(
+  nodeResults: NodeResult[] | null,
+  output: unknown,
+  verdict: WorkflowRunVerdict | undefined,
+): NoNodeResultsNotice | null {
+  if (nodeResults && nodeResults.length > 0) return null;
+  // A shape fault is an output that is present and wrong. An absent one — the
+  // `null` a stopped run settles with — is a run that produced nothing, which
+  // is a fact about the run and not about its encoding.
+  const malformed = nodeResults === null && output !== null && output !== undefined;
+  if (malformed) {
+    return {
+      message:
+        "This run's output didn't match the shape the console can read — the raw engine output is below.",
+      showRaw: true,
+    };
+  }
+  return { message: producedNothingMessage(verdict), showRaw: false };
+}
+
+/**
+ * The one sentence for a run that reached no node output, read off the host's
+ * verdict.
+ *
+ * Every arm is phrased "no step produced output", because that is the only
+ * claim this branch can make: had any step produced any, there would be a card
+ * and the caller would never have asked. An unknown or absent verdict says just
+ * that much and nothing about how the run ended — a host predating issue #981
+ * sends no verdict, and inventing one for it is what this whole path is being
+ * fixed for.
+ */
+function producedNothingMessage(verdict: WorkflowRunVerdict | undefined): string {
+  switch (verdict) {
+    case "running":
+      return "No step has produced output yet — this run is still going.";
+    case "stopped":
+      return "You stopped this run before any step produced output.";
+    case "failed":
+      return "This run failed before any step produced output.";
+    case "blocked":
+    case "awaiting-approval":
+      return "No step produced output before this run stopped for an approval.";
+    case "stranded":
+      return "No step produced output, and this run cannot be continued.";
+    default:
+      return "This run produced no step output.";
+  }
 }
 
 /**

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -50,6 +50,11 @@
 // because a later arm would otherwise consume a directive that was not meant
 // for it.
 //
+//   0. a message carrying `__MOCK_BURN_THEN_FAIL__ <in> <out>` (B-120) — meter
+//      the first call and refuse every one after it, so a turn can spend real
+//      tokens and then die. Tried before the routing below rather than beside
+//      it: every other arm answers, and an answer is the one thing this arm
+//      must not produce.
 //   1. a **triage classification** (issue #678) — answer `chatter` and touch
 //      nothing else. It is handed the operator's raw message, so it carries any
 //      directive that message carried, and serving one here burns it.
@@ -166,6 +171,52 @@ function slowMillis(messages) {
     if (Number.isFinite(ms) && ms > 0) return Math.min(ms, 10_000);
   }
   return 0;
+}
+
+/**
+ * "Burn `<in>` input and `<out>` output tokens, then break" — e.g.
+ * `__MOCK_BURN_THEN_FAIL__ 1200 340` (B-120).
+ *
+ * The first call carrying it answers with a **metered tool call**: real usage in
+ * the envelope, and a call that keeps the turn going. Every call after it is
+ * refused outright, so the turn dies at its second model call having already
+ * spent. openhuman publishes a turn's totals only after the turn succeeds, so
+ * that spend is reported nowhere — which is the exact shape of the run a founder
+ * was shown as `0 tok / $0.000` after ten minutes of real work.
+ *
+ * Every other reply this server sends carries a zeroed usage block on purpose
+ * (see `completion`), so a lane that never asks for this directive still books
+ * no spend at all.
+ */
+const BURN_THEN_FAIL_DIRECTIVE = "__MOCK_BURN_THEN_FAIL__";
+
+/**
+ * How many calls carrying [`BURN_THEN_FAIL_DIRECTIVE`] have been served.
+ * Per-process, like `servedDirectives`: the first is metered, the rest fail.
+ */
+let burnThenFailServed = 0;
+
+/**
+ * The `<in> <out>` token pair a message asks to burn, or `null` when none does.
+ *
+ * @param {any[]} messages
+ * @returns {{ input: number, output: number } | null}
+ */
+function burnThenFail(messages) {
+  for (const message of messages) {
+    const content = typeof message?.content === "string" ? message.content : "";
+    const at = content.indexOf(BURN_THEN_FAIL_DIRECTIVE);
+    if (at === -1) continue;
+    const [input, output] = content
+      .slice(at + BURN_THEN_FAIL_DIRECTIVE.length)
+      .trim()
+      .split(/\s+/)
+      .slice(0, 2)
+      .map((word) => Number.parseInt(word, 10));
+    if (!Number.isFinite(input) || !Number.isFinite(output)) return null;
+    return { input: Math.max(0, input), output: Math.max(0, output) };
+  }
+  return null;
 }
 
 /** The cue that makes the orchestrator open exactly one board card. */
@@ -940,9 +991,53 @@ const server = createServer((request, response) => {
         return;
       }
       if (path.endsWith("/chat/completions")) {
+        const messages = Array.isArray(body?.messages) ? body.messages : [];
+        // B-120: spend, then break. Tried before every other arm, because the
+        // point of it is that no reply ever ends this turn — an arm that
+        // answered first would turn the failure this stages into a success.
+        const burn = burnThenFail(messages);
+        if (burn) {
+          burnThenFailServed += 1;
+          if (burnThenFailServed > 1) {
+            process.stderr.write("[mock brain] refusing the follow-up call\n");
+            sendJson(response, 500, {
+              error: { message: `${BURN_THEN_FAIL_DIRECTIVE} scripted outage`, type: "server_error" },
+            });
+            return;
+          }
+          process.stderr.write(
+            `[mock brain] burning ${burn.input} in / ${burn.output} out, then failing\n`,
+          );
+          // A **tool call**, not a blank message. A blank one also fails the
+          // turn, but tinyagents classifies that as a degenerate completion and
+          // retries at the provider, so the usage of the call it threw away
+          // never reaches the progress stream — the run under test would then be
+          // genuinely free rather than wrongly reported as free. A tool call is
+          // an ordinary, fully-accounted model call that happens not to end the
+          // turn, which is what lets the NEXT call be the one that dies.
+          // `workspace_list` needs no arguments and the harness company grants it.
+          const metered = completion(body?.model ?? "mock", {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "mock-burn-call",
+                type: "function",
+                function: { name: "workspace_list", arguments: "{}" },
+              },
+            ],
+          }, "tool_calls");
+          metered.usage = {
+            prompt_tokens: burn.input,
+            completion_tokens: burn.output,
+            total_tokens: burn.input + burn.output,
+          };
+          sendJson(response, 200, metered);
+          return;
+        }
         // Issue #863: hold the reply back when the prompt asks for it, so a
         // spec can watch a workflow run while it is still walking the graph.
-        const held = slowMillis(Array.isArray(body?.messages) ? body.messages : []);
+        const held = slowMillis(messages);
         if (held > 0) {
           setTimeout(() => sendJson(response, 200, chatCompletion(body)), held);
           return;

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -192,30 +192,40 @@ function slowMillis(messages) {
 const BURN_THEN_FAIL_DIRECTIVE = "__MOCK_BURN_THEN_FAIL__";
 
 /**
- * How many calls carrying [`BURN_THEN_FAIL_DIRECTIVE`] have been served.
- * Per-process, like `servedDirectives`: the first is metered, the rest fail.
+ * How many calls carrying a given [`BURN_THEN_FAIL_DIRECTIVE`] payload have
+ * been served, **keyed by that payload** (CodeRabbit review, PR #2053) — not
+ * a single process-wide count. The mock brain is started once for the whole
+ * Playwright suite, so a bare counter metered only the very first call any
+ * spec anywhere in the run ever made with this directive; every other spec —
+ * or the same spec asking for a different `<in> <out>` pair — would have its
+ * first call refused outright instead of metered, which is the one thing
+ * this directive promises. Unlike `servedDirectives` (a `Set`, since a plan
+ * step either fired or did not), this needs a `Map`: "served" here is a
+ * count, because the *second* call for the same payload is the one meant to
+ * fail.
  */
-let burnThenFailServed = 0;
+const burnThenFailServed = new Map();
 
 /**
  * The `<in> <out>` token pair a message asks to burn, or `null` when none does.
+ * `key` is the exact payload text, and doubles as this call's identity in
+ * {@link burnThenFailServed}.
  *
  * @param {any[]} messages
- * @returns {{ input: number, output: number } | null}
+ * @returns {{ input: number, output: number, key: string } | null}
  */
 function burnThenFail(messages) {
   for (const message of messages) {
     const content = typeof message?.content === "string" ? message.content : "";
     const at = content.indexOf(BURN_THEN_FAIL_DIRECTIVE);
     if (at === -1) continue;
-    const [input, output] = content
-      .slice(at + BURN_THEN_FAIL_DIRECTIVE.length)
-      .trim()
+    const key = content.slice(at + BURN_THEN_FAIL_DIRECTIVE.length).trim();
+    const [input, output] = key
       .split(/\s+/)
       .slice(0, 2)
       .map((word) => Number.parseInt(word, 10));
     if (!Number.isFinite(input) || !Number.isFinite(output)) return null;
-    return { input: Math.max(0, input), output: Math.max(0, output) };
+    return { input: Math.max(0, input), output: Math.max(0, output), key };
   }
   return null;
 }
@@ -1046,9 +1056,10 @@ const server = createServer((request, response) => {
         // answered first would turn the failure this stages into a success.
         const burn = burnThenFail(messages);
         if (burn) {
-          burnThenFailServed += 1;
-          if (burnThenFailServed > 1) {
-            process.stderr.write("[mock brain] refusing the follow-up call\n");
+          const served = (burnThenFailServed.get(burn.key) ?? 0) + 1;
+          burnThenFailServed.set(burn.key, served);
+          if (served > 1) {
+            process.stderr.write(`[mock brain] refusing the follow-up call for <${burn.key}>\n`);
             sendJson(response, 500, {
               error: { message: `${BURN_THEN_FAIL_DIRECTIVE} scripted outage`, type: "server_error" },
             });

--- a/frontend/test/unit/legacy-run-verdict.test.ts
+++ b/frontend/test/unit/legacy-run-verdict.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkflowRunResult } from "@/api/workflows";
+import { legacyRunVerdict } from "@/views/workflows/run-health";
+
+/**
+ * Codex review (PR #2053): a settled run response from a host predating
+ * issue #981 carries no `verdict` key, but still carries enough of the other
+ * fields — `cancelled`, `blockedNodes`, `deliveries`, `pendingApprovals`,
+ * `nodes` — to say the run was NOT clean. Reading only `res.verdict` mapped
+ * every one of those legacy shapes to the green "Workflow ran." fallback,
+ * which is the exact contradiction B-039 exists to close, just for an older
+ * host. `legacyRunVerdict` is the derivation `WorkflowsView.tsx` now calls
+ * when `res.verdict` is absent.
+ */
+
+const BASE: WorkflowRunResult = {
+  output: null,
+  pendingApprovals: [],
+};
+
+describe("legacyRunVerdict", () => {
+  it("reads a cancelled legacy run as stopped", () => {
+    expect(legacyRunVerdict({ ...BASE, cancelled: true })).toBe("stopped");
+  });
+
+  it("reads a run with a blocked node as blocked", () => {
+    expect(
+      legacyRunVerdict({
+        ...BASE,
+        blockedNodes: [{ nodeId: "approve", tools: ["send_email"] }] as never,
+      }),
+    ).toBe("blocked");
+  });
+
+  it("reads a dropped report as undelivered", () => {
+    expect(
+      legacyRunVerdict({
+        ...BASE,
+        deliveries: [{ node: "out", status: "failed" }] as never,
+      }),
+    ).toBe("undelivered");
+  });
+
+  it("reads a run with pending approvals as awaiting-approval", () => {
+    expect(legacyRunVerdict({ ...BASE, pendingApprovals: ["gate-1"] })).toBe(
+      "awaiting-approval",
+    );
+  });
+
+  it("reads a run with a pending delivery as awaiting-approval too", () => {
+    expect(
+      legacyRunVerdict({
+        ...BASE,
+        deliveries: [{ node: "out", status: "pending" }] as never,
+      }),
+    ).toBe("awaiting-approval");
+  });
+
+  it("reads an errored node, with nothing else wrong, as degraded", () => {
+    expect(
+      legacyRunVerdict({
+        ...BASE,
+        nodes: [{ nodeId: "step", status: "error" }] as never,
+      }),
+    ).toBe("degraded");
+  });
+
+  it("reads a run with none of the above as ok", () => {
+    expect(legacyRunVerdict(BASE)).toBe("ok");
+  });
+
+  it("stopped outranks every other reading, the same precedence verdictOf uses", () => {
+    expect(
+      legacyRunVerdict({
+        ...BASE,
+        cancelled: true,
+        blockedNodes: [{ nodeId: "x", tools: ["send_email"] }] as never,
+        pendingApprovals: ["gate-1"],
+      }),
+    ).toBe("stopped");
+  });
+});

--- a/frontend/test/unit/run-output.test.ts
+++ b/frontend/test/unit/run-output.test.ts
@@ -166,4 +166,13 @@ describe("noNodeResultsNotice", () => {
     const notice = noNodeResultsNotice([], { nodes: {} }, undefined);
     expect(notice?.message).toBe("This run produced no step output.");
   });
+
+  it("never claims a failed run finished either (tinysweeper: untested-branch)", () => {
+    // Same wrongness as "stopped" — the old sentence said "The run finished"
+    // for this arm too. A regression back to it would pass every other test
+    // here, since none of them pass `verdict: "failed"` through.
+    const notice = noNodeResultsNotice(parseRunNodes(null, null), null, "failed");
+    expect(notice?.message).toBe("This run failed before any step produced output.");
+    expect(notice?.showRaw).toBe(false);
+  });
 });

--- a/frontend/test/unit/run-output.test.ts
+++ b/frontend/test/unit/run-output.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { WorkflowGraph } from "@/api/workflows";
 import {
+  noNodeResultsNotice,
   nodeOutputFor,
   parseNodeMessages,
   parseRunNodes,
@@ -120,5 +121,49 @@ describe("parseSingleNode", () => {
       port: "yes",
       messages: [{ text: "went left", agentRef: null }],
     });
+  });
+});
+
+/**
+ * B-005 and B-039: what the drawer says when a run produced no per-node cards.
+ *
+ * One sentence used to cover every way of getting here — "The run finished, but
+ * its output didn't match the expected node shape" — and it was wrong twice at
+ * once for the two commonest ones. A run parked on an approval has not
+ * finished, and `{"nodes": {}}` is the correct shape for a run that reached no
+ * node; a stopped run has not finished either, and its `null` output is not a
+ * malformed one. Both surfaces said so on the same screen while this paragraph
+ * contradicted them.
+ */
+describe("noNodeResultsNotice", () => {
+  it("says nothing at all when the run produced cards", () => {
+    const cards = parseRunNodes({ nodes: { a: { items: [{ json: { text: "x" } }] } } }, null);
+    expect(noNodeResultsNotice(cards, { nodes: {} }, "ok")).toBeNull();
+  });
+
+  it("calls an empty nodes map a run that produced nothing, not a bad shape", () => {
+    const notice = noNodeResultsNotice([], { nodes: {} }, "awaiting-approval");
+    expect(notice?.message).toBe(
+      "No step produced output before this run stopped for an approval.",
+    );
+    expect(notice?.showRaw).toBe(false);
+  });
+
+  it("never claims a stopped run finished, and does not push its null output forward", () => {
+    const notice = noNodeResultsNotice(parseRunNodes(null, null), null, "stopped");
+    expect(notice?.message).toBe("You stopped this run before any step produced output.");
+    expect(notice?.showRaw).toBe(false);
+  });
+
+  it("still reports a genuine shape fault, and opens the raw output for it", () => {
+    // Present and wrong — the only thing a shape complaint is true of.
+    const notice = noNodeResultsNotice(parseRunNodes("a bare string", null), "a bare string", "ok");
+    expect(notice?.message).toContain("didn't match the shape");
+    expect(notice?.showRaw).toBe(true);
+  });
+
+  it("says only what it knows when the host sent no verdict", () => {
+    const notice = noNodeResultsNotice([], { nodes: {} }, undefined);
+    expect(notice?.message).toBe("This run produced no step output.");
   });
 });

--- a/frontend/test/unit/settled-run-notice.test.ts
+++ b/frontend/test/unit/settled-run-notice.test.ts
@@ -39,6 +39,32 @@ describe("settledRunNotice", () => {
     }
   });
 
+  it("uses the error tone for an undelivered report, not the info of a merely-parked run", () => {
+    // tinysweeper: untested-branch — the only other arm sharing `info` with
+    // `blocked`/`awaiting-approval` above would have masked a regression that
+    // downgraded this one from `error`; a run whose report failed to send is a
+    // fault, not something waiting on the operator.
+    expect(settledRunNotice("undelivered")).toEqual({
+      tone: "error",
+      message: "The workflow ran, but a report did not go out.",
+    });
+  });
+
+  it("pins the remaining info-toned arms so none of them silently drift", () => {
+    expect(settledRunNotice("stranded")).toEqual({
+      tone: "info",
+      message: "The run stopped for an approval that is no longer in the queue.",
+    });
+    expect(settledRunNotice("degraded")).toEqual({
+      tone: "info",
+      message: "The workflow ran, with a step in error.",
+    });
+    expect(settledRunNotice("running")).toEqual({
+      tone: "info",
+      message: "The workflow is still running.",
+    });
+  });
+
   it("keeps the plain sentence only for a clean run", () => {
     expect(settledRunNotice("ok")).toEqual({ tone: "success", message: "Workflow ran." });
   });

--- a/frontend/test/unit/settled-run-notice.test.ts
+++ b/frontend/test/unit/settled-run-notice.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkflowRunVerdict } from "@/api/workflows";
+import { VERDICT_TONE, settledRunNotice } from "@/views/workflows/run-health";
+
+/**
+ * B-039: what the console says the moment a run an operator started settles.
+ *
+ * It used to say one thing — `toast.success("Workflow ran.")` — for every run
+ * whose body came back, which is every run that did not throw. A run the
+ * operator had just pressed **Stop** on got it too, so one screen reported a
+ * single run three contradictory ways at once: "stopped" on the row, "Workflow
+ * ran." in the toast, and an output-shape error in the drawer.
+ *
+ * The reading now comes from the host's `verdict` (issue #981), the same word
+ * every other reader of a run's outcome already mirrors.
+ */
+describe("settledRunNotice", () => {
+  it("never tells an operator a run they stopped ran", () => {
+    const notice = settledRunNotice("stopped");
+    expect(notice.message).toBe("Run stopped.");
+    // Idle, not a fault, and not a success — the reading `VERDICT_TONE` gives
+    // a stop somebody asked for.
+    expect(notice.tone).toBe("info");
+  });
+
+  it("never tells an operator a run that failed ran", () => {
+    expect(settledRunNotice("failed")).toEqual({
+      tone: "error",
+      message: "The workflow run failed.",
+    });
+  });
+
+  it("says a parked run is waiting on the operator rather than done", () => {
+    for (const verdict of ["blocked", "awaiting-approval"] as const) {
+      const notice = settledRunNotice(verdict);
+      expect(notice.tone).toBe("info");
+      expect(notice.message).toContain("waiting on your approval");
+    }
+  });
+
+  it("keeps the plain sentence only for a clean run", () => {
+    expect(settledRunNotice("ok")).toEqual({ tone: "success", message: "Workflow ran." });
+  });
+
+  it("keeps it for a host that sends no verdict at all, rather than inventing one", () => {
+    // A host predating issue #981 ships no `verdict` key. Guessing a reading
+    // for it is the habit this whole change removes.
+    expect(settledRunNotice(undefined).message).toBe("Workflow ran.");
+  });
+
+  /**
+   * The guard that keeps this honest as the verdict vocabulary grows: a word
+   * the host can send and this function has never heard of would silently fall
+   * to the success arm, which is precisely the false green B-039 is about.
+   */
+  it("greets exactly one verdict with a success tick", () => {
+    const cheerful = (Object.keys(VERDICT_TONE) as WorkflowRunVerdict[]).filter(
+      (verdict) => settledRunNotice(verdict).tone === "success",
+    );
+    expect(cheerful).toEqual(["ok"]);
+  });
+});

--- a/frontend/test/unit/workflow-delete-stops-run.test.ts
+++ b/frontend/test/unit/workflow-delete-stops-run.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { WorkflowGraph } from "@/api/workflows";
+
+/**
+ * B-121: deleting a workflow with a run in flight stops that run, and the
+ * confirmation and the toast both have to say so — this is the tinysweeper
+ * "untested-behavior" gap for PR #2053: the backend's `stop_runs_of_workflow`
+ * was tested, but none of the three presentation changes this PR made were —
+ * the confirmation dialog's wording varies on whether a run is watching, the
+ * success toast varies on the same thing, and the view drops `activeRunId`
+ * so the Stop control does not survive the workflow it belonged to.
+ *
+ * Mounting the view (rather than testing a pure helper) is required here for
+ * the same reason `workflow-run-failure.test.ts` and `workflow-index-first.test.ts`
+ * mount it: what is under test is what ends up on screen, not a return value.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+
+// React Flow measures its container on mount; jsdom has no layout and no
+// `ResizeObserver`. None of these three is under test.
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.assign(globalThis, {
+  ResizeObserver: NoopResizeObserver,
+  DOMMatrixReadOnly: class {
+    m22 = 1;
+  },
+});
+Object.defineProperties(globalThis.HTMLElement.prototype, {
+  offsetHeight: { get: () => 400 },
+  offsetWidth: { get: () => 800 },
+});
+
+const { WorkflowsView } = await import("@/views/WorkflowsView");
+
+const GRAPH: WorkflowGraph = {
+  id: "digest",
+  name: "Weekly digest",
+  version: "v1",
+  nodes: [
+    { id: "start", kind: "trigger", name: "Monday morning" },
+    { id: "n_3", kind: "agent", name: "Draft the digest", agent: "writer" },
+  ],
+  edges: [{ from: "start", to: "n_3" }],
+};
+
+/**
+ * A client whose run POST always accepts and detaches (issue #383's shape),
+ * so `activeRunId` is set the simple way — directly from the response — with
+ * no need to fake the run-history polling that would otherwise derive it.
+ */
+function fakeClient(): { client: OpenCompanyClient; deletes: string[] } {
+  const deletes: string[] = [];
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async (path: string) => {
+      if (path.endsWith("/workflows")) return [{ id: GRAPH.id, name: GRAPH.name }];
+      if (path.includes("/workflows/runs")) return { runs: [], hasMore: false };
+      return GRAPH;
+    },
+    post: async (path: string) => {
+      if (path.includes("/run")) return { runId: "r-live", detached: true };
+      return {};
+    },
+    del: async (path: string) => {
+      const id = path.match(/\/workflows\/([^/?]+)/)?.[1];
+      if (id) deletes.push(decodeURIComponent(id));
+    },
+    // Issue #1845: the week-1 nudge banner polls this on mount; an empty
+    // feed keeps it a no-op for every test in this file, which is not about
+    // the nudge.
+    notifications: async () => ({ notifications: [], unread: 0 }),
+    markNotificationsRead: async () => ({ unread: 0 }),
+  } as unknown as OpenCompanyClient;
+  return { client, deletes };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function button(label: string, scope: ParentNode = container): HTMLButtonElement {
+  const found = Array.from(scope.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no “${label}” button in:\n${(scope as Element).innerHTML}`);
+  return found as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+/** Mount on the workflow's own detail page, where Run/Delete live (issue #1110). */
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(WorkflowsView, { client, company: "acme", sub: GRAPH.id }));
+  });
+}
+
+/** Opens the delete confirmation. The dialog itself portals to `document.body`,
+ * outside `container` — the same reach `workflow-index-first.test.ts` uses for
+ * `workflow-delete-confirm`. */
+function openDeleteConfirm() {
+  button("Delete").click();
+}
+
+describe("deleting a workflow with a run in flight", () => {
+  it("warns about the run in the confirmation, stops it, and says so in the toast", async () => {
+    const { client, deletes } = fakeClient();
+    await mount(client);
+
+    // Dispatch a run and let it detach — `activeRunId` is set directly from
+    // the accepted response (WorkflowsView.tsx's `isDetached` branch).
+    await act(async () => {
+      button("Run").click();
+    });
+    expect(container.querySelector('[data-testid="workflow-cancel-run"]')).not.toBeNull();
+
+    await act(async () => {
+      openDeleteConfirm();
+    });
+    const consequence = document.querySelector('[data-testid="workflow-delete-consequence"]');
+    expect(consequence?.textContent).toContain("A run of this workflow is going right now");
+    expect(consequence?.textContent).toContain("stops that run where it is");
+
+    await act(async () => {
+      button("Delete workflow", document.body).click();
+    });
+
+    expect(deletes).toEqual(["digest"]);
+    // The success toast names the extra consequence the plain delete does not.
+    expect(toasts.success).toHaveBeenCalledWith(
+      expect.stringContaining("and stopped the run in flight."),
+    );
+    // `setActiveRunId(null)` (B-121): the Stop control cannot survive the
+    // workflow it belonged to — asserted by the DOM, since that state is not
+    // otherwise observable from outside the view.
+    expect(container.querySelector('[data-testid="workflow-cancel-run"]')).toBeNull();
+  });
+});
+
+describe("deleting a workflow with no run in flight", () => {
+  it("keeps the plain warning and the plain toast", async () => {
+    const { client, deletes } = fakeClient();
+    await mount(client);
+
+    await act(async () => {
+      openDeleteConfirm();
+    });
+    const consequence = document.querySelector('[data-testid="workflow-delete-consequence"]');
+    expect(consequence?.textContent).toBe(
+      "This removes the workflow and stops it running on its schedule. Past runs stay in the run history. This can't be undone.",
+    );
+
+    await act(async () => {
+      button("Delete workflow", document.body).click();
+    });
+
+    expect(deletes).toEqual(["digest"]);
+    expect(toasts.success).toHaveBeenCalledWith(`Deleted “${GRAPH.name}”.`);
+    // Never claims a run was stopped when there was none to stop.
+    expect(toasts.success).not.toHaveBeenCalledWith(expect.stringContaining("stopped the run"));
+  });
+});

--- a/frontend/test/unit/workflow-delete-stops-run.test.ts
+++ b/frontend/test/unit/workflow-delete-stops-run.test.ts
@@ -167,7 +167,10 @@ describe("deleting a workflow with a run in flight", () => {
     });
     const consequence = document.querySelector('[data-testid="workflow-delete-consequence"]');
     expect(consequence?.textContent).toContain("A run of this workflow is going right now");
-    expect(consequence?.textContent).toContain("stops that run where it is");
+    // Codex review (PR #2053): "every run … still going", not "that run" —
+    // several manual/scheduled runs of the same workflow can overlap, and
+    // the sweep stops all of them, not just the one this view is watching.
+    expect(consequence?.textContent).toContain("stops every run of it still going");
 
     await act(async () => {
       button("Delete workflow", document.body).click();
@@ -182,6 +185,26 @@ describe("deleting a workflow with a run in flight", () => {
     // workflow it belonged to — asserted by the DOM, since that state is not
     // otherwise observable from outside the view.
     expect(container.querySelector('[data-testid="workflow-cancel-run"]')).toBeNull();
+  });
+
+  it("pluralizes the toast when the sweep stopped more than one overlapping run", async () => {
+    // Codex review (PR #2053): manual and scheduled runs of the same
+    // workflow can overlap up to the company's concurrency ceiling, and the
+    // sweep stops every one it finds — the toast must say how many, not
+    // always "the run" as if exactly one were ever possible.
+    const { client } = fakeClient(3);
+    await mount(client);
+
+    await act(async () => {
+      openDeleteConfirm();
+    });
+    await act(async () => {
+      button("Delete workflow", document.body).click();
+    });
+
+    expect(toasts.success).toHaveBeenCalledWith(
+      expect.stringContaining("and stopped 3 runs in flight."),
+    );
   });
 });
 

--- a/frontend/test/unit/workflow-delete-stops-run.test.ts
+++ b/frontend/test/unit/workflow-delete-stops-run.test.ts
@@ -77,7 +77,7 @@ const GRAPH: WorkflowGraph = {
  * so `activeRunId` is set the simple way — directly from the response — with
  * no need to fake the run-history polling that would otherwise derive it.
  */
-function fakeClient(): { client: OpenCompanyClient; deletes: string[] } {
+function fakeClient(stoppedRuns = 0): { client: OpenCompanyClient; deletes: string[] } {
   const deletes: string[] = [];
   const client = {
     scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
@@ -93,6 +93,11 @@ function fakeClient(): { client: OpenCompanyClient; deletes: string[] } {
     del: async (path: string) => {
       const id = path.match(/\/workflows\/([^/?]+)/)?.[1];
       if (id) deletes.push(decodeURIComponent(id));
+      // CodeRabbit review (PR #2053): `deleteWorkflow` resolves to the
+      // host's own post-delete sweep count now, not `void` — `stoppedRuns`
+      // here is what each test below configures the sweep to have found,
+      // deliberately independent of client-side `activeRunId` state.
+      return { stoppedRuns };
     },
     // Issue #1845: the week-1 nudge banner polls this on mount; an empty
     // feed keeps it a no-op for every test in this file, which is not about
@@ -145,7 +150,9 @@ function openDeleteConfirm() {
 
 describe("deleting a workflow with a run in flight", () => {
   it("warns about the run in the confirmation, stops it, and says so in the toast", async () => {
-    const { client, deletes } = fakeClient();
+    // The host's sweep actually stops one run — the toast now reads THIS,
+    // not the pre-request `activeRunId` guess (CodeRabbit review, PR #2053).
+    const { client, deletes } = fakeClient(1);
     await mount(client);
 
     // Dispatch a run and let it detach — `activeRunId` is set directly from
@@ -198,6 +205,43 @@ describe("deleting a workflow with no run in flight", () => {
     expect(deletes).toEqual(["digest"]);
     expect(toasts.success).toHaveBeenCalledWith(`Deleted “${GRAPH.name}”.`);
     // Never claims a run was stopped when there was none to stop.
+    expect(toasts.success).not.toHaveBeenCalledWith(expect.stringContaining("stopped the run"));
+  });
+});
+
+describe("the confirmation's guess and the toast's truth can disagree", () => {
+  it("never claims a stop the sweep didn't actually make, even with a run watched at confirm time", async () => {
+    // CodeRabbit review (PR #2053): the dialog's "a run is going right now" is
+    // a pre-request guess (`watchingRun`), and it can be stale by the time the
+    // delete reaches the host — a long run the console was watching can
+    // finish on its own in the seconds between confirming and this request
+    // landing. `stoppedRuns: 0` here is exactly that: the console still
+    // believed a run was in flight when it asked, but the sweep found
+    // nothing to stop.
+    const { client, deletes } = fakeClient(0);
+    await mount(client);
+
+    await act(async () => {
+      button("Run").click();
+    });
+    expect(container.querySelector('[data-testid="workflow-cancel-run"]')).not.toBeNull();
+
+    await act(async () => {
+      openDeleteConfirm();
+    });
+    // The dialog still warns — it can only ever go on what it knew before asking.
+    expect(
+      document.querySelector('[data-testid="workflow-delete-consequence"]')?.textContent,
+    ).toContain("A run of this workflow is going right now");
+
+    await act(async () => {
+      button("Delete workflow", document.body).click();
+    });
+
+    expect(deletes).toEqual(["digest"]);
+    // The toast reads the sweep's truth (nothing stopped), not the dialog's
+    // pre-request guess.
+    expect(toasts.success).toHaveBeenCalledWith(`Deleted “${GRAPH.name}”.`);
     expect(toasts.success).not.toHaveBeenCalledWith(expect.stringContaining("stopped the run"));
   });
 });

--- a/frontend/test/unit/workflow-delete-stops-run.test.ts
+++ b/frontend/test/unit/workflow-delete-stops-run.test.ts
@@ -195,7 +195,9 @@ describe("deleting a workflow with no run in flight", () => {
     });
     const consequence = document.querySelector('[data-testid="workflow-delete-consequence"]');
     expect(consequence?.textContent).toBe(
-      "This removes the workflow and stops it running on its schedule. Past runs stay in the run history. This can't be undone.",
+      "This removes the workflow, stops it running on its schedule, and stops any run of it " +
+        "still going that hasn't shown up here yet. Past runs stay in the run history. This " +
+        "can't be undone.",
     );
 
     await act(async () => {

--- a/frontend/test/unit/workflow-delete-stops-run.test.ts
+++ b/frontend/test/unit/workflow-delete-stops-run.test.ts
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
-import type { WorkflowGraph } from "@/api/workflows";
+import { deleteWorkflow, type WorkflowGraph } from "@/api/workflows";
 
 /**
  * B-121: deleting a workflow with a run in flight stops that run, and the
@@ -245,5 +245,34 @@ describe("the confirmation's guess and the toast's truth can disagree", () => {
     // pre-request guess.
     expect(toasts.success).toHaveBeenCalledWith(`Deleted “${GRAPH.name}”.`);
     expect(toasts.success).not.toHaveBeenCalledWith(expect.stringContaining("stopped the run"));
+  });
+});
+
+describe("deleteWorkflow tolerates an older host", () => {
+  it("reads a legacy empty (204) response as stoppedRuns: 0 rather than throwing", async () => {
+    // Codex review (PR #2053): before B-121 this route answered 204 with no
+    // body, and OpenCompanyClient's generic reader turns that into
+    // `undefined`. Destructuring `stoppedRuns` straight off that would throw
+    // — after the host had ALREADY deleted the workflow — misreporting a
+    // successful delete as a failure.
+    const client = {
+      scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+      del: async () => undefined,
+    } as unknown as OpenCompanyClient;
+
+    await expect(deleteWorkflow(client, "acme", "digest", "v1")).resolves.toEqual({
+      stoppedRuns: 0,
+    });
+  });
+
+  it("passes a real host's count straight through", async () => {
+    const client = {
+      scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+      del: async () => ({ stoppedRuns: 1 }),
+    } as unknown as OpenCompanyClient;
+
+    await expect(deleteWorkflow(client, "acme", "digest", "v1")).resolves.toEqual({
+      stoppedRuns: 1,
+    });
   });
 });

--- a/frontend/test/unit/workflow-index-first.test.ts
+++ b/frontend/test/unit/workflow-index-first.test.ts
@@ -108,6 +108,12 @@ function makeClient(rows: WorkflowSummary[] = ROWS) {
     del: async (path: string) => {
       const id = path.match(/\/workflows\/([^/?]+)/)?.[1];
       if (id) deletes.push(decodeURIComponent(id));
+      // CodeRabbit review (PR #2053): `deleteWorkflow` now resolves to
+      // `{ stoppedRuns }` (the host's own post-delete sweep count) rather
+      // than `void` — `remove()` destructures it, so a mock answering
+      // nothing throws before the toast this file's own delete tests read.
+      // Nothing in this file's deletes involves a run in flight.
+      return { stoppedRuns: 0 };
     },
     // Issue #1845: the week-1 nudge banner polls this on mount; an empty
     // feed keeps it a no-op for every test in this file, which is not about

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -6236,6 +6236,49 @@ impl CompanyRuntime {
         }
     }
 
+    /// Fires the stop signal on every run of **one** workflow still in flight,
+    /// and answers how many it fired at (B-121).
+    ///
+    /// The sibling of [`stop_live_runs`](Self::stop_live_runs), narrowed to one
+    /// graph, for the single event that makes a run uncontrollable: deleting the
+    /// workflow it belongs to. Delete already tears the schedule and the
+    /// revisions down; the run is the piece it used to leave executing, and it
+    /// left it with nowhere to be stopped from — the console's only Stop button
+    /// lives on the workflow detail page that has just ceased to exist.
+    ///
+    /// Same mechanism and same guarantees as Pause's sweep and as the Stop
+    /// button itself (`run_supervisor().cancel`, issue #383): the engine checks
+    /// the token at the next node boundary, an executing node finishes and is
+    /// journaled, and a wedged one is hard-aborted after a bounded grace. So the
+    /// run settles `cancelled` with its partial trail intact, and its history
+    /// row outlives the workflow exactly as every other past run of it does.
+    ///
+    /// Best-effort in the one way everything that cancels here is: a run
+    /// registered on a superseded runtime (see `RuntimeHandover`) is not
+    /// reachable from this supervisor and still finishes on its own.
+    pub fn stop_runs_of_workflow(&self, workflow_id: &str) -> usize {
+        let stopping: Vec<String> = self
+            .run_supervisor
+            .live()
+            .into_iter()
+            .filter(|(_, wf)| wf == workflow_id)
+            .map(|(run_id, _)| run_id)
+            .collect();
+        if stopping.is_empty() {
+            return 0;
+        }
+        tracing::info!(
+            company = %self.id,
+            workflow = %workflow_id,
+            runs = stopping.len(),
+            "workflow deleted: cancelling the runs of it still in flight"
+        );
+        stopping
+            .iter()
+            .filter(|run_id| self.run_supervisor.cancel(run_id))
+            .count()
+    }
+
     // -- Emergency stop (issue #86) -----------------------------------------
 
     /// Whether the emergency stop is engaged.

--- a/src/harness/built_in/cost.rs
+++ b/src/harness/built_in/cost.rs
@@ -57,6 +57,19 @@ pub struct TurnUsage {
 }
 
 impl TurnUsage {
+    /// Whether this turn moved no tokens and cost nothing.
+    ///
+    /// Mirrors [`TokenUsage::is_zero`] rather than inventing a second rule of
+    /// what counts as usage, and exists for one caller: this is the shape
+    /// `read_turn_usage` reads back when openhuman published no totals at all
+    /// — which, since `run_single` sets them only after its own `?`, is exactly
+    /// what a hard-failed turn leaves behind. Telling that apart from a turn
+    /// that genuinely spent nothing is what lets the live tally observed on the
+    /// progress stream stand in for it.
+    pub fn is_zero(&self) -> bool {
+        self.to_token_usage().is_zero()
+    }
+
     /// This turn as the crate-wide [`TokenUsage`] the metering seam maps from.
     fn to_token_usage(self) -> TokenUsage {
         TokenUsage {

--- a/src/harness/built_in/iteration_cap_turn_test.rs
+++ b/src/harness/built_in/iteration_cap_turn_test.rs
@@ -394,10 +394,8 @@ async fn a_turn_past_the_old_ten_iteration_ceiling_now_finishes() {
     let dir = tempfile::tempdir().unwrap();
     let agent = company_agent(model_url, dir.path(), None, reads).await;
 
-    let (outcome, _usages) = agent
-        .run("Draft and publish the pricing spec.")
-        .await
-        .expect("the turn runs");
+    let (outcome, _usages) = agent.run("Draft and publish the pricing spec.").await;
+    let outcome = outcome.expect("the turn runs");
 
     assert!(
         outcome.reply.contains("Spec published."),
@@ -446,10 +444,8 @@ async fn a_budget_halt_stops_the_turn_and_is_not_an_iteration_cap_pause() {
     let dir = tempfile::tempdir().unwrap();
     let agent = company_agent(model_url, dir.path(), Some(0.05), reads).await;
 
-    let (outcome, _usages) = agent
-        .run("Draft and publish the pricing spec.")
-        .await
-        .expect("the turn runs");
+    let (outcome, _usages) = agent.run("Draft and publish the pricing spec.").await;
+    let outcome = outcome.expect("the turn runs");
 
     assert!(
         !outcome.reply.contains("Spec published."),
@@ -496,10 +492,8 @@ async fn a_turn_with_no_declared_budget_gets_no_in_turn_brake_at_any_cost() {
         "the fixture must actually be undeclared for this test to prove anything"
     );
 
-    let (outcome, _usages) = agent
-        .run("Draft and publish the pricing spec.")
-        .await
-        .expect("the turn runs");
+    let (outcome, _usages) = agent.run("Draft and publish the pricing spec.").await;
+    let outcome = outcome.expect("the turn runs");
 
     assert!(
         outcome.reply.contains("Spec published."),
@@ -534,10 +528,8 @@ async fn exhausting_the_raised_cap_still_reports_an_iteration_cap_pause() {
     let dir = tempfile::tempdir().unwrap();
     let agent = company_agent(model_url, dir.path(), None, reads).await;
 
-    let (outcome, _usages) = agent
-        .run("Draft and publish the pricing spec.")
-        .await
-        .expect("the turn runs");
+    let (outcome, _usages) = agent.run("Draft and publish the pricing spec.").await;
+    let outcome = outcome.expect("the turn runs");
 
     assert!(
         hit_cap(&agent).await,
@@ -628,8 +620,8 @@ async fn a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context() {
             None,
             ChatTarget::channel(Some("sports")),
         )
-        .await
-        .expect("task A runs");
+        .await;
+    let outcome_a = outcome_a.expect("task A runs");
     assert!(
         !outcome_a.steps.is_empty(),
         "task A must actually run a tool step (the fetch) — otherwise the \
@@ -666,8 +658,8 @@ async fn a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context() {
             ChatTarget::channel(Some("smalltalk")),
         ),
     )
-    .await
-    .expect("the greeting runs");
+    .await;
+    let outcome_b = outcome_b.expect("the greeting runs");
 
     // 1) Zero tool steps ran — the greeting never entered the agentic loop.
     assert!(
@@ -771,6 +763,7 @@ async fn a_background_turn_does_not_leak_into_the_next_turn_on_its_bound_chat() 
             ChatTarget::channel(Some("sports")),
         )
         .await
+        .0
         .expect("chat turn 1 runs");
 
     // ── The background task: unthreaded — `stream: None`, same shared Agent. ──
@@ -784,8 +777,8 @@ async fn a_background_turn_does_not_leak_into_the_next_turn_on_its_bound_chat() 
             // A background task names no conversation — the point of the case.
             ChatTarget::default(),
         )
-        .await
-        .expect("background task runs");
+        .await;
+    let outcome_bg = outcome_bg.expect("background task runs");
     assert!(
         !outcome_bg.steps.is_empty(),
         "the background task must actually run a tool step (the fetch) — \
@@ -814,6 +807,7 @@ async fn a_background_turn_does_not_leak_into_the_next_turn_on_its_bound_chat() 
             ChatTarget::channel(Some("sports")),
         )
         .await
+        .0
         .expect("chat turn 2 runs");
 
     assert_eq!(

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -1576,7 +1576,8 @@ impl CompanyAgent {
         let hit_iteration_cap = agent.last_turn_hit_cap();
         drop(agent);
         let events = collector.await.unwrap_or_default();
-        // A hard-failed turn's spend, recovered from the progress stream.
+        // A hard-failed ATTEMPT's spend, recovered from the progress stream —
+        // per attempt, not only when every attempt reported nothing.
         //
         // `read_turn_usage` above reads openhuman's `last_turn_usage_totals`,
         // and `run_single` sets that only AFTER its own `let outcome = outcome?`
@@ -1587,39 +1588,49 @@ impl CompanyAgent {
         // founder most needs the cost of was the one reported as free.
         //
         // The live tally openhuman publishes as it goes — `TurnCostUpdated`,
-        // cumulative across the turn, emitted after each provider response that
-        // carried a usage block — survives the error, because those frames were
-        // already sent down this channel. So a last attempt that reported
-        // nothing takes the last tally the stream carried.
+        // cumulative across ONE `agent.turn`, emitted after each provider
+        // response that carried a usage block — survives the error, because
+        // those frames were already sent down this shared channel before the
+        // attempt failed.
         //
-        // **Only when NO attempt published anything**, which is what makes this
-        // incapable of double-counting. The tally is cumulative per
-        // `agent.turn` — openhuman builds the retry a fresh `TurnCost` starting
-        // back at zero, the same property the spend brake above relies on — so
-        // the last frame belongs to whichever attempt emitted it, and folding it
-        // in beside an attempt that had *also* published its own authoritative
-        // total could charge the same tokens twice. When even one attempt
-        // published, those figures stand alone and this does nothing.
+        // Codex review (PR #2053): the original gate only fired when EVERY
+        // attempt was zero, which recovers at most one attempt — a metered
+        // first attempt that empties, followed by a retry that succeeds and
+        // publishes its OWN authoritative (small) total, left `usages` as
+        // `[zero, retry_total]`. That is not all-zero, so the first attempt's
+        // already-published spend was silently dropped rather than merely
+        // under-reported. Segmenting `events` on `TurnStarted` — emitted
+        // exactly once at the top of each `agent.turn()` call
+        // (`core_turn.rs`), never for a delegated sub-agent's turn, which
+        // uses `SubagentIterationStarted`/`SubagentToolCallStarted` instead —
+        // gives each attempt its own contiguous slice of the stream, so each
+        // zeroed attempt recovers its OWN tally independently.
         //
         // **A lower bound, stated rather than discovered.** `TurnCostUpdated`
         // is suppressed for child scopes (openhuman's `observability`: a
         // sub-agent's spend reaches the parent's `last_turn_usage_totals`
-        // instead), so a failed turn that had delegated under-reports the
-        // delegates. Understating a failed turn is a far smaller wrong than
+        // instead), so an attempt that had delegated under-reports the
+        // delegates. Understating an attempt is a far smaller wrong than
         // reporting it as free, and this seam cannot see more than the stream
         // carries.
-        if usages.iter().all(TurnUsage::is_zero)
-            && let Some(observed) = last_observed_turn_cost(&events)
-            && let Some(last) = usages.last_mut()
-        {
-            tracing::info!(
-                agent = %self.agent_id,
-                input_tokens = observed.input_tokens,
-                output_tokens = observed.output_tokens,
-                cost_usd = observed.cost_usd,
-                "[turn] the attempt published no totals; metering the spend observed on its progress stream"
-            );
-            *last = observed;
+        if usages.iter().any(TurnUsage::is_zero) {
+            let segments = attempt_event_segments(&events, usages.len());
+            for (usage, segment) in usages.iter_mut().zip(segments) {
+                if !usage.is_zero() {
+                    continue;
+                }
+                if let Some(observed) = last_observed_turn_cost(segment) {
+                    tracing::info!(
+                        agent = %self.agent_id,
+                        input_tokens = observed.input_tokens,
+                        output_tokens = observed.output_tokens,
+                        cost_usd = observed.cost_usd,
+                        "[turn] an attempt published no totals; metering the spend observed on \
+                         its own progress-stream segment"
+                    );
+                    *usage = observed;
+                }
+            }
         }
         // The cap openhuman was actually enforcing, for the trace only. Taken
         // from the last `IterationStarted` rather than from config, so the log
@@ -1861,6 +1872,47 @@ fn last_observed_turn_cost(events: &[oh::agent::progress::AgentProgress]) -> Opt
         }),
         _ => None,
     })
+}
+
+/// Splits a turn's flat progress-event stream into one contiguous slice per
+/// attempt, so [`last_observed_turn_cost`] can read a zeroed attempt's own
+/// tally back without crediting it with a DIFFERENT attempt's spend (Codex
+/// review, PR #2053).
+///
+/// [`AgentProgress::TurnStarted`](oh::agent::progress::AgentProgress::TurnStarted)
+/// is emitted exactly once at the very top of every `agent.turn()` call
+/// (`core_turn.rs`, "about to enter the iteration loop") and never for a
+/// delegated sub-agent's turn — those use `SubagentIterationStarted`/
+/// `SubagentToolCallStarted` instead — so each attempt owns exactly one
+/// contiguous run of events starting at its own `TurnStarted` and ending
+/// where the next attempt's begins, or at the stream's end for the last.
+///
+/// `attempts` is `usages.len()` — the number of `agent.turn()` calls the
+/// wrapper actually made (one, or two across the one-shot retry). Always
+/// returns exactly that many slices; an attempt whose `TurnStarted` never
+/// reached this stream (openhuman's collector drops nothing observed in
+/// practice, but the channel is not literally unbounded) gets an empty one,
+/// which is the same "nothing to recover" outcome as before this fix.
+fn attempt_event_segments(
+    events: &[oh::agent::progress::AgentProgress],
+    attempts: usize,
+) -> Vec<&[oh::agent::progress::AgentProgress]> {
+    let starts: Vec<usize> = events
+        .iter()
+        .enumerate()
+        .filter_map(|(i, event)| {
+            matches!(event, oh::agent::progress::AgentProgress::TurnStarted).then_some(i)
+        })
+        .collect();
+    (0..attempts)
+        .map(|i| match starts.get(i) {
+            Some(&start) => {
+                let end = starts.get(i + 1).copied().unwrap_or(events.len());
+                &events[start..end]
+            }
+            None => &events[0..0],
+        })
+        .collect()
 }
 
 /// Writes every attempt's spend of a **finished** turn to the ledger and the
@@ -7728,6 +7780,54 @@ description = "Builds the product."
              progress-stream tally since its own attempt also errors before finalizing totals \
              — never turn one's already-billed total read back a second and third time: \
              {second_usages:?}"
+        );
+    }
+
+    /// Codex review (PR #2053): the original recovery gate only fired when
+    /// EVERY attempt in `usages` reported zero, so it could recover at most
+    /// one attempt's spend. A metered first attempt that empties, followed by
+    /// a retry that succeeds and publishes its OWN authoritative total, left
+    /// `usages` as `[zero, retry_total]` — not all-zero — so the first
+    /// attempt's already-published `TurnCostUpdated` spend was silently
+    /// dropped rather than merely under-reported.
+    ///
+    /// Both scripted replies carry the SAME usage (1,000 tokens each, via the
+    /// one shared `.reporting_usage(...)` every `ScriptedProvider` reply
+    /// gets), so the only way the total comes out to 2,000 rather than 1,000
+    /// is if the first attempt's spend — recovered from its OWN segment of
+    /// the progress stream, per `attempt_event_segments` — survives instead
+    /// of being discarded the moment the retry's real total makes `usages`
+    /// not-all-zero.
+    #[tokio::test]
+    async fn a_metered_empty_attempt_is_still_recovered_when_the_retry_succeeds() {
+        let (agent, _deps) = scripted_agent_over(
+            ScriptedProvider::new(vec![Ok(String::new()), Ok("recovered".to_string())])
+                .reporting_usage(tinyinference::Usage {
+                    input_tokens: 800,
+                    output_tokens: 200,
+                    total_tokens: 1_000,
+                    ..Default::default()
+                }),
+        );
+
+        let (outcome, usages) = agent.run("hi").await;
+        let outcome = outcome.expect("the retry recovers a real reply");
+        assert!(
+            outcome.reply.contains("recovered"),
+            "got {:?}",
+            outcome.reply
+        );
+        assert_eq!(usages.len(), 2, "both attempts' usage is returned");
+
+        let tokens: u64 = usages
+            .iter()
+            .map(|u| u.input_tokens + u.output_tokens)
+            .sum();
+        assert_eq!(
+            tokens, 2_000,
+            "both attempts genuinely burned 1,000 tokens each — the first attempt's spend must \
+             not be dropped just because the retry went on to publish its own (also real) \
+             total: {usages:?}"
         );
     }
 

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -4326,7 +4326,19 @@ impl HarnessPool {
             run_sink.as_ref().map(|s| s.run_id()),
         )
         .await;
-        let outcome = turn_result_after_metering(outcome, metered, company, agent_id)?;
+        // Issue #1846, Codex review (PR #2053): the budget-pause park/retire
+        // side effects below read the turn's OWN outcome, and must run before
+        // `turn_result_after_metering`'s `?` — a ledger write that fails is a
+        // problem with the METER, not with what this turn actually did, and
+        // must not also swallow a genuine pause marker (the operator's only
+        // "add credits and resend" path) or a genuine retirement of a stale
+        // one (leaving a stale CTA that could later re-dispatch a
+        // potentially non-idempotent request a second time). `meter_turn_costs`
+        // itself still runs first and unconditionally, exactly as
+        // `meter_turn_costs`'s own doc requires — this only reorders reading
+        // `outcome` for these two side effects ahead of the point that
+        // `outcome` might get replaced by a metering error.
+        //
         // Issue #1846: park a durable re-issue marker the moment a pause is
         // seen, mirroring the grant-reissue precedent (`crate::runtime::grants`)
         // — mint on the event that needs a later redemption, not on whatever
@@ -4334,131 +4346,134 @@ impl HarnessPool {
         // parked: the operator's own words are what gets re-sent, and
         // retrieve→inject re-runs fresh against whatever memory looks like at
         // redeem time rather than replaying a stale injection.
-        if let Some(pause) = &outcome.budget_paused {
-            let chat_id = match live {
-                LiveStream::On { chat_id, .. } => chat_id.map(str::to_string),
-                LiveStream::Workflow { .. } | LiveStream::Off => None,
-            };
-            // Issue #1846 review (Codex #3869193112): whether an operator
-            // was ever addressing this turn AT ALL, not just whether they
-            // named a specific desk — see `BudgetPauseMarker::background`'s
-            // doc for why this is a different question from `chat_id`
-            // above, which is `None` for BOTH an unaddressed interactive
-            // message and a background turn alike.
-            let is_background = matches!(live, LiveStream::Workflow { .. } | LiveStream::Off);
-            // Issue #1846 review (Codex #3865812419/#3865812423/#3865812432):
-            // the ambient parent/deliverable/mentions the cycle was started
-            // with, so a redeem replays the operator's ORIGINAL
-            // thread/intent/audience instead of the empty defaults
-            // `redeem_budget_pause` used to fall back to.
-            let redeem_context = crate::runtime::grants::current_redeem_context();
-            // Issue #1846 review (Codex #3866418891): `message` here is
-            // whatever this turn actually ran with — for an operator-message
-            // turn that is `composed`, already carrying `with_attachment_refs`
-            // markers baked into the text, which would double up with
-            // `redeem_context.attachments` below once `redeem_budget_pause`
-            // recomposes them fresh. The ambient context's own RAW text (set
-            // once, from the ORIGINAL `OperatorMessage`, before any composing
-            // happened) is preferred whenever one is in scope; falling back to
-            // the local `message` only for a cycle with no `OperatorMessage`
-            // at all (a workflow node's own background turn), which has no
-            // raw/composed split — and no attachments — to begin with.
-            let park_message = redeem_context.text.clone().unwrap_or_else(|| {
-                // Issue #1890 E: the operator's own words, which is what this
-                // fallback has always claimed to hold. `message` here is the
-                // composed turn text, so it carries whatever the cycle appended
-                // — the open-work briefing, the settled-work one, the thread
-                // index — and parking that bakes a machine briefing into the
-                // request a redeem re-sends. It was already reachable through
-                // the #176 briefing whenever the agent had open cards; the
-                // thread index made it reachable on an ordinary channel, which
-                // is how `redeem_replays_the_markers_attachments` caught it.
-                crate::runtime::delegation::operator_words(message).to_string()
-            });
-            let pauses = crate::runtime::grants::budget_pauses_for(company);
-            let marker = if is_background {
-                pauses.park_background(
-                    pause.agent.clone(),
-                    chat_id,
-                    park_message,
-                    pause.summary.clone(),
-                    crate::ports::now_millis(),
-                    redeem_context,
+        if let Ok(turn_outcome) = &outcome {
+            if let Some(pause) = &turn_outcome.budget_paused {
+                let chat_id = match live {
+                    LiveStream::On { chat_id, .. } => chat_id.map(str::to_string),
+                    LiveStream::Workflow { .. } | LiveStream::Off => None,
+                };
+                // Issue #1846 review (Codex #3869193112): whether an operator
+                // was ever addressing this turn AT ALL, not just whether they
+                // named a specific desk — see `BudgetPauseMarker::background`'s
+                // doc for why this is a different question from `chat_id`
+                // above, which is `None` for BOTH an unaddressed interactive
+                // message and a background turn alike.
+                let is_background = matches!(live, LiveStream::Workflow { .. } | LiveStream::Off);
+                // Issue #1846 review (Codex #3865812419/#3865812423/#3865812432):
+                // the ambient parent/deliverable/mentions the cycle was started
+                // with, so a redeem replays the operator's ORIGINAL
+                // thread/intent/audience instead of the empty defaults
+                // `redeem_budget_pause` used to fall back to.
+                let redeem_context = crate::runtime::grants::current_redeem_context();
+                // Issue #1846 review (Codex #3866418891): `message` here is
+                // whatever this turn actually ran with — for an operator-message
+                // turn that is `composed`, already carrying `with_attachment_refs`
+                // markers baked into the text, which would double up with
+                // `redeem_context.attachments` below once `redeem_budget_pause`
+                // recomposes them fresh. The ambient context's own RAW text (set
+                // once, from the ORIGINAL `OperatorMessage`, before any composing
+                // happened) is preferred whenever one is in scope; falling back to
+                // the local `message` only for a cycle with no `OperatorMessage`
+                // at all (a workflow node's own background turn), which has no
+                // raw/composed split — and no attachments — to begin with.
+                let park_message = redeem_context.text.clone().unwrap_or_else(|| {
+                    // Issue #1890 E: the operator's own words, which is what this
+                    // fallback has always claimed to hold. `message` here is the
+                    // composed turn text, so it carries whatever the cycle appended
+                    // — the open-work briefing, the settled-work one, the thread
+                    // index — and parking that bakes a machine briefing into the
+                    // request a redeem re-sends. It was already reachable through
+                    // the #176 briefing whenever the agent had open cards; the
+                    // thread index made it reachable on an ordinary channel, which
+                    // is how `redeem_replays_the_markers_attachments` caught it.
+                    crate::runtime::delegation::operator_words(message).to_string()
+                });
+                let pauses = crate::runtime::grants::budget_pauses_for(company);
+                let marker = if is_background {
+                    pauses.park_background(
+                        pause.agent.clone(),
+                        chat_id,
+                        park_message,
+                        pause.summary.clone(),
+                        crate::ports::now_millis(),
+                        redeem_context,
+                    )
+                } else {
+                    pauses.park(
+                        pause.agent.clone(),
+                        chat_id,
+                        park_message,
+                        pause.summary.clone(),
+                        crate::ports::now_millis(),
+                        redeem_context,
+                    )
+                };
+                tracing::info!(
+                    company = %company,
+                    agent = %pause.agent,
+                    marker_id = %marker.id,
+                    "[budget-pause] parked a re-issue marker; the operator can redeem it once credits are added"
+                );
+            } else if let Some(stale) = {
+                // Issue #1846 review (Codex #3869792503, tightened by
+                // #3869968949): match on the SAME saved-request CONTEXT
+                // `park_message`/`park`/`park_background` above parks a marker
+                // under — text, chat thread, parent, deliverable, mentions AND
+                // attachments — not an unconditional `redeem` and not text
+                // alone. An unrelated turn for this agent (an automatic
+                // background task, a second chat message about something else
+                // entirely, or even a coincidentally-identical-text request in a
+                // DIFFERENT thread) succeeding first must not silently drop the
+                // marker for a DIFFERENT, still-unretried original request. A
+                // resend, by construction, runs with the SAME context the
+                // marker parked; an unrelated success does not.
+                let candidate_chat_id = match live {
+                    LiveStream::On { chat_id, .. } => chat_id.map(str::to_string),
+                    LiveStream::Workflow { .. } | LiveStream::Off => None,
+                };
+                let candidate_redeem = crate::runtime::grants::current_redeem_context();
+                let candidate_message = candidate_redeem.text.clone().unwrap_or_else(|| {
+                    // Stripped on exactly the terms the park above is, or the
+                    // retire-match would compare a briefing-laden candidate against
+                    // a clean parked marker and never retire it (#1890 E).
+                    crate::runtime::delegation::operator_words(message).to_string()
+                });
+                crate::runtime::grants::budget_pauses_for(company).retire_if_message_matches(
+                    agent_id,
+                    &candidate_message,
+                    candidate_chat_id.as_deref(),
+                    &candidate_redeem,
                 )
-            } else {
-                pauses.park(
-                    pause.agent.clone(),
-                    chat_id,
-                    park_message,
-                    pause.summary.clone(),
-                    crate::ports::now_millis(),
-                    redeem_context,
-                )
-            };
-            tracing::info!(
-                company = %company,
-                agent = %pause.agent,
-                marker_id = %marker.id,
-                "[budget-pause] parked a re-issue marker; the operator can redeem it once credits are added"
-            );
-        } else if let Some(stale) = {
-            // Issue #1846 review (Codex #3869792503, tightened by
-            // #3869968949): match on the SAME saved-request CONTEXT
-            // `park_message`/`park`/`park_background` above parks a marker
-            // under — text, chat thread, parent, deliverable, mentions AND
-            // attachments — not an unconditional `redeem` and not text
-            // alone. An unrelated turn for this agent (an automatic
-            // background task, a second chat message about something else
-            // entirely, or even a coincidentally-identical-text request in a
-            // DIFFERENT thread) succeeding first must not silently drop the
-            // marker for a DIFFERENT, still-unretried original request. A
-            // resend, by construction, runs with the SAME context the
-            // marker parked; an unrelated success does not.
-            let candidate_chat_id = match live {
-                LiveStream::On { chat_id, .. } => chat_id.map(str::to_string),
-                LiveStream::Workflow { .. } | LiveStream::Off => None,
-            };
-            let candidate_redeem = crate::runtime::grants::current_redeem_context();
-            let candidate_message = candidate_redeem.text.clone().unwrap_or_else(|| {
-                // Stripped on exactly the terms the park above is, or the
-                // retire-match would compare a briefing-laden candidate against
-                // a clean parked marker and never retire it (#1890 E).
-                crate::runtime::delegation::operator_words(message).to_string()
-            });
-            crate::runtime::grants::budget_pauses_for(company).retire_if_message_matches(
-                agent_id,
-                &candidate_message,
-                candidate_chat_id.as_deref(),
-                &candidate_redeem,
-            )
-        } {
-            // Issue #1846 review (Codex #3868962381): this turn just
-            // completed WITHOUT pausing, which is proof the account that
-            // blocked the LAST turn now has budget again — whether the
-            // operator got there by clicking "Add credits & resend" (which
-            // already took the marker itself, so this finds nothing) or, as
-            // the notice's own copy also invites, by manually adding credits
-            // and resending the message from the composer, bypassing the
-            // CTA/redeem route entirely. Only the second path used to leave
-            // the marker parked: nothing but a click on THIS specific CTA
-            // ever consumed it, so a manual resend left a stale marker and
-            // its stale CTA sitting on the old notice indefinitely. Clicking
-            // it later would silently re-dispatch the OLD message a second
-            // time — a duplicate, and for a non-idempotent request, a
-            // duplicate side effect the operator never asked for.
-            //
-            // `retire_if_message_matches`, not a peek-then-drop: single
-            // atomic check-and-take, same as every other consumer of this
-            // set, so a concurrent CTA click racing this retire cannot
-            // double-consume the same marker.
-            tracing::info!(
-                company = %company,
-                agent = %agent_id,
-                marker_id = %stale.id,
-                "[budget-pause] retired a stale re-issue marker; this agent's turn succeeded \
-                 without it, so the pause it named is already resolved"
-            );
+            } {
+                // Issue #1846 review (Codex #3868962381): this turn just
+                // completed WITHOUT pausing, which is proof the account that
+                // blocked the LAST turn now has budget again — whether the
+                // operator got there by clicking "Add credits & resend" (which
+                // already took the marker itself, so this finds nothing) or, as
+                // the notice's own copy also invites, by manually adding credits
+                // and resending the message from the composer, bypassing the
+                // CTA/redeem route entirely. Only the second path used to leave
+                // the marker parked: nothing but a click on THIS specific CTA
+                // ever consumed it, so a manual resend left a stale marker and
+                // its stale CTA sitting on the old notice indefinitely. Clicking
+                // it later would silently re-dispatch the OLD message a second
+                // time — a duplicate, and for a non-idempotent request, a
+                // duplicate side effect the operator never asked for.
+                //
+                // `retire_if_message_matches`, not a peek-then-drop: single
+                // atomic check-and-take, same as every other consumer of this
+                // set, so a concurrent CTA click racing this retire cannot
+                // double-consume the same marker.
+                tracing::info!(
+                    company = %company,
+                    agent = %agent_id,
+                    marker_id = %stale.id,
+                    "[budget-pause] retired a stale re-issue marker; this agent's turn succeeded \
+                     without it, so the pause it named is already resolved"
+                );
+            }
         }
+        let outcome = turn_result_after_metering(outcome, metered, company, agent_id)?;
         // Store: persist the outcome (original task + reply) so it compounds
         // into later turns. Without this the harness never writes memory back.
         // SECURITY: the reply **text only** — the scrubbed `outcome.steps` never
@@ -6130,6 +6145,32 @@ mod tests {
         async fn append_ledger(&self, _id: &CompanyId, entry: LedgerEntry) -> crate::Result<()> {
             self.ledger.lock().unwrap().push(entry);
             Ok(())
+        }
+    }
+
+    /// `CompanyStore` whose `append_ledger` always fails — the "ledger write
+    /// that also failed" `turn_result_after_metering`'s own doc names, and
+    /// the fixture `a_metering_failure_does_not_swallow_a_budget_pause_marker`
+    /// needs to force `meter_turn_costs` into its `Err` arm on a turn that
+    /// otherwise succeeded (Codex review, PR #2053).
+    #[derive(Default)]
+    struct FailingLedgerStore;
+
+    #[async_trait]
+    impl CompanyStore for FailingLedgerStore {
+        async fn load(&self, _id: &CompanyId) -> crate::Result<Option<CompanyRecord>> {
+            Ok(None)
+        }
+        async fn save(&self, _record: &CompanyRecord) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn list(&self) -> crate::Result<Vec<CompanySummary>> {
+            Ok(Vec::new())
+        }
+        async fn append_ledger(&self, _id: &CompanyId, _entry: LedgerEntry) -> crate::Result<()> {
+            Err(OpenCompanyError::Harness(
+                "scripted ledger outage".to_string(),
+            ))
         }
     }
 
@@ -8501,6 +8542,147 @@ description = "Builds the product."
         assert_eq!(marker.agent, "ceo");
         assert_eq!(marker.message, "Please summarize today's standup notes.");
         assert_eq!(marker.summary, pause.summary);
+    }
+
+    /// Codex review (PR #2053) — **the regression.** A ledger write is a
+    /// separate concern from what the turn itself did, and a failure in it
+    /// must not also swallow the OTHER outcome-side-effect this same code
+    /// block performs: retiring a stale re-issue marker once an agent's turn
+    /// succeeds again, proving the account that blocked it now has budget.
+    /// Before this fix, `turn_result_after_metering`'s `?` ran BEFORE this
+    /// retire logic, so a ledger write that failed for an UNRELATED reason
+    /// left the stale marker — and its stale "Add credits & resend" CTA —
+    /// parked indefinitely, able to later re-dispatch the OLD message a
+    /// second time.
+    ///
+    /// Same fixture as `a_successful_turn_retires_a_stale_reissue_marker_for_the_same_agent`
+    /// — a stale marker parked directly, then one ordinary successful `run`
+    /// for the same agent in the same thread — except this provider's reply
+    /// carries real usage, so `turn_costs` is nonzero and `meter_turn_costs`
+    /// actually attempts (and, against `FailingLedgerStore`, fails) a ledger
+    /// write. Reverting the reordering in `run_inner` makes the final `peek`
+    /// below find the marker still parked instead of `None`.
+    #[tokio::test]
+    async fn a_metering_failure_does_not_swallow_a_stale_marker_retirement() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let company = CompanyId::new("acme-budget-meter-fail-retire-regress");
+        let mut rec = record();
+        rec.id = company.clone();
+        let deps = HarnessDeps {
+            notifications: None,
+            ledgers: None,
+            ledger_registry: Default::default(),
+            // A single, ordinary, non-blank reply — the same shape
+            // `a_successful_turn_retires_a_stale_reissue_marker_for_the_same_agent`
+            // scripts, just with usage attached so this turn's spend is
+            // nonzero and `meter_turn_costs` has something to write.
+            provider: Arc::new(
+                ScriptedProvider::new(vec![Ok("Here's today's standup summary.".to_string()); 4])
+                    .reporting_usage(tinyinference::Usage {
+                        input_tokens: 800,
+                        output_tokens: 200,
+                        total_tokens: 1_000,
+                        ..Default::default()
+                    }),
+            ),
+            provider_slug: "scripted".to_string(),
+            serves: None,
+            context: Arc::new(MockContext::default()),
+            store: Arc::new(FailingLedgerStore),
+            meter: None,
+            workspace_root: dir.path().to_path_buf(),
+            mcp_home: None,
+            workspace_git_enabled: false,
+            audit_root: dir.path().to_path_buf(),
+            model_override: None,
+            tasks: None,
+            artifacts: None,
+            skills: None,
+            skills_source_dir: None,
+            skills_registry: std::sync::Arc::from([]),
+            default_mcp_servers: Vec::new(),
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: DelegationQueue::default(),
+            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: McpFailureQueue::default(),
+            pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
+            run_outputs: crate::harness::orchestrator::RunOutputCache::default(),
+            run_output_store: None,
+            workflow_runs: None,
+            deep_trace: None,
+            workflow_revisions: None,
+            approval_requests: ApprovalRequestQueue::default(),
+            secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            workflow_source_dir: None,
+            plan: None,
+            media: None,
+            composio: None,
+            #[cfg(feature = "chargebee")]
+            chargebee: None,
+            #[cfg(feature = "paypal")]
+            paypal: None,
+            hosting: None,
+            steer: crate::company::steer::InflightRegistry::default(),
+            run_supervisor: crate::runtime::RunSupervisor::default(),
+            delivery: None,
+            search: None,
+            tenant_search: None,
+            workspace: None,
+        };
+
+        let pool = HarnessPool::new();
+        pool.ensure(&rec, &deps).await.expect("pool ensures");
+
+        // Park the stale marker directly — standing in for an earlier turn
+        // that genuinely paused, exactly as the sibling retire test does.
+        crate::runtime::grants::budget_pauses_for(&company).park(
+            "ceo",
+            Some("general".to_string()),
+            "Please summarize today's standup notes.",
+            "Paused — ceo's turn ran out of inference budget/credits.",
+            crate::ports::now_millis(),
+            crate::runtime::grants::RedeemContext::default(),
+        );
+        assert!(
+            crate::runtime::grants::budget_pauses_for(&company)
+                .peek("ceo")
+                .is_some(),
+            "the stale marker must be parked before the run this test exercises"
+        );
+
+        let result = pool
+            .run(
+                &company,
+                "ceo",
+                "Please summarize today's standup notes.",
+                &deps,
+                crate::runtime::delegation::ChatTarget::channel(Some("general")),
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "the turn itself succeeded, so the ledger failure is the only failure there is, \
+             and it still propagates — turn_result_after_metering's own documented contract: \
+             {result:?}"
+        );
+
+        // The retirement must have happened regardless — read off the turn's
+        // OWN outcome, before the metering error ever had a chance to short
+        // circuit it.
+        assert!(
+            crate::runtime::grants::budget_pauses_for(&company)
+                .peek("ceo")
+                .is_none(),
+            "the stale marker must be retired even though the ledger write for THIS turn \
+             failed — the ledger is a separate concern from what the turn itself did, and \
+             leaving it parked would let its stale CTA re-dispatch the old message again"
+        );
     }
 
     /// Issue #1846 review (Codex #3869193105) — **the regression.** A

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -1353,17 +1353,30 @@ impl CompanyAgent {
                     // total billed a second time onto a turn that made no
                     // metered call at all.
                     //
-                    // The fix does not reset the field — openhuman does not
-                    // expose a way to from here (`take_last_turn_usage_totals`
-                    // is `pub(crate)` to that crate) — it snapshots it before
-                    // each attempt and only trusts the post-attempt read when
-                    // it actually moved. A read that comes back identical to
-                    // the pre-attempt snapshot is treated as zero rather than
-                    // as this attempt's total; see `last_observed_turn_cost`
-                    // just below for the fallback that still recovers a
-                    // genuinely spent-and-failed attempt's tokens from the
-                    // progress stream when this leaves `usages` all zero.
-                    let mut last_seen_usage = read_turn_usage(&agent);
+                    // Codex review (PR #2053): an earlier version of this fix
+                    // compared each read against the value seen before the
+                    // attempt and treated an unchanged read as zero — which
+                    // wrongly zeroed a genuinely NEW finalized total on the
+                    // rare turn whose real spend happened to numerically equal
+                    // the immediately preceding one. `agent.turn()`'s own
+                    // `Result` already says, unambiguously, whether THIS
+                    // attempt finalized: `Ok` only ever returns non-empty text
+                    // (a blank `Ok` is retried inside openhuman's own loop
+                    // before it can reach here — see the `Empty` arm below),
+                    // and finalizing `last_turn_usage_totals` is part of what
+                    // makes a turn return `Ok` at all. So trust `read_turn_usage`
+                    // outright on `Ok`, regardless of its value, and never trust
+                    // it on `Err` (no comparison needed there either — an
+                    // `Err` never finalizes, so any read after one is
+                    // necessarily either `None`'s zero or a stale carry-over,
+                    // and either way is not this attempt's own). The fix does
+                    // not reset the field itself — openhuman does not expose a
+                    // way to from here (`take_last_turn_usage_totals` is
+                    // `pub(crate)` to that crate) — it reads the outcome
+                    // instead. See `last_observed_turn_cost` just below for the
+                    // fallback that still recovers a genuinely spent-and-failed
+                    // attempt's tokens from its own progress-stream segment.
+                    //
                     // Issue #1680: timed PER ATTEMPT, not across the retry. Each
                     // `agent.turn` opens a fresh harness run with a fresh
                     // wall-clock budget, so a duration spanning both attempts
@@ -1374,13 +1387,12 @@ impl CompanyAgent {
                     let started = std::time::Instant::now();
                     let first = agent.turn(message).await;
                     let first_elapsed = started.elapsed();
-                    let first_observed = read_turn_usage(&agent);
-                    usages.push(if first_observed == last_seen_usage {
-                        TurnUsage::default()
+                    let first_finalized = first.is_ok();
+                    usages.push(if first_finalized {
+                        read_turn_usage(&agent)
                     } else {
-                        first_observed
+                        TurnUsage::default()
                     });
-                    last_seen_usage = first_observed;
                     let reply: crate::Result<String> = match self
                         .classify_turn(first, first_elapsed)
                     {
@@ -1514,20 +1526,18 @@ impl CompanyAgent {
                                 let retry_started = std::time::Instant::now();
                                 let second = agent.turn(message).await;
                                 let second_elapsed = retry_started.elapsed();
-                                // Same snapshot-and-compare as the first attempt
-                                // above: an `EmptyProviderResponse` retry leaves
-                                // `last_turn_usage_totals` exactly where the
-                                // first attempt's own read left it, and without
-                                // this, that figure would be counted a second
-                                // time as this attempt's own.
-                                let second_observed = read_turn_usage(&agent);
-                                usages.push(if second_observed == last_seen_usage {
-                                    TurnUsage::default()
+                                // Same outcome-trusts-the-read rule as the first
+                                // attempt above: only `Ok` means openhuman
+                                // actually finalized a fresh total for THIS
+                                // attempt, so only `Ok` earns trusting
+                                // `read_turn_usage` — regardless of what value
+                                // it reads back.
+                                let second_finalized = second.is_ok();
+                                usages.push(if second_finalized {
+                                    read_turn_usage(&agent)
                                 } else {
-                                    second_observed
+                                    TurnUsage::default()
                                 });
-                                // No third attempt to compare against — nothing
-                                // downstream reads `last_seen_usage` again.
                                 match self.classify_turn(second, second_elapsed) {
                                     AttemptOutcome::Reply(reply) => Ok(reply),
                                     AttemptOutcome::Empty => Ok(crate::harness::mcp_probe::scrub(
@@ -7828,6 +7838,51 @@ description = "Builds the product."
             "both attempts genuinely burned 1,000 tokens each — the first attempt's spend must \
              not be dropped just because the retry went on to publish its own (also real) \
              total: {usages:?}"
+        );
+    }
+
+    /// Codex review (PR #2053): an earlier version of the reused-agent fix
+    /// above compared each `read_turn_usage` against the value seen before
+    /// that attempt, and zeroed a read that came back unchanged — which is
+    /// wrong for a genuinely NEW finalized total that happens to numerically
+    /// equal the immediately preceding one. Two separate, single-attempt,
+    /// fully successful calls on the SAME agent, both scripted with the exact
+    /// same usage, must each report their own real spend in full — neither
+    /// one is a retry, neither one errors, and a coincidental value match is
+    /// not evidence that the second call spent nothing.
+    #[tokio::test]
+    async fn a_second_successful_turn_is_trusted_even_when_its_total_matches_the_first() {
+        let (agent, _deps) = scripted_agent_over(
+            ScriptedProvider::new(vec![Ok("turn one".to_string()), Ok("turn two".to_string())])
+                .reporting_usage(tinyinference::Usage {
+                    input_tokens: 500,
+                    output_tokens: 100,
+                    total_tokens: 600,
+                    ..Default::default()
+                }),
+        );
+
+        let (first_outcome, first_usages) = agent.run("turn one").await;
+        first_outcome.expect("turn one succeeds in a single attempt");
+        let first_tokens: u64 = first_usages
+            .iter()
+            .map(|u| u.input_tokens + u.output_tokens)
+            .sum();
+        assert_eq!(
+            first_tokens, 600,
+            "turn one's own real spend: {first_usages:?}"
+        );
+
+        let (second_outcome, second_usages) = agent.run("turn two").await;
+        second_outcome.expect("turn two also succeeds in a single attempt");
+        let second_tokens: u64 = second_usages
+            .iter()
+            .map(|u| u.input_tokens + u.output_tokens)
+            .sum();
+        assert_eq!(
+            second_tokens, 600,
+            "turn two's finalized total happens to equal turn one's — that coincidence must \
+             not zero it out: {second_usages:?}"
         );
     }
 

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -1337,6 +1337,33 @@ impl CompanyAgent {
                 hooks,
                 Box::pin(async {
                     let mut usages: Vec<TurnUsage> = Vec::new();
+                    // CodeRabbit review (PR #2053): `agent` is the ONE `Agent`
+                    // this pool reuses for every chat of this `(company,
+                    // agent_id)` pair (see `CompanyAgent::agent`'s doc), and
+                    // openhuman's `last_turn_usage_totals` is set only when a
+                    // turn finalizes normally — an attempt that ends in
+                    // `EmptyProviderResponse` returns before that write, so
+                    // `read_turn_usage` reads back whatever the PREVIOUS
+                    // finalized turn left there, not this attempt's (zero) own.
+                    // Left unguarded, that stale figure would ride home in
+                    // `usages` as if this attempt had spent it — for the
+                    // one-shot retry that is the previous ATTEMPT's total
+                    // double-counted; across two separate calls to this method
+                    // on the same reused agent, it is an unrelated PAST TURN's
+                    // total billed a second time onto a turn that made no
+                    // metered call at all.
+                    //
+                    // The fix does not reset the field — openhuman does not
+                    // expose a way to from here (`take_last_turn_usage_totals`
+                    // is `pub(crate)` to that crate) — it snapshots it before
+                    // each attempt and only trusts the post-attempt read when
+                    // it actually moved. A read that comes back identical to
+                    // the pre-attempt snapshot is treated as zero rather than
+                    // as this attempt's total; see `last_observed_turn_cost`
+                    // just below for the fallback that still recovers a
+                    // genuinely spent-and-failed attempt's tokens from the
+                    // progress stream when this leaves `usages` all zero.
+                    let mut last_seen_usage = read_turn_usage(&agent);
                     // Issue #1680: timed PER ATTEMPT, not across the retry. Each
                     // `agent.turn` opens a fresh harness run with a fresh
                     // wall-clock budget, so a duration spanning both attempts
@@ -1347,7 +1374,13 @@ impl CompanyAgent {
                     let started = std::time::Instant::now();
                     let first = agent.turn(message).await;
                     let first_elapsed = started.elapsed();
-                    usages.push(read_turn_usage(&agent));
+                    let first_observed = read_turn_usage(&agent);
+                    usages.push(if first_observed == last_seen_usage {
+                        TurnUsage::default()
+                    } else {
+                        first_observed
+                    });
+                    last_seen_usage = first_observed;
                     let reply: crate::Result<String> = match self
                         .classify_turn(first, first_elapsed)
                     {
@@ -1481,7 +1514,20 @@ impl CompanyAgent {
                                 let retry_started = std::time::Instant::now();
                                 let second = agent.turn(message).await;
                                 let second_elapsed = retry_started.elapsed();
-                                usages.push(read_turn_usage(&agent));
+                                // Same snapshot-and-compare as the first attempt
+                                // above: an `EmptyProviderResponse` retry leaves
+                                // `last_turn_usage_totals` exactly where the
+                                // first attempt's own read left it, and without
+                                // this, that figure would be counted a second
+                                // time as this attempt's own.
+                                let second_observed = read_turn_usage(&agent);
+                                usages.push(if second_observed == last_seen_usage {
+                                    TurnUsage::default()
+                                } else {
+                                    second_observed
+                                });
+                                // No third attempt to compare against — nothing
+                                // downstream reads `last_seen_usage` again.
                                 match self.classify_turn(second, second_elapsed) {
                                     AttemptOutcome::Reply(reply) => Ok(reply),
                                     AttemptOutcome::Empty => Ok(crate::harness::mcp_probe::scrub(
@@ -7599,6 +7645,89 @@ description = "Builds the product."
             tokens, 1_540,
             "a failed turn must carry home the tokens its own model call burned, \
              not report itself as free: {usages:?}"
+        );
+    }
+
+    /// CodeRabbit review (PR #2053): a turn that fails WITHOUT spending
+    /// anything must not inherit an earlier, unrelated turn's totals off the
+    /// **reused** `Agent` — the same "0 tok / $0.000" bug B-120 fixes, in the
+    /// opposite direction: a turn that spent nothing must not be billed for
+    /// what a PAST turn on this same agent already spent and was already
+    /// billed for.
+    ///
+    /// `CompanyAgent` reuses one `Agent` for every chat of a `(company,
+    /// agent_id)` pair, and openhuman finalizes `last_turn_usage_totals` only
+    /// on a turn that completes normally — an attempt that ends in
+    /// `EmptyProviderResponse` never touches it, so a naive read after such an
+    /// attempt reads back whatever the LAST *successful* turn on this agent
+    /// left there, not this attempt's own (zero) spend. Left unguarded, that
+    /// stale figure — already billed once when the first turn settled — would
+    /// be billed a second time on a completely different, later turn that
+    /// made no metered call at all.
+    ///
+    /// Turn 1 succeeds in one attempt and spends 1,540 tokens for real — the
+    /// exact figure `last_turn_usage_totals` is left holding. Turn 2, on the
+    /// SAME agent, scripts an immediate blank (`EmptyProviderResponse`) and
+    /// then a hard failure on the one-shot retry once the script is exhausted
+    /// — the identical shape `a_hard_failed_turn_still_reports_the_tokens_it_burned`
+    /// already pins, just as the SECOND top-level call on this agent rather
+    /// than the first. Because this provider carries usage on every scripted
+    /// reply, turn 2's own first attempt genuinely burns another 1,540 tokens
+    /// before dying, which the live `TurnCostUpdated` tally still recovers
+    /// (`last_observed_turn_cost`) — so the correct total is 1,540 exactly,
+    /// not 3,080 (turn 1's stale total, read back and double-counted across
+    /// turn 2's own two attempts on top of what turn 2 itself burned).
+    #[tokio::test]
+    async fn a_turn_that_burns_nothing_does_not_inherit_a_past_turns_stale_total() {
+        let (agent, _deps) = scripted_agent_over(
+            ScriptedProvider::new(vec![
+                Ok("turn one finished cleanly".to_string()),
+                Ok(String::new()),
+            ])
+            .reporting_usage(tinyinference::Usage {
+                input_tokens: 1_200,
+                output_tokens: 340,
+                total_tokens: 1_540,
+                ..Default::default()
+            })
+            .failing_when_exhausted(),
+        );
+
+        // Turn one: a real, one-attempt success. Leaves
+        // `last_turn_usage_totals` holding 1,540 tokens.
+        let (outcome, usages) = agent.run("turn one").await;
+        outcome.expect("turn one is a clean, successful reply");
+        assert_eq!(
+            usages
+                .iter()
+                .map(|u| u.input_tokens + u.output_tokens)
+                .sum::<u64>(),
+            1_540,
+            "turn one's own real spend"
+        );
+
+        // Turn two, same agent: attempt 1 consumes the scripted blank
+        // (EmptyProviderResponse), the retry then finds the script exhausted
+        // and hits the permanent failure — both attempts error, neither
+        // finalizes `last_turn_usage_totals`, and without the fix both reads
+        // would instead return turn one's already-billed 1,540 a second AND
+        // third time.
+        let (second_outcome, second_usages) = agent.run("turn two").await;
+        assert!(
+            second_outcome.is_err(),
+            "turn two's provider is permanently down past its first call: {:?}",
+            second_outcome.as_ref().map(|o| o.reply.clone())
+        );
+        let second_tokens: u64 = second_usages
+            .iter()
+            .map(|u| u.input_tokens + u.output_tokens)
+            .sum();
+        assert_eq!(
+            second_tokens, 1_540,
+            "turn two must report its OWN spend — one metered call, recovered via the live \
+             progress-stream tally since its own attempt also errors before finalizing totals \
+             — never turn one's already-billed total read back a second and third time: \
+             {second_usages:?}"
         );
     }
 

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -941,6 +941,18 @@ impl CompanyAgent {
     /// what the model actually consumed (a burnt empty attempt still costs
     /// tokens).
     ///
+    /// # Why the usage is beside the `Result`, not inside it
+    ///
+    /// A failing turn is not a free turn. A wall-clock ceiling fires *because*
+    /// the agent did ten minutes of real work, and the tokens it read back are
+    /// as owed as a success's. Returning `Result<(TurnOutcome, Vec<TurnUsage>)>`
+    /// made "the turn failed" and "there is nothing to meter" the same value, so
+    /// a `?` anywhere downstream silently dropped the spend from the attempt
+    /// row, from the ledger and from the usage meter alike — the console then
+    /// reported ten minutes of model work as `0 tok / $0.000`. The tuple is the
+    /// fix that the compiler enforces: a caller must handle the usage before it
+    /// can even look at the outcome.
+    ///
     /// The usage is read from each just-completed turn via openhuman's public
     /// [`Agent::last_turn_usage`](oh::agent::Agent::last_turn_usage) accessor
     /// while the agent lock is still held. An offline provider that reports no
@@ -957,7 +969,7 @@ impl CompanyAgent {
     /// [`steps::fold_steps`](crate::harness::steps::fold_steps). The sink is
     /// per-turn *local* — deliberately not a [`HarnessDeps`] field — so parallel
     /// turns never collide.
-    pub async fn run(&self, message: &str) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
+    pub async fn run(&self, message: &str) -> (crate::Result<TurnOutcome>, Vec<TurnUsage>) {
         self.run_with_steer(
             message,
             None,
@@ -1018,7 +1030,7 @@ impl CompanyAgent {
         // that type documents: a mis-paired channel and root compiles and then
         // answers into the wrong conversation.
         chat: crate::runtime::delegation::ChatTarget<'_>,
-    ) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
+    ) -> (crate::Result<TurnOutcome>, Vec<TurnUsage>) {
         // Per-turn progress sink + an always-draining collector, so a burst of
         // events never blocks the turn loop on a full channel.
         //
@@ -1319,7 +1331,7 @@ impl CompanyAgent {
         // `Box::pin` at the task-local scope boundary (the nested-scope
         // stack-overflow trap). The turn body owns the retry classification and
         // reports every attempt's usage.
-        let (reply, usages): (crate::Result<String>, Vec<TurnUsage>) =
+        let (reply, mut usages): (crate::Result<String>, Vec<TurnUsage>) =
             oh::agent::stop_hooks::with_stop_hooks(
                 hooks,
                 Box::pin(async {
@@ -1517,6 +1529,51 @@ impl CompanyAgent {
         let hit_iteration_cap = agent.last_turn_hit_cap();
         drop(agent);
         let events = collector.await.unwrap_or_default();
+        // A hard-failed turn's spend, recovered from the progress stream.
+        //
+        // `read_turn_usage` above reads openhuman's `last_turn_usage_totals`,
+        // and `run_single` sets that only AFTER its own `let outcome = outcome?`
+        // — so an attempt that ended in an error publishes nothing at all, and
+        // `read_turn_usage` pushed a zero for it. That is precisely backwards
+        // for the attempts worth accounting for: a wall-clock ceiling fires
+        // *because* the agent did ten minutes of real work, and the run a
+        // founder most needs the cost of was the one reported as free.
+        //
+        // The live tally openhuman publishes as it goes — `TurnCostUpdated`,
+        // cumulative across the turn, emitted after each provider response that
+        // carried a usage block — survives the error, because those frames were
+        // already sent down this channel. So a last attempt that reported
+        // nothing takes the last tally the stream carried.
+        //
+        // **Only when NO attempt published anything**, which is what makes this
+        // incapable of double-counting. The tally is cumulative per
+        // `agent.turn` — openhuman builds the retry a fresh `TurnCost` starting
+        // back at zero, the same property the spend brake above relies on — so
+        // the last frame belongs to whichever attempt emitted it, and folding it
+        // in beside an attempt that had *also* published its own authoritative
+        // total could charge the same tokens twice. When even one attempt
+        // published, those figures stand alone and this does nothing.
+        //
+        // **A lower bound, stated rather than discovered.** `TurnCostUpdated`
+        // is suppressed for child scopes (openhuman's `observability`: a
+        // sub-agent's spend reaches the parent's `last_turn_usage_totals`
+        // instead), so a failed turn that had delegated under-reports the
+        // delegates. Understating a failed turn is a far smaller wrong than
+        // reporting it as free, and this seam cannot see more than the stream
+        // carries.
+        if usages.iter().all(TurnUsage::is_zero)
+            && let Some(observed) = last_observed_turn_cost(&events)
+            && let Some(last) = usages.last_mut()
+        {
+            tracing::info!(
+                agent = %self.agent_id,
+                input_tokens = observed.input_tokens,
+                output_tokens = observed.output_tokens,
+                cost_usd = observed.cost_usd,
+                "[turn] the attempt published no totals; metering the spend observed on its progress stream"
+            );
+            *last = observed;
+        }
         // The cap openhuman was actually enforcing, for the trace only. Taken
         // from the last `IterationStarted` rather than from config, so the log
         // reports the number the turn ran under instead of the one this crate
@@ -1583,20 +1640,21 @@ impl CompanyAgent {
         }
         let steps = steps::fold_steps(events);
 
-        let reply = reply?;
-        Ok((
-            TurnOutcome {
-                reply,
-                steps,
-                hit_iteration_cap,
-                // This is the built_in harness, not the ACP fold — the only
-                // path that produces an abnormal stop (PR #1880 review).
-                abnormal_stop: None,
-                halted_for_spend,
-                budget_paused,
-            },
-            usages,
-        ))
+        // The usage is returned BESIDE the result, never inside it (issue
+        // B-120). `reply?` here would have discarded `usages` on every hard
+        // failure — a wall-clock ceiling, a provider fault, an auth error —
+        // and those attempts had already burned every token they read back.
+        let outcome = reply.map(|reply| TurnOutcome {
+            reply,
+            steps,
+            hit_iteration_cap,
+            // This is the built_in harness, not the ACP fold — the only
+            // path that produces an abnormal stop (PR #1880 review).
+            abnormal_stop: None,
+            halted_for_spend,
+            budget_paused,
+        });
+        (outcome, usages)
     }
 
     /// This turn's in-turn spend ceiling, in USD — the value that
@@ -1728,6 +1786,106 @@ fn read_turn_usage(agent: &Agent) -> TurnUsage {
             cost_usd: u.cost_usd,
         })
         .unwrap_or_default()
+}
+
+/// The last cumulative cost tally openhuman published on a turn's progress
+/// stream, or `None` when the turn made no metered model call.
+///
+/// [`TurnCostUpdated`](oh::agent::progress::AgentProgress::TurnCostUpdated) is
+/// cumulative across one `agent.turn`, so the **last** frame is the whole
+/// attempt's spend and earlier ones must never be summed with it.
+///
+/// This is the only figure a hard-failed attempt leaves behind — see the call
+/// site in [`CompanyAgent::run_with_steer`] for why `read_turn_usage` reads back
+/// nothing for one.
+fn last_observed_turn_cost(events: &[oh::agent::progress::AgentProgress]) -> Option<TurnUsage> {
+    events.iter().rev().find_map(|event| match event {
+        oh::agent::progress::AgentProgress::TurnCostUpdated {
+            input_tokens,
+            output_tokens,
+            cached_input_tokens,
+            total_usd,
+            ..
+        } => Some(TurnUsage {
+            input_tokens: *input_tokens,
+            output_tokens: *output_tokens,
+            cached_input_tokens: *cached_input_tokens,
+            cost_usd: *total_usd,
+        }),
+        _ => None,
+    })
+}
+
+/// Writes every attempt's spend of a **finished** turn to the ledger and the
+/// usage meter, whether that turn succeeded or failed.
+///
+/// The one place `record_turn_cost` is called from the pool, so the two turn
+/// paths cannot disagree about when a turn is metered. Both call it *before*
+/// they unwrap the turn's own result — see
+/// [`turn_result_after_metering`] for why that ordering is the fix and not an
+/// accident of layout.
+async fn meter_turn_costs(
+    turn_costs: &[TurnUsage],
+    agent_id: &str,
+    company: &CompanyId,
+    deps: &HarnessDeps,
+    run_id: Option<&str>,
+) -> crate::Result<()> {
+    // Attribute cost to the provider and model this turn actually resolved to.
+    // With a per-tenant [`TenantProvider`](crate::harness::provider::TenantProvider)
+    // a console BYOK switch changes the slug between turns, so read both live
+    // rather than trusting the static `deps.provider_slug` baked at build. The
+    // model is folded onto the closed vocabulary at the provider so no
+    // operator-authored model name reaches the meter (issue #1749).
+    let provider_slug = deps.provider.telemetry_provider_id();
+    let model_slug = deps.provider.telemetry_model();
+    for turn_cost in turn_costs {
+        record_turn_cost(
+            turn_cost,
+            agent_id,
+            &provider_slug,
+            model_slug,
+            company,
+            deps.store.as_ref(),
+            deps.meter.as_deref(),
+            run_id,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// Resolves a metered turn into the one error that should propagate.
+///
+/// A turn's own failure outranks a metering failure. The turn is the thing the
+/// operator asked for and its error is the one that explains what they see; a
+/// ledger write that also failed is a second, quieter problem, and letting it
+/// replace the first would report "could not append to the ledger" for a run
+/// that actually hit its wall-clock ceiling.
+///
+/// The reverse case is not symmetric: when the turn *succeeded*, a metering
+/// failure is the only failure there is, and it still propagates — losing a
+/// ledger entry silently is the class of bug this whole path exists to close.
+fn turn_result_after_metering(
+    outcome: crate::Result<TurnOutcome>,
+    metered: crate::Result<()>,
+    company: &CompanyId,
+    agent_id: &str,
+) -> crate::Result<TurnOutcome> {
+    match outcome {
+        Err(turn_error) => {
+            if let Err(meter_error) = metered {
+                tracing::warn!(
+                    company = %company,
+                    agent = %agent_id,
+                    error = %meter_error,
+                    "[cost] could not meter a failed turn's spend; reporting the turn's own error"
+                );
+            }
+            Err(turn_error)
+        }
+        Ok(outcome) => metered.map(|()| outcome),
+    }
 }
 
 /// Whether a turn error is the transient empty-response class openhuman raises
@@ -3660,25 +3818,13 @@ impl HarnessPool {
                 None,
                 crate::runtime::delegation::ChatTarget::default(),
             )
-            .await?;
+            .await;
 
-        let provider_slug = deps.provider.telemetry_provider_id();
-        let model_slug = deps.provider.telemetry_model();
-        for turn_cost in &turn_costs {
-            record_turn_cost(
-                turn_cost,
-                confine::CONFINED_AGENT_ID,
-                &provider_slug,
-                model_slug,
-                company,
-                deps.store.as_ref(),
-                deps.meter.as_deref(),
-                None,
-            )
-            .await?;
-        }
-
-        Ok(outcome)
+        // Metered before the outcome is unwrapped: a copilot turn that failed
+        // still consumed whatever it consumed before it failed.
+        let metered =
+            meter_turn_costs(&turn_costs, confine::CONFINED_AGENT_ID, company, deps, None).await;
+        turn_result_after_metering(outcome, metered, company, confine::CONFINED_AGENT_ID)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4038,7 +4184,40 @@ impl HarnessPool {
                 chat,
             )),
         )
-        .await?;
+        .await;
+        // Issue B-120: bank what the turn spent BEFORE its result is unwrapped.
+        //
+        // Both consumers of `turn_costs` used to sit below a `?` on this very
+        // await, so a turn that ended in a hard error — a wall-clock ceiling
+        // above all, which fires precisely *because* the agent worked for ten
+        // minutes — reached neither of them. The attempt row settled with a
+        // default `TokenUsage`, the ledger got no `inference.spend` entry, and
+        // the meter got no `UsageSample`: the console reported the most
+        // expensive runs a founder owns as free, and the company-wide total
+        // agreed with it, because the spend had never been recorded anywhere.
+        //
+        // First consumer: the attempt row's own total (issue #242). Per turn,
+        // not once at the end, so a redirect re-run and a delegate's turn both
+        // count — an attempt's cost is what the attempt spent. This is a second
+        // *reader* of `turn_costs`, not a second writer: the ledger and the
+        // usage meter below stay the only places money is recorded.
+        if let Some(sink) = run_sink.as_ref() {
+            for turn_cost in &turn_costs {
+                sink.add_usage(turn_cost);
+            }
+        }
+        // Second consumer: the ledger and the usage meter. Issue #242 also
+        // attributes the sample to the attempt this turn ran under, so "what did
+        // this run cost?" is answerable from the meter as well as from the row.
+        let metered = meter_turn_costs(
+            &turn_costs,
+            agent_id,
+            company,
+            deps,
+            run_sink.as_ref().map(|s| s.run_id()),
+        )
+        .await;
+        let outcome = turn_result_after_metering(outcome, metered, company, agent_id)?;
         // Issue #1846: park a durable re-issue marker the moment a pause is
         // seen, mirroring the grant-reissue precedent (`crate::runtime::grants`)
         // — mint on the event that needs a later redemption, not on whatever
@@ -4171,42 +4350,6 @@ impl HarnessPool {
                  without it, so the pause it named is already resolved"
             );
         }
-        // Issue #242: fold this turn's spend into the attempt it belongs to.
-        // Per turn, not once at the end, so a redirect re-run and a delegate's
-        // turn both count — an attempt's cost is what the attempt spent. This is
-        // a second *reader* of `turn_costs`, not a second writer: the ledger and
-        // the usage meter below stay the only places money is recorded.
-        if let Some(sink) = run_sink.as_ref() {
-            for turn_cost in &turn_costs {
-                sink.add_usage(turn_cost);
-            }
-        }
-        // Attribute cost to the provider this turn actually resolved to. With a
-        // per-tenant [`TenantProvider`](crate::harness::provider::TenantProvider)
-        // a console BYOK switch changes the slug between turns, so read it live
-        // rather than trusting the static `deps.provider_slug` baked at build.
-        let provider_slug = deps.provider.telemetry_provider_id();
-        // And to the model it actually resolved to, read live for the same
-        // reason and folded onto the closed vocabulary at the provider so no
-        // operator-authored model name reaches the meter (issue #1749).
-        let model_slug = deps.provider.telemetry_model();
-        for turn_cost in &turn_costs {
-            record_turn_cost(
-                turn_cost,
-                agent_id,
-                &provider_slug,
-                model_slug,
-                company,
-                deps.store.as_ref(),
-                deps.meter.as_deref(),
-                // Issue #242: attribute the sample to the attempt this turn ran
-                // under, so "what did this run cost?" is answerable from the
-                // meter as well as from the run row.
-                run_sink.as_ref().map(|s| s.run_id()),
-            )
-            .await?;
-        }
-
         // Store: persist the outcome (original task + reply) so it compounds
         // into later turns. Without this the harness never writes memory back.
         // SECURITY: the reply **text only** — the scrubbed `outcome.steps` never
@@ -7194,6 +7337,58 @@ description = "Builds the product."
         assert!(fx.meter.samples.lock().unwrap().is_empty());
     }
 
+    /// B-120, the half that made a founder's console disagree with their bill:
+    /// a turn that ends in an error is still written to the ledger and the usage
+    /// meter.
+    ///
+    /// Both writes used to sit below a `?` on the turn — so a wall-clock ceiling
+    /// or a provider fault produced no `inference.spend` entry and no
+    /// `UsageSample` at all. The spend was not merely mis-displayed on the run:
+    /// it was never recorded anywhere, which is why the company-wide Observatory
+    /// total agreed that ten minutes of model work had been free.
+    #[tokio::test]
+    async fn a_failed_turn_is_still_written_to_the_ledger_and_the_meter() {
+        let mut fx = fixture();
+        fx.deps.provider = Arc::new(
+            ScriptedProvider::new(vec![Ok(String::new())])
+                .reporting_usage(tinyinference::Usage {
+                    input_tokens: 1_200,
+                    output_tokens: 340,
+                    total_tokens: 1_540,
+                    ..Default::default()
+                })
+                .failing_when_exhausted(),
+        );
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+        let outcome = pool
+            .run(
+                &rec.id,
+                "ceo",
+                "do ten minutes of work",
+                &fx.deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
+            .await;
+
+        assert!(outcome.is_err(), "the scripted provider stays down");
+        let samples = fx.meter.samples.lock().unwrap().clone();
+        assert_eq!(
+            samples.len(),
+            1,
+            "the failed turn's tokens must reach the usage meter: {samples:?}"
+        );
+        assert_eq!(samples[0].input_tokens, 1_200);
+        assert_eq!(samples[0].output_tokens, 340);
+        assert_eq!(
+            fx.store.ledger.lock().unwrap().len(),
+            1,
+            "and its spend must reach the ledger, or the console and the bill disagree"
+        );
+    }
+
     // --- Empty-response turn wrapper ----------------------------------------
 
     /// A model that plays back a scripted sequence of outcomes, one per
@@ -7204,6 +7399,21 @@ description = "Builds the product."
     struct ScriptedProvider {
         script: StdMutex<std::collections::VecDeque<Result<String, String>>>,
         calls: std::sync::atomic::AtomicUsize,
+        /// Usage stamped on every scripted `Ok` response, when the case needs a
+        /// provider that reports any (`None` — the default — mirrors
+        /// `MockProvider`, whose replies carry none at all). Only a response
+        /// carrying usage makes openhuman publish the live
+        /// `TurnCostUpdated` tally the metering path depends on.
+        usage: Option<tinyinference::Usage>,
+        /// What an exhausted script answers: the default `"exhausted"` reply,
+        /// or a permanent error.
+        ///
+        /// A case that needs the turn to *fail* has to script a provider that
+        /// stays failed, because openhuman retries a provider error inside its
+        /// own loop — a finite run of `Err` entries is simply consumed and the
+        /// turn then succeeds on the fallback reply, which is how this
+        /// scripting seam quietly turned a failure case into a passing one.
+        fail_when_exhausted: bool,
     }
 
     impl ScriptedProvider {
@@ -7211,7 +7421,21 @@ description = "Builds the product."
             Self {
                 script: StdMutex::new(outcomes.into_iter().collect()),
                 calls: std::sync::atomic::AtomicUsize::new(0),
+                usage: None,
+                fail_when_exhausted: false,
             }
+        }
+
+        /// Report `usage` on every scripted `Ok` response.
+        fn reporting_usage(mut self, usage: tinyinference::Usage) -> Self {
+            self.usage = Some(usage);
+            self
+        }
+
+        /// Fail every call past the end of the script, permanently.
+        fn failing_when_exhausted(mut self) -> Self {
+            self.fail_when_exhausted = true;
+            self
         }
     }
 
@@ -7223,10 +7447,18 @@ description = "Builds the product."
             _request: ModelRequest,
         ) -> tinyinference::Result<ModelResponse> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let with_usage = |reply: &str| {
+                let mut response = ModelResponse::assistant(reply);
+                response.usage = self.usage;
+                response
+            };
             match self.script.lock().unwrap().pop_front() {
-                Some(Ok(reply)) => Ok(ModelResponse::assistant(reply)),
+                Some(Ok(reply)) => Ok(with_usage(&reply)),
                 Some(Err(err)) => Err(tinyinference::Error::Model(err)),
-                None => Ok(ModelResponse::assistant("exhausted")),
+                None if self.fail_when_exhausted => Err(tinyinference::Error::Model(
+                    "scripted provider is permanently down".to_string(),
+                )),
+                None => Ok(with_usage("exhausted")),
             }
         }
     }
@@ -7240,12 +7472,18 @@ description = "Builds the product."
     /// Build a single [`CompanyAgent`] over a scripted provider so the wrapper can
     /// be exercised directly (its retry logic is the unit under test).
     fn scripted_agent(outcomes: Vec<Result<String, String>>) -> (Arc<CompanyAgent>, HarnessDeps) {
+        scripted_agent_over(ScriptedProvider::new(outcomes))
+    }
+
+    /// As [`scripted_agent`], over an already-configured provider — the seam a
+    /// case that needs the provider to *report usage* builds through.
+    fn scripted_agent_over(provider: ScriptedProvider) -> (Arc<CompanyAgent>, HarnessDeps) {
         let dir = tempfile::tempdir().expect("tempdir");
         let deps = HarnessDeps {
             notifications: None,
             ledgers: None,
             ledger_registry: Default::default(),
-            provider: Arc::new(ScriptedProvider::new(outcomes)),
+            provider: Arc::new(provider),
             provider_slug: "scripted".to_string(),
             serves: None,
             context: Arc::new(MockContext::default()),
@@ -7307,13 +7545,96 @@ description = "Builds the product."
     #[tokio::test]
     async fn turn_wrapper_retries_empty_then_recovers() {
         let (agent, _deps) = scripted_agent(vec![Ok(String::new()), Ok("recovered".into())]);
-        let (outcome, usages) = agent.run("hi").await.expect("wrapper recovers");
+        let (outcome, usages) = agent.run("hi").await;
+        let outcome = outcome.expect("wrapper recovers");
         assert!(
             outcome.reply.contains("recovered"),
             "got {:?}",
             outcome.reply
         );
         assert_eq!(usages.len(), 2, "both attempts' usage is returned");
+    }
+
+    /// B-120: a turn that ends in a **hard error** still reports what it spent.
+    ///
+    /// The failure this pins is the one a founder saw as `0 tok / $0.000` on a
+    /// ten-minute run: openhuman sets `last_turn_usage_totals` only after its
+    /// own `?`, so `read_turn_usage` reads back nothing for an attempt that
+    /// errored, and the usage then rode home on an `Ok` the caller never got.
+    ///
+    /// The script burns a real, usage-reporting model call and then fails:
+    /// attempt 1 answers with usage but no text (openhuman raises
+    /// `EmptyProviderResponse`, so it publishes no totals), and the one-shot
+    /// retry hits a hard provider error. Both attempts therefore report zero of
+    /// their own, and the only surviving figure is the live `TurnCostUpdated`
+    /// tally — which is exactly what has to reach the caller *beside* the
+    /// `Err`, because that is what the attempt row, the ledger and the usage
+    /// meter are all built from.
+    #[tokio::test]
+    async fn a_hard_failed_turn_still_reports_the_tokens_it_burned() {
+        let (agent, _deps) = scripted_agent_over(
+            ScriptedProvider::new(vec![Ok(String::new())])
+                .reporting_usage(tinyinference::Usage {
+                    input_tokens: 1_200,
+                    output_tokens: 340,
+                    total_tokens: 1_540,
+                    ..Default::default()
+                })
+                .failing_when_exhausted(),
+        );
+
+        let (outcome, usages) = agent.run("do ten minutes of work").await;
+
+        assert!(
+            outcome.is_err(),
+            "the provider is permanently down past the first call; the turn must fail: {:?}",
+            outcome.as_ref().map(|o| o.reply.clone())
+        );
+        let tokens: u64 = usages
+            .iter()
+            .map(|u| u.input_tokens + u.output_tokens)
+            .sum();
+        assert_eq!(
+            tokens, 1_540,
+            "a failed turn must carry home the tokens its own model call burned, \
+             not report itself as free: {usages:?}"
+        );
+    }
+
+    /// The tally is **cumulative**, so the last frame is the whole attempt's
+    /// spend — summing the frames would multiply it, and taking the first would
+    /// report only the opening call of a fifty-step run.
+    #[test]
+    fn the_observed_turn_cost_is_the_last_tally_not_the_first_or_the_sum() {
+        let frame = |iteration: u32, input: u64, output: u64, usd: f64| {
+            oh::agent::progress::AgentProgress::TurnCostUpdated {
+                model: "scripted".to_string(),
+                iteration,
+                input_tokens: input,
+                output_tokens: output,
+                cached_input_tokens: 0,
+                total_usd: usd,
+            }
+        };
+        let events = vec![
+            frame(1, 100, 10, 0.001),
+            oh::agent::progress::AgentProgress::TextDelta {
+                delta: "thinking".to_string(),
+                iteration: 2,
+            },
+            frame(2, 900, 250, 0.019),
+        ];
+
+        let observed = last_observed_turn_cost(&events).expect("a tally was published");
+
+        assert_eq!(observed.input_tokens, 900);
+        assert_eq!(observed.output_tokens, 250);
+        assert!((observed.cost_usd - 0.019).abs() < f64::EPSILON);
+        assert_eq!(
+            last_observed_turn_cost(&[]),
+            None,
+            "a turn that made no metered model call has no tally to report"
+        );
     }
 
     /// Issue #111 retry-guard edge: when a steer already pends and the first
@@ -7336,8 +7657,8 @@ description = "Builds the product."
                 None,
                 crate::runtime::delegation::ChatTarget::default(),
             )
-            .await
-            .expect("runs");
+            .await;
+        let _outcome = _outcome.expect("runs");
         assert_eq!(
             usages.len(),
             1,
@@ -7357,7 +7678,8 @@ description = "Builds the product."
     #[tokio::test]
     async fn turn_wrapper_empty_twice_is_graceful() {
         let (agent, _deps) = scripted_agent(vec![Ok(String::new()), Ok(String::new())]);
-        let (outcome, usages) = agent.run("hi").await.expect("graceful, not an Err");
+        let (outcome, usages) = agent.run("hi").await;
+        let outcome = outcome.expect("graceful, not an Err");
         assert!(
             outcome
                 .reply

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1055,13 +1055,17 @@ struct DeleteWorkflowQuery {
 /// holding a stale graph could remove a workflow that changed underneath it. A
 /// missing `?expectedVersion=` is now a `400`.
 ///
-/// `204` on success. `400` for a missing `expectedVersion`; `404` for an unknown
-/// id; `409` for a source-defined or body-less id, or a stale `expectedVersion`.
+/// `200` with [`DeleteWorkflowResponse`] on success — **not** `204` (CodeRabbit
+/// review, PR #2053): the sweep's own count is the only truthful source for
+/// "was a run actually stopped", and a `204` has nowhere to carry it. See that
+/// type's doc for why the console cannot derive the same answer itself. `400`
+/// for a missing `expectedVersion`; `404` for an unknown id; `409` for a
+/// source-defined or body-less id, or a stale `expectedVersion`.
 async fn delete_workflow(
     company: ScopedCompany,
     Path(WorkflowPath { wid }): Path<WorkflowPath>,
     Query(query): Query<DeleteWorkflowQuery>,
-) -> Result<StatusCode, ApiError> {
+) -> Result<Json<DeleteWorkflowResponse>, ApiError> {
     if !safe_wid(&wid) {
         return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
             "workflow {wid}"
@@ -1094,8 +1098,30 @@ async fn delete_workflow(
     // first, or a run cancelled here could be replaced by one racing in behind
     // it through a route that still resolves the graph — the same ordering
     // Pause's sweep takes for the same reason.
-    company.runtime.stop_runs_of_workflow(&wid);
-    Ok(StatusCode::NO_CONTENT)
+    let stopped_runs = company.runtime.stop_runs_of_workflow(&wid);
+    Ok(Json(DeleteWorkflowResponse { stopped_runs }))
+}
+
+/// The `DELETE …/workflows/{wid}` response body (CodeRabbit review, PR #2053).
+///
+/// The console used to guess "did this delete stop a run" from its own
+/// pre-request state (whether it was watching a run when the operator clicked
+/// Delete) and print that guess in the confirmation toast. That guess and this
+/// count can disagree in the most ordinary way possible, no race required: a
+/// long run the console was watching can finish **on its own**, normally, in
+/// the seconds between the operator clicking the confirm button and this
+/// request reaching the sweep — at which point [`stop_runs_of_workflow`]
+/// truthfully stops nothing, while the console's pre-request guess still says
+/// it did. `stopped_runs` is the sweep's own count, the only place that
+/// answer actually lives.
+///
+/// [`stop_runs_of_workflow`]: crate::company::runtime::CompanyRuntime::stop_runs_of_workflow
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeleteWorkflowResponse {
+    /// How many in-flight runs of this workflow the sweep fired a stop at.
+    /// Zero is a completely ordinary answer — see the type doc.
+    stopped_runs: usize,
 }
 
 /// The `PUT …/workflows/{wid}/enabled` body.
@@ -10133,7 +10159,7 @@ mod tests {
                 ))
                 .await
                 .unwrap();
-            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+            assert_eq!(response.status(), StatusCode::OK);
 
             // Gone from the picker…
             let response = router(state.clone())
@@ -10190,7 +10216,7 @@ mod tests {
                 ))
                 .await
                 .unwrap();
-            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+            assert_eq!(response.status(), StatusCode::OK);
 
             let response = router(state)
                 .oneshot(request(
@@ -10327,7 +10353,7 @@ mod tests {
                 ))
                 .await
                 .unwrap();
-            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+            assert_eq!(response.status(), StatusCode::OK);
         }
 
         /// A manifest-`enabled` id with no saved graph is listed but NOT
@@ -11036,7 +11062,13 @@ label = "ok"
                 .oneshot(delete_workflow_request(&version))
                 .await
                 .unwrap();
-            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+            assert_eq!(response.status(), StatusCode::OK);
+            // CodeRabbit review (PR #2053): the count the console's toast now
+            // reads has to be the sweep's own answer, not a client-side guess —
+            // pin it here so a regression back to "no body" or a miscounted
+            // sweep shows up as a body assertion rather than only as a wrong
+            // toast nobody is testing.
+            assert_eq!(json_body(response).await["stoppedRuns"], 1);
 
             let CompanyEvent::WorkflowRunFinished {
                 cancelled,
@@ -11090,7 +11122,11 @@ label = "ok"
                 .await
                 .unwrap();
 
-            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+            assert_eq!(response.status(), StatusCode::OK);
+            // CodeRabbit review (PR #2053): the response body is what the
+            // console's toast now reads, so pin the zero here too — the same
+            // reason the in-flight case above pins its 1.
+            assert_eq!(json_body(response).await["stoppedRuns"], 0);
             assert_eq!(
                 c.runtime.stop_runs_of_workflow("demo"),
                 0,

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1042,6 +1042,14 @@ struct DeleteWorkflowQuery {
 /// the workflow did, and that stays true after it is gone — `GET
 /// …/workflows/runs` keeps serving them. See the module doc.
 ///
+/// **A run still in flight is stopped** (B-121). Delete tore down the schedule
+/// and the revisions and left the run executing — and left it *uncontrollable*,
+/// because the only Stop button in the product lives on the workflow detail page
+/// this request removes. So the run went on calling models and spending with
+/// nothing anywhere able to reach it, while `GET …/workflows/runs` kept
+/// reporting it `running: true` under a workflow that no longer existed. See
+/// [`stop_runs_of_workflow`](crate::company::runtime::CompanyRuntime::stop_runs_of_workflow).
+///
 /// `expectedVersion` is **required** (issue #1013), for the same reason it is on
 /// `PUT`: an absent token used to mean an unconditional delete, so a console
 /// holding a stale graph could remove a workflow that changed underneath it. A
@@ -1082,6 +1090,11 @@ async fn delete_workflow(
     )
     .await
     .map_err(ApiError)?;
+    // B-121: after the durable delete, never before. The workflow has to be gone
+    // first, or a run cancelled here could be replaced by one racing in behind
+    // it through a route that still resolves the graph — the same ordering
+    // Pause's sweep takes for the same reason.
+    company.runtime.stop_runs_of_workflow(&wid);
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -10705,6 +10718,25 @@ label = "ok"
                 .unwrap()
         }
 
+        fn get_workflow_request() -> Request<Body> {
+            Request::builder()
+                .uri("/api/v1/company/workflows/demo")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap()
+        }
+
+        fn delete_workflow_request(version: &str) -> Request<Body> {
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/api/v1/company/workflows/demo?expectedVersion={version}"
+                ))
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap()
+        }
+
         async fn json_body(response: axum::response::Response) -> serde_json::Value {
             let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
             serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
@@ -10955,6 +10987,113 @@ label = "ok"
             assert!(
                 !c.completed.load(Ordering::SeqCst),
                 "the run must not have completed its work"
+            );
+        }
+
+        /// **B-121: deleting a workflow stops the run of it still in flight.**
+        ///
+        /// Delete used to take the schedule and the revisions and leave the run
+        /// executing — and, worse, leave it *uncontrollable*: the only Stop
+        /// button in the product is on the workflow detail page the delete
+        /// removes, so the run went on calling models and spending with nothing
+        /// anywhere able to reach it, still reporting `running: true` under a
+        /// workflow that no longer existed.
+        ///
+        /// The assertion that carries the weight is `completed`: the stalled
+        /// runner finishes its work only when released, so a run that reaches
+        /// its own completion here is one the delete failed to stop.
+        #[tokio::test]
+        async fn deleting_a_workflow_stops_the_run_of_it_still_in_flight() {
+            let home_dir = home();
+            let c = stalled_company(home_dir.path()).await;
+
+            let response = c
+                .app
+                .clone()
+                .oneshot(run_request(serde_json::json!({ "detach": true })))
+                .await
+                .unwrap();
+            let run_id = json_body(response).await["runId"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            c.entered.notified().await;
+            assert_eq!(
+                c.runtime.run_supervisor().live().len(),
+                1,
+                "the run has to be genuinely live, or this proves nothing"
+            );
+
+            let response = c.app.clone().oneshot(get_workflow_request()).await.unwrap();
+            let version = json_body(response).await["version"]
+                .as_str()
+                .expect("the graph carries its version token")
+                .to_string();
+            let response = c
+                .app
+                .clone()
+                .oneshot(delete_workflow_request(&version))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+            let CompanyEvent::WorkflowRunFinished {
+                cancelled,
+                error,
+                run_id: journaled_id,
+                ..
+            } = await_finished(&c.runtime)
+                .await
+                .expect("the deleted workflow's run settles rather than running on")
+            else {
+                unreachable!()
+            };
+            assert!(
+                cancelled,
+                "the run of a deleted workflow settles stopped, on the Stop button's own path"
+            );
+            assert!(
+                error.is_none(),
+                "a stop that follows from a delete is not a failure: {error:?}"
+            );
+            assert_eq!(
+                journaled_id.as_deref(),
+                Some(run_id.as_str()),
+                "the same run the run route handed back — no second identifier"
+            );
+            assert!(
+                !c.completed.load(Ordering::SeqCst),
+                "the run must not have gone on to finish the work of a workflow that no \
+                 longer exists"
+            );
+        }
+
+        /// The mirror: a delete with **no** run in flight cancels nothing.
+        /// Without it the sweep above could quietly grow into "delete stops
+        /// something" for a company that had nothing to stop.
+        #[tokio::test]
+        async fn deleting_an_idle_workflow_stops_nothing() {
+            let home_dir = home();
+            let c = stalled_company(home_dir.path()).await;
+
+            assert!(c.runtime.run_supervisor().live().is_empty());
+            let response = c.app.clone().oneshot(get_workflow_request()).await.unwrap();
+            let version = json_body(response).await["version"]
+                .as_str()
+                .expect("version")
+                .to_string();
+            let response = c
+                .app
+                .clone()
+                .oneshot(delete_workflow_request(&version))
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+            assert_eq!(
+                c.runtime.stop_runs_of_workflow("demo"),
+                0,
+                "nothing was in flight, so nothing was stopped"
             );
         }
 


### PR DESCRIPTION
## Summary

Three commits, the first being the only p0 in the whole founder-run backlog.

- **B-120 (p0)** — a run that failed after ten minutes of real model work and
  53 tool calls reported `tokens 0, cost $0.000`, and the company-wide total
  agreed — this was not a display bug, the spend was never recorded anywhere.
  Two independent losses at the point usage is produced: `run_with_steer`
  discarded a hard-failed attempt's usage before either consumer could read
  it (now returns `(Result<TurnOutcome>, Vec<TurnUsage>)`, so a caller cannot
  reach the outcome without handling spend first); and `read_turn_usage`
  returned zero for exactly the failed case, now falling back to the live
  cumulative tally the harness already emits as it goes, bounded to only
  substitute when every attempt reported zero (to avoid ever double-counting).
- **B-005 + B-039** — one root cause on two surfaces: the console narrated how
  a run ended from an assumption instead of the `verdict` the host already
  sends. A run parked on an approval, and one an operator stopped, both got
  the same wrong sentence ("The run finished, but its output didn't match the
  expected node shape") a paragraph below the *correct* account of what
  happened — plus a green "Workflow ran." toast for a run that had just been
  stopped. `noNodeResultsNotice` and `settledRunNotice` now read off the
  verdict instead of assuming, so no caller can pair a wrong tick with a
  right sentence.
- **B-121** — deleting a workflow left its in-flight run executing,
  uncontrollably — the only Stop button in the product lives on the page
  Delete removes. `delete_workflow` now fires the same stop signal B-037's
  pause sweep uses, one scope down, after the durable delete (so a run can't
  race in behind it through a route that still resolves the graph). The
  confirmation dialog was also word-for-word identical to the idle-workflow
  one and never mentioned the run in flight — it now names it and the
  resulting toast says what happened to it.

## Verified

Every commit was verified live in a browser, before/after, on a host built
from its own commit, against the e2e harness company — the exact figures and
API responses are in each commit's own body. Every new test is mutation-proven
(the commit bodies name exactly which mutation each one catches).

## Root cause fixed, not patched

All three land on the same underlying discipline: read state from the host's
own authoritative signal (`verdict`, the live usage tally, the run supervisor's
own stop path) rather than re-deriving or assuming it client-side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run completion messages now reflect the actual outcome, including stopped, failed, blocked, and degraded runs.
  * Runs with no node results now display a clear explanation and provide raw output when appropriate.
  * Deleting a workflow with an active run now stops that run and confirms this in the interface.

* **Bug Fixes**
  * Token usage is preserved and recorded even when a run fails.
  * Workflow deletion no longer leaves associated runs executing in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->