### PR TITLE
fix(policy): say what read-only actually gates (B-023)

### DIFF
--- a/docs/spec/runtime/manifest-semantics.md
+++ b/docs/spec/runtime/manifest-semantics.md
@@ -238,8 +238,10 @@ each page under the 500-line cap.
       who does want a per-call gate sets
       `[policy].always_approve = ["web_search"]`, which overrides every tier.
     - **`[policy].mode = "readonly"` still denies it.** A search reaches a third
-      party and spends money, so a desk whose contract is that nothing is spent
-      does not get one.
+      party and is billed, and `readonly` denies every `Reach` but `Nothing`.
+      Note the contract is about *tool* spend: inference is not a tool call and
+      reaches neither gate, so a read-only desk still thinks on the company's
+      money (B-023).
     - **There is no `search` Cargo feature.** The tool rides the `openhuman`
       harness feature so CI's gated lane actually compiles and tests it.
 

--- a/frontend/src/components/autonomy-pill.tsx
+++ b/frontend/src/components/autonomy-pill.tsx
@@ -9,7 +9,7 @@
 // **The tier is one of four, not two.** `POLICY_MODES` in
 // `src/company/types.rs:96` is `["readonly", "supervised", "auto", "full"]`.
 // Flattening that to "Auto / not Auto" would report `readonly` — agents that
-// change nothing and spend nothing — and `full` — the broadest autonomy this
+// change nothing, contact nobody and use no connected account — and `full` — the
 // runtime has — as the same thing. The menu therefore lists whatever
 // `status.tiers` holds and never a list of four written here.
 //

--- a/frontend/test/unit/autonomy-pill.test.ts
+++ b/frontend/test/unit/autonomy-pill.test.ts
@@ -56,7 +56,8 @@ const TIERS = [
   {
     value: "readonly",
     label: "Read-only",
-    description: "The agents can look at things but change nothing and spend nothing.",
+    description:
+      "The agents can look at things but change nothing, contact nobody, and use no connected account. Billed tool calls are refused too — but the agents still think, and the company is billed for that.",
   },
   {
     value: "supervised",
@@ -147,10 +148,20 @@ describe("the lead sentence", () => {
     expect(leadSentence(TIERS[2].description)).toBe("Balanced execution autonomy.");
   });
 
-  it("uses a single-sentence description whole", () => {
-    expect(leadSentence(TIERS[0].description)).toBe(
-      "The agents can look at things but change nothing and spend nothing.",
+  // B-023: read-only's description is deliberately two sentences — the
+  // authority claim, then the billing caveat — because the pill can only carry
+  // the first. What the pill shows must therefore be true standing alone, and
+  // must not be the caveat's other half.
+  it("shows read-only's authority on the pill and leaves the billing caveat to the menu", () => {
+    const lead = leadSentence(TIERS[0].description);
+    expect(lead).toBe(
+      "The agents can look at things but change nothing, contact nobody, and use no connected account.",
     );
+    expect(lead).not.toContain("billed");
+  });
+
+  it("uses a single-sentence description whole", () => {
+    expect(leadSentence("Only one sentence.")).toBe("Only one sentence.");
   });
 
   it("uses a description with no sentence break whole", () => {

--- a/frontend/test/unit/policy-tier-autonomy.test.ts
+++ b/frontend/test/unit/policy-tier-autonomy.test.ts
@@ -28,7 +28,8 @@ const TIERS = [
   {
     value: "readonly",
     label: "Read-only",
-    description: "The agents can look at things but change nothing and spend nothing.",
+    description:
+      "The agents can look at things but change nothing, contact nobody, and use no connected account. Billed tool calls are refused too — but the agents still think, and the company is billed for that.",
   },
   {
     value: "supervised",

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -384,7 +384,7 @@ async fn policy_field_reports_the_selectable_tiers_and_when_a_change_takes_effec
     assert_eq!(readonly["label"], "Read-only", "{value}");
     assert_eq!(
         readonly["description"],
-        "The agents can look at things but change nothing and spend nothing.",
+        "The agents can look at things but change nothing, contact nobody, and use no connected account. Billed tool calls are refused too — but the agents still think, and the company is billed for that.",
         "{value}"
     );
 

--- a/src/server/ops/policy.rs
+++ b/src/server/ops/policy.rs
@@ -122,7 +122,35 @@ const TIER_TEXT: &[TierDto] = &[
     TierDto {
         value: "readonly",
         label: "Read-only",
-        description: "The agents can look at things but change nothing and spend nothing.",
+        // **B-023.** "spend nothing" was read as a spend control, and it is not
+        // one. What `readonly` gates is `Reach` (`policy::consequence`): it
+        // denies everything that is not `Reach::Nothing`
+        // (`denied_under_readonly`), which is three distinct things and the
+        // sentence has to carry all three: `Consequence` (state changes, a
+        // counterparty reached, arbitrary code or address), `Money` (a billed
+        // tool call) and `ExternalRead` (a third party's own data read with the
+        // company's connected credential — no change, no bill, and still
+        // denied). So billed *tool calls* really are denied — but inference is
+        // not a tool call and reaches neither gate, so the agents still think
+        // and the company is still billed for it.
+        //
+        // The old sentence therefore promised a bill of zero and delivered one,
+        // and said nothing about `ExternalRead` — which is precisely what an
+        // operator choosing this tier wants to know is blocked. Both halves are
+        // named here rather than in the console, for the reason this table
+        // exists: the prose lives beside the gate it describes so it cannot
+        // drift from it.
+        //
+        // **The first sentence has to stand alone.** The pill renders
+        // `leadSentence(description)` and nothing else (`autonomy-pill.tsx`),
+        // on the argument that half a claim about what the agents may do is
+        // worse than none. So the lead states only the authority — which is
+        // wholly true — and makes no claim about spending at all, where the old
+        // copy made a false one. The billing caveat lands in the second
+        // sentence, which the menu and the settings page both render in full.
+        description: "The agents can look at things but change nothing, contact nobody, and use \
+                      no connected account. Billed tool calls are refused too — but the agents \
+                      still think, and the company is billed for that.",
     },
     TierDto {
         value: "supervised",


### PR DESCRIPTION
## Summary

**B-023 (p0).** The read-only tier promised agents that *"change nothing and
spend nothing"*. The first half is true. The second was read as a spend control,
and it is not one.

## What read-only actually gates

`denied_under_readonly` is `!matches!(self, Reach::Nothing)` — so it denies
three distinct things, and the sentence has to carry all three:

| `Reach` | | read-only |
|---|---|---|
| `Nothing` | nothing changes, nothing billed | allowed |
| `Money` | nothing changes, but the call is billed | **denied** |
| `ExternalRead` | a third party's own data, read with the company's credential | **denied** |
| `Consequence` | state changes, a counterparty reached, arbitrary code or address | **denied** |

Two gates enforce it: the tool path at `harness/built_in/policy.rs`, which sits
*above* grant redemption so an approval given under a laxer mode does not survive
the switch ("consent does not survive the brake"), and the native effect gate at
`policy/gate.rs`, which denies every effect but `request_approval`.

So billed **tool calls** really are refused. What leaks is **inference**: it is
not a tool call and reaches neither gate, so the agents still think and the
company is still billed for it.

The old sentence therefore promised a bill of zero and delivered one — and said
nothing at all about `ExternalRead`, which is precisely what an operator
choosing this tier wants to know is blocked.

## The fix

In `TIER_TEXT`, not the console, for the reason that table exists: the prose
lives beside the gate it describes so it cannot drift from it.

> The agents can look at things but change nothing, contact nobody, and use no
> connected account. Billed tool calls are refused too — but the agents still
> think, and the company is billed for that.

**Why two sentences.** The pill renders `leadSentence(description)` and nothing
else, on the stated argument that half a claim about what the agents may do is
worse than none. A first draft left "make no billed tool call" in the lead with
its qualifier in sentence two — which the pill would have shown stripped. The
lead now makes **no** spend claim at all, where the old copy made a false one,
and the caveat lands where there is room for it.

The spec's own *"a desk whose contract is that nothing is spent"*
(`manifest-semantics.md`) re-seeded the same overclaim, so it is corrected here
too rather than left to reintroduce the confusion.

## Verified in the console

Against a running host, at all three sites this copy reaches:

- **Pill** — the lead sentence alone. Asserted on the DOM: no `spend`, and no
  orphaned `billed`.
- **Pill dropdown** — both sentences.
- **Settings → Approvals** — both sentences, row marked *Current*.

Switching the company to read-only from the pill updates all three, and chat
still round-trips afterwards.

## Verified against the gate, not just the screen

The copy makes four factual claims about enforcement. Rendering tests prove the
words appear; these prove they are true. Gated build (`--features openhuman`),
real OpenRouter-backed company, `mode: readonly`:

**"the agents still think, and the company is billed for that"** — the claim the
whole issue turns on:

```
today, before:  inputTokens 0      outputTokens 0
one chat turn → inputTokens 18324  outputTokens 49
usage.jsonl:    {"kind":"inference","provider":"openrouter",
                 "model":"deepseek-v4-flash","costUsd":0.00257908}
```

**"change nothing"** — asked for a workspace file; the tool was denied and no
file was written (`find … -name b023-probe.md` → 0):

> Blocked: Tool 'workspace_create' was denied by policy 'opencompany-approval'.
> Reason: 'workspace_create' mutates or reaches outside; this desk is read-only,
> so an earlier approval does not apply.

**"contact nobody" / billed tool calls refused** — same refusal for `web_fetch`.

Residual: a true `ExternalRead` (a *connected account*, e.g. a mailbox read
through Composio) is untested — this rig has no connection configured, so
`web_fetch` is the nearest reachable case. Both land on the same predicate
(`denied_under_readonly`), so the classification is shared, but I have not
watched a connected-account read be refused.

## Tests

- `graphql/test.rs` — the host-side assertion on the served description.
- `autonomy-pill.test.ts` — the test titled *"uses a single-sentence description
  whole"* stopped being true of read-only, which is itself the behaviour worth
  pinning. Split: a synthetic case still covers `leadSentence`'s whole-string
  path, and a new case asserts the pill shows the authority and
  `expect(lead).not.toContain("billed")`.
- Both tier fixtures updated to mirror the host.

`cargo test --lib` 4531 pass · `vitest` 4392 pass · `clippy -D warnings` clean ·
`fmt` clean · markdown line cap clean.

## Not addressed here

**Whether read-only should gate inference at all.** That is the other reading of
B-023 and a much larger change — an agent that cannot think cannot look at
anything either. This PR makes the tier honest about what it does today; if the
intent is that read-only costs nothing, that is a separate issue and a runtime
change, not a copy one.

**An asymmetry worth its own look.** The emergency stop exempts
`EffectGroup::Other` specifically so chat survives; the read-only branch has no
such exemption. Chat round-tripped in testing, but this build runs the echo
brain, so that is not proof for a real harness.
