### PR TITLE
fix(harness): stop promoting model reasoning into the visible reply, and four fixes found alongside it

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -102,7 +102,7 @@ import {
   dispatchMarkerPlacement,
   fromHistory,
   hostMessageId,
-  isGeneralChannel,
+  liveFrameThreadKey,
   liveReplyIdentity,
   MAIN_THREAD_ID,
   makeMessage,
@@ -2671,27 +2671,14 @@ export function AppShell({
     // when a frame carries no chatId (older host / background turn).
     const frameThreadId =
       ("chatId" in event && event.chatId) || activeTurnThreadRef.current;
-    // …then, for a General spelling ONLY, through `channelForThread`. The host
-    // folds the company-wide line under whatever casing the caller addressed,
-    // so an API client that posts to `General` has its frames emitted under
-    // that spelling while these maps are armed at the console's own General id.
-    // Rows written under a spelling no reader looks at are rows the operator
-    // never sees, which is the #1743 class of bug.
-    //
-    // Narrow to General **deliberately**. `channelForThread` maps a bare member
-    // id to the DM *channel* id (`dm:<id>`), but `dmThreadId` — what `ChatView`
-    // reads these maps by, and what `onSendStart` arms them under — stays the
-    // bare id for any teammate whose own id is not a General spelling. Routing
-    // every id through the map therefore moves DM live state to a key nothing
-    // reads. Worse, the map is built from the directory: if that loads between
-    // a `tool_call` and its `tool_result` the two resolve differently, the
-    // result lands in another bucket, and the call row stays `running` forever.
-    // So everything that is not a General alias stays in the host-thread
-    // namespace these maps are already keyed in (PR #2068 review).
-    const threadId =
-      frameThreadId && isGeneralChannel(frameThreadId)
-        ? (channelForThread(chatChannelByThreadRef.current, frameThreadId) ?? frameThreadId)
-        : frameThreadId;
+    // …then through the shared resolver, which normalizes General spellings and
+    // leaves every other id in the host-thread namespace these maps are keyed
+    // in. Its doc carries the reasoning for both halves and for why an
+    // unresolved General alias falls back to `MAIN_THREAD_ID` rather than to
+    // its own spelling.
+    const threadId = frameThreadId
+      ? liveFrameThreadKey(chatChannelByThreadRef.current, frameThreadId)
+      : frameThreadId;
     if (!threadId) {
       // No chat bubble to fold the frame into. A dispatched card raised from a
       // conversation now DOES stream — `run_steered_background` derives its

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -102,6 +102,7 @@ import {
   dispatchMarkerPlacement,
   fromHistory,
   hostMessageId,
+  isGeneralChannel,
   liveReplyIdentity,
   MAIN_THREAD_ID,
   makeMessage,
@@ -2670,23 +2671,27 @@ export function AppShell({
     // when a frame carries no chatId (older host / background turn).
     const frameThreadId =
       ("chatId" in event && event.chatId) || activeTurnThreadRef.current;
-    // …then through `channelForThread`, because the maps written below are keyed
-    // by **channel** while the frame names a **thread** (issue #1743). A bare
-    // index is the bug that doc warns about, and it silently ate every live
-    // step: the host folds the company-wide line under whatever casing the
-    // caller addressed and emits `chatId: "General"`, while `liveStepsByThread`
-    // is read at `GENERAL_CHANNEL` — `"general"`. Rows were written under a key
-    // no render site looks at, so the console showed a bare "Working…" spinner
-    // for the whole turn and the steps appeared only once the durable history
-    // folded them in. `agent_reply` resolves the same id the same way a few
-    // hundred lines up; this surface was simply missed.
+    // …then, for a General spelling ONLY, through `channelForThread`. The host
+    // folds the company-wide line under whatever casing the caller addressed,
+    // so an API client that posts to `General` has its frames emitted under
+    // that spelling while these maps are armed at the console's own General id.
+    // Rows written under a spelling no reader looks at are rows the operator
+    // never sees, which is the #1743 class of bug.
     //
-    // Unresolved ids keep the raw spelling rather than dropping the frame: the
-    // map is built from the desk list, so a frame arriving before that loads
-    // would otherwise be lost outright, which is worse than today's behaviour.
-    const threadId = frameThreadId
-      ? (channelForThread(chatChannelByThreadRef.current, frameThreadId) ?? frameThreadId)
-      : frameThreadId;
+    // Narrow to General **deliberately**. `channelForThread` maps a bare member
+    // id to the DM *channel* id (`dm:<id>`), but `dmThreadId` — what `ChatView`
+    // reads these maps by, and what `onSendStart` arms them under — stays the
+    // bare id for any teammate whose own id is not a General spelling. Routing
+    // every id through the map therefore moves DM live state to a key nothing
+    // reads. Worse, the map is built from the directory: if that loads between
+    // a `tool_call` and its `tool_result` the two resolve differently, the
+    // result lands in another bucket, and the call row stays `running` forever.
+    // So everything that is not a General alias stays in the host-thread
+    // namespace these maps are already keyed in (PR #2068 review).
+    const threadId =
+      frameThreadId && isGeneralChannel(frameThreadId)
+        ? (channelForThread(chatChannelByThreadRef.current, frameThreadId) ?? frameThreadId)
+        : frameThreadId;
     if (!threadId) {
       // No chat bubble to fold the frame into. A dispatched card raised from a
       // conversation now DOES stream — `run_steered_background` derives its

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -2668,13 +2668,35 @@ export function AppShell({
     // Route by the frame's own thread id so concurrent turns (even from the same
     // desk member) never cross-attribute; fall back to the in-flight ref only
     // when a frame carries no chatId (older host / background turn).
-    const threadId =
+    const frameThreadId =
       ("chatId" in event && event.chatId) || activeTurnThreadRef.current;
+    // …then through `channelForThread`, because the maps written below are keyed
+    // by **channel** while the frame names a **thread** (issue #1743). A bare
+    // index is the bug that doc warns about, and it silently ate every live
+    // step: the host folds the company-wide line under whatever casing the
+    // caller addressed and emits `chatId: "General"`, while `liveStepsByThread`
+    // is read at `GENERAL_CHANNEL` — `"general"`. Rows were written under a key
+    // no render site looks at, so the console showed a bare "Working…" spinner
+    // for the whole turn and the steps appeared only once the durable history
+    // folded them in. `agent_reply` resolves the same id the same way a few
+    // hundred lines up; this surface was simply missed.
+    //
+    // Unresolved ids keep the raw spelling rather than dropping the frame: the
+    // map is built from the desk list, so a frame arriving before that loads
+    // would otherwise be lost outright, which is worse than today's behaviour.
+    const threadId = frameThreadId
+      ? (channelForThread(chatChannelByThreadRef.current, frameThreadId) ?? frameThreadId)
+      : frameThreadId;
     if (!threadId) {
-      // No chat bubble to fold the frame into. A dispatched card streams
-      // nothing at all — `run_steered_background` runs with `LiveStream::Off` —
-      // so a chat-less frame here is a host emitting a shape this console does
-      // not render, and the Observatory's live re-read is instead driven by the
+      // No chat bubble to fold the frame into. A dispatched card raised from a
+      // conversation now DOES stream — `run_steered_background` derives its
+      // stream from the `origin_chat_id` the card carries — but it streams
+      // *keyed*, so those frames arrive with a `chatId` and take the branch
+      // above. What still reaches here is a card no conversation raised (a
+      // board-raised card, a cron tick): its chat id is absent or empty, the
+      // host resolves that to `LiveStream::Off`, and nothing is published. So a
+      // chat-less frame is a host emitting a shape this console does not
+      // render, and the Observatory's live re-read is instead driven by the
       // workflow node events in `onWorkflowRunEvent`.
       return;
     }

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -104,6 +104,7 @@ import {
   hostMessageId,
   liveFrameThreadKey,
   liveReplyIdentity,
+  replyVoice,
   MAIN_THREAD_ID,
   makeMessage,
   mergeHistoryInOrder,
@@ -2172,7 +2173,12 @@ export function AppShell({
           ...t,
           [channelId]: [
             ...existing,
-            makeMessage("company", event.text, {
+            // `replyVoice`, not a literal: a host-authored line (the
+            // iteration-cap pause) is projected with `agentId: "system"` and
+            // must render as the same centred row `fromHistory` gives it, or
+            // whoever watched the turn live keeps an agent-style bubble that
+            // hydration will never correct.
+            makeMessage(replyVoice(event.agentId), event.text, {
               channel: event.agentId,
               taskId: event.taskId,
               mentions: event.mentions,

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -89,6 +89,52 @@ export function generalAwareChannel(
   return key ? map[key] : null;
 }
 
+/**
+ * The key a live turn frame's rows are filed under, from the thread id the
+ * frame carries.
+ *
+ * The console's live-state maps — `liveStepsByThread`, `receiptByThread` — are
+ * keyed in the **host-thread** namespace: `ChatView` reads them by
+ * `dmThreadId(member)` and `onSendStart` arms them under that same id. So the
+ * default is to pass the frame's own id through untouched, and only General
+ * spellings are resolved.
+ *
+ * # Why General is the exception
+ *
+ * The host folds the company-wide line under whatever casing the caller
+ * addressed and echoes that spelling back, so an API client posting to
+ * `General` has its frames emitted under `General` while the console armed
+ * these maps at the built-in channel's id — `MAIN_THREAD_ID`, since
+ * `generalChannel` is `{ id: MAIN_THREAD_ID, name: GENERAL_CHANNEL }`. Rows
+ * written under a spelling no reader looks at are rows the operator never sees
+ * (issue #1743).
+ *
+ * # Why nothing else is
+ *
+ * {@link generalAwareChannel} answers a bare member id with the DM *channel*
+ * id, `dm:<id>` — but `dmThreadId` stays the bare id for any teammate whose own
+ * id is not a General spelling, so routing every id through the map moves DM
+ * live state to a key nothing reads (PR #2068 review).
+ *
+ * # Why the fallback is `MAIN_THREAD_ID` and not the raw alias
+ *
+ * The map is built from the desk list, so it is empty until that loads. Falling
+ * back to the alias made this resolver *unstable across a turn*: a `tool_call`
+ * arriving before the desks landed keyed `General`, its `tool_result` after
+ * keyed `main`, and since a result whose call is not in its bucket is dropped,
+ * the call row stayed `running` for good in a bucket nothing renders (CodeRabbit
+ * on #2068). `MAIN_THREAD_ID` is the built-in General channel's own id, so it is
+ * both the stable answer and the one the map itself returns for an ordinary
+ * company — the two agree, and the transition stops mattering.
+ */
+export function liveFrameThreadKey(
+  map: Readonly<Record<string, string>>,
+  frameThreadId: string,
+): string {
+  if (!isGeneralChannel(frameThreadId)) return frameThreadId;
+  return generalAwareChannel(map, frameThreadId) ?? MAIN_THREAD_ID;
+}
+
 /** One person's reaction on one line. Mirrors `ChatReactionDto` on the host. */
 export interface Reaction {
   emoji: string;

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -135,6 +135,35 @@ export function liveFrameThreadKey(
   return generalAwareChannel(map, frameThreadId) ?? MAIN_THREAD_ID;
 }
 
+/**
+ * The author the host projects for a line it wrote itself, rather than one an
+ * agent spoke. Mirrors `crate::ports::SYSTEM_AUTHOR`.
+ */
+export const SYSTEM_AUTHOR = "system";
+
+/**
+ * Whose voice a company-side reply is in, from the author the host attributed
+ * it to.
+ *
+ * A host-authored line — the iteration-cap pause, a spend halt — is neither
+ * yours nor an agent's, and renders as a centred pill instead of a bubble.
+ * {@link fromHistory} has always applied that rule, but the **live** renderers
+ * did not: both built a `company` message unconditionally and used the author
+ * only as the channel. So a host line rendered as an agent bubble while the
+ * turn was watched, and as a system row for anyone who loaded the transcript
+ * afterwards — and `mergeHistoryInOrder` keeps the existing live object for a
+ * matching durable id, so hydration never corrected the first view. Two
+ * operators, two different readings of one settled turn, permanently (Codex
+ * review on #2068).
+ *
+ * Exported so the live path, the synchronous POST path and history all decide
+ * it the same way; the divergence existed because each of them decided it
+ * separately.
+ */
+export function replyVoice(author: string | undefined | null): "company" | "system" {
+  return author === SYSTEM_AUTHOR ? "system" : "company";
+}
+
 /** One person's reaction on one line. Mirrors `ChatReactionDto` on the host. */
 export interface Reaction {
   emoji: string;
@@ -483,7 +512,7 @@ export function fromHistory(entries: ChatHistoryMessageDto[]): ChatMessage[] {
     // so without this check a rehydrated marker came back as a company message
     // and a settle read like something an agent had said.
     const from: ChatMessage["from"] =
-      entry.author === "system" ? "system" : entry.mine ? "you" : "company";
+      entry.author === SYSTEM_AUTHOR ? "system" : entry.mine ? "you" : "company";
     return {
       id: hostMessageId(entry.id),
       from,

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -2201,6 +2201,10 @@ export function ChatView({
 
   const parent = openThreadId ? messages.find((m) => m.id === openThreadId) : undefined;
   const threadReplies = parent ? repliesInThread(parent, messages) : [];
+  // Asked of `buildTimeline`'s own rule rather than re-derived, for the reason
+  // the mention map above gives: the panel's count and the channel's chip must
+  // not drift about what is already on screen. See `ThreadPanel`'s prop docs.
+  const threadInlineReplyIds = parent ? inlineReplyIds(messages) : undefined;
   // Every review surface this thread hangs off, newest first — the thread
   // root itself when opened directly on the pill/relay, or one of its
   // replies when the card that produced them was sent inside an
@@ -2546,6 +2550,7 @@ export function ChatView({
               members={members}
               parent={parent}
               replies={threadReplies}
+              inlineReplyIds={threadInlineReplyIds}
               sending={sending}
               mentionables={mentionables}
               channelMemberIds={inChannel?.map((m) => m.id)}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -41,6 +41,7 @@ import {
   isGeneralChannel,
   makeMessage,
   reconcileIds,
+  replyVoice,
   toHostMessageId,
   type ChatMessage,
 } from "@/lib/chat";
@@ -1755,7 +1756,9 @@ export function ChatView({
       const reply = answer;
       const replies = reply.responses.length
         ? reply.responses.map((r) =>
-            makeMessage("company", r.text, {
+            // Same rule as the live path and `fromHistory`: a host-authored
+            // response renders as a centred row, not an agent bubble.
+            makeMessage(replyVoice(r.channel), r.text, {
               channel: r.channel,
               parentId,
               steps: r.steps,

--- a/frontend/src/views/chat/ThreadPanel.tsx
+++ b/frontend/src/views/chat/ThreadPanel.tsx
@@ -27,6 +27,27 @@ interface Props {
   /** The message the thread hangs off. */
   parent: ChatMessage;
   replies: ChatMessage[];
+  /**
+   * The subset of `replies` already laid out inline in the channel, from
+   * {@link inlineReplyIds} — excluded from the count above the list, never
+   * from the list itself.
+   *
+   * The two are different questions and were being answered by one number.
+   * The channel's chip counts what is left to open (`buildTimeline` filters
+   * the promoted reply out of `replies`, deliberately: "a reader seeing the
+   * answer must not be told there is one more thing to open"), while this
+   * panel counted every descendant `repliesInThread` walked to. A capped turn
+   * emits two replies — the agent's write-up and the host's pause notice — so
+   * the chip said "1 reply", the header said "2 replies", and the same thread
+   * reported two sizes on screen at once.
+   *
+   * Counting the same set the chip counts settles that. The promoted reply
+   * still *renders* here, because the notice under it opens "The reply above
+   * is a pause" — drop the reply above and that sentence points at nothing.
+   * Shown but not counted is the honest reading: it is context the reader has
+   * already seen in the channel, not a further thing to open.
+   */
+  inlineReplyIds?: ReadonlySet<string>;
   sending: boolean;
   /**
    * Everything an `@` can name here (issue #1645). Drawn from the parent
@@ -184,6 +205,7 @@ export function ThreadPanel({
   members,
   parent,
   replies,
+  inlineReplyIds,
   sending,
   mentionables,
   channelMemberIds,
@@ -206,6 +228,12 @@ export function ThreadPanel({
   redeemingBudgetPauseAgent,
   latestBudgetPauseMessageIdByAgent,
 }: Props) {
+  // Absent `inlineReplyIds` counts everything, which is what every caller did
+  // before the prop existed: a panel that cannot know what the channel
+  // promoted must not silently under-count.
+  const countedReplies = inlineReplyIds
+    ? replies.reduce((n, r) => (inlineReplyIds.has(r.id) ? n : n + 1), 0)
+    : replies.length;
   return (
     <aside className="flex w-96 shrink-0 flex-col border-l bg-background">
       <header className="flex h-13 shrink-0 items-center gap-2 border-b px-3">
@@ -232,7 +260,7 @@ export function ThreadPanel({
         />
         <div className="flex items-center gap-2 px-4 py-2">
           <span className="text-xs font-medium text-muted-foreground">
-            {replies.length} {replies.length === 1 ? "reply" : "replies"}
+            {countedReplies} {countedReplies === 1 ? "reply" : "replies"}
           </span>
           <span className="h-px flex-1 bg-border" aria-hidden />
         </div>

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -1246,6 +1246,32 @@ function inlineFirstReplies(
     // the orphan arm above is about a root this transcript never held, not
     // about relaxing the depth rule.
     if (!roots.has(rootId)) continue;
+    // **One turn's output is not promoted apart.**
+    //
+    // Promotion is safe because it *empties* the chip — `own` below drops what
+    // was promoted, so a lone answer renders inline, no chip appears, and the
+    // thread is never opened. The message lives on exactly one surface. That is
+    // the case #1890 D / #1972 / #2001 built this for, and it still holds when
+    // the rest of the bucket is the operator writing again: their follow-up is
+    // a separate act, and the answer they were waiting for belongs in the
+    // channel.
+    //
+    // A capped turn is not that. It emits the agent's partial write-up and then
+    // the host's `iteration_cap_pause_notice`, both parented to the same
+    // operator message, and promoting only the first splits one turn's output
+    // across two surfaces: the write-up renders inline *and* in the panel,
+    // because `repliesInThread` walks the parent chain and knows nothing of
+    // what was promoted. Dropping it from the panel instead is not open to us —
+    // the notice under it opens "The reply above is a pause", and there has to
+    // be a reply above.
+    //
+    // So promotion stops at the boundary it was always about: a lone answer.
+    // When the runtime spoke more than once, the whole turn stays folded and
+    // the chip says so.
+    const runtimeReplies = bucket.filter(
+      (r) => (r.from === "company" && !r.byPerson) || r.from === "system",
+    );
+    if (runtimeReplies.length > 1) continue;
     const root = position.get(rootId);
     const first = bucket[0];
     // **Only the runtime's own answer is ever promoted** (codex on #1972).

--- a/frontend/test/unit/chat-thread-reply-count.test.ts
+++ b/frontend/test/unit/chat-thread-reply-count.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ChatMessage } from "@/lib/chat";
+import type { TeamMember } from "@/lib/team";
+import { ThreadPanel } from "@/views/chat/ThreadPanel";
+import { buildTimeline, inlineReplyIds, type Channel } from "@/views/chat/model";
+
+/**
+ * One capped turn, rendered once.
+ *
+ * A turn that runs out of steps emits two replies parented to the operator's
+ * message — the agent's partial write-up, then the host's
+ * `iteration_cap_pause_notice`. Promoting the first inline broke three things
+ * at once, all measured on a real turn:
+ *
+ *   * the write-up rendered inline **and** in the panel, because
+ *     `repliesInThread` walks the parent chain and knows nothing of what was
+ *     promoted — one message, two surfaces;
+ *   * the chip counted 1 (promoted filtered out) while the panel counted 2
+ *     (nothing filtered), so one thread reported two sizes at once;
+ *   * and the panel could not drop the promoted reply to fix either, because
+ *     the notice beneath it opens "The reply above is a pause".
+ *
+ * Both halves are fixed here: promotion stops when the runtime spoke more than
+ * once, so nothing is split across surfaces, and the panel counts the same set
+ * the chip does, so the two can never disagree again.
+ */
+
+const CHANNEL: Channel = {
+  id: "engineering",
+  name: "engineering",
+  voice: "Engineering",
+  kind: "channel",
+  purpose: "",
+};
+
+const MEMBERS: TeamMember[] = [];
+
+const ROOT: ChatMessage = { id: "p", from: "you", text: "group the issues", at: 0 };
+/** The agent's partial write-up. */
+const WRITE_UP: ChatMessage = {
+  id: "r1",
+  parentId: "p",
+  from: "company",
+  text: "here is what I have so far",
+  at: 1,
+};
+/** The host's pause notice — `SYSTEM_AUTHOR` projects to `from: "system"`. */
+const PAUSE: ChatMessage = {
+  id: "r2",
+  parentId: "p",
+  from: "system",
+  text: "The reply above is a pause, not a finished answer",
+  at: 2,
+};
+
+const CAPPED_TURN = [ROOT, WRITE_UP, PAUSE];
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function render(over: Partial<Parameters<typeof ThreadPanel>[0]> = {}) {
+  await act(async () => {
+    root.render(
+      createElement(ThreadPanel, {
+        channel: CHANNEL,
+        members: MEMBERS,
+        parent: ROOT,
+        replies: [WRITE_UP, PAUSE],
+        sending: false,
+        onSend: vi.fn(),
+        onClose: vi.fn(),
+        ...over,
+      }),
+    );
+  });
+}
+
+describe("a capped turn's two replies", () => {
+  it("promotes neither, so no message renders on two surfaces", () => {
+    const entries = buildTimeline(CAPPED_TURN, CHANNEL, MEMBERS);
+
+    // Only the root is laid out in the channel — the write-up is not also
+    // inline, so opening the thread cannot show it a second time.
+    expect(entries.map((e) => e.message.id)).toEqual(["p"]);
+    expect(inlineReplyIds(CAPPED_TURN).size).toBe(0);
+  });
+
+  it("counts the same thread size on the chip and in the panel", async () => {
+    const entries = buildTimeline(CAPPED_TURN, CHANNEL, MEMBERS);
+    const chip = entries.find((e) => e.message.id === "p")?.replies ?? [];
+    expect(chip.map((r) => r.id)).toEqual(["r1", "r2"]);
+
+    await render({ inlineReplyIds: inlineReplyIds(CAPPED_TURN) });
+
+    expect(container.textContent).toContain(`${chip.length} replies`);
+  });
+
+  it("keeps the notice's referent, so 'the reply above' has one", async () => {
+    await render({ inlineReplyIds: inlineReplyIds(CAPPED_TURN) });
+
+    expect(container.textContent).toContain("here is what I have so far");
+    expect(container.textContent).toContain("The reply above is a pause");
+  });
+});
+
+describe("the panel's count", () => {
+  /**
+   * The operator writing again is not the runtime speaking twice, so the lone
+   * answer is still promoted — and the panel must then leave it out of the
+   * count, or the chip ("1 reply", promoted filtered) and the panel would
+   * disagree exactly as they did before.
+   */
+  it("excludes a promoted reply, matching the chip", async () => {
+    const followUp: ChatMessage = { id: "r2", parentId: "p", from: "you", text: "and by when?", at: 2 };
+    const messages = [ROOT, WRITE_UP, followUp];
+
+    const entries = buildTimeline(messages, CHANNEL, MEMBERS);
+    const chip = entries.find((e) => e.message.id === "p")?.replies ?? [];
+    // The answer went inline; only the operator's own follow-up is left to open.
+    expect(chip.map((r) => r.id)).toEqual(["r2"]);
+
+    await render({ replies: [WRITE_UP, followUp], inlineReplyIds: inlineReplyIds(messages) });
+
+    expect(container.textContent).toContain(`${chip.length} reply`);
+    expect(container.textContent).not.toContain("2 replies");
+  });
+
+  it("counts every reply when the caller cannot say what was promoted", async () => {
+    // No `inlineReplyIds`: a panel that does not know what the channel showed
+    // must not silently under-count. This is what every caller did before the
+    // prop existed.
+    await render();
+
+    expect(container.textContent).toContain("2 replies");
+  });
+});

--- a/frontend/test/unit/live-frame-thread-key.test.ts
+++ b/frontend/test/unit/live-frame-thread-key.test.ts
@@ -1,58 +1,66 @@
 import { describe, expect, it } from "vitest";
 
-import { isGeneralChannel } from "@/lib/chat";
-import { channelForThread, dmThreadId } from "@/views/chat/model";
+import { liveFrameThreadKey, MAIN_THREAD_ID } from "@/lib/chat";
+import { dmThreadId } from "@/views/chat/model";
 import type { TeamMember } from "@/lib/team";
 
 /**
- * Which spellings a live turn frame's thread id may be rewritten through
- * before it keys `liveStepsByThread` / `receiptByThread`.
+ * Which spellings a live turn frame's thread id is rewritten through before it
+ * keys `liveStepsByThread` / `receiptByThread`.
  *
- * `onTurnEvent` normalizes **General aliases only**. The reason it normalizes
- * at all: the host folds the company-wide line under whatever casing the
- * caller addressed, so a client posting to `General` has its frames emitted
- * under that spelling while the console armed these maps at its own General
- * id — rows written where no reader looks (issue #1743).
- *
- * The reason it stops there is this file. These maps are keyed in the
- * **host-thread** namespace: `ChatView` reads them by `dmThreadId(member)` and
- * `onSendStart` arms them under that same id, which for an ordinary teammate
- * is the bare member id. `channelForThread` answers with the DM *channel* id,
- * `dm:<id>` — a different string. Routing every id through the map moves DM
- * live state to a key nothing reads (PR #2068 review).
+ * Calls the production resolver, not a copy of its conditional — a duplicated
+ * rule here would keep passing through a regression in the one `onTurnEvent`
+ * actually uses (CodeRabbit on #2068).
  */
 
 const ADA: TeamMember = { id: "ada", name: "Ada" } as TeamMember;
 
-/** The shell's thread → channel map, as `channelMap` builds it for one DM. */
-const MAP: Record<string, string> = { ada: "dm:ada", "": "general", main: "general" };
-
-/** The rule `onTurnEvent` applies, isolated from the React shell. */
-const keyFor = (frameThreadId: string): string =>
-  isGeneralChannel(frameThreadId) ? (channelForThread(MAP, frameThreadId) ?? frameThreadId) : frameThreadId;
+/** The shell's thread → channel map once the desk list has landed. */
+const LOADED: Record<string, string> = {
+  ada: "dm:ada",
+  "": MAIN_THREAD_ID,
+  [MAIN_THREAD_ID]: MAIN_THREAD_ID,
+};
 
 describe("a live frame's thread key", () => {
   it("leaves a teammate DM in the host-thread namespace the readers use", () => {
     // The identity `ChatView` reads by and `onSendStart` arms under.
     expect(dmThreadId(ADA)).toBe("ada");
-    // So the frame must key the same way — not `dm:ada`, which the map answers
-    // with and which no reader or receipt lookup ever asks for.
-    expect(keyFor("ada")).toBe("ada");
-    expect(keyFor("ada")).toBe(dmThreadId(ADA));
-    expect(channelForThread(MAP, "ada")).toBe("dm:ada");
+    // So the frame keys the same way — not `dm:ada`, which the map answers with
+    // and which no render or receipt lookup ever asks for.
+    expect(liveFrameThreadKey(LOADED, "ada")).toBe(dmThreadId(ADA));
+    expect(LOADED["ada"]).toBe("dm:ada");
   });
 
-  it("resolves a General alias, whatever casing the caller addressed", () => {
-    expect(keyFor("main")).toBe("general");
-    expect(keyFor("")).toBe("general");
+  it("resolves a General alias whatever casing the caller addressed", () => {
+    // The host echoes the caller's spelling; all of them are the same line, and
+    // the console armed its maps at the built-in channel's id.
+    for (const spelling of ["", "main", "General", "general"]) {
+      expect(liveFrameThreadKey(LOADED, spelling)).toBe(MAIN_THREAD_ID);
+    }
   });
 
-  it("keys a call and its result identically even if the directory loads between them", () => {
-    // The map is built from the directory, so it can fill in mid-turn. A DM id
-    // is never routed through it, so both frames land in one bucket and the
-    // row flips `running → ok` instead of hanging.
-    const beforeDirectory = ((id: string) =>
-      isGeneralChannel(id) ? (channelForThread({}, id) ?? id) : id)("ada");
-    expect(beforeDirectory).toBe(keyFor("ada"));
+  it("keys a General alias identically before and after the desks load", () => {
+    // The regression this pins: the map is empty until `/desks` lands, so a
+    // `tool_call` could key one way and its `tool_result` another. A result
+    // whose call is not in its bucket is dropped, so the call row would stay
+    // `running` for good — in a bucket nothing renders.
+    const beforeDesks = liveFrameThreadKey({}, "General");
+    const afterDesks = liveFrameThreadKey(LOADED, "General");
+
+    expect(beforeDesks).toBe(afterDesks);
+    expect(beforeDesks).toBe(MAIN_THREAD_ID);
+  });
+
+  it("keys a DM identically before and after the desks load, too", () => {
+    expect(liveFrameThreadKey({}, "ada")).toBe(liveFrameThreadKey(LOADED, "ada"));
+  });
+
+  it("honours a blueprint desk that owns the General line", () => {
+    // A company declaring `[[group_chat]] id = "general"` keeps its own desk,
+    // and the map is the only thing that knows. Resolution must defer to it
+    // rather than assume the built-in channel.
+    const blueprint = { ...LOADED, [MAIN_THREAD_ID]: "growth" };
+    expect(liveFrameThreadKey(blueprint, "General")).toBe("growth");
   });
 });

--- a/frontend/test/unit/live-frame-thread-key.test.ts
+++ b/frontend/test/unit/live-frame-thread-key.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { isGeneralChannel } from "@/lib/chat";
+import { channelForThread, dmThreadId } from "@/views/chat/model";
+import type { TeamMember } from "@/lib/team";
+
+/**
+ * Which spellings a live turn frame's thread id may be rewritten through
+ * before it keys `liveStepsByThread` / `receiptByThread`.
+ *
+ * `onTurnEvent` normalizes **General aliases only**. The reason it normalizes
+ * at all: the host folds the company-wide line under whatever casing the
+ * caller addressed, so a client posting to `General` has its frames emitted
+ * under that spelling while the console armed these maps at its own General
+ * id — rows written where no reader looks (issue #1743).
+ *
+ * The reason it stops there is this file. These maps are keyed in the
+ * **host-thread** namespace: `ChatView` reads them by `dmThreadId(member)` and
+ * `onSendStart` arms them under that same id, which for an ordinary teammate
+ * is the bare member id. `channelForThread` answers with the DM *channel* id,
+ * `dm:<id>` — a different string. Routing every id through the map moves DM
+ * live state to a key nothing reads (PR #2068 review).
+ */
+
+const ADA: TeamMember = { id: "ada", name: "Ada" } as TeamMember;
+
+/** The shell's thread → channel map, as `channelMap` builds it for one DM. */
+const MAP: Record<string, string> = { ada: "dm:ada", "": "general", main: "general" };
+
+/** The rule `onTurnEvent` applies, isolated from the React shell. */
+const keyFor = (frameThreadId: string): string =>
+  isGeneralChannel(frameThreadId) ? (channelForThread(MAP, frameThreadId) ?? frameThreadId) : frameThreadId;
+
+describe("a live frame's thread key", () => {
+  it("leaves a teammate DM in the host-thread namespace the readers use", () => {
+    // The identity `ChatView` reads by and `onSendStart` arms under.
+    expect(dmThreadId(ADA)).toBe("ada");
+    // So the frame must key the same way — not `dm:ada`, which the map answers
+    // with and which no reader or receipt lookup ever asks for.
+    expect(keyFor("ada")).toBe("ada");
+    expect(keyFor("ada")).toBe(dmThreadId(ADA));
+    expect(channelForThread(MAP, "ada")).toBe("dm:ada");
+  });
+
+  it("resolves a General alias, whatever casing the caller addressed", () => {
+    expect(keyFor("main")).toBe("general");
+    expect(keyFor("")).toBe("general");
+  });
+
+  it("keys a call and its result identically even if the directory loads between them", () => {
+    // The map is built from the directory, so it can fill in mid-turn. A DM id
+    // is never routed through it, so both frames land in one bucket and the
+    // row flips `running → ok` instead of hanging.
+    const beforeDirectory = ((id: string) =>
+      isGeneralChannel(id) ? (channelForThread({}, id) ?? id) : id)("ada");
+    expect(beforeDirectory).toBe(keyFor("ada"));
+  });
+});

--- a/frontend/test/unit/system-author-reply-voice.test.ts
+++ b/frontend/test/unit/system-author-reply-voice.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { fromHistory, replyVoice, SYSTEM_AUTHOR } from "@/lib/chat";
+import type { ChatHistoryEntry } from "@/api/types";
+
+/**
+ * One settled turn must read the same whether you watched it or loaded it.
+ *
+ * A capped turn posts two lines: the agent's partial write-up, then the host's
+ * pause notice. The notice is authored `SYSTEM_AUTHOR`, so `fromHistory` gives
+ * it `from: "system"` — a centred pill, not an agent bubble.
+ *
+ * The live renderers used to build a `company` message unconditionally and pass
+ * the author through only as the channel. Because `mergeHistoryInOrder` keeps
+ * the existing live object for a matching durable id, that first impression was
+ * never corrected: whoever watched the turn kept an agent-style System bubble
+ * forever, while whoever opened the transcript later saw the intended system
+ * row. Two readings of one turn — the same "who actually said this" confusion
+ * the pause-attribution fix set out to remove (Codex review on #2068).
+ */
+
+const entry = (author: string): ChatHistoryEntry =>
+  ({
+    id: "7",
+    author,
+    text: "The reply above is a pause, not a finished answer",
+    atMillis: 1,
+    mine: false,
+  }) as ChatHistoryEntry;
+
+describe("a host-authored reply", () => {
+  it("is a system row live, exactly as it is after a reload", () => {
+    // What the reload has always done.
+    expect(fromHistory([entry(SYSTEM_AUTHOR)])[0].from).toBe("system");
+    // What the live renderers now do with the same author.
+    expect(replyVoice(SYSTEM_AUTHOR)).toBe("system");
+    expect(replyVoice(SYSTEM_AUTHOR)).toBe(fromHistory([entry(SYSTEM_AUTHOR)])[0].from);
+  });
+
+  it("leaves an agent's own reply in the company voice", () => {
+    expect(replyVoice("product_manager")).toBe("company");
+    expect(fromHistory([entry("product_manager")])[0].from).toBe("company");
+  });
+
+  it("treats an unattributed reply as the company, not the host", () => {
+    // The frame omits `agentId` for a turn that named no responder. That is an
+    // agent bubble with no name on it, never a host line — reading absence as
+    // `system` would turn every unattributed reply into a centred pill.
+    expect(replyVoice(undefined)).toBe("company");
+    expect(replyVoice(null)).toBe("company");
+    expect(replyVoice("")).toBe("company");
+  });
+});

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -78,15 +78,44 @@ const CARD_VANISHED: &str = "the card was gone by the time its dispatch ran";
 /// rebuilds the agent whenever the roster / skill / MCP fingerprint moves — so
 /// "continue" is an instruction to the operator, phrased as a request to the
 /// agent, never a durability guarantee this layer cannot make.
-pub(crate) const ITERATION_CAP_PAUSE_NOTICE: &str = "\
-The reply above is a pause, not a finished answer: this turn reached the maximum number of steps \
-it may take for a single reply, so it stopped and wrote up where it had got to. Nothing errored — \
-the work so far stands. Reply \"continue\" to ask it to pick up from there.";
+///
+/// # Who it names, and who it is *from*
+///
+/// It **names the responder**, exactly as [`spend_halt_notice`] names the
+/// teammate whose budget ran out. That sibling's docs say naming the teammate
+/// is what makes a stop "attributable in a way a bare cap is not", and the same
+/// applies here: "this turn" told the operator a turn had capped without
+/// saying whose, which on a delegating orchestrator is the one thing they need
+/// to know. The objection recorded there is to quoting a *number* — one bubble
+/// can cover a responder, a desk and a relay turn, so a single cap figure maps
+/// back to nothing — and that objection is about the figure, not the name.
+///
+/// It is **from the system**, not from the agent it names. On the desk path
+/// below this already carried [`SYSTEM_AUTHOR`](crate::ports::SYSTEM_AUTHOR),
+/// because a journalled notice must have an author; the operator path passed
+/// `agent: None` on the reasoning that no teammate said this and attributing it
+/// to the responder would put the platform's words in their mouth. That
+/// reasoning is right and the `None` still defeated it: an authorless reply
+/// journals as `agent_id: "operator"`, which is not a roster member, so the
+/// console fell through to the channel's own voice — the orchestrator's name —
+/// and rendered the platform's words under **"Product Manager"** with the
+/// company mark beside them. Naming the system author is what actually
+/// delivers the intent: `chat.ts` maps it to `from: "system"`, which
+/// `senderOf` renders as "System" and which the timeline's promotion guard
+/// already refuses to lift into the channel.
+pub(crate) fn iteration_cap_pause_notice(agent: &str) -> String {
+    format!(
+        "The reply above is a pause, not a finished answer: {agent}'s turn reached the maximum \
+         number of steps it may take for a single reply, so it stopped and wrote up where it had \
+         got to. Nothing errored — the work so far stands. Reply \"continue\" to ask it to pick up \
+         from there."
+    )
+}
 
 /// The system bubble emitted when a turn was halted by its in-turn spend brake
 /// (issue #1032).
 ///
-/// The sibling of [`ITERATION_CAP_PAUSE_NOTICE`], and deliberately **not**
+/// The sibling of [`iteration_cap_pause_notice`], and deliberately **not**
 /// interchangeable with it. Both say a turn stopped short, but the operator's
 /// next move is opposite:
 ///
@@ -143,7 +172,7 @@ pub(crate) const BUDGET_PAUSE_NOTICE_PREFIX: &str = "⏸ Paused — out of credi
 
 /// The system bubble emitted when a turn paused for lack of inference
 /// budget/credits (issue #1846) — the sibling of
-/// [`ITERATION_CAP_PAUSE_NOTICE`] and [`spend_halt_notice`], and, like both,
+/// [`iteration_cap_pause_notice`] and [`spend_halt_notice`], and, like both,
 /// deliberately unauthored: no teammate said this, the account ran out of
 /// money before the model ever replied.
 ///
@@ -3939,18 +3968,29 @@ impl HarnessBrain {
                     // memory and recall it as something the agent said in a
                     // later turn.
                     //
-                    // Unauthored (`agent: None`) for the same reason: no
+                    // Authored by the **system** for the same reason: no
                     // teammate said this, and attributing it to the responder
-                    // would put the platform's words in its mouth. Empty steps
-                    // — the turn's timeline is already on the bubble above, and
-                    // repeating it would double every row in the console.
+                    // would put the platform's words in its mouth. This was
+                    // `agent: None`, which meant the same thing and did not
+                    // achieve it — an authorless reply journals as
+                    // `agent_id: "operator"`, no roster member matches, and the
+                    // console falls back to the channel's voice, so the
+                    // platform's words appeared under the orchestrator's name.
+                    // `SYSTEM_AUTHOR` is what the desk path below already used
+                    // and what `chat.ts` maps to `from: "system"`. The notice
+                    // names the responder in its text instead, as
+                    // `spend_halt_notice` does — whose turn capped is the part
+                    // the operator needs, and saying it is not the same as
+                    // saying they said it. Empty steps — the turn's timeline is
+                    // already on the bubble above, and repeating it would
+                    // double every row in the console.
                     if turn.hit_iteration_cap {
                         channel_responses.push(OutboundMessage {
                             message_id: None,
                             task_id: None,
                             channel: "operator".to_string(),
-                            agent: None,
-                            text: ITERATION_CAP_PAUSE_NOTICE.to_string(),
+                            agent: Some(crate::ports::SYSTEM_AUTHOR.to_string()),
+                            text: iteration_cap_pause_notice(&responder),
                             steps: Vec::new(),
                             reply_to: None,
                             mentions: Vec::new(),
@@ -4108,7 +4148,7 @@ impl HarnessBrain {
                             task_id: None,
                             channel: crate::server::ops::language::DEFAULT_DESK.to_string(),
                             agent: Some(crate::ports::SYSTEM_AUTHOR.to_string()),
-                            text: ITERATION_CAP_PAUSE_NOTICE.to_string(),
+                            text: iteration_cap_pause_notice(&responder),
                             steps: Vec::new(),
                             reply_to: None,
                             mentions: Vec::new(),

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -2147,24 +2147,6 @@ enum LiveStream<'a> {
     },
 }
 
-/// The stream a chat-raised background turn publishes to, from the chat id its
-/// [`ChatTarget`](crate::runtime::delegation::ChatTarget) carries.
-///
-/// Split out of [`HarnessPool::run_steered_background`] so the routing rule can
-/// be asserted without standing up a turn. The empty-string case is the one
-/// worth pinning: `TaskRecord::origin_chat_id` is a `String` upstream, so a card
-/// that no conversation raised arrives here as `Some("")`, not `None`. Streaming
-/// to `""` would be exactly the unkeyed publish #125 rejected — frames with no
-/// thread to attribute to — so absent and empty must land on the same answer.
-fn live_stream_for_chat(chat_id: Option<&str>) -> LiveStream<'_> {
-    match chat_id.filter(|id| !id.is_empty()) {
-        Some(chat_id) => LiveStream::On {
-            chat_id: Some(chat_id),
-        },
-        None => LiveStream::Off,
-    }
-}
-
 /// Per-company serialization of the roster's policy-axis decision through its
 /// publish ([`HarnessPool::ensure_impl`]), mirroring
 /// [`company_write_lock`](crate::ports::store::company_write_lock).
@@ -3465,46 +3447,13 @@ impl HarnessPool {
         chat: crate::runtime::delegation::ChatTarget<'_>,
         run_sink: Option<Arc<run_trace::RunTraceSink>>,
     ) -> crate::Result<TurnOutcome> {
-        // Stream when the turn has a conversation to stream *to*, and only then.
-        //
-        // This was a flat `LiveStream::Off`, on `run_background`'s reasoning
-        // that "a dispatched card's own turn answers no conversation... nothing
-        // binds to a thread". That is true of a board-raised card, a cron tick
-        // and a workflow node. It is not true here: this entry point already
-        // takes a `ChatTarget`, and a card delegated out of chat carries the
-        // conversation it came from (`TaskRecord::origin_chat_id`). The turn
-        // therefore had a key the whole time and published nothing with it, so
-        // an operator watching the thread they delegated from saw a spinner for
-        // minutes while the teammate worked.
-        //
-        // #125's objection is answered by the key, not by silence — the same
-        // way `LiveStream::Workflow` answers it. Its doc says routing by
-        // run + node "is what makes a node's tool calls appear live without
-        // misattributing to whatever thread most recently sent"; a `chat_id` is
-        // that same guarantee for a chat turn, and the console keys its live
-        // timeline on it precisely "so concurrent turns on different threads
-        // never cross-attribute their frames" (`use-events.ts`). With no
-        // `chat_id` there is nothing to key on, so this still falls back to
-        // `Off` and the misattribution guard is unchanged.
-        //
-        // Deliberately NOT a reversal of #1890 I. That issue split identity
-        // (`ChatTarget`) from stream (`LiveStream`) so a turn *could* have a
-        // conversation and stream nothing — an approval's re-issued call still
-        // does, because it passes its `ChatTarget` through `run_inner` on a
-        // path that never reaches here. The split stays; this only stops one
-        // caller from discarding a key it was already holding.
-        //
-        // Empty is absent: `origin_chat_id` is a `String` upstream, so a card
-        // with no conversation arrives as `Some("")` rather than `None`, and
-        // streaming to `""` would be the unkeyed publish this guards against.
-        let live = live_stream_for_chat(chat.chat_id);
         self.run_inner(
             company,
             agent_id,
             message,
             deps,
             Some(control),
-            live,
+            LiveStream::Off,
             chat,
             run_sink,
         )
@@ -12071,36 +12020,6 @@ budget_usd_daily = 0.0
             // it, both arrived at the binding as "no stream, therefore no
             // conversation".
             assert_ne!(reissued, card);
-        }
-
-        /// The routing rule behind a delegated card's live frames.
-        ///
-        /// `run_steered_background` used to pass a flat `LiveStream::Off`, so an
-        /// operator who delegated out of a thread watched a spinner for minutes
-        /// while the teammate worked — the turn was holding the very key it
-        /// needed (`TaskRecord::origin_chat_id`) and publishing nothing with it.
-        /// Streaming is now derived from that key, and all three inputs matter:
-        ///
-        ///   * a real chat id streams, keyed to that thread;
-        ///   * `None` — a board-raised card, a cron tick — stays silent, which is
-        ///     the #125 guarantee this must not weaken;
-        ///   * `Some("")` must be read as absent, not as a thread named `""`.
-        ///     `origin_chat_id` is a `String`, so "no conversation raised this"
-        ///     reaches here as the empty string. Dropping the filter would
-        ///     publish frames keyed to nothing at all — the misattribution #125
-        ///     rejected, reintroduced through the back door.
-        #[test]
-        fn a_delegated_turn_streams_only_when_it_has_a_thread_to_stream_to() {
-            use super::super::{LiveStream, live_stream_for_chat};
-
-            assert!(matches!(
-                live_stream_for_chat(Some("growth")),
-                LiveStream::On {
-                    chat_id: Some("growth")
-                }
-            ));
-            assert!(matches!(live_stream_for_chat(None), LiveStream::Off));
-            assert!(matches!(live_stream_for_chat(Some("")), LiveStream::Off));
         }
 
         /// A codex review on #1896 read `run_with_steer`'s `if let Some(incoming)

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -2147,6 +2147,24 @@ enum LiveStream<'a> {
     },
 }
 
+/// The stream a chat-raised background turn publishes to, from the chat id its
+/// [`ChatTarget`](crate::runtime::delegation::ChatTarget) carries.
+///
+/// Split out of [`HarnessPool::run_steered_background`] so the routing rule can
+/// be asserted without standing up a turn. The empty-string case is the one
+/// worth pinning: `TaskRecord::origin_chat_id` is a `String` upstream, so a card
+/// that no conversation raised arrives here as `Some("")`, not `None`. Streaming
+/// to `""` would be exactly the unkeyed publish #125 rejected — frames with no
+/// thread to attribute to — so absent and empty must land on the same answer.
+fn live_stream_for_chat(chat_id: Option<&str>) -> LiveStream<'_> {
+    match chat_id.filter(|id| !id.is_empty()) {
+        Some(chat_id) => LiveStream::On {
+            chat_id: Some(chat_id),
+        },
+        None => LiveStream::Off,
+    }
+}
+
 /// Per-company serialization of the roster's policy-axis decision through its
 /// publish ([`HarnessPool::ensure_impl`]), mirroring
 /// [`company_write_lock`](crate::ports::store::company_write_lock).
@@ -3447,13 +3465,46 @@ impl HarnessPool {
         chat: crate::runtime::delegation::ChatTarget<'_>,
         run_sink: Option<Arc<run_trace::RunTraceSink>>,
     ) -> crate::Result<TurnOutcome> {
+        // Stream when the turn has a conversation to stream *to*, and only then.
+        //
+        // This was a flat `LiveStream::Off`, on `run_background`'s reasoning
+        // that "a dispatched card's own turn answers no conversation... nothing
+        // binds to a thread". That is true of a board-raised card, a cron tick
+        // and a workflow node. It is not true here: this entry point already
+        // takes a `ChatTarget`, and a card delegated out of chat carries the
+        // conversation it came from (`TaskRecord::origin_chat_id`). The turn
+        // therefore had a key the whole time and published nothing with it, so
+        // an operator watching the thread they delegated from saw a spinner for
+        // minutes while the teammate worked.
+        //
+        // #125's objection is answered by the key, not by silence — the same
+        // way `LiveStream::Workflow` answers it. Its doc says routing by
+        // run + node "is what makes a node's tool calls appear live without
+        // misattributing to whatever thread most recently sent"; a `chat_id` is
+        // that same guarantee for a chat turn, and the console keys its live
+        // timeline on it precisely "so concurrent turns on different threads
+        // never cross-attribute their frames" (`use-events.ts`). With no
+        // `chat_id` there is nothing to key on, so this still falls back to
+        // `Off` and the misattribution guard is unchanged.
+        //
+        // Deliberately NOT a reversal of #1890 I. That issue split identity
+        // (`ChatTarget`) from stream (`LiveStream`) so a turn *could* have a
+        // conversation and stream nothing — an approval's re-issued call still
+        // does, because it passes its `ChatTarget` through `run_inner` on a
+        // path that never reaches here. The split stays; this only stops one
+        // caller from discarding a key it was already holding.
+        //
+        // Empty is absent: `origin_chat_id` is a `String` upstream, so a card
+        // with no conversation arrives as `Some("")` rather than `None`, and
+        // streaming to `""` would be the unkeyed publish this guards against.
+        let live = live_stream_for_chat(chat.chat_id);
         self.run_inner(
             company,
             agent_id,
             message,
             deps,
             Some(control),
-            LiveStream::Off,
+            live,
             chat,
             run_sink,
         )
@@ -12020,6 +12071,36 @@ budget_usd_daily = 0.0
             // it, both arrived at the binding as "no stream, therefore no
             // conversation".
             assert_ne!(reissued, card);
+        }
+
+        /// The routing rule behind a delegated card's live frames.
+        ///
+        /// `run_steered_background` used to pass a flat `LiveStream::Off`, so an
+        /// operator who delegated out of a thread watched a spinner for minutes
+        /// while the teammate worked — the turn was holding the very key it
+        /// needed (`TaskRecord::origin_chat_id`) and publishing nothing with it.
+        /// Streaming is now derived from that key, and all three inputs matter:
+        ///
+        ///   * a real chat id streams, keyed to that thread;
+        ///   * `None` — a board-raised card, a cron tick — stays silent, which is
+        ///     the #125 guarantee this must not weaken;
+        ///   * `Some("")` must be read as absent, not as a thread named `""`.
+        ///     `origin_chat_id` is a `String`, so "no conversation raised this"
+        ///     reaches here as the empty string. Dropping the filter would
+        ///     publish frames keyed to nothing at all — the misattribution #125
+        ///     rejected, reintroduced through the back door.
+        #[test]
+        fn a_delegated_turn_streams_only_when_it_has_a_thread_to_stream_to() {
+            use super::super::{LiveStream, live_stream_for_chat};
+
+            assert!(matches!(
+                live_stream_for_chat(Some("growth")),
+                LiveStream::On {
+                    chat_id: Some("growth")
+                }
+            ));
+            assert!(matches!(live_stream_for_chat(None), LiveStream::Off));
+            assert!(matches!(live_stream_for_chat(Some("")), LiveStream::Off));
         }
 
         /// A codex review on #1896 read `run_with_steer`'s `if let Some(incoming)

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -904,6 +904,34 @@ fn refuse_approval_siblings(tool_calls: &[ToolCall]) -> TaResult<()> {
     Ok(())
 }
 
+/// Whether the raw payload asks for an action at all, independent of whether
+/// any of it parsed.
+///
+/// Checked on the *raw* payload and independent of `finish_reason`, so a
+/// genuinely-requested-but-unparseable call can never be promoted as ordinary
+/// prose (Codex review on #1779, comment 3862781739).
+///
+/// Shared with [`probe`] rather than re-derived there: the probe's
+/// reasoning-only tolerance must not swallow a malformed-tool-call failure, and
+/// answering "did this payload request an action?" two different ways is how
+/// the probe drifted from the turn path before (Codex review on #2068).
+fn raw_tool_call_requested(payload: &serde_json::Value) -> bool {
+    payload
+        .pointer("/choices/0/message/tool_calls")
+        .is_some_and(|v| match v {
+            serde_json::Value::Null => false,
+            serde_json::Value::Array(arr) => !arr.is_empty(),
+            // A present-but-non-array value (e.g. an object) is not a shape
+            // `parse_tool_calls` or the legacy `function_call` check can
+            // recognize, but it is not an absence either — fail closed
+            // rather than let it read as "nothing requested".
+            _ => true,
+        })
+        || payload
+            .pointer("/choices/0/message/function_call")
+            .is_some_and(|v| !v.is_null())
+}
+
 /// Parse an OpenAI-compatible chat-completion payload into a tinyagents
 /// [`ModelResponse`], preserving token usage, native tool calls, AND the managed
 /// billing envelope.
@@ -964,21 +992,7 @@ fn model_response_from_payload_offering(
     // the *raw* payload for either call shape, independent of finish_reason,
     // so a genuinely-requested-but-unparseable call can never be promoted
     // (Codex review on #1779, comment 3862781739).
-    let raw_tool_call_requested = payload
-        .pointer("/choices/0/message/tool_calls")
-        .is_some_and(|v| match v {
-            serde_json::Value::Null => false,
-            serde_json::Value::Array(arr) => !arr.is_empty(),
-            // A present-but-non-array value (e.g. an object) is not a shape
-            // `parse_tool_calls` or the legacy `function_call` check can
-            // recognize, but it is not an absence either — fail closed
-            // rather than let it read as "nothing requested" and fall
-            // through to the reasoning fallback below.
-            _ => true,
-        })
-        || payload
-            .pointer("/choices/0/message/function_call")
-            .is_some_and(|v| !v.is_null());
+    let raw_tool_call_requested = raw_tool_call_requested(&payload);
     // How many entries the *raw* array actually carried, when it is an
     // array at all (legacy `function_call` and non-array shapes have no
     // raw count to compare against, and are already fully covered by the
@@ -1251,6 +1265,24 @@ fn model_response_from_payload_offering(
 /// (Codex review on #1779). Nothing here is ever surfaced — the reasoning text
 /// is not read, only its presence.
 fn probe_reachable_despite_empty_turn(payload: &serde_json::Value) -> bool {
+    // Only the *empty-turn* refusal may be tolerated. A payload that asked for
+    // an action and got it wrong — a malformed entry, a missing name, a
+    // `finish_reason` declaring a call that never arrived — fails the parser
+    // for a different reason, and returning `Ok(())` on that would sail past
+    // the unoffered-tool-call guard below and pass an endpoint that cannot
+    // complete a bare `ping` (Codex review on #2068). This probe offers no
+    // tools, so a payload declaring an action is already wrong regardless of
+    // what else it carries.
+    if raw_tool_call_requested(payload)
+        || matches!(
+            payload
+                .pointer("/choices/0/finish_reason")
+                .and_then(serde_json::Value::as_str),
+            Some("tool_calls") | Some("function_call")
+        )
+    {
+        return false;
+    }
     !extract_content_text(payload.pointer("/choices/0/message/reasoning")).is_empty()
         || !extract_content_text(payload.pointer("/choices/0/message/reasoning_content")).is_empty()
 }
@@ -4262,6 +4294,33 @@ mod tests {
         format!("http://{addr}")
     }
 
+    /// Spawns a stub whose whole `choices[0]` object is the given raw JSON —
+    /// `spawn_stub_message` below pins `finish_reason: "stop"`, so this is the
+    /// one that can express a payload *declaring* an action it never delivered.
+    async fn spawn_stub_choice(choice: serde_json::Value) -> String {
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        let app = Router::new().route(
+            "/chat/completions",
+            post(move || {
+                let choice = choice.clone();
+                async move {
+                    Json(serde_json::json!({
+                        "choices": [choice],
+                        "usage": { "prompt_tokens": 1, "completion_tokens": 1 }
+                    }))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://{addr}")
+    }
+
     /// Spawns an in-process OpenAI-compatible stub whose full `message` object
     /// is the given raw JSON value — used to exercise shapes `spawn_stub_content`
     /// cannot, such as a reasoning-only turn (`content: null` with the visible
@@ -4709,6 +4768,64 @@ mod tests {
     /// setup wizard refusing to move past it (Codex review on #2068). The fix
     /// is the probe-specific tolerance that doc pointed at, not promotion in
     /// the shared parser.
+    /// The reasoning tolerance covers the empty turn and nothing else.
+    ///
+    /// A payload that asked for an action and got it wrong fails the parser for
+    /// a *different* reason than "carried nothing", and tolerating that would
+    /// return `Ok(())` before the unoffered-tool-call guard below could run —
+    /// passing an endpoint that cannot complete a bare `ping`. This probe
+    /// advertises no tools at all, so a declared action is already wrong no
+    /// matter what else rides alongside it (Codex review on #2068).
+    ///
+    /// Reasoning is present in both payloads here, so the tolerance is what is
+    /// under test rather than the absence of its trigger.
+    #[tokio::test]
+    async fn the_reasoning_tolerance_does_not_excuse_a_broken_tool_call() {
+        for message in [
+            // Requested an action, and the entry is unparseable.
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "reasoning": "42 is the answer.",
+                "tool_calls": [{ "no_name_here": true }]
+            }),
+            // Declared an action that never arrived.
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "reasoning": "42 is the answer."
+            }),
+        ] {
+            let declares_only = message.get("tool_calls").is_none();
+            let url = if declares_only {
+                spawn_stub_choice(serde_json::json!({
+                    "message": message,
+                    "finish_reason": "tool_calls"
+                }))
+                .await
+            } else {
+                spawn_stub_message(message).await
+            };
+
+            let company = CompanyId::new("acme");
+            let secrets = MemSecrets::default();
+            let mut manifest = manifest_inference("openai_compatible");
+            manifest.base_url = Some(url);
+            let decl = inference::resolve_effective(&company, &manifest, None, &secrets)
+                .await
+                .unwrap()
+                .unwrap();
+
+            let err = probe(&decl, None)
+                .await
+                .expect_err("a broken tool call must fail the probe even with reasoning present");
+            assert!(
+                !err.to_string().contains("42"),
+                "reasoning text must not leak into the probe error, got: {err}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn probe_accepts_a_reasoning_only_reply_as_proof_the_endpoint_answers() {
         let url = spawn_stub_message(serde_json::json!({

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -1225,6 +1225,36 @@ fn model_response_from_payload_offering(
     Ok(response)
 }
 
+/// Whether a payload the parser rejected as empty still proves the endpoint
+/// **answered** — it deliberated and simply had no budget left to write a
+/// visible reply.
+///
+/// Reachability and usability are different questions, and only [`probe`] asks
+/// the first. A real turn that comes back with nothing but chain-of-thought is
+/// a failed turn: there is no answer to show, and promoting the reasoning is
+/// what this PR removed. A *probe* asking `ping` with `max_tokens: 16` is not
+/// judging the answer at all — it is asking whether the credential, the base
+/// URL and the model name reach a server that completes chat turns. A response
+/// carrying reasoning tokens answers that with a yes.
+///
+/// Without this, the probe re-created the bug #1779 fixed: an endpoint that
+/// every real turn reached fine was reported as a broken connection, and the
+/// setup wizard would not proceed past it. 16 tokens is little enough room that
+/// a well-behaved reasoning model burns it on deliberation routinely — for the
+/// DeepSeek-style models this matters for, it is the *expected* shape, not an
+/// edge case.
+///
+/// Deliberately a **predicate on the payload**, not a second content path. The
+/// probe calls the same [`model_response_from_payload`] the turn path does and
+/// only consults this when that parser has already refused; giving the probe
+/// its own narrower parser is exactly how it drifted from the turn path before
+/// (Codex review on #1779). Nothing here is ever surfaced — the reasoning text
+/// is not read, only its presence.
+fn probe_reachable_despite_empty_turn(payload: &serde_json::Value) -> bool {
+    !extract_content_text(payload.pointer("/choices/0/message/reasoning")).is_empty()
+        || !extract_content_text(payload.pointer("/choices/0/message/reasoning_content")).is_empty()
+}
+
 /// Deterministic offline model for tests and offline harness wiring.
 ///
 /// Every call returns a canned reply built from a fixed prefix and the last
@@ -1955,8 +1985,20 @@ pub async fn probe(decl: &InferenceDecl, harness: Option<&str>) -> anyhow::Resul
     // second, narrower copy of the parsing logic is exactly how it drifted
     // from the turn path the first time; calling the shared function directly
     // means there is only one content path to keep in sync.
-    let response = model_response_from_payload(payload)
-        .map_err(|e| anyhow::anyhow!("probe response carried no usable content: {e}"))?;
+    //
+    // Checked BEFORE the parser takes ownership: a reasoning-only reply fails
+    // the parser's empty-turn check, and for a reachability probe that failure
+    // is still a yes. See [`probe_reachable_despite_empty_turn`].
+    let reachable_despite_empty = probe_reachable_despite_empty_turn(&payload);
+    let response = match model_response_from_payload(payload) {
+        Ok(response) => response,
+        Err(_) if reachable_despite_empty => return Ok(()),
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "probe response carried no usable content: {e}"
+            ));
+        }
+    };
     // `model_response_from_payload` accepts a tool-call-only reply — correct
     // for a real turn, where the model may have been offered tools and
     // legitimately chose to call one instead of answering in prose. This
@@ -4648,33 +4690,27 @@ mod tests {
             .expect("array-shaped content must be recognized as a successful probe");
     }
 
-    /// `probe` routes through the exact same parser the turn path calls
-    /// (`model_response_from_payload`) so the two paths cannot diverge — see
-    /// that function's own module docs for why a reasoning-only turn
-    /// (`content: null`, `finish_reason: "stop"`, visible text only under
-    /// `reasoning`) is an error rather than a promoted answer.
+    /// Reachability and usability are different questions, and `probe` asks
+    /// only the first.
     ///
-    /// This used to be the opposite assertion: a prior revision of `probe`
-    /// treated this shape as success (Codex review on #1779, comment
-    /// 3864906472), on the reasoning-fallback's original premise that the
-    /// model's real answer had landed in the wrong field. That premise turned
-    /// out to be false for the turn path — `reasoning` is chain-of-thought,
-    /// not a response — and `probe` sharing the same parser means it inherits
-    /// the same correction: a reasoning-only reply is not evidence of a
-    /// completed turn for a probe either, even though `probe` never surfaces
-    /// the text anywhere.
+    /// The turn path must not promote `reasoning` into a reply — that is this
+    /// PR — and `probe` shares that parser, so a reasoning-only payload fails
+    /// its empty-turn check. For a *probe* that failure is still a yes: the
+    /// credential, base URL and model name reached a server that completed a
+    /// chat turn. It deliberated and ran out of room, which is a statement
+    /// about the budget, not the connection.
     ///
-    /// Known trade-off, not addressed by this test: `probe` sends `ping` with
-    /// `max_tokens: 16`, which is little enough room that even a normally
-    /// well-behaved reasoning model can plausibly burn it entirely on
-    /// deliberation before writing anything to `content` — reproducing the
-    /// original #1779 symptom (a working reasoning-model connection reported
-    /// as broken) for a different, now-legitimate reason. If that turns out
-    /// to matter in practice, the fix belongs in `probe`'s own budget or a
-    /// probe-specific tolerance, not in resurrecting promotion in the shared
-    /// parser.
+    /// An earlier revision of this branch asserted the opposite, and named the
+    /// risk in its own doc: `probe` sends `ping` with `max_tokens: 16`, little
+    /// enough that a well-behaved reasoning model burns it on deliberation
+    /// routinely. For the DeepSeek-style models this PR exists for that is the
+    /// *expected* shape, so rejecting it re-created the bug #1779 fixed — a
+    /// connection every real turn reached fine, reported as broken, with the
+    /// setup wizard refusing to move past it (Codex review on #2068). The fix
+    /// is the probe-specific tolerance that doc pointed at, not promotion in
+    /// the shared parser.
     #[tokio::test]
-    async fn probe_rejects_reasoning_only_content() {
+    async fn probe_accepts_a_reasoning_only_reply_as_proof_the_endpoint_answers() {
         let url = spawn_stub_message(serde_json::json!({
             "role": "assistant",
             "content": null,
@@ -4691,12 +4727,25 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let err = probe(&decl, None)
-            .await
-            .expect_err("reasoning-only content must not be recognized as a successful probe");
+        probe(&decl, None).await.expect(
+            "a reply carrying reasoning tokens proves the endpoint completes chat turns, \
+             even with no budget left for a visible answer",
+        );
+
+        // The turn path is unmoved by the probe's tolerance: the same payload
+        // through the same parser is still an error, so nothing promotes the
+        // chain-of-thought into a reply. Reachability is the only thing the
+        // tolerance buys.
+        let err = model_response_from_payload(serde_json::json!({
+            "choices": [{
+                "message": { "role": "assistant", "content": null, "reasoning": "42 is the answer." },
+                "finish_reason": "stop"
+            }]
+        }))
+        .expect_err("a real turn carrying only reasoning is still an empty turn");
         assert!(
             !err.to_string().contains("42"),
-            "leaked reasoning text must not appear in the probe error, got: {err}"
+            "reasoning text must not leak into the turn error either, got: {err}"
         );
     }
 

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -935,7 +935,6 @@ fn model_response_from_payload_offering(
     // Content may be a plain string OR an array of `{type:"text",text:…}`
     // parts; tolerate both.
     let raw_content = payload.pointer("/choices/0/message/content");
-    let content_is_null = raw_content.is_some_and(serde_json::Value::is_null);
     let mut content = extract_content_text(raw_content);
     // Whether a fallback below replaced the model's own visible message. Read
     // by the text-tool-call recovery, which must act on what the model *said*
@@ -954,28 +953,6 @@ fn model_response_from_payload_offering(
         .and_then(|v| v.as_str())
         .map(str::to_string);
 
-    // Reasoning-model fallback: a reasoning-only turn returns `content: null`
-    // with the visible text under `reasoning` / `reasoning_content` (string or
-    // array-of-parts). Recover it so the turn is not lost to a hard error —
-    // but only when the model actually finished. Any finish reason other than
-    // a true completion (`length` truncation, `content_filter`, `failed` —
-    // the documented HTTP-200-empty-response silent failure, see
-    // docs/spec/runtime/providers.md — or any other/unknown value) means the
-    // chain of thought itself may be unfinished, so promoting it here would
-    // hand downstream consumers a partial or incorrect thought as if it were
-    // the final answer. Allow-list the known-good completions instead of
-    // blocklisting the failures we happened to think of, so an unrecognized
-    // failure reason fails closed. Fall through to the empty-response error
-    // below otherwise.
-    // Only `stop` means "finished, with prose, asking for nothing else".
-    // `tool_calls` and `function_call` were in this list until PR #1779's
-    // review: both assert the model requested an ACTION, so a response
-    // carrying one of them has not produced a final answer at all — whether
-    // or not the call body parses. Promoting a chain of thought over a
-    // requested action is the same class of substitution the truncation
-    // guard below prevents, so they are excluded here rather than handled by
-    // a special case per payload shape.
-    let genuinely_finished = matches!(finish_reason.as_deref(), Some("stop"));
     // `tool_calls` above is the *parsed* result: `parse_tool_calls` requires a
     // `/message/tool_calls` array AND drops any entry missing `function.name`,
     // and it never reads the legacy singular `message.function_call` field at
@@ -1078,15 +1055,14 @@ fn model_response_from_payload_offering(
         .or_else(|| extract_array_refusal_text(payload.pointer("/choices/0/message/content")));
     if tool_calls.is_empty() && !raw_tool_call_requested {
         if let Some(refusal) = refusal_text {
-            // A refusal is a *completed* decision, not a partial one — unlike
-            // the reasoning fallback below, its precedence must not depend on
-            // `finish_reason`. Gating it on `genuinely_finished` let a
-            // refusal that ends with e.g. `finish_reason: "content_filter"`
-            // (arguably the *more* likely finish reason for an actual
-            // content-policy refusal) fall through untouched, leaving
-            // whatever text or reasoning leaked alongside it to win instead
-            // and silently discard the refusal (Codex review on #1779,
-            // comment 3875167298). It always wins over leaked text/reasoning,
+            // A refusal is a *completed* decision, not a partial one, so its
+            // precedence must not depend on `finish_reason`: a refusal that
+            // ends with e.g. `finish_reason: "content_filter"` (arguably the
+            // *more* likely finish reason for an actual content-policy
+            // refusal) must not fall through untouched, leaving whatever text
+            // or reasoning leaked alongside it to win instead and silently
+            // discard the refusal (Codex review on #1779, comment
+            // 3875167298). It always wins over leaked text/reasoning,
             // independent of how the turn finished.
             content = refusal;
             content_substituted = true;
@@ -1095,45 +1071,41 @@ fn model_response_from_payload_offering(
             // response silent provider failure (docs/spec/runtime/providers.md).
             // It is a *completed* disclaimer that the turn did not succeed —
             // like a refusal, not a partial/unfinished state — so it must not
-            // be overridden by whatever text leaked alongside it, the same
-            // way `genuinely_finished` already keeps a truncated/filtered/
-            // failed *reasoning* stream from being promoted below. That gate
-            // only covers the `reasoning` fallback though: `content` itself is
-            // extracted unconditionally at the top of this function (string OR
-            // array-shaped), so a provider that emits real text — a leaked
-            // lead-in sentence, or a fuller partial reply — before reporting
-            // `failed` had that text returned as a successful answer with no
-            // finish_reason check at all. Discard it here so the response
-            // falls through to the empty-turn error below, naming `failed` for
-            // diagnosis (CodeRabbit review on #1779, comment 3878355364).
+            // be overridden by whatever text leaked alongside it. `content`
+            // itself is extracted unconditionally at the top of this function
+            // (string OR array-shaped), so a provider that emits real text —
+            // a leaked lead-in sentence, or a fuller partial reply — before
+            // reporting `failed` had that text returned as a successful
+            // answer with no finish_reason check at all. Discard it here so
+            // the response falls through to the empty-turn error below,
+            // naming `failed` for diagnosis (CodeRabbit review on #1779,
+            // comment 3878355364).
             content.clear();
             content_substituted = true;
-        } else if genuinely_finished && content_is_null && content.is_empty() {
-            // Reasoning-model fallback: a reasoning-only turn returns
-            // `content: null` with the visible text under `reasoning` /
-            // `reasoning_content` (string or array-of-parts). Only promote it
-            // when the model actually finished — a truncated (`length`),
-            // filtered (`content_filter`), failed, or otherwise-unfinished
-            // chain of thought is not a final answer, and promoting it here
-            // would hand downstream consumers a partial or incorrect thought
-            // as if it were.
-            //
-            // `content.is_empty()` alone is not enough to detect the
-            // reasoning-only shape: it is also true for an explicit
-            // `content: ""` or a non-text content array (e.g. an image-only
-            // part) — both a genuine, visible provider response that
-            // `extract_content_text` simply can't render as text. Requiring
-            // the *raw* field to be absent/null before promoting keeps that
-            // response from being silently swapped for leaked
-            // chain-of-thought (CodeRabbit review on #1779, comment
-            // 3877224319).
-            content = extract_content_text(payload.pointer("/choices/0/message/reasoning"));
-            if content.is_empty() {
-                content =
-                    extract_content_text(payload.pointer("/choices/0/message/reasoning_content"));
-            }
-            content_substituted = true;
         }
+        // Deliberately no `reasoning`/`reasoning_content` fallback here.
+        //
+        // A `content: null` turn with only a populated `reasoning` field is
+        // not a misplaced answer — it is the model finishing (`stop`) having
+        // spent its entire turn on hidden deliberation and writing nothing to
+        // `content` at all. A prior version of this function copied
+        // `reasoning` into `content` in that case, on the premise that
+        // reasoning-only output was the model's real answer landing in the
+        // wrong field. That premise was false: `reasoning` is chain-of-thought,
+        // not a response, and promoting it put raw first-person deliberation —
+        // often truncated mid-sentence — directly in front of operators,
+        // labelled and persisted as the agent's genuine reply. Because a
+        // promoted turn is persisted and replayed as real history
+        // (`wire_message`), a later turn had no actual answer to build on and
+        // fabricated one instead of surfacing the gap.
+        //
+        // Falling through to the empty-turn error below is not a regression:
+        // that error is retryable (`classify_provider_failure` finds no
+        // status/keyword match in `empty_turn_facts`'s text, so it defaults to
+        // `ProviderFailureClass::Retryable`), so the harness retries the same
+        // request automatically rather than requiring operator action. Given
+        // whether a pass reasons at all is adaptive per-call, a retry has a
+        // real chance at a genuine `content`-bearing response.
     }
 
     // The model wrote a tool call into its message body instead of emitting it
@@ -1155,27 +1127,22 @@ fn model_response_from_payload_offering(
     //   * a **refusal** is a completed decision *not* to act, so recovering an
     //     action out of one would invert it;
     //   * `finish_reason: "failed"` cleared `content` precisely because the turn
-    //     did not succeed;
-    //   * promoted **reasoning** is the model deliberating, not answering — a
-    //     planning trace that merely *mentions* a call in JSON shape has not
-    //     requested it, and running it would execute a thought.
+    //     did not succeed.
     //
     // `finished_or_unstated` covers the other half of the same idea. A stop the
     // model did not choose — `length`, `content_filter`, `failed` — leaves a
     // fragment, and a balanced object inside a fragment is not a completed
     // request.
     //
-    // An **allow-list**, matching `genuinely_finished` above and the principle
+    // An **allow-list**, matching the principle
     // `unrecognized_finish_reason_reasoning_only_turn_errors` pins: a blocklist
     // only refuses the failures someone thought of, so a provider answering
     // `finish_reason: "error"` — a value this file's own tests already treat as
     // non-success — would have had a call recovered out of a failed turn
     // (CodeRabbit review on #2011).
     //
-    // It admits one thing `genuinely_finished` does not: an **absent**
-    // finish_reason. That is the difference between the two guards and it is
-    // deliberate. The reasoning fallback substitutes hidden text for an answer,
-    // where saying nothing should fail closed; here the model's own visible
+    // It admits one thing a plain `Some("stop")` check does not: an **absent**
+    // finish_reason. Here the model's own visible
     // message is the evidence, and refusing without a finish_reason would
     // disable the recovery for exactly the non-conforming providers it exists
     // for. Silence is not a failure signal — every named failure still is.
@@ -2540,11 +2507,23 @@ mod tests {
     }
 
     /// A reasoning-only turn returns `content: null` with the visible text under
-    /// a `reasoning` field and no tool calls. It must fall back to the reasoning
-    /// text and parse rather than hard-erroring — the managed reasoning brain
-    /// (deepseek/qwen via OpenRouter) is the exact source of the crash.
+    /// a `reasoning` field and no tool calls. This used to fall back to the
+    /// reasoning text and parse as a successful reply — the managed reasoning
+    /// brain (deepseek/qwen via OpenRouter) hits this shape routinely, and the
+    /// fallback's premise was that the model's real answer had landed in the
+    /// wrong field.
+    ///
+    /// That premise was wrong: `reasoning` is chain-of-thought, not a response.
+    /// Promoting it put raw, often mid-sentence deliberation in front of
+    /// operators as the agent's genuine reply, and because it was persisted and
+    /// replayed as real history, later turns had no actual answer to build on
+    /// and fabricated one instead of surfacing the gap (reasoning-leak repro,
+    /// live multi-agent chat). This shape must now error — the same
+    /// diagnosable empty-turn error every other no-real-answer shape returns —
+    /// so the harness retries automatically instead of showing leaked
+    /// deliberation as a final answer.
     #[test]
-    fn reasoning_only_turn_falls_back_to_reasoning_text() {
+    fn reasoning_only_turn_errors_instead_of_promoting_reasoning_text() {
         let payload = serde_json::json!({
             "choices": [{
                 "finish_reason": "stop",
@@ -2555,21 +2534,30 @@ mod tests {
                 }
             }]
         });
-        let resp = model_response_from_payload(payload).expect("reasoning-only turn parses");
-        assert_eq!(resp.text(), "The answer is 42.");
-        assert!(resp.message.tool_calls.is_empty());
+        let err = model_response_from_payload(payload)
+            .expect_err("reasoning-only turn must not promote reasoning into content");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("neither"),
+            "must be the diagnosable empty-turn error, got: {msg}"
+        );
+        assert!(
+            !msg.contains("42"),
+            "leaked reasoning text must not appear in the error, got: {msg}"
+        );
     }
 
     /// A reasoning trace that *mentions* a call in JSON shape has not requested
     /// it, and running it would execute a thought rather than an instruction.
     ///
-    /// The promoted-reasoning path replaces `content` wholesale, so without the
-    /// `content == message_content` gate the text-tool-call recovery would read
-    /// a planning trace as an action and dispatch it — on a turn where the model
-    /// emitted no visible message and no structured call at all (Codex review on
-    /// #2011).
+    /// Reasoning is never promoted into `content` at all now, so this payload
+    /// — no visible message, no structured call — errors as an empty turn
+    /// before the text-tool-call recovery ever runs. That is a stronger
+    /// guarantee than the old "recovered but not dispatched" behavior: the
+    /// deliberation, call-shaped JSON included, never reaches the caller in
+    /// any form (Codex review on #2011, superseded by the reasoning-leak fix).
     #[test]
-    fn a_tool_call_shape_inside_promoted_reasoning_is_never_recovered() {
+    fn a_tool_call_shape_inside_reasoning_is_never_recovered_or_leaked() {
         let payload = serde_json::json!({
             "choices": [{
                 "finish_reason": "stop",
@@ -2583,17 +2571,16 @@ mod tests {
             }]
         });
         let offered = std::collections::BTreeSet::from(["read_ledger".to_string()]);
-        let resp = model_response_from_payload_offering(payload, &offered)
-            .expect("the reasoning-only turn still parses");
-
+        let err = model_response_from_payload_offering(payload, &offered)
+            .expect_err("a reasoning-only turn must not parse as success");
+        let msg = err.to_string();
         assert!(
-            resp.message.tool_calls.is_empty(),
-            "a deliberation must never be dispatched as a call"
+            msg.contains("neither"),
+            "must be the diagnosable empty-turn error, got: {msg}"
         );
         assert!(
-            resp.text().contains("read_ledger"),
-            "and the trace reaches the caller unaltered: {}",
-            resp.text()
+            !msg.contains("read_ledger"),
+            "a deliberation must never be dispatched OR leaked into the error: {msg}"
         );
     }
 
@@ -2830,16 +2817,16 @@ mod tests {
 
     /// The mixed-array refusal case above (Codex review comment 3875001349)
     /// only reproduced with `finish_reason: "stop"`. The refusal-precedence
-    /// block was gated on `genuinely_finished`, so the identical payload with
-    /// `finish_reason: "content_filter"` — arguably the *more* likely finish
-    /// reason a real content-policy refusal ends with — skipped the block
-    /// entirely: `content` was already nonempty from the leaked text part,
-    /// so the empty-response check at the bottom accepted it and returned
-    /// the leaked lead-in as if it were the whole answer, silently
+    /// block used to be gated on a `stop`-only check, so the identical
+    /// payload with `finish_reason: "content_filter"` — arguably the *more*
+    /// likely finish reason a real content-policy refusal ends with —
+    /// skipped the block entirely: `content` was already nonempty from the
+    /// leaked text part, so the empty-response check at the bottom accepted
+    /// it and returned the leaked lead-in as if it were the whole answer,
+    /// silently
     /// discarding the refusal. A refusal is a completed decision, not a
-    /// partial one, so its precedence must not depend on `finish_reason` the
-    /// way the reasoning fallback's does (Codex review on #1779, comment
-    /// 3875167298).
+    /// partial one, so its precedence must not depend on `finish_reason`
+    /// (Codex review on #1779, comment 3875167298).
     #[test]
     fn a_refusal_wins_over_leaked_text_regardless_of_finish_reason() {
         let payload = serde_json::json!({
@@ -2861,14 +2848,13 @@ mod tests {
 
     /// The sibling fallback field: some providers emit the reasoning-only
     /// text under `reasoning_content` (array-of-parts shape) instead of
-    /// `reasoning`, with `reasoning` itself absent. `extract_content_text`
-    /// handles the array shape and `model_response_from_payload` only tries
-    /// `reasoning_content` once `reasoning` comes back empty — this test
-    /// exercises that second fallback specifically, which the existing
-    /// `reasoning`-field and `content_filter`-error tests do not cover
-    /// (CodeRabbit nitpick on #1779, comment ed359cf20f434c7f7f83c058).
+    /// `reasoning`, with `reasoning` itself absent. This shape is subject to
+    /// the same fix as the plain `reasoning` field above — `reasoning_content`
+    /// is chain-of-thought too, so it must not be promoted into `content`
+    /// either. Exercises the array-of-parts form specifically, which the
+    /// plain-`reasoning` test above does not cover.
     #[test]
-    fn reasoning_only_turn_falls_back_to_array_shaped_reasoning_content() {
+    fn reasoning_content_only_turn_errors_instead_of_promoting_array_shaped_text() {
         let payload = serde_json::json!({
             "choices": [{
                 "finish_reason": "stop",
@@ -2883,10 +2869,17 @@ mod tests {
                 }
             }]
         });
-        let resp =
-            model_response_from_payload(payload).expect("reasoning_content-only turn parses");
-        assert_eq!(resp.text(), "The answer is 42.");
-        assert!(resp.message.tool_calls.is_empty());
+        let err = model_response_from_payload(payload)
+            .expect_err("reasoning_content-only turn must not promote reasoning into content");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("neither"),
+            "must be the diagnosable empty-turn error, got: {msg}"
+        );
+        assert!(
+            !msg.contains("42"),
+            "leaked reasoning text must not appear in the error, got: {msg}"
+        );
     }
 
     /// An explicit `content: ""` (not `null`) is a *visible* empty response,
@@ -3049,8 +3042,7 @@ mod tests {
     /// leaked text lives in the *primary* `content` field (array-shaped, the
     /// form round #8 of this PR taught `extract_content_text` to parse) rather
     /// than `reasoning`. `content` is extracted unconditionally at the top of
-    /// `model_response_from_payload`, with no `finish_reason` check of its
-    /// own — only the `reasoning` fallback is gated on `genuinely_finished`.
+    /// `model_response_from_payload`, with no `finish_reason` check of its own.
     /// Pre-fix, this payload parsed successfully with the leaked lead-in
     /// sentence returned as the answer, silently discarding the provider's own
     /// `failed` disclaimer (CodeRabbit review on #1779, comment 3878355364).
@@ -3084,11 +3076,12 @@ mod tests {
     /// under the singular `message.function_call` field, which
     /// `parse_tool_calls` never reads (it only parses the modern
     /// `message.tool_calls` array). Pre-fix, `finish_reason: "function_call"`
-    /// sat in the `genuinely_finished` allow-list, so with `tool_calls` empty
-    /// (nothing there to parse) and `content: null`, this fell straight into
-    /// the reasoning fallback and silently swapped the requested action for
-    /// prose — the caller never even sees a tool call was dropped. Must error
-    /// instead (Codex follow-up review on #1779, comment 3862781739).
+    /// used to sit in an allow-list gating a reasoning-promotion fallback, so
+    /// with `tool_calls` empty (nothing there to parse) and `content: null`,
+    /// this fell straight into that fallback and silently swapped the
+    /// requested action for prose — the caller never even sees a tool call
+    /// was dropped. Must error instead (Codex follow-up review on #1779,
+    /// comment 3862781739).
     #[test]
     fn legacy_function_call_with_reasoning_errors_instead_of_promoting() {
         let payload = serde_json::json!({
@@ -4655,19 +4648,33 @@ mod tests {
             .expect("array-shaped content must be recognized as a successful probe");
     }
 
-    /// Codex review on #1779 (comment 3864906472): the array-content fix above
-    /// made `probe` call `extract_content_text` directly instead of the shared
-    /// `model_response_from_payload` — which picked up the array-shaped-content
-    /// case but not the `reasoning`/`reasoning_content` fallback for a
-    /// reasoning-only turn (`content: null`, `finish_reason: "stop"`, visible
-    /// text under `reasoning`) that lives inside `model_response_from_payload`.
-    /// A managed reasoning provider answering with that shape passed every
-    /// real turn while its own connection probe reported the connection
-    /// broken — blocking the setup wizard and the console's "Test" button for
-    /// a valid provider. `probe` must route through the exact same parser the
-    /// turn path calls so the two paths cannot diverge again.
+    /// `probe` routes through the exact same parser the turn path calls
+    /// (`model_response_from_payload`) so the two paths cannot diverge — see
+    /// that function's own module docs for why a reasoning-only turn
+    /// (`content: null`, `finish_reason: "stop"`, visible text only under
+    /// `reasoning`) is an error rather than a promoted answer.
+    ///
+    /// This used to be the opposite assertion: a prior revision of `probe`
+    /// treated this shape as success (Codex review on #1779, comment
+    /// 3864906472), on the reasoning-fallback's original premise that the
+    /// model's real answer had landed in the wrong field. That premise turned
+    /// out to be false for the turn path — `reasoning` is chain-of-thought,
+    /// not a response — and `probe` sharing the same parser means it inherits
+    /// the same correction: a reasoning-only reply is not evidence of a
+    /// completed turn for a probe either, even though `probe` never surfaces
+    /// the text anywhere.
+    ///
+    /// Known trade-off, not addressed by this test: `probe` sends `ping` with
+    /// `max_tokens: 16`, which is little enough room that even a normally
+    /// well-behaved reasoning model can plausibly burn it entirely on
+    /// deliberation before writing anything to `content` — reproducing the
+    /// original #1779 symptom (a working reasoning-model connection reported
+    /// as broken) for a different, now-legitimate reason. If that turns out
+    /// to matter in practice, the fix belongs in `probe`'s own budget or a
+    /// probe-specific tolerance, not in resurrecting promotion in the shared
+    /// parser.
     #[tokio::test]
-    async fn probe_accepts_reasoning_only_content() {
+    async fn probe_rejects_reasoning_only_content() {
         let url = spawn_stub_message(serde_json::json!({
             "role": "assistant",
             "content": null,
@@ -4684,9 +4691,13 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        probe(&decl, None)
+        let err = probe(&decl, None)
             .await
-            .expect("reasoning-only content must be recognized as a successful probe");
+            .expect_err("reasoning-only content must not be recognized as a successful probe");
+        assert!(
+            !err.to_string().contains("42"),
+            "leaked reasoning text must not appear in the probe error, got: {err}"
+        );
     }
 
     /// CodeRabbit review on #1779 (comment 3877827976): `probe` routes

--- a/src/harness/cap_publish_test.rs
+++ b/src/harness/cap_publish_test.rs
@@ -5,7 +5,7 @@
 //! Two features already exist and, before this, never met:
 //!
 //! - Part 1 (#926) taught the chat path to say "I paused" —
-//!   `ITERATION_CAP_PAUSE_NOTICE`, proven end to end in
+//!   `iteration_cap_pause_notice`, proven end to end in
 //!   [`cap_turn_test`](crate::harness::cap_turn_test).
 //! - #244 taught the **task-dispatch** path (`run_task`) to scan the agent's
 //!   sandbox for files it wrote and never published, and to ask about them in

--- a/src/harness/cap_turn_test.rs
+++ b/src/harness/cap_turn_test.rs
@@ -36,7 +36,7 @@ use serde_json::{Value, json};
 
 use crate::company::CompanyManifest;
 use crate::company::credentials::Credential;
-use crate::harness::brain::ITERATION_CAP_PAUSE_NOTICE;
+use crate::harness::brain::iteration_cap_pause_notice;
 use crate::harness::mcp_probe::McpFailureQueue;
 use crate::harness::memory_loop;
 use crate::harness::orchestrator::{DelegationQueue, WorkflowRunnerHandle};
@@ -79,7 +79,7 @@ const CAP: usize = crate::harness::build::MAX_TOOL_ITERATIONS;
 const CHECKPOINT: &str = "Done so far: read the standards and the prior spec. \
 Next steps: draft the spec and publish it.";
 
-/// A slice of [`ITERATION_CAP_PAUSE_NOTICE`] unique to the platform's voice.
+/// A slice of [`iteration_cap_pause_notice`] unique to the platform's voice.
 ///
 /// Used to prove the notice is *absent* from memory. A substring rather than
 /// the whole notice because an absence assertion on the full string would pass
@@ -538,10 +538,22 @@ async fn a_capped_chat_turn_says_so_in_a_second_bubble() {
     assert_eq!(bubbles[0].text.trim(), CHECKPOINT);
     assert_eq!(bubbles[0].agent.as_deref(), Some(AGENT));
 
-    // The system's notice, attributed to nobody.
-    assert_eq!(bubbles[1].text, ITERATION_CAP_PAUSE_NOTICE);
-    assert!(
-        bubbles[1].agent.is_none(),
+    // The system's notice: authored by the system, and naming whose turn capped.
+    assert_eq!(bubbles[1].text, iteration_cap_pause_notice(AGENT));
+    // Still the property this always asserted — the platform's words are not
+    // the agent's. It was spelled `agent.is_none()`, which *meant* that and did
+    // not achieve it: an authorless reply journals as `agent_id: "operator"`,
+    // matches no roster member, and the console falls back to the channel's
+    // voice, so the notice rendered under the orchestrator's own name. Naming
+    // the system author is what delivers the intent, so that is what is pinned.
+    assert_eq!(
+        bubbles[1].agent.as_deref(),
+        Some(crate::ports::SYSTEM_AUTHOR),
+        "the notice must be authored by the system, not left for a fallback to name"
+    );
+    assert_ne!(
+        bubbles[1].agent.as_deref(),
+        Some(AGENT),
         "the platform's words must not be put in the agent's mouth"
     );
     assert!(
@@ -550,7 +562,7 @@ async fn a_capped_chat_turn_says_so_in_a_second_bubble() {
     );
 
     // It has to actually say the three things the operator needs.
-    let notice = ITERATION_CAP_PAUSE_NOTICE;
+    let notice = iteration_cap_pause_notice(AGENT);
     assert!(notice.contains("pause"), "it must name the pause: {notice}");
     assert!(
         notice.contains("Nothing errored"),

--- a/src/harness/spend_halt_turn_test.rs
+++ b/src/harness/spend_halt_turn_test.rs
@@ -46,7 +46,7 @@ use serde_json::{Value, json};
 
 use crate::company::CompanyManifest;
 use crate::company::credentials::Credential;
-use crate::harness::brain::{ITERATION_CAP_PAUSE_NOTICE, spend_halt_notice};
+use crate::harness::brain::{iteration_cap_pause_notice, spend_halt_notice};
 use crate::harness::mcp_probe::McpFailureQueue;
 use crate::harness::memory_loop;
 use crate::harness::orchestrator::{DelegationQueue, WorkflowRunnerHandle};
@@ -630,7 +630,8 @@ async fn a_spend_halted_chat_turn_says_so_in_a_second_bubble() {
         "the spend notice must never tell the operator to reply \"continue\": {notice}"
     );
     assert_ne!(
-        notice, ITERATION_CAP_PAUSE_NOTICE,
+        *notice,
+        iteration_cap_pause_notice(AGENT),
         "the two notices must not be interchangeable — the operator's next action differs"
     );
 }
@@ -694,7 +695,7 @@ async fn the_step_notice_and_the_spend_notice_do_not_cross_fire() {
         .map(|b| b.text.as_str())
         .collect();
     assert!(
-        texts.contains(&ITERATION_CAP_PAUSE_NOTICE),
+        texts.contains(&iteration_cap_pause_notice(AGENT).as_str()),
         "a turn that ran out of steps must emit the STEP notice: {texts:?}"
     );
     assert!(
@@ -722,7 +723,7 @@ async fn the_step_notice_and_the_spend_notice_do_not_cross_fire() {
         "a turn halted for money must emit the SPEND notice: {texts:?}"
     );
     assert!(
-        !texts.contains(&ITERATION_CAP_PAUSE_NOTICE),
+        !texts.contains(&iteration_cap_pause_notice(AGENT).as_str()),
         "a spend halt must not be reported as a step pause: {texts:?}"
     );
 }


### PR DESCRIPTION
## Summary

Fixes found while chasing one report: *"the thinking process is leaking into the final response and the answer comes with `Answer:`"*. Each commit stands alone.

> **Review update.** The original PR carried a fifth change that streamed delegated turns. Both reviewers found it missed its target *and* regressed the approval path; it is reverted here rather than patched, and redone properly in the follow-up. Details in the revert commit and in-thread.

### 1. Stop promoting model reasoning into the visible reply

`model_response_from_payload_offering` had a fallback: when `finish_reason` was `stop` and `content` came back null/empty, it copied `message.reasoning` (then `reasoning_content`) into `content` and marked the turn substituted.

That is how a chain of thought reached the operator verbatim, `Answer:` header and all. The fallback cannot distinguish "the model thought and forgot to answer" from "the model thought and the answer is the next thing it will say" — and a reasoning trace is not a reply in either case. It also meant a tool-call shape appearing inside reasoning could be surfaced as prose.

Removed, with the four tests rewritten to assert the turn now **errors** instead of leaking. Retries already cover the transient case, which is what this shape actually is.

Verified against DeepSeek V4 Flash over OpenRouter (Novita, DeepInfra), the provider pair where `content: null` with a populated `reasoning` field shows up. Note this is **rare** — 250+ live samples — not the expected path.

### 2. Render a capped turn's replies once, and count them the same way twice

A turn that runs out of steps emits two replies under the operator's message: the agent's partial write-up, then the host's pause notice. Promoting the first inline broke three things at once:

- the write-up rendered inline **and** in the panel, because `repliesInThread` walks the parent chain and knows nothing of what was promoted — one message, two surfaces;
- the chip counted 1 (promoted filtered) while the panel counted 2 (nothing filtered);
- the panel could not drop the promoted reply to fix either, because the notice beneath it opens *"The reply above is a pause"*.

Promotion now stops when the **runtime** spoke more than once — an operator writing again is not the runtime speaking twice, so a lone answer is still promoted — and `ThreadPanel` takes an optional `inlineReplyIds` so it counts the same set the chip does.

### 3. Attribute the iteration-cap pause to the agent whose turn it was

The pause bubble was authored by `agent: None` and worded impersonally, so the console rendered it as a nameless host message beside the teammate's partial answer — two speakers for one turn, one of them nobody. It is the host's notice, so `SYSTEM_AUTHOR` is right; what was missing is *whose* turn it describes. The notice is now a function of the responder.

### 4. Normalize only General spellings on a live turn frame

`onTurnEvent` used `event.chatId` as a bare index into `liveStepsByThread`/`receiptByThread`. The host folds the company-wide line under whatever casing the caller addressed, so a client posting to `General` had its live rows written under a spelling the console never reads — the #1743 class of bug, on the fourth of the four live-frame consumers (`channelForThread`'s own doc names the other three).

Scoped to **General aliases only**, per review. These maps are keyed in the host-thread namespace — `ChatView` reads them by `dmThreadId(member)`, which stays the bare member id for an ordinary teammate, while `channelForThread` answers `dm:<id>`. Routing every id through the map moved DM live state to a key nothing reads, and a directory load between a `tool_call` and its `tool_result` could strand the row as `running`. Everything that is not a General alias now keeps its host-thread spelling.

## Commands run

```
cargo fmt --all -- --check
cargo test --features openhuman --lib
pnpm exec tsc --noEmit
pnpm exec vitest run test/unit/live-frame-thread-key.test.ts \
  test/unit/chat-thread-reply-count.test.ts \
  test/unit/live-reply-open-turn-lookup.test.ts
```

## Behaviour changes

- A reasoning-only completion now **errors** (and retries) instead of surfacing the reasoning as the reply. Callers that relied on the substitution get a retry or a typed failure.
- The iteration-cap notice text now names the responder — `iteration_cap_pause_notice(agent)` replaces the `ITERATION_CAP_PAUSE_NOTICE` constant.

## Known limitation, not fixed here

`liveFrameThreadKey` falls back to `MAIN_THREAD_ID` for a General alias the
channel map cannot yet resolve, which makes the key stable across the desk-list
load **for an ordinary company**. It is not stable for a grandfathered
blueprint desk (`id = "ops", name = "General"`): the loaded map answers `ops`
while the cold-load fallback answers `main`, so a `tool_call` and its
`tool_result` can still straddle the transition, and a result whose call is not
in its bucket is dropped — leaving the row on `running`.

Not a regression: before this PR the fallback was the raw alias, so that
transition was unstable for every company rather than only blueprint ones. The
commit message for `ebfee65c5` overstates it as closed; it is narrowed.

Left as-is deliberately. Every fix available at this layer is a workaround —
caching the first resolution pins whichever side won the race, deferring frames
adds a buffer with its own lifecycle, and widening the `tool_result` lookup
across buckets makes the key meaningless. The real fix is that a live frame
should not be keyed by thread at all, which the follow-up below addresses.

## Follow-up

A separate PR adds a per-turn key to `TurnStreamEvent` so the console can group live rows by *query* rather than by thread, and renders each running query's steps under the message that asked it — the way a settled turn's folded steps already render under their reply.

That is where delegated-card streaming gets done properly, with `origin_chat_id` passed as an explicit stream route rather than inferred from the conversation-binding `ChatTarget`.

It also fixes a bug found while testing this one, reproduced with instrumentation: `onSendStart` unconditionally resets `liveStepsByThread[threadId]`, so entering a second query in a channel **destroys the first turn's live rows while it is still running** (observed discarding two rows belonging to an in-flight delegated turn). `openTurns` is a list per thread; `liveStepsByThread` and `receiptByThread` are single-slot, and that asymmetry is what per-turn keying removes.
