### PR TITLE
fix(e2e): keep ledger seeding off a caller-supplied data root

### DIFF
--- a/frontend/test/e2e/finance-number-agreement.spec.ts
+++ b/frontend/test/e2e/finance-number-agreement.spec.ts
@@ -25,7 +25,9 @@ const SEEDED = ledgerPath() !== null;
 test.describe("Finance number agreement", () => {
   test.skip(
     !SEEDED,
-    "needs a host this suite brought up, so the ledger can be seeded on its disk (unset PW_BASE_URL)",
+    "needs a host on this suite's own disposable data root, so the ledger can " +
+      "be seeded and cleared safely (unset PW_BASE_URL, and leave PW_HOST_DATA_DIR " +
+      "unset or pointed inside target/e2e)",
   );
 
   test.beforeEach(async () => {
@@ -87,7 +89,9 @@ test.describe("Finance number agreement", () => {
 test.describe("negative half-cent agreement", () => {
   test.skip(
     !SEEDED,
-    "needs a host this suite brought up, so the ledger can be seeded on its disk (unset PW_BASE_URL)",
+    "needs a host on this suite's own disposable data root, so the ledger can " +
+      "be seeded and cleared safely (unset PW_BASE_URL, and leave PW_HOST_DATA_DIR " +
+      "unset or pointed inside target/e2e)",
   );
 
   test.beforeEach(async () => {

--- a/frontend/test/e2e/ledger.ts
+++ b/frontend/test/e2e/ledger.ts
@@ -1,5 +1,6 @@
-import { appendFileSync, mkdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { appendFileSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { MANAGED_HOST_HOME } from "./host-identity";
 
@@ -19,6 +20,32 @@ import { MANAGED_HOST_HOME } from "./host-identity";
  * record per request, so a seed lands on the next navigation.
  */
 
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../..");
+
+/**
+ * Whether `home` is the suite's own disposable scratch data root
+ * (`target/e2e`) or somewhere inside it — the same boundary `host.sh` checks
+ * before it decides to wipe a data root rather than reuse it.
+ *
+ * A root outside `target/e2e` reaches this file only when a caller supplied
+ * `PW_HOST_DATA_DIR` themselves, and `host.sh` deliberately leaves such a root
+ * untouched so it can be reused across runs. Seeding or clearing a ledger
+ * there would create or destroy state in a root this suite does not own, so
+ * every write below is gated on this check first.
+ */
+export function isDisposableRoot(home: string): boolean {
+  const scratch = join(repoRoot, "target/e2e");
+  mkdirSync(scratch, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  const canonicalScratch = realpathSync(scratch);
+  const canonicalHome = realpathSync(home);
+  return (
+    canonicalHome !== canonicalScratch &&
+    canonicalHome.startsWith(canonicalScratch + sep)
+  );
+}
+
 /** The harness company's id, as the host registers `companies/e2e_harness`. */
 export const HARNESS_COMPANY_ID = "e2e-harness-co";
 
@@ -31,11 +58,14 @@ export interface SeedEntry {
 }
 
 /**
- * Where this run's ledger lives, or `null` when the suite did not bring the
- * host up and so cannot reach its disk (`PW_BASE_URL`).
+ * Where this run's ledger lives, or `null` when this file has no business
+ * writing there at all: the suite did not bring the host up (`PW_BASE_URL`),
+ * or it did but was pointed at a data root outside its own scratch area — one
+ * `host.sh` is reusing rather than wiping, and so is not this file's to touch.
  */
 export function ledgerPath(companyId = HARNESS_COMPANY_ID): string | null {
   if (!MANAGED_HOST_HOME) return null;
+  if (!isDisposableRoot(MANAGED_HOST_HOME)) return null;
   return join(MANAGED_HOST_HOME, "companies", companyId, "ledger.jsonl");
 }
 
@@ -64,9 +94,11 @@ export function seedLedger(
 /**
  * Removes the seeded ledger.
  *
- * The whole file, because this suite is the only thing that writes it on an
- * offline harness host — a surgical removal would need to re-read and rewrite
- * append-only data the host may be holding open.
+ * The whole file, because this suite is the only thing that writes it on the
+ * disposable data root it seeds into — a surgical removal would need to
+ * re-read and rewrite append-only data the host may be holding open. Goes
+ * through {@link ledgerPath}, so a data root this suite does not own is left
+ * alone rather than wiped.
  */
 export function clearLedger(companyId = HARNESS_COMPANY_ID): void {
   const path = ledgerPath(companyId);

--- a/frontend/test/unit/ledger-seed-scope.test.ts
+++ b/frontend/test/unit/ledger-seed-scope.test.ts
@@ -1,0 +1,105 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `test/e2e/ledger.ts` seeds and clears a company's `ledger.jsonl` on the data
+ * root the managed e2e host is serving. That root is only ever the suite's own
+ * disposable scratch area (`target/e2e/...`) when `PW_HOST_DATA_DIR` is unset —
+ * a caller who sets it to a root they keep across runs gets that root reused
+ * as-is by `test/e2e/host.sh`, not wiped.
+ *
+ * `clearLedger()` used to `rmSync` unconditionally, so a Finance spec run
+ * against a reused root deleted the company's entire pre-existing ledger,
+ * including entries that had nothing to do with the test. The property under
+ * test: seeding and clearing only ever touch a root this suite created, never
+ * one a caller supplied.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../..");
+const scratchRoot = join(repoRoot, "target/e2e");
+
+const originalEnv = {
+  PW_BASE_URL: process.env.PW_BASE_URL,
+  PW_HOST_DATA_DIR: process.env.PW_HOST_DATA_DIR,
+  PW_FIRST_RUN: process.env.PW_FIRST_RUN,
+  PW_EULER: process.env.PW_EULER,
+};
+
+let disposableHome: string;
+let persistentHome: string;
+
+beforeEach(() => {
+  delete process.env.PW_BASE_URL;
+  delete process.env.PW_FIRST_RUN;
+  delete process.env.PW_EULER;
+
+  mkdirSync(scratchRoot, { recursive: true });
+  disposableHome = join(scratchRoot, `ledger-seed-scope-disposable-${process.pid}`);
+  persistentHome = mkdtempSync(join(tmpdir(), "ledger-seed-scope-persistent-"));
+});
+
+afterEach(() => {
+  rmSync(disposableHome, { recursive: true, force: true });
+  rmSync(persistentHome, { recursive: true, force: true });
+
+  for (const [name, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
+async function freshLedger() {
+  vi.resetModules();
+  return await import("../e2e/ledger");
+}
+
+describe("ledger seeding scope", () => {
+  it("seeds and clears normally on the suite's own disposable data root", async () => {
+    process.env.PW_HOST_DATA_DIR = disposableHome;
+    const { clearLedger, ledgerPath, seedLedger } = await freshLedger();
+
+    const path = ledgerPath();
+    expect(path).not.toBeNull();
+
+    seedLedger([{ atMillis: Date.now(), kind: "inference.spend", amountUsd: -0.12, memo: "test" }]);
+    expect(readFileSync(path!, "utf8")).toContain("test");
+
+    clearLedger();
+    expect(() => readFileSync(path!, "utf8")).toThrow();
+  });
+
+  it("never deletes a caller-supplied root's pre-existing ledger entries", async () => {
+    const companyDir = join(persistentHome, "companies", "e2e-harness-co");
+    mkdirSync(companyDir, { recursive: true });
+    const preExistingLedgerPath = join(companyDir, "ledger.jsonl");
+    const realEntry = JSON.stringify({
+      at_millis: Date.now() - 86_400_000,
+      kind: "inference.spend",
+      amount_usd: -4.2,
+      memo: "real spend unrelated to this test",
+    });
+    writeFileSync(preExistingLedgerPath, realEntry + "\n");
+
+    process.env.PW_HOST_DATA_DIR = persistentHome;
+    const { clearLedger, ledgerPath, seedLedger } = await freshLedger();
+
+    // The helper must refuse to operate on a root it did not create.
+    expect(ledgerPath()).toBeNull();
+
+    expect(seedLedger([{ atMillis: Date.now(), kind: "inference.spend", amountUsd: -0.005, memo: "seed" }])).toBe(
+      false,
+    );
+
+    // The destructive path this guards against: clearing must not touch a
+    // pre-existing file on a root the suite does not own.
+    clearLedger();
+
+    const survived = readFileSync(preExistingLedgerPath, "utf8");
+    expect(survived).toContain("real spend unrelated to this test");
+    expect(survived).not.toContain("\"memo\":\"seed\"");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up closing a destructive path in a test helper that already merged (`test/e2e/ledger.ts`, part of #2050). `clearLedger()` deleted the company's `ledger.jsonl` unconditionally, and every Finance e2e test calls it before and after running.

`host.sh` only wipes the host's data root when it lives inside the repo's own `target/e2e` scratch area; a caller who points `PW_HOST_DATA_DIR` at a root outside it gets that root reused as-is, on purpose, so it can persist across runs. `MANAGED_HOST_HOME` resolves to whatever root the managed run is using, so in that configuration `clearLedger()` was deleting a persistent root's entire ledger, including entries that had nothing to do with the test. A passing test destroyed real data.

The fix scopes seeding and clearing to a root this suite actually owns: `ledgerPath()` now refuses (returns `null`) unless the data root resolves inside `target/e2e`, mirroring the same boundary check `host.sh` already applies before it decides to wipe. `seedLedger()` and `clearLedger()` both go through `ledgerPath()`, so neither can create or delete state outside that boundary — a reused, caller-supplied root is left untouched. The ordinary managed case (no `PW_HOST_DATA_DIR`, or one pointed inside `target/e2e`) is unaffected; the Finance specs still skip cleanly, with an updated message naming the real condition, when the root they'd need isn't a disposable one.

Swept the rest of `test/e2e/` for other helpers that write to, delete from, or truncate anything under a caller-supplied root: `ledger.ts` was the only file under `test/e2e/` performing filesystem writes at all (`global-setup.ts` only reads `instance-id`), and `host.sh`'s own `rm -rf` is already gated behind the identical scratch-area check. Nothing else needed a change.

## API Or Behavior Changes

`ledgerPath()` (and therefore `seedLedger()`/`clearLedger()`) now returns `null` for a managed host whose data root is outside the suite's `target/e2e` scratch area, in addition to the existing `PW_BASE_URL` case. No production code changed — this is test-harness only.

## Tests

- Added `test/unit/ledger-seed-scope.test.ts`: imports the real `ledger.ts` fresh per case against different `PW_HOST_DATA_DIR` values. Confirmed red against the pre-fix code (the caller-root case failed because the helper still deleted the pre-existing entry); confirmed green after the fix, with the pre-existing entry surviving `seedLedger()`/`clearLedger()` untouched, and the ordinary disposable-root case still seeding and clearing normally.
- `cd frontend && npm run typecheck && npm run typecheck:unit && npm run typecheck:e2e && npx vitest run` — all pass (4411 unit tests).
- `npx playwright test finance-number-agreement.spec.ts` — all 5 specs pass against a managed host, proving seeding still works in the ordinary case.

## Documentation

None needed — this is an internal test-harness safety fix with no public API or documented behavior surface.
