### PR TITLE
fix(tour): stop the overlay turning a click on the page into a navigation

### DIFF
--- a/frontend/src/tour/TourController.tsx
+++ b/frontend/src/tour/TourController.tsx
@@ -275,6 +275,18 @@ export function TourController({
               overlayColor: "rgba(0,0,0,0.45)",
               spotlightPadding: 6,
               arrowSize: 0,
+              // The overlay is a backdrop, not a control. Its default action is
+              // `close`, which under `continuous` advances the run — so a click
+              // anywhere on the dimmed page moved the tour on, and `before`
+              // then drove the console to the next stop's view. An operator
+              // clicking a card got the chat Room and no card.
+              //
+              // The element the tour points at stays interactive
+              // (`blockTargetInteraction` keeps its default): a step's target
+              // always belongs to the view that step is already on, so acting
+              // on it cannot navigate anywhere the tour did not intend, and the
+              // final stop invites typing into the composer it spotlights.
+              overlayClickAction: false,
               before,
             }}
           />

--- a/frontend/test/e2e/tour-overlay-click.spec.ts
+++ b/frontend/test/e2e/tour-overlay-click.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * A click on the dimmed page during the tour must not navigate.
+ *
+ * # The failure this reproduces
+ *
+ * react-joyride draws a full-page overlay with a cutout around the current
+ * stop's target, and its `overlayClickAction` defaults to `close` — which under
+ * `continuous` advances the run. So a click on anything outside the cutout hit
+ * the overlay rather than the element under it: the element's own handler never
+ * ran, the tour stepped forward, and `TourController`'s `before` hook drove the
+ * console to the next stop's view. The first stop is the Room, so an operator
+ * clicking a teammate on Company landed in `#/chat/main` with no teammate open.
+ *
+ * Captured from the running console on the parent commit — the click's own
+ * `composedPath` was:
+ *
+ *     path → svg[spotlight] → div.react-joyride__overlay → …
+ *
+ * It was reported twice, as a teammate card and as a workflow card, which is
+ * what one cause looks like from outside; the cards were never involved. Every
+ * clickable surface reached during a tour behaved this way, and a first-time
+ * operator meets the tour on their first visit to a company.
+ *
+ * # Why this is only a browser test
+ *
+ * The fix is one option on a prop, and a unit test asserting that option is set
+ * would be the same literal written twice — it would pass on a build where the
+ * prop never reached joyride. What must be true is that joyride *receives* the
+ * policy and stops treating its backdrop as a control, which only a real
+ * overlay in a real browser can answer. Same split `tour-completion-persists`
+ * describes for issue #1408.
+ *
+ * # Why the precondition assertion is not optional
+ *
+ * The first version of this spec passed against the broken build. The overlay's
+ * cutout moves with the stop's target and the roster reflows with the viewport,
+ * so at a smaller viewport the click landed on the page rather than on the
+ * overlay and the spec asserted nothing at all — green, for the wrong reason.
+ * `expectOverlayCovers` pins the condition the test needs to be exercising, so
+ * a layout change turns this into a failure rather than a silent pass. The
+ * viewport is fixed here for the same reason.
+ */
+
+test.use({ viewport: { width: 1400, height: 900 } });
+
+const TOUR_STOPS = 7;
+const WELCOME = "Welcome to your company";
+const TEAMMATE = "Chief Executive";
+
+function card(page: Page) {
+  return page.getByTestId("team-card").filter({ hasText: TEAMMATE }).first();
+}
+
+function opener(page: Page) {
+  return card(page).getByTestId("team-card-open");
+}
+
+/** The Company roster, rendered and ready to be clicked. */
+async function goToRoster(page: Page): Promise<void> {
+  // By address rather than by clicking the nav: during a tour the nav is under
+  // the overlay, which is the very thing under test.
+  await page.goto("/#/company");
+  await expect(opener(page)).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Assert joyride's overlay really is the topmost thing over the teammate card.
+ *
+ * Without this the click below can land on the page and prove nothing.
+ */
+async function expectOverlayCovers(page: Page): Promise<void> {
+  const box = await opener(page).boundingBox();
+  expect(box, "the card should have a box to click").not.toBeNull();
+  const covered = await page.evaluate(
+    ({ x, y }) => {
+      const at = document.elementFromPoint(x, y);
+      return {
+        overlay: Boolean(at?.closest(".react-joyride__overlay")),
+        actual: at ? at.tagName : "nothing",
+      };
+    },
+    { x: box!.x + box!.width / 2, y: box!.y + box!.height / 2 },
+  );
+  expect(
+    covered.overlay,
+    `the tour overlay must be over the card for this spec to exercise anything (found ${covered.actual})`,
+  ).toBe(true);
+}
+
+test("a click on the dimmed page neither moves the tour nor changes the address", async ({
+  page,
+}) => {
+  await page.goto("/#/company");
+  await page.getByRole("button", { name: "Take the tour" }).click();
+
+  const tooltip = page.getByRole("alertdialog");
+  await expect(tooltip.getByText(`Step 1 of ${TOUR_STOPS}`)).toBeVisible();
+
+  await goToRoster(page);
+  await expectOverlayCovers(page);
+
+  // `force` because the overlay is genuinely covering the card — that is the
+  // condition under test. The event still lands on whatever is topmost at those
+  // coordinates, which the assertion above has just proven is the overlay.
+  await opener(page).click({ force: true });
+
+  // Give a navigation the chance to happen before concluding none did.
+  await page.waitForTimeout(750);
+
+  await expect(page, "the overlay must not carry the click into the Room").not.toHaveURL(
+    /#\/chat\/main$/,
+  );
+  await expect(page, "the address must not move at all").toHaveURL(/#\/company$/);
+  await expect(
+    tooltip.getByText(`Step 1 of ${TOUR_STOPS}`),
+    "and the tour must not have stepped",
+  ).toBeVisible();
+});
+
+test("the tooltip's own Next still advances the tour", async ({ page }) => {
+  await page.goto("/#/company");
+  await page.getByRole("button", { name: "Take the tour" }).click();
+
+  const tooltip = page.getByRole("alertdialog");
+  await expect(tooltip.getByText(`Step 1 of ${TOUR_STOPS}`)).toBeVisible();
+  await page.waitForTimeout(250);
+  await tooltip.locator("button", { hasText: "Next" }).click();
+
+  await expect(
+    tooltip.getByText(`Step 2 of ${TOUR_STOPS}`),
+    "refusing the overlay's click must not disarm the tour's own controls",
+  ).toBeVisible();
+});
+
+test("with the tour dismissed the same card still opens the teammate", async ({ page }) => {
+  await page.goto("/#/company");
+  await page.getByText(WELCOME).waitFor();
+  await page.getByRole("button", { name: "Skip for now" }).click();
+
+  await goToRoster(page);
+  await opener(page).click();
+
+  await expect(page).toHaveURL(/#\/team\/ceo$/);
+  await expect(page.getByTestId("agent-name")).toHaveText(TEAMMATE);
+});


### PR DESCRIPTION
## Summary

During the guided tour, a click anywhere on the dimmed page was swallowed by
react-joyride's overlay and turned into a navigation the operator did not ask
for. Clicking a teammate card on Company opened the Room with no teammate; the
same click on a workflow card did the same thing. Both were reported as card
bugs. **The cards were never involved.**

react-joyride draws a full-page overlay with a cutout around the current stop's
target, and `overlayClickAction` defaults to `'close'` — which under
`continuous` advances the run. So the click hit the overlay rather than the
element under it, the element's own handler never ran, the tour stepped
forward, and `TourController`'s `before` hook drove the console to the *next
stop's* view. The first stop is the Room, which resolves to `#/chat/main` — the
destination both reports named.

Captured from the running console on the parent commit, the click's own
`composedPath`:

```
path → svg[spotlight] → div.react-joyride__overlay → …
```

and the address log for the same click: `#/company → #/chat/main`, with **no
`#/team/<id>` in between** — the card's navigation never happened at all.

### Blast radius

Not two cards. **Every clickable surface reached during a tour**, for **every
first-time operator** — the tour state is `localStorage` at
`oc-tour:<connection>::<company>`, so it runs once per person per company, on
their first visit. The two the walkthrough happened to find are the two it
happened to click.

The suite already carried the fingerprint: a dozen e2e specs defensively seed
`oc-tour:*` skip markers in `addInitScript` before they can interact with the
page at all.

## What changed

One option: `overlayClickAction: false`. The overlay is a backdrop, not a
control.

### The interaction model, and why this one

The page is **inert while the tour drives, except the element the tour is
pointing at.**

A tour that navigates the console on every step transition has to own the
address for its duration — otherwise the operator's navigation and the tour's
fight, and the tour wins on the next step. A half-live page is exactly the
inconsistency that produced this bug, so the fix is to make the backdrop
honestly inert rather than to teach it which clicks to forward.

The alternative — let clicks through and end the tour on the first real one —
was rejected: it makes every stray click a silent dismissal of the thing the
operator just chose to start, and it still has to answer what happens to the
in-flight step's navigation.

**`blockTargetInteraction` is deliberately left at its default**, so the
spotlit element stays clickable. A stop's target always belongs to the view
that stop is already on, so acting on it cannot navigate anywhere the tour did
not intend — and the last stop invites typing into the composer it spotlights
("Say hi to your company to get going"), which blocking would have made
impossible. Inert means *the backdrop*, not the thing being pointed at.

The tour's own controls are unaffected: Back, Next, Skip and Done all still
work, which the second test pins.

## API Or Behavior Changes

A click on the dimmed area during a tour now does nothing, where it previously
advanced the tour and navigated. No other console behaviour changes; outside a
tour there is no overlay and nothing here applies.

## Tests

`frontend/test/e2e/tour-overlay-click.spec.ts`, three cases. Browser-only, for
the reason `tour-completion-persists.spec.ts` gives about issue #1408: the fix
is one option on a prop, and a unit test asserting that option is set would be
the same literal written twice — it would pass on a build where the prop never
reached joyride. What has to be true is that joyride *receives* the policy.

**Red-proofed** against the parent commit, with the fix reverted and the console
rebuilt:

```
✘  a click on the dimmed page neither moves the tour nor changes the address
   Error: the overlay must not carry the click into the Room
     14 × unexpected value "http://127.0.0.1:12447/#/chat/main"
✓  the tooltip's own Next still advances the tour
✓  with the tour dismissed the same card still opens the teammate
1 failed, 2 passed
```

and `3 passed` with the fix. The two that pass either way are controls by
design — one proves the fix does not disarm the tour's own Next, the other that
it does not simply break the card.

### The first version of this spec passed on the broken build

Worth stating, because it is the failure the spec now defends against. The
overlay's cutout moves with the stop's target and the roster reflows with the
viewport, so at Playwright's default viewport the click landed on the page
instead of the overlay and the spec asserted nothing at all — green, for the
wrong reason, against code I had already reproduced the bug on by hand.

`expectOverlayCovers` now asserts, before clicking, that
`document.elementFromPoint` at the card's centre resolves inside
`.react-joyride__overlay`, and the viewport is fixed at 1400×900. A layout
change that moves the cutout turns this spec into a failure that names what it
found, rather than a silent pass.

### Verified on a running build

Host on `:8601` serving `companies/agentic_design_studio`, the company the
walkthrough used, driven in a real browser:

- Parent commit: card click → `#/company` → `#/chat/main`, tour steps 1 → 2,
  `composedPath` as quoted above.
- With the fix: same preconditions (`elementFromPoint` at the card resolves
  inside `.react-joyride__overlay`), card click → address stays `#/company`,
  tooltip stays "Step 1 of 7".
- Tooltip **Next** still advances → "Step 2 of 7" and `#/chat/main`, so the
  tour itself is intact.

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` — 478 files, 4431 tests passed
- [x] `npm run build`
- [x] `npx playwright test tour` — 8 passed (this spec plus
      `tour-completion-persists` and `tour-popover-in-viewport`, unaffected)

No Rust change, so the Rust gates are untouched by this branch.

## Documentation

None needed — no documented behaviour changes. The tour's stops, copy and
lifecycle are unchanged; only what its backdrop does with a click.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clicking the dimmed area outside the highlighted element during the guided tour no longer advances the tour or changes the displayed view.
  - Highlighted elements remain interactive when appropriate.
  - The tour’s **Next** button continues to advance normally.
  - After dismissing the tour, clicking a teammate card continues to open the teammate details.

- **Tests**
  - Added end-to-end coverage for tour overlay clicks, navigation behavior, and post-tour card interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->