### PR TITLE
feat(composio): bring your own Composio account (BYOK)

### DIFF
--- a/docs/modules/server/connections.md
+++ b/docs/modules/server/connections.md
@@ -175,6 +175,42 @@ asserted over a grant matrix by
 which is the standard #886 stated: prove the two agree by running both, not by
 reading them.
 
+## Two Composio accounts to choose between
+
+`GET …/composio` carries a `mode` alongside `credentialSource`, and the two
+answer different questions: the source names *whose identity* a call presents,
+the mode names *which host* it is presented to.
+
+- `managed` (the default) — Composio through the OpenHuman backend. Nothing to
+  paste; the backend holds the Composio account, enforces its toolkit allowlist
+  and bills the calls.
+- `byok` — straight to `backend.composio.dev` with this company's own Composio
+  API key, set through `PUT …/composio/api-key` (admin-only, write-only, never
+  echoed). An empty `apiKey` clears the key and returns the company to managed.
+
+`backendUrl` reports the host the calls actually reach, so it changes with the
+mode — a status still naming the managed backend after a switch would read as
+though nothing had happened.
+
+The console renders this as one picker in `ComposioSection`, with a
+confirmation on the first switch away from managed: the providers connected
+through OpenHuman's Composio account live in *that* account, so the provider
+grid goes empty until they are connected again in the company's own. That is
+recoverable — clearing the key puts the company back — and saying so before the
+switch is cheaper than explaining an empty grid after it.
+
+Under `byok` the console hides the managed route's token card entirely: the
+BYO backend token, the company TinyHumans key and the instance identity are all
+out of play, so offering a control over them would be offering a control that
+changes nothing about the calls being made.
+
+Everything else the panel offers is unchanged, disconnecting included: the host
+revokes through Composio's own `DELETE /api/v3/connected_accounts/{id}` rather
+than the backend's route, which is a difference in who is dialled, not in what
+the console can offer. `disconnectRouteFor` therefore takes no mode argument —
+the route is resolved from what a tile is connected through, never from which
+Composio the company uses.
+
 ## Releasing a connection: two routes, not interchangeable (issue #404)
 
 There are two disconnects and they act on different things:

--- a/docs/modules/server/connections.md
+++ b/docs/modules/server/connections.md
@@ -200,9 +200,15 @@ recoverable — clearing the key puts the company back — and saying so before 
 switch is cheaper than explaining an empty grid after it.
 
 Under `byok` the console hides the managed route's token card entirely: the
-BYO backend token, the company TinyHumans key and the instance identity are all
-out of play, so offering a control over them would be offering a control that
-changes nothing about the calls being made.
+BYO backend token and the instance identity are out of play for **live
+Composio calls** — authorize, execute, list connections — so offering a
+control over them would be offering a control that changes nothing about
+those calls. The company's TinyHumans key is the one exception: it still
+authenticates the curated-catalog fetch (`TenantComposio::catalog`), so
+clearing it while a company is on BYOK degrades the provider grid to the
+account's own directory even though every Composio call keeps working. See
+`docs/spec/runtime/credentials.md`'s "The catalog is OpenHuman's, even under
+BYOK" for the full precedence.
 
 Everything else the panel offers is unchanged, disconnecting included: the host
 revokes through Composio's own `DELETE /api/v3/connected_accounts/{id}` rather

--- a/docs/spec/runtime/credentials.md
+++ b/docs/spec/runtime/credentials.md
@@ -92,6 +92,101 @@ one precisely so both callers can share it in every build; a console route that
 restated the precedence instead would keep confidently reporting a tier after
 the resolver stopped honouring it.
 
+## BYOK Composio: a route, not a tier
+
+Everything above answers *whose identity* a brokered call presents. Composio
+carries a second, orthogonal question — *which host* it is presented to — and
+that one is not a tier at all.
+
+| | managed | byok |
+| --- | --- | --- |
+| Host | the OpenHuman backend's `/agent-integrations/composio/*` | `backend.composio.dev` |
+| Credential | the precedence chain above | this company's own Composio API key (`composio/api_key`) |
+| Who bills | the platform | whoever owns that Composio account |
+| Toolkit gate | the backend's server-enforced allowlist | the company's own Composio dashboard |
+
+The mode is stored under `composio/mode` and defaults to `managed`, so a
+company that configures nothing is unaffected by any of this. Storing an API
+key through `PUT …/composio/api-key` selects `byok`; clearing it returns the
+company to `managed`. The two writes are one call deliberately: a mode without
+a key is a company with no Composio tools, and a key without a mode is a
+credential nothing reads.
+
+`resolve_access` is the one derivation of both answers, and every reader —
+`TenantComposio::resolve`, `GET …/composio`, `/capabilities` — asks it rather
+than restating the rule, for the same reason `resolve_credential` is derived
+once.
+
+**BYOK does not fall back.** With the mode set and no key stored, the answer is
+`Credential::None` and the company gets no Composio tools — it does not quietly
+drop to the managed chain. Falling back would connect providers into the wrong
+Composio tenant and bill the wrong party, which is a worse failure than having
+no tools. The mode is folded into the roster fingerprint, so a switch in either
+direction reaches the agents on their next turn with no restart.
+
+One thing the managed route carries and BYOK does not: per-toolkit
+`extra_params` at authorize time. The v3 link call takes no such field, and a
+BYOK operator sets those on the auth config in their own Composio account.
+
+**Revoking is not on that list**, though it was until it was checked. The
+vendored `ComposioTool` has no delete method and OpenHuman's direct mode routes
+its revoke through the backend — neither of which says anything about Composio,
+which exposes `DELETE /api/v3/connected_accounts/{id}` perfectly well (a no-auth
+probe answers `401` on it and `404` on a route that does not exist). Taking a
+gap in borrowed code for a gap in the product is how a console comes to hide a
+control that would have worked.
+
+### The catalog is OpenHuman's, even under BYOK
+
+A BYOK company is offered the **same 123 providers a managed one is**, fetched
+from OpenHuman's backend with the *managed-chain* credential
+(`TenantComposio::catalog`) while every Composio call still goes direct.
+Switching a company to its own Composio account changes **who it acts as**, not
+what the console lets it browse.
+
+Neither list a BYOK company can reach alone is the right one: Composio's own
+directory is 1501 entries, most of which this harness has no curated tool
+surface for, and the compiled-in shortlist (`agent_ready_toolkits`) is 31.
+OpenHuman's backend publishes the middle answer.
+
+The two credentials are kept strictly apart — the Composio key is what calls
+present, the managed bearer is *only* ever the curated list's — and both join
+the scrub vector, because both are live credentials on that call. The list
+itself is non-secret and cached for `CATALOG_TTL`; no Composio traffic is
+proxied through it and nothing is billed by it.
+
+With **no managed tier at all** (a standalone host carrying no TinyHumans
+identity) there is no curated list to fetch, and the catalog falls back to the
+company's own Composio directory rather than presenting the Composio key to the
+OpenHuman backend. That fallback is where the bound below applies.
+
+### That fallback is bounded, and says so
+
+Composio's v3 listings are cursor-paginated and large: **1501 toolkits over 8
+pages**, and an unscoped `/tools` query is 52,268 over 262. Following the
+toolkit cursor to the end measures ~8.4s, against a 5s budget on the host
+(`composio_toolkits::FETCH_TIMEOUT`) and another 5s on the console
+(`COMPOSIO_PROBE_TIMEOUT_MS`) — so a complete sweep would not merely be slow,
+it would always time out and degrade to the built-in fallback list.
+
+`MAX_PAGES` is therefore 3 (~600 toolkits, ~3.3s measured), and what it could
+not reach is **counted from Composio's own `total_items` and logged**, never
+dropped in silence: a grid showing 600 providers is indistinguishable from a
+complete one. Serving the whole directory would mean refreshing it off the
+request path rather than raising either budget; that is a follow-up, not
+something a larger timeout fixes.
+
+One parameter is worth knowing about, because Composio v3 **ignores unknown
+query parameters rather than refusing them**: tools are scoped with
+`toolkit_slug=a,b`, not `toolkits=`. The wrong spelling does not error — it
+returns the first page of all 52,268 tools alphabetically. Repeating the
+parameter returns an empty body; one comma-separated value is the working form.
+
+This mirrors OpenHuman's own `backend` / `direct` split
+(`vendor/openhuman/src/openhuman/integrations/composio/client.rs`); the
+vocabulary here is `managed` / `byok` to match `company::search`, which made the
+same choice first.
+
 ## Rotation
 
 The rotation guarantee — "rotating the company key does not silently leave one

--- a/frontend/src/api/composio.ts
+++ b/frontend/src/api/composio.ts
@@ -30,6 +30,23 @@ import type { OpenCompanyClient, RequestOptions } from "./client";
 export type ComposioCredentialSource = "attested" | "company" | "static" | "none";
 
 /**
+ * Which host this company's Composio calls go to.
+ *
+ * - `managed` — proxied through the OpenHuman backend, which owns the Composio
+ *   API key, the toolkit allowlist and the billing. The default, and the route
+ *   that needs no configuration at all.
+ * - `byok` — straight to this company's **own** Composio account with the API key
+ *   its admin stored. Nothing is proxied and nothing is billed here; the
+ *   providers it can connect are whatever that Composio account permits.
+ *
+ * Orthogonal to {@link ComposioCredentialSource}, which names *whose identity* a
+ * call presents rather than *which host* it is presented to. A BYOK company
+ * reports `byok` + `static`; a company that pasted a backend token override
+ * reports `managed` + `static`.
+ */
+export type ComposioMode = "managed" | "byok";
+
+/**
  * One provider in the catalog the host offers, with the backend's own display
  * metadata (issue #600).
  *
@@ -66,7 +83,19 @@ export interface ComposioStatus {
   granted: boolean;
   /** Which credential this company's Composio calls present — never the credential itself. */
   credentialSource: ComposioCredentialSource;
-  /** The effective Composio backend URL (non-secret). */
+  /**
+   * Which host those calls go to — OpenHuman-managed, or this company's own
+   * Composio account.
+   *
+   * Optional on the wire: a host predating BYOK answers without it, and absent
+   * must read as `managed` (the only route those hosts have) rather than as
+   * "unknown".
+   */
+  mode?: ComposioMode;
+  /**
+   * The endpoint the calls actually reach (non-secret) — the managed backend, or
+   * Composio's own API host under `byok`.
+   */
   backendUrl: string;
   /** The manifest toolkit allowlist verbatim (empty = defer to the backend allowlist). */
   toolkits: string[];
@@ -257,6 +286,33 @@ export function setComposioToken(
   token: string,
 ): Promise<ComposioMutation> {
   return client.put<ComposioMutation>(`${client.scopeFor(company)}/composio/token`, { token });
+}
+
+/**
+ * Point this company at its **own** Composio account, or give the managed route
+ * back (BYOK).
+ *
+ * A non-empty `apiKey` stores the key and switches the company to `byok`; an
+ * empty string clears it and returns it to OpenHuman-managed Composio. One call
+ * for both because the mode is a consequence of the key rather than a separate
+ * control — selecting BYOK with nothing stored would leave the company with no
+ * Composio tools and no visible reason why.
+ *
+ * WRITE-ONLY, like every other credential here: the key goes out on this call,
+ * lands in the host's secret store, and is never returned. Admin-only — a member
+ * gets a 403.
+ *
+ * **Not** interchangeable with {@link setComposioToken}. That one stores a bearer
+ * the *TinyHumans backend* recognises and leaves the route managed; this one
+ * stores a key *Composio* recognises and changes the route. They authenticate
+ * different hosts.
+ */
+export function setComposioApiKey(
+  client: OpenCompanyClient,
+  company: string | null,
+  apiKey: string,
+): Promise<ComposioMutation> {
+  return client.put<ComposioMutation>(`${client.scopeFor(company)}/composio/api-key`, { apiKey });
 }
 
 /**

--- a/frontend/src/lib/provider-grid.ts
+++ b/frontend/src/lib/provider-grid.ts
@@ -154,6 +154,11 @@ export function disconnectRouteFor(
   // *for the agents*, which is the connection an operator means. The native
   // secret is inert until #396 lands, so blanking it silently would leave the
   // provider working and the tile still connected.
+  //
+  // The route this resolves to is the same under BYOK: the host revokes through
+  // Composio's own `DELETE /connected_accounts/{id}` there rather than through
+  // the backend, which is a difference in who is dialled, not in what the
+  // console can offer.
   if (live.length > 0) return { kind: "composio", accounts: live };
   if (row.via.includes("native")) return { kind: "native" };
   return null;

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -71,6 +71,46 @@ function modeOf(status: ComposioStatus | null): ComposioMode {
   return mode && mode in MODES ? mode : "managed";
 }
 
+/**
+ * Whether the legacy managed-route token card belongs on screen.
+ *
+ * Requires the SELECTED tile (`mode`) and the PERSISTED route (`!onByok`) to
+ * both be managed — not either alone. Either alone puts a second credential
+ * surface on screen at exactly the moment an operator is switching between
+ * them, and each direction breaks a different way:
+ *
+ * - Selected-only (`mode === "managed"`, ignoring `onByok`) shows this card to
+ *   a BYOK company that has merely *clicked* the managed tile, alongside the
+ *   real "Clear key & use OpenHuman-managed" control. This card's own Clear
+ *   calls the legacy `setComposioToken("")`, which erases the *preserved*
+ *   backend-token override (issue #586) without touching `composio/api_key`
+ *   or `composio/mode` at all — a button that looks like the way back to
+ *   managed but silently destroys a token the design keeps specifically to
+ *   restore, while leaving the company on BYOK regardless.
+ * - Persisted-only (`!onByok`, ignoring `mode`) shows it to a managed company
+ *   that has clicked the BYOK tile, so a Composio API key field and this
+ *   legacy backend-token field are both live with no way to tell which one
+ *   the Save below belongs to.
+ *
+ * Requiring both is the only gate under which exactly one credential surface
+ * is ever on screen, in either direction of the switch.
+ */
+export function showManagedTokenCard(input: {
+  mode: ComposioMode;
+  onByok: boolean;
+  canManage: boolean;
+  credentialed: boolean;
+  showOverride: boolean;
+  byoToken: boolean;
+}): boolean {
+  return (
+    input.mode === "managed" &&
+    !input.onByok &&
+    input.canManage &&
+    (!input.credentialed || input.showOverride || input.byoToken)
+  );
+}
+
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
@@ -144,6 +184,14 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
 
   const requestGeneration = useRef(0);
   const modeButtons = useRef<(HTMLButtonElement | null)[]>([]);
+  // Focus in and back out of the inline confirmation. It is `role="alertdialog"`
+  // over a plain `<div>`, not a modal primitive with its own focus trap (see the
+  // "Not a modal" comment above), so nothing does this for free: opening it
+  // unmounts the "Save key" button that had focus, leaving focus on
+  // `document.body` — invisible to a mouse user, but a screen reader or keyboard
+  // user loses their place entirely.
+  const confirmOpenerRef = useRef<HTMLElement | null>(null);
+  const confirmPrimaryActionRef = useRef<HTMLButtonElement | null>(null);
 
   const refresh = useCallback(async () => {
     const generation = ++requestGeneration.current;
@@ -172,6 +220,23 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
     setLoad("loading");
     void refresh();
   }, [refresh]);
+
+  // Opening moves focus onto the confirmation's primary action; closing
+  // returns it to whatever raised it — but only when focus is still exactly
+  // where opening left it (`document.body`). A save that succeeded and moved
+  // focus somewhere sensible on its own (the row that replaced this one) must
+  // not be yanked back to a button that may no longer say what it said.
+  useEffect(() => {
+    if (confirmSwitch) {
+      confirmPrimaryActionRef.current?.focus();
+      return;
+    }
+    const opener = confirmOpenerRef.current;
+    confirmOpenerRef.current = null;
+    if (opener?.isConnected && document.activeElement === document.body) {
+      opener.focus();
+    }
+  }, [confirmSwitch]);
 
   async function save() {
     if (!token.trim()) return;
@@ -261,6 +326,8 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
    */
   function requestApiKeySave() {
     if (persistedMode === "managed") {
+      confirmOpenerRef.current =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
       setConfirmSwitch(true);
       return;
     }
@@ -313,15 +380,17 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
   // Everything below is about the managed route's credential tiers, and under
   // BYOK none of them is in play — the company's own Composio key is the whole
   // credential. Rendering the token card there would offer a control that
-  // changes nothing about the calls being made.
-  //
-  // Gated on the SELECTED mode, not the persisted one: an operator part-way
-  // through switching to BYOK would otherwise see two credential fields at once
-  // — a Composio API key and a backend token — with no way to tell which one the
-  // Save below belongs to. What is on screen should be the route being looked
-  // at, not the one being left.
-  const showTokenCard =
-    mode === "managed" && canManage && (!credentialed || showOverride || byoToken);
+  // changes nothing about the calls being made. See `showManagedTokenCard`'s
+  // own doc for why this needs both the selected tile AND the persisted route
+  // to agree, not either alone.
+  const showTokenCard = showManagedTokenCard({
+    mode,
+    onByok,
+    canManage,
+    credentialed,
+    showOverride,
+    byoToken,
+  });
   // The composio-grant tri-state, narrowed the same way `ProvidersSection` does
   // (issue #1478): `undefined` reads as "unknown", never as "not granted", so
   // this badge and the grid a few inches below it cannot disagree on the same
@@ -532,7 +601,12 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                       this company back where it is now.
                     </p>
                     <div className="flex flex-wrap gap-2">
-                      <Button size="sm" disabled={busy !== null} onClick={() => void saveApiKey()}>
+                      <Button
+                        ref={confirmPrimaryActionRef}
+                        size="sm"
+                        disabled={busy !== null}
+                        onClick={() => void saveApiKey()}
+                      >
                         {busy === "route" ? (
                           <Loader2 className="size-4 animate-spin" />
                         ) : (

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -1,9 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, KeyRound, Loader2, Plug, Save, ShieldCheck, Trash2 } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  KeyRound,
+  Loader2,
+  Plug,
+  Save,
+  ShieldCheck,
+  Trash2,
+  Wallet,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
-import { getComposioStatus, setComposioToken, type ComposioStatus } from "@/api/composio";
+import {
+  getComposioStatus,
+  setComposioApiKey,
+  setComposioToken,
+  type ComposioMode,
+  type ComposioStatus,
+} from "@/api/composio";
 import { ApiError } from "@/api/types";
 import { grantStanding } from "@/lib/provider-grid";
 import { classifyLoadFailure } from "@/lib/section-load";
@@ -15,6 +31,45 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+/**
+ * The two routes to Composio, as an operator chooses between them.
+ *
+ * One table so the tile's label, its explanation and its billing line cannot
+ * drift apart, and so the order below is the order they render.
+ */
+const MODES: Record<ComposioMode, { label: string; blurb: string; billed: string }> = {
+  managed: {
+    label: "OpenHuman-managed",
+    blurb:
+      "Reached through OpenHuman, which holds the Composio account. Nothing to paste; the providers on offer are the ones OpenHuman permits.",
+    billed: "Billed by OpenHuman",
+  },
+  byok: {
+    label: "This company's own Composio account",
+    blurb:
+      "Calls go straight to Composio with this company's API key. Nothing is proxied here, and the providers on offer are whatever that account has.",
+    billed: "Billed by Composio, to you",
+  },
+};
+
+/** The routes in render order — also the order the arrow keys walk. */
+const MODE_ORDER: ComposioMode[] = ["managed", "byok"];
+
+/**
+ * The route to render for whatever the host said.
+ *
+ * A host predating BYOK omits `mode`, and one from a future shape could name a
+ * route this console has no copy for. Both read as `managed`: it is the only
+ * route every host has, and the one whose controls are safe to offer when we do
+ * not know. Narrowing here means nothing below can index {@link MODES} with a
+ * key it does not hold.
+ */
+function modeOf(status: ComposioStatus | null): ComposioMode {
+  const mode = status?.mode;
+  return mode && mode in MODES ? mode : "managed";
+}
 
 interface Props {
   client: OpenCompanyClient;
@@ -71,12 +126,24 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
   const [load, setLoad] = useState<"loading" | "ready" | "unavailable" | "error">("loading");
   const [status, setStatus] = useState<ComposioStatus | null>(null);
   const [token, setToken] = useState("");
-  const [busy, setBusy] = useState<"save" | "clear" | null>(null);
+  const [busy, setBusy] = useState<"save" | "clear" | "route" | null>(null);
+  // The route the picker shows, and the one actually stored. Kept apart so a
+  // Save can tell "switch this company to BYOK" from "rotate the key it already
+  // uses" — only the first needs the confirmation step below.
+  const [mode, setMode] = useState<ComposioMode>("managed");
+  const [persistedMode, setPersistedMode] = useState<ComposioMode>("managed");
+  const [apiKey, setApiKey] = useState("");
+  // The managed → BYOK confirmation. Not a modal: the warning belongs in the
+  // same scroll context as the control that raised it, and what it warns about
+  // — every provider connected through the managed route becoming invisible —
+  // is not readable off a pair of tiles.
+  const [confirmSwitch, setConfirmSwitch] = useState(false);
   // Only meaningful in the credentialled states, where the paste card is an
   // override rather than the way in.
   const [showOverride, setShowOverride] = useState(false);
 
   const requestGeneration = useRef(0);
+  const modeButtons = useRef<(HTMLButtonElement | null)[]>([]);
 
   const refresh = useCallback(async () => {
     const generation = ++requestGeneration.current;
@@ -84,6 +151,8 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
       const s = await getComposioStatus(client, company);
       if (generation !== requestGeneration.current) return;
       setStatus(s);
+      setMode(modeOf(s));
+      setPersistedMode(modeOf(s));
       // Hide the whole section when the feature is not compiled into this build.
       setLoad(s.inBuild ? "ready" : "unavailable");
     } catch (err) {
@@ -98,6 +167,8 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
   useEffect(() => {
     setStatus(null);
     setShowOverride(false);
+    setApiKey("");
+    setConfirmSwitch(false);
     setLoad("loading");
     void refresh();
   }, [refresh]);
@@ -135,6 +206,91 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
     }
   }
 
+  /**
+   * Store this company's own Composio API key and route it there.
+   *
+   * The key is sent once and never comes back — the field is blanked on success,
+   * and what tells the operator it worked is the status the host returns, not
+   * anything held here.
+   */
+  async function saveApiKey() {
+    if (!apiKey.trim()) return;
+    setBusy("route");
+    try {
+      const res = await setComposioApiKey(client, company, apiKey.trim());
+      setStatus(res.status);
+      setMode(modeOf(res.status));
+      setPersistedMode(modeOf(res.status));
+      setApiKey("");
+      setConfirmSwitch(false);
+      toast.success(res.note);
+      onChanged();
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Could not save the Composio API key.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  /** Give the managed route back: clear the key, and the mode with it. */
+  async function clearApiKey() {
+    setBusy("route");
+    try {
+      const res = await setComposioApiKey(client, company, "");
+      setStatus(res.status);
+      setMode(modeOf(res.status));
+      setPersistedMode(modeOf(res.status));
+      setApiKey("");
+      setConfirmSwitch(false);
+      toast.success(res.note);
+      onChanged();
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Could not clear the Composio API key.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  /**
+   * A Save that would move this company off the managed route for the first
+   * time. Gated on a confirmation because the consequence — the providers
+   * connected through OpenHuman's Composio account are in *that* account and
+   * vanish from the grid until they are connected again here — is not readable
+   * off the tiles. Rotating a key already in use, and switching back, are not
+   * gated: neither strands anything the operator cannot immediately undo.
+   */
+  function requestApiKeySave() {
+    if (persistedMode === "managed") {
+      setConfirmSwitch(true);
+      return;
+    }
+    void saveApiKey();
+  }
+
+  /**
+   * Arrow keys move between the route tiles and select in the same step, the way
+   * native radios behave.
+   *
+   * Without it every tile stays in the Tab order and no Arrow key moves between
+   * them — a screen reader announces radiogroup controls whose keyboard behavior
+   * does not exist. Same shape `policy-settings` uses for its approval tiers,
+   * which states the reasoning at length. Navigates from the tile that has
+   * FOCUS: the keydown bubbles from the focused button to the container, so
+   * `event.target` is that button. Wraps at both ends rather than dead-ending.
+   */
+  function handleModeKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (busy !== null) return;
+    if (!["ArrowDown", "ArrowRight", "ArrowUp", "ArrowLeft"].includes(event.key)) return;
+    const step = event.key === "ArrowDown" || event.key === "ArrowRight" ? 1 : -1;
+    const focused = modeButtons.current.indexOf(event.target as HTMLButtonElement);
+    if (focused === -1) return;
+    event.preventDefault();
+    const next = (focused + step + MODE_ORDER.length) % MODE_ORDER.length;
+    setMode(MODE_ORDER[next]);
+    setConfirmSwitch(false);
+    modeButtons.current[next]?.focus();
+  }
+
   if (load === "unavailable") return null;
 
   const attested = status?.credentialSource === "attested";
@@ -152,7 +308,20 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
   // A company already brokered through its own key is in the same position as an
   // attested one: the paste card is a deliberate override, not the way in.
   const credentialed = attested || companyKey;
-  const showTokenCard = canManage && (!credentialed || showOverride || byoToken);
+  // Which route this company is actually on, as opposed to what the picker shows.
+  const onByok = persistedMode === "byok";
+  // Everything below is about the managed route's credential tiers, and under
+  // BYOK none of them is in play — the company's own Composio key is the whole
+  // credential. Rendering the token card there would offer a control that
+  // changes nothing about the calls being made.
+  //
+  // Gated on the SELECTED mode, not the persisted one: an operator part-way
+  // through switching to BYOK would otherwise see two credential fields at once
+  // — a Composio API key and a backend token — with no way to tell which one the
+  // Save below belongs to. What is on screen should be the route being looked
+  // at, not the one being left.
+  const showTokenCard =
+    mode === "managed" && canManage && (!credentialed || showOverride || byoToken);
   // The composio-grant tri-state, narrowed the same way `ProvidersSection` does
   // (issue #1478): `undefined` reads as "unknown", never as "not granted", so
   // this badge and the grid a few inches below it cannot disagree on the same
@@ -170,11 +339,21 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
       <p className="text-sm text-muted-foreground">
         {!canManage
           ? "Your teammates reach Gmail, Slack & GitHub through Composio. Which account they act through belongs to the company, so an admin manages it — this is what is wired today."
-          : attested
-            ? "Your teammates reach providers through Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Connect providers in the grid below."
-            : companyKey
-              ? "Your teammates reach providers through Composio. This company's own TinyHumans credential already authorizes it — there is no separate Composio token to paste and no provider app to register. Connect providers in the grid below; every teammate in the company can then use what you connect."
-              : "Your teammates reach providers through Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then connect providers in the grid below. A change takes effect on the next turn, no restart."}
+          : onByok
+            ? "Your teammates reach providers through this company's own Composio account. Calls go straight to Composio with the API key stored here — OpenHuman proxies nothing and bills nothing. Connect providers in the grid below; they are connected in that account."
+            : attested
+              ? "Your teammates reach providers through Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Connect providers in the grid below."
+              : companyKey
+                ? "Your teammates reach providers through Composio. This company's own TinyHumans credential already authorizes it — there is no separate Composio token to paste and no provider app to register. Connect providers in the grid below; every teammate in the company can then use what you connect."
+                : // The last arm is the only one that *instructs*, and the
+                  // instruction is route-specific — so it follows the route the
+                  // operator is looking at rather than the one still stored.
+                  // Telling someone to paste a backend token underneath a
+                  // Composio API key field is how copy comes to contradict the
+                  // form directly beneath it.
+                  mode === "byok"
+                  ? "Your teammates reach providers through Composio. Nothing is wired yet — paste this company's own Composio API key below, and it will act through its own Composio account rather than OpenHuman's."
+                  : "Your teammates reach providers through Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then connect providers in the grid below. A change takes effect on the next turn, no restart."}
       </p>
 
       {load === "loading" ? (
@@ -192,7 +371,23 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                     ? "not granted"
                     : "grant unknown"}
               </Badge>
-              {attested ? (
+              {onByok ? (
+                // BYOK with no key stored is a real state the resolver handles —
+                // it withholds the tools rather than borrowing the platform's
+                // identity — so the badge has to tell the two apart. Reporting
+                // "using its own account" for a company whose agents have no
+                // Composio at all is the confident-wrong-answer shape #886 was
+                // filed about, one route over.
+                status.credentialSource === "none" ? (
+                  <span className="inline-flex items-center gap-1 text-xs text-status-blocked-text">
+                    <AlertTriangle className="size-3" /> No API key — agents get no Composio tools
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
+                    <KeyRound className="size-3" /> Using this company&apos;s own Composio account
+                  </span>
+                )
+              ) : attested ? (
                 <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
                   <ShieldCheck className="size-3" /> Linked via cluster identity — nothing stored
                 </span>
@@ -229,12 +424,174 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
             />
           )}
 
+          {canManage && (
+            <Card>
+              <CardContent className="space-y-4">
+                {/* Two tiles, not a dropdown. The choice is binary, consequential,
+                    and both sides need a sentence — a select collapses the option
+                    NOT currently chosen to nothing, which is exactly the half an
+                    operator is trying to evaluate. Same radiogroup shape
+                    `policy-settings` uses for approval tiers, roving tabindex
+                    included. */}
+                <div
+                  role="radiogroup"
+                  aria-label="Which Composio account this company uses"
+                  className="grid gap-2 sm:grid-cols-2"
+                  onKeyDown={handleModeKeyDown}
+                >
+                  {MODE_ORDER.map((m, index) => {
+                    const active = mode === m;
+                    return (
+                      <button
+                        key={m}
+                        ref={(el) => {
+                          modeButtons.current[index] = el;
+                        }}
+                        type="button"
+                        role="radio"
+                        aria-checked={active}
+                        tabIndex={active ? 0 : -1}
+                        disabled={busy !== null}
+                        data-testid={`composio-mode-${m}`}
+                        onClick={() => {
+                          setMode(m);
+                          setConfirmSwitch(false);
+                        }}
+                        className={cn(
+                          "rounded-md border p-3 text-left transition-colors",
+                          "disabled:cursor-not-allowed disabled:opacity-60",
+                          active ? "border-primary bg-primary/5" : "hover:bg-muted/50",
+                        )}
+                      >
+                        <div className="flex items-start gap-2">
+                          <span className="flex-1 text-sm font-medium">{MODES[m].label}</span>
+                          {persistedMode === m && (
+                            <Badge variant="secondary" className="text-xs">
+                              Current
+                            </Badge>
+                          )}
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground">{MODES[m].blurb}</p>
+                        <p className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground">
+                          <Wallet className="size-3 shrink-0" />
+                          {MODES[m].billed}
+                        </p>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {/* The endpoint, so the routing claim above is checkable rather
+                    than merely asserted — but only when the managed token card
+                    below is not already printing it. Two copies of one URL on
+                    one screen reads as two different facts. */}
+                {status && !showTokenCard && (
+                  <p className="truncate font-mono text-xs text-muted-foreground">
+                    {status.backendUrl}
+                  </p>
+                )}
+
+                {mode === "byok" && (
+                  <div className="space-y-1.5">
+                    <Label htmlFor="composio-api-key" className="text-xs">
+                      Composio API key
+                    </Label>
+                    <Input
+                      id="composio-api-key"
+                      type="password"
+                      autoComplete="off"
+                      placeholder={onByok ? "stored — paste a new key to rotate" : "ak_…"}
+                      value={apiKey}
+                      onChange={(e) => setApiKey(e.target.value)}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      From your Composio dashboard at app.composio.dev. Stored on this host, never
+                      shown again.
+                    </p>
+                  </div>
+                )}
+
+                {/* Said before the switch, not after: what it costs is not
+                    readable off the tiles. */}
+                {confirmSwitch && (
+                  <div
+                    role="alertdialog"
+                    aria-labelledby="composio-switch-warning"
+                    className="space-y-3 rounded-md border border-status-blocked/40 bg-status-blocked-soft p-3"
+                  >
+                    <p
+                      id="composio-switch-warning"
+                      className="inline-flex items-center gap-2 text-xs font-medium"
+                    >
+                      <AlertTriangle className="size-3.5 shrink-0" />
+                      Providers connected through OpenHuman stay there
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      They live in OpenHuman&apos;s Composio account, not in this one, so the grid
+                      below will look empty until you connect them again here. Clearing the key puts
+                      this company back where it is now.
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      <Button size="sm" disabled={busy !== null} onClick={() => void saveApiKey()}>
+                        {busy === "route" ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <Save className="size-4" />
+                        )}
+                        Use this company&apos;s account
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={busy !== null}
+                        onClick={() => setConfirmSwitch(false)}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Nothing to act on for a managed company that has stored no
+                    key: no Save (there is nothing to save) and no Clear (there
+                    is nothing to clear). Rendering the row anyway left a band of
+                    empty padding under the tiles that read as a missing
+                    control. */}
+                {!confirmSwitch && (mode === "byok" || onByok) && (
+                  <div className="flex flex-wrap items-center gap-2">
+                    {mode === "byok" ? (
+                      <Button disabled={busy !== null || !apiKey.trim()} onClick={requestApiKeySave}>
+                        {busy === "route" ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <Save className="size-4" />
+                        )}
+                        {onByok ? "Rotate key" : "Save key"}
+                      </Button>
+                    ) : (
+                      onByok && (
+                        <Button disabled={busy !== null} onClick={() => void clearApiKey()}>
+                          {busy === "route" ? (
+                            <Loader2 className="size-4 animate-spin" />
+                          ) : (
+                            <Trash2 className="size-4" />
+                          )}
+                          Clear key & use OpenHuman-managed
+                        </Button>
+                      )
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
           {/* Gated on `credentialed`, not `attested`: a company brokered through
               its own TinyHumans key is equally "already credentialled", so it
               equally needs a way back to the BYO card. Gating this on `attested`
               alone left a company-key admin with the paste card hidden and no
               control to reveal it — the override became unreachable. */}
-          {canManage && credentialed && !showTokenCard && (
+          {canManage && !onByok && credentialed && !showTokenCard && (
             <Button variant="outline" size="sm" onClick={() => setShowOverride(true)}>
               <KeyRound className="size-4" />
               Use your own Composio account instead

--- a/frontend/test/unit/composio-managed-token-card.test.ts
+++ b/frontend/test/unit/composio-managed-token-card.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { showManagedTokenCard } from "@/views/connections/ComposioSection";
+
+/**
+ * `showManagedTokenCard` gates the legacy managed-route credential card, and
+ * both its inputs — the SELECTED tile and the PERSISTED route — have to agree
+ * that the company is on managed before it renders. Either alone puts a
+ * second credential surface on screen at exactly the moment an operator is
+ * mid-switch between the two routes; see the function's own doc for the two
+ * distinct ways that goes wrong.
+ */
+describe("showManagedTokenCard", () => {
+  const base = {
+    mode: "managed" as const,
+    onByok: false,
+    canManage: true,
+    credentialed: false,
+    showOverride: false,
+    byoToken: false,
+  };
+
+  it("shows the card in the steady managed state with nothing credentialled", () => {
+    expect(showManagedTokenCard(base)).toBe(true);
+  });
+
+  // The regression this whole function exists to fix: a BYOK company
+  // (`onByok: true`) clicking the managed tile (`mode: "managed"`) must NOT
+  // show this card. It used to — gated on the selected tile alone — and its
+  // own Clear button calls the legacy `setComposioToken("")`, which erases
+  // the preserved backend-token override without touching `composio/api_key`
+  // or `composio/mode` at all: a control that looks like the way back to
+  // managed but silently destroys a different token while leaving the
+  // company on BYOK regardless.
+  it("hides the card when the company is persisted BYOK, even with the managed tile selected", () => {
+    expect(
+      showManagedTokenCard({ ...base, mode: "managed", onByok: true, byoToken: true }),
+    ).toBe(false);
+  });
+
+  // The other direction: a managed company (`onByok: false`) that has
+  // selected the BYOK tile (`mode: "byok"`) must not see this card either —
+  // it would sit alongside the Composio API key field with no way to tell
+  // which Save it belongs to.
+  it("hides the card when the BYOK tile is selected, even for a persisted-managed company", () => {
+    expect(showManagedTokenCard({ ...base, mode: "byok", onByok: false })).toBe(false);
+  });
+
+  it("hides the card once both the tile and the persisted route agree on BYOK", () => {
+    expect(
+      showManagedTokenCard({ ...base, mode: "byok", onByok: true, byoToken: true }),
+    ).toBe(false);
+  });
+
+  it("hides the card from a viewer who cannot manage the connection", () => {
+    expect(showManagedTokenCard({ ...base, canManage: false })).toBe(false);
+  });
+
+  it("shows the card when an already-credentialled operator asks for the override", () => {
+    expect(
+      showManagedTokenCard({ ...base, credentialed: true, showOverride: false }),
+    ).toBe(false);
+    expect(
+      showManagedTokenCard({ ...base, credentialed: true, showOverride: true }),
+    ).toBe(true);
+  });
+
+  it("shows the card for a company that already pasted a backend token", () => {
+    expect(showManagedTokenCard({ ...base, byoToken: true })).toBe(true);
+  });
+});

--- a/frontend/test/unit/provider-grid.test.ts
+++ b/frontend/test/unit/provider-grid.test.ts
@@ -328,6 +328,25 @@ describe("disconnect routing", () => {
     });
   });
 
+  // BYOK changes who the host dials to revoke — Composio's own
+  // `DELETE /connected_accounts/{id}` rather than the backend's route — and not
+  // whether the console can offer it. The grid is therefore identical in both
+  // modes, which is what this pins: the route is resolved from what the tile is
+  // connected through, never from which Composio the company uses.
+  it("offers the Composio disconnect whichever Composio the company uses", () => {
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states({ provider: "gmail", connected: true, via: ["composio"] }),
+      OPEN,
+      false,
+      { gmail: [account({ id: "conn-gmail-1", account: "ops@acme.test" })] },
+    );
+    const tile = bySlug(providers, "gmail");
+    expect(tile.canDisconnect).toBe(true);
+    expect(disconnectRouteFor(tile)?.kind).toBe("composio");
+  });
+
   it("keeps the native route for a provider only the host itself holds", () => {
     const providers = buildGridProviders(
       [entry("gmail")],

--- a/src/company/composio.rs
+++ b/src/company/composio.rs
@@ -301,9 +301,22 @@ pub async fn load_mode(company: &CompanyId, secrets: &dyn SecretStore) -> Result
 /// selects [`ComposioMode::Byok`]; an empty one clears the key and returns the
 /// company to [`ComposioMode::Managed`].
 ///
-/// The key is written first: if the second write fails, the company is left in
-/// managed mode holding an unread key, which is inert. The other order would
-/// leave it in BYOK mode with no key, which is an outage.
+/// The writes are ordered by **direction**, not fixed key-then-mode: whichever
+/// order leaves a failed second write inert, rather than in the outage this
+/// whole function exists to rule out.
+///
+/// Selecting BYOK writes the key first. If the mode write then fails, the
+/// company is still `Managed` holding an unread key — inert, since managed
+/// resolution never looks at [`API_KEY_KEY`].
+///
+/// Clearing writes the mode first. A fixed key-then-mode order would write the
+/// *empty* key first here — and if the mode write then failed, the company
+/// would stay `Byok` (its old mode, unwritten) with an empty key, which
+/// [`resolve_access`] resolves to [`Credential::None`]: the exact "BYOK mode,
+/// no key" outage the key-first rule above exists to avoid, reached from the
+/// other direction. Writing the mode first instead leaves a failed second
+/// write as `Managed` holding a stale-but-present key — inert, for the same
+/// reason as the set direction.
 pub async fn store_api_key(
     company: &CompanyId,
     secrets: &dyn SecretStore,
@@ -315,12 +328,21 @@ pub async fn store_api_key(
     } else {
         ComposioMode::Byok
     };
-    secrets
-        .set(company, API_KEY_KEY, SecretValue(api_key.to_string()))
-        .await?;
-    secrets
-        .set(company, MODE_KEY, SecretValue(mode.as_str().to_string()))
-        .await?;
+    if mode.is_byok() {
+        secrets
+            .set(company, API_KEY_KEY, SecretValue(api_key.to_string()))
+            .await?;
+        secrets
+            .set(company, MODE_KEY, SecretValue(mode.as_str().to_string()))
+            .await?;
+    } else {
+        secrets
+            .set(company, MODE_KEY, SecretValue(mode.as_str().to_string()))
+            .await?;
+        secrets
+            .set(company, API_KEY_KEY, SecretValue(api_key.to_string()))
+            .await?;
+    }
     Ok(mode)
 }
 
@@ -814,6 +836,117 @@ mod tests {
         assert_eq!(mode, ComposioMode::Managed);
         let access = resolve_access(&company, &secrets, None).await.unwrap();
         assert_eq!(access.mode, ComposioMode::Managed);
+    }
+
+    /// Wraps [`MemSecrets`] and fails every `set` for one chosen key, so a test
+    /// can land a `store_api_key` call exactly at its second write and inspect
+    /// what the first one left behind.
+    struct SecretsFailingToWrite {
+        inner: MemSecrets,
+        blocked_key: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl SecretStore for SecretsFailingToWrite {
+        async fn get(&self, c: &CompanyId, key: &str) -> Result<Option<SecretValue>> {
+            self.inner.get(c, key).await
+        }
+        async fn set(&self, c: &CompanyId, key: &str, value: SecretValue) -> Result<()> {
+            if key == self.blocked_key {
+                return Err(crate::error::OpenCompanyError::Store(
+                    "write refused by test".into(),
+                ));
+            }
+            self.inner.set(c, key, value).await
+        }
+    }
+
+    /// A clear that dies on its **first** write (the mode) must leave the
+    /// company exactly as it was: still `Byok`, still holding the key that was
+    /// working a moment ago. This is the direction issue #… — writing the mode
+    /// first for a clear — exists to protect: a fixed key-then-mode order would
+    /// have written the key EMPTY here, before ever reaching the (blocked) mode
+    /// write, stranding a `Byok` company with no key.
+    #[tokio::test]
+    async fn a_clear_that_fails_on_the_mode_write_leaves_byok_intact() {
+        let company = CompanyId::new("acme");
+        let secrets = SecretsFailingToWrite {
+            inner: MemSecrets::default(),
+            blocked_key: MODE_KEY,
+        };
+        // Seeded directly on `inner`, bypassing the wrapper's own blocking
+        // `set()` — the state under test is "already BYOK", not "how it got
+        // there", and going through `store_api_key` here would hit the very
+        // block this test exists to trigger before the test has even started.
+        secrets
+            .inner
+            .set(&company, API_KEY_KEY, SecretValue("ak_live".into()))
+            .await
+            .unwrap();
+        secrets
+            .inner
+            .set(&company, MODE_KEY, SecretValue(BYOK_MODE.into()))
+            .await
+            .unwrap();
+
+        let err = store_api_key(&company, &secrets, "").await;
+        assert!(
+            err.is_err(),
+            "the blocked write must propagate, not swallow"
+        );
+
+        assert_eq!(
+            load_mode(&company, &secrets).await.unwrap(),
+            ComposioMode::Byok
+        );
+        let access = resolve_access(&company, &secrets, None).await.unwrap();
+        assert_eq!(
+            access.credential.current().await.unwrap().as_deref(),
+            Some("ak_live"),
+            "the key a moment ago worked and must still work — nothing broke"
+        );
+    }
+
+    /// A clear that dies on its **second** write (the key) must still have
+    /// landed the mode: the company reads back as `Managed`, with a stale
+    /// unused key sitting inert in `API_KEY_KEY` — never consulted once the
+    /// mode says managed.
+    #[tokio::test]
+    async fn a_clear_that_fails_on_the_key_write_still_lands_managed() {
+        let company = CompanyId::new("acme");
+        let secrets = SecretsFailingToWrite {
+            inner: MemSecrets::default(),
+            blocked_key: API_KEY_KEY,
+        };
+        // Seeded directly on `inner` for the same reason as the sibling test
+        // above: this test's block is `API_KEY_KEY`, and `store_api_key`'s set
+        // direction writes that key first — routing the initial BYOK selection
+        // through the wrapper would block before there was anything to clear.
+        secrets
+            .inner
+            .set(&company, API_KEY_KEY, SecretValue("ak_live".into()))
+            .await
+            .unwrap();
+        secrets
+            .inner
+            .set(&company, MODE_KEY, SecretValue(BYOK_MODE.into()))
+            .await
+            .unwrap();
+
+        let err = store_api_key(&company, &secrets, "").await;
+        assert!(err.is_err());
+
+        assert_eq!(
+            load_mode(&company, &secrets).await.unwrap(),
+            ComposioMode::Managed,
+            "the mode write is first for a clear, and it landed before the blocked one"
+        );
+        let access = resolve_access(&company, &secrets, None).await.unwrap();
+        assert_eq!(
+            access.mode,
+            ComposioMode::Managed,
+            "a stale key under a managed mode is inert — resolve_access never reads it"
+        );
     }
 
     #[tokio::test]

--- a/src/company/composio.rs
+++ b/src/company/composio.rs
@@ -145,6 +145,252 @@ pub async fn token_configured(company: &CompanyId, secrets: &dyn SecretStore) ->
         .unwrap_or(false))
 }
 
+// ── Routing mode: OpenHuman-managed, or the company's own Composio account ──
+//
+// Everything above this line is the **managed** route: calls go to the
+// OpenHuman/TinyHumans backend (`/agent-integrations/composio/*`), which owns
+// the Composio API key, the billing margin and the server-enforced toolkit
+// allowlist, and derives the Composio entity from the bearer it is handed.
+//
+// A company that holds its own Composio account can route around all of that.
+// In BYOK mode the harness talks to `backend.composio.dev` directly with that
+// company's `x-api-key` — nothing is proxied, nothing is billed here, and the
+// providers it can connect are whatever its own Composio dashboard permits.
+// This mirrors OpenHuman's own `backend` / `direct` split
+// (`vendor/openhuman/src/openhuman/integrations/composio/client.rs::create_composio_client`);
+// the vocabulary here is `managed` / `byok` to match the search surface next
+// door (`crate::company::search`), which made the same choice first.
+
+/// The [`SecretStore`] key holding this company's Composio routing mode — one
+/// of [`MANAGED_MODE`] or [`BYOK_MODE`].
+///
+/// Stored rather than inferred from "is there an API key", for the reason
+/// [`crate::company::search::PROVIDER_SECRET`] is stored: the mode decides
+/// which *API* the credential is presented to, and a credential sent to the
+/// wrong one fails in a way that reads like a bad credential. It also lets the
+/// console report the mode without reading a secret slot at all.
+pub const MODE_KEY: &str = "composio/mode";
+
+/// The [`SecretStore`] key holding this company's **own** Composio API key
+/// (`ak_…`), written by the console's Composio settings and read only to sign a
+/// call. Write-only over the API — never echoed back.
+///
+/// Distinct from [`TOKEN_KEY`], and not interchangeable with it: that one is a
+/// bearer the *TinyHumans backend* recognises, this one is a key *Composio*
+/// recognises. They authenticate different hosts.
+pub const API_KEY_KEY: &str = "composio/api_key";
+
+/// Storage + wire spelling of [`ComposioMode::Managed`].
+pub const MANAGED_MODE: &str = "managed";
+
+/// Storage + wire spelling of [`ComposioMode::Byok`].
+pub const BYOK_MODE: &str = "byok";
+
+/// The Composio API host a BYOK company's calls go to directly. Non-secret, and
+/// reported by the console in place of the backend URL so an operator can see
+/// that the route really did change.
+pub const DIRECT_BASE_URL: &str = "https://backend.composio.dev";
+
+/// The Composio entity a BYOK company's authorizations and executes are scoped
+/// to.
+///
+/// `default` on purpose, matching OpenHuman's own direct mode
+/// (`config.composio.entity_id`) and matching what a user sees in their own
+/// Composio dashboard. Scoping to the company id instead would isolate two
+/// OpenCompany companies sharing one key — but it would also hide every
+/// connection the operator already made in that account, which is the first
+/// thing a BYOK operator looks for. The shared-account caveat is the same one
+/// [`TOKEN_KEY`] already carries: two companies pasting one credential share
+/// one entity, and that cannot be prevented from this side.
+pub const DIRECT_ENTITY_ID: &str = "default";
+
+/// How this company reaches Composio.
+///
+/// Not a [`CredentialSource`](crate::company::credentials::CredentialSource):
+/// that names *whose identity* a call presents, this names *which host* it is
+/// presented to. A BYOK company is `Static`-sourced and `Byok`-routed; a
+/// company that pasted a [`TOKEN_KEY`] override is `Static`-sourced and
+/// `Managed`-routed. Collapsing the two would make either question
+/// unanswerable.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ComposioMode {
+    /// Proxied through the OpenHuman backend — the default, and the only route
+    /// that needs no configuration at all.
+    #[default]
+    Managed,
+    /// Straight to `backend.composio.dev` with the company's own API key.
+    Byok,
+}
+
+impl ComposioMode {
+    /// The stable wire spelling (`managed` / `byok`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Managed => MANAGED_MODE,
+            Self::Byok => BYOK_MODE,
+        }
+    }
+
+    /// Whether `raw` names BYOK. Everything else — including an empty slot, a
+    /// typo, and a mode from some future shape — reads as [`Self::Managed`].
+    ///
+    /// Unknown-means-managed rather than unknown-is-an-error because this is
+    /// read on the roster path: a hand-edited slot must not be able to take a
+    /// company's Composio tools away, and managed is the route that works
+    /// without anything being stored.
+    ///
+    /// ## Why `direct` is accepted too
+    ///
+    /// Three repos in this org spell this split three ways: OpenHuman says
+    /// `direct` / `backend`, TinyMemory says `direct` / `proxied`, and this one
+    /// says `byok` / `managed`. Only [`BYOK_MODE`] is ever *written* here, so
+    /// the alias is not load-bearing today — it is there because of what the
+    /// fallback above would otherwise do to the one spelling somebody is most
+    /// likely to reach for.
+    ///
+    /// `direct` falling through to managed would be silent and wrong in the
+    /// specific way this whole surface refuses: a company that asked to act
+    /// through its own Composio account would act through the platform's
+    /// instead. (It would not *leak* the key — managed resolution reads
+    /// [`TOKEN_KEY`] and the company key, never [`API_KEY_KEY`], so the stored
+    /// Composio key would simply go unread — but the routing surprise is the
+    /// part that matters.) Nothing is gained by making the org's own other
+    /// spelling of "the company's own account" mean its opposite here.
+    ///
+    /// The managed spellings need no aliases: `backend` and `proxied` already
+    /// land on [`Self::Managed`] through the fallback, which is what they mean.
+    pub fn parse(raw: &str) -> Self {
+        let raw = raw.trim();
+        if raw.eq_ignore_ascii_case(BYOK_MODE) || raw.eq_ignore_ascii_case("direct") {
+            Self::Byok
+        } else {
+            Self::Managed
+        }
+    }
+
+    /// Whether this mode talks to Composio directly.
+    pub fn is_byok(self) -> bool {
+        matches!(self, Self::Byok)
+    }
+}
+
+impl std::fmt::Display for ComposioMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// This company's stored routing mode, or [`ComposioMode::Managed`].
+pub async fn load_mode(company: &CompanyId, secrets: &dyn SecretStore) -> Result<ComposioMode> {
+    Ok(secrets
+        .get(company, MODE_KEY)
+        .await?
+        .map(|SecretValue(raw)| ComposioMode::parse(&raw))
+        .unwrap_or_default())
+}
+
+/// Store (or rotate/clear) this company's own Composio API key **and the mode
+/// that goes with it**, returning the resulting mode.
+///
+/// The two are written together on purpose. A mode without a key is a company
+/// with no Composio tools (see [`resolve_access`], which fails closed rather
+/// than borrowing the platform identity), and a key without a mode is a
+/// credential nothing reads — both are states an operator can reach only if
+/// this function lets them. A non-empty value therefore sets the key and
+/// selects [`ComposioMode::Byok`]; an empty one clears the key and returns the
+/// company to [`ComposioMode::Managed`].
+///
+/// The key is written first: if the second write fails, the company is left in
+/// managed mode holding an unread key, which is inert. The other order would
+/// leave it in BYOK mode with no key, which is an outage.
+pub async fn store_api_key(
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+    api_key: &str,
+) -> Result<ComposioMode> {
+    let api_key = api_key.trim();
+    let mode = if api_key.is_empty() {
+        ComposioMode::Managed
+    } else {
+        ComposioMode::Byok
+    };
+    secrets
+        .set(company, API_KEY_KEY, SecretValue(api_key.to_string()))
+        .await?;
+    secrets
+        .set(company, MODE_KEY, SecretValue(mode.as_str().to_string()))
+        .await?;
+    Ok(mode)
+}
+
+/// How a company reaches Composio: the route, and the credential that route
+/// presents.
+///
+/// Returned as a pair rather than resolved twice because the two answers must
+/// agree — a console reporting BYOK while the agents present a platform bearer
+/// is the exact drift [`resolve_credential`]'s own docs exist to prevent.
+pub struct ComposioAccess {
+    /// Which host the calls go to.
+    pub mode: ComposioMode,
+    /// What they authenticate with: a Composio API key under
+    /// [`ComposioMode::Byok`], otherwise whatever [`resolve_credential`]
+    /// resolves.
+    pub credential: Credential,
+}
+
+impl ComposioAccess {
+    /// The non-secret endpoint this access reaches — [`DIRECT_BASE_URL`] for
+    /// BYOK, the resolved backend URL otherwise. Safe to surface on the console
+    /// read plane.
+    pub fn endpoint(&self, backend_url: &str) -> String {
+        match self.mode {
+            ComposioMode::Byok => DIRECT_BASE_URL.to_string(),
+            ComposioMode::Managed => backend_url.to_string(),
+        }
+    }
+}
+
+/// The route and credential this company's Composio calls use.
+///
+/// **Managed** defers wholly to [`resolve_credential`] — the BYO backend token,
+/// then the company's TinyHumans key, then the instance identity — so nothing
+/// about the default path changes by adding this.
+///
+/// **BYOK** reads [`API_KEY_KEY`] and nothing else. It deliberately does *not*
+/// fall back to the managed tiers when the key is missing or blank: a company
+/// that asked to act through its own Composio account and silently acted
+/// through the platform's instead would connect providers into the wrong tenant
+/// and bill the wrong party. [`Credential::None`] here means no tools this
+/// cycle, which is the same fail-closed answer an absent managed credential
+/// gets.
+///
+/// A store read error **propagates**, for the reason it propagates in
+/// [`resolve_credential`]: an unreadable store must not be able to change which
+/// account a call is attributed to.
+pub async fn resolve_access(
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+    token_source: Option<Arc<TinyhumansTokenSource>>,
+) -> Result<ComposioAccess> {
+    let mode = load_mode(company, secrets).await?;
+    let credential = match mode {
+        ComposioMode::Managed => resolve_credential(company, secrets, token_source).await?,
+        ComposioMode::Byok => match secrets.get(company, API_KEY_KEY).await? {
+            Some(SecretValue(key)) => Credential::from_value(key),
+            None => Credential::None,
+        },
+    };
+    if mode.is_byok() && !credential.configured() {
+        tracing::warn!(
+            company = %company,
+            "[composio] this company is in BYOK mode with no Composio API key stored; \
+             withholding tools rather than presenting the platform identity"
+        );
+    }
+    Ok(ComposioAccess { mode, credential })
+}
+
 /// The [`SecretStore`] key holding this company's per-toolkit default
 /// connections — a JSON object `{"gmail": "ca_123"}` written by the console
 /// (issue #820).
@@ -529,6 +775,172 @@ mod tests {
         assert!(
             load_defaults(&company, &secrets).await.unwrap().is_empty(),
             "a hand-edited blob must fall back to Composio's resolution, not withhold the tools"
+        );
+    }
+    // ── BYOK routing ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn a_company_that_configured_nothing_is_openhuman_managed() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        assert_eq!(
+            load_mode(&company, &secrets).await.unwrap(),
+            ComposioMode::Managed
+        );
+        let access = resolve_access(&company, &secrets, None).await.unwrap();
+        assert_eq!(access.mode, ComposioMode::Managed);
+    }
+
+    #[tokio::test]
+    async fn storing_a_key_selects_byok_and_clearing_it_gives_the_managed_route_back() {
+        // The two writes travel together deliberately — a mode without a key is
+        // a company with no Composio tools, and a key without a mode is inert.
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+
+        let mode = store_api_key(&company, &secrets, " ak_live ")
+            .await
+            .unwrap();
+        assert_eq!(mode, ComposioMode::Byok);
+        let access = resolve_access(&company, &secrets, None).await.unwrap();
+        assert_eq!(access.mode, ComposioMode::Byok);
+        assert_eq!(
+            access.credential.current().await.unwrap().as_deref(),
+            Some("ak_live"),
+            "the key is trimmed on the way in — Composio rejects a padded x-api-key"
+        );
+
+        let mode = store_api_key(&company, &secrets, "").await.unwrap();
+        assert_eq!(mode, ComposioMode::Managed);
+        let access = resolve_access(&company, &secrets, None).await.unwrap();
+        assert_eq!(access.mode, ComposioMode::Managed);
+    }
+
+    #[tokio::test]
+    async fn byok_never_falls_back_to_a_managed_credential() {
+        // The load-bearing one. A company that asked to act through its own
+        // Composio account must not silently act through the platform's: that
+        // would connect providers into the wrong tenant and bill the wrong
+        // party. No key means no tools.
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        // A managed-tier credential that *would* answer, so the test proves the
+        // BYOK arm ignores it rather than that there was nothing to fall back to.
+        secrets
+            .set(&company, TOKEN_KEY, SecretValue("backend-bearer".into()))
+            .await
+            .unwrap();
+        secrets
+            .set(&company, MODE_KEY, SecretValue(BYOK_MODE.into()))
+            .await
+            .unwrap();
+
+        let access = resolve_access(&company, &secrets, None).await.unwrap();
+        assert_eq!(access.mode, ComposioMode::Byok);
+        assert!(
+            !access.credential.configured(),
+            "BYOK with no API key resolves to nothing, not to the backend token"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_byok_key_is_never_confused_with_the_backend_token() {
+        // Two different secrets authenticating two different hosts. Selecting
+        // BYOK must present the Composio key, not the bearer stored next to it.
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        secrets
+            .set(&company, TOKEN_KEY, SecretValue("backend-bearer".into()))
+            .await
+            .unwrap();
+        store_api_key(&company, &secrets, "ak_live").await.unwrap();
+
+        let access = resolve_access(&company, &secrets, None).await.unwrap();
+        assert_eq!(
+            access.credential.current().await.unwrap().as_deref(),
+            Some("ak_live")
+        );
+
+        // And clearing the key hands the backend token back untouched — a
+        // switch to BYOK and back must not cost the company its override.
+        store_api_key(&company, &secrets, "").await.unwrap();
+        let access = resolve_access(&company, &secrets, None).await.unwrap();
+        assert_eq!(access.mode, ComposioMode::Managed);
+        assert_eq!(
+            access.credential.current().await.unwrap().as_deref(),
+            Some("backend-bearer")
+        );
+    }
+
+    #[tokio::test]
+    async fn a_hand_edited_mode_slot_cannot_take_a_company_s_tools_away() {
+        // Read on the roster path: an unrecognised mode must degrade to the
+        // route that works without anything stored, not to no route at all.
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        secrets
+            .set(&company, MODE_KEY, SecretValue("nonsense".into()))
+            .await
+            .unwrap();
+        assert_eq!(
+            load_mode(&company, &secrets).await.unwrap(),
+            ComposioMode::Managed,
+            "an unrecognised mode falls back to the route that works without config"
+        );
+
+        // OpenHuman's and TinyMemory's spelling of the same route. Never
+        // written here, but a slot that carried it must not silently mean the
+        // opposite — a company asking for its own account would get the
+        // platform's.
+        secrets
+            .set(&company, MODE_KEY, SecretValue("dirEct".into()))
+            .await
+            .unwrap();
+        assert_eq!(
+            load_mode(&company, &secrets).await.unwrap(),
+            ComposioMode::Byok
+        );
+
+        // …and the managed spellings the other repos use need no alias: they
+        // already mean managed through the fallback.
+        for spelling in ["backend", "proxied"] {
+            secrets
+                .set(&company, MODE_KEY, SecretValue(spelling.into()))
+                .await
+                .unwrap();
+            assert_eq!(
+                load_mode(&company, &secrets).await.unwrap(),
+                ComposioMode::Managed,
+                "`{spelling}` means managed everywhere it is used"
+            );
+        }
+
+        secrets
+            .set(&company, MODE_KEY, SecretValue("  BYOK  ".into()))
+            .await
+            .unwrap();
+        assert_eq!(
+            load_mode(&company, &secrets).await.unwrap(),
+            ComposioMode::Byok,
+            "the one spelling this repo does use is matched case-insensitively"
+        );
+    }
+
+    #[test]
+    fn the_endpoint_reported_is_the_host_the_calls_reach() {
+        let byok = ComposioAccess {
+            mode: ComposioMode::Byok,
+            credential: Credential::from_value("ak_live"),
+        };
+        assert_eq!(byok.endpoint("https://api.tinyhumans.ai"), DIRECT_BASE_URL);
+
+        let managed = ComposioAccess {
+            mode: ComposioMode::Managed,
+            credential: Credential::from_value("bearer"),
+        };
+        assert_eq!(
+            managed.endpoint("https://api.tinyhumans.ai"),
+            "https://api.tinyhumans.ai"
         );
     }
 }

--- a/src/harness/built_in/composio.rs
+++ b/src/harness/built_in/composio.rs
@@ -434,6 +434,19 @@ impl TenantComposio {
                 // all, when a company clears a BYOK key it never used.
                 c.mode.hash(&mut hasher);
                 c.credential.hash_identity(&mut hasher);
+                // Under BYOK this is a *second* live credential — the
+                // managed-chain bearer `list_toolkits` fetches OpenHuman's
+                // curated catalog with, captured at resolve time and re-read
+                // per call through `catalog_token`. Missing it here means
+                // rotating the company's TinyHumans key while BYOK is active
+                // moves neither `mode` nor `credential`, so the roster keeps
+                // presenting the stale bearer: the curated fetch then fails on
+                // it and `LiveClient::list_toolkits` silently widens the
+                // provider grid to the account's own Composio directory,
+                // staying that way until some unrelated change happens to
+                // rebuild the roster. `Credential::None` under managed hashes
+                // to a fixed tag, so this is a no-op there.
+                c.catalog.hash_identity(&mut hasher);
                 c.toolkits.hash(&mut hasher);
                 // The pins are part of what the tools do, so a console change
                 // to one has to reach the agents the same cycle a token change
@@ -2445,6 +2458,49 @@ mod tests {
             TenantComposio::fingerprint(&managed),
             TenantComposio::fingerprint(&byok),
             "managed and BYOK must not fingerprint alike"
+        );
+    }
+
+    /// Under BYOK the config carries a *second* live credential — the
+    /// managed-chain bearer `list_toolkits` fetches OpenHuman's curated catalog
+    /// with. Rotating a company's TinyHumans key while BYOK is active changes
+    /// neither `mode` nor the Composio `credential`, so this bearer is the only
+    /// thing that moves; if the fingerprint did not cover it, the roster would
+    /// keep the stale one until some unrelated change happened to rebuild it,
+    /// and the curated fetch would keep failing on a bearer the operator
+    /// already rotated away from.
+    #[test]
+    fn fingerprint_moves_when_the_catalog_credential_rotates() {
+        let byok_with = |catalog: Credential| {
+            Some(
+                TenantComposio::from_access(
+                    "https://api.tinyhumans.ai",
+                    crate::company::composio::ComposioAccess {
+                        mode: ComposioMode::Byok,
+                        credential: Credential::from_value("ak_live"),
+                    },
+                    vec!["gmail".to_string()],
+                )
+                .with_catalog_credential(catalog),
+            )
+        };
+        let before = byok_with(Credential::from_value("th-company-a"));
+        let after = byok_with(Credential::from_value("th-company-b"));
+        assert_ne!(
+            TenantComposio::fingerprint(&before),
+            TenantComposio::fingerprint(&after),
+            "rotating the catalog bearer alone must still rebuild the roster"
+        );
+
+        // A managed config's `catalog` is always `Credential::None` (see
+        // `TenantComposio::new`), so this must be a genuine no-op there rather
+        // than a source of spurious rebuilds on every managed roster build.
+        let managed_a = config_with(Credential::from_value("same-bytes"));
+        let managed_b = config_with(Credential::from_value("same-bytes"));
+        assert_eq!(
+            TenantComposio::fingerprint(&managed_a),
+            TenantComposio::fingerprint(&managed_b),
+            "an always-None catalog credential must not itself vary the managed fingerprint"
         );
     }
 

--- a/src/harness/built_in/composio.rs
+++ b/src/harness/built_in/composio.rs
@@ -2,6 +2,23 @@
 //! GitHub surface OpenHuman exposes through its backend-proxied Composio routes,
 //! bridged into a company agent's toolbelt behind the opt-in `composio` grant.
 //!
+//! ## Two routes: managed, and the company's own account
+//!
+//! Everything below describes the **managed** route, which is the default and
+//! the one that needs no configuration. A company that holds its own Composio
+//! account can instead store a Composio API key and have every call go straight
+//! to `backend.composio.dev` — no proxy, no platform identity, no platform bill.
+//! That route is [`composio_direct`](crate::harness::composio_direct); the two
+//! meet at [`LiveClient`], which is the only place in this module that knows
+//! which one answered. [`TenantComposio::mode`] is what says which is in force,
+//! and it is folded into the roster fingerprint so switching reaches the agents
+//! on their next turn.
+//!
+//! Under BYOK the tiers below do not apply at all: the company's own key is the
+//! only credential, and its absence means no tools rather than a fallback — see
+//! [`resolve_access`](crate::company::composio::resolve_access) for why
+//! borrowing the platform identity there would be the wrong kind of helpful.
+//!
 //! ## Tenant isolation (the security spine)
 //!
 //! In OpenHuman's **backend mode**, no Composio call carries an `entity_id`: the
@@ -84,8 +101,8 @@ use crate::ports::types::CompanyId;
 // `company::composio` module (so the console read/write plane can manage the
 // token in the default build); re-exported here for the harness call sites.
 pub use crate::company::composio::{
-    COMPOSIO_BACKEND_URL_ENV, TINYHUMANS_API_URL_ENV, TOKEN_KEY, backend_url_or_default,
-    resolve_credential,
+    API_KEY_KEY, COMPOSIO_BACKEND_URL_ENV, ComposioMode, DIRECT_BASE_URL, TINYHUMANS_API_URL_ENV,
+    TOKEN_KEY, backend_url_or_default, resolve_access, resolve_credential,
 };
 
 /// A per-tenant Composio configuration: the backend URL, how the outbound bearer
@@ -105,7 +122,45 @@ pub struct TenantComposio {
     pub backend_url: String,
     /// How the outbound bearer is obtained: the company's own stored token, or
     /// this instance's platform identity. Resolved per call — see the module docs.
+    ///
+    /// Under [`ComposioMode::Byok`] this holds the company's own **Composio API
+    /// key** instead, which is presented as `x-api-key` to Composio itself
+    /// rather than as a bearer to the OpenHuman backend. One field because it is
+    /// one thing — the single secret this config authenticates with — and
+    /// [`Self::mode`] is what says which host it is presented to.
     credential: Credential,
+    /// Which host the calls go to: the OpenHuman-managed backend, or the
+    /// company's own Composio account (issue: BYOK Composio).
+    ///
+    /// Part of the config rather than re-read per call for the same reason
+    /// [`Self::toolkits`] is: it is a company decision that must reach the
+    /// agents through a roster rebuild, not a value a tool re-derives while it
+    /// runs.
+    mode: ComposioMode,
+    /// The **managed-chain** credential, kept alongside the BYOK one for a
+    /// single purpose: fetching OpenHuman's curated toolkit list.
+    ///
+    /// ## Why a BYOK company still asks OpenHuman what to offer
+    ///
+    /// Because neither list a BYOK company can reach on its own describes what
+    /// it should be shown. Composio's directory is 1501 entries — the whole
+    /// integration catalogue, most of which this harness has no curated tool
+    /// surface for — and the compiled-in shortlist is 31. OpenHuman's backend
+    /// publishes the middle answer, 123 providers, and it is the same list a
+    /// managed company is offered, which is the point: switching a company to
+    /// its own Composio account should change *who it acts as*, not what the
+    /// console lets it browse.
+    ///
+    /// This is a **non-secret list**, fetched once per
+    /// [`CATALOG_TTL`](crate::server::ops::composio_toolkits::CATALOG_TTL). No
+    /// Composio traffic is proxied through it and nothing is billed by it —
+    /// authorize and execute still go straight to the company's own account.
+    ///
+    /// [`Credential::None`] when no managed tier resolves (a standalone host
+    /// with no TinyHumans identity at all), in which case the catalog falls back
+    /// to the company's own Composio directory — see
+    /// [`LiveClient::list_toolkits`].
+    catalog: Credential,
     /// The toolkit allowlist (Gmail / Slack / GitHub, …). Empty defers to the
     /// backend's server-enforced allowlist (open mode); non-empty narrows
     /// strictly, client-side, before any network round-trip.
@@ -123,8 +178,12 @@ pub struct TenantComposio {
 }
 
 impl TenantComposio {
-    /// A config over an explicit credential — the constructor tests and callers
-    /// outside the resolver use.
+    /// A **managed** config over an explicit bearer — the constructor tests and
+    /// callers outside the resolver use.
+    ///
+    /// The bearer is presented to the OpenHuman backend. A caller holding an
+    /// answer from [`resolve_access`] wants [`Self::from_access`] instead,
+    /// which cannot lose the route.
     pub fn new(
         backend_url: impl Into<String>,
         credential: Credential,
@@ -133,8 +192,71 @@ impl TenantComposio {
         Self {
             backend_url: backend_url.into(),
             credential,
+            mode: ComposioMode::Managed,
+            catalog: Credential::None,
             toolkits,
             defaults: Default::default(),
+        }
+    }
+
+    /// The same config with the managed-chain credential attached, for the
+    /// curated toolkit list only. Meaningless under
+    /// [`ComposioMode::Managed`], where [`Self::credential`] already is it.
+    pub fn with_catalog_credential(mut self, catalog: Credential) -> Self {
+        self.catalog = catalog;
+        self
+    }
+
+    /// A config over a resolved
+    /// [`ComposioAccess`](crate::company::composio::ComposioAccess) — the
+    /// **only** way to build a BYOK config, and the only constructor a caller
+    /// that resolved a credential should use.
+    ///
+    /// ## Why this is not a `with_mode(…)` builder
+    ///
+    /// Because a builder would make the dangerous thing representable. Under
+    /// BYOK the credential is a **Composio** API key; under managed it is a
+    /// bearer the **TinyHumans backend** recognises. A call site that resolved
+    /// the first and then forgot to say so would build a managed config around
+    /// it, and [`live_call`] would send that company's `ak_…` to
+    /// `api.tinyhumans.ai` as a bearer — a credential delivered to a host that
+    /// has no business holding it, on a path where nothing would look wrong.
+    ///
+    /// Taking the pair that [`resolve_access`] returns, as one value, means the
+    /// route cannot be dropped on the floor between resolving a credential and
+    /// presenting it. [`Self::new`] stays for the callers that genuinely mean
+    /// "managed, with this bearer" — every existing one, and the tests.
+    pub fn from_access(
+        backend_url: impl Into<String>,
+        access: crate::company::composio::ComposioAccess,
+        toolkits: Vec<String>,
+    ) -> Self {
+        Self {
+            backend_url: backend_url.into(),
+            credential: access.credential,
+            mode: access.mode,
+            catalog: Credential::None,
+            toolkits,
+            defaults: Default::default(),
+        }
+    }
+
+    /// Which host this company's Composio calls go to.
+    pub fn mode(&self) -> ComposioMode {
+        self.mode
+    }
+
+    /// The non-secret endpoint the calls actually reach — Composio's own API
+    /// host under BYOK, the managed backend otherwise.
+    ///
+    /// The console reports this rather than [`Self::backend_url`] so that
+    /// switching to BYOK visibly changes where the traffic goes; a status line
+    /// still naming `api.tinyhumans.ai` after the switch would read as though
+    /// nothing had happened.
+    pub fn endpoint(&self) -> &str {
+        match self.mode {
+            ComposioMode::Byok => DIRECT_BASE_URL,
+            ComposioMode::Managed => &self.backend_url,
         }
     }
 
@@ -161,7 +283,13 @@ impl TenantComposio {
     /// Resolve a per-tenant Composio config, or `None` (fail closed) when no
     /// credential can be obtained at all.
     ///
-    /// Precedence: the company's **own Composio** token under [`TOKEN_KEY`] wins
+    /// A company in **BYOK** mode short-circuits everything below: its own
+    /// Composio API key is the credential, and if it is missing this yields
+    /// `None` rather than falling back to a managed tier. An operator who asked
+    /// to act through their own Composio account must never silently act
+    /// through the platform's.
+    ///
+    /// Managed precedence: the company's **own Composio** token under [`TOKEN_KEY`] wins
     /// — a company that pasted one keeps it even on the hosted platform. Failing
     /// that, the shared brokered-credential seam
     /// [`company_key::resolve`](crate::company::company_key::resolve) answers:
@@ -190,14 +318,11 @@ impl TenantComposio {
         api_url_env: Option<String>,
         token_source: Option<Arc<TinyhumansTokenSource>>,
     ) -> Option<Self> {
-        let credential = match crate::company::composio::resolve_credential(
-            company,
-            secrets,
-            token_source,
-        )
-        .await
-        {
-            Ok(credential) => credential,
+        // Cloned because both resolutions below want it: the access one, and the
+        // curated-catalog one under BYOK.
+        let catalog_source = token_source.clone();
+        let access = match resolve_access(company, secrets, token_source).await {
+            Ok(access) => access,
             Err(err) => {
                 tracing::warn!(
                     company = %company,
@@ -208,9 +333,10 @@ impl TenantComposio {
                 return None;
             }
         };
-        match credential {
+        let mode = access.mode;
+        match access.credential {
             Credential::None => None,
-            credential => {
+            _ => {
                 // Which account the company means, per toolkit (issue #820).
                 // Read here rather than per call so it lands in the fingerprint
                 // below: changing the pin then rebuilds the roster on the next
@@ -222,12 +348,25 @@ impl TenantComposio {
                 let defaults = crate::company::composio::load_defaults(company, secrets)
                     .await
                     .unwrap_or_default();
+                // Under BYOK, resolve the managed chain *as well* — not to act
+                // through, only to ask OpenHuman which providers to offer. A
+                // failure here is not a failure of the config: the company's own
+                // Composio key is what its agents present, and an unavailable
+                // curated list degrades the catalog, never the credential.
+                let catalog = if mode.is_byok() {
+                    crate::company::composio::resolve_credential(company, secrets, catalog_source)
+                        .await
+                        .unwrap_or(Credential::None)
+                } else {
+                    Credential::None
+                };
                 Some(
-                    Self::new(
+                    Self::from_access(
                         backend_url_or_default(backend_url_env, api_url_env),
-                        credential,
+                        access,
                         toolkits,
                     )
+                    .with_catalog_credential(catalog)
                     .with_defaults(defaults),
                 )
             }
@@ -248,6 +387,18 @@ impl TenantComposio {
     /// call rather than dialling the backend unauthenticated.
     pub async fn current_token(&self) -> crate::Result<Option<String>> {
         self.credential.current().await
+    }
+
+    /// The bearer for the **curated toolkit list**, or `None` when no managed
+    /// tier resolved.
+    ///
+    /// Only ever presented to the OpenHuman backend, and only for a non-secret
+    /// list. Never to Composio, and never in place of
+    /// [`Self::current_token`] — the two authenticate different hosts, and
+    /// confusing them is the failure [`from_access`](Self::from_access) exists
+    /// to make unrepresentable one level up.
+    pub async fn catalog_token(&self) -> crate::Result<Option<String>> {
+        self.catalog.current().await
     }
 
     /// A stable, credential-safe fingerprint of the resolved config, folded into
@@ -276,6 +427,12 @@ impl TenantComposio {
             Some(c) => {
                 1u8.hash(&mut hasher);
                 c.backend_url.hash(&mut hasher);
+                // Switching between managed and BYOK changes which Composio
+                // account the agents act through, so it has to rebuild the
+                // roster on the next turn exactly as a rotated token does — and
+                // it can happen without the credential's *bytes* changing at
+                // all, when a company clears a BYOK key it never used.
+                c.mode.hash(&mut hasher);
                 c.credential.hash_identity(&mut hasher);
                 c.toolkits.hash(&mut hasher);
                 // The pins are part of what the tools do, so a console change
@@ -414,8 +571,14 @@ mod live {
 
     use oh::integrations::IntegrationClient;
     use oh::integrations::composio::ComposioClient;
+    use oh::integrations::composio::types::{
+        ComposioAuthorizeResponse, ComposioConnectionsResponse, ComposioDeleteResponse,
+        ComposioExecuteResponse, ComposioToolkitsResponse, ComposioToolsResponse,
+    };
     use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
     use openhuman_core::openhuman as oh;
+
+    use crate::harness::built_in::composio_direct::DirectComposio;
 
     /// What `composio_execute` needs to meter a call it just made: the company
     /// the sample belongs to, the agent that made it, and the meter to write to.
@@ -495,17 +658,198 @@ mod live {
     ///
     /// The scrub vector carries exactly the token that went out, so it cannot
     /// survive into agent-visible output even if the backend reflects it.
-    async fn live_call(config: &TenantComposio) -> Result<(ComposioClient, Vec<String>)> {
-        let token = config
+    async fn live_call(config: &TenantComposio) -> Result<(LiveClient, Vec<String>)> {
+        let secret = config
             .current_token()
             .await
             .map_err(|e| anyhow::anyhow!("resolving this company's Composio credential: {e}"))?
             .ok_or_else(|| anyhow::anyhow!("no Composio credential is configured"))?;
-        let client = ComposioClient::new(Arc::new(IntegrationClient::new(
-            config.backend_url.clone(),
-            token.clone(),
-        )));
-        Ok((client, vec![token]))
+        let mut secrets = vec![secret.clone()];
+        let client = match config.mode() {
+            ComposioMode::Managed => LiveClient::Managed(ComposioClient::new(Arc::new(
+                IntegrationClient::new(config.backend_url.clone(), secret.clone()),
+            ))),
+            ComposioMode::Byok => {
+                // The curated-list client, when a managed tier resolves. Built
+                // here rather than inside `list_toolkits` so its bearer joins
+                // the scrub vector: it is a second live credential on this call,
+                // and it must no more survive into agent-visible output than the
+                // Composio key does.
+                let catalog = match config.catalog_token().await {
+                    Ok(Some(token)) => {
+                        secrets.push(token.clone());
+                        Some(ComposioClient::new(Arc::new(IntegrationClient::new(
+                            config.backend_url.clone(),
+                            token,
+                        ))))
+                    }
+                    Ok(None) => None,
+                    Err(err) => {
+                        // Degrades the catalog, never the call: the company's
+                        // own key is unaffected by this.
+                        tracing::warn!(
+                            error = %err,
+                            "[composio-byok] could not resolve the managed credential for the \
+                             curated toolkit list; falling back to this account's own catalogue"
+                        );
+                        None
+                    }
+                };
+                LiveClient::Byok {
+                    direct: DirectComposio::new(&secret),
+                    catalog,
+                }
+            }
+        };
+        Ok((client, secrets))
+    }
+
+    /// The two routes a Composio call can take, behind one surface.
+    ///
+    /// Every caller in this module speaks these six operations and none of them
+    /// branches on the route: a BYOK answer arrives in the same envelope a
+    /// managed one does, so the allowlist filtering, the scrubbing, the
+    /// rendering and the metering downstream of here are shared rather than
+    /// duplicated. The branch lives once, in the impl below, which is also the
+    /// only place that has to state what BYOK cannot do.
+    enum LiveClient {
+        /// Proxied through the OpenHuman backend — the default route.
+        Managed(ComposioClient),
+        /// Straight to the company's own Composio account.
+        Byok {
+            /// The company's own Composio account — every call but the toolkit
+            /// catalogue.
+            direct: DirectComposio,
+            /// OpenHuman's curated toolkit list, when a managed tier resolved to
+            /// fetch it with. `None` on a host with no TinyHumans identity at
+            /// all, where the company's own directory is the only list there is.
+            catalog: Option<ComposioClient>,
+        },
+    }
+
+    impl LiveClient {
+        /// The catalog of toolkits this company may connect.
+        ///
+        /// Managed: the backend's server-enforced allowlist. BYOK: whatever the
+        /// company's own Composio account lists, every entry connectable —
+        /// there is no gate between a company and its own account.
+        async fn list_toolkits(&self) -> Result<ComposioToolkitsResponse> {
+            match self {
+                Self::Managed(client) => client.list_toolkits().await,
+                // The curated list first, so a BYOK company browses the same
+                // 123 providers a managed one does. Switching a company to its
+                // own Composio account changes who it acts as; it should not
+                // also change what the console lets it look at.
+                Self::Byok {
+                    catalog: Some(catalog),
+                    direct,
+                } => match catalog.list_toolkits().await {
+                    Ok(resp) if !resp.toolkits.is_empty() || !resp.catalog.is_empty() => Ok(resp),
+                    // An empty or failed curated list is not worth failing the
+                    // catalogue over — the company's own directory is a real
+                    // answer, just a longer and less curated one.
+                    other => {
+                        if let Err(ref err) = other {
+                            tracing::warn!(
+                                error = %format!("{err:#}"),
+                                "[composio-byok] the curated toolkit list could not be read; \
+                                 falling back to this account's own catalogue"
+                            );
+                        }
+                        direct.list_toolkits().await
+                    }
+                },
+                Self::Byok {
+                    catalog: None,
+                    direct,
+                } => direct.list_toolkits().await,
+            }
+        }
+
+        /// The connected accounts this company holds.
+        async fn list_connections(&self) -> Result<ComposioConnectionsResponse> {
+            match self {
+                Self::Managed(client) => client.list_connections().await,
+                Self::Byok { direct, .. } => direct.list_connections().await,
+            }
+        }
+
+        /// The action schemas for `toolkits` (all of them when `None`).
+        async fn list_tools(
+            &self,
+            toolkits: Option<&[String]>,
+            tags: Option<&[String]>,
+        ) -> Result<ComposioToolsResponse> {
+            match self {
+                Self::Managed(client) => client.list_tools(toolkits, tags).await,
+                Self::Byok { direct, .. } => {
+                    if tags.is_some_and(|tags| !tags.is_empty()) {
+                        // Nothing in this repo passes tags today; say so rather
+                        // than silently narrowing to nothing if something starts.
+                        tracing::warn!(
+                            "[composio-byok] list_tools: tag filtering is not applied on the                              BYOK route; returning the unfiltered toolkit listing"
+                        );
+                    }
+                    direct.list_tools(toolkits.unwrap_or(&[])).await
+                }
+            }
+        }
+
+        /// Begin an OAuth handoff and return the hosted connect URL.
+        async fn authorize(
+            &self,
+            toolkit: &str,
+            extra: Option<Value>,
+        ) -> Result<ComposioAuthorizeResponse> {
+            match self {
+                Self::Managed(client) => client.authorize(toolkit, extra).await,
+                Self::Byok { direct, .. } => {
+                    if extra.is_some() {
+                        // The v3 link call takes no per-toolkit extras; a
+                        // BYOK operator configures them on the auth config in
+                        // their own Composio dashboard. Same answer OpenHuman's
+                        // direct branch gives, and it is logged rather than
+                        // failed so a toolkit that does not need them still
+                        // connects.
+                        tracing::warn!(
+                            toolkit = %toolkit,
+                            "[composio-byok] authorize: extra_params are not forwarded on the                              BYOK route — set them on the toolkit's auth config at app.composio.dev"
+                        );
+                    }
+                    direct.authorize(toolkit).await
+                }
+            }
+        }
+
+        /// Run one action, optionally as a named connected account.
+        async fn execute(
+            &self,
+            tool: &str,
+            arguments: Option<Value>,
+            connection_id: Option<&str>,
+        ) -> Result<ComposioExecuteResponse> {
+            match self {
+                // No pin — the ordinary case — is the untouched path: the
+                // vendored client's own call, with no connection id, resolved
+                // by Composio for the entity.
+                Self::Managed(client) => match connection_id {
+                    None => client.execute_tool(tool, arguments).await,
+                    Some(connection_id) => {
+                        execute_pinned(client, tool, arguments, connection_id).await
+                    }
+                },
+                Self::Byok { direct, .. } => direct.execute(tool, arguments, connection_id).await,
+            }
+        }
+
+        /// Revoke one connected account — the backend's route under managed,
+        /// Composio's own `DELETE /connected_accounts/{id}` under BYOK.
+        async fn delete_connection(&self, connection_id: &str) -> Result<ComposioDeleteResponse> {
+            match self {
+                Self::Managed(client) => client.delete_connection(connection_id).await,
+                Self::Byok { direct, .. } => direct.delete_connection(connection_id).await,
+            }
+        }
     }
 
     /// Run a Composio action **as a named connected account** (issue #820).
@@ -638,8 +982,14 @@ mod live {
 
     /// A scrubbed error result — the tenant token is stripped from any error
     /// body (mirrors [`crate::harness::mcp`]'s failure handling).
+    ///
+    /// `{err:#}` renders the whole cause chain, not just its outermost layer.
+    /// The managed client's errors are single-level so the two used to read
+    /// alike; the BYOK client wraps its calls in `.context(…)`, and with plain
+    /// `{err}` an agent was handed the bare call name — "Composio v3 /toolkits"
+    /// — with the reason it failed silently discarded one frame below.
     fn scrubbed_err(context: &str, err: &anyhow::Error, secrets: &[String]) -> ToolResult {
-        ToolResult::error(scrub(&format!("{context}: {err}"), secrets))
+        ToolResult::error(scrub(&format!("{context}: {err:#}"), secrets))
     }
 
     /// Pull a required, non-empty string argument.
@@ -676,7 +1026,7 @@ mod live {
         let (client, secrets) = live_call(config).await?;
         match client.authorize(toolkit, None).await {
             Ok(resp) => Ok(resp.connect_url),
-            Err(err) => Err(anyhow::anyhow!(scrub(&format!("{err}"), &secrets))),
+            Err(err) => Err(anyhow::anyhow!(scrub(&format!("{err:#}"), &secrets))),
         }
     }
 
@@ -697,7 +1047,7 @@ mod live {
         let (client, secrets) = live_call(config).await?;
         let resp = match client.list_connections().await {
             Ok(resp) => resp,
-            Err(err) => return Err(anyhow::anyhow!(scrub(&format!("{err}"), &secrets))),
+            Err(err) => return Err(anyhow::anyhow!(scrub(&format!("{err:#}"), &secrets))),
         };
         let mut rows: Vec<ComposioConnectionRow> = resp
             .connections
@@ -800,7 +1150,7 @@ mod live {
                 "Composio declined to delete the connection"
             ))),
             Err(err) => Err(DisconnectError::Upstream(anyhow::anyhow!(scrub(
-                &format!("{err}"),
+                &format!("{err:#}"),
                 &secrets
             )))),
         }
@@ -902,7 +1252,7 @@ mod live {
         let (client, secrets) = live_call(config).await?;
         let resp = match client.list_toolkits().await {
             Ok(resp) => resp,
-            Err(err) => return Err(anyhow::anyhow!(scrub(&format!("{err}"), &secrets))),
+            Err(err) => return Err(anyhow::anyhow!(scrub(&format!("{err:#}"), &secrets))),
         };
         let normalize = |slug: &str| slug.trim().to_ascii_lowercase();
         // A `BTreeMap` keyed on the normalized slug keeps the de-duplication and
@@ -1366,15 +1716,9 @@ mod live {
                     return Ok(ToolResult::error(format!("composio_execute failed: {err}")));
                 }
             };
-            // No pin — the ordinary case — is the untouched path: the same call
-            // this tool has always made, with no connection id, resolved by
-            // Composio for the entity.
-            let call = match pinned.as_deref() {
-                None => client.execute_tool(&tool, arguments).await,
-                Some(connection_id) => {
-                    execute_pinned(&client, &tool, arguments, connection_id).await
-                }
-            };
+            // A pin, when the company set one, is threaded through the route
+            // façade; an unpinned call is the untouched path it has always been.
+            let call = client.execute(&tool, arguments, pinned.as_deref()).await;
             match call {
                 Ok(resp) => {
                     // Metered only on success — i.e. a call that actually
@@ -2079,6 +2423,183 @@ mod tests {
             TenantComposio::fingerprint(&attested),
             TenantComposio::fingerprint(&a),
             "a tier change must move the fingerprint"
+        );
+    }
+
+    /// Switching routes is an identity change even when the credential's bytes
+    /// do not move: the same string means a different Composio account
+    /// depending on which host it is presented to, so the roster has to rebuild
+    /// or the agents keep calling the account the company just left.
+    #[test]
+    fn fingerprint_moves_when_the_route_changes() {
+        let managed = config_with(Credential::from_value("same-bytes"));
+        let byok = Some(TenantComposio::from_access(
+            "https://api.tinyhumans.ai",
+            crate::company::composio::ComposioAccess {
+                mode: ComposioMode::Byok,
+                credential: Credential::from_value("same-bytes"),
+            },
+            vec!["gmail".to_string()],
+        ));
+        assert_ne!(
+            TenantComposio::fingerprint(&managed),
+            TenantComposio::fingerprint(&byok),
+            "managed and BYOK must not fingerprint alike"
+        );
+    }
+
+    /// The endpoint a config reports is the host it dials — under BYOK that is
+    /// Composio itself, whatever managed backend URL was resolved alongside it.
+    #[test]
+    fn a_byok_config_reports_composios_own_host() {
+        let managed = TenantComposio::new(
+            "https://api.tinyhumans.ai",
+            Credential::from_value("k"),
+            vec![],
+        );
+        assert_eq!(managed.endpoint(), "https://api.tinyhumans.ai");
+        assert_eq!(managed.mode(), ComposioMode::Managed);
+
+        let byok = TenantComposio::from_access(
+            "https://api.tinyhumans.ai",
+            crate::company::composio::ComposioAccess {
+                mode: ComposioMode::Byok,
+                credential: Credential::from_value("k"),
+            },
+            vec![],
+        );
+        assert_eq!(byok.endpoint(), DIRECT_BASE_URL);
+        assert_eq!(byok.mode(), ComposioMode::Byok);
+    }
+
+    /// The hazard `from_access` exists to make unrepresentable: a BYOK
+    /// credential is a **Composio** key, and pairing it with the managed route
+    /// would send it to `api.tinyhumans.ai` as a bearer. Building from the
+    /// resolved pair carries the route with the credential, so the two cannot
+    /// be separated by a caller that forgets.
+    #[test]
+    fn a_byok_credential_cannot_be_built_onto_the_managed_route() {
+        let config = TenantComposio::from_access(
+            "https://api.tinyhumans.ai",
+            crate::company::composio::ComposioAccess {
+                mode: ComposioMode::Byok,
+                credential: Credential::from_value("ak_live"),
+            },
+            vec![],
+        );
+        assert_eq!(config.mode(), ComposioMode::Byok);
+        assert_eq!(
+            config.endpoint(),
+            DIRECT_BASE_URL,
+            "the key must be presented to Composio, never to the managed backend"
+        );
+    }
+
+    /// A BYOK company still resolves the managed chain — not to act through, but
+    /// to ask OpenHuman which providers to offer. The two credentials are kept
+    /// apart: the Composio key is what calls present, the managed bearer is only
+    /// ever the curated list's.
+    #[tokio::test]
+    async fn byok_keeps_the_managed_credential_for_the_curated_catalog_only() {
+        use crate::company::company_key;
+        use crate::company::composio::store_api_key;
+        use crate::store::FsSecretStore;
+
+        let dir = tempfile::Builder::new()
+            .prefix("oc-composio-catalog-")
+            .tempdir()
+            .expect("tempdir");
+        let secrets = FsSecretStore::new(dir.path());
+        let company = CompanyId::new("acme");
+
+        company_key::store_key(&company, &secrets, "th_company")
+            .await
+            .unwrap();
+        store_api_key(&company, &secrets, "ak_live").await.unwrap();
+
+        let config = TenantComposio::resolve(&company, &secrets, vec![], None, None, None)
+            .await
+            .expect("a BYOK company has a config");
+
+        assert_eq!(config.mode(), ComposioMode::Byok);
+        assert_eq!(
+            config.current_token().await.unwrap().as_deref(),
+            Some("ak_live"),
+            "calls present the company's own Composio key"
+        );
+        assert_eq!(
+            config.catalog_token().await.unwrap().as_deref(),
+            Some("th_company"),
+            "the curated list is fetched with the managed credential, not the Composio key"
+        );
+    }
+
+    /// With no managed tier at all — a standalone host carrying no TinyHumans
+    /// identity — there is no curated list to fetch, and the config says so
+    /// rather than presenting the Composio key to the OpenHuman backend.
+    #[tokio::test]
+    async fn byok_without_a_managed_tier_has_no_curated_catalog_credential() {
+        use crate::company::composio::store_api_key;
+        use crate::store::FsSecretStore;
+
+        let dir = tempfile::Builder::new()
+            .prefix("oc-composio-standalone-")
+            .tempdir()
+            .expect("tempdir");
+        let secrets = FsSecretStore::new(dir.path());
+        let company = CompanyId::new("acme");
+        store_api_key(&company, &secrets, "ak_live").await.unwrap();
+
+        let config = TenantComposio::resolve(&company, &secrets, vec![], None, None, None)
+            .await
+            .expect("a BYOK company has a config");
+        assert_eq!(
+            config.current_token().await.unwrap().as_deref(),
+            Some("ak_live")
+        );
+        assert!(
+            config.catalog_token().await.unwrap().is_none(),
+            "no managed tier means no curated list — never the Composio key standing in for one"
+        );
+    }
+
+    /// The roster path honours the stored route: a company that brought its own
+    /// Composio account resolves to a BYOK config carrying that key, and one
+    /// that selected BYOK without storing a key resolves to **no tools** rather
+    /// than to the platform identity standing in for it.
+    #[tokio::test]
+    async fn resolve_follows_the_stored_route() {
+        use crate::company::composio::{BYOK_MODE, MODE_KEY, store_api_key};
+        use crate::store::FsSecretStore;
+
+        let dir = tempfile::Builder::new()
+            .prefix("oc-composio-byok-")
+            .tempdir()
+            .expect("tempdir");
+        let secrets = FsSecretStore::new(dir.path());
+        let company = CompanyId::new("acme");
+        store_api_key(&company, &secrets, "ak_live").await.unwrap();
+
+        let config = TenantComposio::resolve(&company, &secrets, vec![], None, None, None)
+            .await
+            .expect("a BYOK company has a config");
+        assert_eq!(config.mode(), ComposioMode::Byok);
+        assert_eq!(
+            config.current_token().await.unwrap().as_deref(),
+            Some("ak_live")
+        );
+
+        // BYOK selected with nothing stored: fail closed.
+        let bare = CompanyId::new("bare");
+        secrets
+            .set(&bare, MODE_KEY, SecretValue(BYOK_MODE.into()))
+            .await
+            .unwrap();
+        assert!(
+            TenantComposio::resolve(&bare, &secrets, vec![], None, None, None)
+                .await
+                .is_none(),
+            "an operator who asked for their own account must never silently get the platform's"
         );
     }
 }

--- a/src/harness/built_in/composio_direct.rs
+++ b/src/harness/built_in/composio_direct.rs
@@ -1,0 +1,978 @@
+//! BYOK Composio: the company's **own** Composio account, reached directly.
+//!
+//! [`composio`](crate::harness::composio) is the managed route — every call
+//! goes to the OpenHuman/TinyHumans backend, which holds the Composio API key,
+//! enforces its own toolkit allowlist, bills the margin, and derives the
+//! Composio entity from the bearer it is handed. That is the default and needs
+//! no configuration.
+//!
+//! This module is the other route. A company that has its own Composio account
+//! stores its API key ([`API_KEY_KEY`](crate::company::composio::API_KEY_KEY))
+//! and every Composio call is then made against `backend.composio.dev` with
+//! that key in `x-api-key` — no proxy, no platform identity, no platform bill.
+//! It mirrors OpenHuman's own `backend` / `direct` split (see
+//! `vendor/openhuman/src/openhuman/integrations/composio/client.rs::create_composio_client`),
+//! and reuses OpenHuman's direct client
+//! ([`oh::tools::ComposioTool`]) and its response reshapers wherever they are
+//! reachable, so a BYOK result is the same envelope a managed one is and the
+//! callers in [`composio`](crate::harness::composio) never branch on shape.
+//!
+//! # What is reused, and what is written here
+//!
+//! * `authorize`, `execute` and `list connections` are the vendored client's —
+//!   [`oh::tools::ComposioTool::get_connection_url`],
+//!   [`direct_execute`] and [`direct_list_connections`]. Nothing about the
+//!   Composio contract is restated here.
+//! * `list tools` and `list toolkits` are **not** reachable: the vendored
+//!   reshapers for both are `pub(crate)` inside OpenHuman, and `vendor/openhuman`
+//!   is a submodule this repo consumes rather than edits. They are re-stated
+//!   below against the same two documented v3 endpoints, in the same envelopes,
+//!   and marked so — if OpenHuman ever widens their visibility, both should be
+//!   deleted in favour of the upstream ones.
+//!
+//! # What BYOK does not carry
+//!
+//! Per-toolkit `extra_params` at authorize time: the v3 link call takes no such
+//! field, and a BYOK operator sets those on the auth config in their own
+//! Composio dashboard. Everything else the managed route offers — including
+//! revoking a connected account — has a direct equivalent here.
+//!
+//! # The credential still never reaches an agent
+//!
+//! The API key is handled exactly as the managed bearer is: it is the scrub
+//! vector for every result, it is absent from every tracing line, and no type
+//! here derives [`Debug`] over it. And the egress spine is the same — a BYOK
+//! execute discloses (and under `LocalOnly` refuses) the transfer before the
+//! round-trip, so choosing BYOK is not a way around the gate.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use serde_json::Value;
+
+use openhuman_core::openhuman as oh;
+
+use oh::integrations::composio::client::{direct_execute, direct_list_connections};
+use oh::integrations::composio::types::{
+    ComposioAuthorizeResponse, ComposioConnectionsResponse, ComposioDeleteResponse,
+    ComposioExecuteResponse, ComposioToolFunction, ComposioToolSchema, ComposioToolkitCatalogEntry,
+    ComposioToolkitsResponse, ComposioToolsResponse,
+};
+
+use crate::company::composio::{DIRECT_BASE_URL, DIRECT_ENTITY_ID};
+
+/// Composio's v3 API root, derived from the non-secret base the console reports
+/// so the two cannot name different hosts.
+fn v3_base() -> String {
+    format!("{DIRECT_BASE_URL}/api/v3")
+}
+
+/// How many rows one page pulls. Composio's own maximum for these endpoints.
+const PAGE_LIMIT: &str = "200";
+
+/// How many pages one listing will follow before it stops.
+///
+/// Composio's v3 listings are cursor-paginated and **large**: the toolkit
+/// directory is 1501 entries over 8 pages, and an unscoped `/tools` query is
+/// 52,268 over 262. Following either to the end is not an option on a request
+/// path — one full toolkit sweep measured 8.4s against a 5s budget on both the
+/// host (`composio_toolkits::FETCH_TIMEOUT`) and the console
+/// (`COMPOSIO_PROBE_TIMEOUT_MS`), so it would not merely be slow, it would
+/// always time out and degrade to the fallback list.
+///
+/// Three pages is what fits that budget with margin (~3.2s measured). It is a
+/// **bound, not a belief that 600 is enough** — [`Paged::dropped`] carries what
+/// was left behind so no caller can mistake a truncated listing for a complete
+/// one, which is the whole reason this is a named constant with a number
+/// attached rather than a bare `limit=200` and silence.
+const MAX_PAGES: usize = 3;
+
+/// One listing, and what it did not reach.
+pub(crate) struct Paged<T> {
+    /// The rows fetched.
+    pub(crate) items: Vec<T>,
+    /// How many rows Composio said exist beyond the ones fetched, when it said.
+    /// `0` means the listing is complete.
+    pub(crate) dropped: usize,
+}
+
+/// A company's own Composio account.
+///
+/// Holds the vendored direct client for the operations it covers and the raw
+/// key for the two this module states itself. No [`Debug`]: the key is a
+/// credential, and this type exists on the request path.
+#[derive(Clone)]
+pub(crate) struct DirectComposio {
+    tool: Arc<oh::tools::ComposioTool>,
+    api_key: String,
+    /// The v3 root the two listings below are addressed to.
+    ///
+    /// A field rather than the const inline so the tests can point them at a
+    /// local mock. It is `#[cfg(test)]`-settable only: production has exactly
+    /// one constructor, and it always pins Composio's HTTPS host — an
+    /// injectable base reachable from a shipped build would be a way to send
+    /// the `x-api-key` header somewhere else.
+    v3_base: String,
+}
+
+impl DirectComposio {
+    /// A client over this company's API key.
+    ///
+    /// The vendored [`oh::tools::ComposioTool`] takes a [`SecurityPolicy`] for
+    /// its own `Tool::execute` gating; nothing here goes through that surface —
+    /// the harness's own approval policy and grant gate are what admit a
+    /// Composio call in this repo — so the default policy is what it is handed,
+    /// exactly as OpenHuman's own factory does.
+    ///
+    /// [`SecurityPolicy`]: oh::security::SecurityPolicy
+    pub(crate) fn new(api_key: &str) -> Self {
+        let api_key = api_key.trim().to_string();
+        let tool = oh::tools::ComposioTool::new(
+            &api_key,
+            Some(DIRECT_ENTITY_ID),
+            Arc::new(oh::security::SecurityPolicy::default()),
+        );
+        Self {
+            tool: Arc::new(tool),
+            api_key,
+            v3_base: v3_base(),
+        }
+    }
+
+    /// Test-only seam: the same client with its v3 listings pointed at `base`,
+    /// so the response parsing can be exercised against a local mock instead of
+    /// `backend.composio.dev`.
+    #[cfg(test)]
+    pub(crate) fn with_v3_base_for_test(mut self, base: impl Into<String>) -> Self {
+        self.v3_base = base.into();
+        self
+    }
+
+    /// The connected accounts this company holds, in the managed route's own
+    /// envelope. Straight through to the vendored reshaper, which also carries
+    /// the invalid-key backoff gate — an `ak_` that Composio has revoked stops
+    /// being re-presented on every poll.
+    pub(crate) async fn list_connections(&self) -> Result<ComposioConnectionsResponse> {
+        direct_list_connections(&self.tool).await
+    }
+
+    /// Begin an OAuth handoff and return Composio's hosted connect URL.
+    ///
+    /// The v3 link response carries no stable connection id — the row is
+    /// created when the operator finishes OAuth on Composio's page — so the id
+    /// is reported empty and the console's existing connection poll is what
+    /// surfaces the result. Same answer OpenHuman's `direct_authorize` gives;
+    /// it is `pub(super)` upstream, so the four lines are re-stated rather than
+    /// called.
+    pub(crate) async fn authorize(&self, toolkit: &str) -> Result<ComposioAuthorizeResponse> {
+        let toolkit = toolkit.trim();
+        if toolkit.is_empty() {
+            anyhow::bail!("composio authorize: toolkit must not be empty");
+        }
+        let connect_url = self
+            .tool
+            .get_connection_url(Some(toolkit), None, DIRECT_ENTITY_ID)
+            .await?;
+        Ok(ComposioAuthorizeResponse {
+            connect_url,
+            connection_id: String::new(),
+        })
+    }
+
+    /// Run one Composio action as this company's own account.
+    ///
+    /// The egress spine runs first, exactly as the managed pinned path does: a
+    /// BYOK call ships the same arguments to the same third party, so it
+    /// discloses the transfer — and under `LocalOnly` is refused — before the
+    /// round-trip rather than after it.
+    pub(crate) async fn execute(
+        &self,
+        tool: &str,
+        arguments: Option<Value>,
+        connection_id: Option<&str>,
+    ) -> Result<ComposioExecuteResponse> {
+        use oh::security::egress::{EgressDescriptor, emit_external_transfer, enforce_egress};
+
+        let egress = EgressDescriptor::composio(tool);
+        enforce_egress(&egress)?;
+        emit_external_transfer(egress);
+
+        direct_execute(&self.tool, tool, arguments, DIRECT_ENTITY_ID, connection_id).await
+    }
+
+    /// Composio v3 `GET /tools`, in the managed route's [`ComposioToolsResponse`]
+    /// envelope — **with** each action's input schema.
+    ///
+    /// Schemas are the point. `oh::tools::ComposioTool::list_actions` is public
+    /// and hits the same endpoint, but flattens to a name/description shape that
+    /// drops `input_parameters`; an agent handed that has no way to learn an
+    /// action's arguments and starts guessing them. OpenHuman's own
+    /// schema-preserving reshaper (`direct_list_tools`) is `pub(crate)`, so this
+    /// restates it — same endpoint, same `toolkit_versions=latest` pin (without
+    /// it v3 answers from a snapshot that lists nothing for any toolkit
+    /// published since launch), same envelope.
+    pub(crate) async fn list_tools(&self, toolkits: &[String]) -> Result<ComposioToolsResponse> {
+        let mut params: Vec<(&str, String)> = vec![
+            ("limit", PAGE_LIMIT.to_string()),
+            ("toolkit_versions", "latest".to_string()),
+        ];
+        let slugs: Vec<&str> = toolkits
+            .iter()
+            .map(|slug| slug.trim())
+            .filter(|slug| !slug.is_empty())
+            .collect();
+        if !slugs.is_empty() {
+            // `toolkit_slug`, NOT `toolkits`. Composio v3 silently **ignores**
+            // an unknown query parameter rather than refusing it, so
+            // `toolkits=gmail` does not narrow anything — it returns the first
+            // page of the entire 52,268-tool catalogue, alphabetically, which
+            // is how an agent asking for Gmail came back holding
+            // `0CODEKIT_CALCULATE_BMI`. Verified against the live API:
+            // `toolkits=gmail` → 52,268 items, `toolkit_slug=gmail` → 63.
+            //
+            // Multiple slugs go as ONE comma-separated value; repeating the
+            // parameter returns an empty body instead of a union.
+            params.push(("toolkit_slug", slugs.join(",")));
+        }
+        let paged: Paged<V3Tool> = self
+            .get_paged("/tools", &params)
+            .await
+            .context("Composio v3 /tools")?;
+        if paged.dropped > 0 {
+            tracing::warn!(
+                toolkits = ?slugs,
+                fetched = paged.items.len(),
+                dropped = paged.dropped,
+                "[composio-byok] list_tools: stopped at the page budget; narrow the toolkit list \
+                 to see the rest"
+            );
+        }
+        Ok(ComposioToolsResponse {
+            tools: paged
+                .items
+                .into_iter()
+                .filter_map(|item| {
+                    let name = item.slug.or(item.name.clone())?;
+                    let name = name.trim().to_string();
+                    (!name.is_empty()).then(|| ComposioToolSchema {
+                        kind: "function".to_string(),
+                        function: ComposioToolFunction {
+                            name,
+                            description: item.description,
+                            parameters: item.input_parameters,
+                            output_parameters: item.output_parameters,
+                        },
+                    })
+                })
+                .collect(),
+        })
+    }
+
+    /// Revoke one connected account: Composio v3
+    /// `DELETE /connected_accounts/{id}`.
+    ///
+    /// The vendored [`oh::tools::ComposioTool`] has no delete, and OpenHuman's
+    /// own direct mode routes its revoke through the backend — but neither is a
+    /// statement about Composio, which exposes the route perfectly well. A
+    /// no-auth probe answers `401` on it and `404` on a route that does not
+    /// exist, so the endpoint is real; the vendored client simply never grew a
+    /// method for it.
+    ///
+    /// A 2xx is the revoke. Composio's delete responses carry no body worth
+    /// mapping, so success is reported as `deleted: true` and the
+    /// memory-chunk count the backend-proxied shape carries stays zero — that
+    /// field counts what the *OpenHuman backend* cleaned up alongside the
+    /// revoke, and on this route there is no backend to have done so.
+    pub(crate) async fn delete_connection(
+        &self,
+        connection_id: &str,
+    ) -> Result<ComposioDeleteResponse> {
+        let connection_id = connection_id.trim();
+        if connection_id.is_empty() {
+            anyhow::bail!("composio delete_connection: a connection id is required");
+        }
+        // A Composio connection id is an opaque nanoid (`ca_…`). Rather than
+        // pull in an escaper for it, refuse anything that is not one: a value
+        // carrying a slash or a query character is not an id this company holds,
+        // and interpolating it into a path would let it address a different
+        // route entirely.
+        if !connection_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        {
+            anyhow::bail!("composio delete_connection: `{connection_id}` is not a connection id");
+        }
+        let url = format!("{}/connected_accounts/{connection_id}", self.v3_base);
+        let resp = oh::config::build_runtime_proxy_client_with_timeouts("composio.byok", 60, 10)
+            .delete(&url)
+            .header("x-api-key", &self.api_key)
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            if status == reqwest::StatusCode::UNAUTHORIZED {
+                anyhow::bail!(
+                    "Composio rejected this company's API key — check it at app.composio.dev, \
+                     or clear it to go back to OpenHuman-managed Composio"
+                );
+            }
+            anyhow::bail!("Composio answered {status}");
+        }
+        Ok(ComposioDeleteResponse {
+            deleted: true,
+            memory_chunks_deleted: 0,
+        })
+    }
+
+    /// Composio v3 `GET /toolkits`, in the managed route's
+    /// [`ComposioToolkitsResponse`] envelope.
+    ///
+    /// A BYOK company has **no server-enforced allowlist** — its Composio
+    /// dashboard is the boundary — so what this returns is the catalog of what
+    /// that account can connect, and every entry is reported `enabled`. That is
+    /// the honest answer for this route and it is what makes the console's
+    /// provider grid work in BYOK mode; OpenHuman's direct branch returns an
+    /// empty list here, which would leave the grid blank with nothing saying
+    /// why.
+    ///
+    /// Every field but `slug` is best-effort. Composio nests the display
+    /// metadata under `meta`, and its category entries are objects with a name;
+    /// both are parsed tolerantly, because a catalog row that will not fully
+    /// deserialize should still be connectable.
+    pub(crate) async fn list_toolkits(&self) -> Result<ComposioToolkitsResponse> {
+        let paged: Paged<V3Toolkit> = self
+            .get_paged("/toolkits", &[("limit", PAGE_LIMIT.to_string())])
+            .await
+            .context("Composio v3 /toolkits")?;
+        if paged.dropped > 0 {
+            // Composio publishes 1501 toolkits; the budget above reaches 600 of
+            // them. Said out loud because a console grid showing 600 providers
+            // looks exactly like a complete one.
+            tracing::warn!(
+                fetched = paged.items.len(),
+                dropped = paged.dropped,
+                "[composio-byok] list_toolkits: stopped at the page budget — the provider grid is \
+                 showing part of this account's catalogue"
+            );
+        }
+        let catalog: Vec<ComposioToolkitCatalogEntry> = paged
+            .items
+            .into_iter()
+            .filter_map(|item| {
+                let slug = item.slug.trim().to_ascii_lowercase();
+                if slug.is_empty() {
+                    return None;
+                }
+                let meta = item.meta.unwrap_or_default();
+                Some(ComposioToolkitCatalogEntry {
+                    name: item.name.trim().to_string(),
+                    logo: meta
+                        .logo
+                        .map(|logo| logo.trim().to_string())
+                        .filter(|logo| !logo.is_empty()),
+                    description: meta
+                        .description
+                        .map(|text| text.trim().to_string())
+                        .filter(|text| !text.is_empty()),
+                    categories: meta
+                        .categories
+                        .into_iter()
+                        .filter_map(V3Category::name)
+                        .collect(),
+                    // No gate stands between a BYOK company and its own
+                    // account, so every listed toolkit is connectable.
+                    enabled: Some(true),
+                    slug,
+                })
+            })
+            .collect();
+        Ok(ComposioToolkitsResponse {
+            toolkits: catalog.iter().map(|entry| entry.slug.clone()).collect(),
+            catalog,
+        })
+    }
+
+    /// Follow Composio's cursor pagination for up to [`MAX_PAGES`], returning
+    /// what was fetched and what was left behind.
+    ///
+    /// Every v3 listing answers `{items, next_cursor, total_items, …}`, and the
+    /// cursor is strictly sequential — page N+1's cursor only exists once page N
+    /// has been read — so this cannot be parallelised into the request budget.
+    /// It stops at whichever comes first: the cursor running out (a complete
+    /// listing, `dropped: 0`) or the page budget.
+    ///
+    /// `dropped` is computed from Composio's own `total_items` rather than
+    /// guessed, so a truncated listing can say how much it is missing instead of
+    /// merely admitting that it might be.
+    async fn get_paged<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        params: &[(&str, String)],
+    ) -> Result<Paged<T>> {
+        let mut items: Vec<T> = Vec::new();
+        let mut cursor: Option<String> = None;
+        let mut total: Option<usize> = None;
+
+        for _ in 0..MAX_PAGES {
+            let mut page_params: Vec<(&str, String)> = params.to_vec();
+            if let Some(ref cursor) = cursor {
+                page_params.push(("cursor", cursor.clone()));
+            }
+            let page: V3Page<T> = self.get(path, &page_params).await?;
+            total = total.or(page.total_items);
+            items.extend(page.items);
+            match page.next_cursor.filter(|c| !c.trim().is_empty()) {
+                // No cursor left: the listing is complete, whatever `total_items`
+                // claimed. Trusting the count over the cursor here would invent a
+                // `dropped` for a listing that had already ended.
+                None => return Ok(Paged { items, dropped: 0 }),
+                Some(next) => cursor = Some(next),
+            }
+        }
+
+        let dropped = total.unwrap_or(0).saturating_sub(items.len());
+        Ok(Paged { items, dropped })
+    }
+
+    /// One authenticated v3 GET, decoded into `T`.
+    ///
+    /// Built through OpenHuman's own runtime HTTP factory so a BYOK call
+    /// inherits the same proxy configuration and timeouts every other Composio
+    /// call in this process has — the alternative, a bare `reqwest::Client`,
+    /// would quietly ignore a proxy the operator configured for everything else.
+    async fn get<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        params: &[(&str, String)],
+    ) -> Result<T> {
+        let url = format!("{}{path}", self.v3_base);
+        let resp = oh::config::build_runtime_proxy_client_with_timeouts("composio.byok", 60, 10)
+            .get(&url)
+            .header("x-api-key", &self.api_key)
+            .query(params)
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            // The body may echo the request; it is not rendered here at all —
+            // the caller scrubs, but a status line cannot carry a key and is
+            // enough to tell a bad key from an outage.
+            //
+            // 401 is called by name because it is the one failure an operator
+            // can act on, and by far the likeliest: a key that was mistyped,
+            // revoked, or belongs to a different Composio account. "Composio
+            // answered 401 Unauthorized" is a fact; "Composio rejected this
+            // company's API key" is the same fact plus what to do about it.
+            if status == reqwest::StatusCode::UNAUTHORIZED {
+                anyhow::bail!(
+                    "Composio rejected this company's API key — check it at app.composio.dev, \
+                     or clear it to go back to OpenHuman-managed Composio"
+                );
+            }
+            anyhow::bail!("Composio answered {status}");
+        }
+        resp.json::<T>().await.context("decoding the response")
+    }
+}
+
+// ── v3 wire shapes ──────────────────────────────────────────────────
+//
+// Deliberately private and deliberately tolerant: every field is optional, so
+// a Composio response that grows or renames something degrades to a thinner
+// row rather than failing the whole listing.
+
+/// One page of any v3 listing.
+///
+/// Generic over the row because `/tools` and `/toolkits` differ only in what
+/// `items` holds — the pagination envelope around them is identical, and two
+/// copies of it would be two places to get the cursor handling wrong.
+#[derive(Debug, Deserialize)]
+struct V3Page<T> {
+    #[serde(default = "Vec::new")]
+    items: Vec<T>,
+    /// Absent or blank on the last page.
+    #[serde(default)]
+    next_cursor: Option<String>,
+    /// How many rows exist across every page, when Composio says.
+    #[serde(default)]
+    total_items: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct V3Tool {
+    #[serde(default)]
+    slug: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    /// v3 names the input schema `input_parameters`; older payloads say
+    /// `parameters`. Both land here, matching the vendored client's own alias.
+    #[serde(default, alias = "parameters")]
+    input_parameters: Option<Value>,
+    #[serde(default)]
+    output_parameters: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct V3Toolkit {
+    #[serde(default)]
+    slug: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    meta: Option<V3ToolkitMeta>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct V3ToolkitMeta {
+    #[serde(default)]
+    logo: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    categories: Vec<V3Category>,
+}
+
+/// A category, which Composio publishes as an object but which older payloads
+/// (and the backend-proxied path) carry as a bare string.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum V3Category {
+    Name(String),
+    Object {
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        slug: Option<String>,
+    },
+}
+
+impl V3Category {
+    /// The display name, preferring the published name over the slug. `None`
+    /// when the row carries neither.
+    fn name(self) -> Option<String> {
+        let raw = match self {
+            Self::Name(name) => Some(name),
+            Self::Object { name, slug } => name.or(slug),
+        }?;
+        let trimmed = raw.trim().to_string();
+        (!trimmed.is_empty()).then_some(trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_v3_tool_keeps_the_schema_an_agent_needs_to_call_it() {
+        // The whole reason this module restates the listing: `list_actions`
+        // would drop `input_parameters`, and an agent without an action's
+        // schema invents arguments.
+        let body: V3Page<V3Tool> = serde_json::from_str(
+            r#"{"items":[{"slug":"GMAIL_SEND_EMAIL","description":"Send",
+                 "input_parameters":{"type":"object"},"output_parameters":{"type":"object"}}]}"#,
+        )
+        .unwrap();
+        assert_eq!(body.items.len(), 1);
+        assert!(body.items[0].input_parameters.is_some());
+        assert!(body.items[0].output_parameters.is_some());
+    }
+
+    #[test]
+    fn an_older_payload_spelling_parameters_still_carries_its_schema() {
+        let body: V3Page<V3Tool> =
+            serde_json::from_str(r#"{"items":[{"slug":"X","parameters":{"type":"object"}}]}"#)
+                .unwrap();
+        assert!(body.items[0].input_parameters.is_some());
+    }
+
+    #[test]
+    fn categories_parse_whether_composio_sends_objects_or_strings() {
+        let meta: V3ToolkitMeta = serde_json::from_str(
+            r#"{"categories":[{"name":"Productivity","slug":"productivity"},"email",{"slug":"crm"}]}"#,
+        )
+        .unwrap();
+        let names: Vec<String> = meta
+            .categories
+            .into_iter()
+            .filter_map(V3Category::name)
+            .collect();
+        assert_eq!(names, vec!["Productivity", "email", "crm"]);
+    }
+
+    #[test]
+    fn a_toolkit_row_missing_everything_but_a_slug_is_still_connectable() {
+        // A thin catalog row must not drop the provider — the console renders
+        // its own typography for slug-only entries, and a missing row is a
+        // provider the operator simply cannot connect.
+        let body: V3Page<V3Toolkit> =
+            serde_json::from_str(r#"{"items":[{"slug":"GMAIL"},{"slug":"  "}]}"#).unwrap();
+        assert_eq!(body.items.len(), 2);
+        let kept: Vec<String> = body
+            .items
+            .into_iter()
+            .map(|item| item.slug.trim().to_ascii_lowercase())
+            .filter(|slug| !slug.is_empty())
+            .collect();
+        assert_eq!(
+            kept,
+            vec!["gmail"],
+            "a blank slug is dropped, a bare one is kept"
+        );
+    }
+
+    /// A mock Composio v3 that answers the two listings this module states
+    /// itself, asserting the `x-api-key` header on the way through: the whole
+    /// point of BYOK is that the *company's* key, and no other credential,
+    /// reaches Composio.
+    async fn spawn_composio_v3() -> String {
+        use axum::extract::Query;
+        use axum::http::HeaderMap;
+        use axum::routing::get;
+        use axum::{Json, Router};
+        use std::collections::HashMap;
+
+        async fn toolkits(headers: HeaderMap) -> Json<serde_json::Value> {
+            assert_eq!(
+                headers.get("x-api-key").and_then(|v| v.to_str().ok()),
+                Some("ak_live"),
+                "a BYOK call must present the company's own key"
+            );
+            Json(serde_json::json!({"items": [
+                {"slug": "GMAIL", "name": "Gmail",
+                 "meta": {"logo": "https://cdn/gmail.png", "description": " Email ",
+                          "categories": [{"name": "Productivity"}, "email"]}},
+                {"slug": "slack", "name": "Slack"}
+            ]}))
+        }
+
+        async fn tools(
+            headers: HeaderMap,
+            Query(params): Query<HashMap<String, String>>,
+        ) -> Json<serde_json::Value> {
+            assert_eq!(
+                headers.get("x-api-key").and_then(|v| v.to_str().ok()),
+                Some("ak_live")
+            );
+            assert_eq!(
+                params.get("toolkit_versions").map(String::as_str),
+                Some("latest"),
+                "without the pin, v3 answers from a snapshot listing nothing recent"
+            );
+            // `toolkits` is the parameter Composio v3 silently ignores; if it
+            // ever comes back the listing stops being scoped at all.
+            assert!(
+                !params.contains_key("toolkits"),
+                "`toolkits` scopes nothing on Composio v3 — `toolkit_slug` is the one it honours"
+            );
+            let scoped = params.get("toolkit_slug").cloned().unwrap_or_default();
+            Json(serde_json::json!({"items": [
+                {"slug": "GMAIL_SEND_EMAIL", "description": scoped,
+                 "input_parameters": {"type": "object"}}
+            ]}))
+        }
+
+        let app = Router::new()
+            .route("/toolkits", get(toolkits))
+            .route("/tools", get(tools));
+        let listener =
+            tokio::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn the_catalog_is_the_company_s_own_and_every_row_is_connectable() {
+        // OpenHuman's direct branch answers this with an empty list, which
+        // would leave the console's provider grid blank with nothing saying
+        // why. A BYOK company has no gate above its own account, so what it is
+        // offered is what that account lists.
+        let base = spawn_composio_v3().await;
+        let direct = DirectComposio::new("ak_live").with_v3_base_for_test(base);
+
+        let resp = direct.list_toolkits().await.expect("catalog");
+        assert_eq!(
+            resp.toolkits,
+            vec!["gmail", "slack"],
+            "slugs are normalized"
+        );
+        assert!(
+            resp.catalog.iter().all(|e| e.enabled == Some(true)),
+            "nothing stands between a company and its own account"
+        );
+        let gmail = &resp.catalog[0];
+        assert_eq!(gmail.name, "Gmail");
+        assert_eq!(gmail.description.as_deref(), Some("Email"));
+        assert_eq!(gmail.logo.as_deref(), Some("https://cdn/gmail.png"));
+        assert_eq!(gmail.categories, vec!["Productivity", "email"]);
+        // A row with no `meta` at all is still offered, described by its slug.
+        assert_eq!(resp.catalog[1].slug, "slack");
+        assert!(resp.catalog[1].description.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_tool_listing_carries_the_schema_and_is_scoped_to_the_toolkits_asked_for() {
+        let base = spawn_composio_v3().await;
+        let direct = DirectComposio::new("ak_live").with_v3_base_for_test(base);
+
+        let resp = direct
+            .list_tools(&["gmail".to_string(), "  ".to_string(), "slack".to_string()])
+            .await
+            .expect("tools");
+        assert_eq!(resp.tools.len(), 1);
+        let function = &resp.tools[0].function;
+        assert_eq!(function.name, "GMAIL_SEND_EMAIL");
+        assert!(
+            function.parameters.is_some(),
+            "an agent without the schema invents arguments"
+        );
+        assert_eq!(
+            function.description.as_deref(),
+            Some("gmail,slack"),
+            "blank slugs are dropped, the rest are sent as one csv"
+        );
+    }
+
+    /// Composio's listings are cursor-paginated and far larger than one page:
+    /// 1501 toolkits, and 52,268 tools unscoped. A single `limit=200` request
+    /// returns the first 200 and says nothing, which is indistinguishable from a
+    /// complete answer — so the listing follows the cursor, and reports what it
+    /// could not reach.
+    #[tokio::test]
+    async fn a_listing_follows_the_cursor_and_says_what_it_could_not_reach() {
+        use axum::extract::Query;
+        use axum::routing::get;
+        use axum::{Json, Router};
+        use std::collections::HashMap;
+
+        // Five pages of one row each, against a three-page budget.
+        async fn toolkits(
+            Query(params): Query<HashMap<String, String>>,
+        ) -> Json<serde_json::Value> {
+            let page: usize = params
+                .get("cursor")
+                .and_then(|c| c.parse().ok())
+                .unwrap_or(1);
+            Json(serde_json::json!({
+                "items": [{ "slug": format!("tk{page}"), "name": format!("Toolkit {page}") }],
+                "next_cursor": (page < 5).then(|| (page + 1).to_string()),
+                "total_items": 5,
+            }))
+        }
+
+        let app = Router::new().route("/toolkits", get(toolkits));
+        let listener =
+            tokio::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let direct = DirectComposio::new("ak_live").with_v3_base_for_test(format!("http://{addr}"));
+        let resp = direct.list_toolkits().await.expect("catalog");
+        assert_eq!(
+            resp.toolkits,
+            vec!["tk1", "tk2", "tk3"],
+            "three pages are followed, not one"
+        );
+    }
+
+    /// A listing that ends inside the budget is complete, and must not claim to
+    /// have dropped anything — the cursor running out is the authority, not the
+    /// `total_items` count beside it.
+    #[tokio::test]
+    async fn a_listing_that_fits_reports_nothing_dropped() {
+        use axum::routing::get;
+        use axum::{Json, Router};
+
+        let app = Router::new().route(
+            "/toolkits",
+            get(|| async {
+                Json(serde_json::json!({
+                    "items": [{ "slug": "gmail", "name": "Gmail" }],
+                    "next_cursor": null,
+                    // Deliberately inconsistent with `items`: an exhausted cursor
+                    // ends the listing whatever the count says.
+                    "total_items": 99,
+                }))
+            }),
+        );
+        let listener =
+            tokio::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let direct = DirectComposio::new("ak_live").with_v3_base_for_test(format!("http://{addr}"));
+        let paged: Paged<V3Toolkit> = direct
+            .get_paged("/toolkits", &[("limit", "200".to_string())])
+            .await
+            .expect("page");
+        assert_eq!(paged.items.len(), 1);
+        assert_eq!(paged.dropped, 0, "an exhausted cursor means complete");
+    }
+
+    /// Revoking works on this route. It is worth a test precisely because it was
+    /// once assumed not to: the vendored client has no delete method, and that
+    /// was mistaken for Composio not having the endpoint. It has one — a no-auth
+    /// probe answers 401 on it and 404 on a route that does not exist.
+    #[tokio::test]
+    async fn an_account_can_be_revoked_on_this_route() {
+        use axum::extract::Path;
+        use axum::http::HeaderMap;
+        use axum::routing::delete;
+        use axum::{Json, Router};
+        use std::sync::{Arc, Mutex};
+
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let app = Router::new().route(
+            "/connected_accounts/{id}",
+            delete(move |Path(id): Path<String>, headers: HeaderMap| {
+                let sink = Arc::clone(&sink);
+                async move {
+                    assert_eq!(
+                        headers.get("x-api-key").and_then(|v| v.to_str().ok()),
+                        Some("ak_live"),
+                        "a revoke presents the company's own key, like every other BYOK call"
+                    );
+                    sink.lock().unwrap().push(id);
+                    Json(serde_json::json!({}))
+                }
+            }),
+        );
+        let listener =
+            tokio::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let direct = DirectComposio::new("ak_live").with_v3_base_for_test(format!("http://{addr}"));
+        let resp = direct
+            .delete_connection("ca_abc123")
+            .await
+            .expect("revoked");
+        assert!(resp.deleted);
+        assert_eq!(seen.lock().unwrap().as_slice(), ["ca_abc123"]);
+    }
+
+    /// An id that is not one cannot be interpolated into the path — a value
+    /// carrying a slash would address a different route entirely.
+    #[tokio::test]
+    async fn a_value_that_is_not_a_connection_id_is_refused_before_any_request() {
+        let direct = DirectComposio::new("ak_live").with_v3_base_for_test("http://127.0.0.1:1");
+        for bad in ["", "  ", "ca_1/../../toolkits", "ca_1?x=y"] {
+            assert!(
+                direct.delete_connection(bad).await.is_err(),
+                "`{bad}` must not reach the wire"
+            );
+        }
+    }
+
+    /// Live end-to-end against a real Composio account, driving the exact calls
+    /// the agent's `composio_list_tools` and `composio_execute` make.
+    ///
+    /// `#[ignore]`d: it needs a real `ak_…` and a live connected GitHub account,
+    /// so it cannot run in CI. Run it by hand against a rig:
+    ///
+    /// ```text
+    /// COMPOSIO_LIVE_KEY=$(cat <data-dir>/companies/<id>/secrets/%k-composio%2Fapi%5Fkey) \
+    ///   cargo test --features composio --lib live_byok -- --ignored --nocapture
+    /// ```
+    #[tokio::test]
+    #[ignore = "needs a real Composio key and a live GitHub connection"]
+    async fn live_byok_lists_and_executes_against_real_composio() {
+        let key = std::env::var("COMPOSIO_LIVE_KEY").expect("COMPOSIO_LIVE_KEY");
+        let owner = std::env::var("LIVE_OWNER").unwrap_or_else(|_| "tinyhumansai".into());
+        let repo = std::env::var("LIVE_REPO").unwrap_or_else(|_| "opencompany".into());
+        let direct = DirectComposio::new(&key);
+
+        // 1. The listing the agent discovers actions through.
+        let tools = direct
+            .list_tools(&["github".to_string()])
+            .await
+            .expect("list_tools");
+        let target = tools
+            .tools
+            .iter()
+            .find(|t| t.function.name == "GITHUB_LIST_PULL_REQUESTS")
+            .expect("GITHUB_LIST_PULL_REQUESTS is in the listing");
+        assert!(
+            target.function.parameters.is_some(),
+            "the agent needs the schema to build arguments"
+        );
+        println!("listed {} github tools", tools.tools.len());
+
+        // 2. The execute the agent then makes.
+        let resp = direct
+            .execute(
+                "GITHUB_LIST_PULL_REQUESTS",
+                Some(serde_json::json!({
+                    "owner": owner, "repo": repo,
+                    "state": "open", "sort": "created", "per_page": 5
+                })),
+                None,
+            )
+            .await
+            .expect("execute");
+        println!("successful={} error={:?}", resp.successful, resp.error);
+        let items = resp
+            .data
+            .get("details")
+            .or_else(|| resp.data.get("data"))
+            .cloned()
+            .unwrap_or(resp.data.clone());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&items).unwrap_or_default()
+        );
+        assert!(resp.successful, "execute failed: {:?}", resp.error);
+    }
+
+    #[tokio::test]
+    async fn a_refused_key_is_reported_without_echoing_it() {
+        use axum::Router;
+        use axum::http::StatusCode;
+        use axum::routing::get;
+
+        let app = Router::new().route(
+            "/toolkits",
+            get(|| async { (StatusCode::UNAUTHORIZED, "Invalid API key: ak_live") }),
+        );
+        let listener =
+            tokio::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let direct = DirectComposio::new("ak_live").with_v3_base_for_test(format!("http://{addr}"));
+        let err = format!("{:#}", direct.list_toolkits().await.expect_err("401"));
+        assert!(
+            err.contains("rejected this company's API key"),
+            "a rejected key is named as such, not left as a bare status: {err}"
+        );
+        assert!(
+            !err.contains("ak_live"),
+            "a body that echoes the key must never reach the caller: {err}"
+        );
+    }
+}

--- a/src/harness/built_in/composio_direct.rs
+++ b/src/harness/built_in/composio_direct.rs
@@ -404,7 +404,13 @@ impl DirectComposio {
     ///
     /// `dropped` is computed from Composio's own `total_items` rather than
     /// guessed, so a truncated listing can say how much it is missing instead of
-    /// merely admitting that it might be.
+    /// merely admitting that it might be. When `total_items` never arrived on
+    /// any page — an older/degraded response shape — the exact count is
+    /// unknowable, but reaching this line at all is only possible via the page
+    /// budget running out with a live cursor still in hand (the loop's only
+    /// other exit returns early with `dropped: 0`), so *some* truncation is a
+    /// certainty even without a number for it. `.max(1)` reports that
+    /// certainty instead of letting an absent count read as a complete list.
     async fn get_paged<T: serde::de::DeserializeOwned>(
         &self,
         path: &str,
@@ -431,7 +437,12 @@ impl DirectComposio {
             }
         }
 
-        let dropped = total.unwrap_or(0).saturating_sub(items.len());
+        // Reaching here means the budget ran out with a cursor still live —
+        // see the doc comment above. `.max(1)` is a floor, not a substitute for
+        // the real count: when `total` is present, its subtraction already
+        // exceeds it (there is more data than what was fetched, by
+        // definition), so the floor only ever engages when `total` was absent.
+        let dropped = total.unwrap_or(0).saturating_sub(items.len()).max(1);
         Ok(Paged { items, dropped })
     }
 
@@ -784,6 +795,58 @@ mod tests {
             resp.toolkits,
             vec!["tk1", "tk2", "tk3"],
             "three pages are followed, not one"
+        );
+    }
+
+    /// A listing that hits the page budget with no `total_items` on any page —
+    /// an older or degraded response shape — still must not report `dropped: 0`.
+    /// Reaching the end of the budget with a live cursor in hand is itself proof
+    /// that more exists; the exact count is merely unknown, not zero.
+    #[tokio::test]
+    async fn a_truncated_listing_with_no_total_still_reports_dropped() {
+        use axum::extract::Query;
+        use axum::routing::get;
+        use axum::{Json, Router};
+        use std::collections::HashMap;
+
+        async fn toolkits(
+            Query(params): Query<HashMap<String, String>>,
+        ) -> Json<serde_json::Value> {
+            let page: usize = params
+                .get("cursor")
+                .and_then(|c| c.parse().ok())
+                .unwrap_or(1);
+            // No `total_items` field at all on any page.
+            Json(serde_json::json!({
+                "items": [{ "slug": format!("tk{page}"), "name": format!("Toolkit {page}") }],
+                "next_cursor": (page + 1).to_string(),
+            }))
+        }
+
+        let app = Router::new().route("/toolkits", get(toolkits));
+        let listener =
+            tokio::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let direct = DirectComposio::new("ak_live").with_v3_base_for_test(format!("http://{addr}"));
+        let paged: Paged<V3Toolkit> = direct
+            .get_paged("/toolkits", &[("limit", "200".to_string())])
+            .await
+            .expect("page");
+        assert_eq!(
+            paged.items.len(),
+            3,
+            "the page budget, not the never-ending cursor"
+        );
+        assert!(
+            paged.dropped >= 1,
+            "no total_items must not read as a complete listing: dropped={}",
+            paged.dropped
         );
     }
 

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -55,6 +55,12 @@ pub mod composio;
 /// live tools are behind `composio`, which CI never *runs*) — see
 /// [`composio_catalog`].
 pub mod composio_catalog;
+/// The BYOK half of the Composio surface: a company's **own** Composio account,
+/// reached directly at `backend.composio.dev` instead of through the
+/// OpenHuman-managed proxy. Mirrors OpenHuman's `backend` / `direct` split. See
+/// [`composio_direct`].
+#[cfg(feature = "composio")]
+pub mod composio_direct;
 /// End-to-end proof that #410's narrowable, self-describing Composio listing is
 /// reachable from a real turn on two large toolkits — the harness, the grant
 /// gate, the approval policy and the Composio client are all real; only the

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -338,10 +338,11 @@ fn unconfigured(flags: OptInFlags) -> CapabilityStatusDto {
 /// `None` when the secret store could not be read.
 ///
 /// Asks
-/// [`resolve_credential`](crate::company::composio::resolve_credential) rather
-/// than restating its precedence. The three-tier resolution — BYO
+/// [`resolve_access`](crate::company::composio::resolve_access) rather
+/// than restating its precedence. The three-tier managed resolution — BYO
 /// `composio/token`, then the company's own TinyHumans key, then this instance's
-/// platform identity — is the *same* one
+/// platform identity — and the BYOK route that bypasses all three, are the
+/// *same* answer
 /// [`TenantComposio::resolve`](crate::harness::composio::TenantComposio::resolve)
 /// gates the toolbelt on, and the whole point of #886 is that this panel had a
 /// second, one-tier copy of the question that disagreed with it. There must be
@@ -365,14 +366,14 @@ async fn composio_credential_source(
     runtime: &CompanyRuntime,
     token_source: Option<std::sync::Arc<TinyhumansTokenSource>>,
 ) -> Option<CredentialSource> {
-    match crate::company::composio::resolve_credential(
+    match crate::company::composio::resolve_access(
         runtime.id(),
         runtime.secrets().as_ref(),
         token_source,
     )
     .await
     {
-        Ok(credential) => Some(credential.source()),
+        Ok(access) => Some(access.credential.source()),
         Err(err) => {
             tracing::warn!(
                 company = %runtime.id(),

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -70,7 +70,9 @@ use crate::AppState;
 // `token_configured` is gone from this list deliberately: the status route no
 // longer re-derives the credential tier from booleans, it asks the resolver
 // (`resolve_credential`) — see `credential_source_for` below.
-use crate::company::composio::{CatalogEntry, backend_url_or_default, store_token};
+use crate::company::composio::{
+    CatalogEntry, ComposioMode, backend_url_or_default, resolve_access, store_api_key, store_token,
+};
 use crate::company::credentials::{CredentialSource, TinyhumansTokenSource};
 use crate::company::runtime::CompanyRuntime;
 use crate::ports::types::CompanyEvent;
@@ -91,6 +93,20 @@ const SWITCH_NOTE: &str =
 /// (issue #1471).
 const CLEAR_NOTE: &str =
     "Composio token cleared. Agents use whatever credential remains on their next turn.";
+
+/// The reminder attached to switching a company onto its own Composio account.
+///
+/// It names the consequence the radio button cannot: the providers connected
+/// through the managed route live in the platform's Composio tenant and are not
+/// visible from the company's own account, so the grid will look empty until
+/// they are connected again there.
+const BYOK_NOTE: &str = "This company now reaches Composio through its own account. Agents pick \
+     that up on their next turn. Providers connected through OpenHuman-managed Composio stay in \
+     that account — connect them again here, or clear the key to switch back.";
+
+/// The reminder attached to giving the managed route back.
+const MANAGED_NOTE: &str = "Composio API key cleared. This company is back on OpenHuman-managed \
+     Composio from the agents' next turn, with the providers it had connected there.";
 
 /// The toolkits the console should offer for a company, whether that answer
 /// came from open mode, and where the list came from.
@@ -211,7 +227,12 @@ async fn fetch_catalog(runtime: &CompanyRuntime) -> Result<Vec<CatalogEntry>, St
             "the Composio backend did not answer within {}s",
             composio_toolkits::FETCH_TIMEOUT.as_secs()
         )),
-        Ok(Err(err)) => Err(err.to_string()),
+        // `{err:#}`, not `to_string()`: the latter renders only the outermost
+        // context and drops the cause chain behind it, so a catalog that failed
+        // on a rejected API key reported the bare call name — "Composio v3
+        // /toolkits" — with nothing saying what went wrong. The operator-facing
+        // notice is the only place this surfaces, so it has to carry the reason.
+        Ok(Err(err)) => Err(format!("{err:#}")),
         Ok(Ok(toolkits)) if toolkits.is_empty() => {
             Err("the Composio backend returned an empty catalog".to_string())
         }
@@ -240,6 +261,7 @@ async fn fetch_catalog(_runtime: &CompanyRuntime) -> Result<Vec<CatalogEntry>, S
 pub fn router() -> Router<AppState> {
     scoped("/composio", get(get_status))
         .merge(scoped("/composio/token", put(set_token)))
+        .merge(scoped("/composio/api-key", put(set_api_key)))
         .merge(scoped("/composio/authorize", post(authorize)))
         .merge(scoped("/composio/connections", get(connections)))
         .merge(scoped(
@@ -272,7 +294,21 @@ struct ComposioStatusDto {
     ///
     /// A tier name, never a credential and never a path.
     credential_source: CredentialSource,
-    /// The effective Composio backend URL (env override or default). Non-secret.
+    /// Which host this company's Composio calls go to — `managed` (proxied
+    /// through the OpenHuman backend, the default) or `byok` (straight to this
+    /// company's own Composio account).
+    ///
+    /// Orthogonal to [`Self::credential_source`], which names *whose identity*
+    /// a call presents rather than *which host* it is presented to. A BYOK
+    /// company reports `byok` + `static`; a company that pasted a backend token
+    /// override reports `managed` + `static`. Collapsing them into one field
+    /// would leave the console unable to say which of the two an operator is
+    /// looking at.
+    mode: ComposioMode,
+    /// The effective Composio backend URL (env override or default), or
+    /// Composio's own API host under BYOK. Non-secret, and the address the
+    /// calls really go to — a status line still naming the managed backend
+    /// after a switch to BYOK would read as though nothing had happened.
     backend_url: String,
     /// The manifest toolkit allowlist verbatim (empty = defer to the backend
     /// allowlist, i.e. open mode). Kept as-is so an operator can still see what
@@ -342,6 +378,22 @@ struct MutationResponse {
 #[serde(rename_all = "camelCase")]
 struct SetToken {
     token: String,
+}
+
+/// Set-API-key body. `apiKey` is write-only intake (never returned): a non-empty
+/// value stores this company's own Composio API key and switches it to BYOK, an
+/// explicit empty string clears the key and returns it to OpenHuman-managed
+/// Composio.
+///
+/// One field, not two. A `mode` an operator could set independently of the key
+/// would let them select BYOK with nothing stored — a company with no Composio
+/// tools and no obvious reason why — so the mode is a consequence of the key
+/// rather than a separate control. See
+/// [`store_api_key`](crate::company::composio::store_api_key).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetApiKey {
+    api_key: String,
 }
 
 /// `POST …/composio/authorize` body: the toolkit slug (`gmail` / `slack` /
@@ -425,7 +477,8 @@ struct ConnectedAccountDto {
     is_default: bool,
 }
 
-/// Which tier a company's Composio credential comes from.
+/// How a company reaches Composio — the route, and which tier its credential
+/// comes from.
 ///
 /// Asks the resolver itself rather than restating its precedence. The console
 /// must never be able to name a tier the agents are not on, and a second copy of
@@ -437,18 +490,14 @@ struct ConnectedAccountDto {
 /// below makes the whole handler future non-`Send`, which axum rejects. Callers
 /// resolve it from whichever environment they mean, so the matrix stays testable
 /// without mutating the process environment.
-async fn credential_source_for(
+async fn access_for(
     runtime: &CompanyRuntime,
     token_source: Option<std::sync::Arc<TinyhumansTokenSource>>,
-) -> Result<CredentialSource, ApiError> {
-    Ok(crate::company::composio::resolve_credential(
-        runtime.id(),
-        runtime.secrets().as_ref(),
-        token_source,
-    )
-    .await
-    .map_err(ApiError)?
-    .source())
+) -> Result<(ComposioMode, CredentialSource), ApiError> {
+    let access = resolve_access(runtime.id(), runtime.secrets().as_ref(), token_source)
+        .await
+        .map_err(ApiError)?;
+    Ok((access.mode, access.credential.source()))
 }
 
 /// Resolves the Composio status DTO for a company.
@@ -469,17 +518,24 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
             env.get(crate::company::composio::TINYHUMANS_API_URL_ENV),
         )
     };
-    let credential_source = credential_source_for(
+    let (mode, credential_source) = access_for(
         runtime,
         TinyhumansTokenSource::from_env(&env).map(std::sync::Arc::new),
     )
     .await?;
     let (open_mode, effective) = effective_toolkits(runtime, &toolkits).await;
+    // Report the host the calls actually reach. Under BYOK the managed backend
+    // URL is resolved and then not used, so echoing it would be misdirection.
+    let backend_url = match mode {
+        ComposioMode::Byok => crate::company::composio::DIRECT_BASE_URL.to_string(),
+        ComposioMode::Managed => backend_url_or_default(env_url, api_url),
+    };
     Ok(ComposioStatusDto {
         in_build: cfg!(feature = "composio"),
         granted,
         credential_source,
-        backend_url: backend_url_or_default(env_url, api_url),
+        mode,
+        backend_url,
         toolkits,
         open_mode,
         effective_toolkits: effective.slugs(),
@@ -532,6 +588,50 @@ async fn set_token(
             CLEAR_NOTE.to_string()
         } else {
             SWITCH_NOTE.to_string()
+        },
+    }))
+}
+
+/// `PUT …/composio/api-key` — bring this company's **own** Composio account, or
+/// give it back.
+///
+/// A non-empty `apiKey` stores the key and routes every Composio call straight
+/// to `backend.composio.dev` with it; an empty one clears the key and returns
+/// the company to the OpenHuman-managed backend. This is the BYOK half of the
+/// surface OpenHuman calls `direct` mode.
+///
+/// **Admin-only**, for the same reason [`set_token`] is: the key decides which
+/// Composio account every one of the company's agents acts through, and — since
+/// a BYOK account is billed to whoever owns it — who pays for the calls.
+///
+/// A switch in either direction is a **different tenant**: the providers
+/// connected under the old route are not the ones connected under the new one,
+/// so the console's cached catalog is dropped here exactly as a token change
+/// drops it, and the response carries the freshly-read status so the operator
+/// sees the new answer rather than the previous account's.
+async fn set_api_key(
+    company: AdminScopedCompany,
+    Json(body): Json<SetApiKey>,
+) -> Result<Json<MutationResponse>, ApiError> {
+    let runtime = company.runtime.as_ref();
+    let mode = store_api_key(runtime.id(), runtime.secrets().as_ref(), &body.api_key)
+        .await
+        .map_err(ApiError)?;
+    evict_catalog_cache(runtime);
+    journal(
+        &company,
+        match mode {
+            ComposioMode::Byok => "composio_byok_set",
+            ComposioMode::Managed => "composio_byok_cleared",
+        },
+        None,
+    )
+    .await?;
+    Ok(Json(MutationResponse {
+        status: effective_status(runtime).await?,
+        note: match mode {
+            ComposioMode::Byok => BYOK_NOTE.to_string(),
+            ComposioMode::Managed => MANAGED_NOTE.to_string(),
         },
     }))
 }
@@ -632,23 +732,33 @@ pub(crate) async fn resolve_tenant(
     // would attribute a company's Gmail to whichever identity happened to
     // resolve during the outage. The roster path can afford to shrug and
     // withhold tools; this one must say what went wrong and connect nothing.
-    let credential = crate::company::composio::resolve_credential(
+    let access = resolve_access(
         runtime.id(),
         runtime.secrets().as_ref(),
         crate::company::TinyhumansTokenSource::from_env(&env).map(std::sync::Arc::new),
     )
     .await
     .map_err(ApiError)?;
-    if !credential.configured() {
+    if !access.credential.configured() {
+        // The two routes fail for different reasons and are recoverable in
+        // different places, so they say different things. A BYOK company told
+        // to "set its TinyHumans credential" would be sent to a control that
+        // has no effect on the route it chose.
         return Err(ApiError(crate::error::OpenCompanyError::Conflict(
-            "no Composio credential is available for this company — set the company's TinyHumans \
-             credential, or paste its own Composio token"
-                .to_string(),
+            match access.mode {
+                ComposioMode::Byok => "this company uses its own Composio account but no Composio \
+                     API key is stored — paste one, or clear it to go back to OpenHuman-managed \
+                     Composio"
+                    .to_string(),
+                ComposioMode::Managed => "no Composio credential is available for this company — \
+                     set the company's TinyHumans credential, or paste its own Composio token"
+                    .to_string(),
+            },
         )));
     }
-    Ok(crate::harness::composio::TenantComposio::new(
+    Ok(crate::harness::composio::TenantComposio::from_access(
         backend_url_or_default(backend_env, api_env),
-        credential,
+        access,
         toolkits,
     ))
 }
@@ -1013,8 +1123,11 @@ async fn connections_impl(_runtime: &CompanyRuntime) -> Result<Json<Vec<Connecti
 #[cfg(test)]
 mod tests {
     use super::{
-        CatalogEntry, CatalogSource, ComposioStatusDto, CredentialSource, credential_source_for,
+        CatalogEntry, CatalogSource, ComposioMode, ComposioStatusDto, CredentialSource,
+        TinyhumansTokenSource, access_for,
     };
+    use crate::company::runtime::CompanyRuntime;
+    use crate::server::error::ApiError;
     use crate::server::ops::composio_toolkits;
 
     use axum::body::{Body, to_bytes};
@@ -1534,6 +1647,98 @@ mod tests {
         assert_eq!(resp["status"]["credentialSource"], "none");
     }
 
+    /// BYOK end to end over the route: storing a Composio API key moves the
+    /// company onto its own account, the read plane says so without ever
+    /// carrying the key, and clearing it hands the managed route back.
+    #[tokio::test]
+    async fn a_company_can_bring_its_own_composio_account_and_give_it_back() {
+        const API_KEY: &str = "ak_live_company_own_key";
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), GRANTED).await;
+
+        // Managed is the default and needs nothing stored.
+        let (_, dto, _) = send(&state, "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(dto["mode"], "managed");
+
+        let (status, resp, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/composio/api-key",
+            Some(json!({ "apiKey": API_KEY })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(resp["status"]["mode"], "byok");
+        assert_eq!(
+            resp["status"]["credentialSource"], "static",
+            "the key is this company's own, which is the static tier"
+        );
+        assert!(
+            !raw.contains(API_KEY),
+            "the PUT response leaked the key: {raw}"
+        );
+
+        // The read plane reports the route and the host it reaches, and still
+        // carries no credential.
+        let (_, dto, raw) = send(&state, "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(dto["mode"], "byok");
+        assert_eq!(
+            dto["backendUrl"],
+            crate::company::composio::DIRECT_BASE_URL,
+            "a status still naming the managed backend would read as though nothing changed"
+        );
+        assert!(
+            !raw.contains(API_KEY),
+            "the GET status leaked the key: {raw}"
+        );
+
+        // Clearing it returns the company to the managed route.
+        let (_, resp, _) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/composio/api-key",
+            Some(json!({ "apiKey": "" })),
+        )
+        .await;
+        assert_eq!(resp["status"]["mode"], "managed");
+        assert_ne!(
+            resp["status"]["backendUrl"],
+            crate::company::composio::DIRECT_BASE_URL
+        );
+    }
+
+    /// Whose Composio account a company acts through — and therefore who pays
+    /// for the calls — is an admin's decision, exactly as the backend token is.
+    #[tokio::test]
+    async fn a_member_cannot_bring_its_own_composio_account() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), GRANTED).await;
+        let member = crate::server::test_support::seed_session(
+            &state,
+            "acme",
+            crate::ports::UserRole::Member,
+        )
+        .await;
+
+        let (status, body, raw) = send_as(
+            &state,
+            "PUT",
+            "/api/v1/company/composio/api-key",
+            Some(json!({ "apiKey": "ak_live" })),
+            Auth::Cookie(member),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{raw}");
+        assert_eq!(body["code"], "forbidden", "{body}");
+
+        // The refusal is real: the route did not move.
+        let (_, dto, _) = send(&state, "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(
+            dto["mode"], "managed",
+            "a refused write stored nothing: {dto}"
+        );
+    }
+
     /// The note on a write names the operation (issue #1471): a set tells the
     /// operator a new token is live, a clear must not claim one exists — the
     /// effective credential after a clear is whatever tier remains, which may
@@ -1576,6 +1781,18 @@ mod tests {
             clear_note.contains("cleared"),
             "the clear names what it did: {clear_note}"
         );
+    }
+
+    /// The credential tier alone.
+    ///
+    /// The matrix below is about credential *precedence*; which route a company
+    /// takes is a separate question, asserted separately. Projecting here keeps
+    /// each test about one of them.
+    async fn credential_source_for(
+        runtime: &CompanyRuntime,
+        token_source: Option<std::sync::Arc<TinyhumansTokenSource>>,
+    ) -> Result<CredentialSource, ApiError> {
+        Ok(access_for(runtime, token_source).await?.1)
     }
 
     /// The hosted shape, driven through the env seam (no process mutation): a
@@ -1707,6 +1924,7 @@ mod tests {
             in_build: true,
             granted: true,
             credential_source: CredentialSource::Attested,
+            mode: ComposioMode::Managed,
             backend_url: "https://api.tinyhumans.ai".to_string(),
             toolkits: vec!["gmail".to_string()],
             open_mode: false,
@@ -1718,6 +1936,7 @@ mod tests {
         let json = serde_json::to_value(&dto).unwrap();
         assert_eq!(json["credentialSource"], "attested");
         assert_eq!(json["catalogSource"], "manifest");
+        assert_eq!(json["mode"], "managed");
         let mut keys: Vec<&String> = json.as_object().unwrap().keys().collect();
         keys.sort_unstable();
         assert_eq!(
@@ -1731,6 +1950,7 @@ mod tests {
                 "effectiveToolkits",
                 "granted",
                 "inBuild",
+                "mode",
                 "openMode",
                 "toolkits",
             ],


### PR DESCRIPTION
## What

A company can store its own Composio API key and reach Composio directly, instead of only through the OpenHuman-managed backend. Mirrors OpenHuman's own `backend` / `direct` split; the vocabulary here is `managed` / `byok` to match `company::search`, which made the same choice first.

|  | managed | byok |
| --- | --- | --- |
| Host | the backend's `/agent-integrations/composio/*` | `backend.composio.dev` |
| Credential | the existing precedence chain | this company's own key (`composio/api_key`) |
| Who bills | the platform | whoever owns that Composio account |

`resolve_access` is the single derivation of route + credential, and every reader asks it — the roster build, `GET …/composio`, `/capabilities`, `resolve_tenant`. The default path is untouched: a company that configures nothing is `managed`, exactly as before.

## Design notes worth reviewing

**BYOK never falls back.** Mode set with no key means no tools, not a quiet drop to the managed chain — that would connect providers into the wrong Composio tenant and bill the wrong party. The mode joins the roster fingerprint, so a switch reaches agents on their next turn with no restart.

**`LiveClient` is the adapter.** The five agent tools and six console helpers contain *no* mode awareness; whatever Composio is configured is what they get. Adding BYOK touched no tool implementation, and the pinned-account path, post-OAuth retry and metering kept working unchanged.

**`from_access` instead of a `with_mode` builder.** The builder made the dangerous thing representable: a caller that resolved a BYOK credential and forgot to say so would build a *managed* config around a Composio `ak_…` and present it to `api.tinyhumans.ai` as a bearer. Taking the pair as one value means the route can't be dropped between resolving a credential and presenting it.

**The catalogue stays OpenHuman's 123 under BYOK**, fetched with the *managed*-chain credential while every Composio call goes direct. Switching a company to its own account changes who it acts as, not what the console lets it browse. The two credentials are kept strictly apart and both join the scrub vector.

## Two things only the live API could teach

- **Composio v3 ignores unknown query parameters** rather than refusing them, so tools are scoped with `toolkit_slug=a,b`, not `toolkits=`. The wrong spelling silently returns the first page of all 52,268 tools alphabetically — verified: `toolkits=gmail` → 52,268 items, `toolkit_slug=gmail` → 63. **The vendored OpenHuman client has the same bug** (`list_tool_schemas_v3` sends `toolkits`); `list_actions_v3` only works by accident because it happens to send both spellings.
- **The v3 listings are cursor-paginated and large** — 1501 toolkits over 8 pages. A full sweep measures ~8.4s against a 5s budget on both the host and the console probe, so it is followed to a page budget and what it could not reach is counted from Composio's own `total_items` and logged, never dropped silently.

## Also fixed

Error rendering moves to `{err:#}` at five sites. `to_string()` renders only anyhow's outermost context, which was invisible while the managed client — whose errors are single-level — was the only caller. With a rejected key an operator saw the bare call name, `Composio v3 /toolkits`, with the reason discarded one frame below. **This also fixes the managed path's agent-facing errors**, which had the same latent flattening.

## Verified

Against a real Composio account, end to end through the console: authorize, the OAuth handshake, connection discovery by polling, the schema-preserving tool listing, and a real `GITHUB_LIST_PULL_REQUESTS` executed by an agent from chat — which returned this repo's five most recent open PRs.

`203` tests on the composio lane, `4424` frontend tests, `cargo fmt --check`, `cargo clippy --features composio --all-targets`, `tsc -b` — all clean.

## Known follow-ups, not in this PR

- **`MAX_PAGES = 3` is the wrong bound for the agent path.** It was chosen to fit the console's 5s probe, but `composio_list_tools` is not the console. The live run logged `toolkits=["github"] fetched=600 dropped=293` and an unscoped `fetched=600 dropped=51668`. It found `GITHUB_LIST_PULL_REQUESTS` because that slug falls inside the first 600 alphabetically; a tool sorting later would be invisible to the agent and would look like model incapability. Wants a split budget, and an unscoped `list_tools` should refuse rather than truncate.
- **The missing-auth-config error is badly packaged.** BYOK connects need a per-toolkit auth config in the company's own Composio account, and `authorize_impl` wraps every failure as `TinyHumans` → `502`. So the most common BYOK failure reads `tinyhumans error (composio_authorize)` — naming a host that was never called — with a dead v2 fallback clause (`HTTP 410`, retired) and a status that invites a pointless retry. Wants a `409` and one clean sentence.
- **`extra_params` at authorize** has no BYOK path. Stated as unverified rather than asserted, because I made exactly that mistake once in this branch and it cost a wrong refusal.
- **Serving the full 1501-toolkit catalogue** means refreshing off the request path, not a larger timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for choosing between OpenHuman-managed Composio and a company’s own Composio account.
  * Added secure API-key setup and removal for the company-owned option.
  * Added route-aware status information, endpoint display, and warnings when an API key is missing.
  * Preserved toolkit catalog access and connection management across both options.

* **Documentation**
  * Documented Composio routing, credentials, catalog behavior, and account switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->