### PR TITLE
fix(spec): report that an OpenHuman checkout is configured, not where it is

### DIFF
--- a/gitbooks/developers/cli.md
+++ b/gitbooks/developers/cli.md
@@ -26,7 +26,7 @@ opencompany serve --company companies/agentic_marketing_agency
 | `--company <DIR>` | A company to load at boot — a manifest file or a directory containing one. **Repeatable** for multi-company hosting. |
 | `--home <DIR>` | OpenCompany home holding company bundles (`<home>/companies/<slug>`). Falls back to `OPENCOMPANY_DATA_DIR`, then to `$HOME/.opencompany`. |
 | `--discoverable` | Opt every loaded company into going public on [tiny.place](../overview/tiny-place.md), regardless of each manifest's `[place].discoverable`. Needs the `tinyplace` feature to reach the network. |
-| `--openhuman-root <PATH>` | OpenHuman checkout to use. `/spec` reports whether one is configured, not where it is. |
+| `--openhuman-root <PATH>` | Records that an OpenHuman checkout is configured. Reporting only: `/spec` surfaces it as `openhuman_configured` (a boolean, never the path), and nothing else reads it — it does not choose a checkout to run. To launch one, see [`open-human`](#open-human), which takes its own `--root`. |
 
 ## `check`
 
@@ -52,8 +52,9 @@ opencompany doctor --json
 
 ## `spec`
 
-Print a JSON runtime specification. Accepts `--openhuman-root <PATH>`, reported as
-`openhuman_configured` rather than as a path.
+Print a JSON runtime specification. Accepts `--openhuman-root <PATH>`, which is
+reported as `openhuman_configured` — a boolean, never the path — and is not used
+to run anything.
 
 ## `issue-password`
 

--- a/gitbooks/developers/cli.md
+++ b/gitbooks/developers/cli.md
@@ -26,7 +26,7 @@ opencompany serve --company companies/agentic_marketing_agency
 | `--company <DIR>` | A company to load at boot — a manifest file or a directory containing one. **Repeatable** for multi-company hosting. |
 | `--home <DIR>` | OpenCompany home holding company bundles (`<home>/companies/<slug>`). Falls back to `OPENCOMPANY_DATA_DIR`, then to `$HOME/.opencompany`. |
 | `--discoverable` | Opt every loaded company into going public on [tiny.place](../overview/tiny-place.md), regardless of each manifest's `[place].discoverable`. Needs the `tinyplace` feature to reach the network. |
-| `--openhuman_root <PATH>` | Optional OpenHuman checkout path to report in `/spec`. |
+| `--openhuman-root <PATH>` | OpenHuman checkout to use. `/spec` reports whether one is configured, not where it is. |
 
 ## `check`
 
@@ -52,7 +52,8 @@ opencompany doctor --json
 
 ## `spec`
 
-Print a JSON runtime specification. Accepts `--openhuman_root <PATH>`.
+Print a JSON runtime specification. Accepts `--openhuman-root <PATH>`, reported as
+`openhuman_configured` rather than as a path.
 
 ## `issue-password`
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1142,11 +1142,7 @@ impl AppState {
                 "tiny",
             ],
             runtime_modules: RuntimeModuleStatus::all(),
-            openhuman_root: self
-                .config
-                .openhuman_root
-                .as_ref()
-                .map(|path| path.display().to_string()),
+            openhuman_configured: self.config.openhuman_root.is_some(),
             api_url: self.config.api_url.clone(),
             cycles_available: self.config.cycles_available(),
             instance_id: self.instance_id().to_string(),
@@ -1227,8 +1223,11 @@ pub struct AppSpec {
     pub modules: Vec<&'static str>,
     /// Runtime module integration status.
     pub runtime_modules: Vec<RuntimeModuleStatus>,
-    /// Configured OpenHuman checkout path, if any.
-    pub openhuman_root: Option<String>,
+    /// Whether an OpenHuman checkout is configured on this host.
+    ///
+    /// The bare fact, not the location: `/spec` is unauthenticated, so this
+    /// reports a checkout the same way [`Self::storage`] reports a backend.
+    pub openhuman_configured: bool,
     /// TinyHumans orchestration API base URL.
     pub api_url: String,
     /// Whether hosted cognition can run (hosted brain plus a credential this

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -22,7 +22,9 @@ use crate::{BUILD_COMMIT, VERSION, tiny::RuntimeModuleStatus};
 pub struct AppConfig {
     /// Address for the Axum HTTP server.
     pub bind: String,
-    /// Optional sibling OpenHuman checkout used by launcher commands.
+    /// Optional sibling OpenHuman checkout, recorded rather than used: `/spec`
+    /// reports whether one is set and nothing reads the path. `open-human`
+    /// launches a checkout, and takes its own `--root`.
     pub openhuman_root: Option<PathBuf>,
     /// TinyHumans orchestration API base URL.
     pub api_url: String,

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -32,7 +32,7 @@ enum Command {
         /// `bind` key of `config.toml`, then `127.0.0.1:8080`.
         #[arg(long)]
         bind: Option<String>,
-        /// Optional OpenHuman checkout path to report in `/spec`.
+        /// Optional OpenHuman checkout path. `/spec` reports only that one is set.
         #[arg(long)]
         openhuman_root: Option<PathBuf>,
         /// A company to load and register at boot (a manifest file or a
@@ -52,7 +52,7 @@ enum Command {
     },
     /// Print a JSON runtime specification.
     Spec {
-        /// Optional OpenHuman checkout path to report.
+        /// Optional OpenHuman checkout path. Reported as a boolean, not a path.
         #[arg(long)]
         openhuman_root: Option<PathBuf>,
     },

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -950,6 +950,81 @@ mod tests {
         assert!(!rendered.contains("mongodb://"), "no connection strings");
     }
 
+    /// Every string `/spec` serves must be a build fact. The previous test
+    /// pins the home path, but it builds its state from `AppConfig::default()`,
+    /// where every configurable path is `None` — so it asserts against fields
+    /// nothing populated. This one configures them.
+    #[tokio::test]
+    async fn spec_never_leaks_a_configured_host_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("sentinel-openhuman-checkout");
+        let state = AppState::new(AppConfig {
+            openhuman_root: Some(root.clone()),
+            ..AppConfig::default()
+        })
+        .with_home(dir.path().to_path_buf());
+
+        let rendered = spec_body(state).await.to_string();
+        assert!(
+            !rendered.contains("sentinel-openhuman-checkout"),
+            "a configured checkout path must not appear in /spec: {rendered}"
+        );
+        assert!(
+            !rendered.contains(&dir.path().display().to_string()),
+            "the home path must not appear in /spec: {rendered}"
+        );
+    }
+
+    /// Catches the *next* such field rather than this one: whatever `/spec`
+    /// grows, no value it serves may be an absolute filesystem path. The
+    /// fixture above can only assert about fields whoever wrote it knew to
+    /// populate; this holds for fields that do not exist yet.
+    #[tokio::test]
+    async fn spec_serves_no_absolute_path_in_any_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(AppConfig {
+            openhuman_root: Some(dir.path().join("checkout")),
+            instance_name: Some("prod-eu".to_string()),
+            ..AppConfig::default()
+        })
+        .with_home(dir.path().to_path_buf());
+
+        let mut offenders = Vec::new();
+        collect_absolute_paths(&spec_body(state).await, String::new(), &mut offenders);
+        assert!(
+            offenders.is_empty(),
+            "/spec serves deployment paths at {offenders:?}"
+        );
+    }
+
+    /// Walks a JSON value and records the location of every string that reads
+    /// as an absolute POSIX path.
+    fn collect_absolute_paths(value: &serde_json::Value, at: String, out: &mut Vec<String>) {
+        match value {
+            serde_json::Value::String(text) => {
+                if text.starts_with('/') {
+                    out.push(format!("{at} = {text}"));
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for (index, item) in items.iter().enumerate() {
+                    collect_absolute_paths(item, format!("{at}[{index}]"), out);
+                }
+            }
+            serde_json::Value::Object(fields) => {
+                for (key, field) in fields {
+                    let at = if at.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{at}.{key}")
+                    };
+                    collect_absolute_paths(field, at, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
     #[tokio::test]
     async fn spec_does_not_disclose_memory_engine_details() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -964,7 +964,13 @@ mod tests {
         })
         .with_home(dir.path().to_path_buf());
 
-        let rendered = spec_body(state).await.to_string();
+        let body = spec_body(state).await;
+        // The replacement contract, not just the absence: without this the test
+        // also passes on a host that dropped the field altogether, or that
+        // reports `false` while a checkout is configured.
+        assert_eq!(body["openhuman_configured"].as_bool(), Some(true));
+
+        let rendered = body.to_string();
         assert!(
             !rendered.contains("sentinel-openhuman-checkout"),
             "a configured checkout path must not appear in /spec: {rendered}"
@@ -973,6 +979,11 @@ mod tests {
             !rendered.contains(&dir.path().display().to_string()),
             "the home path must not appear in /spec: {rendered}"
         );
+
+        let unset =
+            spec_body(AppState::new(AppConfig::default()).with_home(dir.path().to_path_buf()))
+                .await;
+        assert_eq!(unset["openhuman_configured"].as_bool(), Some(false));
     }
 
     /// Catches the *next* such field rather than this one: whatever `/spec`
@@ -997,12 +1008,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn absolute_paths_are_recognised_on_both_platforms() {
+        for path in [
+            "/Users/someone/checkout",
+            "/data",
+            r"C:\checkout",
+            r"c:/checkout",
+            r"\\server\share",
+        ] {
+            assert!(is_absolute_path(path), "`{path}` is an absolute path");
+        }
+        for text in [
+            "vendor/openhuman",
+            "https://api.tinyhumans.ai",
+            "fs",
+            "prod-eu",
+            "",
+            "C:",
+            "Cx\\checkout",
+        ] {
+            assert!(!is_absolute_path(text), "`{text}` is not an absolute path");
+        }
+    }
+
+    /// Whether a string reads as an absolute filesystem path.
+    ///
+    /// Windows shapes as well as POSIX: this host builds for Windows, and a
+    /// guard that only knows `/` would pass while `/spec` served `C:\checkout`.
+    fn is_absolute_path(text: &str) -> bool {
+        if text.starts_with('/') || text.starts_with(r"\\") {
+            return true;
+        }
+        let mut chars = text.chars();
+        matches!(
+            (chars.next(), chars.next(), chars.next()),
+            (Some(drive), Some(':'), Some('\\' | '/')) if drive.is_ascii_alphabetic()
+        )
+    }
+
     /// Walks a JSON value and records the location of every string that reads
-    /// as an absolute POSIX path.
+    /// as an absolute filesystem path.
     fn collect_absolute_paths(value: &serde_json::Value, at: String, out: &mut Vec<String>) {
         match value {
             serde_json::Value::String(text) => {
-                if text.starts_with('/') {
+                if is_absolute_path(text) {
                     out.push(format!("{at} = {text}"));
                 }
             }


### PR DESCRIPTION
## Summary

`/spec` is unauthenticated, and it served the configured OpenHuman checkout path
verbatim. On any host started with `--openhuman-root`, an absolute path naming
the host account was readable with no credentials:

```
$ curl -s http://<host>/spec | jq -r .openhuman_root
/Users/<account>/…/vendor/openhuman
```

The field now reports the bare fact — `openhuman_configured: true|false` —
keeping the diagnostic signal ("is a checkout wired to this host?") without the
location. This is the shape the struct already uses next door: `storage` reports
a backend kind rather than a path or connection string, and `cycles_available`
is a boolean.

The struct's own documentation already drew this line. `build_commit`'s comment
distinguishes **build facts** (identical for every instance from an artifact)
from **deployment facts** ("the storage path two fields below, a connection
string, a data root") and admits only the former here. `openhuman_root` was the
second kind.

### Was it the only field of that shape?

Checked, and yes — today:

| Field | Verdict |
|---|---|
| `openhuman_root` | The only runtime-configured host path. Fixed. |
| `runtime_modules[].path` | `&'static str` compile-time constants, repo-relative (`vendor/openhuman`). Build fact. |
| `storage` | Backend kind only, already deliberate. |
| `instance_id` | Random, not derived from host state. |
| `display_name` | Operator-set, documented display-only. |
| `api_url` | A configured URL, and the one deployment fact kept: a client needs the orchestration endpoint to function, and it is a service address rather than host layout. Left as-is deliberately. |

`openhuman_root` is also the only path-typed field on `AppConfig` (of 18), so
nothing else currently reaches this surface.

Rather than rely on that list staying true, the second test below enforces the
rule structurally.

## API Or Behavior Changes

`/spec` replaces `openhuman_root: string | null` with
`openhuman_configured: boolean`. No in-repo consumer reads either — the console's
spec type reads only `setup_complete`, and there is no other reader in the
frontend, tests, or scripts.

The `--openhuman-root` flag is unchanged on both `serve` and `spec`; only what
the specification reports about it changed.

Also corrects a pre-existing error in the CLI reference, found while editing
those lines: it documented `--openhuman_root`, which clap rejects
(`error: unexpected argument '--openhuman_root' found`). The flag is
`--openhuman-root`.

## Tests

Two new tests in `src/server/routes.rs`. Both were confirmed **red against the
pre-fix code** before the change landed:

```
test spec_never_leaks_a_configured_host_path ... FAILED
test spec_serves_no_absolute_path_in_any_field ... FAILED
test result: FAILED. 5 passed; 2 failed
```

and green after it (`7 passed`).

The existing guard, `spec_never_leaks_the_storage_location`, passed throughout —
including against the unfixed code. It builds its state from
`AppConfig::default()`, where `openhuman_root` is `None`, so its assertion ran
against a field nothing had populated. Its comment states the intent this change
restores: *"`/spec` is unauthenticated. The backend kind is useful to a client; a
path or a connection string would be a gift to anyone who asks."*

- `spec_never_leaks_a_configured_host_path` — configures the path and asserts it
  is absent. Catches this regression.
- `spec_serves_no_absolute_path_in_any_field` — walks the whole response and
  rejects any string that reads as an absolute path, reporting the offending
  field by name. Catches the *next* such field without anyone remembering to
  extend a fixture. Run against the pre-fix code it names the offender exactly:
  `/spec serves deployment paths at ["openhuman_root = /var/folders/…/checkout"]`.

Verified on a running build, both paths that reach the field:

- `GET /spec` unauthenticated, host started with `--openhuman-root` →
  `"openhuman_configured": true`, and no absolute path anywhere in the response.
- `opencompany spec --openhuman-root /Users/…/secret-checkout` →
  `openhuman_configured = true`, payload contains neither `/Users/` nor
  `secret-checkout`.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (run as `--no-deps`, per the vendored-submodule convention; also green with `--features openhuman`)
- [x] `cargo build --all-targets`
- [x] `cargo test` — 4564 passed, 0 failed, 1 ignored
- [x] `cargo check --all-features`
- [x] Frontend unaffected and confirmed: `typecheck`, `typecheck:unit`, `typecheck:e2e`, `vitest run` (4423 passed), `build`

## Documentation

`gitbooks/developers/cli.md` — updated what `/spec` reports for the flag, and
corrected the flag spelling on both the `serve` table row and the `spec` section.
Flag help text in `src/bin/opencompany.rs` updated to match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Renamed the CLI option from `--openhuman_root` to `--openhuman-root` for consistency.
  - Updated `/spec` to report only whether an OpenHuman checkout is configured, rather than exposing its filesystem path.
  - Clarified that the option records configuration status and does not select a checkout to run.

- **Documentation**
  - Updated CLI help and developer documentation to describe the renamed option and boolean configuration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->