### PR TITLE
build(console): pass the console's Sentry DSN and build commit into the image

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -153,9 +153,31 @@ jobs:
           # which revision it is compiling — every hosted tenant would report
           # `unknown` forever. `actions/checkout` checked out `github.sha`, so
           # this names the commit that was actually built.
+          #
+          # `VITE_SENTRY_DSN` / `VITE_BUILD_COMMIT` are the console's half of
+          # crash reporting, and the host's runtime env cannot supply them: Vite
+          # inlines them into the bundle during this image build, so a DSN set
+          # on the StatefulSet afterwards arrives far too late and is a silent
+          # no-op (`docs/spec/runtime/crash-reporting.md`).
+          #
+          # The DSN is a repository VARIABLE, not a secret. A browser bundle's
+          # DSN is public by construction — anyone who opens the console can
+          # read it — so masking would buy nothing and would only stop this
+          # workflow from being able to report whether it is set.
+          #
+          # Empty when the variable is unset, which keeps the console silent
+          # rather than failing the build: the same "no DSN, no client" gate
+          # every local `npm run build` already takes.
+          #
+          # `VITE_BUILD_COMMIT` takes the SAME value as the Rust half above so
+          # both surfaces compute one `opencompany@<version>+<commit>` release
+          # string. Passed different values they still both report — and their
+          # events silently never join in one filter.
           build-args: |
             FEATURES=${{ env.TENANT_FEATURES }}
             OPENCOMPANY_BUILD_COMMIT=${{ github.sha }}
+            VITE_SENTRY_DSN=${{ vars.OPENCOMPANY_REACT_SENTRY_DSN }}
+            VITE_BUILD_COMMIT=${{ github.sha }}
           push: true
           tags: |
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:staging-${{ github.sha }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -186,6 +186,14 @@ jobs:
           # bundle at build time, where the manager's runtime env can never
           # reach it (Codex on #2073).
           #
+          # `VITE_SENTRY_TRACES_SAMPLE_RATE` gets NO fallback, unlike the
+          # environment above. Absent means `0` and no tracing integration at
+          # all, which is what both surfaces already default to and what this
+          # repository deliberately chose: transactions bill separately from
+          # errors and are emitted per page load, so defaulting anyone into them
+          # here would be a recurring cost nobody asked for. Set the variable to
+          # turn tracing on knowingly.
+          #
           # `VITE_BUILD_COMMIT` takes the SAME value as the Rust half above so
           # both surfaces compute one `opencompany@<version>+<commit>` release
           # string. Passed different values they still both report — and their
@@ -196,6 +204,7 @@ jobs:
             VITE_SENTRY_DSN=${{ vars.OPENCOMPANY_REACT_SENTRY_DSN }}
             VITE_BUILD_COMMIT=${{ github.sha }}
             VITE_SENTRY_ENVIRONMENT=${{ vars.OPENCOMPANY_SENTRY_ENVIRONMENT || 'hosted-tenant' }}
+            VITE_SENTRY_TRACES_SAMPLE_RATE=${{ vars.OPENCOMPANY_SENTRY_TRACES_SAMPLE_RATE }}
           push: true
           tags: |
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:staging-${{ github.sha }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -171,11 +171,20 @@ jobs:
           #
           # `VITE_SENTRY_ENVIRONMENT` reads the SAME variable the manager injects
           # into the tenant as `OPENCOMPANY_SENTRY_ENVIRONMENT`, so one value
-          # tags both surfaces. Their defaults differ — the host falls back to
-          # its deployment kind (`hosted-tenant`), the console to `production` —
-          # so leaving it unset splits one tenant's reports across two
-          # `environment` values, and the console's copy is baked in where the
-          # manager's runtime env cannot reach it.
+          # tags both surfaces.
+          #
+          # The `|| 'hosted-tenant'` is the part that matters, because an empty
+          # build-arg is NOT the same as an unset one here. Passed empty, the
+          # console keeps its own default of `production` while the host keeps
+          # its deployment kind — and everything this image builds is a hosted
+          # tenant. The fallback is `Deployment::HostedTenant::as_str()`
+          # verbatim, which is exactly what the host reports when the manager
+          # leaves the variable unset, so unset now means "both agree" instead
+          # of "both guess differently".
+          #
+          # It has to be decided here: the console's copy is baked into the
+          # bundle at build time, where the manager's runtime env can never
+          # reach it (Codex on #2073).
           #
           # `VITE_BUILD_COMMIT` takes the SAME value as the Rust half above so
           # both surfaces compute one `opencompany@<version>+<commit>` release
@@ -186,7 +195,7 @@ jobs:
             OPENCOMPANY_BUILD_COMMIT=${{ github.sha }}
             VITE_SENTRY_DSN=${{ vars.OPENCOMPANY_REACT_SENTRY_DSN }}
             VITE_BUILD_COMMIT=${{ github.sha }}
-            VITE_SENTRY_ENVIRONMENT=${{ vars.OPENCOMPANY_SENTRY_ENVIRONMENT }}
+            VITE_SENTRY_ENVIRONMENT=${{ vars.OPENCOMPANY_SENTRY_ENVIRONMENT || 'hosted-tenant' }}
           push: true
           tags: |
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:staging-${{ github.sha }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -169,6 +169,14 @@ jobs:
           # rather than failing the build: the same "no DSN, no client" gate
           # every local `npm run build` already takes.
           #
+          # `VITE_SENTRY_ENVIRONMENT` reads the SAME variable the manager injects
+          # into the tenant as `OPENCOMPANY_SENTRY_ENVIRONMENT`, so one value
+          # tags both surfaces. Their defaults differ — the host falls back to
+          # its deployment kind (`hosted-tenant`), the console to `production` —
+          # so leaving it unset splits one tenant's reports across two
+          # `environment` values, and the console's copy is baked in where the
+          # manager's runtime env cannot reach it.
+          #
           # `VITE_BUILD_COMMIT` takes the SAME value as the Rust half above so
           # both surfaces compute one `opencompany@<version>+<commit>` release
           # string. Passed different values they still both report — and their
@@ -178,6 +186,7 @@ jobs:
             OPENCOMPANY_BUILD_COMMIT=${{ github.sha }}
             VITE_SENTRY_DSN=${{ vars.OPENCOMPANY_REACT_SENTRY_DSN }}
             VITE_BUILD_COMMIT=${{ github.sha }}
+            VITE_SENTRY_ENVIRONMENT=${{ vars.OPENCOMPANY_SENTRY_ENVIRONMENT }}
           push: true
           tags: |
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:staging-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,13 @@ WORKDIR /console
 # builds no client without a DSN, and `sentryRelease()` falls back to the bare
 # version without a commit. A local `docker build` therefore needs neither.
 #
+# `VITE_SENTRY_ENVIRONMENT` has to be passed for the same reason, and is easy to
+# miss because both surfaces default to something plausible and different: the
+# host falls back to its deployment kind (`hosted-tenant`), a browser bundle
+# cannot know that and falls back to `production`. Left unset, one tenant's
+# reports split across two `environment` values and no filter shows both. The
+# manager's `OPENCOMPANY_SENTRY_ENVIRONMENT` is the value to match.
+#
 # `VITE_BUILD_COMMIT` is the frontend's spelling of the builder stage's
 # `OPENCOMPANY_BUILD_COMMIT`, not a second source of truth — `vite.config.ts`
 # shortens it to the same twelve characters `src/build_stamp.rs` normalizes to,
@@ -101,8 +108,10 @@ RUN npm ci
 # `node_modules`.
 ARG VITE_SENTRY_DSN=""
 ARG VITE_BUILD_COMMIT=""
+ARG VITE_SENTRY_ENVIRONMENT=""
 ENV VITE_SENTRY_DSN=$VITE_SENTRY_DSN \
-    VITE_BUILD_COMMIT=$VITE_BUILD_COMMIT
+    VITE_BUILD_COMMIT=$VITE_BUILD_COMMIT \
+    VITE_SENTRY_ENVIRONMENT=$VITE_SENTRY_ENVIRONMENT
 
 COPY frontend/ ./
 RUN npm run build && npm run build:pages-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,13 @@ WORKDIR /console
 # reports split across two `environment` values and no filter shows both. The
 # manager's `OPENCOMPANY_SENTRY_ENVIRONMENT` is the value to match.
 #
+# `VITE_SENTRY_TRACES_SAMPLE_RATE` is here for the same build-time reason, and
+# is deliberately given NO default: absent means `0`, which installs no tracing
+# integration at all. That is the shipped choice, not an oversight — errors and
+# transactions bill separately, and a transaction is emitted per page load
+# rather than only when something breaks, so a rate chosen on an operator's
+# behalf is a recurring bill they did not ask for.
+#
 # `VITE_BUILD_COMMIT` is the frontend's spelling of the builder stage's
 # `OPENCOMPANY_BUILD_COMMIT`, not a second source of truth — `vite.config.ts`
 # shortens it to the same twelve characters `src/build_stamp.rs` normalizes to,
@@ -109,9 +116,11 @@ RUN npm ci
 ARG VITE_SENTRY_DSN=""
 ARG VITE_BUILD_COMMIT=""
 ARG VITE_SENTRY_ENVIRONMENT=""
+ARG VITE_SENTRY_TRACES_SAMPLE_RATE=""
 ENV VITE_SENTRY_DSN=$VITE_SENTRY_DSN \
     VITE_BUILD_COMMIT=$VITE_BUILD_COMMIT \
-    VITE_SENTRY_ENVIRONMENT=$VITE_SENTRY_ENVIRONMENT
+    VITE_SENTRY_ENVIRONMENT=$VITE_SENTRY_ENVIRONMENT \
+    VITE_SENTRY_TRACES_SAMPLE_RATE=$VITE_SENTRY_TRACES_SAMPLE_RATE
 
 COPY frontend/ ./
 RUN npm run build && npm run build:pages-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,39 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # already carries it into the runtime image with no second COPY needed.
 FROM node:22-slim AS console
 WORKDIR /console
+
+# Console crash reporting (`docs/spec/runtime/crash-reporting.md`).
+#
+# These are read by Vite at BUILD time and inlined into the bundle, so unlike
+# the host's `OPENCOMPANY_SENTRY_DSN` they cannot be injected into the running
+# container: by the time k8s sets env, the bundle is already built. Without
+# them there is no path for a console DSN to reach a hosted tenant at all, and
+# setting one on the StatefulSet is a silent no-op.
+#
+# Both default to empty, which is the shipped behaviour: `resolveCrashReporting`
+# builds no client without a DSN, and `sentryRelease()` falls back to the bare
+# version without a commit. A local `docker build` therefore needs neither.
+#
+# `VITE_BUILD_COMMIT` is the frontend's spelling of the builder stage's
+# `OPENCOMPANY_BUILD_COMMIT`, not a second source of truth — `vite.config.ts`
+# shortens it to the same twelve characters `src/build_stamp.rs` normalizes to,
+# so both surfaces compute one `opencompany@<version>+<commit>` release string.
+# Passed the same value, a console event and a host event from this image line
+# up in one filter; passed different ones, they silently never join.
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
+
+# Declared AFTER `npm ci` on purpose. `ENV` invalidates every layer beneath it
+# and `VITE_BUILD_COMMIT` changes on every commit, so hoisting these above the
+# install would re-run a full `npm ci` for each build — the same cache argument
+# the builder stage makes for `OPENCOMPANY_BUILD_COMMIT`, which is cheap there
+# only because the cargo `target` mount survives it. Nothing survives a lost
+# `node_modules`.
+ARG VITE_SENTRY_DSN=""
+ARG VITE_BUILD_COMMIT=""
+ENV VITE_SENTRY_DSN=$VITE_SENTRY_DSN \
+    VITE_BUILD_COMMIT=$VITE_BUILD_COMMIT
+
 COPY frontend/ ./
 RUN npm run build && npm run build:pages-sdk
 

--- a/docs/spec/runtime/crash-reporting.md
+++ b/docs/spec/runtime/crash-reporting.md
@@ -382,14 +382,18 @@ Named so they are countable rather than implied.
   be reporting nothing, with every signal in this product saying it is healthy.
   This was observed against a real project, not imagined. Check quota in Sentry
   itself; nothing in the boot line or `sentry-test` will say.
-- **The two surfaces' release tags can disagree on the version.** Both are
-  shaped `opencompany@<version>[+<commit>]`, but the host reads
-  `Cargo.toml`'s version and the console reads `frontend/package.json`'s, and
-  nothing keeps those two numbers in step — they are `0.1.1` and `0.1.0` as
-  this is written. The commit half still matches for a build that sets
-  `OPENCOMPANY_BUILD_COMMIT` / `VITE_BUILD_COMMIT`, which is what actually
+- **Nothing enforces that the two surfaces' versions stay in step.** Both tags
+  are shaped `opencompany@<version>[+<commit>]`, but the host reads
+  `Cargo.toml`'s version and the console reads `frontend/package.json`'s. They
+  agree as this is written, and they agree only because someone kept them that
+  way: no check compares them, so a release that bumps one and forgets the
+  other drifts them silently and nothing reports it. That is not hypothetical —
+  `chore(release): 0.1.1` bumped `Cargo.toml`, both `src-tauri` manifests and
+  `tauri.conf.json`, missed `frontend/package.json`, and the gap was found in
+  review rather than by any lane. The commit half still matches for a build that
+  sets `OPENCOMPANY_BUILD_COMMIT` / `VITE_BUILD_COMMIT`, which is what actually
   identifies a build; set `SENTRY_RELEASE` explicitly if the two surfaces must
-  file under one exact string.
+  file under one exact string whatever the versions say.
 - **Host spans stop at the HTTP boundary.** See
   [tracing.md](tracing.md#known-limitations).
 - **`Authorization: Token <value>` with an unprefixed value is not scrubbed.**

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencompany-console",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencompany-console",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@fontsource-variable/geist": "^5.2.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencompany-console",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A company-agnostic operator console for any OpenCompany host, built with Vite + React.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Crash reporting landed in #2067 with both surfaces configurable — but on a **hosted tenant only the host's half can actually be configured**.

`OPENCOMPANY_SENTRY_DSN` is runtime env the manager injects, so it works today. `VITE_SENTRY_DSN` is read by Vite at **build** time and inlined into the bundle, and that bundle is built inside this image (`RUN npm run build` in the `console` stage). By the time k8s sets env on the StatefulSet the string is already baked in, so a console DSN set there is a silent no-op — and there was no build-arg to set it by instead.

Net effect: a hosted tenant had no way to report console errors at all. The doc says as much:

> ### The console
> Read at **build** time by Vite, so they must be set when the console bundle is built, not when the host runs.

## What this adds

- `ARG`/`ENV` for `VITE_SENTRY_DSN` and `VITE_BUILD_COMMIT` in the `console` stage
- both passed as build-args from `deploy-staging.yml`

## Why `VITE_BUILD_COMMIT` rides along

The release tags have to agree or the two surfaces never correlate. `sentryRelease()` shortens it to the same twelve characters `src/build_stamp.rs` normalizes to, so both compute `opencompany@<version>+<commit>` from the one `github.sha`. Left unset the console falls back to the bare version and its events silently never join the host's in a filter — the same class of failure the doc already flags for source maps, where *"stack traces stay minified with no error anywhere to say why."*

## Placement

Declared **after** `npm ci`, not beside `WORKDIR`. `ENV` invalidates every layer beneath it and the commit changes on every build, so hoisting them would re-run a full dependency install each time. The builder stage can afford that for `OPENCOMPANY_BUILD_COMMIT` only because its cargo `target` mount survives the invalidation; nothing survives a lost `node_modules`.

## Variable, not secret

A browser bundle's DSN is public by construction — anyone who opens the console can read it — so masking buys nothing and would only stop the workflow reporting whether it is set. It needs a repo variable `OPENCOMPANY_REACT_SENTRY_DSN`; unset, the build passes empty and the console stays silent, exactly as every local `npm run build` already does.

Per the doc, this should be a **different Sentry project from the host's**: *"mixing it with a server project means anyone who opens the console can write to it."*

## Testing

Both args default to empty, so `docker build` with no arguments behaves exactly as before — no DSN means `resolveCrashReporting` builds no client.

I could not build the image locally (no Docker daemon on this machine), so the wiring is verified by inspection rather than execution:

- the block scalar contains only `KEY=VALUE` lines — comments are outside it, since `build-args: |` is literal text and a `#` line would be passed to Docker verbatim
- `ARG`/`ENV` are in the `console` stage and precede `RUN npm run build`
- `vite.config.ts` reads `process.env.VITE_BUILD_COMMIT` and `import.meta.env.VITE_SENTRY_DSN`

**The first staging deploy is the real verification.** Afterwards, on a post-merge image:

```
kubectl -n <tenant> exec opencompany-0 -- grep -rl "sentry" /app/console | head
```

Today that returns nothing on `tenant-marketing` — but note its running image (`681bd86d3`) predates #2067, so that is not yet evidence either way.

## Not included

`SENTRY_AUTH_TOKEN` and source-map upload. Without it console traces arrive minified, but it is a separate and riskier change — a bad token **fails the build** rather than degrading, and enabling `build.sourcemap` without the plugin to delete the maps would ship the console's source to every viewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved frontend crash reporting by including the deployed build version and environment with reported errors.
  - Builds remain successful and the console stays silent when crash-reporting configuration is unavailable.

- **Chores**
  - Updated staging builds to correctly include frontend crash-reporting configuration at build time.
  - Updated the frontend version to 0.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->