### PR TITLE
fix(tasks): name a card after the work, not the message that asked for it

### DIFF
--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -351,7 +351,17 @@ export interface Task {
 
 /** The create body; the host defaults column→`pending`, priority→`medium`. */
 export interface CreateTask {
-  title: string;
+  /**
+   * The card's headline, when a person typed one.
+   *
+   * Omit it and the host names the card from `note`. The board's `+` dialog and
+   * the prompt box both send one and it is taken verbatim; "Add to board" sends
+   * none, because a chat message is not a title and shortening one in the
+   * browser is how a card ended up called `hey can you take a look at the…`.
+   *
+   * Omitting both this and `note` is a 400.
+   */
+  title?: string;
   note?: string;
   column?: string;
   priority?: string;

--- a/frontend/src/views/CreateTaskDialog.tsx
+++ b/frontend/src/views/CreateTaskDialog.tsx
@@ -46,9 +46,6 @@ import { ADD_TASK_COLUMN, labelFor } from "@/lib/board-columns";
 import { AssigneeSelect } from "./AssigneeSelect";
 
 
-/** How long a derived title may run before the full prompt moves to the note. */
-const TITLE_CAP = 80;
-
 /** The card priorities the host and its edit dialog support. */
 const PRIORITIES = ["low", "medium", "high"] as const;
 type TaskPriority = (typeof PRIORITIES)[number];
@@ -56,22 +53,21 @@ type TaskPriority = (typeof PRIORITIES)[number];
 /**
  * Splits a prompt into the card's `{title, note}` (issue #301).
  *
- * The dialog asks for one thing — what needs doing — so the card's two text
- * fields are derived rather than collected. The rule mirrors the host's own
- * chat task-intent derivation (`src/server/operator.rs`) and `delegate_to_desk`'s
- * `first_line(…, 80)`: the title is the prompt's first line, capped; the note
- * carries the **full** prompt only when the title was shortened from it, so a
- * one-liner does not duplicate itself onto its own card.
+ * The prompt box asks "what needs doing?", so what it collects is an *ask*, not
+ * a name. It used to cut that ask at its first line and post it as the title —
+ * the same rule the chat handler and `delegate_to_desk` used, and the reason a
+ * board of prompt-box cards read as a list of half-sentences. Now the whole
+ * prompt goes as the note and the host names the card from it.
  *
- * The invariant that matters: the operator's full text always survives on the
- * card, in the title or the note. Epic #183 §4's planner reads it from there.
+ * Returns no title at all rather than a derived one: `title` is optional on the
+ * wire precisely so a caller can say "I have no name for this, name it".
+ *
+ * The invariant that matters is unchanged: the operator's full text always
+ * survives on the card. It is simply always in the note now.
  */
-export function derivePromptCard(prompt: string): { title: string; note?: string } {
+export function derivePromptCard(prompt: string): { title?: string; note?: string } {
   const full = prompt.trim();
-  const firstLine = full.split("\n")[0].trim();
-  const title =
-    firstLine.length > TITLE_CAP ? `${firstLine.slice(0, TITLE_CAP).trimEnd()}…` : firstLine;
-  return { title, note: title === full ? undefined : full };
+  return full ? { note: full } : {};
 }
 
 /**
@@ -100,9 +96,9 @@ export function newTaskBody({
   /** The wire value: `""` (unassigned), a desk id, or a teammate id. */
   assignee: string;
 }): CreateTask | null {
-  const { title, note } = derivePromptCard(prompt);
-  if (!title) return null;
-  const body: CreateTask = { title, note };
+  const { note } = derivePromptCard(prompt);
+  if (!note) return null;
+  const body: CreateTask = { note };
   if (deliverable === "workflow") body.deliverable = "workflow";
   if (priority !== "medium") body.priority = priority;
   // Issue #1106. Sent verbatim — a desk stays a desk, exactly as
@@ -230,7 +226,7 @@ export function CreateTaskDialog({
             className="min-h-32 resize-y"
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
-            placeholder="Describe the work. The first line becomes the card's title."
+            placeholder="Describe the work. The card gets named from it."
           />
         </div>
 

--- a/frontend/test/e2e/board-columns.spec.ts
+++ b/frontend/test/e2e/board-columns.spec.ts
@@ -196,7 +196,7 @@ test("new work enters through one prompt box and lands in Pending", async ({ pag
   await expect(page.locator("#new-assignee")).toHaveCount(1);
   await expect(page.locator("#new-priority")).toHaveCount(1);
 
-  // A prompt longer than the title cap: the title is shortened and the full
+  // A prompt longer than the title cap: the host names the card and the full
   // text survives in the note, so nothing the operator typed is lost.
   const marker = `e2e board shape ${Date.now()}`;
   const long = `${marker} — and then a great deal more detail that runs well past the eighty character title cap so the note has to carry it`;
@@ -211,14 +211,21 @@ test("new work enters through one prompt box and lands in Pending", async ({ pag
   type Row = { title: string; note?: string; column: string; priority: string; assignee: string };
   const find = async (): Promise<Row | undefined> => {
     const rows = (await (await request.get(`${API}/tasks`)).json()) as Row[];
-    return rows.find((r) => r.title.startsWith(marker));
+    // Keyed on the NOTE, never the title. The title is derived — a titling
+    // pass names the card from the prompt — so matching the prompt against it
+    // asserts what the host chose to call the work rather than which card this
+    // is. The note carries the operator's text verbatim, which is the property
+    // this test already asserts below and the one that makes it an identity.
+    return rows.find((r) => r.note?.startsWith(marker));
   };
 
   await expect.poll(async () => (await find()) !== undefined, { timeout: 15_000 }).toBe(true);
   const created = (await find())!;
 
   expect(created.column).toBe("pending");
-  expect(created.title.length).toBeLessThanOrEqual(81); // 80 + the ellipsis
+  // The cap the headline type advertises, with the ellipsis budgeted inside it
+  // rather than added past it.
+  expect(created.title.length).toBeLessThanOrEqual(80);
   expect(created.note).toBe(long);
   expect(created.priority).toBe("high");
   // The #1106 default, and the reason adding the control is a no-op for anyone

--- a/frontend/test/e2e/chat-to-card.spec.ts
+++ b/frontend/test/e2e/chat-to-card.spec.ts
@@ -144,8 +144,15 @@ test("a card raised inside a thread opens that thread on the jump back, not just
 
   const tasksResponse = await request.get(`${API}/tasks`);
   expect(tasksResponse.ok()).toBeTruthy();
-  const tasks = (await tasksResponse.json()) as Array<{ id: string; title: string }>;
-  const card = tasks.find((t) => t.title.includes(String(marker)));
+  const tasks = (await tasksResponse.json()) as Array<{
+    id: string;
+    title: string;
+    note?: string;
+  }>;
+  // Keyed on the NOTE, never the title: the card's headline is named by a
+  // titling pass, so the message that opened it is not in there — the note is
+  // where the operator's own words are kept.
+  const card = tasks.find((t) => (t.note ?? "").includes(String(marker)));
   expect(card, `no card opened from "${replyText}": ${JSON.stringify(tasks)}`).toBeTruthy();
 
   await page.goto(`/#/tasks/${card!.id}`);

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -68,7 +68,8 @@
 //      agent call a named MCP tool without a model that might decide not to.
 //   5. a message carrying `SPAWNONE` — call `spawn_task` once, which is what
 //      `chat-to-card.spec.ts` needs an orchestrator to do.
-//   6. anything else — a fixed line carrying the `__MOCK_LLM__` marker.
+//   6. a **card-titling pass** — answer with a short fixed name.
+//   7. anything else — a fixed line carrying the `__MOCK_LLM__` marker.
 //
 // # Why the plain reply quotes nothing
 //
@@ -667,6 +668,45 @@ function isPlanningRequest(messages) {
 }
 
 /**
+ * A card-titling pass, recognised by its own system prompt.
+ *
+ * Beside the triage and planning arms and for their reasons: it runs with no
+ * tools and is not an agent turn, so it must not reach the directive arms — a
+ * request whose text happened to carry `SPAWNONE` would otherwise burn that
+ * directive here and leave the real turn without it.
+ *
+ * @param {any[]} messages
+ * @returns {boolean}
+ */
+function isTitleRequest(messages) {
+  const first = messages[0];
+  return typeof textOf(first) === "string" && textOf(first).includes("You name tasks");
+}
+
+/**
+ * The name this lane gives every card it is asked to title.
+ *
+ * # Why it does not echo the request
+ *
+ * Echoing the first few words back would make every card's headline a prefix
+ * of the message that opened it — which is the exact defect the titling pass
+ * exists to remove, reproduced inside the fixture. A spec that keyed a request
+ * against a title would then pass here and be wrong against any real model, so
+ * the coupling would be hidden rather than gone. A card is identified by its
+ * `note`, which carries the operator's words verbatim; nothing needs the title
+ * to carry them too.
+ *
+ * # Why it carries no `__MOCK_LLM__`
+ *
+ * Every other reply here carries the marker so a spec can prove the reply is
+ * ours. A title is different: it is rendered as a card's headline all over the
+ * console, and specs assert that raw mock text does NOT leak into the UI
+ * (`orchestration-live.spec.ts`). A marker in a title would put it on the board
+ * by construction.
+ */
+const MOCK_TITLE = "Mock titled task";
+
+/**
  * The plan this lane answers every planning pass with (issue #1106).
  *
  * Deliberately **ambiguous**: it names two teammates the `e2e_harness` roster
@@ -745,6 +785,15 @@ function chatCompletion(body) {
   if (isPlanningRequest(messages)) {
     process.stderr.write("[mock brain] planning pass (ambiguous plan, no directive consumed)\n");
     return completion(model, { role: "assistant", content: AMBIGUOUS_PLAN }, "stop");
+  }
+
+  // Third of the not-a-turn arms. Without it a titling pass fell through to the
+  // turn arms and every card in this lane was headlined with the canned reply —
+  // marker and all — which is both unlike anything a real titler returns and a
+  // way for `__MOCK_LLM__` to reach the board.
+  if (isTitleRequest(messages)) {
+    process.stderr.write("[mock brain] card titling pass (no directive consumed)\n");
+    return completion(model, { role: "assistant", content: MOCK_TITLE }, "stop");
   }
 
   // Ahead of the directive arms, and only when the instruction is the LAST

--- a/frontend/test/unit/create-task-body.test.ts
+++ b/frontend/test/unit/create-task-body.test.ts
@@ -30,14 +30,16 @@ describe("newTaskBody", () => {
 
   /**
    * The load-bearing one: a card created without touching either new control
-   * must post what it posted before those controls existed. `column` is absent
-   * for the same reason it always was (#301) — the server's intake default is
-   * what keeps the human drag into In progress the only thing that spends.
+   * posts the prompt and nothing else. `column` is absent for the same reason it
+   * always was (#301) — the server's intake default is what keeps the human drag
+   * into In progress the only thing that spends. `title` is absent because the
+   * host names the card; the browser cutting the prompt into a headline is what
+   * made a board read as a list of half-sentences.
    */
-  it("posts the pre-#580/#1106 body when neither control is touched", () => {
+  it("posts only the prompt when neither control is touched", () => {
     expect(
       newTaskBody({ prompt: "ship the thing", deliverable: "once", priority: "medium", assignee: "" }),
-    ).toEqual({ title: "ship the thing", note: undefined });
+    ).toEqual({ note: "ship the thing" });
   });
 
   it("carries a chosen priority", () => {
@@ -83,21 +85,22 @@ describe("newTaskBody", () => {
     expect(body?.assignee).toBe("devrel");
   });
 
-  it("refuses a prompt with no title to derive", () => {
+  it("refuses a prompt with nothing in it to name a card from", () => {
     expect(
       newTaskBody({ prompt: "   \n  ", deliverable: "once", priority: "medium", assignee: "devrel" }),
     ).toBeNull();
   });
 
   /**
-   * The long-prompt split is #301's and is not re-specified here — this only
-   * pins that routing it through `newTaskBody` did not drop the note, since the
-   * operator's full text surviving on the card is what the planner reads.
+   * The operator's full text surviving on the card is what the planner reads,
+   * and it is now always the note — the dialog sends no title, so the host names
+   * the card instead of the browser cutting the prompt at its first line.
    */
-  it("keeps the full prompt on the note when the title was shortened", () => {
+  it("sends the whole prompt as the note and lets the host name the card", () => {
     const prompt = `${"a".repeat(100)}\nsecond line`;
     const body = newTaskBody({ prompt, deliverable: "once", priority: "medium", assignee: "" });
     expect(body?.note).toBe(prompt);
-    expect(body?.title).toBe(derivePromptCard(prompt).title);
+    expect(body).not.toHaveProperty("title");
+    expect(derivePromptCard(prompt).title).toBeUndefined();
   });
 });

--- a/frontend/test/unit/mock-brain.test.ts
+++ b/frontend/test/unit/mock-brain.test.ts
@@ -359,6 +359,60 @@ describe("the mock inference backend", () => {
     expect(orchestrator.choices[0].message.tool_calls[0].function.name).toBe("spawn_task");
   });
 
+  it("answers a card-titling pass with a short name, not the canned reply", async () => {
+    const titling = await chat([
+      { role: "system", content: "You name tasks. You are given one message somebody sent." },
+      {
+        role: "user",
+        content: "can you fix the checkout bug, it has been dropping one in twenty orders",
+      },
+    ]);
+    const title = titling.choices[0].message.content;
+    expect(
+      titling.choices[0].message.tool_calls,
+      "a titling pass must never be answered with a tool call",
+    ).toBeUndefined();
+    // Short and title-shaped, so a card in this lane has a plausible headline.
+    expect(title.length).toBeLessThanOrEqual(80);
+    // No marker: a title is rendered as a card headline all over the console,
+    // and specs assert raw mock text does not reach the UI.
+    expect(title).not.toContain("__MOCK_LLM__");
+    // And deliberately NOT the request echoed back. A fixture that answered
+    // with a prefix of the request would reproduce the very defect the titling
+    // pass removes, and would let a spec key a request against a title and pass
+    // here while being wrong against any real model.
+    expect(title).not.toContain("checkout");
+  });
+
+  it("does not let a card-titling pass consume a directive", async () => {
+    // The hazard the triage and planning arms already close, one prompt later:
+    // a titling pass is handed the operator's RAW message, so it carries any
+    // directive that message carried.
+    //
+    // A payload of its own: `servedDirectives` is per-process, so reusing the
+    // triage test's directive would find it already served and prove nothing.
+    const directive = `__MOCK_TOOL_CALL__ ${JSON.stringify({
+      name: "mcp_call_tool",
+      arguments: { server: "simple", tool: "echo", arguments: { text: "burned-by-titling?" } },
+    })}`;
+
+    const titling = await chat([
+      { role: "system", content: "You name tasks. You are given one message somebody sent." },
+      { role: "user", content: directive },
+    ]);
+    expect(
+      titling.choices[0].message.tool_calls,
+      "a titling pass must never be answered with a tool call",
+    ).toBeUndefined();
+
+    // The turn that follows must still get its tool call — the whole point.
+    const turn = await chat([
+      { role: "system", content: "You are the CEO of Acme." },
+      { role: "user", content: directive },
+    ]);
+    expect(turn.choices[0].message.tool_calls?.[0]?.function?.name).toBe("mcp_call_tool");
+  });
+
   it("does not let a triage classification consume a plan step", async () => {
     // The same hazard #678 fixed for `__MOCK_TOOL_CALL__`, one directive later.
     const directive = plan("p-303", [

--- a/src/analytics/types.rs
+++ b/src/analytics/types.rs
@@ -306,6 +306,7 @@ pub fn sample_kind_slug(kind: SampleKind) -> &'static str {
         SampleKind::SetupCall => "setup-call",
         SampleKind::AuthoringCall => "authoring-call",
         SampleKind::SelectorCall => "selector-call",
+        SampleKind::TitleCall => "title-call",
     }
 }
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -902,6 +902,16 @@ impl CompanyRuntime {
         &self.id
     }
 
+    /// The pass that names the work a card is opened for, when this company's
+    /// brain has a model to name it with.
+    ///
+    /// `None` on an echo brain and in any build without the harness, which
+    /// leaves [`mint_task_title`](crate::ports::tasks::mint_task_title) on the
+    /// shortened request.
+    pub fn titler(&self) -> Option<&dyn crate::ports::tasks::TitleSummariser> {
+        self.brain.titler()
+    }
+
     /// This company's secret store (SMTP creds, OAuth tokens, domain config).
     /// Sets the install-wide default MCP servers (issue #527). Called by
     /// [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) from resolved config.
@@ -6627,6 +6637,7 @@ mod tests {
         CompanyEvent, continuation_failure_notice, emergency_from_load, task_enters_in_progress,
         task_enters_planning,
     };
+    use crate::ports::tasks::TaskTitle;
 
     /// Issue #880: which parked approvals name a workflow run, and which must
     /// not.
@@ -7023,7 +7034,7 @@ mod tests {
 
         let card = TaskRecord {
             id: "card-1".to_string(),
-            title: "Draft the spec".to_string(),
+            title: TaskTitle::authored("Draft the spec"),
             note: None,
             column: COLUMN_TODO.to_string(),
             priority: "medium".to_string(),
@@ -7038,6 +7049,7 @@ mod tests {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             // A stale chip from a dispatch attempt that already bounced.
             bounced: Some("a previous run's dispatch failed".to_string()),
         };
@@ -7101,7 +7113,7 @@ mod tests {
 
         let card = TaskRecord {
             id: "card-2".to_string(),
-            title: "Draft the spec".to_string(),
+            title: TaskTitle::authored("Draft the spec"),
             note: None,
             column: COLUMN_TODO.to_string(),
             priority: "medium".to_string(),
@@ -7116,6 +7128,7 @@ mod tests {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             // A stale chip from a dispatch attempt that already bounced.
             bounced: Some("a previous run's dispatch failed".to_string()),
         };
@@ -7609,7 +7622,7 @@ mod tests {
 
         let card = TaskRecord {
             id: "t-1".to_string(),
-            title: "Ship it".to_string(),
+            title: TaskTitle::authored("Ship it"),
             note: None,
             column: COLUMN_IN_PROGRESS.to_string(),
             priority: "medium".to_string(),
@@ -7624,6 +7637,7 @@ mod tests {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
 
@@ -7703,7 +7717,7 @@ mod tests {
 
         let card = TaskRecord {
             id: "t-1".to_string(),
-            title: "Ship it".to_string(),
+            title: TaskTitle::authored("Ship it"),
             note: None,
             column: COLUMN_IN_PROGRESS.to_string(),
             priority: "medium".to_string(),
@@ -7718,6 +7732,7 @@ mod tests {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
 
@@ -7859,7 +7874,7 @@ mod tests {
 
         let card = TaskRecord {
             id: "t-1".to_string(),
-            title: "Ship it".to_string(),
+            title: TaskTitle::authored("Ship it"),
             note: None,
             column: COLUMN_IN_PROGRESS.to_string(),
             priority: "medium".to_string(),
@@ -7876,6 +7891,7 @@ mod tests {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
 
@@ -8016,7 +8032,7 @@ mod tests {
         let orchestrator = "ceo";
         let card = |id: &str, origin: &str| TaskRecord {
             id: id.to_string(),
-            title: "Ship it".to_string(),
+            title: TaskTitle::authored("Ship it"),
             note: None,
             column: COLUMN_IN_REVIEW.to_string(),
             priority: "medium".to_string(),
@@ -8031,6 +8047,7 @@ mod tests {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
         let dm_card = card("t-dm", "writer");
@@ -8250,7 +8267,7 @@ mod tests {
 
         let mut card = crate::ports::tasks::TaskRecord {
             id: "t-relay".to_string(),
-            title: "Draft the launch email".to_string(),
+            title: TaskTitle::authored("Draft the launch email"),
             note: None,
             column: crate::ports::tasks::COLUMN_IN_REVIEW.to_string(),
             priority: "medium".to_string(),
@@ -8265,6 +8282,7 @@ mod tests {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
         rt.tasks().upsert(&id, &card).await.unwrap();
@@ -8910,7 +8928,9 @@ mod tests {
     #[cfg(feature = "openhuman")]
     mod review {
         use crate::ports::TaskRecord;
-        use crate::ports::tasks::{COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, TaskStore};
+        use crate::ports::tasks::{
+            COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, TaskStore, TaskTitle,
+        };
         use crate::ports::types::{CompanyEvent, CompanyId, EventSeq};
         use std::sync::Arc;
         use tempfile::TempDir;
@@ -9044,7 +9064,7 @@ mod tests {
         fn card(id: &str, origin: &str, column: &str) -> TaskRecord {
             TaskRecord {
                 id: id.to_string(),
-                title: "Ship it".to_string(),
+                title: TaskTitle::authored("Ship it"),
                 note: None,
                 column: column.to_string(),
                 priority: "medium".to_string(),
@@ -9059,6 +9079,7 @@ mod tests {
                 workflow_proposal: None,
                 origin_run_id: None,
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             }
         }
@@ -9856,7 +9877,7 @@ mod tests {
         use crate::company::task_intent::BlockerReplyIntent;
         use crate::ports::blockers::{BlockerKind, BlockerPayload, BlockerSource, BlockerStep};
         use crate::ports::tasks::{
-            COLUMN_IN_PROGRESS, COLUMN_PAUSED, COLUMN_TODO, TaskDeliverable, TaskRecord,
+            COLUMN_IN_PROGRESS, COLUMN_PAUSED, COLUMN_TODO, TaskDeliverable, TaskRecord, TaskTitle,
         };
         use crate::ports::types::CompanyId;
         use std::path::Path;
@@ -9912,7 +9933,7 @@ mod tests {
         fn card(id: &str, column: &str) -> TaskRecord {
             TaskRecord {
                 id: id.to_string(),
-                title: "Draft the launch note".to_string(),
+                title: TaskTitle::authored("Draft the launch note"),
                 note: None,
                 column: column.to_string(),
                 priority: "medium".to_string(),
@@ -9927,6 +9948,7 @@ mod tests {
                 workflow_proposal: None,
                 origin_run_id: None,
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             }
         }

--- a/src/company/task_file.rs
+++ b/src/company/task_file.rs
@@ -89,7 +89,7 @@ impl TaskSeed {
     pub fn to_record(&self, at_millis: u64) -> TaskRecord {
         TaskRecord {
             id: self.id.clone(),
-            title: self.title.clone(),
+            title: crate::ports::tasks::TaskTitle::authored(&self.title),
             note: self.note.clone(),
             column: COLUMN_TODO.to_string(),
             priority: self
@@ -107,6 +107,7 @@ impl TaskSeed {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -47,9 +47,11 @@
 //! ambiguous.
 //!
 //! [`detect_task_intent`] remains as the thin `Track`-only wrapper the card
-//! paths call, so the issue-#463 title contract with
-//! `DelegationRunner::chat_handler_card` — which has to derive byte-for-byte
-//! the same title the handler wrote — is untouched.
+//! paths call to decide **whether** a message is work. What the card is then
+//! *named* is no longer its business: a title is minted through
+//! [`mint_task_title`](crate::ports::tasks::mint_task_title), and the card the
+//! handler wrote is found again by the message's own sequence position rather
+//! than by re-deriving its headline.
 //!
 //! # What this deliberately is not
 //!
@@ -605,10 +607,12 @@ pub fn small_talk(text: &str) -> Option<SmallTalk> {
 /// Returns a cleaned task title when `text` is an actionable request, else
 /// `None` — the [`MessageTriage::Track`]-only view of [`triage_message`].
 ///
-/// Kept as its own function because two card paths depend on it agreeing with
-/// itself byte-for-byte: the REST chat handler writes the title, and
-/// `DelegationRunner::chat_handler_card` re-derives it moments later to find
-/// the card that handler wrote (issue #463).
+/// The title it returns is a *fallback* name, used when no titling pass is
+/// wired or the model could not answer. Nothing re-derives it to find a card
+/// again — adoption is keyed on
+/// [`TaskRecord::origin_message_seq`](crate::ports::tasks::TaskRecord::origin_message_seq) —
+/// so this no longer has to agree with itself byte-for-byte across two call
+/// sites.
 pub fn detect_task_intent(text: &str) -> Option<String> {
     match triage_message(text) {
         MessageTriage::Track(title) => Some(title),

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -253,6 +253,10 @@ pub struct HarnessBrain {
     /// use (issue #1835). Lazy and `OnceLock` for exactly [`Self::triage`]'s
     /// reasons — it needs the company id, and once built it is immutable.
     selector: std::sync::OnceLock<crate::harness::selector::MeteredSelector>,
+    /// The card-titling pass, built on first use. Lazy and `OnceLock` for
+    /// exactly [`Self::triage`]'s reasons — it needs the company id, and once
+    /// built it is immutable.
+    titler: std::sync::OnceLock<crate::harness::title::MeteredTitler>,
     /// The company's record, **re-read from the store at the top of every
     /// cycle** (issue #707).
     ///
@@ -464,6 +468,7 @@ impl HarnessBrain {
             runs: None,
             triage: std::sync::OnceLock::new(),
             selector: std::sync::OnceLock::new(),
+            titler: std::sync::OnceLock::new(),
         }
     }
 
@@ -1091,7 +1096,7 @@ impl HarnessBrain {
                 key: card.id.clone(),
                 task_id: Some(card.id.clone()),
                 kind: InflightKind::Task,
-                title: card.title.clone(),
+                title: card.title.to_string(),
                 agent_id: responder.clone(),
                 started_at_millis: now_millis(),
                 pending_action: None,
@@ -2706,7 +2711,9 @@ impl HarnessBrain {
 
         let card = TaskRecord {
             id: generate_id(),
-            title: publish::conversation_card_title(&published),
+            title: crate::ports::tasks::TaskTitle::system(&publish::conversation_card_title(
+                &published,
+            )),
             note: Some(publish::conversation_card_note(responder, &published)),
             // Finished agent work a person has not accepted yet — the same
             // landing `column_for_settled_run(Succeeded)` gives a dispatched run.
@@ -2732,6 +2739,7 @@ impl HarnessBrain {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
         // The card is written **first**: an artifact's `task_id` must name a
@@ -3203,6 +3211,17 @@ impl HarnessBrain {
         .with_approvals(&self.deps.approval_requests)
         .with_workflow_refs(&self.deps.workflow_refs)
         .with_triage(self.triage_escalation(&record.id))
+        .with_titler(self.title_pass(&record.id))
+    }
+
+    /// The company's card-titling pass, built once.
+    fn title_pass(
+        &self,
+        company: &crate::ports::types::CompanyId,
+    ) -> &crate::harness::title::MeteredTitler {
+        self.titler.get_or_init(|| {
+            crate::harness::title::MeteredTitler::from_deps(&self.deps, company.clone())
+        })
     }
 
     /// The company's triage escalation, built once (issue #678).
@@ -3379,6 +3398,12 @@ fn settle(card: &mut TaskRecord, end: TaskRunEnd, responder: &str, body: &str) {
 
 #[async_trait]
 impl Brain for HarnessBrain {
+    /// The company's titling pass, so the card-opening paths that compile
+    /// without the harness can still name what they open.
+    fn titler(&self) -> Option<&dyn crate::ports::tasks::TitleSummariser> {
+        Some(self.title_pass(&self.record().id))
+    }
+
     async fn run_cycle(&self, req: CycleRequest, host: &dyn CycleHost) -> Result<CycleResult> {
         // Issue #707: re-read the record before anything routes on it, so a desk
         // reorder / new desk / added desk member saved through the console
@@ -4298,6 +4323,7 @@ impl HarnessBrain {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::tasks::TaskTitle;
 
     use tinyinference::message::Message;
     use tinyinference::model::{ChatModel, ModelRequest, ModelResponse};
@@ -5864,7 +5890,7 @@ members = ["engineer"]
     fn card(id: &str, assignee: &str) -> TaskRecord {
         TaskRecord {
             id: id.to_string(),
-            title: "Ship the thing".to_string(),
+            title: TaskTitle::authored("Ship the thing"),
             note: None,
             column: "in_progress".to_string(),
             priority: "high".to_string(),
@@ -5879,6 +5905,7 @@ members = ["engineer"]
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }
@@ -10116,7 +10143,7 @@ members = ["eng1", "eng2"]
     fn card_in_review(id: &str) -> TaskRecord {
         TaskRecord {
             id: id.to_string(),
-            title: format!("Work item {id}"),
+            title: TaskTitle::authored(&format!("Work item {id}")),
             note: None,
             column: COLUMN_IN_REVIEW.to_string(),
             priority: "medium".to_string(),
@@ -10131,6 +10158,7 @@ members = ["eng1", "eng2"]
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -10984,6 +10984,38 @@ members = ["eng1", "eng2"]
         );
     }
 
+    /// The same ceiling, one pass later (codex on #2055): naming a card is a
+    /// model call with no agent behind it, exactly like a selection, so
+    /// `total_ceiling_refusal` never fires for it either.
+    ///
+    /// Without the gate in `MeteredTitler::title` the provider answers and this
+    /// returns `Some("chief")` — a tenant past its hard ceiling paying once per
+    /// card opened, forever.
+    #[tokio::test]
+    async fn an_exhausted_total_ceiling_names_a_card_without_paying_for_a_title() {
+        use crate::ports::tasks::TitleSummariser;
+
+        let dir = tempfile::tempdir().unwrap();
+        let meter = Arc::new(SpentMeter);
+        let plan = crate::harness::capability_budget::CapabilityPlan {
+            period: crate::harness::capability_budget::BudgetPeriod::Daily,
+            budgets: Default::default(),
+            total_budget: Some(10),
+        };
+        let (brain, _provider) =
+            brain_that_selects_with(dir.path(), "chief", Some(plan), Some(meter));
+        let company = brain.record().id.clone();
+
+        assert_eq!(
+            brain
+                .title_pass(&company)
+                .title("can you fix the checkout bug, it keeps dropping orders")
+                .await,
+            None,
+            "past the ceiling the card is named from the request, not by a model"
+        );
+    }
+
     /// Issue #1872 (codex P2): a channel emptied *after* creation.
     ///
     /// `POST …/desks` refuses an empty auto channel, but `DELETE …/team/{id}`

--- a/src/harness/built_in/lifecycle.rs
+++ b/src/harness/built_in/lifecycle.rs
@@ -570,11 +570,12 @@ pub fn relay_reply(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ports::tasks::TaskTitle;
 
     fn card(column: &str, note: Option<&str>) -> TaskRecord {
         TaskRecord {
             id: "t-1".to_string(),
-            title: "Ship the thing".to_string(),
+            title: TaskTitle::authored("Ship the thing"),
             note: note.map(str::to_string),
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -589,6 +590,7 @@ mod test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -151,6 +151,7 @@ pub mod selector;
 pub mod skills;
 pub mod steer;
 pub mod steps;
+pub mod title;
 pub mod tool_dispatcher;
 pub mod toolbelt;
 pub mod triage;

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -5898,6 +5898,7 @@ pub(crate) fn create_workflow_parameters_schema() -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::tasks::TaskTitle;
     use std::sync::Mutex as StdMutex;
 
     use crate::ports::runs::RunStatus;
@@ -11723,7 +11724,7 @@ name = "Morning"
     fn task_card(id: &str, title: &str, column: &str, assignee: &str) -> TaskRecord {
         TaskRecord {
             id: id.to_string(),
-            title: title.to_string(),
+            title: TaskTitle::authored(title),
             note: None,
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -11738,6 +11739,7 @@ name = "Morning"
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/harness/built_in/planning/test.rs
+++ b/src/harness/built_in/planning/test.rs
@@ -24,6 +24,7 @@ use tinyinference::{Error as InferenceError, Result as TaResult};
 
 use super::*;
 use crate::company::CompanyManifest;
+use crate::ports::tasks::TaskTitle;
 use crate::ports::types::CompanyId;
 use tempfile;
 
@@ -1756,7 +1757,7 @@ async fn runtime_with(model: Arc<ScriptedModel>) -> (tempfile::TempDir, Arc<Comp
 fn card(id: &str, assignee: &str) -> TaskRecord {
     TaskRecord {
         id: id.to_string(),
-        title: "Ship the changelog".to_string(),
+        title: TaskTitle::authored("Ship the changelog"),
         note: None,
         column: COLUMN_PLANNING.to_string(),
         priority: "medium".to_string(),
@@ -1774,6 +1775,7 @@ fn card(id: &str, assignee: &str) -> TaskRecord {
         output: None,
         origin_run_id: None,
         origin_workflow_id: None,
+        origin_message_seq: None,
         bounced: None,
     }
 }

--- a/src/harness/built_in/publish_turn_test.rs
+++ b/src/harness/built_in/publish_turn_test.rs
@@ -38,7 +38,7 @@ use crate::harness::publish::PUBLISH_ARTIFACT_TOOL;
 use crate::harness::{HarnessBrain, HarnessDeps, HarnessPool};
 use crate::ports::artifacts::{ArtifactRecord, ArtifactStore};
 use crate::ports::brain::{Brain, CycleHost};
-use crate::ports::tasks::{COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, TaskRecord, TaskStore};
+use crate::ports::tasks::{COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, TaskRecord, TaskStore, TaskTitle};
 use crate::ports::types::{
     ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult, CycleRequest,
     Effect, EffectDisposition, ToolCall, ToolResult,
@@ -410,7 +410,7 @@ fn company() -> CompanyId {
 fn card(id: &str) -> TaskRecord {
     TaskRecord {
         id: id.to_string(),
-        title: "Draft the launch spec".to_string(),
+        title: TaskTitle::authored("Draft the launch spec"),
         note: None,
         column: COLUMN_IN_PROGRESS.to_string(),
         priority: "medium".to_string(),
@@ -425,6 +425,7 @@ fn card(id: &str) -> TaskRecord {
         workflow_proposal: None,
         origin_run_id: None,
         origin_workflow_id: None,
+        origin_message_seq: None,
         bounced: None,
     }
 }

--- a/src/harness/built_in/title.rs
+++ b/src/harness/built_in/title.rs
@@ -1,0 +1,373 @@
+//! The card-titling pass: one tool-less model call that names the work a
+//! request asks for.
+//!
+//! # What it replaces
+//!
+//! Every card was named by shortening the message that opened it, so a board
+//! read as a chat log — `hey can you take a look at the pricing page, I think
+//! the tiers are…` where a task list wanted `Reword the middle pricing tier`.
+//! Three producers had each written their own truncator and all three landed on
+//! the same shape, because nothing said a title was anything other than the
+//! first eighty characters of whatever arrived.
+//!
+//! # It names, it does not scope
+//!
+//! The request is the specification; this only says what it is. A model that
+//! adds a step nobody asked for writes a card the company may then work, so the
+//! prompt forbids it and the caller keeps the full ask in the card's note either
+//! way — nothing is lost by a title that is too plain, and something is invented
+//! by one that is too helpful. The request carries no tools, so there is no loop
+//! and nothing it can reach.
+//!
+//! # Failure is a duller title, never an error
+//!
+//! Unreachable, slow, or unreadable all return `None`, and the caller falls back
+//! to shortening the request exactly as before. A card is never left unnamed and
+//! card creation never fails for want of a model: an offline company keeps the
+//! behaviour it has today, and the operator is never shown an inference error
+//! for a headline.
+//!
+//! # The cap is enforced here, not requested
+//!
+//! [`TaskTitle`] normalises and bounds every value it holds, so a model that
+//! answers with a paragraph, a quoted string, `Title: …`, markdown emphasis, or
+//! a trailing full stop is corrected rather than trusted. The prompt asks for
+//! the right shape because that produces better titles; the type is what
+//! guarantees it.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tinyinference::message::Message;
+use tinyinference::model::{ModelRequest, ModelResponse};
+
+use crate::harness::HarnessDeps;
+use crate::harness::build::model_for_tier;
+use crate::harness::provider::HarnessModel;
+use crate::ports::tasks::{TaskTitle, TitleSummariser};
+use crate::ports::types::TokenUsage;
+
+/// How long a titling pass may wait on the model before it is abandoned.
+///
+/// The same budget class as a triage escalation and for the same reason: a
+/// person is watching a chat thread with no reply, and the card is opened on the
+/// way to answering them. Past this the shortened request is simply better than
+/// a late name, and the fallback costs nothing.
+const TITLE_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Output-token ceiling. The answer is a handful of words; this is headroom for
+/// a model that wraps them in punctuation, not room to explain itself.
+const MAX_OUTPUT_TOKENS: u32 = 32;
+
+/// Deterministic. The same request should name the same card every time — a
+/// board whose headlines shift between two runs of the same ask is a board
+/// nobody can scan.
+const TEMPERATURE: f64 = 0.0;
+
+/// The system prompt.
+///
+/// Written as instructions about the *output*, not about the domain: the model
+/// is given one message and asked for one line. The negative rules are the
+/// load-bearing half — every one of them names a failure seen from a model
+/// asked to summarise, and the sanitiser behind them assumes none of them held.
+fn system_prompt() -> String {
+    "You name tasks. You are given one message somebody sent to their company's \
+     chat, and you reply with a short title for the work it asks for.\n\
+     \n\
+     Reply with the title and nothing else. No quotes, no markdown, no \
+     `Title:` prefix, no trailing full stop, no explanation.\n\
+     \n\
+     Rules:\n\
+     \n\
+     - Start with a verb, in the imperative: `Reword the middle pricing tier`, \
+     `Fix the login redirect`, `Draft the Q3 board update`.\n\
+     - At most eight words. Shorter is better.\n\
+     - Name only what was actually asked for. Do not add steps, deliverables, \
+     or scope the message does not ask for. If the message asks for one small \
+     thing, the title is that one small thing.\n\
+     - Drop the politeness, the hedging, the reasoning and the background. \
+     Those stay on the card; the title is the headline.\n\
+     - Keep the message's own language. Do not translate it.\n\
+     - Do not add names, dates, numbers or systems the message does not \
+     mention.\n\
+     \n\
+     If the message is already a short task title, reply with it unchanged."
+        .to_string()
+}
+
+/// The system prompt, for the fixture that has to recognise a titling request
+/// without consuming a scripted turn.
+#[cfg(test)]
+pub fn system_prompt_for_test() -> String {
+    system_prompt()
+}
+
+/// A model that names the work a request asks for.
+///
+/// Holds no runtime handle, mirroring [`TriageEvaluator`]: the caller already
+/// has the handles metering needs, and an evaluator that owned the runtime back
+/// would be a cycle that never frees.
+///
+/// [`TriageEvaluator`]: crate::harness::triage::TriageEvaluator
+pub struct TitleEvaluator {
+    model: Arc<dyn HarnessModel>,
+    model_name: String,
+}
+
+impl TitleEvaluator {
+    /// Wires an evaluator to a model and the name to address it by.
+    pub fn new(model: Arc<dyn HarnessModel>, model_name: String) -> Self {
+        Self { model, model_name }
+    }
+
+    /// Wires an evaluator from the harness deps.
+    ///
+    /// Takes the roster's own default rather than naming a cheap tier, for the
+    /// reason [`TriageEvaluator::from_deps`] gives at length: an abstract tier a
+    /// tenant's `[inference].models` table does not map is passed to their
+    /// provider verbatim, so inventing one here would send an unknown model name
+    /// to every BYOK tenant that had not opted in. Cheapness comes from the
+    /// shape of the call — no tools, a short prompt, a tiny output ceiling.
+    ///
+    /// [`TriageEvaluator::from_deps`]: crate::harness::triage::TriageEvaluator::from_deps
+    pub fn from_deps(deps: &HarnessDeps) -> Self {
+        let model_name = deps
+            .model_override
+            .clone()
+            .unwrap_or_else(|| model_for_tier(None));
+        Self::new(deps.provider.clone(), model_name)
+    }
+
+    /// The provider slug this evaluator's usage is metered under, read live so a
+    /// BYOK switch re-attributes the next pass.
+    pub fn provider_slug(&self) -> String {
+        self.model.telemetry_provider_id()
+    }
+
+    /// The model this pass's usage is metered against, read live off the
+    /// provider. `None` before the provider has issued a turn, or when it cannot
+    /// name a model.
+    pub fn model_slug(&self) -> Option<crate::metering::ModelSlug> {
+        self.model.telemetry_model()
+    }
+
+    /// Names the work `request` asks for, with what the call cost.
+    ///
+    /// Never returns an error: unreachable, too slow, and unreadable are all
+    /// `None`, and the caller shortens the request instead. The [`TokenUsage`]
+    /// is still returned when the reply could not be used, because those tokens
+    /// were really spent and must still be metered.
+    ///
+    /// An empty or whitespace-only request short-circuits: there is nothing to
+    /// name, and a model asked to title nothing invents something.
+    pub async fn title(&self, request: &str) -> (Option<TaskTitle>, TokenUsage) {
+        if request.trim().is_empty() {
+            return (None, TokenUsage::default());
+        }
+        let request = ModelRequest {
+            messages: vec![
+                Message::system(system_prompt()),
+                Message::user(request.to_string()),
+            ],
+            model: Some(self.model_name.clone()),
+            temperature: Some(TEMPERATURE),
+            max_tokens: Some(MAX_OUTPUT_TOKENS),
+            ..ModelRequest::default()
+        };
+        let response =
+            match tokio::time::timeout(TITLE_TIMEOUT, self.model.invoke(&(), request)).await {
+                Ok(Ok(response)) => response,
+                Ok(Err(err)) => {
+                    tracing::debug!(
+                        error = %err,
+                        "[title] the model could not be reached; shortening the request instead"
+                    );
+                    return (None, TokenUsage::default());
+                }
+                Err(_elapsed) => {
+                    tracing::debug!(
+                        timeout_s = TITLE_TIMEOUT.as_secs(),
+                        "[title] the model did not answer in time; shortening the request instead"
+                    );
+                    return (None, TokenUsage::default());
+                }
+            };
+        let usage = usage_from(&response);
+        (TaskTitle::summarised(&response.text()), usage)
+    }
+}
+
+/// The production pass: a [`TitleEvaluator`] whose spend lands on the company's
+/// usage and ledger before the title is returned.
+pub struct MeteredTitler {
+    evaluator: TitleEvaluator,
+    company: crate::ports::types::CompanyId,
+    store: Arc<dyn crate::ports::CompanyStore>,
+    meter: Option<Arc<dyn crate::ports::usage::UsageMeter>>,
+}
+
+impl MeteredTitler {
+    /// Wires a titling pass for `company` from the harness deps.
+    pub fn from_deps(deps: &HarnessDeps, company: crate::ports::types::CompanyId) -> Self {
+        Self {
+            evaluator: TitleEvaluator::from_deps(deps),
+            company,
+            store: deps.store.clone(),
+            meter: deps.meter.clone(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TitleSummariser for MeteredTitler {
+    async fn title(&self, request: &str) -> Option<TaskTitle> {
+        let (title, usage) = self.evaluator.title(request).await;
+        crate::metering::record_title_usage(
+            &usage,
+            &self.evaluator.provider_slug(),
+            self.evaluator.model_slug(),
+            &self.company,
+            self.store.as_ref(),
+            self.meter.as_ref().map(|meter| meter.as_ref()),
+        )
+        .await;
+        title
+    }
+}
+
+/// Token spend for one titling pass, including the cost the managed provider
+/// reports on the wire. Mirrors the triage pass's reader.
+fn usage_from(response: &ModelResponse) -> TokenUsage {
+    let tokens = response.usage.unwrap_or_default();
+    let cost_usd = response
+        .raw
+        .as_ref()
+        .and_then(|raw| raw.pointer("/openhuman_usage_meta/charged_amount_usd"))
+        .and_then(serde_json::Value::as_f64)
+        .filter(|c| c.is_finite() && *c > 0.0)
+        .unwrap_or(0.0);
+    TokenUsage {
+        input: tokens.input_tokens,
+        output: tokens.output_tokens,
+        cached_input: tokens.cache_read_tokens,
+        cost_usd,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tinyinference::Result as TaResult;
+    use tinyinference::model::ChatModel;
+
+    /// A model that answers every request with one canned reply.
+    struct Canned(&'static str);
+
+    #[async_trait::async_trait]
+    impl ChatModel<()> for Canned {
+        async fn invoke(&self, _state: &(), _request: ModelRequest) -> TaResult<ModelResponse> {
+            Ok(ModelResponse::assistant(self.0))
+        }
+    }
+
+    impl HarnessModel for Canned {
+        fn telemetry_provider_id(&self) -> String {
+            "test".to_string()
+        }
+
+        fn telemetry_model(&self) -> Option<crate::metering::ModelSlug> {
+            None
+        }
+    }
+
+    async fn titled(reply: &'static str) -> Option<TaskTitle> {
+        TitleEvaluator::new(Arc::new(Canned(reply)), "chat-v1".to_string())
+            .title("do the thing")
+            .await
+            .0
+    }
+
+    /// The shapes a model actually replies in — quoted, prefixed, emphasised,
+    /// full-stopped — all reduce to the bare name.
+    #[tokio::test]
+    async fn a_title_survives_the_shapes_a_model_replies_in() {
+        for reply in [
+            "Reword the middle pricing tier",
+            "\"Reword the middle pricing tier\"",
+            "Title: Reword the middle pricing tier",
+            "**Reword the middle pricing tier**",
+            "`Reword the middle pricing tier`",
+            "Reword the middle pricing tier.",
+            "Task: \"Reword the middle pricing tier\".",
+            "  Reword the middle pricing tier  \n\nLet me know if you want another.",
+        ] {
+            assert_eq!(
+                titled(reply).await.expect(reply).as_str(),
+                "Reword the middle pricing tier",
+                "{reply}"
+            );
+        }
+    }
+
+    /// A reply with no name in it leaves the caller on its fallback rather than
+    /// putting punctuation on the board.
+    #[tokio::test]
+    async fn an_unusable_reply_is_no_title_rather_than_a_bad_one() {
+        for reply in ["", "   ", "\n\n", "\"\"", "**", "...", "Title:"] {
+            assert!(titled(reply).await.is_none(), "{reply:?}");
+        }
+    }
+
+    /// A model that ignores the word ceiling is cut to the cap the type
+    /// advertises — the prompt asks, the type enforces.
+    #[tokio::test]
+    async fn a_paragraph_is_bounded_rather_than_trusted() {
+        let title = titled(
+            "Take a really good look at the whole of the pricing page and then rewrite \
+             every single one of the tiers from scratch including the middle one",
+        )
+        .await
+        .expect("a long reply still names something");
+        assert!(
+            title.as_str().chars().count() <= crate::ports::tasks::TASK_TITLE_MAX_CHARS,
+            "{title}"
+        );
+        assert!(!title.as_str().contains('\n'));
+    }
+
+    /// Nothing asked is nothing named, and the model is never consulted about
+    /// it — an empty request is the one input that makes a titler invent.
+    #[tokio::test]
+    async fn an_empty_request_is_not_sent_to_the_model() {
+        let evaluator = TitleEvaluator::new(Arc::new(Canned("Invented work")), "m".to_string());
+        for request in ["", "   ", "\n\t "] {
+            assert!(evaluator.title(request).await.0.is_none(), "{request:?}");
+        }
+    }
+
+    /// A request already written as a title comes back as one, not degraded.
+    #[tokio::test]
+    async fn an_already_good_title_is_left_alone() {
+        assert_eq!(
+            titled("Fix the login redirect")
+                .await
+                .expect("a title")
+                .as_str(),
+            "Fix the login redirect"
+        );
+    }
+
+    /// Non-Latin scripts survive intact — the sanitiser is character-wise
+    /// throughout, and capitalisation is a no-op where the script has no case.
+    #[tokio::test]
+    async fn a_non_english_title_is_not_mangled() {
+        assert_eq!(
+            titled("価格ページの中段プランを書き直す")
+                .await
+                .expect("a title")
+                .as_str(),
+            "価格ページの中段プランを書き直す"
+        );
+    }
+}

--- a/src/harness/built_in/title.rs
+++ b/src/harness/built_in/title.rs
@@ -204,6 +204,9 @@ pub struct MeteredTitler {
     company: crate::ports::types::CompanyId,
     store: Arc<dyn crate::ports::CompanyStore>,
     meter: Option<Arc<dyn crate::ports::usage::UsageMeter>>,
+    /// Held for the plan-level ceiling check alone. The pass runs before any
+    /// teammate has the card, so there is no agent whose refusal would carry it.
+    deps: HarnessDeps,
 }
 
 impl MeteredTitler {
@@ -214,6 +217,7 @@ impl MeteredTitler {
             company,
             store: deps.store.clone(),
             meter: deps.meter.clone(),
+            deps: deps.clone(),
         }
     }
 }
@@ -221,6 +225,20 @@ impl MeteredTitler {
 #[async_trait::async_trait]
 impl TitleSummariser for MeteredTitler {
     async fn title(&self, request: &str) -> Option<TaskTitle> {
+        // The plan-level total-token ceiling gates naming a card, exactly as it
+        // gates a responder selection (issue #1872). Both run before any agent
+        // exists, so `total_ceiling_refusal` has nobody to refuse as and never
+        // fires — and without this a tenant past the hard ceiling keeps paying,
+        // one call per card opened, after the point that is supposed to permit
+        // no model calls at all. `None` costs nothing and lands the caller on
+        // the name it would have used anyway (codex on #2055).
+        if crate::harness::HarnessPool::total_ceiling_spent(&self.company, &self.deps).await {
+            tracing::info!(
+                company = %self.company,
+                "[title] total token ceiling reached; naming the card from the request instead"
+            );
+            return None;
+        }
         let (title, usage) = self.evaluator.title(request).await;
         crate::metering::record_title_usage(
             &usage,

--- a/src/harness/built_in/triage.rs
+++ b/src/harness/built_in/triage.rs
@@ -33,11 +33,8 @@
 //! * Everything else leaves the gate exactly where the abstention left it.
 //!
 //! **It never mints a card.** A verdict does not become
-//! [`MessageTriage::Track`], because the title a card is opened under is pinned
-//! byte-for-byte between the REST handler and `chat_handler_card` (issue #463) —
-//! a model-authored title would desynchronise them and orphan the card. That
-//! also keeps the issue's own tie-breaker intact: a missed card costs one
-//! follow-up message, a spurious card pollutes the board permanently.
+//! [`MessageTriage::Track`], on the issue's own tie-breaker: a missed card costs
+//! one follow-up message, a spurious card pollutes the board permanently.
 //!
 //! # Failure is silence, not an error
 //!

--- a/src/harness/built_in/triage.rs
+++ b/src/harness/built_in/triage.rs
@@ -36,6 +36,17 @@
 //! [`MessageTriage::Track`], on the issue's own tie-breaker: a missed card costs
 //! one follow-up message, a spurious card pollutes the board permanently.
 //!
+//! That tie-breaker is now the *whole* of the reason, and it used to be the
+//! lesser half. A card's title was once pinned byte-for-byte between the REST
+//! handler and `DelegationRunner::chat_handler_card`, which re-derived it to
+//! find the card the handler had opened — so a model-authored title
+//! desynchronised the two and orphaned the card. That constraint is gone:
+//! adoption keys on the message's own journal position
+//! ([`TaskRecord::origin_message_seq`](crate::ports::tasks::TaskRecord::origin_message_seq)),
+//! and titles are model-authored by design. A maintainer weighing whether this
+//! verdict may open a card is therefore weighing the tie-breaker alone, and
+//! nothing mechanical stands in the way any more.
+//!
 //! # Failure is silence, not an error
 //!
 //! Unreachable, slow, or unparseable all return [`TriageVerdict::Unavailable`],

--- a/src/harness/built_in/workflow_build/test.rs
+++ b/src/harness/built_in/workflow_build/test.rs
@@ -29,6 +29,7 @@ use super::tools::{
 use super::*;
 use crate::company::CompanyManifest;
 use crate::ports::runs::{NewRun, RunStatus};
+use crate::ports::tasks::TaskTitle;
 use crate::ports::types::CompanyId;
 use crate::ports::{UsageMeter, UsageSample};
 use openhuman_core::openhuman::tools::traits::Tool;
@@ -917,7 +918,7 @@ async fn runtime_with_agent(
 fn card(id: &str, plan: Option<crate::ports::tasks::TaskPlan>) -> TaskRecord {
     TaskRecord {
         id: id.to_string(),
-        title: "Automate the weekly digest".to_string(),
+        title: TaskTitle::authored("Automate the weekly digest"),
         note: Some("It should go out every Monday morning.".to_string()),
         column: COLUMN_IN_PROGRESS.to_string(),
         priority: "medium".to_string(),
@@ -932,6 +933,7 @@ fn card(id: &str, plan: Option<crate::ports::tasks::TaskPlan>) -> TaskRecord {
         workflow_proposal: None,
         origin_run_id: None,
         origin_workflow_id: None,
+        origin_message_seq: None,
         bounced: None,
     }
 }

--- a/src/harness/built_in/workspace_provision_turn_test.rs
+++ b/src/harness/built_in/workspace_provision_turn_test.rs
@@ -35,7 +35,7 @@ use crate::harness::policy::ApprovalRequestQueue;
 use crate::harness::provider::{HostedProvider, HostedProviderConfig};
 use crate::harness::{HarnessBrain, HarnessDeps, HarnessPool};
 use crate::ports::brain::{Brain, CycleHost};
-use crate::ports::tasks::{COLUMN_IN_PROGRESS, TaskRecord, TaskStore};
+use crate::ports::tasks::{COLUMN_IN_PROGRESS, TaskRecord, TaskStore, TaskTitle};
 use crate::ports::types::{
     ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult, CycleRequest,
     Effect, EffectDisposition, OverlayAgent, ToolCall, ToolResult,
@@ -327,7 +327,7 @@ fn build_brain(
 fn card(id: &str, assignee: &str) -> TaskRecord {
     TaskRecord {
         id: id.to_string(),
-        title: "Write the first note".to_string(),
+        title: TaskTitle::authored("Write the first note"),
         note: None,
         column: COLUMN_IN_PROGRESS.to_string(),
         priority: "medium".to_string(),
@@ -342,6 +342,7 @@ fn card(id: &str, assignee: &str) -> TaskRecord {
         workflow_proposal: None,
         origin_run_id: None,
         origin_workflow_id: None,
+        origin_message_seq: None,
         bounced: None,
     }
 }

--- a/src/ledger/native.rs
+++ b/src/ledger/native.rs
@@ -31,7 +31,7 @@ pub fn entries_from_tasks(tasks: &[TaskRecord]) -> Entries {
         .enumerate()
         .map(|(position, task)| {
             let mut fields: BTreeMap<String, String> = BTreeMap::new();
-            fields.insert("title".to_string(), task.title.clone());
+            fields.insert("title".to_string(), task.title.to_string());
             // The row's **status** is the phase, because that is the ledger's
             // declared vocabulary and the console's column list. The stage
             // rides alongside as prose, so a reader still learns that a working
@@ -93,13 +93,13 @@ mod test {
     use crate::ledger::registry::Registry;
     use crate::ports::tasks::{
         COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED, COLUMN_TODO,
-        TaskDeliverable,
+        TaskDeliverable, TaskTitle,
     };
 
     fn card(id: &str, column: &str, updated: u64) -> TaskRecord {
         TaskRecord {
             id: id.to_string(),
-            title: format!("card {id}"),
+            title: TaskTitle::authored(&format!("card {id}")),
             note: None,
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -114,6 +114,7 @@ mod test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/metering/capability.rs
+++ b/src/metering/capability.rs
@@ -268,6 +268,10 @@ pub fn plan_named(name: &str) -> Option<CapabilityPlan> {
 /// (issue #1835): per-message company-driven spend, uncappable by any
 /// teammate's budget, that must stop when the tier ceiling does.
 ///
+/// [`SampleKind::TitleCall`] is counted on the same terms (card titling): a
+/// pass runs per card opened, so a company left able to name cards indefinitely
+/// past its ceiling would keep paying per tracked request.
+///
 /// [`SampleKind::SetupCall`] is counted too, and its exposure is the smallest of
 /// the three: a company runs first-run setup once. It is included so the ceiling
 /// covers every completion billed to the tenant rather than only the ones that
@@ -289,6 +293,7 @@ pub fn tokens_in(samples: &[UsageSample]) -> u64 {
                     | SampleKind::JudgeCall
                     | SampleKind::TriageCall
                     | SampleKind::SelectorCall
+                    | SampleKind::TitleCall
                     | SampleKind::SetupCall
                     | SampleKind::AuthoringCall
             )

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -66,6 +66,7 @@ pub mod profile_draft;
 pub mod roster_build;
 pub mod search;
 pub mod selector;
+pub mod title;
 pub mod triage;
 mod types;
 mod usage;
@@ -94,6 +95,7 @@ pub use search::{
     FALLBACK_SEARCH_COST_USD, MANAGED_SEARCH_PROVIDER, record_search_call, search_call_sample,
 };
 pub use selector::{record_selector_usage, selector_sample};
+pub use title::{record_title_usage, title_sample};
 pub use triage::{record_triage_usage, triage_sample};
 pub use types::{
     AgentTokens, CategorySpend, Direction, Finances, ProviderCalls, Transaction, Usage, UsagePoint,

--- a/src/metering/title.rs
+++ b/src/metering/title.rs
@@ -1,0 +1,145 @@
+//! Emitting [`SampleKind::TitleCall`] usage samples — what naming a card costs,
+//! and who it is charged to.
+//!
+//! # Why this is not a teammate's inference
+//!
+//! A titling pass is the tool-less model call that turns a request into a card's
+//! headline. It happens while the card is being opened, before it has been
+//! handed to anybody, so there is no agent to attribute it to. Like a triage
+//! escalation and a responder selection, it is charged to the whole-company
+//! bucket ([`UNATTRIBUTED_AGENT`]) with no `run_id`.
+//!
+//! It is deliberately not folded into
+//! [`SampleKind::TriageCall`](crate::ports::usage::SampleKind). Triage runs on
+//! every message the lexical layer abstained on; titling runs only on the ones
+//! that become cards. Sharing a kind would make the triage line item move
+//! whenever the board got busier, and neither number could be tuned against the
+//! other.
+//!
+//! # Both writes are logged and swallowed
+//!
+//! Same rule as the triage and selector paths: the card has already been named
+//! and the operator's turn is already running by the time this is called. A
+//! ledger or meter hiccup must cost the accounting row and never the card. The
+//! tokens were genuinely spent either way, which is why the failure is logged
+//! rather than silently dropped.
+
+use crate::ports::types::{CompanyId, TokenUsage};
+use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
+use crate::ports::{CompanyStore, now_millis};
+
+use super::inference::{UNATTRIBUTED_AGENT, inference_ledger_entry};
+
+/// Builds the [`SampleKind::TitleCall`] sample for one completed titling pass,
+/// or `None` when it moved no tokens and cost nothing.
+///
+/// The `None` case is the offline/mock path, exactly as in
+/// [`selector_sample`](super::selector_sample): a provider reporting no usage
+/// yields a zero [`TokenUsage`], and a row for it would claim a call happened
+/// that is indistinguishable from a real free one.
+///
+/// `agent` is not a parameter — attribution to [`UNATTRIBUTED_AGENT`] is the
+/// rule this module holds, so no caller can bill a card's name to whoever the
+/// card was then assigned to.
+pub fn title_sample(
+    usage: &TokenUsage,
+    provider: &str,
+    model: Option<crate::metering::ModelSlug>,
+) -> Option<UsageSample> {
+    if usage.is_zero() {
+        return None;
+    }
+    Some(UsageSample {
+        at_millis: now_millis(),
+        agent: UNATTRIBUTED_AGENT.to_string(),
+        provider: super::oauth::normalize_provider(provider),
+        input_tokens: usage.input,
+        output_tokens: usage.output,
+        cached_input_tokens: usage.cached_input,
+        cost_usd: usage.cost_usd,
+        kind: SampleKind::TitleCall,
+        run_id: None,
+        model,
+    })
+}
+
+/// Records one completed titling pass: the Finances ledger entry (when it cost
+/// USD) and, when a usage meter is wired, the usage sample.
+///
+/// The ledger entry goes through the same [`inference_ledger_entry`] the cycle's
+/// inference spend uses, under the same `inference.spend` kind — titling spend
+/// is inference spend as far as the money is concerned, and only the *usage*
+/// breakdown cares about the distinction. The meter is deliberately optional: a
+/// host with no usage meter still records the spend it can prove.
+pub async fn record_title_usage(
+    usage: &TokenUsage,
+    provider: &str,
+    model: Option<crate::metering::ModelSlug>,
+    company: &CompanyId,
+    store: &dyn CompanyStore,
+    meter: Option<&dyn UsageMeter>,
+) {
+    if usage.is_zero() {
+        return;
+    }
+    tracing::debug!(
+        company = %company,
+        provider = %provider,
+        input = usage.input,
+        output = usage.output,
+        cached_input = usage.cached_input,
+        cost_usd = usage.cost_usd,
+        "[usage] recording a card titling pass"
+    );
+    if let Some(entry) = inference_ledger_entry(usage, UNATTRIBUTED_AGENT)
+        && let Err(err) = store.append_ledger(company, entry).await
+    {
+        tracing::warn!(
+            company = %company,
+            error = %err,
+            "[usage] failed to append the titling spend entry; the card still stands"
+        );
+    }
+    if let Some(sample) = title_sample(usage, provider, model)
+        && let Some(meter) = meter
+        && let Err(err) = meter.record(company, &sample).await
+    {
+        tracing::warn!(
+            company = %company,
+            error = %err,
+            "[usage] failed to record the titling usage sample; the card still stands"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn usage() -> TokenUsage {
+        TokenUsage {
+            input: 90,
+            output: 7,
+            cached_input: 0,
+            cost_usd: 0.0001,
+        }
+    }
+
+    /// A titling pass that moved tokens mints a [`SampleKind::TitleCall`] row
+    /// charged to the whole-company bucket — never to the card's assignee.
+    #[test]
+    fn a_titling_pass_samples_under_its_own_kind_and_no_teammate() {
+        let sample = title_sample(&usage(), "openrouter", None).expect("a real spend samples");
+        assert_eq!(sample.kind, SampleKind::TitleCall);
+        assert_eq!(sample.agent, UNATTRIBUTED_AGENT);
+        assert_eq!(sample.run_id, None);
+        assert_eq!(sample.input_tokens, 90);
+    }
+
+    /// The offline/mock path — zero usage — mints no row: a free fake call is
+    /// indistinguishable from a real free one, so no row is the honest record.
+    #[test]
+    fn zero_usage_mints_no_sample() {
+        assert!(title_sample(&TokenUsage::default(), "openrouter", None).is_none());
+    }
+}

--- a/src/ports/brain.rs
+++ b/src/ports/brain.rs
@@ -123,6 +123,21 @@ pub trait Brain: Send + Sync {
     fn cognition(&self) -> Cognition {
         Cognition::default()
     }
+
+    /// The pass that names the work a card is opened for, when this brain has a
+    /// model to name it with.
+    ///
+    /// On the [`Brain`] seam rather than reached for directly because three of
+    /// the four card-opening paths compile without the harness. They still need
+    /// a title, and this is the only handle they all hold.
+    ///
+    /// The default is `None`, which is every brain that is not the harness: an
+    /// echo brain has no model, and
+    /// [`mint_task_title`](crate::ports::tasks::mint_task_title) falls back to
+    /// shortening the request — exactly what the default build has always done.
+    fn titler(&self) -> Option<&dyn crate::ports::tasks::TitleSummariser> {
+        None
+    }
 }
 
 /// Callbacks the brain makes into the host mid-cycle.

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -1266,6 +1266,14 @@ fn normalise(text: &str) -> String {
             break;
         }
     }
+    // A result with nothing nameable left in it is not a title. Stripping
+    // pairs cannot catch every shape a model produces — `"""` peels to a lone
+    // `"`, `-` and `#` never paired at all — and each of those becomes a card
+    // headline that is one punctuation mark. Asking whether anything survived
+    // is the check that does not have to enumerate the ways it can fail.
+    if !current.chars().any(char::is_alphanumeric) {
+        return String::new();
+    }
     cap(&current, TASK_TITLE_MAX_CHARS)
 }
 
@@ -1739,7 +1747,24 @@ mod test {
     /// falls back rather than putting punctuation on the board.
     #[test]
     fn decoration_with_no_name_in_it_is_no_title() {
-        for junk in ["\"\"", "**", "...", "Title:", "``", "#"] {
+        for junk in [
+            "\"\"",
+            "**",
+            "...",
+            "Title:",
+            "``",
+            "#",
+            // Odd counts and unpaired marks: these do not peel to nothing, they
+            // peel to ONE punctuation character, which a length check passes.
+            "\"\"\"",
+            "*",
+            "-",
+            "—",
+            "?!",
+            "'",
+            "\"\"\"\"\"",
+            "   \"\"\"   ",
+        ] {
             assert!(TaskTitle::summarised(junk).is_none(), "{junk:?}");
         }
     }

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -1060,13 +1060,25 @@ impl TaskTitle {
 
     /// A title a model wrote for a request.
     ///
-    /// `None` when the reply sanitises to nothing — an empty string, pure
+    /// `None` when the reply has nothing nameable in it — an empty string, pure
     /// punctuation, a refusal — which is the caller's signal to fall back to
     /// [`truncated`](Self::truncated) rather than to leave a card unnamed.
+    ///
+    /// # Why this test lives here and not in [`normalise`]
+    ///
+    /// It was in `normalise` for one commit, which put it on every constructor
+    /// — and a person who titles a card `🚀` or `---` means it. Those are not
+    /// junk, they are somebody's title, and blanking them persisted a card with
+    /// no headline at all: worse than the punctuation title this check exists
+    /// to prevent. Only a *model's* reply is guessed at, so only a model's
+    /// reply can be rejected as unusable (codex on #2055).
     #[must_use]
     pub fn summarised(reply: &str) -> Option<Self> {
         let title = normalise(reply);
-        (!title.is_empty()).then_some(Self(title))
+        title
+            .chars()
+            .any(char::is_alphanumeric)
+            .then_some(Self(title))
     }
 
     /// The deterministic fallback: the request itself, shortened.
@@ -1266,14 +1278,6 @@ fn normalise(text: &str) -> String {
             break;
         }
     }
-    // A result with nothing nameable left in it is not a title. Stripping
-    // pairs cannot catch every shape a model produces — `"""` peels to a lone
-    // `"`, `-` and `#` never paired at all — and each of those becomes a card
-    // headline that is one punctuation mark. Asking whether anything survived
-    // is the check that does not have to enumerate the ways it can fail.
-    if !current.chars().any(char::is_alphanumeric) {
-        return String::new();
-    }
     cap(&current, TASK_TITLE_MAX_CHARS)
 }
 
@@ -1290,7 +1294,16 @@ fn strip_wrappers(text: &str) -> String {
         ("“", "”"),
         ("‘", "’"),
     ];
-    let mut current = text.trim().trim_start_matches('#').trim().to_string();
+    // Markdown heading syntax is `#` followed by a space, and only that is
+    // decoration: `#1` and `#launch` are somebody's title, and eating the hash
+    // silently renames their card.
+    let trimmed = text.trim();
+    let hashes = trimmed.len() - trimmed.trim_start_matches('#').len();
+    let after = &trimmed[hashes..];
+    let mut current = match hashes > 0 && after.starts_with(char::is_whitespace) {
+        true => after.trim_start().to_string(),
+        false => trimmed.to_string(),
+    };
     loop {
         // `>=`, not `>`: a reply that is *only* a pair — `""`, `**` — has to
         // strip to nothing, or a model that answered with bare punctuation puts
@@ -1713,6 +1726,7 @@ mod test {
             "**Title: Reword the middle pricing tier.**",
             "\"**Reword the middle pricing tier**\"",
             "# Reword the middle pricing tier",
+            "### Reword the middle pricing tier",
             "Reword the middle pricing tier.",
             "_Reword the middle pricing tier_",
             "“Reword the middle pricing tier”",
@@ -1767,6 +1781,23 @@ mod test {
         ] {
             assert!(TaskTitle::summarised(junk).is_none(), "{junk:?}");
         }
+    }
+
+    /// A person's own title is kept whatever it is made of. The junk test that
+    /// rejects an unusable *model reply* must never reach these constructors:
+    /// somebody who names a card `🚀` means it, and blanking it persists a card
+    /// with no headline — worse than the punctuation title the test prevents.
+    #[test]
+    fn a_symbol_only_title_a_person_chose_is_kept() {
+        for chosen in ["🚀", "✅", "---", "???", "42", "#1"] {
+            assert_eq!(TaskTitle::authored(chosen).as_str(), chosen, "{chosen}");
+            assert_eq!(TaskTitle::system(chosen).as_str(), chosen, "{chosen}");
+            assert!(!TaskTitle::truncated(chosen).is_empty(), "{chosen}");
+        }
+        // …and the same text from a model is still refused, because that is a
+        // guess at a name rather than somebody's choice of one.
+        assert!(TaskTitle::summarised("---").is_none());
+        assert!(TaskTitle::summarised("🚀").is_none());
     }
 
     /// Non-Latin scripts are neither mangled nor case-folded — the pass is

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -994,14 +994,338 @@ impl TaskOrigin {
     }
 }
 
+/// How many characters of a card title survive.
+pub const TASK_TITLE_MAX_CHARS: usize = 80;
+
+/// A card's headline: one short line naming the work to be done.
+///
+/// # Why this is a type and not a `String`
+///
+/// The contract — a short imperative name — was documented on the field and
+/// enforced by nothing, so each producer minted its own and three independently
+/// converged on the same shape: take the raw message, cut it at eighty
+/// characters. A board of those reads as a chat log. A bare `String` field gives
+/// the next producer the same freedom, which is why the fix is a type rather
+/// than a patch to the three truncators.
+///
+/// Every way in is a constructor named for **where the text came from**, and all
+/// of them run the same [`normalise`] pass: one line, no wrapping quotes or
+/// backticks, no markdown emphasis, no `Task:`-style preamble, no trailing
+/// sentence punctuation, bounded length. Shape is therefore total — no
+/// `TaskTitle` anywhere in the process can be a paragraph, and no `From<String>`
+/// or `From<&str>` impl exists to smuggle one in.
+///
+/// # What the type does not promise
+///
+/// Shape is checkable; *being a good name for the work* is not. That comes from
+/// the producer picking the right constructor, and the naming is the guardrail:
+/// a raw ask goes through [`summarised`](Self::summarised) with
+/// [`truncated`](Self::truncated) behind it, never through
+/// [`authored`](Self::authored).
+///
+/// # Stored titles are read back verbatim
+///
+/// `Deserialize` is transparent: a board written by an older build loads exactly
+/// as it was stored, raw-message titles included. Normalising on read would
+/// silently rewrite durable records, and re-summarising would cost a model call
+/// per card per load and make the board unstable between refreshes. The
+/// invariant is enforced where new titles enter, which is where the defect
+/// entered.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TaskTitle(String);
+
+impl TaskTitle {
+    /// A title a person typed for themselves.
+    ///
+    /// Authoritative: the console's create and edit dialogs and a `tasks.toml`
+    /// seed all land here, and nothing may re-word what they carry.
+    #[must_use]
+    pub fn authored(text: &str) -> Self {
+        Self(normalise(text))
+    }
+
+    /// A title that arrived as a structured title *field* rather than as prose
+    /// — a published file's name, a workflow's name, or the `title` argument of
+    /// a `spawn_task` tool call the model filled in deliberately.
+    ///
+    /// Already a name, whoever wrote it, so there is nothing for a summarising
+    /// pass to improve. This is the constructor for text that was **meant as a
+    /// title when it was written**; free text that merely gets used as one goes
+    /// to [`mint_task_title`].
+    #[must_use]
+    pub fn system(text: &str) -> Self {
+        Self(normalise(text))
+    }
+
+    /// A title a model wrote for a request.
+    ///
+    /// `None` when the reply sanitises to nothing — an empty string, pure
+    /// punctuation, a refusal — which is the caller's signal to fall back to
+    /// [`truncated`](Self::truncated) rather than to leave a card unnamed.
+    #[must_use]
+    pub fn summarised(reply: &str) -> Option<Self> {
+        let title = normalise(reply);
+        (!title.is_empty()).then_some(Self(title))
+    }
+
+    /// The deterministic fallback: the request itself, shortened.
+    ///
+    /// What every card was named before, kept because a dull title is better
+    /// than a failed card creation. Reached only when no model is configured or
+    /// the summarising pass could not answer in its budget.
+    #[must_use]
+    pub fn truncated(request: &str) -> Self {
+        Self(normalise(request))
+    }
+
+    /// The headline as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether this names nothing — the empty title an empty request produces.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for TaskTitle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::ops::Deref for TaskTitle {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for TaskTitle {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PartialEq<str> for TaskTitle {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for TaskTitle {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<String> for TaskTitle {
+    fn eq(&self, other: &String) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<TaskTitle> for str {
+    fn eq(&self, other: &TaskTitle) -> bool {
+        self == other.0
+    }
+}
+
+impl PartialEq<TaskTitle> for &str {
+    fn eq(&self, other: &TaskTitle) -> bool {
+        *self == other.0
+    }
+}
+
+impl PartialEq<TaskTitle> for String {
+    fn eq(&self, other: &TaskTitle) -> bool {
+        *self == other.0
+    }
+}
+
+/// Names the work a request asks for.
+///
+/// A port rather than a harness type because three of the four card-opening
+/// paths live outside the `openhuman` build — the REST chat handler, the
+/// desk hand-off tool, and the board's own create route — and every one of them
+/// mints a title from free text. A trait only the harness could name would have
+/// left them on the truncator that caused this.
+///
+/// The only implementation is the harness's metered titling pass. `None` in
+/// place of one — a default build, a company with no inference configured — is
+/// not an error condition: [`mint_task_title`] falls back and the card is named
+/// exactly as it was before.
+#[async_trait]
+pub trait TitleSummariser: Send + Sync {
+    /// Names the work `request` asks for, or `None` to leave the caller on its
+    /// deterministic fallback.
+    async fn title(&self, request: &str) -> Option<TaskTitle>;
+}
+
+/// Turn a free-text request into a card's headline. **The one way in.**
+///
+/// Every path that opens a card from something a person or an agent *said* goes
+/// through here: the REST chat handler, the direct and handed-off cards the
+/// delegation runner opens, and the desk hand-off tool. That is the whole of the
+/// fix — the three truncators those paths used to carry are gone, so there is no
+/// longer a second way to name a card from a message, and a fourth producer
+/// added tomorrow has one obvious function to call.
+///
+/// Titles that are **not** derived from free text do not belong here and must
+/// not be routed through it: a person's own words go to
+/// [`TaskTitle::authored`], and a name the host composes from facts it already
+/// holds goes to [`TaskTitle::system`]. Sending either to a model would re-word
+/// something that was already right.
+///
+/// Degrades in one direction only. No titler, an unreachable or slow model, a
+/// reply that sanitises to nothing — all of them land on `fallback`, which is
+/// the behaviour the caller had before. Card creation cannot fail here, and no
+/// inference error reaches the operator.
+///
+/// `fallback` is the name this caller would have used on its own, for the
+/// callers that have a better one than the request itself: the REST chat
+/// handler's lexical classifier already returns a tidied title, and throwing it
+/// away would make an offline company's cards *worse* than before rather than
+/// merely no better. `None` means "the request, shortened", which is what the
+/// paths with no lexical layer in front of them have always done.
+pub async fn mint_task_title(
+    request: &str,
+    fallback: Option<&str>,
+    titler: Option<&dyn TitleSummariser>,
+) -> TaskTitle {
+    if let Some(titler) = titler
+        && let Some(title) = titler.title(request).await
+    {
+        return title;
+    }
+    TaskTitle::truncated(fallback.unwrap_or(request))
+}
+
+/// Preambles a model reaches for when asked for a title, stripped so the answer
+/// is the name rather than a label plus the name.
+const TITLE_PREAMBLES: &[&str] = &[
+    "task title:",
+    "card title:",
+    "title:",
+    "task:",
+    "todo:",
+    "to-do:",
+    "here is the title:",
+    "here's the title:",
+];
+
+/// Reduce free text to the one bounded line a headline is allowed to be.
+///
+/// Order matters: the line is taken first so a model's chatty second paragraph
+/// cannot survive as content, the wrappers come off before the preamble so a
+/// quoted `"Title: x"` is caught, and the cap runs last so it bounds the final
+/// value rather than a prefix that later steps shorten anyway.
+///
+/// **Casing is left alone.** An earlier pass upper-cased the first character,
+/// which reads well on a sentence and corrupts every title that starts with a
+/// deliberately lower-case token — `iPhone sync is broken` became `IPhone …`,
+/// and a card named after a published `notes.md` became `Notes.md`. The model
+/// is asked for an imperative, which already starts capitalised; a human's own
+/// words and a file's own name are not this function's to restyle.
+fn normalise(text: &str) -> String {
+    let line = text
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or_default();
+    let mut current = line.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Wrappers, preambles and sentence punctuation all nest inside each other in
+    // real replies — `Title: "ship it"`, `"Title: ship it"`, `Task: "ship it".`
+    // — so all three come off together until a pass changes nothing. Running any
+    // one of them once, in a fixed order, leaves the others' leftovers behind:
+    // stripping the preamble off `Task: "ship it".` exposes quotes a one-shot
+    // wrapper pass has already been and gone past.
+    loop {
+        let before = current.clone();
+        current = strip_wrappers(&current);
+        let lowered = current.to_lowercase();
+        if let Some(preamble) = TITLE_PREAMBLES
+            .iter()
+            .find(|preamble| lowered.starts_with(**preamble))
+        {
+            current = current[preamble.len()..].trim_start().to_string();
+        }
+        // Sentence punctuation only. A closing bracket or a question mark that
+        // is part of the name (`Ship v2 (phase 1)`, `Why is checkout slow?`) is
+        // content, not decoration.
+        current = current
+            .trim_end_matches(['.', ',', ';', ':', '!', ' '])
+            .trim()
+            .to_string();
+        if current == before {
+            break;
+        }
+    }
+    cap(&current, TASK_TITLE_MAX_CHARS)
+}
+
+/// Peel one layer of quotes, backticks or markdown emphasis off both ends.
+fn strip_wrappers(text: &str) -> String {
+    const PAIRS: &[(&str, &str)] = &[
+        ("\"", "\""),
+        ("'", "'"),
+        ("`", "`"),
+        ("**", "**"),
+        ("__", "__"),
+        ("*", "*"),
+        ("_", "_"),
+        ("“", "”"),
+        ("‘", "’"),
+    ];
+    let mut current = text.trim().trim_start_matches('#').trim().to_string();
+    loop {
+        // `>=`, not `>`: a reply that is *only* a pair — `""`, `**` — has to
+        // strip to nothing, or a model that answered with bare punctuation puts
+        // that punctuation on the board as a title.
+        let Some((open, close)) = PAIRS.iter().find(|(open, close)| {
+            current.len() >= open.len() + close.len()
+                && current.starts_with(*open)
+                && current.ends_with(*close)
+        }) else {
+            return current;
+        };
+        current = current[open.len()..current.len() - close.len()]
+            .trim()
+            .to_string();
+    }
+}
+
+/// Shorten to `max` characters on a character boundary, preferring a whole word.
+///
+/// The ellipsis is budgeted inside `max`, so the result never exceeds the cap it
+/// advertises. Character-wise throughout: a byte slice would panic mid-codepoint
+/// on any title that is not ASCII.
+fn cap(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(max - 1).collect();
+    let head = match head.rsplit_once(' ') {
+        Some((whole, _)) if !whole.is_empty() => whole,
+        _ => head.as_str(),
+    };
+    format!("{head}…")
+}
+
 /// One card on the company's task board.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskRecord {
     /// Stable id for the task within the company.
     pub id: String,
-    /// The task's title.
-    pub title: String,
+    /// The card's headline. See [`TaskTitle`] for what is enforced and where
+    /// each producer's text is allowed to come from.
+    pub title: TaskTitle,
     /// An optional longer note.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
@@ -1154,6 +1478,33 @@ pub struct TaskRecord {
     /// like [`Self::parent_task_id`], so no stored board needs migrating.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin_run_id: Option<String>,
+    /// The operator message this card was opened for, by its position in the
+    /// company's event log.
+    ///
+    /// # Why a card needs to name its message
+    ///
+    /// The REST chat handler opens a card, and the runtime turn that follows has
+    /// to find it again to adopt it — one message, one card. It used to find it
+    /// by re-running the same lexical detector over the same words and matching
+    /// the two titles for byte equality, which made the headline an identity key
+    /// and pinned it to a pure function of the raw message. That is why the
+    /// board read as a chat log and could not be improved: a model-authored
+    /// title is not reproducible, so any better name broke adoption — the "Card
+    /// opened" chip vanished and a turn's workflow stranded its card in To-do,
+    /// all without an error.
+    ///
+    /// A sequence position is the identity that was wanted. It is stable, it is
+    /// unique per message, and it frees the headline to be a name. It also
+    /// settles a case title equality got wrong on its own terms: two messages in
+    /// one thread that happen to read alike are two cards, and the newest-first
+    /// scan adopted whichever came back first.
+    ///
+    /// `None` for a card raised anywhere but a chat handler, and for every card
+    /// written before this field existed — additive on the wire like
+    /// [`origin_run_id`](Self::origin_run_id), so no stored board needs
+    /// migrating.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_message_seq: Option<EventSeq>,
     /// The workflow graph whose run opened this card (issue #661 / M5).
     ///
     /// Carried beside [`origin_run_id`](Self::origin_run_id) rather than derived
@@ -1227,6 +1578,276 @@ pub trait TaskStore: Send + Sync {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    // ── the card headline's shape invariant ──────────────────────────────────
+
+    /// Every constructor bounds its result, whatever it was handed. This is the
+    /// property a `String` field could not have: a producer that shoved a
+    /// paragraph in used to get a paragraph back.
+    #[test]
+    fn no_constructor_can_produce_an_unbounded_title() {
+        let paragraph = "hey can you take a look at the pricing page, I think the tiers are \
+                         confusing and we should probably reword the middle one because \
+                         nobody I have shown it to can tell me what it is actually for";
+        for title in [
+            TaskTitle::authored(paragraph),
+            TaskTitle::system(paragraph),
+            TaskTitle::truncated(paragraph),
+            TaskTitle::summarised(paragraph).expect("a paragraph still names something"),
+        ] {
+            assert!(
+                title.as_str().chars().count() <= TASK_TITLE_MAX_CHARS,
+                "{title}"
+            );
+            assert!(!title.as_str().contains('\n'));
+        }
+    }
+
+    /// The cap counts characters, not bytes, and budgets the ellipsis inside
+    /// itself. A byte slice here would panic mid-codepoint; an unbudgeted
+    /// ellipsis would return one character more than the type advertises.
+    #[test]
+    fn the_cap_is_utf8_safe_and_includes_its_own_ellipsis() {
+        let long = "價".repeat(TASK_TITLE_MAX_CHARS + 40);
+        let title = TaskTitle::truncated(&long);
+        assert_eq!(title.as_str().chars().count(), TASK_TITLE_MAX_CHARS);
+        assert!(title.as_str().ends_with('…'));
+
+        let exact = "a".repeat(TASK_TITLE_MAX_CHARS);
+        assert_eq!(TaskTitle::truncated(&exact).as_str(), exact);
+    }
+
+    /// A title never breaks mid-word — the truncator prefers the last whole one.
+    #[test]
+    fn a_shortened_title_stops_at_a_word() {
+        let title = TaskTitle::truncated(
+            "Reword the middle pricing tier and also the top one and the bottom one              and everything else on that page",
+        );
+        assert!(title.as_str().ends_with('…'));
+        assert!(!title.as_str().contains("  "));
+    }
+
+    /// Whitespace-only and empty are the same answer: nothing. A caller that
+    /// gets this back is expected to refuse rather than open a blank card.
+    #[test]
+    fn nothing_in_is_nothing_out() {
+        for text in ["", "   ", "\n\t\n", "  \n  \n "] {
+            assert!(TaskTitle::authored(text).is_empty(), "{text:?}");
+            assert!(TaskTitle::truncated(text).is_empty(), "{text:?}");
+            assert!(TaskTitle::summarised(text).is_none(), "{text:?}");
+        }
+    }
+
+    /// A request that is already a good title is not degraded by passing
+    /// through — the commonest input on the board, and the easiest to break.
+    #[test]
+    fn an_already_good_title_survives_unchanged() {
+        for good in [
+            "Fix the login redirect",
+            "Draft the Q3 board update",
+            "Ship v2 (phase 1)",
+            "Why is the pricing page slow?",
+        ] {
+            assert_eq!(TaskTitle::authored(good).as_str(), good, "{good}");
+        }
+    }
+
+    /// A one-word ask is a one-word title, not padding and not an ellipsis.
+    #[test]
+    fn a_one_word_request_is_a_one_word_title() {
+        assert_eq!(TaskTitle::truncated("ship").as_str(), "ship");
+    }
+
+    /// Casing is never touched. Upper-casing the first character reads well on
+    /// a sentence and corrupts every name that starts with a deliberately
+    /// lower-case token — which is most tool names, some brands, and every
+    /// title derived from a file.
+    #[test]
+    fn a_deliberately_lower_case_name_is_not_restyled() {
+        for name in [
+            "iPhone sync is broken",
+            "notes.md",
+            "npm audit is failing",
+            "kubectl context keeps resetting",
+            "eBay listing export",
+        ] {
+            assert_eq!(TaskTitle::system(name).as_str(), name, "{name}");
+            assert_eq!(TaskTitle::authored(name).as_str(), name, "{name}");
+        }
+    }
+
+    /// A multi-paragraph brief is reduced to its first line, so the detail
+    /// cannot ride into the headline — the note is where it belongs.
+    #[test]
+    fn a_multi_paragraph_brief_keeps_only_its_first_line() {
+        let title = TaskTitle::summarised(
+            "Reword the middle pricing tier\n\nBackground: three customers have \
+             asked what it means.\n\nDeadline: Friday.",
+        )
+        .expect("a brief names something");
+        assert_eq!(title.as_str(), "Reword the middle pricing tier");
+    }
+
+    /// The wrappers and preambles a model reaches for come off, including when
+    /// they are nested the other way round.
+    #[test]
+    fn model_decoration_is_stripped_rather_than_trusted() {
+        for decorated in [
+            "\"Reword the middle pricing tier\"",
+            "**Reword the middle pricing tier**",
+            "`Reword the middle pricing tier`",
+            "Title: Reword the middle pricing tier",
+            "Task: \"Reword the middle pricing tier\"",
+            "\"Title: Reword the middle pricing tier\"",
+            // Decoration nested three deep. Each layer hides the next from a
+            // single-pass stripper, which is why the pass runs to a fixed point.
+            "Task: \"Reword the middle pricing tier\".",
+            "**Title: Reword the middle pricing tier.**",
+            "\"**Reword the middle pricing tier**\"",
+            "# Reword the middle pricing tier",
+            "Reword the middle pricing tier.",
+            "_Reword the middle pricing tier_",
+            "“Reword the middle pricing tier”",
+        ] {
+            assert_eq!(
+                TaskTitle::summarised(decorated).expect(decorated).as_str(),
+                "Reword the middle pricing tier",
+                "{decorated}"
+            );
+        }
+    }
+
+    /// Punctuation that is part of the name stays. Only sentence-ending
+    /// decoration is stripped, or `Ship v2 (phase 1)` loses its bracket.
+    #[test]
+    fn punctuation_inside_a_name_is_content_not_decoration() {
+        assert_eq!(
+            TaskTitle::summarised("Ship v2 (phase 1)")
+                .expect("a title")
+                .as_str(),
+            "Ship v2 (phase 1)"
+        );
+        assert_eq!(
+            TaskTitle::summarised("Why is checkout slow?")
+                .expect("a title")
+                .as_str(),
+            "Why is checkout slow?"
+        );
+    }
+
+    /// A reply that is nothing but decoration names nothing, so the caller
+    /// falls back rather than putting punctuation on the board.
+    #[test]
+    fn decoration_with_no_name_in_it_is_no_title() {
+        for junk in ["\"\"", "**", "...", "Title:", "``", "#"] {
+            assert!(TaskTitle::summarised(junk).is_none(), "{junk:?}");
+        }
+    }
+
+    /// Non-Latin scripts are neither mangled nor case-folded — the pass is
+    /// character-wise, and upper-casing is a no-op where a script has no case.
+    #[test]
+    fn a_non_english_title_is_left_intact() {
+        for text in [
+            "価格ページの中段プランを書き直す",
+            "Переписать средний тариф",
+            "إعادة صياغة الفئة الوسطى",
+        ] {
+            assert_eq!(
+                TaskTitle::summarised(text).expect(text).as_str(),
+                text,
+                "{text}"
+            );
+        }
+    }
+
+    /// A stored board loads back exactly as it was written, raw-message titles
+    /// and all. Normalising on read would silently rewrite durable records, and
+    /// re-summarising would make the board unstable between refreshes.
+    #[test]
+    fn a_title_stored_by_an_older_build_round_trips_verbatim() {
+        let legacy = "hey can you take a look at the pricing page, I think the tiers are…";
+        let json = serde_json::to_string(&legacy).expect("serialises");
+        let loaded: TaskTitle = serde_json::from_str(&json).expect("deserialises");
+        assert_eq!(loaded.as_str(), legacy);
+        assert_eq!(serde_json::to_string(&loaded).expect("re-serialises"), json);
+    }
+
+    /// The type is transparent on the wire, so no stored board needs migrating
+    /// and no console field changes shape.
+    #[test]
+    fn a_title_is_a_bare_string_on_the_wire() {
+        let json = serde_json::to_string(&TaskTitle::authored("Ship it")).expect("serialises");
+        assert_eq!(json, "\"Ship it\"");
+    }
+
+    /// No titler wired is the offline company and the default build: the card
+    /// is named exactly as it was before any of this existed.
+    #[tokio::test]
+    async fn without_a_titler_a_card_is_named_by_shortening_the_request() {
+        let request = "hey can you take a look at the pricing page, I think the tiers are \
+                       confusing and we should probably reword the middle one";
+        assert_eq!(
+            mint_task_title(request, None, None).await,
+            TaskTitle::truncated(request)
+        );
+    }
+
+    /// A titler that cannot answer — unreachable, too slow, unreadable — leaves
+    /// the card named, never unnamed and never failed.
+    #[tokio::test]
+    async fn a_titler_that_declines_falls_back_rather_than_failing() {
+        struct Silent;
+
+        #[async_trait]
+        impl TitleSummariser for Silent {
+            async fn title(&self, _request: &str) -> Option<TaskTitle> {
+                None
+            }
+        }
+
+        let request = "reword the middle pricing tier please";
+        assert_eq!(
+            mint_task_title(request, None, Some(&Silent)).await,
+            TaskTitle::truncated(request)
+        );
+        assert!(
+            !mint_task_title(request, None, Some(&Silent))
+                .await
+                .is_empty()
+        );
+    }
+
+    /// The fix itself, at the seam: a rambling ask is named after the **work**,
+    /// and the headline is no longer the message wearing an ellipsis.
+    #[tokio::test]
+    async fn a_rambling_ask_is_named_after_the_work() {
+        struct Names(&'static str);
+
+        #[async_trait]
+        impl TitleSummariser for Names {
+            async fn title(&self, _request: &str) -> Option<TaskTitle> {
+                TaskTitle::summarised(self.0)
+            }
+        }
+
+        let request = "hey can you take a look at the pricing page, I think the tiers are \
+                       confusing and we should probably reword the middle one";
+        let title = mint_task_title(
+            request,
+            None,
+            Some(&Names("Reword the middle pricing tier")),
+        )
+        .await;
+
+        assert_eq!(title.as_str(), "Reword the middle pricing tier");
+        // The property that actually broke: the headline is not the message.
+        assert!(
+            !request.starts_with(title.as_str().trim_end_matches('…')),
+            "the title is still an excerpt of the request: {title}"
+        );
+        assert!(!title.as_str().ends_with('…'));
+    }
 
     /// Pins the **Rust** list's ids and their order against a literal, so a
     /// reorder or a rename is a deliberate two-place edit rather than a
@@ -1623,7 +2244,7 @@ mod test {
     fn plain_card() -> TaskRecord {
         TaskRecord {
             id: "t-1".to_string(),
-            title: "Draft the spec".to_string(),
+            title: TaskTitle::authored("Draft the spec"),
             note: None,
             column: COLUMN_IN_REVIEW.to_string(),
             priority: "medium".to_string(),
@@ -1640,6 +2261,7 @@ mod test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/ports/usage.rs
+++ b/src/ports/usage.rs
@@ -107,6 +107,23 @@ pub enum SampleKind {
     /// leak: selection is per-message spend, so a company past its ceiling
     /// must not keep paying to route.
     SelectorCall,
+    /// One completed card-titling pass — the single tool-less model call that
+    /// names the work a request asks for.
+    ///
+    /// Charged to the whole-company bucket with no `run_id`, on
+    /// [`SampleKind::TriageCall`]'s exact terms: the pass runs while a card is
+    /// being opened, before any teammate has been handed it, so there is no
+    /// agent whose budget it could belong to.
+    ///
+    /// Its own kind rather than folded into `TriageCall` because the two are
+    /// driven by different things — triage by every abstained-on message,
+    /// titling only by messages that become cards — so a shared kind would move
+    /// the triage line whenever the board got busier, and neither number could
+    /// be tuned against the other.
+    ///
+    /// Counts toward the capability-tier token budget: it is per-card spend a
+    /// company past its ceiling must stop paying.
+    TitleCall,
     /// One completed first-run setup pass — the single tool-less model call
     /// that turns three answers into a starting roster
     /// (`docs/spec/runtime/company-setup.md`).

--- a/src/runtime/advance.rs
+++ b/src/runtime/advance.rs
@@ -360,6 +360,7 @@ pub async fn sweep_stranded_planning(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ports::tasks::TaskTitle;
     use crate::ports::tasks::{COLUMN_IN_REVIEW, COLUMN_PAUSED, TaskRecord};
     use crate::store::FsOps;
     use std::sync::Arc;
@@ -367,7 +368,7 @@ mod test {
     fn card(id: &str, column: &str) -> TaskRecord {
         TaskRecord {
             id: id.to_string(),
-            title: "Draft the spec".to_string(),
+            title: TaskTitle::authored("Draft the spec"),
             note: None,
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -382,6 +383,7 @@ mod test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/runtime/board_events.rs
+++ b/src/runtime/board_events.rs
@@ -165,6 +165,7 @@ impl TaskStore for BoardAnnouncer {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ports::tasks::TaskTitle;
     use crate::ports::types::{EventSeq, StoredEvent};
     use futures::stream::BoxStream;
     use std::sync::Mutex;
@@ -255,7 +256,7 @@ mod test {
     fn card(id: &str, column: &str) -> TaskRecord {
         TaskRecord {
             id: id.to_string(),
-            title: "Draft the launch note".to_string(),
+            title: TaskTitle::authored("Draft the launch note"),
             note: None,
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -270,6 +271,7 @@ mod test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -6443,7 +6443,7 @@ mod test {
 
         let card = |id: &str, column: &str| crate::ports::tasks::TaskRecord {
             id: id.to_string(),
-            title: "Do the thing".to_string(),
+            title: crate::ports::tasks::TaskTitle::authored("Do the thing"),
             note: None,
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -6457,6 +6457,7 @@ mod test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
             planning_attempts: Vec::new(),
         };
@@ -6819,7 +6820,7 @@ mod test {
         let id = CompanyId::new("acme");
         let card = |task: &str, column: &str| TaskRecord {
             id: task.to_string(),
-            title: "Draft the spec".to_string(),
+            title: crate::ports::tasks::TaskTitle::authored("Draft the spec"),
             note: Some("[maya] started".to_string()),
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -6834,6 +6835,7 @@ mod test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
 
@@ -6947,7 +6949,7 @@ mod test {
         let id = CompanyId::new("acme");
         let card = |task: &str, column: &str| TaskRecord {
             id: task.to_string(),
-            title: "Draft the spec".to_string(),
+            title: crate::ports::tasks::TaskTitle::authored("Draft the spec"),
             note: None,
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -6962,6 +6964,7 @@ mod test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
 

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -3520,7 +3520,7 @@ impl<'a> CycleHostImpl<'a> {
         };
         let card = TaskRecord {
             id: generate_id(),
-            title: parsed.title.clone(),
+            title: crate::ports::tasks::TaskTitle::system(&parsed.title),
             note: parsed.note,
             column: COLUMN_TODO.to_string(),
             priority: "medium".to_string(),
@@ -3545,6 +3545,7 @@ impl<'a> CycleHostImpl<'a> {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
         self.rt.tasks().upsert(&self.company, &card).await?;
@@ -3643,7 +3644,12 @@ impl<'a> CycleHostImpl<'a> {
         };
         let card = TaskRecord {
             id: generate_id(),
-            title: first_line(&parsed.instruction, 80),
+            title: crate::ports::tasks::mint_task_title(
+                &parsed.instruction,
+                None,
+                self.rt.titler(),
+            )
+            .await,
             note: Some(note),
             column: COLUMN_TODO.to_string(),
             priority: "medium".to_string(),
@@ -3668,6 +3674,7 @@ impl<'a> CycleHostImpl<'a> {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
         self.rt.tasks().upsert(&self.company, &card).await?;
@@ -4087,6 +4094,7 @@ impl CycleHost for CycleHostImpl<'_> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ports::tasks::TaskTitle;
 
     /// `single_agent` picks an agent slot only when the batch is one addressed
     /// operator message, and falls back to the whole-company lock otherwise —
@@ -4227,7 +4235,7 @@ mod test {
 
         let card = |id: &str, title: &str, column: &str| TaskRecord {
             id: id.to_string(),
-            title: title.to_string(),
+            title: TaskTitle::authored(title),
             note: None,
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -4242,6 +4250,7 @@ mod test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
         rt.tasks()
@@ -4402,7 +4411,7 @@ mod test {
                 rt.id(),
                 &TaskRecord {
                     id: "t-paused".to_string(),
-                    title: "Investigate the flaky nightly job".to_string(),
+                    title: TaskTitle::authored("Investigate the flaky nightly job"),
                     note: None,
                     column: crate::ports::tasks::COLUMN_PAUSED.to_string(),
                     priority: "medium".to_string(),
@@ -4417,6 +4426,7 @@ mod test {
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -4544,7 +4554,7 @@ mod test {
                     rt.id(),
                     &TaskRecord {
                         id: format!("t-{n}"),
-                        title: format!("Card {n}"),
+                        title: TaskTitle::authored(&format!("Card {n}")),
                         note: None,
                         column: COLUMN_TODO.to_string(),
                         priority: "medium".to_string(),
@@ -4559,6 +4569,7 @@ mod test {
                         workflow_proposal: None,
                         origin_run_id: None,
                         origin_workflow_id: None,
+                        origin_message_seq: None,
                         bounced: None,
                     },
                 )
@@ -5438,7 +5449,7 @@ members = ["writer"]
                 rt.id(),
                 &TaskRecord {
                     id: "t-1".to_string(),
-                    title: "Draft the spec".to_string(),
+                    title: TaskTitle::authored("Draft the spec"),
                     note: None,
                     column: COLUMN_IN_PROGRESS.to_string(),
                     priority: "medium".to_string(),
@@ -5455,6 +5466,7 @@ members = ["writer"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -5525,7 +5537,7 @@ members = ["writer"]
                 rt.id(),
                 &TaskRecord {
                     id: "t-1".to_string(),
-                    title: "Draft the spec".to_string(),
+                    title: TaskTitle::authored("Draft the spec"),
                     note: Some("[operator] parked this".to_string()),
                     column: COLUMN_PAUSED.to_string(),
                     priority: "medium".to_string(),
@@ -5542,6 +5554,7 @@ members = ["writer"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -9937,7 +9950,7 @@ members = ["writer"]
                 rt.id(),
                 &TaskRecord {
                     id: "t1".into(),
-                    title: "Ship invoicing".into(),
+                    title: TaskTitle::authored("Ship invoicing"),
                     note: Some("build the importer".into()),
                     column: COLUMN_TODO.into(),
                     priority: "medium".into(),
@@ -9954,6 +9967,7 @@ members = ["writer"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -10017,7 +10031,7 @@ members = ["writer"]
                 rt.id(),
                 &TaskRecord {
                     id: "t1".into(),
-                    title: "Already finished".into(),
+                    title: TaskTitle::authored("Already finished"),
                     note: None,
                     column: "done".into(),
                     priority: "medium".into(),
@@ -10034,6 +10048,7 @@ members = ["writer"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -11164,7 +11179,7 @@ members = ["writer"]
     fn a_card_has_settled_only_once_its_run_stopped() {
         let card = |column: &str, bounced: Option<&str>| TaskRecord {
             id: "t-1".to_string(),
-            title: "Ship the thing".to_string(),
+            title: TaskTitle::authored("Ship the thing"),
             note: None,
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -11179,6 +11194,7 @@ members = ["writer"]
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: bounced.map(str::to_string),
         };
         // Stopped, whether or not it succeeded — the misleading case this
@@ -11219,7 +11235,7 @@ members = ["writer"]
     fn a_settled_line_names_the_landing_and_a_bounce_names_its_reason() {
         let mut card = TaskRecord {
             id: "t-1".to_string(),
-            title: "Draft the investor update".to_string(),
+            title: TaskTitle::authored("Draft the investor update"),
             note: None,
             column: crate::ports::tasks::COLUMN_IN_REVIEW.to_string(),
             priority: "medium".to_string(),
@@ -11234,6 +11250,7 @@ members = ["writer"]
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
         assert_eq!(
@@ -11453,7 +11470,7 @@ timeout)",
     fn settled_card(id: &str, title: &str) -> TaskRecord {
         TaskRecord {
             id: id.to_string(),
-            title: title.to_string(),
+            title: TaskTitle::authored(title),
             note: None,
             column: crate::ports::tasks::COLUMN_IN_REVIEW.to_string(),
             priority: "medium".to_string(),
@@ -11473,6 +11490,7 @@ timeout)",
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -33,15 +33,13 @@ use crate::harness::policy::ApprovalRequestQueue;
 use crate::harness::run_trace::RunTraceSink;
 use crate::harness::workflow_refs::WorkflowRefQueue;
 use crate::ports::tasks::{
-    COLUMN_PLANNING, COLUMN_TODO, TaskOutput, TaskOutputAction, TaskOutputSource,
-    TaskOutputWorkflow,
+    COLUMN_TODO, TaskOutput, TaskOutputAction, TaskOutputSource, TaskOutputWorkflow,
 };
 use crate::ports::types::{CompanyId, CompanyRecord, EventSeq, OutboundMessage, TurnStep};
 use crate::ports::{TaskOrigin, TaskRecord, TaskStore, generate_id, now_millis};
 use crate::runtime::assignee;
 use crate::runtime::cycle::{
     BUILDER_ANNOTATION, OPEN_WORK_ANNOTATION, SETTLED_WORK_ANNOTATION, THREAD_INDEX_ANNOTATION,
-    assignment_matches,
 };
 
 /// One agent turn, abstracted so delegation orchestration never touches the
@@ -803,6 +801,10 @@ pub(crate) struct DelegationRunner<'a> {
     /// build wires no evaluator — keeps the deterministic answer, which is the
     /// behaviour this had before.
     triage: Option<&'a dyn crate::harness::triage::TriageEscalation>,
+    /// Names the work a card is opened for. `None` — every pre-existing
+    /// constructor, and any company whose build wires no titler — falls back to
+    /// shortening the request, which is what every card was named before.
+    titler: Option<&'a dyn crate::ports::tasks::TitleSummariser>,
     /// Workflows the turn authored in-flight with the inline `create_workflow`
     /// tool (issues #112, #339), read so an operator turn can settle the card it
     /// adopted instead of leaving it in To-do (issue #678).
@@ -845,6 +847,7 @@ impl<'a> DelegationRunner<'a> {
             workflow_run: None,
             workflow_refs: None,
             triage: None,
+            titler: None,
         }
     }
 
@@ -898,6 +901,7 @@ impl<'a> DelegationRunner<'a> {
             workflow_run: Some(run),
             workflow_refs: None,
             triage: None,
+            titler: None,
         }
     }
 
@@ -939,6 +943,18 @@ impl<'a> DelegationRunner<'a> {
         triage: &'a dyn crate::harness::triage::TriageEscalation,
     ) -> Self {
         self.triage = Some(triage);
+        self
+    }
+
+    /// Wires the pass that names the work a card is opened for.
+    ///
+    /// Without it a card is named by shortening the request, which is what
+    /// every card was named before.
+    pub(crate) fn with_titler(
+        mut self,
+        titler: &'a dyn crate::ports::tasks::TitleSummariser,
+    ) -> Self {
+        self.titler = Some(titler);
         self
     }
 
@@ -1248,11 +1264,10 @@ impl<'a> DelegationRunner<'a> {
         // does not make.
         //
         // An escalation can only ever *narrow* the claim, never widen what the
-        // turn may do, and it never mints a card: the title a card opens under
-        // is pinned byte-for-byte between the REST handler and
-        // `chat_handler_card` (issue #463), so a model-authored one would
-        // orphan it. `Work` and `Chatter` therefore both leave the gate where
-        // the abstention left it, and only `Answer` moves it.
+        // turn may do, and it never mints a card: a missed card costs one
+        // follow-up message, a spurious card pollutes the board permanently.
+        // `Work` and `Chatter` therefore both leave the gate where the
+        // abstention left it, and only `Answer` moves it.
         let mut answering = triage.is_answer();
         // Issue #984: the same escalation, read for BOTH of its useful answers.
         //
@@ -1404,7 +1419,7 @@ impl<'a> DelegationRunner<'a> {
         // authored. Run records stay reserved for actual work attempts (#183
         // §4), so this turn mints none — see `TaskOutputSource`.
         let handler_card = match carded_by_handler {
-            true => self.chat_handler_card(message, chat_id).await?,
+            true => self.chat_handler_card().await?,
             false => None,
         };
         // Issue #442, path one: a desk lead or teammate asked DIRECTLY carries
@@ -2666,7 +2681,7 @@ impl<'a> DelegationRunner<'a> {
         }
         let card = TaskRecord {
             id: generate_id(),
-            title: card_title(request),
+            title: crate::ports::tasks::mint_task_title(request, None, self.titler).await,
             note: Some(append_note(None, "operator", request)),
             // The agent runs it in this turn, so the board shows it in progress
             // while that happens — the same window `hand_card_over` opens for a
@@ -2690,6 +2705,7 @@ impl<'a> DelegationRunner<'a> {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
         tasks.upsert(self.company, &card).await?;
@@ -2815,103 +2831,59 @@ impl<'a> DelegationRunner<'a> {
         self.open_work_card(responder, message, chat_id, ctx).await
     }
 
-    /// Whether a card assigned to `assignee` is assigned to whoever `chat_id`
-    /// addresses (issue #982).
-    ///
-    /// The comparison itself is [`assignment_matches`] — the one comparator on
-    /// this seam — asked twice: once for the key as the console sent it, and
-    /// once for the `dm:<teammate-id>` form with its prefix stripped, which the
-    /// chat route resolves the same way and in the same order.
-    fn addressed_to(&self, chat_id: Option<&str>, assignee: &str) -> bool {
-        let Some(chat) = chat_id else {
-            return false;
-        };
-        assignment_matches(self.record, chat, assignee)
-            || assignee::dm_key(chat)
-                .is_some_and(|key| assignment_matches(self.record, key, assignee))
-    }
-
     /// The card the REST chat handler opened for this message, when it opened
     /// one and it is still on the board (issue #463).
     ///
-    /// Only ever called once [`detect_task_intent`] has already fired, so the
-    /// title it derives is byte-for-byte the one the handler wrote — the handler
-    /// runs the same detector over the same words moments earlier. The match is
-    /// deliberately narrow, and every clause is a property of a card **that
-    /// handler** writes: its landing column, an assignee it is entitled to have,
-    /// and an origin thread that is this one. `list` is newest-first, so the
-    /// first match is the one just written rather than a months-old card that
-    /// happens to share a title.
+    /// Found by the **sequence position of the message itself**
+    /// ([`TaskRecord::origin_message_seq`]), which the handler stamps as it
+    /// writes. One message has one journal position and one card, so this is an
+    /// identity lookup rather than a search.
     ///
-    /// # The assignee clause is no longer "blank" (issue #982)
+    /// # It used to match on the title, and that is why boards read as chat logs
     ///
-    /// It was, and it had to stop being, in the same change that made the
-    /// handler assign the card to the thread it was addressed to. A blank-only
-    /// clause and an assigning handler do not fail loudly together: they stop
-    /// matching, `spawned_task` falls back, the "Card opened" chip silently
-    /// disappears from every carded chat message, and
-    /// `settle_authored_workflow_card` stops running so a workflow the turn
-    /// authored strands its card in To-do. Nothing errors, and the
-    /// duplicate-card guard is keyed on the detector rather than on adoption, so
-    /// there is not even a second card to notice.
+    /// This re-ran the same lexical detector over the same words and compared
+    /// the two titles for byte equality, narrowed by the card's column, its
+    /// assignee and its origin thread. It worked, and it made the headline an
+    /// identity key: any better name for a card broke adoption, so a
+    /// model-authored title was refused outright rather than risk it. That is
+    /// the constraint that kept every card named after the message that opened
+    /// it.
     ///
-    /// What replaces it is the same question one narrower: blank, **or** an
-    /// assignee that is who this message was addressed to, compared with
-    /// [`assignment_matches`] — the comparator the direct-card path already uses
-    /// (issue #176) rather than a second one that could drift. A card assigned to
-    /// somebody *else* is still refused, which is what the clause was protecting.
+    /// The failure mode is also why the coupling had to go rather than be worked
+    /// around. Nothing errors when adoption stops matching — `spawned_task`
+    /// falls back, the "Card opened" chip silently disappears from every carded
+    /// chat message, and `settle_authored_workflow_card` stops running so a
+    /// workflow the turn authored strands its card in To-do. Issues #982 and
+    /// #576 are both that same silence, found twice, after the handler changed
+    /// an assignee and then a column out from under clauses that were reading
+    /// them.
     ///
-    /// The origin clause moved for the same reason and reads the same way: the
-    /// handler now stamps the thread it opened the card from, so `None` (an
-    /// unaddressed message) **or** this very thread is the handler's write, and
-    /// a card carrying somebody else's thread is still not ours to adopt.
+    /// A sequence position has none of that surface: it is stamped by the write
+    /// this looks for, it does not move when the handler changes what column or
+    /// assignee it opens a card under, and it cannot be re-derived wrongly
+    /// because it is not derived at all. It also settles a case title equality
+    /// got wrong on its own terms — two alike-reading messages in one thread are
+    /// two cards, and a newest-first scan adopted whichever came back first.
     ///
-    /// **Two landing columns, not one** (issue #576). The handler opens a
-    /// person's card directly in Planning and a machine's in To-do, so pinning
-    /// this clause to To-do stopped recognising the commonest card of the two —
-    /// and the cost is invisible from here: `spawned_task` falls back, the
-    /// operator bubble reports no card, and the chip tying the reply to the
-    /// board silently disappears while the card itself is created correctly.
-    /// Both columns are named explicitly rather than dropping the clause,
-    /// because the clause is what keeps this from adopting a card the operator
-    /// dragged somewhere; a card resting anywhere else was moved by somebody.
-    ///
-    /// `None` when no store is wired, or when nothing matches — which is the
-    /// honest answer for a handler write that failed (it is best-effort there)
-    /// and for every non-REST caller of this seam, none of which have a chat
-    /// handler in front of them. Callers must not read `None` as "the handler
-    /// did not fire": the stand-down is keyed on the detector, not on this.
-    async fn chat_handler_card(
-        &self,
-        message: &str,
-        chat_id: Option<&str>,
-    ) -> Result<Option<String>> {
+    /// `None` when no store is wired, when the turn is not answering a journaled
+    /// message, or when nothing matches — the honest answer for a handler write
+    /// that failed (it is best-effort there), for a card written before this
+    /// field existed, and for every non-REST caller of this seam, none of which
+    /// have a chat handler in front of them. Callers must not read `None` as
+    /// "the handler did not fire": the stand-down is keyed on the detector, not
+    /// on this.
+    async fn chat_handler_card(&self) -> Result<Option<String>> {
         let Some(tasks) = self.tasks else {
             return Ok(None);
         };
-        let Some(title) = crate::company::task_intent::detect_task_intent(operator_words(message))
-        else {
+        let Some(seq) = self.message_seq else {
             return Ok(None);
         };
         Ok(tasks
             .list(self.company)
             .await?
             .into_iter()
-            .find(|card| {
-                card.title == title
-                    && (card.column == COLUMN_TODO || card.column == COLUMN_PLANNING)
-                    && (card.assignee.is_empty() || self.addressed_to(chat_id, &card.assignee))
-                    // Desk **and** thread. Matching the desk alone lets a turn
-                    // adopt a same-titled card raised in a *different* thread of
-                    // the same desk, and then settle somebody else's card into
-                    // this thread — the split #1890 B exists to prevent, arrived
-                    // at from the other side. An origin-less card is still
-                    // adoptable: it belongs to no conversation, so it contradicts
-                    // none (coderabbit on #1982).
-                    && (card.origin_chat_id().is_none()
-                        || (card.origin_chat_id() == chat_id
-                            && card.origin_parent() == self.thread_root))
-            })
+            .find(|card| card.origin_message_seq == Some(seq))
             .map(|card| card.id))
     }
 
@@ -3046,8 +3018,9 @@ impl<'a> DelegationRunner<'a> {
                 };
                 let card = TaskRecord {
                     id: generate_id(),
-                    title,
+                    title: crate::ports::tasks::TaskTitle::system(&title),
                     note,
+                    origin_message_seq: None,
                     column: COLUMN_TODO.to_string(),
                     priority: "medium".to_string(),
                     assignee: assignee.unwrap_or_default(),
@@ -3818,39 +3791,18 @@ pub(crate) fn is_chat_only_turn() -> bool {
     CHAT_ONLY_TURN.try_with(|v| *v).unwrap_or(false)
 }
 
-/// How many characters of a request survive into the card's title.
-const TITLE_CHARS: usize = 80;
-
-/// A one-line card title from the request that opened it.
-///
-/// Collapses whitespace, then truncates on a **character** boundary — never a
-/// byte one — and prefers the last whole word so a title never breaks mid-word.
-/// The ellipsis is budgeted inside [`TITLE_CHARS`], so the result is never
-/// longer than the cap it advertises.
-fn card_title(text: &str) -> String {
-    let one_line = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    if one_line.chars().count() <= TITLE_CHARS {
-        return one_line;
-    }
-    let head: String = one_line.chars().take(TITLE_CHARS - 1).collect();
-    let head = match head.rsplit_once(' ') {
-        Some((whole, _)) if !whole.is_empty() => whole,
-        _ => head.as_str(),
-    };
-    format!("{head}…")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::tasks::TaskTitle;
 
     use std::collections::VecDeque;
     use std::sync::Mutex;
 
     use crate::ports::TaskStore;
     use crate::ports::tasks::{
-        COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED, COLUMN_TODO,
-        TaskOutputSource,
+        COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED, COLUMN_PLANNING,
+        COLUMN_TODO, TaskOutputSource,
     };
     use crate::ports::types::LedgerEntry;
     use crate::store::FsOps;
@@ -4250,10 +4202,16 @@ finished → In review\n]"
     #[test]
     fn a_card_title_is_bounded_and_utf8_safe() {
         let long = "рынок ".repeat(60);
-        let title = card_title(&long);
-        assert!(title.chars().count() <= TITLE_CHARS, "{title}");
+        let title = crate::ports::tasks::TaskTitle::truncated(&long);
+        assert!(
+            title.chars().count() <= crate::ports::tasks::TASK_TITLE_MAX_CHARS,
+            "{title}"
+        );
         assert!(title.ends_with('…'), "{title}");
-        assert_eq!(card_title("  keep   it   short  "), "keep it short");
+        assert_eq!(
+            crate::ports::tasks::TaskTitle::truncated("  keep   it   short  "),
+            "keep it short"
+        );
     }
 
     // ── harness ─────────────────────────────────────────────────────────────
@@ -4958,7 +4916,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let card = TaskRecord {
             id: "card-1".to_string(),
-            title: "Draft the launch plan".to_string(),
+            title: TaskTitle::authored("Draft the launch plan"),
             note: Some("[engineer] drafted".to_string()),
             column: COLUMN_IN_REVIEW.to_string(),
             priority: "medium".to_string(),
@@ -4973,6 +4931,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
         fx.tasks
@@ -5882,10 +5841,21 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
     /// A card standing in for the one the REST chat handler opened (#463), in
     /// the column it landed in — To-do for a machine's card, Planning for a
     /// person's (issue #576).
+    /// The journal position of the operator message a seeded handler card was
+    /// opened for.
+    ///
+    /// Adoption keys on this alone, so a fixture that seeds a card without it is
+    /// a card no turn can claim — which is the point: the runner must be told
+    /// which message it is answering (`.answering(Some(HANDLER_SEQ))`) exactly
+    /// as the chat drain tells it in production.
+    fn handler_seq() -> EventSeq {
+        EventSeq::new(41)
+    }
+
     fn handler_card_in(title: String, column: &str) -> TaskRecord {
         TaskRecord {
             id: "t-handler".to_string(),
-            title,
+            title: TaskTitle::authored(&title),
             note: None,
             column: column.to_string(),
             priority: "medium".to_string(),
@@ -5900,8 +5870,190 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: Some(handler_seq()),
             bounced: None,
         }
+    }
+
+    /// A titling pass that answers with one canned name, and records what it
+    /// was asked to name.
+    struct ScriptedTitler {
+        title: &'static str,
+        asked: Mutex<Vec<String>>,
+    }
+
+    impl ScriptedTitler {
+        fn new(title: &'static str) -> Self {
+            Self {
+                title,
+                asked: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn asked(&self) -> Vec<String> {
+            self.asked.lock().expect("asked").clone()
+        }
+    }
+
+    #[async_trait]
+    impl crate::ports::tasks::TitleSummariser for ScriptedTitler {
+        async fn title(&self, request: &str) -> Option<TaskTitle> {
+            self.asked.lock().expect("asked").push(request.to_string());
+            TaskTitle::summarised(self.title)
+        }
+    }
+
+    /// The defect, at the seam that produced it: a card opened for a rambling
+    /// ask is named after the **work**, not after the message.
+    ///
+    /// The assertion that matters is the negative one. A card titled
+    /// `hey can you take a look at the pricing page, I think the tiers are…` is
+    /// a prefix of the request wearing an ellipsis, and that is what a board of
+    /// them read as — a chat log. Asserting only the expected string would still
+    /// pass if the title were an excerpt that happened to match.
+    #[tokio::test]
+    async fn a_card_is_named_after_the_work_not_the_message_that_asked_for_it() {
+        let rambling = "hey can you take a look at the pricing page, I think the tiers are \
+                        confusing and we should probably reword the middle one";
+        let fx = Fixture::new();
+        let titler = ScriptedTitler::new("Reword the middle pricing tier");
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+
+        fx.runner(&turns)
+            .with_titler(&titler)
+            .handle_operator_message("engineer", rambling, Some("engineer"))
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "one message, one card: {cards:?}");
+        assert_eq!(cards[0].title, "Reword the middle pricing tier");
+        assert!(
+            !rambling.starts_with(cards[0].title.trim_end_matches('…')),
+            "the headline is still an excerpt of the request: {}",
+            cards[0].title
+        );
+        // The full ask is not lost — it moved to where the detail belongs.
+        assert!(
+            cards[0]
+                .note
+                .as_deref()
+                .is_some_and(|note| note.contains("the tiers are confusing")),
+            "the operator's words must survive on the card: {:?}",
+            cards[0].note
+        );
+        // The pass saw the operator's words, not the open-work briefing the
+        // cycle appends to a desk-addressed message.
+        assert_eq!(titler.asked(), vec![rambling.to_string()]);
+    }
+
+    /// No titler wired — an offline company, a default build — still opens the
+    /// card, named the way every card was named before.
+    #[tokio::test]
+    async fn without_a_titler_a_card_is_still_opened_and_still_named() {
+        // The same message the test above names semantically — one the lexical
+        // layer does not recognise, so the direct-card path is the one that
+        // opens it rather than standing down for the chat handler.
+        let request = "hey can you take a look at the pricing page, I think the tiers are \
+                       confusing and we should probably reword the middle one";
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+
+        fx.runner(&turns)
+            .handle_operator_message("engineer", request, Some("engineer"))
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "one message, one card: {cards:?}");
+        assert_eq!(
+            cards[0].title,
+            crate::ports::tasks::TaskTitle::truncated(request)
+        );
+        assert!(!cards[0].title.is_empty());
+    }
+
+    /// The coupling this change exists to break: the handler's card is adopted
+    /// even when its headline bears **no relation** to the message.
+    ///
+    /// Adoption used to re-derive the title lexically and match it byte-for-byte,
+    /// so this card — named the way a titling pass names one — was invisible to
+    /// it. That is the whole reason a model-authored title could not ship: the
+    /// failure is silent, and it costs the "Card opened" chip and the workflow
+    /// settle rather than an error.
+    #[tokio::test]
+    async fn a_handler_card_is_adopted_by_its_message_not_by_its_title() {
+        let imperative = "draft the launch plan for next quarter";
+        let fx = Fixture::new();
+        let mut handler =
+            handler_card_in("Reword the middle pricing tier".to_string(), COLUMN_TODO);
+        handler.id = "handler-card".to_string();
+        TaskStore::upsert(&*fx.tasks, &fx.record.id, &handler)
+            .await
+            .expect("seed the handler card");
+
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+        let turn = fx
+            .runner(&turns)
+            .answering(Some(handler_seq()))
+            .handle_operator_message("chief", imperative, None)
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "one message, one card: {cards:?}");
+        assert_eq!(
+            turn.spawned_task.as_deref(),
+            Some("handler-card"),
+            "a card whose title is a NAME is still this message's card"
+        );
+    }
+
+    /// Two alike-reading messages in one thread are two cards, and a turn
+    /// adopts its **own** — even when that is not the newest one on the board.
+    ///
+    /// Title equality could not tell them apart: both cards carry the headline
+    /// the old key derived from the message, so the matcher had two equally good
+    /// candidates and took the first the store returned. `list` is newest-first,
+    /// so it took the *later* card — and a person who asks twice in one thread
+    /// then watches their first ask settle the second ask's card.
+    ///
+    /// The fixture puts the right answer in the older card deliberately. With
+    /// both cards equally titled and the newer one wrong, only an identity that
+    /// names the message can pick correctly.
+    #[tokio::test]
+    async fn a_turn_adopts_its_own_card_not_the_newest_alike_one() {
+        let imperative = "draft the launch plan for next quarter";
+        let derived = crate::company::task_intent::detect_task_intent(imperative)
+            .expect("fixture must be a message the chat handler cards");
+        let fx = Fixture::new();
+        // The card this turn's message opened — and the OLDER of the two.
+        for (id, seq, updated) in [
+            ("card-mine", 41u64, 1_000u64),
+            ("card-later", 77u64, 2_000u64),
+        ] {
+            let mut card = handler_card_in(derived.clone(), COLUMN_TODO);
+            card.id = id.to_string();
+            card.origin_message_seq = Some(EventSeq::new(seq));
+            card.updated_at_millis = updated;
+            TaskStore::upsert(&*fx.tasks, &fx.record.id, &card)
+                .await
+                .expect("seed a handler card");
+        }
+
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+        let turn = fx
+            .runner(&turns)
+            .answering(Some(EventSeq::new(41)))
+            .handle_operator_message("chief", imperative, None)
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turn.spawned_task.as_deref(),
+            Some("card-mine"),
+            "the turn must adopt the card opened for ITS message, not the newest alike one"
+        );
     }
 
     fn authored(workflow_id: &str) -> TaskOutputWorkflow {
@@ -5935,6 +6087,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
+            .answering(Some(handler_seq()))
             .handle_operator_message("chief", imperative, Some("general"))
             .await
             .expect("operator message handled");
@@ -5983,6 +6136,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
+            .answering(Some(handler_seq()))
             .handle_operator_message("chief", imperative, None)
             .await
             .expect("operator message handled");
@@ -6039,6 +6193,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
+            .answering(Some(handler_seq()))
             .handle_operator_message("chief", imperative, Some("general"))
             .await
             .expect("operator message handled");
@@ -6101,6 +6256,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             )],
         );
         fx.runner(&turns)
+            .answering(Some(handler_seq()))
             .handle_operator_message("chief", imperative, Some("general"))
             .await
             .expect("operator message handled");
@@ -6234,7 +6390,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 &fx.record.id,
                 &TaskRecord {
                     id: "handler-card".to_string(),
-                    title,
+                    title: TaskTitle::authored(&title),
                     note: None,
                     column: COLUMN_TODO.to_string(),
                     priority: "medium".to_string(),
@@ -6249,6 +6405,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: Some(handler_seq()),
                     bounced: None,
                 },
             )
@@ -6265,6 +6422,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
         let turn = fx
             .runner(&turns)
+            .answering(Some(handler_seq()))
             .handle_operator_message("chief", imperative, None)
             .await
             .expect("operator message handled");
@@ -6300,7 +6458,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 &fx.record.id,
                 &TaskRecord {
                     id: "handler-card".to_string(),
-                    title,
+                    title: TaskTitle::authored(&title),
                     note: None,
                     column: COLUMN_PLANNING.to_string(),
                     priority: "medium".to_string(),
@@ -6315,6 +6473,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: Some(handler_seq()),
                     bounced: None,
                 },
             )
@@ -6324,6 +6483,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
+            .answering(Some(handler_seq()))
             .handle_operator_message("chief", imperative, None)
             .await
             .expect("operator message handled");
@@ -6357,7 +6517,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 &fx.record.id,
                 &TaskRecord {
                     id: "handler-card".to_string(),
-                    title,
+                    title: TaskTitle::authored(&title),
                     note: None,
                     column: COLUMN_PLANNING.to_string(),
                     priority: "medium".to_string(),
@@ -6372,6 +6532,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: Some(handler_seq()),
                     bounced: None,
                 },
             )
@@ -6381,6 +6542,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
+            .answering(Some(handler_seq()))
             .handle_operator_message("engineer", imperative, Some("engineer"))
             .await
             .expect("operator message handled");
@@ -6407,7 +6569,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 &fx.record.id,
                 &TaskRecord {
                     id: "handler-card".to_string(),
-                    title,
+                    title: TaskTitle::authored(&title),
                     note: None,
                     column: COLUMN_PLANNING.to_string(),
                     priority: "medium".to_string(),
@@ -6422,6 +6584,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: Some(handler_seq()),
                     bounced: None,
                 },
             )
@@ -6431,6 +6594,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
+            .answering(Some(handler_seq()))
             .handle_operator_message("engineer", imperative, Some("dm:engineer"))
             .await
             .expect("operator message handled");
@@ -6453,7 +6617,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 &fx.record.id,
                 &TaskRecord {
                     id: "handler-card".to_string(),
-                    title,
+                    title: TaskTitle::authored(&title),
                     note: None,
                     column: COLUMN_PLANNING.to_string(),
                     priority: "medium".to_string(),
@@ -6468,6 +6632,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: Some(handler_seq()),
                     bounced: None,
                 },
             )
@@ -6477,6 +6642,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
+            .answering(Some(handler_seq()))
             .handle_operator_message("engineer", imperative, Some("dm:engineer"))
             .await
             .expect("operator message handled");
@@ -6503,7 +6669,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 &fx.record.id,
                 &TaskRecord {
                     id: "another-threads-card".to_string(),
-                    title,
+                    title: TaskTitle::authored(&title),
                     note: None,
                     column: COLUMN_PLANNING.to_string(),
                     priority: "medium".to_string(),
@@ -6523,6 +6689,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -6556,7 +6723,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 &fx.record.id,
                 &TaskRecord {
                     id: "another-threads-card".to_string(),
-                    title,
+                    title: TaskTitle::authored(&title),
                     note: None,
                     column: COLUMN_PLANNING.to_string(),
                     priority: "medium".to_string(),
@@ -6571,6 +6738,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -6604,7 +6772,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 &fx.record.id,
                 &TaskRecord {
                     id: "someone-elses-card".to_string(),
-                    title,
+                    title: TaskTitle::authored(&title),
                     note: None,
                     column: COLUMN_PLANNING.to_string(),
                     priority: "medium".to_string(),
@@ -6619,6 +6787,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -6652,7 +6821,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 &fx.record.id,
                 &TaskRecord {
                     id: "moved-on".to_string(),
-                    title,
+                    title: TaskTitle::authored(&title),
                     note: None,
                     column: COLUMN_IN_PROGRESS.to_string(),
                     priority: "medium".to_string(),
@@ -6667,6 +6836,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -8704,7 +8874,12 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             "the member's own turn gets the full per-turn cap, and no more"
         );
         // Three follow-up cards from the member, plus the hand-off's own card.
-        let mut titles: Vec<String> = fx.cards().await.into_iter().map(|c| c.title).collect();
+        let mut titles: Vec<String> = fx
+            .cards()
+            .await
+            .into_iter()
+            .map(|c| c.title.to_string())
+            .collect();
         titles.sort();
         assert_eq!(titles.len(), 4, "{titles:?}");
         assert!(
@@ -8808,7 +8983,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::nested();
         let mut card = TaskRecord {
             id: "card-1".to_string(),
-            title: "Ship the API".to_string(),
+            title: TaskTitle::authored("Ship the API"),
             note: None,
             column: COLUMN_TODO.to_string(),
             priority: "medium".to_string(),
@@ -8823,6 +8998,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         };
         fx.tasks.upsert(&fx.record.id, &card).await.expect("seed");

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -2316,6 +2316,7 @@ mod test {
 mod dead_card_test {
     use super::*;
     use crate::company::CompanyManifest;
+    use crate::ports::tasks::TaskTitle;
     use crate::ports::tasks::{COLUMN_TODO, TaskDeliverable, TaskRecord};
     use crate::ports::types::CompanyId;
     use crate::runtime::RuntimeBuilder;
@@ -2329,7 +2330,7 @@ mod dead_card_test {
     fn card(id: &str) -> TaskRecord {
         TaskRecord {
             id: id.to_string(),
-            title: "Draft the launch note".to_string(),
+            title: TaskTitle::authored("Draft the launch note"),
             note: None,
             column: COLUMN_TODO.to_string(),
             priority: "medium".to_string(),
@@ -2344,6 +2345,7 @@ mod dead_card_test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/server/graphql/tasks.rs
+++ b/src/server/graphql/tasks.rs
@@ -46,7 +46,7 @@ impl From<TaskRecord> for TaskGql {
     fn from(record: TaskRecord) -> Self {
         Self {
             id: ID(record.id),
-            title: record.title,
+            title: record.title.to_string(),
             note: record.note,
             column: record.column,
             priority: record.priority,

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -9,6 +9,7 @@ use tower::ServiceExt;
 
 use crate::company::CompanyManifest;
 use crate::ports::CompanyStore;
+use crate::ports::tasks::TaskTitle;
 use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::runtime::RuntimeBuilder;
 use crate::server::router;
@@ -891,7 +892,7 @@ async fn chat_history_projects_the_card_a_reply_opened() {
             runtime.id(),
             &crate::ports::tasks::TaskRecord {
                 id: "t-77".to_string(),
-                title: "Draft the launch note".to_string(),
+                title: TaskTitle::authored("Draft the launch note"),
                 note: None,
                 column: crate::ports::tasks::COLUMN_TODO.to_string(),
                 priority: "medium".to_string(),
@@ -906,6 +907,7 @@ async fn chat_history_projects_the_card_a_reply_opened() {
                 workflow_proposal: None,
                 origin_run_id: None,
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             },
         )
@@ -1204,7 +1206,7 @@ async fn tasks_page_reflects_upserts_and_column_filter() {
             runtime.id(),
             &TaskRecord {
                 id: "t1".into(),
-                title: "Launch".into(),
+                title: TaskTitle::authored("Launch"),
                 note: None,
                 column: "todo".into(),
                 priority: "high".into(),
@@ -1219,6 +1221,7 @@ async fn tasks_page_reflects_upserts_and_column_filter() {
                 workflow_proposal: None,
                 origin_run_id: None,
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             },
         )

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -2244,7 +2244,12 @@ async fn run_chat(
     let not_work = message
         .deliverable
         .is_some_and(crate::ports::types::MessageIntent::is_chat);
-    if let Some(title) = (!confined && !not_work)
+    // The lexical layer answers two questions at once, and only the first is a
+    // decision: whether this message becomes a card, and — for a host with no
+    // model wired — what to call it. The second is now a fallback. Keeping it
+    // matters: the classifier returns a *tidied* title, so discarding it would
+    // make an offline company's cards worse than before rather than no better.
+    let lexical = (!confined && !not_work)
         .then(|| crate::company::task_intent::triage_message(&message.text))
         .and_then(|triage| match triage {
             crate::company::task_intent::MessageTriage::Track(title) => Some(title),
@@ -2254,12 +2259,19 @@ async fn run_chat(
         .or_else(|| {
             workflow_requested.then(|| crate::company::task_intent::to_title(message.text.trim()))
         })
-        .filter(|title| !title.trim().is_empty())
-    {
-        // Keep the full message as the note only when the title was shortened
-        // from it, so a one-line ask doesn't duplicate itself.
-        let note =
-            (title.trim_end_matches('…') != message.text.trim()).then(|| message.text.clone());
+        .filter(|title| !title.trim().is_empty());
+    if let Some(lexical) = lexical {
+        let title = crate::ports::tasks::mint_task_title(
+            message.text.trim(),
+            Some(&lexical),
+            runtime.titler(),
+        )
+        .await;
+        // The full ask, kept as the note whenever the headline is not already
+        // the whole of it — which a named title almost always is not. This is
+        // where the context, the caveats and the operator's own wording live now
+        // that the title is a name rather than an excerpt.
+        let note = (title.as_str() != message.text.trim()).then(|| message.text.clone());
         // Issue #576: the prompt box opens the card **already in Planning**, so
         // the spine epic #183 draws — prompt in, deliverable out — runs without
         // a human dragging the first step. The card is created *directly* in
@@ -2368,6 +2380,10 @@ async fn run_chat(
             // behind a chat turn, and inventing one would be a lie the board
             // then carries forever.
             origin_run_id: accepted.turn_id.clone(),
+            // The message this card was opened for. The runtime turn that
+            // follows finds the card by this and nothing else, so the headline
+            // above is free to be a name rather than an excerpt.
+            origin_message_seq: Some(accepted.message_seq),
             origin_workflow_id: None,
             bounced: None,
         };
@@ -4796,6 +4812,7 @@ mod test {
 
     use super::*;
     use crate::company::CompanyManifest;
+    use crate::ports::tasks::TaskTitle;
     use crate::ports::types::CompanyRecord;
     use crate::runtime::RuntimeBuilder;
     use crate::server::router;
@@ -8303,7 +8320,7 @@ mode = "full"
                 runtime.id(),
                 &crate::ports::tasks::TaskRecord {
                     id: "t-77".to_string(),
-                    title: "Draft the launch note".to_string(),
+                    title: TaskTitle::authored("Draft the launch note"),
                     note: None,
                     column: crate::ports::tasks::COLUMN_TODO.to_string(),
                     priority: "medium".to_string(),
@@ -8318,6 +8335,7 @@ mode = "full"
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -13662,7 +13680,7 @@ mode = "full"
                     runtime.id(),
                     &crate::ports::tasks::TaskRecord {
                         id: task_id.to_string(),
-                        title: "Ship it".to_string(),
+                        title: TaskTitle::authored("Ship it"),
                         note: None,
                         column: crate::ports::tasks::COLUMN_IN_REVIEW.to_string(),
                         priority: "medium".to_string(),
@@ -13677,6 +13695,7 @@ mode = "full"
                         workflow_proposal: None,
                         origin_run_id: None,
                         origin_workflow_id: None,
+                        origin_message_seq: None,
                         bounced: None,
                     },
                 )
@@ -13738,7 +13757,7 @@ mode = "full"
                 runtime.id(),
                 &crate::ports::tasks::TaskRecord {
                     id: "t-review".to_string(),
-                    title: "Ship it".to_string(),
+                    title: TaskTitle::authored("Ship it"),
                     note: None,
                     column: crate::ports::tasks::COLUMN_IN_REVIEW.to_string(),
                     priority: "medium".to_string(),
@@ -13753,6 +13772,7 @@ mode = "full"
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -13799,7 +13819,7 @@ mode = "full"
                 runtime.id(),
                 &crate::ports::tasks::TaskRecord {
                     id: "t-1".to_string(),
-                    title: "Ship it".to_string(),
+                    title: TaskTitle::authored("Ship it"),
                     note: Some("[writer] first draft".to_string()),
                     column: crate::ports::tasks::COLUMN_IN_REVIEW.to_string(),
                     priority: "medium".to_string(),
@@ -13814,6 +13834,7 @@ mode = "full"
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -13874,7 +13895,7 @@ mode = "full"
                 runtime.id(),
                 &crate::ports::tasks::TaskRecord {
                     id: "t-1".to_string(),
-                    title: "Ship it".to_string(),
+                    title: TaskTitle::authored("Ship it"),
                     note: None,
                     column: crate::ports::tasks::COLUMN_IN_REVIEW.to_string(),
                     priority: "medium".to_string(),
@@ -13889,6 +13910,7 @@ mode = "full"
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -13984,7 +14006,7 @@ mode = "full"
                 runtime.id(),
                 &crate::ports::tasks::TaskRecord {
                     id: "t-1".to_string(),
-                    title: "Ship it".to_string(),
+                    title: TaskTitle::authored("Ship it"),
                     note: None,
                     column: crate::ports::tasks::COLUMN_IN_REVIEW.to_string(),
                     priority: "medium".to_string(),
@@ -13999,6 +14021,7 @@ mode = "full"
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -14047,7 +14070,7 @@ mode = "full"
                 runtime.id(),
                 &crate::ports::tasks::TaskRecord {
                     id: "t-1".to_string(),
-                    title: "Ship it".to_string(),
+                    title: TaskTitle::authored("Ship it"),
                     note: None,
                     column: crate::ports::tasks::COLUMN_IN_REVIEW.to_string(),
                     priority: "medium".to_string(),
@@ -14062,6 +14085,7 @@ mode = "full"
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -14132,7 +14156,7 @@ mode = "full"
     fn card_in_review(id: &str, chat_id: &str) -> crate::ports::tasks::TaskRecord {
         crate::ports::tasks::TaskRecord {
             id: id.to_string(),
-            title: "Ship it".to_string(),
+            title: TaskTitle::authored("Ship it"),
             note: None,
             column: crate::ports::tasks::COLUMN_IN_REVIEW.to_string(),
             priority: "medium".to_string(),
@@ -14147,6 +14171,7 @@ mode = "full"
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/server/ops/task_cost.rs
+++ b/src/server/ops/task_cost.rs
@@ -164,13 +164,14 @@ pub(super) fn reconcile(
 mod tests {
     use super::*;
     use crate::ports::runs::{RunRecord, RunStatus};
+    use crate::ports::tasks::TaskTitle;
     use crate::ports::tasks::{TaskDeliverable, TaskPlanningUsage};
     use crate::ports::types::{CompanyId, TokenUsage};
 
     fn task(id: &str, parent: Option<&str>, planning_cost: f64) -> TaskRecord {
         TaskRecord {
             id: id.to_string(),
-            title: id.to_string(),
+            title: TaskTitle::authored(id),
             note: None,
             column: "done".to_string(),
             priority: "low".to_string(),
@@ -194,6 +195,7 @@ mod tests {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -523,6 +523,30 @@ async fn create_task(
     company: ScopedCompany,
     Json(body): Json<CreateTask>,
 ) -> Result<Json<TaskCard>, ApiError> {
+    // Named BEFORE the lock. Naming reads nothing off the board and writes
+    // nothing to it, and it can spend the titling pass's whole deadline on a
+    // model — inside the critical section that would queue every concurrent
+    // patch, delete, review and create for this company behind it, and a burst
+    // of creates would serialise those delays cumulatively (codex on #2055).
+    let title = match body.title.as_deref().map(str::trim) {
+        Some(title) if !title.is_empty() => crate::ports::tasks::TaskTitle::authored(title),
+        _ => {
+            let source = body.note.as_deref().map(str::trim).unwrap_or_default();
+            if source.is_empty() {
+                return Err(ApiError(OpenCompanyError::InvalidRequest(
+                    "a task needs a title, or a note to name it from".to_string(),
+                )));
+            }
+            crate::ports::tasks::mint_task_title(source, None, company.runtime.titler()).await
+        }
+    };
+    // A headline that normalises away leaves a card with nothing on its face, so
+    // it is refused here rather than persisted blank.
+    if title.is_empty() {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            "that title has no name in it".to_string(),
+        )));
+    }
     // Read → validate → write is one critical section. Two concurrent requests
     // that each read the board before either has written would both validate
     // against a snapshot missing the other's edge, and could persist a lineage
@@ -547,18 +571,6 @@ async fn create_task(
         None => COLUMN_TODO.to_string(),
     };
     let assignee = resolve_assignee(&company, body.assignee.unwrap_or_default()).await?;
-    let title = match body.title.as_deref().map(str::trim) {
-        Some(title) if !title.is_empty() => crate::ports::tasks::TaskTitle::authored(title),
-        _ => {
-            let source = body.note.as_deref().map(str::trim).unwrap_or_default();
-            if source.is_empty() {
-                return Err(ApiError(OpenCompanyError::InvalidRequest(
-                    "a task needs a title, or a note to name it from".to_string(),
-                )));
-            }
-            crate::ports::tasks::mint_task_title(source, None, company.runtime.titler()).await
-        }
-    };
     let record = TaskRecord {
         id: generate_id(),
         title,
@@ -636,7 +648,13 @@ async fn patch_task(
         .cloned()
         .ok_or_else(|| OpenCompanyError::CompanyNotFound(format!("task {task_id}")))?;
     if let Some(title) = body.title {
-        record.title = crate::ports::tasks::TaskTitle::authored(&title);
+        let renamed = crate::ports::tasks::TaskTitle::authored(&title);
+        if renamed.is_empty() {
+            return Err(ApiError(OpenCompanyError::InvalidRequest(
+                "that title has no name in it".to_string(),
+            )));
+        }
+        record.title = renamed;
     }
     if let Some(note) = body.note {
         record.note = Some(note);

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -207,7 +207,7 @@ impl From<TaskRecord> for TaskCard {
         };
         Self {
             id: t.id,
-            title: t.title,
+            title: t.title.to_string(),
             note: t.note,
             column: crate::ledger::board::phase_of(&t.column).to_string(),
             stage: stage_of(&t.column),
@@ -233,11 +233,12 @@ impl From<TaskRecord> for TaskCard {
 mod task_card_origin_test {
     use super::*;
     use crate::ports::tasks::TaskOrigin;
+    use crate::ports::tasks::TaskTitle;
 
     fn plain_record() -> TaskRecord {
         TaskRecord {
             id: "t-1".to_string(),
-            title: "Draft the spec".to_string(),
+            title: TaskTitle::authored("Draft the spec"),
             note: None,
             column: "todo".to_string(),
             priority: "medium".to_string(),
@@ -252,6 +253,7 @@ mod task_card_origin_test {
             workflow_proposal: None,
             origin_run_id: None,
             origin_workflow_id: None,
+            origin_message_seq: None,
             bounced: None,
         }
     }
@@ -287,7 +289,20 @@ mod task_card_origin_test {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CreateTask {
-    title: String,
+    /// The card's headline, when a person typed one.
+    ///
+    /// Optional since semantic titling. The board's `+` dialog and the prompt
+    /// box both send one and it is taken verbatim — a name a person chose is
+    /// authoritative and is never re-worded. The transcript's "Add to board"
+    /// action sends **no** title and only the message as `note`, and the host
+    /// names the card from it; that action used to shorten the message in the
+    /// browser, which is how a card ended up titled with the first eighty
+    /// characters of somebody's chat.
+    ///
+    /// Absent with no `note` to name the card from is a `400` — a card has to
+    /// be called something.
+    #[serde(default)]
+    title: Option<String>,
     #[serde(default)]
     note: Option<String>,
     #[serde(default)]
@@ -532,9 +547,21 @@ async fn create_task(
         None => COLUMN_TODO.to_string(),
     };
     let assignee = resolve_assignee(&company, body.assignee.unwrap_or_default()).await?;
+    let title = match body.title.as_deref().map(str::trim) {
+        Some(title) if !title.is_empty() => crate::ports::tasks::TaskTitle::authored(title),
+        _ => {
+            let source = body.note.as_deref().map(str::trim).unwrap_or_default();
+            if source.is_empty() {
+                return Err(ApiError(OpenCompanyError::InvalidRequest(
+                    "a task needs a title, or a note to name it from".to_string(),
+                )));
+            }
+            crate::ports::tasks::mint_task_title(source, None, company.runtime.titler()).await
+        }
+    };
     let record = TaskRecord {
         id: generate_id(),
-        title: body.title,
+        title,
         note: body.note,
         column,
         priority: body.priority.unwrap_or_else(|| "medium".to_string()),
@@ -582,6 +609,7 @@ async fn create_task(
         workflow_proposal: None,
         origin_run_id: None,
         origin_workflow_id: None,
+        origin_message_seq: None,
         bounced: None,
     };
     company.runtime.upsert_task(&record).await?;
@@ -608,7 +636,7 @@ async fn patch_task(
         .cloned()
         .ok_or_else(|| OpenCompanyError::CompanyNotFound(format!("task {task_id}")))?;
     if let Some(title) = body.title {
-        record.title = title;
+        record.title = crate::ports::tasks::TaskTitle::authored(&title);
     }
     if let Some(note) = body.note {
         record.note = Some(note);
@@ -1101,7 +1129,7 @@ impl LineageRef {
     fn from_task(t: &TaskRecord, cost: Option<CostDisplay>) -> Self {
         Self {
             id: t.id.clone(),
-            title: t.title.clone(),
+            title: t.title.to_string(),
             column: crate::ledger::board::phase_of(&t.column).to_string(),
             cost,
         }
@@ -2780,6 +2808,7 @@ mod steer_redirect_test {
     use super::*;
     use crate::company::CompanyManifest;
     use crate::company::steer::InflightKind;
+    use crate::ports::tasks::TaskTitle;
     use crate::ports::types::{CompanyId, CompanyRecord, EventSeq};
     use crate::runtime::RuntimeBuilder;
     use crate::server::router;
@@ -2881,7 +2910,7 @@ mod steer_redirect_test {
                 &company,
                 &crate::ports::tasks::TaskRecord {
                     id: id.to_string(),
-                    title: "Draft the launch note".to_string(),
+                    title: TaskTitle::authored("Draft the launch note"),
                     note: None,
                     column: crate::ports::tasks::COLUMN_IN_PROGRESS.to_string(),
                     priority: "medium".to_string(),
@@ -2896,6 +2925,7 @@ mod steer_redirect_test {
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: None,
                 },
             )
@@ -3141,7 +3171,7 @@ mod patch_clears_bounced_test {
                 &company,
                 &crate::ports::tasks::TaskRecord {
                     id: id.to_string(),
-                    title: "Draft the launch note".to_string(),
+                    title: crate::ports::tasks::TaskTitle::authored("Draft the launch note"),
                     note: None,
                     column: crate::ports::tasks::COLUMN_TODO.to_string(),
                     priority: "medium".to_string(),
@@ -3156,6 +3186,7 @@ mod patch_clears_bounced_test {
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
+                    origin_message_seq: None,
                     bounced: Some("a previous run's dispatch failed".to_string()),
                 },
             )

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1998,7 +1998,7 @@ async fn run_artifacts(
                 latest_version,
                 updated_at_millis: record.updated_at_millis,
                 workspace_node_id,
-                task_title: Some(card.title.clone()),
+                task_title: Some(card.title.to_string()),
             });
         }
     }
@@ -7373,7 +7373,7 @@ mod tests {
         ) -> crate::ports::TaskRecord {
             crate::ports::TaskRecord {
                 id: id.into(),
-                title: title.into(),
+                title: crate::ports::tasks::TaskTitle::authored(title),
                 note: None,
                 column: "in_review".into(),
                 priority: "medium".into(),
@@ -7388,6 +7388,7 @@ mod tests {
                 workflow_proposal: None,
                 origin_run_id: origin_run_id.map(str::to_string),
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             }
         }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -10,7 +10,7 @@ use tower::ServiceExt;
 use crate::company::CompanyManifest;
 use crate::company::steer::{InflightEntry, InflightKind};
 use crate::ports::facts::{FactKind, FactRecord};
-use crate::ports::tasks::TaskRecord;
+use crate::ports::tasks::{TaskRecord, TaskTitle};
 use crate::ports::types::{CompanyId, CompanyRecord, CompressedTrace, ContextChunk};
 use crate::runtime::RuntimeBuilder;
 use crate::runtime::journal::{ApprovalConversation, TaskLink};
@@ -584,7 +584,7 @@ async fn a_task_detail_response_carries_the_thread_root_of_a_threaded_origin() {
             &company,
             &TaskRecord {
                 id: "threaded".into(),
-                title: "Ship the brief".into(),
+                title: TaskTitle::authored("Ship the brief"),
                 note: None,
                 column: crate::ports::tasks::COLUMN_TODO.into(),
                 priority: "medium".into(),
@@ -602,6 +602,7 @@ async fn a_task_detail_response_carries_the_thread_root_of_a_threaded_origin() {
                 workflow_proposal: None,
                 origin_run_id: None,
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             },
         )
@@ -812,7 +813,7 @@ async fn steer_task_validates_statuses_and_journals_acceptance() {
             &company,
             &TaskRecord {
                 id: "idle".into(),
-                title: "Idle".into(),
+                title: TaskTitle::authored("Idle"),
                 note: None,
                 column: crate::ports::tasks::COLUMN_TODO.into(),
                 priority: "medium".into(),
@@ -827,6 +828,7 @@ async fn steer_task_validates_statuses_and_journals_acceptance() {
                 workflow_proposal: None,
                 origin_run_id: None,
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             },
         )
@@ -4511,7 +4513,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
 
     let card = |id: &str, title: &str, parent: Option<&str>| TaskRecord {
         id: id.into(),
-        title: title.into(),
+        title: TaskTitle::authored(title),
         note: None,
         column: "in_review".into(),
         priority: "medium".into(),
@@ -4526,6 +4528,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
         workflow_proposal: None,
         origin_run_id: None,
         origin_workflow_id: None,
+        origin_message_seq: None,
         bounced: None,
     };
     for t in [
@@ -4709,7 +4712,7 @@ async fn inflight_read_is_not_shadowed_by_task_detail() {
 fn discussion_card(id: &str, title: &str) -> TaskRecord {
     TaskRecord {
         id: id.into(),
-        title: title.into(),
+        title: TaskTitle::authored(title),
         note: None,
         column: "todo".into(),
         priority: "medium".into(),
@@ -4724,6 +4727,7 @@ fn discussion_card(id: &str, title: &str) -> TaskRecord {
         workflow_proposal: None,
         origin_run_id: None,
         origin_workflow_id: None,
+        origin_message_seq: None,
         bounced: None,
     }
 }
@@ -5378,7 +5382,7 @@ async fn task_export_serves_a_readable_document_and_alters_nothing() {
             &company,
             &TaskRecord {
                 id: "t-1".into(),
-                title: "Launch post".into(),
+                title: TaskTitle::authored("Launch post"),
                 note: Some("Write the launch post.".into()),
                 column: "in_review".into(),
                 priority: "high".into(),
@@ -5393,6 +5397,7 @@ async fn task_export_serves_a_readable_document_and_alters_nothing() {
                 workflow_proposal: None,
                 origin_run_id: None,
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             },
         )
@@ -5501,7 +5506,7 @@ async fn task_timeline_scopes_approvals_to_the_run_window() {
             &company,
             &TaskRecord {
                 id: "t-1".into(),
-                title: "Ship it".into(),
+                title: TaskTitle::authored("Ship it"),
                 note: None,
                 column: "in_review".into(),
                 priority: "medium".into(),
@@ -5516,6 +5521,7 @@ async fn task_timeline_scopes_approvals_to_the_run_window() {
                 workflow_proposal: None,
                 origin_run_id: None,
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             },
         )
@@ -5609,7 +5615,7 @@ async fn dispatched_task(
             company,
             &TaskRecord {
                 id: "t-1".into(),
-                title: "Ship it".into(),
+                title: TaskTitle::authored("Ship it"),
                 note: None,
                 column: "in_progress".into(),
                 priority: "medium".into(),
@@ -5624,6 +5630,7 @@ async fn dispatched_task(
                 workflow_proposal: None,
                 origin_run_id: None,
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             },
         )
@@ -6070,7 +6077,7 @@ async fn a_second_task_in_the_same_window_does_not_absorb_the_first_s_approvals(
             &company,
             &TaskRecord {
                 id: "t-2".into(),
-                title: "Also ship it".into(),
+                title: TaskTitle::authored("Also ship it"),
                 note: None,
                 column: "in_progress".into(),
                 priority: "medium".into(),
@@ -6085,6 +6092,7 @@ async fn a_second_task_in_the_same_window_does_not_absorb_the_first_s_approvals(
                 workflow_proposal: None,
                 origin_run_id: None,
                 origin_workflow_id: None,
+                origin_message_seq: None,
                 bounced: None,
             },
         )
@@ -7538,7 +7546,7 @@ async fn seed_proposal_card_assigned(state: &AppState, ops: Value, assignee: &st
     let id = crate::ports::generate_id();
     let record = TaskRecord {
         id: id.clone(),
-        title: "Automate the weekly digest".to_string(),
+        title: TaskTitle::authored("Automate the weekly digest"),
         note: None,
         column: "in_review".to_string(),
         priority: "medium".to_string(),
@@ -7558,6 +7566,7 @@ async fn seed_proposal_card_assigned(state: &AppState, ops: Value, assignee: &st
         }),
         origin_run_id: None,
         origin_workflow_id: None,
+        origin_message_seq: None,
         bounced: None,
     };
     runtime

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -205,6 +205,69 @@ async fn send_auth(
     (status, value)
 }
 
+/// A headline that normalises away is refused, not persisted (coderabbit on
+/// #2055).
+///
+/// The `"""` bug's sibling, one layer out. That one was a *model* reply peeling
+/// to a lone quote; this is a person typing punctuation into the title field.
+/// The junk test that catches the first deliberately does not apply here — a
+/// person who names a card `🚀` means it — so the boundary that persists the
+/// card is what has to refuse a name with nothing in it, on both routes that
+/// can set one.
+#[tokio::test]
+async fn a_title_that_normalises_to_nothing_is_refused_on_create_and_rename() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    // Non-blank on the wire, and nothing left after the sentence-punctuation
+    // strip — so a length check on the raw input passes it through.
+    for junk in ["...", "!!!", " . . . "] {
+        let (status, _body) = send(
+            &state,
+            "POST",
+            "/api/v1/company/tasks",
+            Some(json!({ "title": junk })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "create accepted {junk:?}");
+    }
+
+    // A symbol a person plainly meant is still a title, and still lands.
+    let (status, rocket) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({ "title": "🚀" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(rocket["title"], "🚀");
+    let id = rocket["id"].as_str().unwrap().to_string();
+
+    // …and the rename route refuses the same junk rather than blanking it.
+    let (status, _body) = send(
+        &state,
+        "PATCH",
+        &format!("/api/v1/company/tasks/{id}"),
+        Some(json!({ "title": "..." })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let (_, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    let still = board
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["id"] == id.as_str());
+    assert_eq!(
+        still.map(|t| &t["title"]),
+        Some(&json!("🚀")),
+        "a refused rename leaves the card named as it was"
+    );
+}
+
 #[tokio::test]
 async fn tasks_crud_round_trips_under_both_scopes() {
     let home_dir = home();

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -40,7 +40,7 @@ use crate::ports::run_output::{
 use crate::ports::sessions::{SessionKind, SessionRecord, SessionStore};
 use crate::ports::skills_state::{SkillSource, SkillState, SkillStateStore};
 use crate::ports::store::CompanyStore;
-use crate::ports::tasks::{TaskOrigin, TaskRecord, TaskStore};
+use crate::ports::tasks::{TaskOrigin, TaskRecord, TaskStore, TaskTitle};
 use crate::ports::types::{
     Attachment, ChunkAddr, ChunkMeta, CompanyEvent, CompanyId, CompanyRecord, CompressedTrace,
     ContextChunk, EventSeq, LedgerEntry, SecretValue, TemplateProvenance,
@@ -1577,7 +1577,7 @@ pub async fn assert_task_store(tasks: Arc<dyn TaskStore>) {
     let beta = CompanyId::new("beta");
     let task = |id: &str, col: &str, at: u64| TaskRecord {
         id: id.to_string(),
-        title: format!("title {id}"),
+        title: TaskTitle::authored(&format!("title {id}")),
         note: Some(format!("note {id}")),
         column: col.to_string(),
         priority: "medium".to_string(),
@@ -1592,6 +1592,7 @@ pub async fn assert_task_store(tasks: Arc<dyn TaskStore>) {
         workflow_proposal: None,
         origin_run_id: None,
         origin_workflow_id: None,
+        origin_message_seq: None,
         bounced: None,
     };
 

--- a/src/workflows/board_turn_test.rs
+++ b/src/workflows/board_turn_test.rs
@@ -27,6 +27,7 @@ use serde_json::{Value, json};
 
 use crate::company::parse_workflow;
 use crate::harness::HarnessPool;
+use crate::ports::tasks::TaskTitle;
 use crate::ports::types::CompanyId;
 use crate::ports::{RunCancel, TaskRecord, TaskStore, WorkflowBoardAction, WorkflowRunContext};
 use crate::store::FsOps;
@@ -228,7 +229,7 @@ async fn a_workflow_node_assigns_an_existing_card_without_moving_it() {
     let dir = tempfile::tempdir().unwrap();
     let seed = TaskRecord {
         id: "card-1".to_string(),
-        title: "Quarterly close".to_string(),
+        title: TaskTitle::authored("Quarterly close"),
         note: None,
         column: crate::ports::tasks::COLUMN_TODO.to_string(),
         priority: "medium".to_string(),
@@ -243,6 +244,7 @@ async fn a_workflow_node_assigns_an_existing_card_without_moving_it() {
         workflow_proposal: None,
         origin_run_id: None,
         origin_workflow_id: None,
+        origin_message_seq: None,
         bounced: None,
     };
     let (run, store, _run_id) = run_with_board(


### PR DESCRIPTION
## Summary

Task cards were named after the message that opened them, shortened to eighty characters, so a board read as a chat log — `hey can you take a look at the pricing page, I think the tiers are…` where a task list wanted `Reword the middle pricing tier`.

An LLM titling pass now names the work. Verified on a local build against staging inference: the same request that produced the headline above now produces **`Fix the checkout bug`**, and with inference unreachable it falls back to today's title with no error and no lost card.

## Problem

The truncator was not the cause. `TaskRecord.title` was a bare `String` whose contract lived only in its doc comment (`/// A short imperative title.`), enforced by nothing — so four producers each hand-rolled a titler and three independently converged on the same shape:

| Site | What it did |
|---|---|
| `delegation.rs` `card_title` | raw message, cut at 80 |
| `task_intent.rs` `to_title` (REST chat handler) | raw message, tidied, cut at 80 |
| `cycle.rs` `first_line(…, 80)` (desk hand-off) | raw message, cut at 80 |
| `chat.ts` `titleFromMessage` / `CreateTaskDialog` `derivePromptCard` | raw message, cut at 80, in the browser |

The headline was **also an identity key**, which is why this could not simply be improved. `chat_handler_card` re-derived the title lexically and matched it byte-for-byte to find the card the REST handler had opened. Any better name broke adoption — and broke it *silently*: `spawned_task` falls back, the "Card opened" chip disappears, and a turn's authored workflow strands its card in To-do with nothing erroring. Issues #982 and #576 are both that same silence, found twice, after the handler changed an assignee and then a column out from under clauses reading them. `triage.rs` documented a standing refusal to let a model author a title for exactly this reason.

## Solution

**A type, so shape is total.** `TaskTitle` has no `From<String>`/`From<&str>`; four constructors named for provenance (`authored` / `system` / `summarised` / `truncated`) all run one normaliser — first line, strip wrappers, preambles, markdown and trailing sentence punctuation to a fixed point, character-safe cap with the ellipsis budgeted inside. Nothing in the process can hold a paragraph. `Deserialize` is transparent, so stored boards load verbatim and nothing needs migrating.

**An identity that is not the headline.** `TaskRecord.origin_message_seq` records the operator message a card was opened for; adoption is a lookup on it. It is stamped by the write it looks for and cannot be re-derived wrongly. This also fixes a latent bug on its own terms: two alike-reading messages in one thread are two cards, and the newest-first scan adopted the wrong one.

**One seam.** `mint_task_title(request, fallback, titler)` is the only path from free text to a headline. The three Rust truncators are gone as title minters. `TitleSummariser` is a **port**, not a harness type, because three of the four producers compile without `openhuman`; `Brain::titler()` defaults to `None`.

**The pass** (`harness/built_in/title.rs`) mirrors `triage.rs`: tool-less, 3s deadline, 32 output tokens, temperature 0, infallible, its own `SampleKind::TitleCall` metered to the whole-company bucket. Inline rather than async — a re-title write would go through `upsert_task`, which fires the dispatch edge.

Titles that are already names never reach it: a person's own words stay `authored` (verbatim), and a published file's or a `spawn_task` argument's name is `system`.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings`
- [x] `cargo check --all-features`
- [x] `cargo test --features openhuman,mcp,composio --lib` — 6880 passed, 0 failed
- [x] Console: `typecheck`, `typecheck:unit`, `typecheck:e2e`, `vitest run` (4391 passed), `build`
- [x] Verified on a local build through the console against staging inference

Three regression tests were confirmed to fail against the pre-fix behaviour, not merely pass against the new:

| Reverted | Old behaviour observed |
|---|---|
| the titler | `TaskTitle("hey can you take a look at the pricing page, I think the tiers are confusing…")` |
| adoption key | `None` — the silent adoption failure |
| adoption key, two alike cards | adopted `card-later`, the wrong card |

## Impact

Every card opened from something a person or an agent *said* is now named after the work. Observed on a local build:

| Request in | Title out |
|---|---|
| `can you fix the checkout bug, it has been dropping about one in twenty orders since the deploy on tuesday and support is drowning in refund requests` | `Fix the checkout bug` |
| `can you build me something that emails a summary of what the team shipped every friday afternoon so I stop chasing people for it` | `Build the Friday shipping summary email` |
| `the invoice PDFs we email out still have last year's VAT number on them and finance keeps having to reissue them by hand` | `Update the VAT number on invoice PDFs` |

Degradation was driven explicitly. Inference unreachable → the card is still created, named `Fix the checkout bug, it has been dropping about one in twenty orders since…` (the previous behaviour), no error surfaced. A model replying with junk → same fallback, tokens still metered.

**A bug this found:** a reply of `"""` peeled to a lone `"` and put one punctuation mark on the board. Fixed by requiring an alphanumeric character to survive, rather than enumerating pair shapes.

Cost is one short completion per card opened (~265 in / 4 out, ~$0.00016 observed), on its own `SampleKind` so it can be tuned against triage rather than hidden inside it.

Not fixed here, deliberately: the transcript's "Add to board" action has the same defect, but #2051 deletes `views/conversation/` whole and Room has no equivalent surface, so a fix there lands in a file that is about to be removed.

## Related

Fixes the raw-message card titles reported 2026-09-03.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task cards can now receive concise, automatically generated titles from their content.
  * Full prompts are preserved as notes instead of being shortened into titles.
  * Task creation requests may omit a title; a title is generated from the note.
  * Cards created from conversations are more reliably associated with their originating message.

* **Bug Fixes**
  * Improved handling of long prompts and card naming.
  * Requests without either a title or note now return a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->