### PR TITLE
fix(console): use the real history DTO type in the reply-voice test

### DIFF
--- a/frontend/test/unit/system-author-reply-voice.test.ts
+++ b/frontend/test/unit/system-author-reply-voice.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { fromHistory, replyVoice, SYSTEM_AUTHOR } from "@/lib/chat";
-import type { ChatHistoryEntry } from "@/api/types";
+import type { ChatHistoryMessageDto } from "@/api/types";
 
 /**
  * One settled turn must read the same whether you watched it or loaded it.
@@ -19,14 +19,14 @@ import type { ChatHistoryEntry } from "@/api/types";
  * the pause-attribution fix set out to remove (Codex review on #2068).
  */
 
-const entry = (author: string): ChatHistoryEntry =>
-  ({
-    id: "7",
-    author,
-    text: "The reply above is a pause, not a finished answer",
-    atMillis: 1,
-    mine: false,
-  }) as ChatHistoryEntry;
+const entry = (author: string): ChatHistoryMessageDto => ({
+  id: "7",
+  channel: author,
+  author,
+  text: "The reply above is a pause, not a finished answer",
+  atMillis: 1,
+  mine: false,
+});
 
 describe("a host-authored reply", () => {
   it("is a system row live, exactly as it is after a reload", () => {


### PR DESCRIPTION
## Summary

`main` is red on `typecheck:unit`. #2068 was merged at its last-but-one head, where the `Console` and `Console (current Node, advisory)` lanes were failing; the fix was pushed to the branch four minutes after the merge and so is not on `main`.

```
test/unit/system-author-reply-voice.test.ts(4,15): error TS2305:
  Module '"@/api/types"' has no exported member 'ChatHistoryEntry'.
```

`fromHistory` takes `ChatHistoryMessageDto`. The test imported a type that does not exist.

Also drops the `as` cast that was papering over it, so the fixture is checked against the real DTO — `channel` is required, and the cast hid that too.

## Why it reached `main`

`npm run typecheck` is `tsc -b --noEmit` over the app project and does not cover `test/`, while vitest strips types — so the unit suite ran green locally against a type that was never checked. `Console` runs `typecheck`, `typecheck:e2e` and `typecheck:unit` as three separate steps, and only the first was run before pushing.

## Commands run

```
npm run typecheck        # pass
npm run typecheck:unit   # pass  <- the failing lane
npm run typecheck:e2e    # pass
pnpm exec vitest run test/unit/system-author-reply-voice.test.ts   # 3 passed
```

Test-only change; no runtime code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to use the current chat history message format.
  * No changes to test coverage or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->