### PR TITLE
fix(console): render each running query's live steps under the query itself

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -99,6 +99,8 @@ import { REWRITE_RETIRED } from "@/lib/console-route-rewrites";
 import { taskIdFromSegment } from "@/lib/task-route";
 import { toast } from "sonner";
 
+import { foldLiveFrame } from "@/lib/live-frame";
+
 import {
   dispatchMarkerPlacement,
   fromHistory,
@@ -774,6 +776,11 @@ export function AppShell({
   useEffect(() => {
     setOpenTurns((prev) => (Object.keys(prev).length === 0 ? prev : {}));
   }, [company]);
+  // Company-scoped for the reason `openTurns` above is: the keys are message ids
+  // from one company's journal, and two companies' sequences collide freely.
+  useEffect(() => {
+    setLiveStepsByMessage((prev) => (Object.keys(prev).length === 0 ? prev : {}));
+  }, [company]);
   // The live tool timeline, per thread, built from the transient `tool_call` /
   // `tool_result` SSE frames while a turn runs (mirrors OpenHuman's live tool
   // rows). Cleared when the turn's final reply — carrying the authoritative
@@ -781,6 +788,26 @@ export function AppShell({
   // in-place flip; it is structurally a superset of `TurnStep`, so these render
   // through the same `StepTimeline` as the final steps.
   const [liveStepsByThread, setLiveStepsByThread] = useState<
+    Record<string, (TurnStep & { toolCallId?: string })[]>
+  >({});
+  // The same timeline, per **query** rather than per thread, for a frame that
+  // says which operator message its turn answers (`messageSeq`). Keyed by that
+  // message's console id, so a running turn's rows render under the question
+  // that asked them — the way a settled turn's folded steps already render under
+  // its reply.
+  //
+  // Two turns in one thread is the case this exists for. `liveStepsByThread`
+  // holds ONE row-list per thread, and `onSendStart` resets it, so asking a
+  // second question destroyed the first turn's rows outright — and a turn
+  // blocked on a teammate emits nothing further, so its timeline never came
+  // back. Measured on a real pair: the reset discarded two rows from a live
+  // delegated turn. Separate keys mean neither turn can clear the other, and
+  // the merged pile that would otherwise render is split back into the two
+  // questions it came from.
+  //
+  // Not a replacement: a frame with no `messageSeq` still keys by thread, which
+  // is every turn answering no journaled message and every older host.
+  const [liveStepsByMessage, setLiveStepsByMessage] = useState<
     Record<string, (TurnStep & { toolCallId?: string })[]>
   >({});
   // The live receipt for each synchronous chat turn in flight (issue #1934),
@@ -2164,6 +2191,23 @@ export function AppShell({
       // only when polling recovers the durable history (issue #1743).
       const channelId = channelForThread(chatChannelByThread, event.chatId);
       if (!channelId) return;
+      // This turn's answer is here, carrying the authoritative folded steps, so
+      // the live rows filed under the question it answers have done their job.
+      // Same swap `liveStepsByThread` makes when a reply lands — the durable
+      // timeline replaces the transient one with no empty frame between them.
+      //
+      // Addressed by the reply's parent, which is the message that asked: the
+      // same id `messageSeq` resolved to when the rows were filed. A reply with
+      // no parent answers no journaled message and so filed no rows.
+      if (event.parentId) {
+        const askedBy = hostMessageId(event.parentId);
+        setLiveStepsByMessage((prev) => {
+          if (!(askedBy in prev)) return prev;
+          const next = { ...prev };
+          delete next[askedBy];
+          return next;
+        });
+      }
       setTranscripts((t) => {
         const existing = t[channelId] ?? [];
         // The same recent-tail content dedupe the thread store uses. It still
@@ -2679,6 +2723,13 @@ export function AppShell({
     [typing.typers, companyPeople],
   );
   const onTurnEvent = useCallback((event: CompanyStreamEvent) => {
+    // The three kinds this folds. `use-events` only routes these here, so the
+    // guard is a type narrowing rather than a runtime filter — but it is stated
+    // rather than assumed, because `foldLiveFrame` takes the narrow shape and a
+    // cast would let a fourth kind through silently if that routing ever grew.
+    if (event.type !== "tool_call" && event.type !== "tool_result" && event.type !== "thinking") {
+      return;
+    }
     // Workflow agent-node frames carry `workflowRunId`/`nodeId` instead of a
     // `chatId` (issue #1702) and belong to the run-trace sheet's own
     // subscription, not to any chat timeline. Route them out BEFORE the legacy
@@ -2711,60 +2762,26 @@ export function AppShell({
       // workflow node events in `onWorkflowRunEvent`.
       return;
     }
-    setLiveStepsByThread((prev) => {
-      const rows = prev[threadId] ? [...prev[threadId]] : [];
-      if (event.type === "tool_call") {
-        const idx = event.toolCallId
-          ? rows.findIndex((r) => r.toolCallId === event.toolCallId)
-          : -1;
-        const row = {
-          kind: "tool_call" as const,
-          status: "running" as const,
-          label: event.label ?? "Working",
-          toolCallId: event.toolCallId,
-        };
-        if (idx >= 0) rows[idx] = { ...rows[idx], ...row };
-        else rows.push(row);
-      } else if (event.type === "tool_result") {
-        let idx = event.toolCallId
-          ? rows.findIndex((r) => r.toolCallId === event.toolCallId)
-          : -1;
-        if (idx < 0 && event.toolCallId) return prev;
-        if (idx < 0) idx = rows.findIndex((r) => r.status === "running");
-        const status = event.status === "error" ? ("error" as const) : ("ok" as const);
-        if (idx >= 0) {
-          rows[idx] = {
-            ...rows[idx],
-            status,
-            detail: event.detail ?? rows[idx].detail,
-            // `result` is what came back — the summary `StepTimeline` renders
-            // under the label. Carried for the same reason `detail` is: the
-            // live row and the folded step it is replaced by should not say
-            // different amounts about the same call. It was dropped here while
-            // only the built-in harness streamed (its rows lean on `detail`,
-            // derived from the arguments); an ACP tool call carries its
-            // summary in `result` and nothing else, so a dropped `result` is
-            // the whole of what the row could have said.
-            result: event.result ?? rows[idx].result,
-            elapsedMs: event.elapsedMs,
-          };
-        } else {
-          rows.push({
-            kind: "tool_call",
-            status,
-            label: event.label ?? "Working",
-            detail: event.detail,
-            result: event.result,
-            elapsedMs: event.elapsedMs,
-            toolCallId: event.toolCallId,
-          });
-        }
-      } else if (event.type === "thinking") {
-        // The backend already coalesces a thinking run into one frame, so each
-        // arrival is a distinct row (mirrors the folded "Thinking" step).
-        rows.push({ kind: "thinking", status: "ok", label: "Thinking" });
-      }
-      return { ...prev, [threadId]: rows };
+    // Which bucket this row belongs in. A frame that names the operator message
+    // it answers is filed under that **query**; one that does not falls back to
+    // the thread, which is every turn answering no journaled message and every
+    // host older than `messageSeq`.
+    //
+    // Filing under one or the other — never both — is what keeps a row from
+    // rendering twice, and is why arming a second turn can no longer clear the
+    // first one's rows: they are not in the same list any more.
+    const messageKey =
+      "messageSeq" in event && event.messageSeq !== undefined
+        ? hostMessageId(String(event.messageSeq))
+        : undefined;
+    const setRows = messageKey ? setLiveStepsByMessage : setLiveStepsByThread;
+    const rowKey = messageKey ?? threadId;
+    setRows((prev) => {
+      const rows = foldLiveFrame(prev[rowKey] ?? [], event);
+      // `null` is "this frame belongs to rows we do not hold" — keep the
+      // previous object so React skips the re-render.
+      if (!rows) return prev;
+      return { ...prev, [rowKey]: rows };
     });
     // Keep this thread's receipt alive off the same frame (issue #1934): a frame
     // arriving means the turn is advancing, so bump `lastFrameAt` (which clears
@@ -3490,6 +3507,7 @@ export function AppShell({
           scopeRef={scopeRef}
               openTurns={openTurns}
               liveStepsByThread={liveStepsByThread}
+              liveStepsByMessage={liveStepsByMessage}
               receiptByThread={receiptByThread}
               agentNames={agentNames}
               unread={unread}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -102,6 +102,7 @@ import { toast } from "sonner";
 import { foldLiveFrame } from "@/lib/live-frame";
 
 import {
+  type ChatMessage,
   dispatchMarkerPlacement,
   fromHistory,
   hostMessageId,
@@ -810,6 +811,39 @@ export function AppShell({
   const [liveStepsByMessage, setLiveStepsByMessage] = useState<
     Record<string, (TurnStep & { toolCallId?: string })[]>
   >({});
+  /**
+   * Retires the live rows of every message that now has durable steps of its
+   * own, and of every message named in `alsoDrop`.
+   *
+   * Two cleanup paths meet here because a turn can end two ways.
+   *
+   * A turn that **answers** journals its folded steps onto the message, so the
+   * arrival of those steps is the swap signal — the durable timeline is there
+   * to replace the transient one, with no empty frame between them. That is a
+   * fact about the message itself, unlike the reply's `parentId`, which names
+   * the thread root rather than the question (see `renderAgentReply`).
+   *
+   * A turn that **fails** journals a `TurnFailed` line and no reply at all, so
+   * nothing ever grows steps for it. Its bucket would sit there for the life of
+   * the session — quite possibly holding a row still marked `running`, since a
+   * result that never arrived cannot flip it. `alsoDrop` is how the terminal
+   * settle path retires those (Codex on #2069).
+   */
+  const clearLiveRowsSettledBy = useCallback(
+    (messages: readonly ChatMessage[], alsoDrop: readonly string[] = []) => {
+      setLiveStepsByMessage((prev) => {
+        const done = new Set(alsoDrop);
+        for (const m of messages) if (m.steps && m.steps.length > 0) done.add(m.id);
+        let hit = false;
+        for (const id of done) if (id in prev) { hit = true; break; }
+        if (!hit) return prev;
+        const next = { ...prev };
+        for (const id of done) delete next[id];
+        return next;
+      });
+    },
+    [],
+  );
   // The live receipt for each synchronous chat turn in flight (issue #1934),
   // keyed by host thread id — armed on `onSendStart`, bumped by every live
   // frame (which also captures who picked the turn up), and cleared on whichever
@@ -1243,6 +1277,10 @@ export function AppShell({
         .then((entries) => {
           if (cancelled || requestCompany !== company) return;
           const hydrated = fromHistory(entries);
+          // Any message that came back carrying steps has a durable timeline
+          // now, so its transient one is spent. Covers the ordinary success
+          // swap, and re-converges a console that reloaded mid-turn.
+          clearLiveRowsSettledBy(hydrated);
           if (hydrated.length > 0) {
             // Persisted rows take the history's own oldest-first order, and
             // local rows the host has not persisted yet stay at the tail — so
@@ -1648,6 +1686,16 @@ export function AppShell({
               delete next[liveKey];
               return next;
             });
+            // The per-query buckets retire on the same transition, inside the
+            // same guard and for the same reason: a queued sibling still
+            // running owns its rows, and this must not take them.
+            //
+            // Every message here, not only those carrying steps — which is what
+            // covers a turn that FAILED. It journals a `TurnFailed` line and no
+            // reply, so it never grows durable steps to swap for, and its bucket
+            // would otherwise hold a row marked `running` for the whole session
+            // (Codex on #2069).
+            clearLiveRowsSettledBy(hydrated, hydrated.map((m) => m.id));
           }
           const channelId = channelForThread(chatChannelByThreadRef.current, threadId);
           // The thread settled before the desks/roster effect populated its
@@ -2193,21 +2241,19 @@ export function AppShell({
       if (!channelId) return;
       // This turn's answer is here, carrying the authoritative folded steps, so
       // the live rows filed under the question it answers have done their job.
-      // Same swap `liveStepsByThread` makes when a reply lands — the durable
-      // timeline replaces the transient one with no empty frame between them.
+      // NOT keyed off `event.parentId`. That is the reply's *placement* parent,
+      // and `AcceptedTurn::thread_root` is explicit that "a reply is parented to
+      // its question's parent, never to the question" — so for a follow-up typed
+      // inside a thread it names the thread ROOT. Clearing by it would leave the
+      // follow-up's own rows resident and, far worse, delete the root's bucket:
+      // if the root's turn were still running this would erase a live sibling's
+      // timeline, which is the exact failure this whole change exists to stop
+      // (Codex on #2069).
       //
-      // Addressed by the reply's parent, which is the message that asked: the
-      // same id `messageSeq` resolved to when the rows were filed. A reply with
-      // no parent answers no journaled message and so filed no rows.
-      if (event.parentId) {
-        const askedBy = hostMessageId(event.parentId);
-        setLiveStepsByMessage((prev) => {
-          if (!(askedBy in prev)) return prev;
-          const next = { ...prev };
-          delete next[askedBy];
-          return next;
-        });
-      }
+      // The swap is driven by the durable steps instead — see
+      // `clearLiveRowsSettledBy` below, which retires a bucket once the message
+      // it belongs to has real steps to render, and the terminal settle path,
+      // which covers a turn that failed and so journals no reply at all.
       setTranscripts((t) => {
         const existing = t[channelId] ?? [];
         // The same recent-tail content dedupe the thread store uses. It still

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -379,6 +379,19 @@ export type CompanyStreamEvent =
       toolCallId?: string;
       label?: string;
       status?: string;
+      /**
+       * The journal sequence of the operator message this turn answers (`h`-less
+       * — {@link hostMessageId} prefixes it to reach a console id).
+       *
+       * `chatId` says which conversation; this says which *query*. Two questions
+       * asked in one channel share the thread and, whenever the same desk
+       * answers both, the agent too — so before this there was nothing to group
+       * a row by but the thread, and both turns' rows merged into one timeline.
+       *
+       * Absent on a turn answering no journaled message (a relay, a dispatched
+       * card, a workflow node), where a consumer falls back to keying by thread.
+       */
+      messageSeq?: number;
     }
   | {
       type: "tool_result";
@@ -403,11 +416,20 @@ export type CompanyStreamEvent =
       result?: string;
       status?: string;
       elapsedMs?: number;
+      /** See {@link CompanyStreamEvent} `tool_call.messageSeq`. */
+      messageSeq?: number;
     }
   // A coalesced "Thinking" run between tool calls — streamed so the live
   // timeline shows the same rows the final folded one does (else the count
   // jumps up when the reply lands).
-  | { type: "thinking"; seq: number; agentId?: string; chatId?: string }
+  | {
+      type: "thinking";
+      seq: number;
+      agentId?: string;
+      chatId?: string;
+      /** See {@link CompanyStreamEvent} `tool_call.messageSeq`. */
+      messageSeq?: number;
+    }
   // Somebody arrived, went idle, or left. Published on a CHANGE only — a
   // console heartbeats every minute whether or not anything moved, and
   // republishing that would be one frame per person per minute for no visible

--- a/frontend/src/lib/live-frame.ts
+++ b/frontend/src/lib/live-frame.ts
@@ -1,0 +1,95 @@
+import type { TurnStep } from "@/api/types";
+
+/** A live row: a {@link TurnStep} plus the transient key that pairs a result to
+ * its call so the row flips `running → ok/error` in place. */
+export type LiveRow = TurnStep & { toolCallId?: string };
+
+/** The live-frame shape this fold reads — the fields common to `tool_call`,
+ * `tool_result` and `thinking` on {@link CompanyStreamEvent}. */
+export interface LiveFrame {
+  type: "tool_call" | "tool_result" | "thinking";
+  toolCallId?: string;
+  label?: string;
+  detail?: string;
+  result?: string;
+  status?: string;
+  elapsedMs?: number;
+}
+
+/**
+ * Folds one live frame into a turn's rows, or returns `null` to drop it.
+ *
+ * Extracted from `AppShell.onTurnEvent` so the two maps that hold live rows —
+ * `liveStepsByThread` and `liveStepsByMessage` — fold identically. A second
+ * copy is how the two would drift, and a drifted fold is invisible: both keep
+ * rendering, just differently.
+ *
+ * It also exists so the test can call the rule instead of restating it. The
+ * review on #2068 caught exactly that: `keyFor` duplicated `onTurnEvent`'s
+ * conditional, so it would have kept passing through a regression in the branch
+ * the shell actually runs.
+ *
+ * `null` rather than an unchanged array is the "drop this frame" answer, so a
+ * caller can bail out of its `setState` with the previous object identity and
+ * let React skip the re-render.
+ */
+export function foldLiveFrame(rows: readonly LiveRow[], frame: LiveFrame): LiveRow[] | null {
+  const next = [...rows];
+  if (frame.type === "tool_call") {
+    const idx = frame.toolCallId
+      ? next.findIndex((r) => r.toolCallId === frame.toolCallId)
+      : -1;
+    const row = {
+      kind: "tool_call" as const,
+      status: "running" as const,
+      label: frame.label ?? "Working",
+      toolCallId: frame.toolCallId,
+    };
+    if (idx >= 0) next[idx] = { ...next[idx], ...row };
+    else next.push(row);
+    return next;
+  }
+  if (frame.type === "tool_result") {
+    let idx = frame.toolCallId
+      ? next.findIndex((r) => r.toolCallId === frame.toolCallId)
+      : -1;
+    // A result whose call is not in these rows belongs to another bucket.
+    // Dropping it is deliberate: adopting it would invent a row with no start,
+    // and pairing it with an unrelated `running` row would mark the wrong call
+    // finished. The keying above is what keeps this from happening.
+    if (idx < 0 && frame.toolCallId) return null;
+    if (idx < 0) idx = next.findIndex((r) => r.status === "running");
+    const status = frame.status === "error" ? ("error" as const) : ("ok" as const);
+    if (idx >= 0) {
+      next[idx] = {
+        ...next[idx],
+        status,
+        detail: frame.detail ?? next[idx].detail,
+        // `result` is what came back — the summary `StepTimeline` renders under
+        // the label. Carried for the same reason `detail` is: the live row and
+        // the folded step it is replaced by should not say different amounts
+        // about the same call. It was dropped while only the built-in harness
+        // streamed (its rows lean on `detail`, derived from the arguments); an
+        // ACP tool call carries its summary in `result` and nothing else, so a
+        // dropped `result` is the whole of what the row could have said.
+        result: frame.result ?? next[idx].result,
+        elapsedMs: frame.elapsedMs,
+      };
+    } else {
+      next.push({
+        kind: "tool_call",
+        status,
+        label: frame.label ?? "Working",
+        detail: frame.detail,
+        result: frame.result,
+        elapsedMs: frame.elapsedMs,
+        toolCallId: frame.toolCallId,
+      });
+    }
+    return next;
+  }
+  // The backend already coalesces a thinking run into one frame, so each
+  // arrival is a distinct row (mirrors the folded "Thinking" step).
+  next.push({ kind: "thinking", status: "ok", label: "Thinking" });
+  return next;
+}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -2590,6 +2590,10 @@ export function ChatView({
               parent={parent}
               replies={threadReplies}
               inlineReplyIds={threadInlineReplyIds}
+              // A query typed into this panel renders only here — parented
+              // messages never reach the channel timeline — so the panel needs
+              // the per-query rows too, or its turns show nothing at all.
+              liveStepsByMessage={liveStepsByMessage}
               sending={sending}
               mentionables={mentionables}
               channelMemberIds={inChannel?.map((m) => m.id)}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -247,6 +247,14 @@ interface Props {
    */
   liveStepsByThread?: Record<string, TurnStep[]>;
   /**
+   * Live rows per query, keyed by the asking message's id (see
+   * `MessageTimeline`). Passed straight through — unlike `liveStepsByThread`,
+   * nothing here has to resolve a key for it: the message id is the key, so it
+   * needs neither `activeThreadId` nor the desk map, and cannot be affected by
+   * their load order.
+   */
+  liveStepsByMessage?: Record<string, TurnStep[]>;
+  /**
    * The live receipt for a synchronous chat turn in flight, keyed by **host
    * thread id** (issue #1934) — resolved to this channel's thread the same way
    * `liveStepsByThread` is. Present between the operator's send and the reply
@@ -413,6 +421,7 @@ export function ChatView({
   scopeRef,
   openTurns,
   liveStepsByThread,
+  liveStepsByMessage,
   receiptByThread,
   agentNames,
   unread,
@@ -2310,6 +2319,11 @@ export function ChatView({
               typing={sending || !!openTurn}
               queued={!!openTurn?.queued}
               liveSteps={openThreadId ? undefined : liveSteps}
+              // NOT excluded when a thread is open: these rows render inside
+              // their own message rather than as one strip for the channel, so
+              // there is no ambiguity about which turn they describe — which is
+              // the whole reason `liveSteps` above is withheld.
+              liveStepsByMessage={liveStepsByMessage}
               // Thread-panel receipts are out of v1 (issue #1934): excluded here
               // the same way `liveSteps` is when a thread is open.
               receipt={openThreadId ? undefined : receipt}

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -1,7 +1,7 @@
 import { MessageSquareReply } from "lucide-react";
 
 import type { TaskStatus } from "@/api/tasks";
-import type { CognitionState } from "@/api/types";
+import type { CognitionState, TurnStep } from "@/api/types";
 import { AgentAvatarButton, useAgentProfileOpener } from "@/components/agent-profile-sheet";
 import { Markdown } from "@/components/markdown";
 import { TeammateAvatar } from "@/components/teammate-avatar";
@@ -28,6 +28,21 @@ import { WorkingIndicator } from "./WorkingIndicator";
 
 interface Props {
   entry: TimelineEntry;
+  /**
+   * The live tool rows of a turn answering **this** message, while it runs.
+   *
+   * A settled turn's steps render under its reply, from `message.steps`. Until
+   * the reply exists there is nothing to hang them on, so a running turn's rows
+   * used to go to one per-thread strip at the foot of the channel — which meant
+   * two questions asked at once shared a single timeline, and arming the second
+   * turn cleared the first one's rows.
+   *
+   * Rendered through the same collapsed {@link StepTimeline} the settled steps
+   * use, so a turn looks the same while it runs as it does once it is done.
+   * Absent for a turn whose frames carry no `messageSeq`, which still uses the
+   * thread strip.
+   */
+  liveSteps?: readonly TurnStep[];
   /** True when the thread panel is showing this row's replies. */
   threadOpen: boolean;
   onOpenThread: (messageId: string) => void;
@@ -219,6 +234,7 @@ function actionsUnavailableFor(message: ChatMessage): string | undefined {
  */
 export function MessageRow({
   entry,
+  liveSteps,
   threadOpen,
   onOpenThread,
   onReact,
@@ -320,6 +336,11 @@ export function MessageRow({
         )}
 
         {message.steps && message.steps.length > 0 && <StepTimeline steps={message.steps} />}
+        {/* The running turn this message asked for. Opens by default: unlike a
+            settled turn's steps — which sit behind a count because the answer
+            above them is what the reader came for — there is no answer yet, and
+            these rows are the only account of what is happening. */}
+        {!!liveSteps?.length && <StepTimeline steps={[...liveSteps]} defaultOpen />}
         {message.taskId && (
           <div className="flex flex-wrap items-center gap-2">
             <CardChip

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -50,6 +50,16 @@ interface Props {
    */
   liveSteps?: TurnStep[];
   /**
+   * Live rows per **query**, keyed by the asking message's console id — the
+   * per-turn half of `liveSteps` above, which is the per-thread strip.
+   *
+   * Both exist because a frame only knows which query it belongs to when the
+   * host stamps `messageSeq` on it. One that does renders under its own
+   * message; one that does not (a relay, a dispatched card, an older host)
+   * falls back to the strip.
+   */
+  liveStepsByMessage?: Record<string, TurnStep[]>;
+  /**
    * The live receipt for a synchronous chat turn this console just sent (issue
    * #1934). When present it supersedes {@link TypingRow} — it says "Sent →
    * Picked up → on step" with a ticking clock instead of bare typing dots — and
@@ -167,6 +177,7 @@ export function MessageTimeline({
   typing,
   queued,
   liveSteps,
+  liveStepsByMessage,
   receipt,
   agentNames,
   onOpenThread,
@@ -384,6 +395,11 @@ export function MessageTimeline({
               {item.entry.dayLabel && <DayDivider label={item.entry.dayLabel} />}
               <MessageRow
                 entry={item.entry}
+                // The turn this message asked for, while it runs. Keyed by the
+                // message's own id, so two questions in one channel each get
+                // their own timeline instead of sharing the foot-of-channel
+                // strip (and clearing each other's rows).
+                liveSteps={liveStepsByMessage?.[item.entry.message.id]}
                 threadOpen={item.entry.message.id === openThreadId}
                 onOpenThread={onOpenThread}
                 onReact={onReact}

--- a/frontend/src/views/chat/ThreadPanel.tsx
+++ b/frontend/src/views/chat/ThreadPanel.tsx
@@ -4,12 +4,13 @@ import { Markdown } from "@/components/markdown";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Button } from "@/components/ui/button";
 import type { MessageIntent } from "@/api/tasks";
-import type { AttachmentDto, CognitionState } from "@/api/types";
+import type { AttachmentDto, CognitionState, TurnStep } from "@/api/types";
 import type { ChatMessage } from "@/lib/chat";
 import type { TeamMember } from "@/lib/team";
 import { BudgetPauseNoticeCard } from "./BudgetPauseNoticeCard";
 import { EchoPlaceholder, echoMarkerFor } from "./EchoPlaceholder";
 import { MessageAttachments } from "./MessageAttachments";
+import { StepTimeline } from "./StepTimeline";
 import { MessageComposer } from "./MessageComposer";
 import { TypingLine } from "./TypingLine";
 import { WorkingIndicator } from "./WorkingIndicator";
@@ -48,6 +49,15 @@ interface Props {
    * already seen in the channel, not a further thing to open.
    */
   inlineReplyIds?: ReadonlySet<string>;
+  /**
+   * Live rows per query, keyed by the asking message's id.
+   *
+   * The panel needs its own copy because `buildTimeline` keeps every parented
+   * line out of the channel timeline: a query typed into an open thread renders
+   * here or nowhere. Passing this only to `MessageTimeline` left such a turn
+   * with no render path at all (Codex on #2069).
+   */
+  liveStepsByMessage?: Record<string, TurnStep[]>;
   sending: boolean;
   /**
    * Everything an `@` can name here (issue #1645). Drawn from the parent
@@ -206,6 +216,7 @@ export function ThreadPanel({
   parent,
   replies,
   inlineReplyIds,
+  liveStepsByMessage,
   sending,
   mentionables,
   channelMemberIds,
@@ -251,6 +262,7 @@ export function ThreadPanel({
           channel={channel}
           members={members}
           message={parent}
+          liveSteps={liveStepsByMessage?.[parent.id]}
           youAvatar={youAvatar}
           resolveAttachmentUrl={resolveAttachmentUrl}
           cognition={cognition}
@@ -270,6 +282,7 @@ export function ThreadPanel({
             channel={channel}
             members={members}
             message={r}
+            liveSteps={liveStepsByMessage?.[r.id]}
             youAvatar={youAvatar}
             resolveAttachmentUrl={resolveAttachmentUrl}
             cognition={cognition}
@@ -374,6 +387,7 @@ function Line({
   channel,
   members,
   message,
+  liveSteps,
   youAvatar,
   resolveAttachmentUrl,
   cognition,
@@ -384,6 +398,8 @@ function Line({
   channel: Channel;
   members: TeamMember[];
   message: ChatMessage;
+  /** This message's in-flight turn rows, if one is running (see `MessageRow`). */
+  liveSteps?: readonly TurnStep[];
   youAvatar?: string;
   resolveAttachmentUrl?: (nodeId: string) => Promise<string>;
   cognition?: CognitionState | null;
@@ -452,6 +468,15 @@ function Line({
             resolveUrl={resolveAttachmentUrl}
           />
         )}
+        {/* The same two step blocks `MessageRow` renders, because a message
+            asked or answered inside a thread is not a lesser message.
+            `buildTimeline` keeps every parented line OUT of the channel
+            timeline, so this panel is the only surface a threaded query has —
+            without these, a turn started from an open thread showed no account
+            of itself anywhere, even after the panel was closed (Codex on
+            #2069). */}
+        {message.steps && message.steps.length > 0 && <StepTimeline steps={message.steps} />}
+        {!!liveSteps?.length && <StepTimeline steps={[...liveSteps]} defaultOpen />}
       </div>
     </div>
   );

--- a/frontend/test/unit/live-frame-per-query.test.ts
+++ b/frontend/test/unit/live-frame-per-query.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { foldLiveFrame, type LiveRow } from "@/lib/live-frame";
+
+/**
+ * Two questions asked in one channel, and why their rows must not share a list.
+ *
+ * Before `messageSeq`, a chat frame's only routing keys were `chatId` and
+ * `agentId`. Two questions in one channel share the thread, and whenever the
+ * same desk answers both they share the agent too — so there was nothing to
+ * group a row by, and both turns folded into one per-thread list.
+ *
+ * The cost was not merely a merged pile. The console holds ONE list per thread
+ * and `onSendStart` resets it, so asking a second question discarded the first
+ * turn's rows outright. Measured on a real pair: two rows dropped from a
+ * delegated turn that was still running — and a turn blocked on a teammate
+ * emits nothing further, so its timeline never came back.
+ *
+ * These tests pin the fold itself. It is shared by both maps deliberately: a
+ * second copy is how the two would drift, and the review on #2068 caught a test
+ * that restated `onTurnEvent`'s rule instead of calling it, which would have
+ * kept passing through a regression in the branch the shell actually runs.
+ */
+
+const call = (toolCallId: string, label: string) =>
+  ({ type: "tool_call", toolCallId, label }) as const;
+const result = (toolCallId: string, status: string) =>
+  ({ type: "tool_result", toolCallId, status, elapsedMs: 12 }) as const;
+
+describe("folding a live frame", () => {
+  it("flips a call to its result in place, rather than appending a second row", () => {
+    const started = foldLiveFrame([], call("c1", "Http Request"));
+    expect(started).not.toBeNull();
+    expect(started).toHaveLength(1);
+    expect(started![0].status).toBe("running");
+
+    const done = foldLiveFrame(started!, result("c1", "ok"));
+    expect(done).toHaveLength(1);
+    expect(done![0].status).toBe("ok");
+    expect(done![0].label).toBe("Http Request");
+    expect(done![0].elapsedMs).toBe(12);
+  });
+
+  it("carries an error status through rather than reporting success", () => {
+    const rows = foldLiveFrame(foldLiveFrame([], call("c1", "Curl"))!, result("c1", "error"));
+    expect(rows![0].status).toBe("error");
+  });
+
+  /**
+   * The drop that made a mis-keyed frame *worse* than invisible. A result whose
+   * call is not in these rows is refused rather than adopted — adopting it
+   * would invent a row with no start, and pairing it with an unrelated running
+   * row would mark the wrong call finished.
+   *
+   * This is what left a spinner running forever when a key changed mid-turn
+   * (PR #2068 review): the call went to one bucket, the result to another, and
+   * the result was dropped on arrival. The fold's job is to refuse; keeping the
+   * key stable is what stops it being asked.
+   */
+  it("refuses a result whose call it does not hold", () => {
+    expect(foldLiveFrame([], result("c-unknown", "ok"))).toBeNull();
+
+    const other: LiveRow[] = [
+      { kind: "tool_call", status: "running", label: "Web Fetch", toolCallId: "c1" },
+    ];
+    expect(foldLiveFrame(other, result("c2", "ok"))).toBeNull();
+    // …and left the row it does hold untouched, still running.
+    expect(other[0].status).toBe("running");
+  });
+
+  it("appends a thinking row per frame, since the host already coalesced them", () => {
+    const rows = foldLiveFrame([], { type: "thinking" });
+    expect(rows).toHaveLength(1);
+    expect(rows![0].kind).toBe("thinking");
+  });
+
+  it("never mutates the rows it was given", () => {
+    const rows: LiveRow[] = [];
+    foldLiveFrame(rows, call("c1", "Http Request"));
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("two queries in one thread", () => {
+  /**
+   * The point of the split, stated as a property: each question's rows are
+   * folded against its own list, so neither can clear or contaminate the other
+   * — which is precisely what one shared per-thread list could not promise.
+   */
+  it("keep separate lists, so neither turn can lose the other's rows", () => {
+    // QUERY A delegates and then blocks on a teammate, emitting nothing more.
+    let a = foldLiveFrame([], call("a1", "Delegate To Teammate"))!;
+    a = foldLiveFrame(a, result("a1", "ok"))!;
+    expect(a).toHaveLength(1);
+
+    // QUERY B is asked while A is still open, and runs its own calls.
+    let b = foldLiveFrame([], call("b1", "Http Request"))!;
+    b = foldLiveFrame(b, result("b1", "ok"))!;
+
+    // A's row survived B's whole turn, and the two never mixed.
+    expect(a).toHaveLength(1);
+    expect(a[0].label).toBe("Delegate To Teammate");
+    expect(b).toHaveLength(1);
+    expect(b[0].label).toBe("Http Request");
+  });
+
+  /**
+   * And the shape that made the merged list unreadable even when nothing was
+   * lost: `seq` is per-turn, so both turns count from zero. Ordering a merged
+   * list by it is meaningless — which is why the split is by key rather than by
+   * sorting harder.
+   */
+  it("cannot be ordered by seq, because each turn counts from its own zero", () => {
+    const aFirst = { seq: 0, messageSeq: 45 };
+    const bFirst = { seq: 0, messageSeq: 49 };
+    expect(aFirst.seq).toBe(bFirst.seq);
+    expect(aFirst.messageSeq).not.toBe(bFirst.messageSeq);
+  });
+});

--- a/frontend/test/unit/live-steps-cleanup.test.ts
+++ b/frontend/test/unit/live-steps-cleanup.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const appShell = readFileSync("src/components/app-shell.tsx", "utf8");
+const threadPanel = readFileSync("src/views/chat/ThreadPanel.tsx", "utf8");
+const chatView = readFileSync("src/views/ChatView.tsx", "utf8");
+
+/**
+ * The four gaps the Codex review on #2069 found in per-query live rows, each
+ * pinned so it cannot come back.
+ *
+ * Filing rows per query fixed the case it was written for — two channel-rooted
+ * queries on the built-in harness — and left four ways for a bucket to be
+ * written that nothing renders, or rendered that nothing clears. All four are
+ * invisible in the happy path, which is exactly why they need pinning.
+ */
+
+describe("a threaded query's rows have somewhere to render", () => {
+  /**
+   * `buildTimeline` keeps every parented line out of the channel timeline
+   * (`if (!m.parentId) continue`), so a query typed into an open thread renders
+   * through `ThreadPanel` or nowhere at all. Passing the per-query map only to
+   * `MessageTimeline` left such a turn with no render path — and, because its
+   * frames now carry `messageSeq`, no per-thread fallback either.
+   */
+  it("ThreadPanel takes the per-query map and hands it to every line", () => {
+    expect(threadPanel).toContain("liveStepsByMessage?: Record<string, TurnStep[]>;");
+    // Both the question at the top of the panel and each reply under it.
+    expect(threadPanel).toContain("liveSteps={liveStepsByMessage?.[parent.id]}");
+    expect(threadPanel).toContain("liveSteps={liveStepsByMessage?.[r.id]}");
+  });
+
+  it("a panel line renders the live rows, not only the durable ones", () => {
+    expect(threadPanel).toContain("<StepTimeline steps={message.steps} />");
+    expect(threadPanel).toContain("<StepTimeline steps={[...liveSteps]} defaultOpen />");
+  });
+
+  it("ChatView supplies it, so the panel is never handed an empty map", () => {
+    expect(chatView).toMatch(/<ThreadPanel[\s\S]{0,600}liveStepsByMessage=\{liveStepsByMessage\}/);
+  });
+});
+
+describe("cleanup is addressed by the message that was answered", () => {
+  /**
+   * `AcceptedTurn::thread_root` is explicit that "a reply is parented to its
+   * question's parent, never to the question", so a reply's `parentId` names
+   * the thread ROOT for any follow-up typed inside a thread.
+   *
+   * Clearing by it would leave the follow-up's own bucket resident and — far
+   * worse — delete the root's. With the root's own turn still running that
+   * erases a live sibling's timeline: precisely the failure per-query rows
+   * exist to prevent, reintroduced by the cleanup path.
+   */
+  it("never keys the per-query clear on a reply's placement parent", () => {
+    const reply = appShell.slice(appShell.indexOf("const renderAgentReply"));
+    const body = reply.slice(0, reply.indexOf("setTranscripts("));
+    expect(body).not.toContain("setLiveStepsByMessage(");
+    expect(body).not.toMatch(/hostMessageId\(event\.parentId\)[\s\S]{0,200}delete/);
+  });
+
+  /**
+   * A turn that answers grows durable steps on its own message, which is a fact
+   * about that message rather than about where its reply was placed — so the
+   * swap is driven by their arrival.
+   */
+  it("retires a bucket once its message carries durable steps", () => {
+    expect(appShell).toMatch(/if \(m\.steps && m\.steps\.length > 0\) done\.add\(m\.id\)/);
+    // Driven from the history hydrate, so a mid-turn reload re-converges too.
+    expect(appShell).toMatch(/const hydrated = fromHistory\(entries\);[\s\S]{0,400}clearLiveRowsSettledBy\(hydrated\)/);
+  });
+
+  /**
+   * A turn that FAILS journals a `TurnFailed` line and no reply, so it never
+   * grows steps to swap for. Without this its bucket outlives the turn holding
+   * a row still marked `running` — a result that never arrived cannot flip it.
+   */
+  it("retires a failed turn's bucket on the terminal settle, inside the guard", () => {
+    const guardAt = appShell.indexOf(
+      "if (!hasOtherOpenTurns(openTurnsRef.current, liveKey, settledTurnId)) {",
+    );
+    expect(guardAt, "the settle guard must be present").toBeGreaterThan(-1);
+    // Inside the guard: a queued sibling still running owns its rows.
+    const block = appShell.slice(guardAt, guardAt + 1600);
+    expect(block).toContain("clearLiveRowsSettledBy(hydrated, hydrated.map((m) => m.id))");
+  });
+});

--- a/src/harness/acp/run_turn.rs
+++ b/src/harness/acp/run_turn.rs
@@ -375,16 +375,24 @@ impl AcpRunTurn {
     /// live rows land on the same thread the durable reply does — byte for
     /// byte the rule `built_in`'s `LiveStream::On` applies, because a frame
     /// routed to a different thread than its reply is worse than no frame.
-    fn chat_ctx(company: &CompanyId, agent_id: &str, chat_id: Option<&str>) -> TurnStreamCtx {
+    fn chat_ctx(company: &CompanyId, agent_id: &str, chat: ChatTarget<'_>) -> TurnStreamCtx {
         TurnStreamCtx {
             company: company.clone(),
             agent_id: agent_id.to_string(),
             route: LiveRoute::Chat {
-                chat_id: chat_id
+                chat_id: chat
+                    .chat_id
                     .map(str::to_string)
                     .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string()),
             },
-            message_seq: None,
+            // Takes the whole `ChatTarget` rather than the id alone, so this
+            // cannot go on answering with `None` while the caller holds the
+            // sequence. An ACP agent answers operator messages in a shared chat
+            // exactly as the built-in harness does, so without it two of its
+            // turns in one thread share a single row-list and arming the second
+            // erases the first — the failure this field exists to stop, left in
+            // place for one of the two harnesses (Codex on #2069).
+            message_seq: chat.message_seq.map(|seq| seq.value()),
         }
     }
 
@@ -686,7 +694,7 @@ impl RunTurn for AcpRunTurn {
         // (`LiveRoute::Chat`), and #1890's `thread_root` narrows *which
         // conversation inside it* the durable reply hangs from — a dimension
         // the transient timeline does not carry.
-        let ctx = Self::chat_ctx(company, agent_id, chat.chat_id);
+        let ctx = Self::chat_ctx(company, agent_id, chat);
         self.run_once(company, agent_id, message, chat.chat_id, Some(ctx))
             .await
     }
@@ -700,7 +708,7 @@ impl RunTurn for AcpRunTurn {
         chat: ChatTarget<'_>,
         _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
     ) -> Result<TurnOutcome> {
-        let ctx = Self::chat_ctx(company, agent_id, chat.chat_id);
+        let ctx = Self::chat_ctx(company, agent_id, chat);
         self.steered(company, agent_id, message, control, chat.chat_id, Some(ctx))
             .await
     }
@@ -996,6 +1004,41 @@ impl AcpRunTurn {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// An ACP agent's frames say which query they belong to, exactly as the
+    /// built-in harness's do.
+    ///
+    /// `chat_ctx` used to take `chat_id` alone and hard-code `message_seq:
+    /// None`, so every ACP frame fell into the shared per-thread bucket — two
+    /// of its turns in one chat shared a single row-list, and arming the second
+    /// erased the first's timeline. That is the failure `messageSeq` exists to
+    /// stop, and it was left in place for one of the two harnesses (Codex on
+    /// #2069).
+    ///
+    /// It now takes the whole `ChatTarget`, which is what keeps the two from
+    /// drifting again: there is no `chat_id`-only shape left to answer with.
+    #[test]
+    fn an_acp_chat_turn_carries_the_query_it_answers() {
+        use crate::ports::types::EventSeq;
+
+        let company = CompanyId::new("acp-msg-seq");
+
+        let answering = AcpRunTurn::chat_ctx(
+            &company,
+            "product_manager",
+            ChatTarget::channel(Some("general")).answering(Some(EventSeq::new(45))),
+        );
+        assert_eq!(answering.message_seq, Some(45));
+
+        // And a turn answering no journaled message still says nothing, so the
+        // consumer falls back to the thread exactly as it did before.
+        let unaddressed = AcpRunTurn::chat_ctx(
+            &company,
+            "product_manager",
+            ChatTarget::channel(Some("general")),
+        );
+        assert_eq!(unaddressed.message_seq, None);
+    }
 
     fn turn(updates: Vec<AcpUpdate>) -> AcpTurn {
         AcpTurn {

--- a/src/harness/acp/run_turn.rs
+++ b/src/harness/acp/run_turn.rs
@@ -384,6 +384,7 @@ impl AcpRunTurn {
                     .map(str::to_string)
                     .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string()),
             },
+            message_seq: None,
         }
     }
 
@@ -772,6 +773,8 @@ impl RunTurn for AcpRunTurn {
                 run_id: workflow_run_id.to_string(),
                 node_id: node_id.to_string(),
             },
+            // A workflow node answers a graph, not a message.
+            message_seq: None,
         };
         self.run_once(company, agent_id, message, None, Some(ctx))
             .await

--- a/src/harness/built_in/iteration_cap_turn_test.rs
+++ b/src/harness/built_in/iteration_cap_turn_test.rs
@@ -579,6 +579,7 @@ fn stream_for(chat: &str) -> crate::turn_stream::TurnStreamCtx {
         route: crate::turn_stream::LiveRoute::Chat {
             chat_id: chat.to_string(),
         },
+        message_seq: None,
     }
 }
 

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -1112,6 +1112,11 @@ impl CompanyAgent {
                             frame.with_workflow(run_id.clone(), node_id.clone())
                         }
                     };
+                    // Which *query* inside that thread, so a console holding two
+                    // in-flight turns on one thread keeps their rows apart.
+                    // Absent on a turn answering no journaled message, where the
+                    // console falls back to keying by thread alone.
+                    let frame = frame.with_message_seq(ctx.message_seq);
                     crate::turn_stream::publish(&ctx.company, frame);
                     seq += 1;
                 }
@@ -3651,6 +3656,12 @@ impl HarnessPool {
                     .map(str::to_string)
                     .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string()),
             },
+            // A copilot turn is addressed by `chat_id` alone — this entry point
+            // takes no `ChatTarget` — so its frames key by thread, as every
+            // frame did before `messageSeq` existed. A copilot thread runs one
+            // turn at a time, so there is nothing here for the finer key to
+            // separate.
+            message_seq: None,
         });
 
         // The message goes to the model AS SENT. This is the retrieve→inject
@@ -3969,6 +3980,13 @@ impl HarnessPool {
                         .map(str::to_string)
                         .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string()),
                 },
+                // The operator message this turn answers, read off the
+                // `ChatTarget` the caller already passes. Nothing new is
+                // threaded through the runtime to get it here — and pointedly
+                // NOT used to decide *whether* to stream, which is the
+                // conflation #1890 I removed and the revert of aa2787e9a
+                // re-established. `LiveStream` still decides that alone.
+                message_seq: chat.message_seq.map(|seq| seq.value()),
             }),
             // A workflow agent node (issue #1702): streams live, but keyed on
             // the workflow run + node so its frames land on the console's
@@ -3980,6 +3998,8 @@ impl HarnessPool {
                     run_id: run_id.to_string(),
                     node_id: node_id.to_string(),
                 },
+                // A workflow node answers a graph, not a message.
+                message_seq: None,
             }),
             LiveStream::Off => None,
         };

--- a/src/turn_stream.rs
+++ b/src/turn_stream.rs
@@ -260,6 +260,29 @@ pub struct TurnStreamEvent {
     /// Wall-clock the completed call took, on `tool_result` only.
     #[serde(rename = "elapsedMs", skip_serializing_if = "Option::is_none")]
     pub elapsed_ms: Option<u64>,
+    /// The journal sequence of the operator message this turn is answering,
+    /// when it is answering one at all.
+    ///
+    /// `chatId` says which *conversation* a frame belongs to; this says which
+    /// *query*. The distinction only starts to matter when one conversation has
+    /// two turns in flight, which is exactly when the console needs it. Keyed by
+    /// thread alone, a second send shares one live timeline with the first, so
+    /// two questions' rows pile into one list with nothing to tell them apart —
+    /// and because the console holds a single row-list per thread, arming the
+    /// second turn discards the first's rows outright. A turn blocked on a
+    /// teammate emits nothing further, so its timeline never comes back.
+    ///
+    /// With this, a console can group live rows per query and render each under
+    /// the message that asked it, the same way a settled turn's folded steps
+    /// already render under their reply.
+    ///
+    /// Carried from `ChatTarget::message_seq`, so it is `None` on every turn
+    /// that answers no journaled operator message — a relay, a delegate's
+    /// instruction, a dispatched card, a workflow node. A consumer falls back to
+    /// keying by `chatId` alone, which is what every consumer did before this
+    /// field existed.
+    #[serde(rename = "messageSeq", skip_serializing_if = "Option::is_none")]
+    pub message_seq: Option<u64>,
     /// The workflow **run** this frame belongs to, when the turn is a workflow
     /// agent node rather than a chat turn (issue #1702). The console's run-trace
     /// sheet keys the live tool timeline on this so a node's in-flight frames
@@ -293,6 +316,7 @@ impl Default for TurnStreamEvent {
             truncated: false,
             status: None,
             elapsed_ms: None,
+            message_seq: None,
             workflow_run_id: None,
             node_id: None,
         }
@@ -323,6 +347,17 @@ impl TurnStreamEvent {
         self.node_id = Some(node_id.into());
         self
     }
+
+    /// Stamps the operator message this turn answers, so the console can group
+    /// the frame under that query rather than under the thread as a whole.
+    ///
+    /// Takes the `Option` rather than the value: every publish site reads it off
+    /// a `ChatTarget` that may legitimately carry none, and answering no
+    /// journaled message is the normal case for half of them.
+    pub fn with_message_seq(mut self, seq: Option<u64>) -> Self {
+        self.message_seq = seq;
+        self
+    }
 }
 
 /// Routing context a turn carries so its live frames reach the right console
@@ -341,6 +376,11 @@ pub struct TurnStreamCtx {
     /// workflow run+node. The two are mutually exclusive, so an enum keeps a
     /// frame from ever carrying both (or neither) routing key.
     pub route: LiveRoute,
+    /// The operator message this turn answers, stamped onto every frame as
+    /// `messageSeq` so two turns sharing a thread stay tellable apart. `None`
+    /// for a turn answering no journaled message; see
+    /// [`TurnStreamEvent::message_seq`].
+    pub message_seq: Option<u64>,
 }
 
 /// Which console surface a turn's live frames route to.
@@ -591,6 +631,7 @@ mod tests {
             truncated: false,
             status: Some("ok"),
             elapsed_ms: Some(12),
+            message_seq: None,
             workflow_run_id: None,
             node_id: None,
         };
@@ -601,5 +642,59 @@ mod tests {
         assert_eq!(j["status"], "ok");
         assert_eq!(j["chatId"], "General");
         assert!(j.get("agentId").is_none(), "empty optional omitted");
+    }
+
+    /// Two turns racing in one chat are tellable apart, and by nothing else.
+    ///
+    /// `chatId` is the *conversation*; two questions asked in one channel share
+    /// it. So does `agentId` whenever the same desk answers both — which is the
+    /// common case, not a corner. Before `messageSeq` those were the only
+    /// routing keys a chat frame carried, so a console had no way to say which
+    /// question a row belonged to and merged both into one timeline.
+    ///
+    /// The observed cost was worse than a merged list: the console holds a
+    /// single row-list per thread, so arming the second turn cleared the first
+    /// turn's rows outright — and a turn blocked on a teammate emits nothing
+    /// further, so its steps never came back.
+    #[test]
+    fn two_queries_in_one_chat_are_told_apart_by_message_seq() {
+        let first = serde_json::to_value(
+            frame("tool_call", 0)
+                .with_chat("general")
+                .with_agent("product_manager")
+                .with_message_seq(Some(45)),
+        )
+        .expect("serialize");
+        let second = serde_json::to_value(
+            frame("tool_call", 0)
+                .with_chat("general")
+                .with_agent("product_manager")
+                .with_message_seq(Some(49)),
+        )
+        .expect("serialize");
+
+        // Every key they previously routed on agrees — including `seq`, which is
+        // per-turn and so restarts at 0 for each of them.
+        assert_eq!(first["chatId"], second["chatId"]);
+        assert_eq!(first["agentId"], second["agentId"]);
+        assert_eq!(first["seq"], second["seq"]);
+        // The query does not.
+        assert_eq!(first["messageSeq"], 45);
+        assert_eq!(second["messageSeq"], 49);
+        assert_ne!(first["messageSeq"], second["messageSeq"]);
+    }
+
+    /// Omitted, not null, on a turn answering no journaled message — a relay, a
+    /// dispatched card, a workflow node. A console that keys on its presence
+    /// falls back to the thread, which is what every console did before the
+    /// field existed, so an older one reads the wire form unchanged.
+    #[test]
+    fn a_turn_answering_no_message_carries_no_message_seq() {
+        let j =
+            serde_json::to_value(frame("tool_call", 0).with_chat("general")).expect("serialize");
+        assert!(
+            j.get("messageSeq").is_none(),
+            "absent rather than null, so presence is the check: {j}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two questions asked in one channel used to share a single live tool timeline — and asking the second one **destroyed the first turn's rows**.

A chat frame's routing keys were `chatId` and `agentId`. Two questions in one channel share the thread, and whenever the same desk answers both they share the agent too, so there was nothing to group a row by. `seq` cannot break the tie either: it is per-turn, so both turns count from zero and a merged list cannot even be ordered.

The console holds one row-list per thread and `onSendStart` resets it, so the second send cleared the first turn's rows outright. A turn blocked on a teammate emits nothing further, so its timeline never came back — the operator watched a spinner with no account of what was happening.

## The change

**Host** — `messageSeq` on `TurnStreamEvent`: the journal sequence of the operator message the turn answers. Read straight off the `ChatTarget` `run_inner` already receives, so nothing new is threaded through the runtime, and it needs no lookup table to resolve — unlike a thread key, it cannot depend on whether the desk list has loaded (the race fixed in `ebfee65c5`).

Pointedly **not** used to decide *whether* a turn streams. That conflation is what #1890 I removed and what the revert of `aa2787e9a` on #2068 re-established; `LiveStream` still answers that alone. This only labels a frame that was already being published.

**Console** — rows file under the asking message (`messageSeq` → `hostMessageId`) and render there through the same collapsed `StepTimeline` the settled steps already use, so a turn looks the same while it runs as it does once it is done. `defaultOpen`, whose doc already reserved it "for the live timeline of a turn still running": there is no answer above these rows yet, so they are the only account of what is happening. Cleared when the reply lands and the durable folded steps take over.

Two queries cannot share a list, so neither can clear the other's rows.

## Not a replacement

A frame with no `messageSeq` still keys by thread — every turn answering no journaled message (a relay, a delegate's instruction, a dispatched card, a workflow node, a copilot thread) and every older host. Those keep the existing per-thread strip.

Nor is it withheld when a thread is open, unlike `liveSteps`. The reason that one is withheld is that a single strip cannot say which turn it describes, which is exactly what this fixes.

## Testing

The fold moved to `lib/live-frame.ts` so both maps share one implementation **and the test calls the rule rather than restating it** — the trap the review on #2068 caught in `keyFor`, where a duplicated conditional would have kept passing through a regression in the branch the shell actually runs.

Verified end to end on a live tenant, on a binary built from this branch:

```
messageSeq=129  (query C)   78 frames
messageSeq=133  (query D)    2 frames
```

Both `chatId=main`, same agent — previously indistinguishable. C ran 04:00:15 → 04:02:45; D was sent at 04:00:36, mid-flight. C's rows rendered under C's own message and grew 5 → 11 → 18 across that window, untouched by D's send. Before this, that send discarded them: an instrumented run measured `sendStart:resetSteps | had=2`, two rows dropped from a live delegated turn. Both turns' rows cleared correctly once their replies landed.

```
cargo fmt --all -- --check
cargo test --features openhuman --lib      # 6868 passed, 0 failed
cargo check --features openhuman,acp --lib --tests
pnpm typecheck && pnpm typecheck:unit
pnpm exec vitest run test/unit             # 482 files, 4446 passed
```

## Behaviour changes

- `TurnStreamEvent` gains an optional `messageSeq`, omitted rather than null, so a consumer that ignores it reads the wire form unchanged.
- `TurnStreamCtx` gains a `message_seq` field — every construction site updated, including the ACP lane.

## Follow-up not included

A delegated card still does not stream. `run_task` calls `run_steered_background` with `ChatTarget::default()`, so there is no chat id to route on, and the revert on #2068 was right that fixing it needs `origin_chat_id` plumbed through as an explicit stream route rather than inferred. That is a separate change; `messageSeq` is a prerequisite for it rendering usefully, not a substitute.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live tool activity now appears directly beneath the message that initiated it.
  * Multiple simultaneous turns in the same conversation remain separated, with each timeline showing its own progress and results.
  * In-progress, successful, and failed tool steps are updated in place for clearer status tracking.

* **Bug Fixes**
  * Prevented activity from one turn from overwriting or clearing another turn’s timeline.
  * Preserved existing thread-level activity display for older or unassociated events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->