### PR TITLE
feat(console): cancel a delegation that has no card (#2058)

### DIFF
--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -907,6 +907,27 @@ export interface InflightRun {
 }
 
 /**
+ * Which steer verbs a run supports, derived from the run itself.
+ *
+ * The host is the authority — a delegation answers `400 "this run only supports
+ * cancel"` to anything else — and this mirrors that rule so a surface offers a
+ * control the run can actually take. Read it from the run rather than from what
+ * the surface knows about it: every run in {@link listInflight} is steerable by
+ * its `key`, including a delegation whose `taskId` is null, so a surface that
+ * decides from a card it happens to have on hand is asking the wrong object.
+ */
+export function steerActionsFor(run: InflightRun): readonly SteerAction[] {
+  return run.kind === "delegation"
+    ? (["cancel"] as const)
+    : (["pause", "cancel", "redirect"] as const);
+}
+
+/** Whether `action` is one this run accepts. See {@link steerActionsFor}. */
+export function supportsSteerAction(run: InflightRun, action: SteerAction): boolean {
+  return steerActionsFor(run).includes(action);
+}
+
+/**
  * The live board state Chat needs for a card-linked background turn (#1758).
  *
  * `column` is the task's stage when the current three-column API provides one,
@@ -919,7 +940,13 @@ export interface TaskStatus {
   startedAt?: number;
 }
 
-/** Task id -> status, merged from the board and in-flight reads (#1758). */
+/**
+ * Task id -> status, merged from the board and in-flight reads (#1758).
+ *
+ * Card-keyed, so a run with no card cannot be represented and is dropped. This
+ * is a board-decoration map, never the inventory of what is running: a surface
+ * asking "what is in flight?" must read {@link listInflight} itself.
+ */
 export function taskStatusesById(
   tasks: readonly Task[],
   inflight: readonly InflightRun[],

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -53,6 +53,7 @@ import {
   listInflight,
   listTasks,
   taskStatusesById,
+  type InflightRun,
   type TaskStatus,
 } from "@/api/tasks";
 import { startVisiblePolling } from "@/lib/visible-poll";
@@ -670,6 +671,12 @@ export function AppShell({
   const [taskStatusByTaskId, setTaskStatusByTaskId] = useState<
     Record<string, TaskStatus>
   >({});
+  /**
+   * The same in-flight read, kept whole rather than only as the card-keyed map
+   * above. A delegation has no card, so `taskStatusByTaskId` cannot hold it and
+   * a surface offering a control over a run needs the rows themselves.
+   */
+  const [inflightRuns, setInflightRuns] = useState<readonly InflightRun[]>([]);
   const taskStatusRead = useRef(0);
   // Issue #1015: bumped on every `run_status_changed`, so the task detail screen
   // sees an attempt move rather than waiting up to four seconds for its poll —
@@ -967,11 +974,17 @@ export function AppShell({
         inflight.status === "fulfilled" ? inflight.value : [],
       ),
     );
+    // Only on a read that actually landed. A failed inflight poll must not empty
+    // the bar and take a still-running delegation's cancel with it.
+    if (inflight.status === "fulfilled") setInflightRuns(inflight.value);
   }, [client, company]);
 
   useEffect(() => {
     taskStatusRead.current += 1;
     setTaskStatusByTaskId({});
+    // A steer key is company-scoped, so a row held across a company switch
+    // would address the previous company's registry.
+    setInflightRuns([]);
   }, [client, company]);
 
   // Ride the existing visible-tab company poll, and also re-read immediately
@@ -3467,6 +3480,8 @@ export function AppShell({
               approvals={feed.approvals}
               chatChannelByThread={chatChannelByThread}
               taskStatusByTaskId={taskStatusByTaskId}
+              inflightRuns={inflightRuns}
+              onInflightSteered={refreshTaskStatuses}
               now={feed.now}
               onDecideApproval={(approval, verdict, scope) =>
                 void decideApproval(approval, verdict, scope)

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -332,7 +332,7 @@ interface Props {
    */
   inflightRuns?: readonly InflightRun[];
   /** Re-read the in-flight list after a steer lands. */
-  onInflightSteered?: () => void;
+  onInflightSteered?: () => void | Promise<void>;
   /** Now, for a card's "waiting N minutes" line. */
   now?: number;
   /**

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -15,7 +15,7 @@ import { toast } from "sonner";
 
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
-import { deleteTask, type MessageIntent, type TaskStatus } from "@/api/tasks";
+import { deleteTask, type InflightRun, type MessageIntent, type TaskStatus } from "@/api/tasks";
 import { turnStateKey, type OpenTurn } from "@/lib/live-reply";
 import { setInboxEnabled } from "@/api/inbox";
 import { uploadChatAttachment } from "@/api/chat";
@@ -64,6 +64,7 @@ import { ChannelRail } from "./chat/ChannelRail";
 import { ChatHeader } from "./chat/ChatHeader";
 import { MembersPane } from "./chat/MembersPane";
 import { TypingLine } from "./chat/TypingLine";
+import { InflightRunBar } from "./chat/InflightRunBar";
 import { MessageComposer } from "./chat/MessageComposer";
 import {
   mentionablesFor,
@@ -324,6 +325,14 @@ interface Props {
   chatChannelByThread?: Record<string, string>;
   /** Board task id -> live state for card-linked background turns (#1758). */
   taskStatusByTaskId?: Readonly<Record<string, TaskStatus>>;
+  /**
+   * The company's steerable runs, whole. Separate from `taskStatusByTaskId`
+   * because that map is card-keyed and a delegation has no card, so the runs
+   * that most need a control here are exactly the ones it cannot carry.
+   */
+  inflightRuns?: readonly InflightRun[];
+  /** Re-read the in-flight list after a steer lands. */
+  onInflightSteered?: () => void;
   /** Now, for a card's "waiting N minutes" line. */
   now?: number;
   /**
@@ -413,6 +422,8 @@ export function ChatView({
   approvals,
   chatChannelByThread,
   taskStatusByTaskId,
+  inflightRuns,
+  onInflightSteered,
   now,
   onDecideApproval,
   decidingApprovals,
@@ -2507,6 +2518,17 @@ export function ChatView({
                 DOM gets nothing — no textarea, no Send, no `data-tour` anchor —
                 while the draft survives. See that prop's doc for why a
                 `display:none` wrapper is not the same thing. */}
+            {/* Above the composer, and outside the read-only branch: a channel
+                nobody may post in is still a place the company's runs are
+                visible, and stopping one is not posting. */}
+            {inflightRuns !== undefined && onInflightSteered !== undefined && (
+              <InflightRunBar
+                client={client}
+                company={company}
+                runs={inflightRuns}
+                onSteered={onInflightSteered}
+              />
+            )}
             <MessageComposer
               suppressed={readOnly}
               placeholder={`Message ${channelTitle(channel)}`}

--- a/frontend/src/views/chat/InflightRunBar.tsx
+++ b/frontend/src/views/chat/InflightRunBar.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useState } from "react";
+import { Loader2, X } from "lucide-react";
+import { toast } from "sonner";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { steerTask, supportsSteerAction, type InflightRun } from "@/api/tasks";
+import { ApiError } from "@/api/types";
+import { Button } from "@/components/ui/button";
+
+/**
+ * The company's in-flight runs, with the controls each one supports, above the
+ * composer in a Room.
+ *
+ * ## Why the runs arrive as a prop
+ *
+ * The shell already reads `GET …/tasks/inflight` on the company poll and on
+ * every task-lifecycle tick. A second reader here would double that traffic and
+ * give two surfaces two different answers to "what is running", so the shell
+ * owns the read and this renders it.
+ *
+ * ## Why it is company-scoped inside a room
+ *
+ * A run carries no conversation id, so there is no honest way to say which room
+ * a delegation belongs to. The choice is between showing the company's runs in
+ * every room and showing them nowhere; a runaway sub-agent the operator cannot
+ * stop is the worse of the two. The heading says "company" so the list does not
+ * read as "this channel's work".
+ *
+ * ## Why a delegation is the case that matters
+ *
+ * A dispatched card is reachable at its own detail screen, which offers the
+ * same verbs. A delegation has no card, so this is the only place its cancel
+ * exists — which is why the row is keyed on `run.key` and never on `taskId`.
+ */
+export function InflightRunBar({
+  client,
+  company,
+  runs,
+  onSteered,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  runs: readonly InflightRun[];
+  /** Re-read the inflight list, so a settled or cancelled run leaves the bar. */
+  onSteered: () => void;
+}) {
+  if (runs.length === 0) return null;
+
+  return (
+    <div className="border-t bg-muted/30" data-testid="inflight-run-bar">
+      <div className="mx-auto w-full max-w-3xl px-4 py-2">
+        <p className="mb-1.5 px-1 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+          In flight across this company · {runs.length}
+        </p>
+        <div className="flex flex-col gap-1.5">
+          {runs.map((run) => (
+            <InflightRunRow
+              key={run.key}
+              run={run}
+              client={client}
+              company={company}
+              onSteered={onSteered}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Past-tense badge copy while a steer of the given verb is already in flight. */
+const PENDING_LABEL: Record<string, string> = {
+  pause: "pausing…",
+  cancel: "cancelling…",
+  redirect: "redirecting…",
+};
+
+export function InflightRunRow({
+  run,
+  client,
+  company,
+  onSteered,
+}: {
+  run: InflightRun;
+  client: OpenCompanyClient;
+  company: string | null;
+  onSteered: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  const pending = run.pendingAction ?? null;
+  const disabled = busy || pending !== null;
+
+  const cancel = useCallback(async () => {
+    if (!window.confirm(`Cancel “${run.title}”? This stops the run.`)) return;
+    setBusy(true);
+    try {
+      await steerTask(client, company, run.key, { action: "cancel", confirm: true });
+      toast.success(`Cancelling “${run.title}”…`);
+    } catch (e) {
+      // A run that settled while the click was in flight is no longer in the
+      // registry, and the host says so with 404/409. That is the run ending on
+      // its own, not a failure to act on it — reporting it as an error would
+      // tell the operator their cancel broke when the work is already over.
+      if (isAlreadyGone(e)) {
+        toast.info(`“${run.title}” had already finished.`);
+      } else {
+        toast.error(e instanceof Error ? e.message : "could not cancel the run");
+      }
+    } finally {
+      setBusy(false);
+      // Always re-read, on both paths: the cancel landed, or the row is stale
+      // and the refetch is what removes it.
+      onSteered();
+    }
+  }, [client, company, run.key, run.title, onSteered]);
+
+  return (
+    <div className="rounded-lg border bg-card px-2.5 py-1.5" data-testid="inflight-run-row">
+      <div className="flex items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-xs font-medium">{run.title}</p>
+          <p className="truncate text-2xs text-muted-foreground">
+            {run.kind === "delegation" ? "Delegation" : "Task"} · {run.agentId}
+          </p>
+        </div>
+
+        {pending !== null ? (
+          <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-3xs font-medium text-muted-foreground">
+            {PENDING_LABEL[pending] ?? "steering…"}
+          </span>
+        ) : (
+          <div className="flex shrink-0 items-center gap-1">
+            {busy && <Loader2 className="size-3.5 animate-spin text-muted-foreground" />}
+            {supportsSteerAction(run, "cancel") && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs text-destructive hover:text-destructive"
+                disabled={disabled}
+                aria-label={`Cancel ${run.title}`}
+                onClick={() => void cancel()}
+              >
+                <X className="mr-1 size-3.5" />
+                Cancel
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Whether a failed steer means the run is no longer in flight.
+ *
+ * The host answers `404` for a key it does not know and `409` for a card that
+ * exists but is not running; both mean the same thing to an operator who just
+ * asked to stop something. `fromHost` is required, so a proxy's own 404 — which
+ * says nothing about the run — still surfaces as the error it is.
+ */
+function isAlreadyGone(e: unknown): boolean {
+  return (
+    e instanceof ApiError && e.fromHost && (e.status === 404 || e.status === 409)
+  );
+}

--- a/frontend/src/views/chat/InflightRunBar.tsx
+++ b/frontend/src/views/chat/InflightRunBar.tsx
@@ -26,11 +26,11 @@ import { Button } from "@/components/ui/button";
  * stop is the worse of the two. The heading says "company" so the list does not
  * read as "this channel's work".
  *
- * ## Why a delegation is the case that matters
+ * ## Why a row is keyed on `run.key`
  *
- * A dispatched card is reachable at its own detail screen, which offers the
- * same verbs. A delegation has no card, so this is the only place its cancel
- * exists — which is why the row is keyed on `run.key` and never on `taskId`.
+ * Every run in the in-flight read is steerable by its `key`, and a delegation's
+ * `taskId` is null. Keying a row on the card would drop exactly the runs that
+ * have no other control.
  */
 export function InflightRunBar({
   client,

--- a/frontend/src/views/chat/InflightRunBar.tsx
+++ b/frontend/src/views/chat/InflightRunBar.tsx
@@ -41,8 +41,11 @@ export function InflightRunBar({
   client: OpenCompanyClient;
   company: string | null;
   runs: readonly InflightRun[];
-  /** Re-read the inflight list, so a settled or cancelled run leaves the bar. */
-  onSteered: () => void;
+  /**
+   * Re-read the inflight list, so a settled or cancelled run leaves the bar.
+   * Awaited where it is called, so it must report when it has finished.
+   */
+  onSteered: () => void | Promise<void>;
 }) {
   if (runs.length === 0) return null;
 
@@ -84,7 +87,7 @@ export function InflightRunRow({
   run: InflightRun;
   client: OpenCompanyClient;
   company: string | null;
-  onSteered: () => void;
+  onSteered: () => void | Promise<void>;
 }) {
   const [busy, setBusy] = useState(false);
 
@@ -95,23 +98,28 @@ export function InflightRunRow({
     if (!window.confirm(`Cancel “${run.title}”? This stops the run.`)) return;
     setBusy(true);
     try {
-      await steerTask(client, company, run.key, { action: "cancel", confirm: true });
-      toast.success(`Cancelling “${run.title}”…`);
-    } catch (e) {
-      // A run that settled while the click was in flight is no longer in the
-      // registry, and the host says so with 404/409. That is the run ending on
-      // its own, not a failure to act on it — reporting it as an error would
-      // tell the operator their cancel broke when the work is already over.
-      if (isAlreadyGone(e)) {
-        toast.info(`“${run.title}” had already finished.`);
-      } else {
-        toast.error(e instanceof Error ? e.message : "could not cancel the run");
+      try {
+        await steerTask(client, company, run.key, { action: "cancel", confirm: true });
+        toast.success(`Cancelling “${run.title}”…`);
+      } catch (e) {
+        // A run that settled while the click was in flight is no longer in the
+        // registry, and the host says so with 404/409. That is the run ending on
+        // its own, not a failure to act on it — reporting it as an error would
+        // tell the operator their cancel broke when the work is already over.
+        if (isAlreadyGone(e)) {
+          toast.info(`“${run.title}” had already finished.`);
+        } else {
+          toast.error(e instanceof Error ? e.message : "could not cancel the run");
+        }
       }
+      // Always re-read, on both paths: the cancel landed, or the row is stale
+      // and the refetch is what removes it. Awaited before the control comes
+      // back, because until the fresh row arrives carrying its own
+      // `pendingAction` there is nothing else holding the button down, and a
+      // second click inside that window buys a second accepted steer.
+      await onSteered();
     } finally {
       setBusy(false);
-      // Always re-read, on both paths: the cancel landed, or the row is stale
-      // and the refetch is what removes it.
-      onSteered();
     }
   }, [client, company, run.key, run.title, onSteered]);
 

--- a/frontend/test/e2e/inflight-cancel.spec.ts
+++ b/frontend/test/e2e/inflight-cancel.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "@playwright/test";
+
+import { openChannel } from "./chat-helpers";
+
+/**
+ * Cancelling an in-flight run that has no card, from Room.
+ *
+ * A `kind: "delegation"` run carries `taskId: null`. The host registers it so
+ * an operator can stop it, and `POST …/tasks/{key}/steer` accepts `cancel` for
+ * it, but every console control over a run used to be reached through a card.
+ *
+ * The in-flight read is intercepted rather than driven through a real
+ * delegation: a delegated turn against the scripted brain settles in seconds,
+ * so a spec racing that window would assert on whether it lost the race. What
+ * is under test here is the console's side — that a taskless row is offered a
+ * control at all, and that the control addresses the run by its `key`.
+ */
+
+const ENGINEERING = "engineering";
+
+/** Same tour suppression as `agent-profile-panel.spec.ts` — seeded before boot. */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const seen = JSON.stringify({ skipped: true, seenAt: Date.now() });
+    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+      window.localStorage.setItem(key, seen);
+    }
+  });
+});
+
+/** The cancel control for a run, by the accessible name the row gives it. */
+function cancelFor(page: import("@playwright/test").Page, title: string) {
+  return page.locator(`[data-testid="inflight-run-bar"] button[aria-label="Cancel ${title}"]`);
+}
+
+/** A delegation as `GET …/tasks/inflight` returns one: running, and cardless. */
+const DELEGATION = {
+  taskId: null,
+  key: "01a0682eba78-000000000039",
+  kind: "delegation",
+  title: "content",
+  agentId: "writer",
+  startedAt: 1_788_454_287_992,
+  pendingAction: null,
+};
+
+/**
+ * The other producer's shape. Its key is `approval:<id>`, so it also pins that
+ * a colon survives the round trip into the request path.
+ */
+const REISSUE = {
+  ...DELEGATION,
+  key: "approval:01a0682fc5ae-000000000040",
+  title: "re-issue request_approval",
+  agentId: "ceo",
+};
+
+/** Serve `runs` from the in-flight read, and hand back the steers it receives. */
+async function withInflight(
+  page: import("@playwright/test").Page,
+  runs: readonly unknown[],
+) {
+  const steers: { url: string; body: unknown }[] = [];
+  let current = [...runs];
+
+  await page.route("**/tasks/inflight", (route) =>
+    route.fulfill({ json: current }),
+  );
+  await page.route("**/steer", async (route) => {
+    steers.push({
+      url: route.request().url(),
+      body: route.request().postDataJSON(),
+    });
+    // The run leaves the registry, which is what clears the row on the refetch
+    // the console issues after a steer lands.
+    current = [];
+    await route.fulfill({ status: 202, body: "" });
+  });
+
+  page.on("dialog", (dialog) => void dialog.accept());
+  return steers;
+}
+
+test("a delegation with no card is offered a cancel", async ({ page }) => {
+  await withInflight(page, [DELEGATION]);
+  await openChannel(page, ENGINEERING);
+
+  await expect(page.getByTestId("inflight-run-bar")).toBeVisible({ timeout: 30_000 });
+  await expect(cancelFor(page, "content")).toBeVisible();
+});
+
+test("the cancel addresses the run by its key, not by a card", async ({ page }) => {
+  const steers = await withInflight(page, [DELEGATION]);
+  await openChannel(page, ENGINEERING);
+
+  await cancelFor(page, "content").click();
+  await expect.poll(() => steers.length, { timeout: 30_000 }).toBe(1);
+
+  // The whole point of #2058: `taskId` is null and cannot address anything.
+  expect(decodeURIComponent(steers[0].url)).toContain(`/tasks/${DELEGATION.key}/steer`);
+  expect(steers[0].body).toEqual({ action: "cancel", confirm: true });
+});
+
+test("a key carrying a colon reaches the host intact", async ({ page }) => {
+  const steers = await withInflight(page, [REISSUE]);
+  await openChannel(page, ENGINEERING);
+
+  await cancelFor(page, "re-issue request_approval").click();
+  await expect.poll(() => steers.length, { timeout: 30_000 }).toBe(1);
+
+  expect(decodeURIComponent(steers[0].url)).toContain(`/tasks/${REISSUE.key}/steer`);
+  expect(steers[0].url).toContain("approval%3A");
+});
+
+test("the row leaves once the run is no longer in flight", async ({ page }) => {
+  await withInflight(page, [DELEGATION]);
+  await openChannel(page, ENGINEERING);
+
+  await cancelFor(page, "content").click();
+  await expect(page.getByTestId("inflight-run-bar")).toHaveCount(0, { timeout: 30_000 });
+});
+
+test("nothing in flight draws no bar", async ({ page }) => {
+  await withInflight(page, []);
+  await openChannel(page, ENGINEERING);
+
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible();
+  await expect(page.getByTestId("inflight-run-bar")).toHaveCount(0);
+});

--- a/frontend/test/e2e/inflight-cancel.spec.ts
+++ b/frontend/test/e2e/inflight-cancel.spec.ts
@@ -120,6 +120,40 @@ test("the row leaves once the run is no longer in flight", async ({ page }) => {
   await expect(page.getByTestId("inflight-run-bar")).toHaveCount(0, { timeout: 30_000 });
 });
 
+test("a double click buys only one steer", async ({ page }) => {
+  const steers: unknown[] = [];
+  let current: readonly unknown[] = [DELEGATION];
+  let reads = 0;
+
+  // The re-read that follows the steer is held open, so the window between the
+  // POST landing and the fresh row arriving is wide enough for a second press
+  // to land in. That window is the whole bug: the host accepts the second
+  // cancel and journals a second `TaskSteered` for one operator intent.
+  await page.route("**/tasks/inflight", async (route) => {
+    reads += 1;
+    if (reads > 1) await new Promise((r) => setTimeout(r, 3000));
+    await route.fulfill({ json: current });
+  });
+  await page.route("**/steer", async (route) => {
+    steers.push(route.request().postDataJSON());
+    current = [];
+    await route.fulfill({ status: 202, body: "" });
+  });
+  page.on("dialog", (dialog) => void dialog.accept());
+
+  await openChannel(page, ENGINEERING);
+  const button = cancelFor(page, "content");
+  await expect(button).toBeVisible({ timeout: 30_000 });
+
+  await button.dblclick();
+  for (let i = 0; i < 3; i++) {
+    await button.click({ force: true, timeout: 1_000 }).catch(() => {});
+  }
+
+  await page.waitForTimeout(6_000);
+  expect(steers).toEqual([{ action: "cancel", confirm: true }]);
+});
+
 test("nothing in flight draws no bar", async ({ page }) => {
   await withInflight(page, []);
   await openChannel(page, ENGINEERING);

--- a/frontend/test/unit/inflight-run-cancel.test.ts
+++ b/frontend/test/unit/inflight-run-cancel.test.ts
@@ -102,6 +102,20 @@ function click(el: HTMLElement) {
   });
 }
 
+/**
+ * A real activation, which a disabled control refuses.
+ *
+ * {@link click} dispatches the event straight at the element and so reaches the
+ * handler whatever the button's state; that is what most of these tests want.
+ * A test about the control being *held down* has to go through the path a
+ * person does.
+ */
+function press(el: HTMLElement) {
+  act(() => {
+    el.click();
+  });
+}
+
 /** Let the click's async handler settle. */
 async function settle() {
   await act(async () => {
@@ -242,6 +256,74 @@ describe("a run that is already going away", () => {
     render([delegation({ pendingAction: "cancel" })]);
     expect(cancelButton("Research the competitor pricing")).toBeNull();
     expect(host.textContent).toContain("cancelling…");
+  });
+});
+
+describe("one intent buys one steer", () => {
+  beforeEach(() => vi.stubGlobal("confirm", vi.fn(() => true)));
+
+  /** A re-read this test opens and closes, so the window can be stood still in. */
+  function deferredRefresh() {
+    let release!: () => void;
+    const done = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return { onSteered: vi.fn(() => done), release };
+  }
+
+  it("holds the control down until the re-read settles", async () => {
+    const { onSteered, release } = deferredRefresh();
+    render([delegation()], onSteered);
+
+    press(cancelButton("Research the competitor pricing")!);
+    await settle();
+    expect(steerTask).toHaveBeenCalledTimes(1);
+    expect(onSteered).toHaveBeenCalledTimes(1);
+
+    // The steer has landed, but the row carrying `pendingAction: "cancel"` has
+    // not arrived yet. Nothing but `busy` is holding the button down here, so
+    // a second press in this window is what buys a second accepted cancel —
+    // and a second `TaskSteered` in the journal for one operator intent.
+    press(cancelButton("Research the competitor pricing")!);
+    await settle();
+    expect(steerTask).toHaveBeenCalledTimes(1);
+    expect(cancelButton("Research the competitor pricing")!.disabled).toBe(true);
+
+    release();
+    await settle();
+  });
+
+  it("lets the control back up once the re-read has landed", async () => {
+    const { onSteered, release } = deferredRefresh();
+    render([delegation()], onSteered);
+
+    press(cancelButton("Research the competitor pricing")!);
+    await settle();
+
+    release();
+    await settle();
+
+    // A run the re-read still reports keeps its control: the freeze is the
+    // window, not a one-way door.
+    expect(cancelButton("Research the competitor pricing")!.disabled).toBe(false);
+  });
+
+  it("holds the control down through a refresh that follows a failed steer", async () => {
+    steerTask.mockRejectedValue(new ApiError(500, "internal", "the host fell over", true));
+    const { onSteered, release } = deferredRefresh();
+    render([delegation()], onSteered);
+
+    press(cancelButton("Research the competitor pricing")!);
+    await settle();
+    expect(onSteered).toHaveBeenCalledTimes(1);
+
+    press(cancelButton("Research the competitor pricing")!);
+    await settle();
+    expect(steerTask).toHaveBeenCalledTimes(1);
+    expect(cancelButton("Research the competitor pricing")!.disabled).toBe(true);
+
+    release();
+    await settle();
   });
 });
 

--- a/frontend/test/unit/inflight-run-cancel.test.ts
+++ b/frontend/test/unit/inflight-run-cancel.test.ts
@@ -1,0 +1,269 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
+import type { InflightRun } from "@/api/tasks";
+
+/**
+ * Cancelling a run that has no card.
+ *
+ * A `kind: "delegation"` run carries `taskId: null` — it is a sub-agent turn,
+ * not a dispatched board card — and the only console surface that could stop
+ * one was a strip on the retired `#/conversation` route. Every other control
+ * over a run is reached through a card: the task detail screen resolves its
+ * run with `runs.find((r) => r.taskId === taskId)`, which a null taskId can
+ * never match, and it is only addressable at `#/tasks/<id>` in the first place.
+ *
+ * So the affordance was attached to the card while the steer API was already
+ * keyed on the run: `POST …/tasks/{key}/steer` resolves `key` against the
+ * in-flight registry, where a delegation's key is a synthetic run id. These
+ * tests pin the control to that key, because reaching for `taskId` is exactly
+ * the mistake that made a delegation uncancellable.
+ */
+
+const toasts = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), toasts),
+}));
+
+const steerTask = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/tasks", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/api/tasks")>()),
+  steerTask,
+}));
+
+const { InflightRunBar } = await import("@/views/chat/InflightRunBar");
+
+const CLIENT = {
+  scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+} as unknown as OpenCompanyClient;
+
+/** A delegation: running, and with no card behind it. */
+function delegation(over: Partial<InflightRun> = {}): InflightRun {
+  return {
+    taskId: null,
+    key: "run_7f3c9a",
+    kind: "delegation",
+    title: "Research the competitor pricing",
+    agentId: "analyst",
+    startedAt: 1_700_000_000_000,
+    pendingAction: null,
+    ...over,
+  };
+}
+
+function task(over: Partial<InflightRun> = {}): InflightRun {
+  return { ...delegation(), taskId: "t-42", key: "t-42", kind: "task", ...over };
+}
+
+let host: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+  steerTask.mockResolvedValue(undefined);
+  host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  host.remove();
+  vi.unstubAllGlobals();
+});
+
+function render(runs: readonly InflightRun[], onSteered = vi.fn()) {
+  act(() => {
+    root.render(
+      createElement(InflightRunBar, {
+        client: CLIENT,
+        company: "acme",
+        runs,
+        onSteered,
+      }),
+    );
+  });
+  return onSteered;
+}
+
+/** The cancel control for a run, found by its accessible name. */
+function cancelButton(title: string): HTMLButtonElement | null {
+  return host.querySelector<HTMLButtonElement>(
+    `button[aria-label="Cancel ${title}"]`,
+  );
+}
+
+function click(el: HTMLElement) {
+  act(() => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+/** Let the click's async handler settle. */
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("a delegation with no card can be cancelled", () => {
+  beforeEach(() => vi.stubGlobal("confirm", vi.fn(() => true)));
+
+  it("offers Cancel for a run whose taskId is null", () => {
+    render([delegation()]);
+    expect(cancelButton("Research the competitor pricing")).not.toBeNull();
+  });
+
+  it("steers by the run key, never by taskId", async () => {
+    render([delegation()]);
+    click(cancelButton("Research the competitor pricing")!);
+    await settle();
+
+    expect(steerTask).toHaveBeenCalledTimes(1);
+    const [, company, key, body] = steerTask.mock.calls[0];
+    // The whole point: a null taskId cannot address anything, and the key can.
+    expect(key).toBe("run_7f3c9a");
+    expect(company).toBe("acme");
+    expect(body).toEqual({ action: "cancel", confirm: true });
+  });
+
+  it("sends confirm, which the host requires for a cancel", async () => {
+    render([delegation()]);
+    click(cancelButton("Research the competitor pricing")!);
+    await settle();
+    expect(steerTask.mock.calls[0][3]).toMatchObject({ confirm: true });
+  });
+
+  it("re-reads the in-flight list so the cancelled run leaves the bar", async () => {
+    const onSteered = render([delegation()]);
+    click(cancelButton("Research the competitor pricing")!);
+    await settle();
+    expect(onSteered).toHaveBeenCalled();
+  });
+
+  it("renders nothing when nothing is in flight", () => {
+    render([]);
+    expect(host.querySelector("[data-testid='inflight-run-bar']")).toBeNull();
+  });
+
+  it("gives every run of many its own control", () => {
+    render([
+      delegation(),
+      delegation({ key: "run_b", title: "Draft the brief" }),
+      task({ title: "Ship the changelog" }),
+    ]);
+    expect(host.querySelectorAll("[data-testid='inflight-run-row']")).toHaveLength(3);
+    expect(cancelButton("Draft the brief")).not.toBeNull();
+    expect(cancelButton("Ship the changelog")).not.toBeNull();
+  });
+
+  it("cancels one of several without touching the others", async () => {
+    render([delegation(), delegation({ key: "run_b", title: "Draft the brief" })]);
+    click(cancelButton("Draft the brief")!);
+    await settle();
+    expect(steerTask).toHaveBeenCalledTimes(1);
+    expect(steerTask.mock.calls[0][2]).toBe("run_b");
+  });
+});
+
+describe("the operator is asked before a run is stopped", () => {
+  it("does not steer when the confirmation is declined", async () => {
+    vi.stubGlobal("confirm", vi.fn(() => false));
+    render([delegation()]);
+    click(cancelButton("Research the competitor pricing")!);
+    await settle();
+    expect(steerTask).not.toHaveBeenCalled();
+  });
+});
+
+describe("a run that is already going away", () => {
+  beforeEach(() => vi.stubGlobal("confirm", vi.fn(() => true)));
+
+  it("reads a host 404 as the run having finished, not as a failure", async () => {
+    // The run settled between the render and the click: its key is no longer
+    // in the registry. Telling the operator the cancel failed would be false —
+    // the work they wanted stopped is over.
+    steerTask.mockRejectedValue(new ApiError(404, "not_found", "task run_7f3c9a", true));
+    render([delegation()]);
+    click(cancelButton("Research the competitor pricing")!);
+    await settle();
+
+    expect(toasts.info).toHaveBeenCalled();
+    expect(toasts.error).not.toHaveBeenCalled();
+  });
+
+  it("reads a host 409 the same way", async () => {
+    steerTask.mockRejectedValue(
+      new ApiError(409, "conflict", "task t-42 is not in flight", true),
+    );
+    render([task()]);
+    click(cancelButton("Research the competitor pricing")!);
+    await settle();
+
+    expect(toasts.info).toHaveBeenCalled();
+    expect(toasts.error).not.toHaveBeenCalled();
+  });
+
+  it("still refreshes after a rejected steer, so a stale row is cleared", async () => {
+    steerTask.mockRejectedValue(new ApiError(404, "not_found", "gone", true));
+    const onSteered = render([delegation()]);
+    click(cancelButton("Research the competitor pricing")!);
+    await settle();
+    expect(onSteered).toHaveBeenCalled();
+  });
+
+  it("surfaces a real failure as an error", async () => {
+    steerTask.mockRejectedValue(new ApiError(500, "internal", "the host fell over", true));
+    render([delegation()]);
+    click(cancelButton("Research the competitor pricing")!);
+    await settle();
+
+    expect(toasts.error).toHaveBeenCalled();
+    expect(toasts.info).not.toHaveBeenCalled();
+  });
+
+  it("does not claim a run finished when it was a proxy that 404'd", async () => {
+    // `fromHost: false` means nothing between here and the registry answered
+    // about this run. Reporting "already finished" would be an invention.
+    steerTask.mockRejectedValue(new ApiError(404, "http_error", "HTTP 404", false));
+    render([delegation()]);
+    click(cancelButton("Research the competitor pricing")!);
+    await settle();
+
+    expect(toasts.error).toHaveBeenCalled();
+    expect(toasts.info).not.toHaveBeenCalled();
+  });
+
+  it("freezes a row whose steer the host is already applying", () => {
+    render([delegation({ pendingAction: "cancel" })]);
+    expect(cancelButton("Research the competitor pricing")).toBeNull();
+    expect(host.textContent).toContain("cancelling…");
+  });
+});
+
+describe("a delegation that gains a card mid-run stays cancellable", () => {
+  beforeEach(() => vi.stubGlobal("confirm", vi.fn(() => true)));
+
+  it("addresses the same key after a taskId appears", async () => {
+    // The hand-off path opens a card while the delegated turn is already
+    // registered. The key is minted once and does not move, so a row that
+    // acquires a taskId under the operator still cancels the same run.
+    render([delegation({ taskId: "t-99" })]);
+    click(cancelButton("Research the competitor pricing")!);
+    await settle();
+    expect(steerTask.mock.calls[0][2]).toBe("run_7f3c9a");
+  });
+});

--- a/frontend/test/unit/inflight-run-cancel.test.ts
+++ b/frontend/test/unit/inflight-run-cancel.test.ts
@@ -11,18 +11,9 @@ import type { InflightRun } from "@/api/tasks";
 /**
  * Cancelling a run that has no card.
  *
- * A `kind: "delegation"` run carries `taskId: null` — it is a sub-agent turn,
- * not a dispatched board card — and the only console surface that could stop
- * one was a strip on the retired `#/conversation` route. Every other control
- * over a run is reached through a card: the task detail screen resolves its
- * run with `runs.find((r) => r.taskId === taskId)`, which a null taskId can
- * never match, and it is only addressable at `#/tasks/<id>` in the first place.
- *
- * So the affordance was attached to the card while the steer API was already
- * keyed on the run: `POST …/tasks/{key}/steer` resolves `key` against the
- * in-flight registry, where a delegation's key is a synthetic run id. These
- * tests pin the control to that key, because reaching for `taskId` is exactly
- * the mistake that made a delegation uncancellable.
+ * A `kind: "delegation"` run carries `taskId: null`, and `POST …/tasks/{key}/steer`
+ * resolves `key` against the in-flight registry. These tests pin the control to
+ * that key: addressing a run by `taskId` cannot reach a delegation at all.
  */
 
 const toasts = vi.hoisted(() => ({

--- a/frontend/test/unit/inflight-run-surface.test.ts
+++ b/frontend/test/unit/inflight-run-surface.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { steerActionsFor, supportsSteerAction, type InflightRun } from "@/api/tasks";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
+
+const RUN: InflightRun = {
+  taskId: null,
+  key: "run_1",
+  kind: "delegation",
+  title: "t",
+  agentId: "a",
+  startedAt: 0,
+  pendingAction: null,
+};
+
+/**
+ * What a run supports is a property of the run.
+ *
+ * The host rejects `pause` and `redirect` on a delegation with `400 "this run
+ * only supports cancel"`. That rule lived inline on each surface as a
+ * `run.kind === "task"` branch, which is how it came to be spelled once per
+ * surface and enforced on none of them from a single place.
+ */
+describe("steer verbs are derived from the run", () => {
+  it("gives a delegation cancel and nothing else", () => {
+    expect(steerActionsFor(RUN)).toEqual(["cancel"]);
+    expect(supportsSteerAction(RUN, "cancel")).toBe(true);
+    expect(supportsSteerAction(RUN, "pause")).toBe(false);
+    expect(supportsSteerAction(RUN, "redirect")).toBe(false);
+  });
+
+  it("gives a dispatched card all three", () => {
+    const card: InflightRun = { ...RUN, kind: "task", taskId: "t-1", key: "t-1" };
+    expect([...steerActionsFor(card)].sort()).toEqual(["cancel", "pause", "redirect"]);
+  });
+
+  it("does not consult taskId", () => {
+    // A delegation that has acquired a card is still cancel-only, and a card
+    // run with a null taskId would still be a card run. `kind` is the axis.
+    expect(steerActionsFor({ ...RUN, taskId: "t-9" })).toEqual(["cancel"]);
+  });
+});
+
+/**
+ * The surface that carries the control.
+ *
+ * The retired `#/conversation` route held the only strip that listed runs by
+ * key; the Room that replaced it offered no control over a run at all. These
+ * pin the replacement to Room, and pin the shell to keeping the whole in-flight
+ * read rather than only its card-keyed projection — a delegation has no card,
+ * so that projection is precisely where it was being dropped.
+ */
+describe("the Room carries the in-flight control", () => {
+  const chatView = read("views/ChatView.tsx");
+  const appShell = read("components/app-shell.tsx");
+  const tasksApi = read("api/tasks.ts");
+
+  it("ChatView renders the in-flight bar", () => {
+    expect(chatView).toContain('import { InflightRunBar } from "./chat/InflightRunBar";');
+    expect(chatView).toContain("<InflightRunBar");
+  });
+
+  it("the bar is fed the runs and a refresh from the shell", () => {
+    expect(appShell).toContain("inflightRuns={inflightRuns}");
+    expect(appShell).toContain("onInflightSteered={refreshTaskStatuses}");
+  });
+
+  it("the shell keeps the in-flight rows, not only the card-keyed map", () => {
+    expect(appShell).toContain(
+      "const [inflightRuns, setInflightRuns] = useState<readonly InflightRun[]>([]);",
+    );
+    expect(appShell).toContain(
+      'if (inflight.status === "fulfilled") setInflightRuns(inflight.value);',
+    );
+  });
+
+  it("the shell drops in-flight rows when the company changes", () => {
+    // A steer key is company-scoped: a row surviving a switch would offer a
+    // cancel that addresses the previous company's registry.
+    const idx = appShell.indexOf("setTaskStatusByTaskId({});");
+    expect(idx).toBeGreaterThan(-1);
+    expect(appShell.slice(idx, idx + 400)).toContain("setInflightRuns([]);");
+  });
+
+  it("the card-keyed projection still says it cannot carry a cardless run", () => {
+    // `taskStatusesById` is allowed to drop them — it is a board decoration —
+    // but the contract has to be written down, because reading it as "what is
+    // running" is what left a delegation with no surface.
+    const idx = tasksApi.indexOf("export function taskStatusesById");
+    expect(tasksApi.slice(Math.max(0, idx - 400), idx)).toContain("Card-keyed");
+  });
+
+  it("does not reach back into the retired conversation surface", () => {
+    expect(chatView).not.toContain("views/conversation/");
+    expect(chatView).not.toContain("InflightStrip");
+  });
+});


### PR DESCRIPTION
## Summary

A **desk delegation** — an in-flight run with `taskId == null` and `kind: "delegation"` — had no cancel anywhere in the console. This adds one to Room, keyed on the run rather than on a card.

Closes #2058.

**Root cause.** Cancellation was never holed on its own; it was only ever *reachable* through a card. The steer API has always addressed a run by its `key` (`POST …/tasks/{key}/steer`), and every run in `GET …/tasks/inflight` has one. But the console reached that API by two card-shaped paths — `taskStatusesById`, which opens `if (!run.taskId) continue;`, and `TaskDetailView`, addressable only at `#/tasks/<id>` — so a run with no card fell through both. An affordance keyed to the wrong object.

The fix is at that seam: the shell keeps the in-flight rows whole alongside the card-keyed map, and `steerActionsFor(run)` derives the verbs a run supports from the run itself, mirroring the host's own rule.

**Why Room and not Observatory.** Observatory was the other candidate and cannot host this. It reads `ObservatoryRun` over GraphQL — a journal record with `id`/`agentId`/`workflowRunId` and **no `key`** — while `InflightRun` carries a `key` and **no run id**. There is no join between them, so an actionable Observatory would have to match on `agentId` plus a timestamp, which is the same "address the run by whatever is on hand" mistake this issue is about. A desk delegation also has no `workflowRunId`, and Observatory is addressed `#/observatory/<workflowRunId>`. Room is where the operator already is when a delegation starts, and it is the surface both producers announce themselves on.

**Sweep.** Every `taskId` gate over an in-flight run was checked. `taskStatusesById` is the only one that dropped a run, and it is correct as a board-decoration map — its doc now says so. `TaskDetailView`'s `runs.find(r => r.taskId === taskId)` and `TaskEditDialog`'s delete-block are per-card resolves and right as they stand. No sibling control (pause, redirect, retry, reassign) is holed: they already key on `run.key`/`run.kind`.

## API Or Behavior Changes

No host or wire changes — this is console-only, and every route it uses already existed.

- New: an in-flight bar above the composer in Room, listing the company's steerable runs and offering each the verbs it supports. Company-scoped, because a run carries no conversation id.
- `steerActionsFor` / `supportsSteerAction` are new exports from `api/tasks.ts`; a delegation offers `cancel` only, which mirrors the host answering `400 "this run only supports cancel"` to anything else.
- The shell now retains the raw in-flight rows. They are cleared on a company switch (a steer key is company-scoped) and are **not** emptied by a failed poll, so a transient error cannot take a running delegation's cancel with it.

**Worth knowing for review:** a settled delegation answers **404, never 409**. Its key is synthetic (`generate_id()`, or `approval:<id>`) and never a board id, so the 409 arm — which `delete_task` returns for a card that exists but is not running — cannot fire for one. The console treats both as "already finished" rather than as a failure, and requires `fromHost` so a proxy's own 404 still surfaces as an error.

## Tests

Two producers of a taskless delegation exist, and both were driven on a local host rather than reasoned about:

- **`run_hand_off`** (`src/runtime/delegation.rs`) via the `delegate_to_desk` / `delegate_to_teammate` tools — the ordinary orchestrator → desk path.
- **`redispatch_granted_call`** (`src/harness/built_in/brain.rs`) via an operator approving a parked gated call, which re-issues it under the key `approval:<id>`, titled `re-issue <tool>`.

Run state from the in-flight API and the journal, before and after, on a real host:

```
[16:51:42.141] BEFORE  [{"taskId":null,"key":"01a0682eba78-000000000039","kind":"delegation",
                         "title":"content","agentId":"writer","pendingAction":null}]
[16:51:42.258] STEER   HTTP 202
[16:51:42.304] DURING  [{… "pendingAction":"cancel"}]
[16:51:45.383] AFTER   []
events.jsonl  {"seq":22,"event":{"kind":"TaskSteered",
                "task_id":"01a0682eba78-000000000039","action":"cancel"}}
```

Producer B behaved identically under the key `approval:01a0682fc5ae-000000000040`.

Edge cases, all against the running host:

| Case | Result |
|---|---|
| Run settles while the cancel is in flight | `404 not_found` → reported as "already finished", not an error |
| Already-cancelled / unknown key | `404` |
| Key containing a colon (`approval:<id>`) | round-trips intact; `encodeURIComponent` at the call site |
| `cancel` without `confirm` | `400 cancel requires confirm: true` |
| `pause` / `redirect` on a delegation | `400 this run only supports cancel` — what `steerActionsFor` mirrors |
| Concurrent cancels on one run | both `202`; run leaves the registry once |
| Unauthenticated | `401` → surfaces as an error, not as "finished" |
| Zero / one / many in flight | no bar / one row / one row each with its own control |
| Card appears mid-run | the key is minted once and does not move; unit-pinned |
| Failed in-flight poll | rows retained, so a running delegation keeps its cancel |

Who may cancel: the route takes `ScopedCompany`, so any authenticated member of the company — and there is no agent tool for steering anywhere, so it stays operator-only.

**Red-proofed.** Both new suites were run against mutated pre-fix code and fail for the right reason, not merely fail:

- reinstating the card-keyed filter (`runs.filter(r => r.taskId)`) → 12 of 15 unit tests fail, leading with `offers Cancel for a run whose taskId is null: expected null not to be null`. The 3 that still pass are exactly the ones that should: the empty case and the two runs that *have* a `taskId`.
- addressing the card instead of the run (`run.taskId` for `run.key`) → exactly the 3 key-pinning tests fail, with `expected null to be 'run_7f3c9a'`.
- the same first mutation against the e2e spec → 4 of 5 fail; "nothing in flight draws no bar" correctly still passes.

Commands run locally, each unpiped with its own exit code:

- [x] `cargo fmt --all -- --check` — 0
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` — 0
- [x] `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings` — 0
- [x] `cargo check --all-features` — 0
- [x] `cargo build --features openhuman,mcp,composio` — 0
- [x] `npm run typecheck` / `typecheck:unit` / `typecheck:e2e` — 0
- [x] `npx vitest run` — 0, 4447 passed across 479 files
- [x] `npm run build` — 0
- [x] `npx playwright test inflight-cancel.spec.ts` against a local host — 5 passed

No Rust source changed, so `cargo test` was not re-run for this branch.

## Documentation

The behaviour is documented where it is decided rather than in a separate page: `steerActionsFor` states the host rule it mirrors, `taskStatusesById` now says outright that it is a board-decoration map and never the inventory of what is running, and `InflightRunBar` records why the runs arrive as a prop and why the bar is company-scoped. `views/chat/README.md` needed no change — the bar is a control inside the existing surface, not a new address.

**Note for the two drafts touching these files:** this lands small additive hunks in `app-shell.tsx` (in-flight state, and one prop pass to `ChatView`) and `ChatView.tsx` (a prop and one render slot above the composer). #2054 and #1998 overlap those regions and will need a rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-flight runs bar above the chat composer.
  * Users can view active tasks and delegations and cancel supported runs with confirmation.
  * Run status refreshes automatically after cancellation, with clear handling for completed runs and errors.
  * Cancellation controls remain available for runs without an associated card.

* **Bug Fixes**
  * Prevented duplicate cancellation requests during pending actions.
  * Ensured cancellation uses the run identifier consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->