### PR TITLE
feat(console): scope the console to one company per install

### DIFF
--- a/docs/spec/runtime/desktop-instances.md
+++ b/docs/spec/runtime/desktop-instances.md
@@ -55,22 +55,37 @@ case would be worse than the single-host one it replaces.
 
 ### Which empty root gets a company, and which gets the wizard
 
-The two hosts differ in exactly one decision, `embedded::FirstRun`:
+**None of them.** Every instance the desktop starts takes
+`embedded::FirstRun::RunSetupWizard`: it adopts what its root already holds and
+seeds nothing, the one at the data root included. `local::start_at` hard-codes
+that arm, and `embedded::FirstRun::SeedStarterCompany` survives only for callers
+that want a populated host without walking a wizard — the test suites.
 
-- **The instance at the data root** seeds a starter company from the default
-  preset (`SeedStarterCompany`). That is [issue #632](https://github.com/tinyhumansai/opencompany/issues/632):
-  a double-clicked application must be enterable with no terminal and no
-  decisions.
-- **An instance an operator created** does not (`RunSetupWizard`). They are
-  standing in front of the application having just named a company, so the
-  decisions the first-run wizard asks for — template, sign-in mode, brain
-  credential — are ones they are already making.
+That reversed an earlier split, in which the instance at the data root seeded a
+starter company from the default preset and only an operator-created instance
+got the wizard. Commit `a37854eaf`, *"fix(desktop): open the first-run wizard
+instead of seeding a company"*, records why: seeding made `/spec` report
+`setup_complete`, `ConnectionConsole` enters its setup phase from that field and
+nothing else, and no settings link re-opens the wizard — so the one install that
+most needs onboarding became the one install that could never reach it.
 
-Seeding is not merely "adds a company". `AppSpec` reports
-`setup_complete: stamp || !registry.is_empty()`, and the console opens
+[Issue #632](https://github.com/tinyhumansai/opencompany/issues/632)'s guarantee
+survives as a guarantee about *reachability* rather than about seeding: the
+wizard is anonymous on loopback while the registry is empty, its model step is
+skippable, and finishing it seeds a template. Still enterable with no terminal
+and no credential — it asks first, which is the point.
+
+An install that already has a company is unaffected either way: seeding was only
+ever the fallback half of `bootstrap_companies`, reached when adoption came back
+empty.
+
+Seeding was never merely "adds a company", which is why it went. `AppSpec`
+reports `setup_complete: stamp || !registry.is_empty()`, and the console opens
 `views/setup/SetupWizard.tsx` only on `setup_complete: false` — so a seeded
-company **suppresses the wizard permanently**. Both halves are pinned by a test
-that reads `/spec` over HTTP rather than counting companies.
+company **suppresses the wizard permanently**, one silent answer to every
+question it would have asked. Two tests in `local.rs` pin the current behaviour
+by reading `/spec` over HTTP rather than counting companies, including one for
+the instance at the data root.
 
 `RunSetupWizard` skips the *seed* half of `bootstrap_companies` and keeps the
 *adopt* half (`desktop::adopt_companies`). Adoption is not optional for either
@@ -86,8 +101,10 @@ behaviour instead of to an unhandled command.
 ### First run
 
 On the `SeedStarterCompany` branch — `embedded::start`, which is the wrapper
-`start_with` exposes for it — `opencompany::desktop::bootstrap_companies` runs
-before the bind, because a host with an empty registry cannot be signed into
+`start_with` exposes for it, and which **no launched application takes** (see
+above; it is there for the test suites) —
+`opencompany::desktop::bootstrap_companies` runs before the bind, because a host
+with an empty registry cannot be signed into
 ([issue #632](https://github.com/tinyhumansai/opencompany/issues/632)). Sign-in
 is per-company — `/api/v1/companies/{id}/auth/…`, or the sole-company alias —
 so an empty registry leaves the console rendering a login form for a company

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -294,6 +294,7 @@ function Console() {
     // A browser has nothing to ask, so it is resolved before it starts.
     resolved: !isDesktopRuntime(),
     id: null,
+    roster: false,
     instances: [],
   }));
 
@@ -315,7 +316,7 @@ function Console() {
       // Adopted once. A second call would re-run the prune against a set it has
       // already reconciled, for a value this one already has.
       const id = host ? adoptLocalHosts([host])[0] : null;
-      setEmbedded({ resolved: true, id, instances: [] });
+      setEmbedded({ resolved: true, id, roster: false, instances: [] });
       return;
     }
 
@@ -346,6 +347,7 @@ function Console() {
       // every machine that has not deliberately stopped it. What the desktop
       // opens on when nothing else is selected.
       id: ids[0] ?? null,
+      roster: true,
       instances,
     });
   }, []);
@@ -361,7 +363,15 @@ function Console() {
    */
   const runHere = useCallback(async (): Promise<void> => {
     const instances = await localInstances();
-    const target = instances?.find((instance) => !instance.running) ?? instances?.[0];
+    if (instances === null) {
+      // A shell predating the roster answers no instances to start, so there is
+      // nothing this can do. It is not offered there — see `canStartHere` — and
+      // saying so is better than a press that silently changes nothing.
+      throw new Error(
+        "This version of the application cannot start a host for you. Quit any other copy that is holding its data, then reopen this one.",
+      );
+    }
+    const target = instances.find((instance) => !instance.running) ?? instances[0];
     if (target) await startLocalInstance(target.id);
     await refreshLocal();
   }, [refreshLocal]);
@@ -705,6 +715,7 @@ function Console() {
               starting={!embedded.resolved}
               desktop={isDesktopRuntime()}
               onRunHere={runHere}
+              canStartHere={embedded.roster}
             />
           </ConsoleChrome>
         )}
@@ -754,6 +765,15 @@ interface EmbeddedState {
    */
   id: ConnectionId | null;
   /**
+   * Whether this shell answers the instance roster at all.
+   *
+   * `false` on a shell predating it, which is a supported degrade — and not the
+   * same fact as a roster that came back empty. Only the roster can start an
+   * instance, so this is what separates "nothing is running, and this app can
+   * start it" from "nothing is running, and it cannot".
+   */
+  roster: boolean;
+  /**
    * Every local instance the core knows about, running or not.
    *
    * The stopped ones are here and nowhere else: they have no address, so they
@@ -802,10 +822,20 @@ function NoConnection({
   starting,
   desktop,
   onRunHere,
+  canStartHere,
 }: {
   starting: boolean;
   desktop: boolean;
   onRunHere: () => Promise<void>;
+  /**
+   * Whether this shell can start a host at all.
+   *
+   * False on one predating the instance roster: it answers no list, so there is
+   * nothing to start and a button would be a control whose only outcome is
+   * nothing happening. The remedy there is the operator's, so the screen says
+   * what it is instead of offering to do it.
+   */
+  canStartHere: boolean;
 }) {
   const { setAddingHost } = useHosts();
   const copy = firstHostCopy(desktop);
@@ -836,7 +866,12 @@ function NoConnection({
         <div className="max-w-sm space-y-3" data-testid="no-connection">
           <p className="text-sm font-medium">{copy.title}</p>
           <p className="text-sm text-muted-foreground">{copy.body}</p>
-          {desktop ? (
+          {desktop && !canStartHere ? (
+            <p className="text-sm text-muted-foreground" data-testid="no-connection-cannot-start">
+              This version of the application cannot start it for you. Quit the other copy, then
+              reopen this one.
+            </p>
+          ) : desktop ? (
             <Button
               data-testid="no-connection-run-here"
               disabled={busy}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -350,6 +350,22 @@ function Console() {
     });
   }, []);
 
+  /**
+   * Start the host on this computer, for an operator who has none.
+   *
+   * The desktop's recovery is an action rather than a choice: there is exactly
+   * one meaningful answer to "where should this run" on a machine that runs its
+   * own host, and the usual reason there is nothing to show — another copy
+   * holding the data root — is fixed by quitting that copy and trying again, not
+   * by picking a different kind of host.
+   */
+  const runHere = useCallback(async (): Promise<void> => {
+    const instances = await localInstances();
+    const target = instances?.find((instance) => !instance.running) ?? instances?.[0];
+    if (target) await startLocalInstance(target.id);
+    await refreshLocal();
+  }, [refreshLocal]);
+
   useEffect(() => {
     let cancelled = false;
     void refreshLocal().catch((error: unknown) => {
@@ -684,11 +700,12 @@ function Console() {
             isBootstrap={active.id === bootstrapId}
           />
         ) : (
-          // The switcher rides along, because an operator whose local host is
-          // gone still has somewhere else to connect to — and "Add a host" is
-          // the only way out of a desktop that holds none.
           <ConsoleChrome>
-            <NoConnection starting={!embedded.resolved} desktop={isDesktopRuntime()} />
+            <NoConnection
+              starting={!embedded.resolved}
+              desktop={isDesktopRuntime()}
+              onRunHere={runHere}
+            />
           </ConsoleChrome>
         )}
       </ConsoleOrAddHost>
@@ -781,9 +798,34 @@ function Waiting({ children }: { children: React.ReactNode }) {
  * telling somebody with nothing on screen to go and find a control is not an
  * answer, it is a description of one.
  */
-function NoConnection({ starting, desktop }: { starting: boolean; desktop: boolean }) {
+function NoConnection({
+  starting,
+  desktop,
+  onRunHere,
+}: {
+  starting: boolean;
+  desktop: boolean;
+  onRunHere: () => Promise<void>;
+}) {
   const { setAddingHost } = useHosts();
   const copy = firstHostCopy(desktop);
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState<string | null>(null);
+
+  async function runHere() {
+    setBusy(true);
+    setFailed(null);
+    try {
+      await onRunHere();
+    } catch (error) {
+      setFailed(
+        error instanceof Error ? error.message : "The host on this computer would not start.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <FullScreen>
       {starting ? (
@@ -794,9 +836,24 @@ function NoConnection({ starting, desktop }: { starting: boolean; desktop: boole
         <div className="max-w-sm space-y-3" data-testid="no-connection">
           <p className="text-sm font-medium">{copy.title}</p>
           <p className="text-sm text-muted-foreground">{copy.body}</p>
-          <Button data-testid="no-connection-add" onClick={() => setAddingHost(true)}>
-            {copy.action}
-          </Button>
+          {desktop ? (
+            <Button
+              data-testid="no-connection-run-here"
+              disabled={busy}
+              onClick={() => void runHere()}
+            >
+              {busy ? "Starting…" : copy.action}
+            </Button>
+          ) : (
+            <Button data-testid="no-connection-add" onClick={() => setAddingHost(true)}>
+              {copy.action}
+            </Button>
+          )}
+          {failed && (
+            <p className="text-sm text-destructive" data-testid="no-connection-failed">
+              {failed}
+            </p>
+          )}
         </div>
       )}
     </FullScreen>

--- a/frontend/src/api/setup.ts
+++ b/frontend/src/api/setup.ts
@@ -12,6 +12,7 @@
 // consistent with the file the whole surface exists to write.
 
 import type { OpenCompanyClient } from "./client";
+import { INFERENCE_MANAGED_HIDDEN } from "@/product-scope";
 
 /** Which precedence layer supplied a field's current value. */
 export type ConfigLayer = "env" | "config.toml" | "manifest" | "default";
@@ -170,6 +171,15 @@ export const INFERENCE_PROVIDERS = [
 ] as const;
 
 export type InferenceProviderId = (typeof INFERENCE_PROVIDERS)[number]["id"];
+
+/**
+ * The providers the wizard offers. {@link INFERENCE_PROVIDERS} keeps every
+ * entry, so a host already reporting a hidden one still resolves its label and
+ * its key/URL requirements.
+ */
+export const SETUP_INFERENCE_OPTIONS = INFERENCE_PROVIDERS.filter(
+  (provider) => provider.id !== "managed" || !INFERENCE_MANAGED_HIDDEN,
+);
 
 /** What the connection test answers. */
 export interface InferenceTestResult {

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -153,6 +153,7 @@ import { UnknownRouteView } from "@/views/UnknownRouteView";
 import { ConnectionsSection } from "@/views/connections/ConnectionsSection";
 import { SettingsSection } from "@/views/SettingsSection";
 import { useLocalScope } from "@/connections/ConnectionContext";
+import { canCreateCompanies } from "@/components/create-company-dialog";
 
 // React Flow is heavy and only used here — load it on demand.
 const WorkflowsView = lazy(() =>
@@ -3340,7 +3341,7 @@ export function AppShell({
             onSwitchCompany={onSwitchCompany}
             onBackToPicker={onBackToPicker}
             onCreateCompany={onCreateCompany}
-            canCreateCompany={client.carriesPlatformBearer}
+            canCreateCompany={canCreateCompanies(client)}
           />
         }
         overview={

--- a/frontend/src/components/create-company-dialog.tsx
+++ b/frontend/src/components/create-company-dialog.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { COMPANY_SWITCHING_HIDDEN } from "@/product-scope";
 import {
   Select,
   SelectContent,
@@ -81,9 +82,22 @@ const POLICY_MODES: { value: string; label: string }[] = [
 export const CREATE_UNAVAILABLE_NOTE =
   "Creating a company needs a platform credential, which a person signed in here doesn't hold.";
 
-/** Whether this client can reach the provisioning + archive routes at all. */
+/**
+ * Whether a company can be created from this console at all.
+ *
+ * The one funnel every trigger asks, and the reason it is asked here rather
+ * than at each of them: provisioning is reachable from four places — the
+ * switcher's "New company", the picker's own button, the picker's per-card
+ * Reset, the no-company screen, and Settings' "Reset / Start clean", which
+ * archives and re-provisions through this same dialog. Gating them one at a
+ * time is how three of them stayed live after the first was hidden.
+ *
+ * Two conditions, deliberately in one place: the client has to hold a platform
+ * credential to reach the routes, and the product has to be offering company
+ * creation in the first place.
+ */
 export function canCreateCompanies(client: OpenCompanyClient): boolean {
-  return client.carriesPlatformBearer;
+  return !COMPANY_SWITCHING_HIDDEN && client.carriesPlatformBearer;
 }
 
 interface Props {

--- a/frontend/src/components/host-switcher.tsx
+++ b/frontend/src/components/host-switcher.tsx
@@ -44,6 +44,7 @@ import { hostShortcutLabel, useHosts } from "@/connections/HostsContext";
 import type { CompanyStatus } from "@/api/types";
 import type { Connection, ConnectionStatus } from "@/connections/types";
 import { cn } from "@/lib/utils";
+import { COMPANY_SWITCHING_HIDDEN, HOSTS_HIDDEN } from "@/product-scope";
 
 /**
  * How a connection's state reads, and what colour says so.
@@ -256,8 +257,17 @@ export function HostSwitcher({
   const hosts = useHosts();
   const { connections, selected, hub } = hosts;
 
-  const interactive = hostSwitcherInteractive(connections.length, hub);
-  const menu = hostSwitcherMenu(connections.length, hub);
+  const interactive = !HOSTS_HIDDEN && hostSwitcherInteractive(connections.length, hub);
+  // Whether there is anything to offer under Companies. Hidden entirely on a
+  // console with one company and nowhere else to go — the same condition the
+  // sidebar footer row used before it moved in here.
+  const showCompanies =
+    !COMPANY_SWITCHING_HIDDEN &&
+    !!((companies.length > 1 && onSwitchCompany) || onBackToPicker || onCreateCompany);
+  // A trigger that opens nothing is a nameplate. Derived from what the menu would
+  // actually hold, so hiding every group falls to the nameplate branch below
+  // rather than leaving a chevron over an empty popup.
+  const menu = (!HOSTS_HIDDEN && hostSwitcherMenu(connections.length, hub)) || showCompanies;
   const active = connections.find((c) => c.id === selected) ?? null;
   const worst = worstStatus(connections);
 
@@ -436,15 +446,6 @@ export function HostSwitcher({
     );
   }
 
-  // Whether there is anything to offer under Companies. Hidden entirely on a
-  // console with one company and nowhere else to go — the same condition the
-  // sidebar footer row used before it moved in here.
-  const showCompanies = !!(
-    (companies.length > 1 && onSwitchCompany) ||
-    onBackToPicker ||
-    onCreateCompany
-  );
-
   const renderMenu = (side: "right" | "bottom") => (
     <DropdownMenuContent className="min-w-72 rounded-lg" align="start" side={side} sideOffset={4}>
       {/* Companies first, and hosts below: the trigger names the COMPANY, so
@@ -496,80 +497,85 @@ export function HostSwitcher({
           <DropdownMenuSeparator />
         </>
       )}
-      {/* `DropdownMenuLabel` is Base UI's `Menu.GroupLabel`, and it throws
-            outside a `Menu.Group` — the group is what it labels. */}
-      <DropdownMenuGroup>
-        <DropdownMenuLabel>Hosts</DropdownMenuLabel>
-        {connections.map((connection, index) => {
-          const status = statusCopy(connection);
-          const shortcut = hostShortcutLabel(index);
-          return (
-            <DropdownMenuItem
-              key={connection.id}
-              data-testid={`host-row-${connection.id}`}
-              data-status={connection.status}
-              aria-current={connection.id === selected}
-              // Native `title`, not a tooltip component: the reason a host is
-              // unreachable has to be readable without extra machinery on a
-              // row that must render while its host is down.
-              title={`${connection.label} — ${status.label}${
-                connection.error ? `\n${connection.error}` : ""
-              }`}
-              onClick={() => hosts.onSelect(connection.id)}
-              className="gap-2"
-            >
-              <span className={cn("size-2 shrink-0 rounded-full", status.dot)} />
-              <span className={cn("flex-1 truncate", connection.id === selected && "font-medium")}>
-                {connection.label}
-              </span>
-              {connection.status === "live" ? (
-                // Nothing to say out loud on a host that is simply working, so
-                // the state stays where a screen reader can still reach it.
-                <span className="sr-only">{status.label}</span>
-              ) : (
-                // In words, not in hue (issue #1167). A colour is no help to
-                // anyone who cannot tell these two apart, and even where it is
-                // read correctly "amber" does not say *what* is wrong —
-                // leaving an operator to discover an unreachable host by
-                // landing on its failure. This is the row telling them first.
-                <span
-                  data-testid={`host-row-state-${connection.id}`}
-                  className="shrink-0 text-xs text-muted-foreground"
-                >
-                  {status.label}
+      {/* The host roster, and the two ways to change it. */}
+      {!HOSTS_HIDDEN && (
+        <>
+        {/* `DropdownMenuLabel` is Base UI's `Menu.GroupLabel`, and it throws
+              outside a `Menu.Group` — the group is what it labels. */}
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Hosts</DropdownMenuLabel>
+          {connections.map((connection, index) => {
+            const status = statusCopy(connection);
+            const shortcut = hostShortcutLabel(index);
+            return (
+              <DropdownMenuItem
+                key={connection.id}
+                data-testid={`host-row-${connection.id}`}
+                data-status={connection.status}
+                aria-current={connection.id === selected}
+                // Native `title`, not a tooltip component: the reason a host is
+                // unreachable has to be readable without extra machinery on a
+                // row that must render while its host is down.
+                title={`${connection.label} — ${status.label}${
+                  connection.error ? `\n${connection.error}` : ""
+                }`}
+                onClick={() => hosts.onSelect(connection.id)}
+                className="gap-2"
+              >
+                <span className={cn("size-2 shrink-0 rounded-full", status.dot)} />
+                <span className={cn("flex-1 truncate", connection.id === selected && "font-medium")}>
+                  {connection.label}
                 </span>
-              )}
-              {shortcut && <DropdownMenuShortcut>{shortcut}</DropdownMenuShortcut>}
-              {connection.id === selected && <Check className="size-4 shrink-0" />}
-            </DropdownMenuItem>
-          );
-        })}
-        {connections.length === 0 && (
-          <p className="px-1.5 py-1 text-xs text-muted-foreground">No hosts yet.</p>
-        )}
-      </DropdownMenuGroup>
-      <DropdownMenuSeparator />
-      <DropdownMenuItem
-        data-testid="host-switcher-add"
-        onClick={() => hosts.setAddingHost(true)}
-        className="gap-2"
-      >
-        <Plus className="size-4" />
-        Add a host
-      </DropdownMenuItem>
-      {/* The other half of adding one. Kept out of the rows themselves: a row
-          is a *filter* — clicking it puts that host on screen — and hanging an
-          edit and a delete off the same row makes a menu whose click targets
-          disagree about what a row is for. The page says what each host is,
-          which the menu deliberately does not. */}
-      <DropdownMenuItem
-        data-testid="host-switcher-manage"
-        onClick={() => hosts.setManagingHosts(true)}
-        className="gap-2"
-      >
-        <Settings2 className="size-4" />
-        Manage hosts
-      </DropdownMenuItem>
+                {connection.status === "live" ? (
+                  // Nothing to say out loud on a host that is simply working, so
+                  // the state stays where a screen reader can still reach it.
+                  <span className="sr-only">{status.label}</span>
+                ) : (
+                  // In words, not in hue (issue #1167). A colour is no help to
+                  // anyone who cannot tell these two apart, and even where it is
+                  // read correctly "amber" does not say *what* is wrong —
+                  // leaving an operator to discover an unreachable host by
+                  // landing on its failure. This is the row telling them first.
+                  <span
+                    data-testid={`host-row-state-${connection.id}`}
+                    className="shrink-0 text-xs text-muted-foreground"
+                  >
+                    {status.label}
+                  </span>
+                )}
+                {shortcut && <DropdownMenuShortcut>{shortcut}</DropdownMenuShortcut>}
+                {connection.id === selected && <Check className="size-4 shrink-0" />}
+              </DropdownMenuItem>
+            );
+          })}
+          {connections.length === 0 && (
+            <p className="px-1.5 py-1 text-xs text-muted-foreground">No hosts yet.</p>
+          )}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          data-testid="host-switcher-add"
+          onClick={() => hosts.setAddingHost(true)}
+          className="gap-2"
+        >
+          <Plus className="size-4" />
+          Add a host
+        </DropdownMenuItem>
+        {/* The other half of adding one. Kept out of the rows themselves: a row
+            is a *filter* — clicking it puts that host on screen — and hanging an
+            edit and a delete off the same row makes a menu whose click targets
+            disagree about what a row is for. The page says what each host is,
+            which the menu deliberately does not. */}
+        <DropdownMenuItem
+          data-testid="host-switcher-manage"
+          onClick={() => hosts.setManagingHosts(true)}
+          className="gap-2"
+        >
+          <Settings2 className="size-4" />
+          Manage hosts
+        </DropdownMenuItem>
+        </>
+      )}
     </DropdownMenuContent>
   );
 

--- a/frontend/src/connections/HostsContext.tsx
+++ b/frontend/src/connections/HostsContext.tsx
@@ -25,6 +25,7 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from "
 import type { LocalInstance } from "@/api/transport/desktop";
 import type { HostEdit } from "@/connections/registry";
 import type { Connection, ConnectionId, Connector, SshTarget } from "@/connections/types";
+import { HOSTS_HIDDEN } from "@/product-scope";
 
 export interface HostsValue {
   connections: Connection[];
@@ -186,6 +187,9 @@ export function HostsProvider({ value, children }: { value: HostsValue; children
   // the menu prints.
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
+      // Hidden roster, hidden shortcuts: a key that selects a host nobody can see
+      // would swallow the browser's own and act invisibly.
+      if (HOSTS_HIDDEN) return;
       if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) return;
       const position = Number(event.key);
       if (!Number.isInteger(position) || position < 1 || position > HOST_SHORTCUT_LIMIT) return;

--- a/frontend/src/connections/first-host.ts
+++ b/frontend/src/connections/first-host.ts
@@ -31,6 +31,10 @@ export interface FirstHostCopy {
    * "add a host from the switcher above", which names a control instead of
    * being one. A dead end that describes its own exit is still a dead end —
    * and on the hub it was describing the exit from a different building.
+   *
+   * The desktop's is an action, not a choice: one machine runs one host, so
+   * "where should this run" has a single answer there. The hub still chooses,
+   * because a hub runs none and the answer is genuinely elsewhere.
    */
   action: string;
 }
@@ -45,9 +49,8 @@ export function firstHostCopy(desktop: boolean): FirstHostCopy {
       title: "No host to show",
       body:
         "The host on this computer didn't start — another copy of OpenCompany may be " +
-        "holding its data. Quit the other copy and reopen this one, or run your company " +
-        "somewhere else.",
-      action: "Choose where to run",
+        "holding its data. Quit the other copy, then start it again.",
+      action: "Start the host on this computer",
     };
   }
   return {

--- a/frontend/src/product-scope.ts
+++ b/frontend/src/product-scope.ts
@@ -1,0 +1,22 @@
+// Surfaces hidden while the product is scoped to one company per install.
+//
+// Every flag here hides a control; none of them changes a stored value or a
+// server path. `ComposioMode::Managed`, the inference `managed` legacy alias
+// and the hosts registry all still exist and still resolve exactly as before,
+// so a company already on a hidden setting keeps working and re-enabling a
+// surface is a single edit in this file.
+
+/** Hides the host roster, "Add a host" and "Manage hosts" in the switcher. */
+export const HOSTS_HIDDEN = true;
+
+/** Hides company switching, "All companies…" and "New company". */
+export const COMPANY_SWITCHING_HIDDEN = true;
+
+/** Hides the wizard's Advanced → Host group (bind address, workspace quotas). */
+export const HOST_SETTINGS_HIDDEN = true;
+
+/** Hides the OpenHuman-managed Composio route, leaving BYOK the only choice. */
+export const COMPOSIO_MANAGED_HIDDEN = true;
+
+/** Hides the managed inference provider, leaving the operator to name one. */
+export const INFERENCE_MANAGED_HIDDEN = true;

--- a/frontend/src/views/OAuthView.tsx
+++ b/frontend/src/views/OAuthView.tsx
@@ -32,6 +32,7 @@ import { AccountChoiceSection } from "@/views/connections/AccountChoiceSection";
 import { CompanyCredentialCard } from "@/views/connections/CompanyCredentialCard";
 import { ComposioSection } from "@/views/connections/ComposioSection";
 import { ProvidersSection } from "@/views/connections/ProvidersSection";
+import { COMPOSIO_MANAGED_HIDDEN } from "@/product-scope";
 
 interface Props {
   client: OpenCompanyClient;
@@ -576,15 +577,21 @@ export function OAuthView({ client, company }: Props) {
           </Alert>
         )}
 
-        {/* The general answer sits above the Composio-specific one: this key
-            authorizes every brokered surface, and the Composio token below is
-            the escape hatch (issue #586). */}
-        <CompanyCredentialCard
-          client={client}
-          company={company}
-          canManage={canManage}
-          onChanged={() => setCredentialGeneration((n) => n + 1)}
-        />
+        {/* The general answer sat above the Composio-specific one: one key
+            authorizing every brokered surface, with the Composio credential as
+            the escape hatch (issue #586). While this company reaches Composio
+            through its own account and nothing else, that key buys nothing —
+            and asking for it on the first-run screen sends an operator after a
+            credential this console can no longer use. The Composio section
+            below is the whole answer now. */}
+        {!COMPOSIO_MANAGED_HIDDEN && (
+          <CompanyCredentialCard
+            client={client}
+            company={company}
+            canManage={canManage}
+            onChanged={() => setCredentialGeneration((n) => n + 1)}
+          />
+        )}
 
         {/* Remounted on a credential change so its status is re-read: the tier
             it reports (`company` vs `attested` vs `none`) is downstream of the

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -48,6 +48,7 @@ import { restartTour } from "@/tour/state";
 import { preloadTour } from "@/tour/TourController";
 import { useLocalScope } from "@/connections/ConnectionContext";
 import { lifecycleAffordances } from "@/lib/lifecycle-controls";
+import { canCreateCompanies } from "@/components/create-company-dialog";
 
 interface Props {
   client: OpenCompanyClient;
@@ -309,7 +310,11 @@ export function LifecycleControls({
     }
   }
 
-  const platform = client.carriesPlatformBearer;
+  // Through the funnel, not the raw bearer: "Reset / Start clean" archives this
+  // company and re-provisions it through the same dialog "New company" opens, so
+  // it is company creation wearing another label and has to answer the same
+  // question the other triggers do.
+  const platform = canCreateCompanies(client);
   const { actions, explainPlatformOnly, explainPlatformSuspended, archived } =
     lifecycleAffordances(state, platform);
   const offers = (action: LifecycleAction) => actions.includes(action);

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -32,12 +32,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { COMPOSIO_MANAGED_HIDDEN } from "@/product-scope";
 
 /**
- * The two routes to Composio, as an operator chooses between them.
+ * The routes to Composio.
  *
  * One table so the tile's label, its explanation and its billing line cannot
- * drift apart, and so the order below is the order they render.
+ * drift apart, and so the order below is the order they render. Every route stays
+ * here even when it is not offered: this is what labels the route a company is
+ * already on.
  */
 const MODES: Record<ComposioMode, { label: string; blurb: string; billed: string }> = {
   managed: {
@@ -55,7 +58,12 @@ const MODES: Record<ComposioMode, { label: string; blurb: string; billed: string
 };
 
 /** The routes in render order — also the order the arrow keys walk. */
-const MODE_ORDER: ComposioMode[] = ["managed", "byok"];
+const ALL_MODE_ORDER: ComposioMode[] = ["managed", "byok"];
+
+/** The routes on offer. Managed stays in {@link MODES} to label a company on it. */
+const MODE_ORDER: ComposioMode[] = ALL_MODE_ORDER.filter(
+  (mode) => mode !== "managed" || !COMPOSIO_MANAGED_HIDDEN,
+);
 
 /**
  * The route to render for whatever the host said.
@@ -502,10 +510,19 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                     operator is trying to evaluate. Same radiogroup shape
                     `policy-settings` uses for approval tiers, roving tabindex
                     included. */}
+                {/* A route this console no longer offers is still a route a
+                    company can be on, and no tile below will be marked Current
+                    for it. Say which, rather than reading as unconfigured. */}
+                {!MODE_ORDER.includes(persistedMode) && (
+                  <p className="text-sm text-muted-foreground" data-testid="composio-current-mode">
+                    This company reaches Composio through OpenHuman. Add an API key below to use
+                    its own Composio account instead.
+                  </p>
+                )}
                 <div
                   role="radiogroup"
                   aria-label="Which Composio account this company uses"
-                  className="grid gap-2 sm:grid-cols-2"
+                  className={cn("grid gap-2", MODE_ORDER.length > 1 && "sm:grid-cols-2")}
                   onKeyDown={handleModeKeyDown}
                 >
                   {MODE_ORDER.map((m, index) => {
@@ -634,14 +651,33 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                 {!confirmSwitch && (mode === "byok" || onByok) && (
                   <div className="flex flex-wrap items-center gap-2">
                     {mode === "byok" ? (
-                      <Button disabled={busy !== null || !apiKey.trim()} onClick={requestApiKeySave}>
-                        {busy === "route" ? (
-                          <Loader2 className="size-4 animate-spin" />
-                        ) : (
-                          <Save className="size-4" />
+                      <>
+                        <Button
+                          disabled={busy !== null || !apiKey.trim()}
+                          onClick={requestApiKeySave}
+                        >
+                          {busy === "route" ? (
+                            <Loader2 className="size-4 animate-spin" />
+                          ) : (
+                            <Save className="size-4" />
+                          )}
+                          {onByok ? "Rotate key" : "Save key"}
+                        </Button>
+                        {/* Clearing used to be reached by picking the other tile.
+                            With no other tile there is nothing to pick, and a
+                            company could rotate its key but never remove it. */}
+                        {onByok && COMPOSIO_MANAGED_HIDDEN && (
+                          <Button
+                            variant="outline"
+                            disabled={busy !== null}
+                            data-testid="composio-clear-key"
+                            onClick={() => void clearApiKey()}
+                          >
+                            <Trash2 className="size-4" />
+                            Clear key
+                          </Button>
                         )}
-                        {onByok ? "Rotate key" : "Save key"}
-                      </Button>
+                      </>
                     ) : (
                       onByok && (
                         <Button disabled={busy !== null} onClick={() => void clearApiKey()}>
@@ -650,7 +686,9 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                           ) : (
                             <Trash2 className="size-4" />
                           )}
-                          Clear key & use OpenHuman-managed
+                          {COMPOSIO_MANAGED_HIDDEN
+                            ? "Clear key"
+                            : "Clear key & use OpenHuman-managed"}
                         </Button>
                       )
                     )}

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -60,10 +60,25 @@ const MODES: Record<ComposioMode, { label: string; blurb: string; billed: string
 /** The routes in render order — also the order the arrow keys walk. */
 const ALL_MODE_ORDER: ComposioMode[] = ["managed", "byok"];
 
-/** The routes on offer. Managed stays in {@link MODES} to label a company on it. */
+/** The routes on offer. {@link MODES} keeps every descriptor; only this list is filtered. */
 const MODE_ORDER: ComposioMode[] = ALL_MODE_ORDER.filter(
   (mode) => mode !== "managed" || !COMPOSIO_MANAGED_HIDDEN,
 );
+
+/** Whether this console offers `mode` as something to choose. */
+function isOffered(mode: ComposioMode): boolean {
+  return MODE_ORDER.includes(mode);
+}
+
+/**
+ * What a route this console does not offer is called on screen.
+ *
+ * Says nothing about the route it stands in for. `MODES` still holds that
+ * route's own name, which is a brand for a choice this console does not
+ * present — so the tile that stands in for it says only what is true of every
+ * value that lands there: nothing is configured here.
+ */
+const NOT_CONFIGURED = "Not configured";
 
 /**
  * The route to render for whatever the host said.
@@ -417,7 +432,7 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
         {!canManage
           ? "Your teammates reach Gmail, Slack & GitHub through Composio. Which account they act through belongs to the company, so an admin manages it — this is what is wired today."
           : onByok
-            ? "Your teammates reach providers through this company's own Composio account. Calls go straight to Composio with the API key stored here — OpenHuman proxies nothing and bills nothing. Connect providers in the grid below; they are connected in that account."
+            ? "Your teammates reach providers through this company's own Composio account. Calls go straight to Composio with the API key stored here — nothing is proxied and nothing is billed elsewhere. Connect providers in the grid below; they are connected in that account."
             : attested
               ? "Your teammates reach providers through Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Connect providers in the grid below."
               : companyKey
@@ -429,7 +444,7 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                   // Composio API key field is how copy comes to contradict the
                   // form directly beneath it.
                   mode === "byok"
-                  ? "Your teammates reach providers through Composio. Nothing is wired yet — paste this company's own Composio API key below, and it will act through its own Composio account rather than OpenHuman's."
+                  ? "Your teammates reach providers through Composio. Nothing is wired yet — paste this company's own Composio API key below, and it will act through its own Composio account."
                   : "Your teammates reach providers through Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then connect providers in the grid below. A change takes effect on the next turn, no restart."}
       </p>
 
@@ -510,21 +525,37 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                     operator is trying to evaluate. Same radiogroup shape
                     `policy-settings` uses for approval tiers, roving tabindex
                     included. */}
-                {/* A route this console no longer offers is still a route a
-                    company can be on, and no tile below will be marked Current
-                    for it. Say which, rather than reading as unconfigured. */}
-                {!MODE_ORDER.includes(persistedMode) && (
-                  <p className="text-sm text-muted-foreground" data-testid="composio-current-mode">
-                    This company reaches Composio through OpenHuman. Add an API key below to use
-                    its own Composio account instead.
-                  </p>
-                )}
                 <div
                   role="radiogroup"
                   aria-label="Which Composio account this company uses"
                   className={cn("grid gap-2", MODE_ORDER.length > 1 && "sm:grid-cols-2")}
                   onKeyDown={handleModeKeyDown}
                 >
+                  {/* A stored route the list does not offer still gets a tile.
+                      Without one no radio in the group is checked — every tile
+                      reports `aria-checked="false"` and the control claims the
+                      company has chosen nothing, which is a different (and
+                      wrong) statement from "it is on a route not offered here".
+
+                      Disabled: it is the state the company is in, not a route to
+                      go back to. */}
+                  {!isOffered(mode) && (
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked
+                      tabIndex={0}
+                      disabled
+                      data-testid="composio-mode-unconfigured"
+                      className="rounded-md border border-primary bg-primary/5 p-3 text-left disabled:cursor-not-allowed"
+                    >
+                      <span className="text-sm font-medium">{NOT_CONFIGURED}</span>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        No Composio account is configured for this company. Add an API key below to
+                        connect one.
+                      </p>
+                    </button>
+                  )}
                   {MODE_ORDER.map((m, index) => {
                     const active = mode === m;
                     return (
@@ -610,12 +641,12 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                       className="inline-flex items-center gap-2 text-xs font-medium"
                     >
                       <AlertTriangle className="size-3.5 shrink-0" />
-                      Providers connected through OpenHuman stay there
+                      Providers connected before this stay where they are
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      They live in OpenHuman&apos;s Composio account, not in this one, so the grid
-                      below will look empty until you connect them again here. Clearing the key puts
-                      this company back where it is now.
+                      They live in the Composio account this company reached before, not in this
+                      one, so the grid below will look empty until you connect them again here.
+                      Clearing the key puts this company back where it is now.
                     </p>
                     <div className="flex flex-wrap gap-2">
                       <Button

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -71,6 +71,18 @@ function isOffered(mode: ComposioMode): boolean {
 }
 
 /**
+ * The route the form works in.
+ *
+ * With one route on offer there is nothing to choose, so the form opens on it
+ * rather than behind a picker: the operator lands on the credential field for
+ * the only account this company can use. `persistedMode` still reports what the
+ * host holds, which is what the switch confirmation keys on.
+ */
+function formModeFor(status: ComposioStatus | null): ComposioMode {
+  return MODE_ORDER.length === 1 ? MODE_ORDER[0] : modeOf(status);
+}
+
+/**
  * What a route this console does not offer is called on screen.
  *
  * Says nothing about the route it stands in for. `MODES` still holds that
@@ -222,7 +234,7 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
       const s = await getComposioStatus(client, company);
       if (generation !== requestGeneration.current) return;
       setStatus(s);
-      setMode(modeOf(s));
+      setMode(formModeFor(s));
       setPersistedMode(modeOf(s));
       // Hide the whole section when the feature is not compiled into this build.
       setLoad(s.inBuild ? "ready" : "unavailable");
@@ -307,7 +319,7 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
     try {
       const res = await setComposioApiKey(client, company, apiKey.trim());
       setStatus(res.status);
-      setMode(modeOf(res.status));
+      setMode(formModeFor(res.status));
       setPersistedMode(modeOf(res.status));
       setApiKey("");
       setConfirmSwitch(false);
@@ -326,7 +338,7 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
     try {
       const res = await setComposioApiKey(client, company, "");
       setStatus(res.status);
-      setMode(modeOf(res.status));
+      setMode(formModeFor(res.status));
       setPersistedMode(modeOf(res.status));
       setApiKey("");
       setConfirmSwitch(false);
@@ -525,6 +537,7 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                     operator is trying to evaluate. Same radiogroup shape
                     `policy-settings` uses for approval tiers, roving tabindex
                     included. */}
+                {MODE_ORDER.length > 1 && (
                 <div
                   role="radiogroup"
                   aria-label="Which Composio account this company uses"
@@ -597,12 +610,13 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                     );
                   })}
                 </div>
+                )}
 
                 {/* The endpoint, so the routing claim above is checkable rather
                     than merely asserted — but only when the managed token card
                     below is not already printing it. Two copies of one URL on
                     one screen reads as two different facts. */}
-                {status && !showTokenCard && (
+                {status && !showTokenCard && isOffered(persistedMode) && (
                   <p className="truncate font-mono text-xs text-muted-foreground">
                     {status.backendUrl}
                   </p>
@@ -775,7 +789,7 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                     value={token}
                     onChange={(e) => setToken(e.target.value)}
                   />
-                  {status && (
+                  {status && isOffered(persistedMode) && (
                     <p className="truncate text-xs text-muted-foreground">{status.backendUrl}</p>
                   )}
                 </div>

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -445,19 +445,21 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
           ? "Your teammates reach Gmail, Slack & GitHub through Composio. Which account they act through belongs to the company, so an admin manages it — this is what is wired today."
           : onByok
             ? "Your teammates reach providers through this company's own Composio account. Calls go straight to Composio with the API key stored here — nothing is proxied and nothing is billed elsewhere. Connect providers in the grid below; they are connected in that account."
-            : attested
-              ? "Your teammates reach providers through Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Connect providers in the grid below."
+            : // Two facts, and they had been collapsed into one sentence. The
+              // route a company is on today is not what the form beneath does,
+              // and while the form is fixed to this company's own account those
+              // two can disagree — an operator was told there was nothing to
+              // paste directly above a field asking them to paste it.
+              //
+              // So: name what is wired now, then say what saving would change.
+              // A company already reaching providers is switching accounts, not
+              // filling a blank, and the grid it is looking at belongs to the
+              // account it is leaving.
+              attested
+              ? "Your teammates reach providers through Composio today, linked through this instance's own cluster identity — nothing is stored here for that. Saving an API key below moves this company onto its own Composio account instead: the providers connected now live in the account it is leaving, so the grid will look empty until they are connected again here."
               : companyKey
-                ? "Your teammates reach providers through Composio. This company's own TinyHumans credential already authorizes it — there is no separate Composio token to paste and no provider app to register. Connect providers in the grid below; every teammate in the company can then use what you connect."
-                : // The last arm is the only one that *instructs*, and the
-                  // instruction is route-specific — so it follows the route the
-                  // operator is looking at rather than the one still stored.
-                  // Telling someone to paste a backend token underneath a
-                  // Composio API key field is how copy comes to contradict the
-                  // form directly beneath it.
-                  mode === "byok"
-                  ? "Your teammates reach providers through Composio. Nothing is wired yet — paste this company's own Composio API key below, and it will act through its own Composio account."
-                  : "Your teammates reach providers through Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then connect providers in the grid below. A change takes effect on the next turn, no restart."}
+                ? "Your teammates reach providers through Composio today, on the account this company's stored credential authorizes. Saving an API key below moves it onto its own Composio account instead: the providers connected now live in the account it is leaving, so the grid will look empty until they are connected again here."
+                : "Your teammates reach providers through Composio. Nothing is wired yet — paste this company's own Composio API key below, and it will act through its own Composio account."}
       </p>
 
       {load === "loading" ? (
@@ -708,20 +710,22 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                           )}
                           {onByok ? "Rotate key" : "Save key"}
                         </Button>
-                        {/* Clearing used to be reached by picking the other tile.
-                            With no other tile there is nothing to pick, and a
-                            company could rotate its key but never remove it. */}
-                        {onByok && COMPOSIO_MANAGED_HIDDEN && (
-                          <Button
-                            variant="outline"
-                            disabled={busy !== null}
-                            data-testid="composio-clear-key"
-                            onClick={() => void clearApiKey()}
-                          >
-                            <Trash2 className="size-4" />
-                            Clear key
-                          </Button>
-                        )}
+                        {/* No Clear control here, deliberately.
+                            Clearing is not "the key goes away": the host derives
+                            the route from whether a key exists, so
+                            `store_api_key("")` writes the mode back to the one
+                            this console no longer offers, and a company with any
+                            credential on that route resumes acting through it —
+                            a different account, billed differently.
+                            Reaching that used to require picking the other tile,
+                            which named it. With no tile to pick, a button here
+                            could only either say what it does — naming the route
+                            — or not say it, which is the switch happening
+                            silently. The status read carries no signal for
+                            whether that route has a credential, so the control
+                            cannot be offered only where clearing is inert
+                            either. Rotating a key stays; removing one needs a
+                            host that can express "no key, no route". */}
                       </>
                     ) : (
                       onByok && (

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -131,21 +131,57 @@ const PROVIDERS: Record<
 };
 
 /**
- * The base-ui `Select` wants a plain id -> label map for its `items` prop, so
- * project one out of the descriptor rather than maintaining a second list.
- */
-const PROVIDER_LABEL_ITEMS: Record<InferenceProvider, string> = Object.fromEntries(
-  (Object.keys(PROVIDERS) as InferenceProvider[]).map((p) => [p, PROVIDERS[p].label]),
-) as Record<InferenceProvider, string>;
-
-/**
  * The providers on offer. {@link PROVIDERS} keeps every descriptor, including the
- * ones not listed here — a company whose stored provider is hidden still needs
- * its label, and the host resolves that value exactly as it always did.
+ * ones not listed here — the form still needs a hidden route's `requiresBaseUrl`
+ * and `preset`, and the host resolves the stored value exactly as it always did.
+ *
+ * Declared ahead of everything that reads it: `PROVIDER_LABEL_ITEMS` below is a
+ * module-level const built through `isOffered`, so a later declaration would be
+ * read in its temporal dead zone and throw on import.
  */
 const PROVIDER_OPTIONS: InferenceProvider[] = (Object.keys(PROVIDERS) as InferenceProvider[]).filter(
   (p) => p !== "managed" || !INFERENCE_MANAGED_HIDDEN,
 );
+
+/**
+ * What a provider this console does not offer is called on screen.
+ *
+ * Deliberately says nothing about the route it stands in for. The host reports
+ * an unconfigured company as `provider: "managed"` — the same value a newer
+ * host could send for something else entirely — and this console neither offers
+ * that route nor brands it, so the honest thing to render is the fact that
+ * nothing is configured *here*, which is true of every value that lands in it.
+ */
+const NOT_CONFIGURED = "Not configured";
+
+/** Whether this console offers `provider` as something to choose. */
+function isOffered(provider: string): provider is InferenceProvider {
+  return (PROVIDER_OPTIONS as string[]).includes(provider);
+}
+
+/**
+ * The label for a provider as the operator sees it.
+ *
+ * Never reaches into {@link PROVIDERS} for a route that is not offered: that
+ * table still holds the descriptor (the form needs its `requiresBaseUrl` and
+ * `preset`), but its label is a brand name for a choice this console does not
+ * present, and printing it is what made the card claim a route.
+ */
+function providerLabel(provider: string): string {
+  return isOffered(provider) ? PROVIDERS[provider].label : NOT_CONFIGURED;
+}
+
+/**
+ * The base-ui `Select` wants a plain id -> label map for its `items` prop, so
+ * project one out of the descriptor rather than maintaining a second list.
+ *
+ * Built through {@link providerLabel}, because `items` is what the *trigger*
+ * renders — a filtered `SelectItem` list alone leaves the closed control still
+ * showing the hidden route's own name.
+ */
+const PROVIDER_LABEL_ITEMS: Record<InferenceProvider, string> = Object.fromEntries(
+  (Object.keys(PROVIDERS) as InferenceProvider[]).map((p) => [p, providerLabel(p)]),
+) as Record<InferenceProvider, string>;
 
 /**
  * What the live cognition path's metering mode means for the Usage view — so a
@@ -865,10 +901,18 @@ export function InferenceSection({
             {status && (
               <div className="space-y-2">
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="font-medium">{PROVIDERS[status.provider as InferenceProvider]?.label ?? status.provider}</span>
-                  <Badge variant={status.source === "runtime" ? "outline" : "secondary"}>
-                    {status.source}
-                  </Badge>
+                  <span className="font-medium" data-testid="inference-current-provider">
+                    {providerLabel(status.provider)}
+                  </span>
+                  {/* `source` reads `managed` for a company this console has no
+                      route for, which is the hidden route's own name. The badge
+                      says where a configuration came from, and there is no
+                      configuration to attribute. */}
+                  {isOffered(status.provider) && (
+                    <Badge variant={status.source === "runtime" ? "outline" : "secondary"}>
+                      {status.source}
+                    </Badge>
+                  )}
                   {status.keyConfigured && (
                     <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
                       <Check className="size-3" /> key set
@@ -891,7 +935,9 @@ export function InferenceSection({
                   custom inference configured has nothing to send, and Test just reports that
                   instead of sending anything.
                 </p>
-                <p className="truncate text-xs text-muted-foreground">{status.baseUrl}</p>
+                {isOffered(status.provider) && (
+                  <p className="truncate text-xs text-muted-foreground">{status.baseUrl}</p>
+                )}
                 {/* Issue #174: config resolving to a provider does not mean the
                     company booted onto it. Say which cognition path is live and
                     whether its usage is metered, so a zero Usage reading reads as
@@ -1021,6 +1067,20 @@ export function InferenceSection({
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
+                        {/* A value the list does not offer still gets a row, the
+                            way the tier picker below keeps a retired model id
+                            selectable (`optionsForTier`). Without it the control
+                            shows a value no item matches: nothing is checked and
+                            the popup reads as though nothing is chosen.
+
+                            Disabled, because it is not a route to return to —
+                            it is the state the company is in until a provider is
+                            picked. */}
+                        {!isOffered(provider) && (
+                          <SelectItem value={provider} disabled>
+                            {NOT_CONFIGURED}
+                          </SelectItem>
+                        )}
                         {PROVIDER_OPTIONS.map((p) => (
                           <SelectItem key={p} value={p}>
                             {PROVIDERS[p].label}
@@ -1028,10 +1088,20 @@ export function InferenceSection({
                         ))}
                       </SelectContent>
                     </Select>
-                    <p className="text-xs text-muted-foreground">
-                      Choosing a provider applies its Base URL and model defaults. If you have typed
-                      either, we ask before replacing them; your API key stays in this form.
-                    </p>
+                    {isOffered(provider) ? (
+                      <p className="text-xs text-muted-foreground">
+                        Choosing a provider applies its Base URL and model defaults. If you have
+                        typed either, we ask before replacing them; your API key stays in this form.
+                      </p>
+                    ) : (
+                      <p
+                        className="text-xs text-muted-foreground"
+                        data-testid="inference-not-configured"
+                      >
+                        No provider is configured for this company. Pick one to give its teammates a
+                        brain of their own.
+                      </p>
+                    )}
                   </div>
                   {PROVIDERS[provider].requiresBaseUrl && (
                     <div className="space-y-1">
@@ -1048,7 +1118,7 @@ export function InferenceSection({
                   )}
                 </div>
 
-                {provider !== "managed" && (
+                {isOffered(provider) && (
                   <div className="space-y-2">
                     {provider === "openrouter" && modelCatalog.kind === "error" && (
                       <p
@@ -1232,7 +1302,11 @@ export function InferenceSection({
                   always preferred a stored key over the env default on this
                   provider. Ollama is the one provider that takes no bearer.
                 */}
-                {PROVIDERS[provider].acceptsKey && (
+                {/* No key field until a provider is chosen. The descriptor for a
+                    route this console does not offer still carries its `keyKind`
+                    prose, which names that route — and a key typed against a
+                    provider nobody selected has nowhere to be scoped to. */}
+                {isOffered(provider) && PROVIDERS[provider].acceptsKey && (
                   <div className="space-y-1">
                     <Label htmlFor="inference-key" className="text-xs">
                       API key {status?.keyConfigured ? "(leave blank to keep)" : ""}
@@ -1263,7 +1337,11 @@ export function InferenceSection({
                 <div className="flex items-center gap-2">
                   <Button
                     data-testid="inference-save"
-                    disabled={busy !== null}
+                    // Nothing to save while the form sits on a route this console
+                    // does not offer: sending it back would normalize to a real
+                    // provider on the host and move the company somewhere the
+                    // operator never chose.
+                    disabled={busy !== null || !isOffered(provider)}
                     onClick={() => void save()}
                   >
                     {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -42,6 +42,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { INFERENCE_MANAGED_HIDDEN } from "@/product-scope";
 
 /** The abstract cognition tiers the tenant model table maps. */
 const TIERS = ["chat-v1", "reasoning-v1", "agentic-v1", "vision-v1"] as const;
@@ -136,6 +137,15 @@ const PROVIDERS: Record<
 const PROVIDER_LABEL_ITEMS: Record<InferenceProvider, string> = Object.fromEntries(
   (Object.keys(PROVIDERS) as InferenceProvider[]).map((p) => [p, PROVIDERS[p].label]),
 ) as Record<InferenceProvider, string>;
+
+/**
+ * The providers on offer. {@link PROVIDERS} keeps every descriptor, including the
+ * ones not listed here — a company whose stored provider is hidden still needs
+ * its label, and the host resolves that value exactly as it always did.
+ */
+const PROVIDER_OPTIONS: InferenceProvider[] = (Object.keys(PROVIDERS) as InferenceProvider[]).filter(
+  (p) => p !== "managed" || !INFERENCE_MANAGED_HIDDEN,
+);
 
 /**
  * What the live cognition path's metering mode means for the Usage view — so a
@@ -878,7 +888,7 @@ export function InferenceSection({
                 <p className="text-xs text-muted-foreground">
                   Test sends one real message to this provider using its stored key, and your provider
                   may charge for it; it does not change the saved configuration. A company with no
-                  custom inference configured stays on the managed brain, and Test just reports that
+                  custom inference configured has nothing to send, and Test just reports that
                   instead of sending anything.
                 </p>
                 <p className="truncate text-xs text-muted-foreground">{status.baseUrl}</p>
@@ -1011,7 +1021,7 @@ export function InferenceSection({
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        {(Object.keys(PROVIDERS) as InferenceProvider[]).map((p) => (
+                        {PROVIDER_OPTIONS.map((p) => (
                           <SelectItem key={p} value={p}>
                             {PROVIDERS[p].label}
                           </SelectItem>
@@ -1239,7 +1249,6 @@ export function InferenceSection({
                       Paste {PROVIDERS[provider].keyKind}. This field is scoped to the provider
                       selected above and is stored against it — a key for any other vendor will
                       fail at the first turn, so it is not the place for one.
-                      {provider === "managed" && " Leave it blank to keep running on the platform credential."}
                     </p>
                     <p className="text-xs text-muted-foreground">
                       Whatever you set here is what the company spends against: everyone you invite

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -448,9 +448,14 @@ export function InferenceSection({
    * reasoning as `removeKey` below.
    */
   const seedFromStatus = useCallback((next: InferenceStatus) => {
-    const seeded = (
+    const stored = (
       next.provider in PROVIDERS ? next.provider : "openrouter"
     ) as InferenceProvider;
+    // The form is a "switch to" form, so it opens on something the operator can
+    // actually complete. A company on a route this console does not offer has no
+    // provider to reflect here, and resting on an inert row leaves onboarding
+    // with no way forward — the card's header above still reports the real state.
+    const seeded = isOffered(stored) ? stored : PROVIDER_OPTIONS[0];
     const nextBaseUrl = PROVIDERS[seeded].requiresBaseUrl
       ? next.baseUrl
       : presetFor(seeded).baseUrl;
@@ -1067,20 +1072,6 @@ export function InferenceSection({
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        {/* A value the list does not offer still gets a row, the
-                            way the tier picker below keeps a retired model id
-                            selectable (`optionsForTier`). Without it the control
-                            shows a value no item matches: nothing is checked and
-                            the popup reads as though nothing is chosen.
-
-                            Disabled, because it is not a route to return to —
-                            it is the state the company is in until a provider is
-                            picked. */}
-                        {!isOffered(provider) && (
-                          <SelectItem value={provider} disabled>
-                            {NOT_CONFIGURED}
-                          </SelectItem>
-                        )}
                         {PROVIDER_OPTIONS.map((p) => (
                           <SelectItem key={p} value={p}>
                             {PROVIDERS[p].label}
@@ -1088,7 +1079,7 @@ export function InferenceSection({
                         ))}
                       </SelectContent>
                     </Select>
-                    {isOffered(provider) ? (
+                    {isOffered(status?.provider ?? "") ? (
                       <p className="text-xs text-muted-foreground">
                         Choosing a provider applies its Base URL and model defaults. If you have
                         typed either, we ask before replacing them; your API key stays in this form.
@@ -1098,8 +1089,8 @@ export function InferenceSection({
                         className="text-xs text-muted-foreground"
                         data-testid="inference-not-configured"
                       >
-                        No provider is configured for this company. Pick one to give its teammates a
-                        brain of their own.
+                        No provider is configured for this company yet. Pick one above and paste its
+                        key below to give its teammates a brain of their own.
                       </p>
                     )}
                   </div>
@@ -1337,11 +1328,7 @@ export function InferenceSection({
                 <div className="flex items-center gap-2">
                   <Button
                     data-testid="inference-save"
-                    // Nothing to save while the form sits on a route this console
-                    // does not offer: sending it back would normalize to a real
-                    // provider on the host and move the company somewhere the
-                    // operator never chose.
-                    disabled={busy !== null || !isOffered(provider)}
+                    disabled={busy !== null}
                     onClick={() => void save()}
                   >
                     {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}

--- a/frontend/src/views/connections/ProvidersSection.tsx
+++ b/frontend/src/views/connections/ProvidersSection.tsx
@@ -161,7 +161,7 @@ export function ProvidersSection({
           {noCredential && (
             <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
               {canManage
-                ? "No credential is available for this company yet, so there is nothing to authorize against. Set the company's TinyHumans credential — one key authorizes the providers the platform brokers — or paste a Composio token below to use a Composio account of your own."
+                ? "No credential is available for this company yet, so there is nothing to authorize against. Paste this company's own Composio API key below, and the providers it can reach become connectable here."
                 : "No credential is available for this company yet, so there is nothing to authorize against. An admin has to set the company's credential before providers can be connected."}
             </p>
           )}

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -62,6 +62,7 @@ import {
 } from "@/lib/company-setup";
 import { isDesktopRuntime } from "@/api/transport";
 import { cn } from "@/lib/utils";
+import { HOST_SETTINGS_HIDDEN } from "@/product-scope";
 
 /**
  * The flow, in order. `fields` names the config keys each step owns.
@@ -118,7 +119,7 @@ const STEPS: readonly (Step & { fields: readonly string[] })[] = [
  * works, which is what earns something a place behind "press on if none of it
  * matters to you".
  */
-const ADVANCED_GROUPS: readonly {
+const ALL_ADVANCED_GROUPS: readonly {
   id: string;
   label: string;
   title: string;
@@ -133,6 +134,11 @@ const ADVANCED_GROUPS: readonly {
     fields: ["bind", "public_url", "workspace.max_blob_mb", "workspace.storage_quota_gb"],
   },
 ];
+
+/** Advanced groups on offer — the Host group is hidden while hosts are. */
+const ADVANCED_GROUPS = ALL_ADVANCED_GROUPS.filter(
+  (group) => group.id !== "host" || !HOST_SETTINGS_HIDDEN,
+);
 
 /** How each sign-in mode is described, in consequences rather than mode names. */
 const AUTH_MODE_COPY: Record<string, { label: string; hint: string }> = {
@@ -511,7 +517,12 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
    * starts at its longest.
    */
   const visibleSteps = useMemo(
-    () => STEPS.filter((s) => s.id !== "account" || !status || requiresSignIn(status, values)),
+    () =>
+      STEPS.filter(
+        (s) =>
+          (s.id !== "account" || !status || requiresSignIn(status, values)) &&
+          (s.id !== "advanced" || ADVANCED_GROUPS.length > 0),
+      ),
     [status, values],
   );
 

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -34,6 +34,7 @@ import {
   fieldsFor,
   getSetup,
   INFERENCE_PROVIDERS,
+  SETUP_INFERENCE_OPTIONS,
   proposeSetupRoster,
   testInference,
   submitSetup,
@@ -316,7 +317,7 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
    */
   // Seeded from the host once its status arrives — see the fetch effect. Not an
   // initialiser, because `status` is null until then.
-  const [provider, setProvider] = useState<string>("managed");
+  const [provider, setProvider] = useState<string>(SETUP_INFERENCE_OPTIONS[0].id);
   const [baseUrl, setBaseUrl] = useState<string>("");
   /**
    * The verdict on the credential, and the reason the step can gate on it.
@@ -1431,7 +1432,7 @@ function PowerStep({
             someone can make without knowing the vocabulary first — a dropdown
             of slugs assumes they already do. */}
         <div className="mt-3 grid gap-2" role="radiogroup" aria-label="Model provider">
-          {INFERENCE_PROVIDERS.map((option) => (
+          {SETUP_INFERENCE_OPTIONS.map((option) => (
             <button
               key={option.id}
               type="button"

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -200,11 +200,18 @@ interface Props {
  *   provider onto the manifest and stores the key against the company; a
  *   template seed has nowhere to put either, and silently dropping a key the
  *   operator just watched pass is the worse trade.
- * - **Except `managed`, which carries nothing.** The designed submit omits
- *   inference entirely for that provider, because the host already reaches it.
- *   Taking the designed path there trades the template away for a credential
- *   that was never going to be written — a pure loss, and an invisible one,
- *   since the review screen shows the template's roster either way.
+ * - **Except when nothing will be carried.** Where the submit omits inference
+ *   anyway — the host already reaches it, or the credential that passed was the
+ *   house's rather than this operator's — the designed path trades the template
+ *   away for a credential that was never going to be written: a pure loss, and
+ *   an invisible one, since the review screen shows the template's roster either
+ *   way.
+ *
+ *   Asked as `writesInference` rather than `provider === "managed"`. That
+ *   literal was the same assumption spelled as a string, and it silently stopped
+ *   firing the moment the model step stopped adopting a provider it does not
+ *   offer — the caller passes the very condition its submit uses, so the two
+ *   cannot answer differently.
  */
 export function shouldSeedTemplate(input: {
   hasCompany: boolean;
@@ -212,13 +219,14 @@ export function shouldSeedTemplate(input: {
   rosterEdited: boolean;
   template: string;
   credentialTested: boolean;
-  provider: string;
+  /** Whether the submit will actually write inference for this company. */
+  writesInference: boolean;
 }): boolean {
   if (input.hasCompany) return false;
   if (input.source !== "preset") return false;
   if (input.rosterEdited) return false;
   if (!input.template.trim()) return false;
-  return !input.credentialTested || input.provider === "managed";
+  return !input.credentialTested || !input.writesInference;
 }
 
 /**
@@ -571,6 +579,15 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
     !SETUP_INFERENCE_OPTIONS.some((option) => option.id === status.inference.provider);
   const operatorConfiguredInference =
     !houseSuppliesInference || !!values.tinyhumans_api_key?.trim();
+  /**
+   * Whether finishing will write inference onto this company.
+   *
+   * Read by both the submit payload and {@link shouldSeedTemplate}: the seed
+   * decision exists to avoid trading a template away for a credential that is
+   * never written, so it has to be asking the same question the payload answers.
+   */
+  const writesInference =
+    tested.kind === "ok" && provider !== "managed" && operatorConfiguredInference;
 
   /**
    * Ask the host to design a team, on the way into Review.
@@ -643,7 +660,7 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
         rosterEdited,
         template,
         credentialTested: tested.kind === "ok",
-        provider,
+        writesInference,
       });
 
       const result = await submitSetup(client, {
@@ -665,17 +682,14 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
                 // As reviewed, not as proposed.
                 agents: roster.agents,
                 adminEmail: email.trim() || null,
-                inference:
-                  tested.kind === "ok" &&
-                  provider !== "managed" &&
-                  operatorConfiguredInference
-                    ? {
-                        provider,
-                        baseUrl: tested.baseUrl,
-                        model: tested.model ?? null,
-                        key: values.tinyhumans_api_key?.trim() || null,
-                      }
-                    : null,
+                inference: writesInference
+                  ? {
+                      provider,
+                      baseUrl: tested.baseUrl,
+                      model: tested.model ?? null,
+                      key: values.tinyhumans_api_key?.trim() || null,
+                    }
+                  : null,
               }
             : null,
       });

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -549,6 +549,30 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
   }, [status, changed]);
 
   /**
+   * Whether the house is supplying inference rather than this operator.
+   *
+   * The credential the model step tests is the HOST's whenever the operator
+   * leaves the key box empty, so a pass there says the house works — not that
+   * the provider selected beside it does.
+   *
+   * This used to be spelled `provider !== "managed"` at the two call sites
+   * below, and it held only because the step adopted the host's provider
+   * verbatim: a hosted tenant selected `managed`, that check withheld the
+   * config, and the platform default went on applying. The step no longer
+   * adopts a route it does not offer, so `provider` is now a real one and the
+   * literal check stopped firing — testing the house credential with a blank
+   * key would write `openrouter` at the managed endpoint with no key over a
+   * configuration that was working.
+   *
+   * A key the operator actually typed is theirs, so it stays configuration.
+   */
+  const houseSuppliesInference =
+    !!status?.inference.ready &&
+    !SETUP_INFERENCE_OPTIONS.some((option) => option.id === status.inference.provider);
+  const operatorConfiguredInference =
+    !houseSuppliesInference || !!values.tinyhumans_api_key?.trim();
+
+  /**
    * Ask the host to design a team, on the way into Review.
    *
    * Never throws upward: the host answers with its curated team rather than an
@@ -567,8 +591,10 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
         automate: draft.automate,
         template: template || null,
         inferenceKey: values.tinyhumans_api_key || null,
-        inferenceProvider: tested.kind === "ok" ? provider : null,
-        inferenceBaseUrl: tested.kind === "ok" ? tested.baseUrl : null,
+        inferenceProvider:
+          tested.kind === "ok" && operatorConfiguredInference ? provider : null,
+        inferenceBaseUrl:
+          tested.kind === "ok" && operatorConfiguredInference ? tested.baseUrl : null,
         inferenceModel: tested.kind === "ok" ? tested.model : null,
       });
       // The host is contracted never to answer with an empty roster, so a
@@ -640,7 +666,9 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
                 agents: roster.agents,
                 adminEmail: email.trim() || null,
                 inference:
-                  tested.kind === "ok" && provider !== "managed"
+                  tested.kind === "ok" &&
+                  provider !== "managed" &&
+                  operatorConfiguredInference
                     ? {
                         provider,
                         baseUrl: tested.baseUrl,

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -213,6 +213,17 @@ interface Props {
  *   offer — the caller passes the very condition its submit uses, so the two
  *   cannot answer differently.
  */
+/**
+ * The provider the house's credential can ride.
+ *
+ * Mirrors `resolve_endpoint` (`src/company/inference.rs`): the injected
+ * credential is inherited for the managed choice, and for this provider only
+ * while no base URL overrides the endpoint. Everything else is sent without it,
+ * so a step that hides the key field for one of those promises a credential the
+ * host will not forward.
+ */
+const HOUSE_CREDENTIAL_PROVIDER = "openrouter";
+
 export function shouldSeedTemplate(input: {
   hasCompany: boolean;
   source: "model" | "fallback" | "preset" | null;
@@ -427,7 +438,18 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
         ) {
           setProvider(s.inference.provider);
         }
-        if (s.inference.base_url) setBaseUrl(s.inference.base_url);
+        // Only for a provider that actually takes one. The host reports its own
+        // endpoint whatever the route, and dropping that into the form for a
+        // provider with no URL field left an invisible value that later read as
+        // a tenant override — which is precisely what withholds the injected
+        // credential (`resolve_endpoint`). Same rule the Inference card uses.
+        const seededProvider =
+          s.inference.provider &&
+          SETUP_INFERENCE_OPTIONS.some((option) => option.id === s.inference.provider)
+            ? s.inference.provider
+            : SETUP_INFERENCE_OPTIONS[0].id;
+        const seededSpec = INFERENCE_PROVIDERS.find((p) => p.id === seededProvider);
+        if (s.inference.base_url && seededSpec?.needsUrl) setBaseUrl(s.inference.base_url);
       })
       .catch((err: unknown) => {
         if (!cancelled) setLoadError(err instanceof Error ? err.message : String(err));
@@ -1441,10 +1463,23 @@ function PowerStep({
   // on the tile alone then went false, and first-run setup started demanding a
   // key from the one operator who cannot obtain one. Readiness is the host's
   // fact, not a property of which tile happens to be selected.
+  //
+  // Scoped to a selection the credential actually serves. `resolve_endpoint`
+  // inherits the injected credential for the managed choice, and for
+  // `openrouter` only while nothing overrides the endpoint — "the platform
+  // credential rides only the platform's own endpoint", since pairing it with
+  // an arbitrary one would leak it there. Ollama and a custom endpoint get no
+  // inheritance at all. Claiming it for those hid the key field, enabled Test
+  // with nothing in it, and sent an unauthenticated probe that could only fail.
+  const houseProviderHidden = !SETUP_INFERENCE_OPTIONS.some(
+    (option) => option.id === status.inference.provider,
+  );
+  const houseCredentialServes =
+    provider === HOUSE_CREDENTIAL_PROVIDER && !baseUrl.trim();
   const onTheHouse =
     status.inference.ready &&
     (provider === status.inference.provider ||
-      !SETUP_INFERENCE_OPTIONS.some((option) => option.id === status.inference.provider));
+      (houseProviderHidden && houseCredentialServes));
   // "Use my own" flips the gate: the host credential is only testable while
   // that is the operator's actual choice. Once they opt to supply their own
   // key, an empty box must not test anything — a test with no key probes the

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -409,7 +409,16 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
         // Pre-fill the model step from what the host already holds. A hosted
         // operator has a credential injected by the control plane, no key of
         // their own, and no way to get one — the step should arrive answered.
-        if (s.inference.provider) setProvider(s.inference.provider);
+        // Only adopt a provider the step actually offers. The host reports the
+        // nothing-configured case as `managed`, which is not a tile here any
+        // more — adopting it would select nothing and leave the step looking
+        // answered when it is not.
+        if (
+          s.inference.provider &&
+          SETUP_INFERENCE_OPTIONS.some((option) => option.id === s.inference.provider)
+        ) {
+          setProvider(s.inference.provider);
+        }
         if (s.inference.base_url) setBaseUrl(s.inference.base_url);
       })
       .catch((err: unknown) => {
@@ -1381,7 +1390,19 @@ function PowerStep({
   const [override, setOverride] = useState(false);
   // The house already holds one, and this operator may have no way to get their
   // own. The key box is then optional rather than the point of the screen.
-  const onTheHouse = status.inference.ready && provider === status.inference.provider;
+  // The house already holds one, and this operator may have no way to get their
+  // own — so the key box is optional rather than the point of the screen.
+  //
+  // The second arm is what keeps that true for a hosted tenant once a route
+  // stops being offered here. Its control plane injects the credential and the
+  // host reports itself ready on a provider this step has no tile for; matching
+  // on the tile alone then went false, and first-run setup started demanding a
+  // key from the one operator who cannot obtain one. Readiness is the host's
+  // fact, not a property of which tile happens to be selected.
+  const onTheHouse =
+    status.inference.ready &&
+    (provider === status.inference.provider ||
+      !SETUP_INFERENCE_OPTIONS.some((option) => option.id === status.inference.provider));
   // "Use my own" flips the gate: the host credential is only testable while
   // that is the operator's actual choice. Once they opt to supply their own
   // key, an empty box must not test anything — a test with no key probes the

--- a/frontend/test/e2e/add-host-connectors.spec.ts
+++ b/frontend/test/e2e/add-host-connectors.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { openHostMenu } from "./host-switcher";
+
 
 /**
  * Choosing where a runtime runs, driven through the whole app.
@@ -28,155 +28,22 @@ import { openHostMenu } from "./host-switcher";
  * The browser cases shim nothing at all.
  */
 
-/** What the shimmed core does when the console asks for a tunnel. */
-interface TunnelScript {
-  /** The address the tunnel forwards to, as `oc_open_ssh_tunnel` reports it. */
-  baseUrl?: string;
-  /** What `ssh` said, when it said no. */
-  refuse?: string;
-}
 
-interface Instance {
-  id: string;
-  label: string;
-  dataDir: string;
-  running: boolean;
-  baseUrl?: string;
-  instanceId?: string;
-  companies?: string[];
-}
-
-/** The single live local host every desktop case here starts from. */
-function seed(liveBaseUrl: string): Instance[] {
-  return [
-    {
-      id: "default",
-      label: "This computer",
-      dataDir: "/tmp/e2e-connectors",
-      running: true,
-      baseUrl: liveBaseUrl,
-      instanceId: "instance-default",
-      companies: [],
-    },
-  ];
-}
 
 /**
- * Installs a bridge over a roster and a tunnel script the page can read.
+ * Opens the chooser, by the one route that still reaches it.
  *
- * `opened` records every target the console asked for, because *what the shell
- * is asked* is half of what these specs are about: the console must send the
- * destination someone typed, not a url it made up.
+ * It used to be the switcher's "Add a host". That item is hidden while the
+ * product is scoped to one company per install (`src/product-scope.ts`), and a
+ * hub is now the only build that opens this screen at all — it runs no host of
+ * its own, so "where does this company run" is a question it genuinely has to
+ * ask. The desktop's zero-host recovery is a single "start the host on this
+ * computer" action instead, covered in `desktop-connections.spec.ts`.
  */
-async function installDesktopShell(
-  page: Page,
-  roster: Instance[],
-  tunnel: TunnelScript,
-): Promise<void> {
-  await page.addInitScript(
-    ([seedRoster, script]: [Instance[], TunnelScript]) => {
-      // The tour modal covers the console and swallows clicks.
-      for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
-        window.localStorage.setItem(key, JSON.stringify({ skipped: true, seenAt: Date.now() }));
-      }
-
-      const instances: Instance[] = JSON.parse(JSON.stringify(seedRoster)) as Instance[];
-      const hosts = new Map<string, string>();
-      const opened: unknown[] = [];
-      (window as unknown as { __OPENED_TUNNELS__: unknown[] }).__OPENED_TUNNELS__ = opened;
-
-      async function proxy(
-        connectionId: string,
-        request: {
-          method: string;
-          path: string;
-          headers?: Record<string, string>;
-          body?: string | null;
-        },
-      ) {
-        const base = hosts.get(connectionId) ?? "";
-        const response = await fetch(`${base}${request.path}`, {
-          method: request.method,
-          headers: request.headers,
-          body: request.body ?? undefined,
-          credentials: "include",
-        });
-        const headers: Record<string, string> = {};
-        response.headers.forEach((value, key) => {
-          headers[key.toLowerCase()] = value;
-        });
-        return {
-          status: response.status,
-          statusText: response.statusText,
-          url: response.url,
-          text: await response.text(),
-          headers,
-        };
-      }
-
-      (window as unknown as { __TAURI__: unknown }).__TAURI__ = {
-        core: {
-          invoke(command: string, args: Record<string, unknown> = {}) {
-            switch (command) {
-              case "oc_local_instances":
-                return Promise.resolve(JSON.parse(JSON.stringify(instances)) as Instance[]);
-              case "oc_open_ssh_tunnel": {
-                opened.push(args.target);
-                if (script.refuse) return Promise.reject(new Error(script.refuse));
-                const target = args.target as { destination: string; remotePort: number };
-                return Promise.resolve({
-                  id: `${target.destination}:22:${target.remotePort}`,
-                  destination: target.destination,
-                  remotePort: target.remotePort,
-                  baseUrl: script.baseUrl,
-                });
-              }
-              case "oc_close_ssh_tunnel":
-              case "oc_ssh_tunnels":
-                return Promise.resolve([]);
-              case "oc_connect":
-                hosts.set(args.connectionId as string, args.baseUrl as string);
-                return Promise.resolve();
-              case "oc_disconnect":
-                hosts.delete(args.connectionId as string);
-                return Promise.resolve();
-              case "oc_connections":
-                return Promise.resolve([...hosts.keys()]);
-              case "oc_request":
-                return proxy(
-                  args.connectionId as string,
-                  args.request as unknown as Parameters<typeof proxy>[1],
-                );
-              case "oc_subscribe":
-                return Promise.resolve();
-              default:
-                return Promise.resolve(undefined);
-            }
-          },
-          Channel: class {
-            onmessage: unknown = null;
-          },
-        },
-      };
-    },
-    [roster, tunnel] as [Instance[], TunnelScript],
-  );
-}
-
-/** Opens "Add a host" and waits for the chooser. */
 async function openTheChooser(page: Page): Promise<void> {
-  const chooser = page.getByTestId("add-host-remote");
-  // Choosing "Add a host" closes the menu the item lives in, so the click can
-  // observe its own target detaching and then retry against a menu that is
-  // already gone. The chooser's arrival is the assertion — drive the
-  // open-and-choose pair until it lands, same shape as `clickClearOfToasts`.
-  await expect(async () => {
-    await openHostMenu(page);
-    await page.getByTestId("host-switcher-add").click({ timeout: 2_000 }).catch(() => {
-      // The menu closed under the click; the chooser check below is the verdict.
-    });
-    await expect(chooser).toBeVisible({ timeout: 2_000 });
-  }).toPass({ timeout: 15_000, intervals: [250] });
+  await expect(page.getByTestId("no-connection")).toBeVisible({ timeout: 30_000 });
+  await page.getByTestId("no-connection-add").click();
+  await expect(page.getByTestId("add-host-remote")).toBeVisible({ timeout: 5_000 });
 }
 
 /** Every connector this console is offering right now. */
@@ -188,71 +55,29 @@ async function offeredConnectors(page: Page): Promise<string[]> {
   return present.filter((kind): kind is string => kind !== null);
 }
 
-/** What the console wrote down about the hosts it holds. */
-async function storedConnectors(page: Page): Promise<unknown[]> {
-  return page.evaluate(() => {
-    const raw = window.localStorage.getItem("oc.connections.v1");
-    return raw
-      ? (JSON.parse(raw) as { connector?: unknown }[]).map((profile) => profile.connector)
-      : [];
-  });
-}
-
-const switcher = (page: Page) => page.getByTestId("host-switcher");
-
-test("a desktop offers all four places a runtime can run", async ({ page, baseURL }) => {
-  await installDesktopShell(page, seed(baseURL ?? ""), {});
-  await page.goto("/");
-  await openTheChooser(page);
-
-  expect(await offeredConnectors(page)).toEqual(["local", "cloud", "remote", "ssh"]);
-});
-
 /**
- * The chooser is a screen of the onboarding flow, not a popup over the console
- * ([#1531](https://github.com/tinyhumansai/opencompany/issues/1531)).
+ * Four cases retired with the desktop's chooser.
  *
- * It was a `Dialog`, and the dialog is 24rem wide: four connector tabs clipped
- * their own labels inside it. Asserting the *symptom* — every tab strip fitting
- * the box it is drawn in — rather than the absence of a `role=dialog`, because
- * the width is what a person reports and a future card that is too narrow again
- * should fail here.
+ * They covered the screen an operator reaches from "Add a host": that a desktop
+ * offers all four places a runtime can run (this computer, the hosted platform,
+ * a gateway, over ssh); that the chooser is a screen whose tabs fit the card
+ * they are drawn in rather than overflowing it; that a host reached over ssh is
+ * added at the address the shell actually opened rather than the one typed; and
+ * that ssh's refusal stays on screen instead of quietly becoming a host.
+ *
+ * All four need the desktop shell, and the desktop has no way onto that screen
+ * while the product is scoped to one company per install
+ * (`src/product-scope.ts`, `HOSTS_HIDDEN`): the switcher opens nothing, and the
+ * zero-host recovery is a single "start the host on this computer" action,
+ * covered in `desktop-connections.spec.ts`. The local and ssh connectors are
+ * desktop-only, so a hub cannot stand in for them — retargeting these would
+ * change what they test rather than where they run.
+ *
+ * The connector registry, the ssh address rule and the tab set are untouched in
+ * the source; turning the flag off restores the screen and all four cases. The
+ * two below still run, because a hub genuinely has to ask where a company runs
+ * and so keeps the chooser.
  */
-test("the chooser is a screen, and its tabs fit the card they are drawn in", async ({
-  page,
-  baseURL,
-}) => {
-  await installDesktopShell(page, seed(baseURL ?? ""), {});
-  await page.goto("/");
-  await openTheChooser(page);
-
-  const card = page.getByTestId("add-host");
-  await expect(card).toBeVisible();
-  // Its title stays put rather than scrolling away to make room for the form,
-  // which is the other half of what the dialog could not do.
-  await expect(card.getByRole("heading", { name: "Add a host" })).toBeVisible();
-
-  const strip = card.locator("[data-slot=tabs-list]").first();
-  const stripBox = await strip.boundingBox();
-  expect(stripBox, "the tab strip should have a box").not.toBeNull();
-  for (const kind of ["local", "cloud", "remote", "ssh"]) {
-    const tab = page.getByTestId(`add-host-${kind}`);
-    const box = await tab.boundingBox();
-    expect(box, `${kind} should have a box`).not.toBeNull();
-    expect(box!.x, `${kind} starts inside the strip`).toBeGreaterThanOrEqual(stripBox!.x - 1);
-    expect(
-      box!.x + box!.width,
-      `${kind} ends inside the strip`,
-    ).toBeLessThanOrEqual(stripBox!.x + stripBox!.width + 1);
-  }
-
-  // And there is a way back, to the console that was there before — which is
-  // still the console it was, rather than a re-booted one: a screen that
-  // unmounted it would replay "Connecting…" here.
-  await page.getByTestId("add-host-back").click();
-  await expect(card).toHaveCount(0);
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "1");
-});
 
 test("a browser is offered only the two connectors it can honour", async ({ page }) => {
   // A hub, because it is the browser shape that genuinely holds N hosts, and
@@ -280,145 +105,21 @@ test("a browser is told a gateway has to allow this console's origin", async ({ 
   await expect(page.getByText("OPENCOMPANY_CORS_ORIGINS")).toBeVisible();
 });
 
-test("a host reached over ssh is added at the address the shell opened", async ({
-  page,
-  baseURL,
-}) => {
-  // The tunnel forwards to the live harness host, which is what a real one
-  // would do: the console addresses loopback and something answers there.
-  await installDesktopShell(page, seed(baseURL ?? ""), { baseUrl: baseURL ?? "" });
-  await page.goto("/");
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "1");
-
-  await openTheChooser(page);
-  await page.getByTestId("add-host-ssh").click();
-  await page.getByLabel("Machine").fill("acme-vps");
-  await page.getByRole("button", { name: "Connect" }).click();
-
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
-
-  // The shell was asked for the machine someone typed, with the far side's
-  // port defaulted rather than left undefined.
-  //
-  // Asked more than once, and that is the design rather than a slip: the
-  // dialog opens the tunnel so a refusal lands in the form, and the probe that
-  // follows asks again because *every* launch has to. Opening is idempotent
-  // per target on the core's side, which is what makes asking twice free — so
-  // what this asserts is that every ask names the same target.
-  const asked = await page.evaluate(
-    () => (window as unknown as { __OPENED_TUNNELS__: unknown[] }).__OPENED_TUNNELS__,
-  );
-  expect(asked.length).toBeGreaterThan(0);
-  for (const target of asked) {
-    expect(target).toEqual({ destination: "acme-vps", remotePort: 8080 });
-  }
-
-  // And the connector is written down. Nothing about `http://127.0.0.1:<port>`
-  // says it is a tunnel, and the port is this launch's — so a console that did
-  // not record the target could not reopen it, and would mint a fresh id and
-  // orphan every scoped key under it next launch (issue #615).
-  expect(await storedConnectors(page)).toContainEqual({
-    kind: "ssh",
-    target: { destination: "acme-vps", remotePort: 8080 },
-  });
-});
-
-test("ssh's refusal stays on screen instead of becoming a host", async ({ page, baseURL }) => {
-  await installDesktopShell(page, seed(baseURL ?? ""), {
-    refuse: "Permission denied (publickey).",
-  });
-  await page.goto("/");
-  await openTheChooser(page);
-  await page.getByTestId("add-host-ssh").click();
-  await page.getByLabel("Machine").fill("acme-vps");
-  await page.getByRole("button", { name: "Connect" }).click();
-
-  // `ssh`'s own words, in the dialog the operator is standing in front of.
-  // Opening the tunnel here rather than leaving it to the first probe is what
-  // buys that: the alternative is a red row they have to go and read, saying
-  // "could not be reached" about a machine that answered and refused them.
-  await expect(page.getByText("Permission denied (publickey).")).toBeVisible();
-
-  // No host was added, and the dialog is still open to be corrected.
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "1");
-  await expect(page.getByLabel("Machine")).toBeVisible();
-});
-
 /**
- * A dead address, for the two rows below. Port 9 is `discard`, which nothing
- * on a test runner is listening on.
+ * Two cases retired with the roster they read from.
+ *
+ * They covered the reason a connector is written down at all: the same dead
+ * address means different things depending on what is behind it. A cloud tenant
+ * that is asleep reads "Waking…" and ranks as connecting, because something is
+ * going to wake it; a gateway somebody runs themselves reads "Unreachable",
+ * because nothing is. Both are read off a `host-row-…`, and the roster is hidden
+ * while the product is scoped to one company per install
+ * (`src/product-scope.ts`, `HOSTS_HIDDEN`).
+ *
+ * The distinction itself is untouched — `keepWaking` and the connector field it
+ * reads are still unit-tested in `connectors.test.ts` — so what went is the
+ * rendering of it. Turning the flag off restores both rows.
  */
-const ASLEEP = "http://127.0.0.1:9";
-
-/** Seeds a second host at a dead address, as the given connector. */
-async function seedSecondHost(page: Page, connector: unknown): Promise<void> {
-  await page.addInitScript(
-    ([dead, kind]: [string, unknown]) => {
-      // The tour modal covers the console and swallows every click, including
-      // the one that opens the switcher.
-      for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
-        window.localStorage.setItem(key, JSON.stringify({ skipped: true, seenAt: Date.now() }));
-      }
-      window.localStorage.setItem(
-        "oc.connections.v1",
-        JSON.stringify([
-          {
-            id: "conn-primary",
-            baseUrl: "",
-            label: "Primary",
-            defaultCompany: null,
-            credential: { kind: "cookie" },
-          },
-          {
-            id: "conn-second",
-            baseUrl: dead,
-            label: "Second",
-            defaultCompany: null,
-            credential: { kind: "cookie" },
-            connector: kind,
-          },
-        ]),
-      );
-    },
-    [ASLEEP, connector] as [string, unknown],
-  );
-}
-
-test("a cloud tenant that is asleep is being woken, not unreachable", async ({ page }) => {
-  // The platform starts an idle tenant when a request arrives, so its first
-  // request takes seconds. Reporting that as a host that is gone tells an
-  // operator their company is broken when it is merely asleep — and nothing
-  // re-probes, so the row would stay wrong.
-  await seedSecondHost(page, { kind: "cloud", tenant: "acme" });
-  await page.goto("/");
-
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
-  await openHostMenu(page);
-  await expect(page.getByTestId("host-row-state-conn-second")).toHaveText("Waking…", {
-    timeout: 30_000,
-  });
-  // In the same rank as any other connecting host: waking is not a fifth
-  // status, it is a connecting one that says what it is doing.
-  await expect(page.getByTestId("host-row-conn-second")).toHaveAttribute(
-    "data-status",
-    "connecting",
-  );
-});
-
-test("the same address as a gateway you run is simply unreachable", async ({ page }) => {
-  // The other half, and the reason the connector has to be written down: these
-  // two rows are the same url and the same failure, and they mean different
-  // things. Nothing is going to wake a gateway somebody runs themselves, so
-  // waiting on it would be a spinner that never resolves.
-  await seedSecondHost(page, { kind: "remote" });
-  await page.goto("/");
-
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
-  await openHostMenu(page);
-  await expect(page.getByTestId("host-row-state-conn-second")).toHaveText("Unreachable", {
-    timeout: 30_000,
-  });
-});
 
 test("a hub with no hosts offers the choice rather than describing it", async ({ page }) => {
   // The onboarding dead end. A hub's own origin serves assets and nothing

--- a/frontend/test/e2e/connection-degrade.spec.ts
+++ b/frontend/test/e2e/connection-degrade.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { openHostMenu } from "./host-switcher";
+
 
 /**
  * The headline requirement, and the regression that comes with it.
@@ -74,85 +74,32 @@ async function seedSecondHost(page: Page) {
   }, DEAD_HOST);
 }
 
-test("a host that is down reddens its own row and leaves the others working", async ({
-  page,
-}) => {
-  await seedSecondHost(page);
-  await page.goto("/#/ledgers/tasks");
+/**
+ * Three cases retired with the roster they read from.
+ *
+ * They covered issue #1167: a host that is down reddening its own row while the
+ * others go on working, selecting the dead host to see its failure without
+ * disturbing the live one, and — the naming half — a same-origin host the
+ * console was told nothing about being named by the address it answers on
+ * rather than by a constant, so two unnamed rows could not read identically
+ * with only a dot colour between them.
+ *
+ * Every one of them reads a `host-row-…`, and the roster is hidden while the
+ * product is scoped to one company per install (`src/product-scope.ts`,
+ * `HOSTS_HIDDEN`). The degrade behaviour itself is untouched — the status probe,
+ * the per-host error console and the naming rule all still run — so turning the
+ * flag off restores the rows and these cases with them.
+ *
+ * Written down rather than deleted: the coverage that went is worth a reader
+ * knowing about. What remains below is the case that still has a subject.
+ */
 
-  // Both hosts are present, so the switcher is a control rather than a
-  // nameplate.
-  const switcher = page.getByTestId("host-switcher");
-  await expect(switcher).toBeVisible({ timeout: 30_000 });
-  await expect(switcher).toHaveAttribute("data-host-count", "2");
-
-  // The trigger says so with the menu shut. This is the rail's amber dot,
-  // carried across (issue #1142): the console on screen is fine, and an
-  // operator still learns that something somewhere is not — without which
-  // hiding the rows behind a dropdown would be a net loss.
-  await expect(switcher).toHaveAttribute("data-worst-status", "down", { timeout: 30_000 });
-
-  // The live one reaches `live`; the dead one reaches `down`. Neither waits on
-  // the other — that independence is the property, and a global phase would
-  // have blanked the app before either resolved.
-  await openHostMenu(page);
-  await expect(page.getByTestId("host-row-conn-primary")).toHaveAttribute(
-    "data-status",
-    "live",
-    { timeout: 30_000 },
-  );
-  await expect(page.getByTestId("host-row-conn-dead")).toHaveAttribute("data-status", "down", {
-    timeout: 30_000,
-  });
-  // And it says so in words, not only in the colour of its dot. An operator
-  // who cannot separate amber from green — or who can, and still does not know
-  // *what* amber means here — otherwise learns the host is gone by switching
-  // to it and landing on its failure (issue #1167).
-  await expect(page.getByTestId("host-row-state-conn-dead")).toHaveText("Unreachable");
-  // The working row stays quiet: a state printed beside every host is a state
-  // beside none of them.
-  await expect(page.getByTestId("host-row-state-conn-primary")).toHaveCount(0);
-  await page.keyboard.press("Escape");
-
-  // THE assertion. The working host's console is rendered, not a full-screen
-  // error — the dead host is contained to its row.
-  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1);
-  await expect(page.getByTestId("connection-error")).toHaveCount(0);
-});
-
-test("selecting the dead host shows its failure without disturbing the live one", async ({
-  page,
-}) => {
-  await seedSecondHost(page);
-  await page.goto("/#/tasks");
-  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
-    timeout: 30_000,
-  });
-
-  await openHostMenu(page);
-  await page.getByTestId("host-row-conn-dead").click();
-
-  // The dead host says so, in the console area rather than over the whole app.
-  await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
-
-  // And the switcher is still there — on a screen with no sidebar to hold it,
-  // which is the case the rail used to cover for free by living outside the
-  // console. Without it this screen is a dead end with only a reload.
-  await openHostMenu(page);
-  // Still showing the live host as live: selecting a broken connection must not
-  // tear down a working one. This is exactly what a stateful "apply" switch
-  // would break.
-  await expect(page.getByTestId("host-row-conn-primary")).toHaveAttribute("data-status", "live");
-
-  // Switching back finds the working console still working, with no reload.
-  await page.getByTestId("host-row-conn-primary").click();
-  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1);
-  await expect(page.getByTestId("connection-error")).toHaveCount(0);
-});
-
-test("the number row switches hosts, and leaves the browser alone past the last one", async ({
-  page,
-}) => {
+test("the number row goes with the roster it selected from", async ({ page }) => {
+  // It used to switch hosts: the listener is installed on `window` by the hosts
+  // provider, not by the menu, so hiding the roster does not remove it. Left
+  // live it would swallow the browser's own Cmd-2 and put an unreachable host
+  // on screen with nothing naming it — the roster row that used to explain the
+  // switch is gone.
   await seedSecondHost(page);
   await page.goto("/#/tasks");
   await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
@@ -161,77 +108,12 @@ test("the number row switches hosts, and leaves the browser alone past the last 
 
   const mod = process.platform === "darwin" ? "Meta" : "Control";
 
-  // Second host: the dead one, whose console reports its own failure.
+  // The dead host is seeded and reachable by the old shortcut. Nothing happens.
   await page.keyboard.press(`${mod}+2`);
-  await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("connection-error")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1);
 
-  // Third host: there isn't one. Nothing happens, and — the reason this is
-  // asserted rather than assumed — the key is not swallowed to do nothing, so
-  // the browser keeps its own use of it.
-  await page.keyboard.press(`${mod}+3`);
-  await expect(page.getByTestId("connection-error")).toBeVisible();
-
-  // First host: back to a working console, without a reload.
   await page.keyboard.press(`${mod}+1`);
   await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1);
   await expect(page.getByTestId("connection-error")).toHaveCount(0);
-});
-
-/**
- * The naming half of issue #1167, and the state that produced the screenshot.
- *
- * The same-origin host is the one with no url of its own to read, and it used
- * to be named by a constant — so a console holding it beside anything else
- * unnamed offered two rows reading "This host", one live and one not, with only
- * a dot colour between them. Nothing is seeded for it here on purpose: the
- * point is what the console calls a host it was told nothing about.
- */
-test("names the host it was told nothing about by the address it answers on", async ({
-  page,
-  baseURL,
-}) => {
-  const origin = new URL(baseURL ?? "http://127.0.0.1:8080").host;
-  await silenceTour(page);
-  await page.addInitScript((dead) => {
-    window.localStorage.setItem(
-      "oc.connections.v1",
-      JSON.stringify([
-        // A second host, and nothing about the bootstrap one — which is exactly
-        // the arrangement an ordinary console reaches by adding a host.
-        {
-          id: "conn-unnamed-dead",
-          baseUrl: dead,
-          label: "Offline host",
-          defaultCompany: null,
-          credential: { kind: "cookie" },
-        },
-      ]),
-    );
-  }, DEAD_HOST);
-
-  await page.goto("/#/ledgers/tasks");
-  await openHostMenu(page);
-
-  // The host rows, by what marks them as host rows rather than by what they
-  // are not: the menu's trailing actions ("Add a host", "Manage hosts") carry
-  // their own testids, and filtering those out by their *text* would drop a
-  // real host somebody named "Add a host" — labels here are typed by an
-  // operator. The menu-item role as well as the prefix, because a row that is
-  // not `live` also renders a `host-row-state-…` span *inside* itself, and the
-  // prefix alone counts that span as a third host.
-  //
-  // Down to each row's first line: a row carries its state and its shortcut
-  // too, and a shortcut differs on every row, so comparing whole rows would
-  // call two identical names distinct.
-  const rows = await page
-    .getByRole("menuitem")
-    .and(page.locator('[data-testid^="host-row-"]'))
-    .allInnerTexts();
-  const names = rows.map((text) => text.split("\n")[0].trim());
-  expect(names.length).toBe(2);
-  expect(new Set(names).size, `two hosts must not read alike: ${JSON.stringify(names)}`).toBe(2);
-  // Addressable, so it distinguishes — and distinct from every other row, which
-  // a constant could never promise.
-  expect(names.some((name) => name.includes(origin))).toBe(true);
-  expect(names.some((name) => name.includes("This host"))).toBe(false);
 });

--- a/frontend/test/e2e/desktop-connections.spec.ts
+++ b/frontend/test/e2e/desktop-connections.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { openHostMenu } from "./host-switcher";
+
 
 /**
  * What the desktop opens on, driven against a real host.
@@ -273,18 +273,18 @@ test("a remembered host does not take the launch just by being older", async ({
   });
   await expect(page.getByTestId("connection-error")).toHaveCount(0);
 
-  // Said directly, rather than inferred from what rendered: the remembered host
-  // is present and not current, and whatever is current is live.
-  await openHostMenu(page);
-  await expect(page.getByTestId("host-row-conn-remembered-remote")).toHaveAttribute(
-    "aria-current",
-    "false",
-  );
-  await expect(page.locator('[data-testid^="host-row-"][aria-current="true"]')).toHaveAttribute(
-    "data-status",
-    "live",
-  );
-  await page.keyboard.press("Escape");
+  // Said off the closed trigger. The per-row `aria-current` this used to read is
+  // hidden with the roster (`src/product-scope.ts`), so what survives is the
+  // count — the remembered host is still held, not dropped — and the worst
+  // status across the set, which is what the rows would have had to agree with.
+  // Only the count survives off the closed trigger: the remembered host is still
+  // held rather than dropped. Which row is current, and that the current one is
+  // live, were per-row facts — the trigger reports the WORST status across the
+  // set, which is `down` here precisely because the remembered host is dead, so
+  // it cannot stand in for them. The assertion above (no connection error, and
+  // the embedded host's console on screen) is what still says the launch went to
+  // the right one.
+  await expect(page.getByTestId("host-switcher")).toHaveAttribute("data-host-count", /[2-9]/);
 });
 
 test("a desktop waits for its own host rather than borrowing a remembered one", async ({
@@ -372,13 +372,11 @@ test("a paired host on plain http is refused, and says why", async ({ page, base
     timeout: 30_000,
   });
 
-  await openHostMenu(page);
-  const refused = page.getByTestId("host-row-conn-paired-cleartext");
-  await expect(refused).toHaveAttribute("data-status", "down");
-  // THE assertion. Before this, the row read "cannot reach the company host at
-  // http://192.168.1.20:8080" — indistinguishable from a host that is simply
-  // switched off, and it sends the operator to look at a network that works.
-  await expect(refused).toHaveAttribute("title", /not encrypted/);
+  // The row that carried the refusal — and its "not encrypted" title, which is
+  // what told the operator not to go looking at a working network — is hidden
+  // with the roster (`src/product-scope.ts`). The refusal itself is unchanged
+  // and is still asserted where it matters most: nothing was sent.
+  await expect(page.getByTestId("host-switcher")).toHaveAttribute("data-worst-status", "down");
 
   // And nothing was sent there. The status is not a label applied after a round
   // trip; the round trip is what must not happen.
@@ -417,23 +415,26 @@ test("an unencrypted host with no credential still connects", async ({ page, bas
   await expect(page.getByTestId("host-switcher")).toHaveAttribute("data-worst-status", "live", {
     timeout: 30_000,
   });
-  await openHostMenu(page);
-  await expect(page.getByTestId("host-row-conn-anonymous-http")).toHaveAttribute(
-    "data-status",
-    "live",
-  );
 });
 
-test("a desktop whose host did not start says so, and can still add one", async ({ page }) => {
+test("a desktop whose host did not start offers to start it, not a choice of where", async ({
+  page,
+}) => {
   // No embedded host, no remembered hosts: the state that used to render an
   // empty pane once the same-origin connection stopped filling it.
   await asDesktop(page, { embedded: null });
   await page.goto("/");
 
   await expect(page.getByTestId("no-connection")).toBeVisible({ timeout: 30_000 });
-  // The switcher holds the only "add a host" control, so it has to survive a
-  // count of zero — and it has no sidebar to live in on this screen, which is
-  // the case the rail used to cover for free by standing outside the console.
-  await expect(page.getByTestId("host-switcher")).toBeVisible();
-  await openHostMenu(page);
+
+  // One machine runs one host, so the recovery is an action rather than a
+  // four-way chooser between this computer, the cloud, a gateway and ssh.
+  await expect(page.getByTestId("no-connection-run-here")).toBeVisible();
+  await expect(page.getByTestId("no-connection-run-here")).toHaveText(
+    "Start the host on this computer",
+  );
+  await expect(page.getByTestId("no-connection-add")).toHaveCount(0);
+
+  // And the copy stops offering the alternative it no longer has.
+  await expect(page.getByTestId("no-connection")).not.toContainText("somewhere else");
 });

--- a/frontend/test/e2e/desktop-embedded-identity.spec.ts
+++ b/frontend/test/e2e/desktop-embedded-identity.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { openHostMenu } from "./host-switcher";
+
 
 /**
  * Issue #615 — one "This computer" row, however many times the app restarts.
@@ -255,8 +255,11 @@ test("a relaunch at a new port re-addresses the connection instead of adding one
 
   // And the row that survived is the working one: this status comes back from a
   // real request to the real host, through the console's own probe.
-  await openHostMenu(page);
-  await expect(page.getByTestId(`host-row-${first.id}`)).toHaveAttribute("data-status", "live", {
+  // Read off the closed trigger. The roster it used to be read from is hidden
+  // (`src/product-scope.ts`), but the trigger still reports the worst status
+  // across every host — with one row left, that IS this row's status, and it
+  // still comes back from a real probe of the real host.
+  await expect(page.getByTestId("host-switcher")).toHaveAttribute("data-worst-status", "live", {
     timeout: 30_000,
   });
 });

--- a/frontend/test/e2e/desktop-local-instances.spec.ts
+++ b/frontend/test/e2e/desktop-local-instances.spec.ts
@@ -1,285 +1,47 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-import { openHostMenu } from "./host-switcher";
+import { expectHostMenuGone } from "./host-switcher";
 
 /**
- * More than one host on this computer, driven through the whole app.
+ * Hosts on this computer, and why this file no longer drives them.
  *
- * The unit tests drive `adoptLocalHosts` directly. This drives the console the
- * way the packaged shell does — real browser, real `localStorage`, the built
- * bundle, a live host behind one of the instances — because the thing that
- * broke before (issue #615, and the prune this feature had to widen) lives in
- * `App`'s wiring rather than in the registry's exports.
+ * It covered the desktop's local-instance roster end to end, through the UI
+ * that fronts the shell commands: a stopped instance listed and startable
+ * rather than shown as a broken row, a host started here stopped again without
+ * losing the others, a second company created on this computer, a
+ * desktop-created company deleted after an explicit confirmation, and the
+ * default instance refusing deletion because its root is the application data
+ * directory itself.
  *
- * ## What is shimmed
+ * All of it is reached through the "Add a host" screen's local tab, and that
+ * screen has no entry point on the desktop while the product is scoped to one
+ * company per install (`src/product-scope.ts`, `HOSTS_HIDDEN`): the switcher
+ * opens nothing, and the zero-host recovery is now a single "start the host on
+ * this computer" action rather than a chooser.
  *
- * `window.__TAURI__` exists only inside the packaged shell, so the bridge is
- * shimmed and nothing else. It answers `oc_local_instances` from a roster the
- * spec holds, and `oc_create_local_instance` / `oc_start_local_instance` /
- * `oc_stop_local_instance` mutate that roster — which is exactly what
- * `LocalHosts` does in Rust, minus the sockets. Every decision asserted on
- * belongs to the console.
+ * **This is the largest coverage loss in this change.** The Tauri commands
+ * underneath (`oc_local_instances`, `oc_create_local_instance`,
+ * `oc_start_local_instance`, `oc_stop_local_instance`,
+ * `oc_delete_local_instance`) are untouched and still unit-tested in Rust; what
+ * is no longer exercised is the console wiring in front of them. Turning the
+ * flag off restores the screen and every case above.
  *
- * Only one live host exists here, so the extra instances are given closed
- * ports. That is deliberate rather than a shortcut: a connection whose host is
- * unreachable must still get a row, and asserting on rows that cannot answer
- * proves the rail renders the *roster*, not just whatever replied.
+ * Retired rather than deleted or skipped, so the gap is recorded where the next
+ * reader will look for it.
  */
 
-interface Instance {
-  id: string;
-  label: string;
-  dataDir: string;
-  running: boolean;
-  baseUrl?: string;
-  instanceId?: string;
-  companies?: string[];
-}
-
-/** Installs a bridge backed by a roster the page can mutate, as the core is. */
-async function installDesktopShell(page: Page, roster: Instance[]): Promise<void> {
-  await page.addInitScript((seed: Instance[]) => {
-    // The tour modal covers the console and swallows clicks.
-    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
-      window.localStorage.setItem(key, JSON.stringify({ skipped: true, seenAt: Date.now() }));
-    }
-
-    const instances: Instance[] = JSON.parse(JSON.stringify(seed)) as Instance[];
-    const hosts = new Map<string, string>();
-
-    async function proxy(
-      connectionId: string,
-      request: {
-        method: string;
-        path: string;
-        headers?: Record<string, string>;
-        body?: string | null;
-      },
-    ) {
-      const base = hosts.get(connectionId) ?? "";
-      const response = await fetch(`${base}${request.path}`, {
-        method: request.method,
-        headers: request.headers,
-        body: request.body ?? undefined,
-        credentials: "include",
-      });
-      const headers: Record<string, string> = {};
-      response.headers.forEach((value, key) => {
-        headers[key.toLowerCase()] = value;
-      });
-      return {
-        status: response.status,
-        statusText: response.statusText,
-        url: response.url,
-        text: await response.text(),
-        headers,
-      };
-    }
-
-    (window as unknown as { __TAURI__: unknown }).__TAURI__ = {
-      core: {
-        invoke(command: string, args: Record<string, string> = {}) {
-          const find = (id: string) => instances.find((instance) => instance.id === id);
-          switch (command) {
-            case "oc_local_instances":
-              return Promise.resolve(JSON.parse(JSON.stringify(instances)) as Instance[]);
-            case "oc_create_local_instance": {
-              // A fresh root, a fresh identity, a port of its own — the core's
-              // shape, with a port nothing answers on.
-              const id = args.label.toLowerCase().replace(/[^a-z0-9]+/g, "-");
-              const created: Instance = {
-                id,
-                label: args.label,
-                dataDir: `/tmp/instances/${id}`,
-                running: true,
-                baseUrl: "http://127.0.0.1:65999",
-                instanceId: `instance-${id}`,
-                companies: [],
-              };
-              instances.push(created);
-              return Promise.resolve(created);
-            }
-            case "oc_start_local_instance": {
-              const instance = find(args.id);
-              if (!instance) return Promise.reject(new Error(`no such instance: ${args.id}`));
-              instance.running = true;
-              instance.baseUrl ??= "http://127.0.0.1:65998";
-              instance.instanceId ??= `instance-${instance.id}`;
-              return Promise.resolve(instance);
-            }
-            case "oc_stop_local_instance": {
-              const instance = find(args.id);
-              if (!instance) return Promise.reject(new Error(`no such instance: ${args.id}`));
-              instance.running = false;
-              return Promise.resolve(instance);
-            }
-            case "oc_delete_local_instance": {
-              const index = instances.findIndex((instance) => instance.id === args.id);
-              if (index < 0) return Promise.reject(new Error(`no such instance: ${args.id}`));
-              if (args.id === "default") {
-                return Promise.reject(
-                  new Error("the instance on this computer cannot be removed"),
-                );
-              }
-              instances.splice(index, 1);
-              return Promise.resolve();
-            }
-            case "oc_connect":
-              hosts.set(args.connectionId, args.baseUrl);
-              return Promise.resolve();
-            case "oc_disconnect":
-              hosts.delete(args.connectionId);
-              return Promise.resolve();
-            case "oc_connections":
-              return Promise.resolve([...hosts.keys()]);
-            case "oc_request":
-              return proxy(
-                args.connectionId,
-                args.request as unknown as Parameters<typeof proxy>[1],
-              );
-            case "oc_subscribe":
-              return Promise.resolve();
-            default:
-              return Promise.resolve(undefined);
-          }
-        },
-        Channel: class {
-          onmessage: unknown = null;
-        },
-      },
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
     };
-  }, roster);
-}
-
-/** The roster every one of these starts from: one live host, one stopped. */
-function seed(liveBaseUrl: string): Instance[] {
-  return [
-    {
-      id: "default",
-      label: "This computer",
-      dataDir: "/tmp/e2e-embedded",
-      running: true,
-      baseUrl: liveBaseUrl,
-      instanceId: "instance-default",
-      companies: [],
-    },
-    {
-      id: "scratch",
-      label: "Scratch",
-      dataDir: "/tmp/instances/scratch",
-      running: false,
-    },
-  ];
-}
-
-/**
- * How many hosts the console holds, read off the switcher's closed trigger.
- *
- * The count has to be answerable while the roster dialog is open, which is when
- * every one of these asserts — and the menu the rows live in is shut by then.
- * `data-host-count` is on the trigger for exactly this: the roster size is not
- * a fact that should require opening a menu, which is the same reason the
- * trigger also carries the worst status across hosts. (It also sidesteps
- * `getByRole` skipping the `aria-hidden` subtree behind an open dialog.)
- */
-function hostCount(page: Page) {
-  return page.getByTestId("host-switcher");
-}
-
-async function openTheRoster(page: Page): Promise<void> {
-  await openHostMenu(page);
-  await page.getByTestId("host-switcher-add").click();
-  await page.getByTestId("add-host-local").click();
-  await expect(page.getByTestId("local-instances")).toBeVisible();
-}
-
-test("a stopped instance is listed and startable, not a broken row", async ({
-  page,
-  baseURL,
-}) => {
-  await installDesktopShell(page, seed(baseURL ?? ""));
-  await page.goto("/");
-
-  // One connection, because one instance is listening. A stopped instance has
-  // no address, so a row for it in the menu could only fail its probe forever.
-  await expect(hostCount(page)).toHaveAttribute("data-host-count", "1");
-
-  await openTheRoster(page);
-  const scratch = page.getByTestId("local-instance-scratch");
-  await expect(scratch).toHaveAttribute("data-running", "false");
-  await scratch.getByRole("button", { name: "Start" }).click();
-
-  // Started, and now a host the console holds alongside the first.
-  await expect(scratch).toHaveAttribute("data-running", "true");
-  await expect(hostCount(page)).toHaveAttribute("data-host-count", "2");
+  });
 });
 
-test("a host started here can be stopped again without losing the others", async ({
-  page,
-  baseURL,
-}) => {
-  await installDesktopShell(page, seed(baseURL ?? ""));
-  await page.goto("/");
-  await openTheRoster(page);
+test("the console offers no way onto the add-a-host screen", async ({ page }) => {
+  await page.goto("/#/company");
 
-  const scratch = page.getByTestId("local-instance-scratch");
-  await scratch.getByRole("button", { name: "Start" }).click();
-  await expect(hostCount(page)).toHaveAttribute("data-host-count", "2");
-
-  await scratch.getByRole("button", { name: "Stop" }).click();
-  await expect(scratch).toHaveAttribute("data-running", "false");
-  // Back to the live host alone — and crucially *not* to zero: stopping one
-  // instance must not prune the rows of the ones still running, which is the
-  // failure the single-host prune would have produced.
-  await expect(hostCount(page)).toHaveAttribute("data-host-count", "1");
-  await expect(page.getByTestId("local-instance-default")).toHaveAttribute(
-    "data-running",
-    "true",
-  );
-});
-
-test("a second company can be created on this computer", async ({ page, baseURL }) => {
-  await installDesktopShell(page, seed(baseURL ?? ""));
-  await page.goto("/");
-  await openTheRoster(page);
-
-  // The graph behind the roster now exposes its node labels as accessible
-  // names (e.g. "SOP tasks: e2e rename …"), which the substring form of
-  // `getByLabel` would match — so pin the exact label of the form field.
-  await page.getByLabel("Name", { exact: true }).fill("Acme");
-  await page.getByTestId("local-instance-add").click();
-
-  await expect(page.getByTestId("local-instance-acme")).toHaveAttribute(
-    "data-running",
-    "true",
-  );
-  // Three instances now, two of them listening: the new one and the original.
-  await expect(hostCount(page)).toHaveAttribute("data-host-count", "2");
-});
-
-test("a desktop-created company can be deleted after confirmation", async ({
-  page,
-  baseURL,
-}) => {
-  await installDesktopShell(page, seed(baseURL ?? ""));
-  await page.goto("/");
-  await openTheRoster(page);
-
-  const scratch = page.getByTestId("local-instance-scratch");
-  await scratch.getByRole("button", { name: "Delete Scratch" }).click();
-
-  await expect(page.getByText("Delete Scratch from this computer?")).toBeVisible();
-  await expect(scratch).toBeVisible();
-  await page.getByTestId("local-instance-delete-confirm-scratch").click();
-
-  await expect(scratch).not.toBeVisible();
-  await expect(page.getByTestId("local-instance-default")).toBeVisible();
-});
-
-test("the default desktop company cannot be deleted", async ({ page, baseURL }) => {
-  await installDesktopShell(page, seed(baseURL ?? ""));
-  await page.goto("/");
-  await openTheRoster(page);
-
-  await expect(page.getByTestId("local-instance-delete-default")).toHaveCount(0);
+  await expectHostMenuGone(page);
+  await expect(page.getByTestId("add-host-page")).toHaveCount(0);
 });

--- a/frontend/test/e2e/host-switch-history.spec.ts
+++ b/frontend/test/e2e/host-switch-history.spec.ts
@@ -1,188 +1,39 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-import { openHostMenu } from "./host-switcher";
+import { expectHostMenuGone } from "./host-switcher";
 
 /**
- * Switching hosts is a navigation, and the address says whose page it is
- * (issue #1358).
+ * Switching hosts is a navigation, and why this file no longer drives one.
  *
- * ## The report
+ * It covered issue #1358: with two hosts and the second one down, picking the
+ * dead host from the switcher pushed a history entry, so Back undid the switch
+ * instead of silently spending the working host's route stack; a copied address
+ * reopened the host it named, failure and all; and a host that could not be
+ * reached could be forgotten from the failure screen itself.
  *
- * Two hosts, the second one down. On the Tasks board of the working host, pick
- * the dead one from the switcher: a full-screen "Can't connect" comes up and
- * the address bar goes on reading `#/ledgers/tasks` — a page of the host just
- * left. Press Back to undo the switch and **nothing appears to happen**: the
- * failed host's console does not read the route, so no pixel changes. Press it
- * again, same. Then switch back to the working host and land on Overview,
- * because those two inert-looking presses were popping *its* history.
+ * All of it starts by picking a host from the switcher, and the switcher opens
+ * nothing while the product is scoped to one company per install
+ * (`src/product-scope.ts`, `HOSTS_HIDDEN`). The `?host=` routing and its
+ * history behaviour are untouched in the source — turning the flag off restores
+ * the entry point and these cases with it.
  *
- * Two defects with one symptom, and the sequence below is the only way to see
- * either of them:
- *
- *   1. selection was plain React state, so Back could not undo a switch;
- *   2. the hash named a page without naming a host, so Back on the failed
- *      host's screen spent the working host's route stack instead.
- *
- * Together they made the natural recovery gesture the thing that destroyed
- * your place, silently.
- *
- * ## Why this is an e2e spec
- *
- * `test/unit/host-route.test.ts` pins the scope helpers and the hooks against a
- * synthetic hash. It cannot reach the thing that was actually broken: a real
- * `history` stack, a real Back, and a console whose shell is not mounted for
- * the host on screen. The bug lives exactly in that gap — every piece worked
- * on its own.
- *
- * The dead host is an address nothing listens on, for the reason
- * `connection-degrade.spec.ts` gives: a spec that needs two live servers is a
- * spec nobody runs.
+ * Retired rather than deleted or skipped, so the coverage that was lost is
+ * written down where the next reader will look for it.
  */
 
-/** A port nothing is listening on, so the second connection is always down. */
-const DEAD_HOST = "http://127.0.0.1:8451";
-
-/** The tour modal covers the board and swallows clicks. */
-async function silenceTour(page: Page) {
+test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
-    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
-      window.localStorage.setItem(key, JSON.stringify({ skipped: true, seenAt: Date.now() }));
-    }
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
   });
-}
+});
 
-/** Seeds a working host and an unreachable one, the way the app persists them. */
-async function seedTwoHosts(page: Page) {
-  await silenceTour(page);
-  await page.addInitScript((dead) => {
-    window.localStorage.setItem(
-      "oc.connections.v1",
-      JSON.stringify([
-        {
-          id: "conn-primary",
-          baseUrl: "",
-          label: "Primary",
-          defaultCompany: null,
-          credential: { kind: "cookie" },
-        },
-        {
-          id: "conn-dead",
-          baseUrl: dead,
-          label: "Offline host",
-          defaultCompany: null,
-          credential: { kind: "cookie" },
-        },
-      ]),
-    );
-  }, DEAD_HOST);
-}
-
-/** The hash, which is where the whole of this issue is visible. */
-function hash(page: Page): string {
-  return new URL(page.url()).hash;
-}
-
-test("Back undoes a host switch instead of silently spending the other host's route", async ({
-  page,
-}) => {
-  await seedTwoHosts(page);
+test("there is no host to switch to, so no switch to undo", async ({ page }) => {
   await page.goto("/#/ledgers/tasks");
 
-  // The board of the working host, and an address that says so. Before this
-  // fix the `?host=` half simply did not exist.
-  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
-    timeout: 30_000,
-  });
-  await expect(page).toHaveURL(/#\/ledgers\/tasks\?host=conn-primary$/);
-
-  // Step 2 of the report: pick the host that is down.
-  await openHostMenu(page);
-  await page.getByTestId("host-row-conn-dead").click();
-  await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
-
-  // Defect 2. The bar named `conn-primary`'s Tasks board for the whole time
-  // this failure was on screen; now it names the host the failure belongs to,
-  // so the URL can be copied and reloaded onto what is actually being looked
-  // at. The path is *frozen*, not rewritten — going back to a working host
-  // returns to the page that was open, which was already correct and must stay
-  // so.
-  expect(hash(page)).toBe("#/ledgers/tasks?host=conn-dead");
-
-  // Steps 3–4, and defect 1. One Back, and the working host's Tasks board is
-  // back — the switch is undone. Before this, Back consumed
-  // `#/ledgers/tasks` → `#/ledgers` while the screen stayed on "Can't connect",
-  // and it took a second press and a manual switch to discover the damage.
-  await page.goBack();
-  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
-    timeout: 30_000,
-  });
-  await expect(page.getByTestId("connection-error")).toHaveCount(0);
-  expect(hash(page)).toBe("#/ledgers/tasks?host=conn-primary");
-});
-
-test("the working host's own route stack is intact after a trip through the failure", async ({
-  page,
-}) => {
-  // The damage the operator could not see. Two views deep on the working host,
-  // then out to the dead one and back: the entries behind them must still be
-  // the ones they walked in on, not two shallower.
-  await seedTwoHosts(page);
-  await page.goto("/#/overview");
-  await expect(page.getByTestId("host-switcher")).toBeVisible({ timeout: 30_000 });
-
-  await page.evaluate(() => {
-    window.location.hash = "/ledgers/tasks";
-  });
-  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
-    timeout: 30_000,
-  });
-  await expect(page).toHaveURL(/#\/ledgers\/tasks\?host=conn-primary$/);
-
-  await openHostMenu(page);
-  await page.getByTestId("host-row-conn-dead").click();
-  await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
-
-  // Back out of the failure, then back through the page that was open before
-  // it. Each press moves one step, and the steps are the working host's —
-  // which is the whole of "nothing was spent while the error screen was up".
-  // Before this, the first press was silently the second: it popped
-  // `#/ledgers/tasks` while the error screen stayed put, so this Overview was
-  // one press closer than the operator believed.
-  await page.goBack();
-  expect(hash(page)).toBe("#/ledgers/tasks?host=conn-primary");
-  await page.goBack();
-  await expect(page).toHaveURL(/#\/overview\?host=conn-primary$/);
-});
-
-test("a copied address reopens the host it named, failure and all", async ({ page }) => {
-  // The other half of defect 2. Reloading the failure screen used to drop back
-  // to the bootstrap connection, so "Retry" on a non-bootstrap host quietly
-  // moved you to a different one — the address carried no host to return to.
-  await seedTwoHosts(page);
-  await page.goto("/#/ledgers/tasks?host=conn-dead");
-  await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
-  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(0);
-});
-
-test("a host that cannot be reached can be forgotten from the failure itself", async ({
-  page,
-}) => {
-  // The adjacent half of the issue. This screen used to offer Retry and the
-  // single-host boot hint — telling somebody who picked a row out of a switcher
-  // to "set the host with ?api=" — and no way to dispose of a host that is
-  // simply gone.
-  await seedTwoHosts(page);
-  await page.goto("/#/ledgers/tasks?host=conn-dead");
-  await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
-  await expect(page.getByTestId("connection-error")).not.toContainText("?api=");
-
-  await page.getByTestId("connection-error-forget").click();
-
-  // Forgetting selects what is left, and the console it lands on is a working
-  // one. The switcher drops to a single host, so the address stops carrying a
-  // scope there is no longer anything to disambiguate.
-  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
-    timeout: 30_000,
-  });
-  await expect(page.getByTestId("host-switcher")).toHaveAttribute("data-host-count", "1");
+  await expectHostMenuGone(page);
+  // The address keeps naming the page, not a host — nothing scoped it to one.
+  await expect(page).toHaveURL(/#\/ledgers\/tasks/);
 });

--- a/frontend/test/e2e/host-switcher.ts
+++ b/frontend/test/e2e/host-switcher.ts
@@ -31,9 +31,19 @@ export async function expectHostMenuGone(page: Page): Promise<void> {
   const trigger = page.getByTestId("host-switcher");
   await expect(trigger).toBeVisible({ timeout: 30_000 });
   await trigger.click();
+
+  // Nothing opened, and nothing that would have.
   await expect(page.locator('[role="menu"]')).toHaveCount(0);
   await expect(page.getByTestId("host-switcher-add")).toHaveCount(0);
   await expect(page.getByTestId("host-switcher-manage")).toHaveCount(0);
   await expect(page.getByTestId("switcher-new-company")).toHaveCount(0);
   await expect(page.locator('[data-testid^="host-row-"]')).toHaveCount(0);
+
+  // An absent menu is not the same fact as a trigger that stopped behaving like
+  // one. A control still announcing itself as a button with a popup — reachable
+  // by Tab, actionable by Enter, described to a screen reader as something that
+  // opens — is a promise the console no longer keeps, whatever the popup does.
+  await expect(trigger.locator("button")).toHaveCount(0);
+  await expect(trigger).not.toHaveAttribute("aria-haspopup", /.*/);
+  await expect(trigger).not.toHaveAttribute("aria-expanded", /.*/);
 }

--- a/frontend/test/e2e/host-switcher.ts
+++ b/frontend/test/e2e/host-switcher.ts
@@ -1,25 +1,39 @@
 import { expect, type Page } from "@playwright/test";
 
 /**
- * Driving the host switcher, which replaced the icon rail (issue #1142).
+ * Driving the host switcher, which replaced the icon rail (issue #1142) and is
+ * now a nameplate.
  *
  * The rail was permanently on screen, so a spec could read any host's status
- * straight off it. A dropdown cannot be read until it is open — so the trigger
- * carries the two things worth knowing without opening it (`data-host-count`
- * and `data-worst-status`, both asserted directly by the specs), and this
- * module holds the one gesture that gets at the rest.
+ * straight off it. A dropdown could not be read until it was open, so the
+ * trigger carried the two things worth knowing without opening it
+ * (`data-host-count` and `data-worst-status`) and this module held the gesture
+ * that got at the rest.
+ *
+ * That gesture is gone. While the product is scoped to one company per install
+ * (`src/product-scope.ts`) the trigger opens nothing at all: no roster, no
+ * "Add a host", no "Manage hosts", no company rows and no "New company". The
+ * two trigger attributes survive, and are still what a spec reads.
+ *
+ * `openHostMenu` is deliberately NOT kept as a no-op. Every caller of it was
+ * driving a flow that no longer has an entry point, and a helper that silently
+ * succeeded would have let those specs go green while testing nothing.
  */
 
 /**
- * Opens the menu and waits for it to be there.
+ * Asserts the trigger is a name rather than a control.
  *
- * Waits on "Add a host" rather than on a host row, because it is the one item
- * present at every count — including the zero a desktop with no host has, which
- * is exactly when the menu matters most.
+ * Clicks it first, because the trap worth guarding is not "the roster is
+ * hidden" but "the trigger still opens" — onto a menu with every group hidden,
+ * which is a chevron over an empty popup rather than a company's name.
  */
-export async function openHostMenu(page: Page): Promise<void> {
+export async function expectHostMenuGone(page: Page): Promise<void> {
   const trigger = page.getByTestId("host-switcher");
   await expect(trigger).toBeVisible({ timeout: 30_000 });
   await trigger.click();
-  await expect(page.getByTestId("host-switcher-add")).toBeVisible();
+  await expect(page.locator('[role="menu"]')).toHaveCount(0);
+  await expect(page.getByTestId("host-switcher-add")).toHaveCount(0);
+  await expect(page.getByTestId("host-switcher-manage")).toHaveCount(0);
+  await expect(page.getByTestId("switcher-new-company")).toHaveCount(0);
+  await expect(page.locator('[data-testid^="host-row-"]')).toHaveCount(0);
 }

--- a/frontend/test/e2e/inference.spec.ts
+++ b/frontend/test/e2e/inference.spec.ts
@@ -49,23 +49,49 @@ async function openConnections(page: Page) {
     });
 }
 
-test("a key typed for a BYOK provider is not discarded by switching to managed", async ({
+test("the managed brain is not offered as something to switch to", async ({ page }) => {
+  await openConnections(page);
+
+  // The company has no `[inference]` section, so the host still answers
+  // `provider: "managed"` — unchanged, this is a console-only change. What the
+  // card must not do is render that as a route: the header reports the state,
+  // and the form opens on something the operator can actually finish.
+  await expect(page.getByTestId("inference-current-provider")).toHaveText("Not configured", {
+    timeout: 30_000,
+  });
+  await expect(page.locator("#inference-provider")).toHaveText(/OpenRouter/);
+  await expect(page.locator("body")).not.toContainText("Managed (TinyHumans)");
+
+  // And it is not in the list, so nothing can be switched *to* it.
+  await page.locator("#inference-provider").click();
+  await expect(page.getByRole("option", { name: "OpenRouter", exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("option", { name: "Managed (TinyHumans)", exact: true }),
+  ).toHaveCount(0);
+  await page.keyboard.press("Escape");
+});
+
+test("a key typed for a BYOK provider is not discarded by switching provider", async ({
   page,
 }) => {
   await openConnections(page);
 
-  // Managed is the default selection, and since #585 it offers the key input
-  // like every other provider but Ollama — with the line that says what paying
-  // for the company actually means.
+  // Since #585 the key input is offered for every provider but Ollama — with
+  // the line that says what paying for the company actually means.
   await expect(page.locator("#inference-key")).toBeVisible({ timeout: 30_000 });
   await expect(page.getByTestId("inference-key-note")).toBeVisible();
 
-  // Type a key under a BYOK provider, then switch back to managed. The value
-  // survives the switch — that is the state that used to lose it.
+  // Type a key under one provider, then switch to another and back. The value
+  // survives the switch — that is the state that used to lose it. The pair used
+  // to be OpenRouter and managed; managed is no longer selectable, and the
+  // defect was never about *which* two providers, only about crossing between
+  // any of them.
   await pickProvider(page, "OpenRouter");
   const typed = `pw-e2e-${Date.now()}`;
   await page.locator("#inference-key").fill(typed);
-  await pickProvider(page, "Managed (TinyHumans)");
+  await pickProvider(page, "Custom (OpenAI-compatible)");
+  await expect(page.locator("#inference-key")).toHaveValue(typed);
+  await pickProvider(page, "OpenRouter");
   await expect(page.locator("#inference-key")).toHaveValue(typed);
 
   // Saving now stores it rather than reverting past it. The credential is
@@ -80,7 +106,9 @@ test("a key typed for a BYOK provider is not discarded by switching to managed",
   expect(after.ok()).toBeTruthy();
   const body = await after.json();
   expect(body.keyConfigured).toBe(true);
-  // Setting only a key must not move the company off the managed brain.
+  // Setting a key under OpenRouter lands on OpenRouter — which is also what the
+  // legacy `managed` alias normalizes to, so this stays the same assertion it
+  // was when the switch above ended on managed.
   expect(body.provider).toBe("openrouter");
 
   // And it can be taken back off again — set / rotate / clear, all from here.

--- a/frontend/test/e2e/manage-hosts.spec.ts
+++ b/frontend/test/e2e/manage-hosts.spec.ts
@@ -1,183 +1,40 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-import { openHostMenu } from "./host-switcher";
-
-/**
- * Modifying a host, driven the way a person does it.
- *
- * The unit tests drive `editConnection` directly — what a move does to the id,
- * what is dropped when an address changes, which connectors may be re-typed.
- * What they cannot cover is the wiring this page is: the menu item that opens
- * it, the roster it draws from context, and the fact that forgetting the host
- * on screen has to move the selection *and* leave the page standing.
- *
- * The property underneath all of it: a connection id is the namespace every
- * browser-local key hangs off (`scopedKey`), so "this host moved" must be
- * expressible without minting a new one.
- */
-
-/** A dead address, as in `add-host-connectors.spec.ts`. Port 9 is `discard`. */
-const ASLEEP = "http://127.0.0.1:9";
+import { expectHostMenuGone } from "./host-switcher";
 
 /**
- * A second dead address, for the move to land on.
+ * The "Manage hosts" page, and why this file no longer drives it.
  *
- * Deliberately *not* the console's own origin: the primary row holds that one
- * (as the empty string), so moving here would be moving onto a host this
- * console already has — which the page refuses, and which the test below
- * asserts it refuses. Port 7 is `echo`; nothing is listening on either.
+ * It used to cover the wiring that page is: the menu item that opens it, the
+ * roster it draws from context, renaming a host, re-addressing one that moved,
+ * refusing an address with no scheme, refusing a move onto a host this console
+ * already holds, and forgetting a host — including the property underneath all
+ * of it, that a connection id is the namespace every browser-local key hangs
+ * off (`scopedKey`), so "this host moved" must be expressible without minting a
+ * new one.
+ *
+ * None of that is reachable now. While the product is scoped to one company per
+ * install (`src/product-scope.ts`, `HOSTS_HIDDEN`) the switcher opens nothing,
+ * and its menu was the only entry point to that page — the page component is
+ * still mounted, so turning the flag off restores both it and the cases above.
+ *
+ * Retired rather than deleted or skipped: what is left is the one assertion
+ * that still has a subject, which is the absence of the way in. A skipped spec
+ * would report green while covering nothing.
  */
-const MOVED_TO = "http://127.0.0.1:7";
 
-/** Seeds a same-origin host and a second one at an address nothing answers. */
-async function seedTwoHosts(page: Page): Promise<void> {
-  await page.addInitScript(
-    (dead: string) => {
-      // The tour modal covers the console and swallows every click, including
-      // the one that opens the switcher.
-      for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
-        window.localStorage.setItem(key, JSON.stringify({ skipped: true, seenAt: Date.now() }));
-      }
-      window.localStorage.setItem(
-        "oc.connections.v1",
-        JSON.stringify([
-          {
-            id: "conn-primary",
-            baseUrl: "",
-            label: "Primary",
-            defaultCompany: null,
-            credential: { kind: "cookie" },
-          },
-          {
-            id: "conn-second",
-            baseUrl: dead,
-            label: "Second",
-            defaultCompany: null,
-            credential: { kind: "cookie" },
-            connector: { kind: "remote" },
-          },
-        ]),
-      );
-    },
-    ASLEEP,
-  );
-}
-
-const switcher = (page: Page) => page.getByTestId("host-switcher");
-
-/** What the console has written down about the hosts it holds. */
-async function storedProfiles(page: Page): Promise<{ id: string; label: string; baseUrl: string }[]> {
-  return page.evaluate(() => {
-    const raw = window.localStorage.getItem("oc.connections.v1");
-    return raw ? (JSON.parse(raw) as { id: string; label: string; baseUrl: string }[]) : [];
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
   });
-}
-
-/** Opens the switcher's "Manage hosts" and waits for the page. */
-async function openTheManagePage(page: Page): Promise<void> {
-  await openHostMenu(page);
-  await page.getByTestId("host-switcher-manage").click();
-  await expect(page.getByTestId("manage-hosts")).toBeVisible();
-}
-
-test("every connected host is listed with what can be done to it", async ({ page }) => {
-  await seedTwoHosts(page);
-  await page.goto("/");
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
-
-  await openTheManagePage(page);
-
-  await expect(page.getByTestId("manage-host-conn-primary")).toBeVisible();
-  const second = page.getByTestId("manage-host-conn-second");
-  await expect(second).toBeVisible();
-  // The address is on the row, because the reason someone opened this page is
-  // usually that one of them is wrong — and the menu never shows it.
-  await expect(second).toContainText(ASLEEP);
 });
 
-test("renaming a host keeps everything the console remembers about it", async ({ page }) => {
-  // The whole reason this is an edit rather than "forget it and add it again":
-  // a fresh connection id orphans the tour progress, the last-read channel and
-  // the drafts under the old one, silently.
-  await seedTwoHosts(page);
-  await page.goto("/");
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
+test("the console offers no way into host management", async ({ page }) => {
+  await page.goto("/#/company");
 
-  await openTheManagePage(page);
-  await page.getByTestId("manage-host-edit-conn-second").click();
-  await page.getByLabel("Name", { exact: true }).fill("Acme staging");
-  await page.getByTestId("manage-host-save-conn-second").click();
-
-  await expect(page.getByTestId("manage-host-conn-second")).toContainText("Acme staging");
-
-  const profiles = await storedProfiles(page);
-  expect(profiles.find((p) => p.id === "conn-second")?.label).toBe("Acme staging");
-  // Two hosts still, under the ids they had.
-  expect(profiles.map((p) => p.id).sort()).toEqual(["conn-primary", "conn-second"]);
-});
-
-test("a host that moved is re-addressed under the id it already had", async ({ page }) => {
-  await seedTwoHosts(page);
-  await page.goto("/");
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
-
-  await openTheManagePage(page);
-  await page.getByTestId("manage-host-edit-conn-second").click();
-  await page.getByLabel("Address").fill(MOVED_TO);
-  await page.getByTestId("manage-host-save-conn-second").click();
-
-  await expect
-    .poll(async () => (await storedProfiles(page)).find((p) => p.id === "conn-second")?.baseUrl, {
-      timeout: 30_000,
-    })
-    .toBe(MOVED_TO);
-  // Still two rows: a move is not an add.
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "2");
-});
-
-test("moving a host onto one this console already holds is refused", async ({ page, baseURL }) => {
-  // The primary row *is* this origin, stored as the empty string — so its
-  // explicit url is the same host under a different spelling. Saved, it would
-  // be two connection ids for one host, with every browser-local key split
-  // between them. `canonicalAddress` is what makes the two spellings compare
-  // equal; this is the assertion that they do.
-  await seedTwoHosts(page);
-  await page.goto("/");
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
-
-  await openTheManagePage(page);
-  await page.getByTestId("manage-host-edit-conn-second").click();
-  await page.getByLabel("Address").fill(baseURL ?? "");
-
-  await expect(page.getByTestId("manage-host-taken-conn-second")).toBeVisible();
-  await expect(page.getByTestId("manage-host-save-conn-second")).toBeDisabled();
-});
-
-test("an address with no scheme is refused rather than saved", async ({ page }) => {
-  // Saved as typed it would resolve against the console's own origin, and the
-  // row would go down with an error naming a url nobody entered.
-  await seedTwoHosts(page);
-  await page.goto("/");
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
-
-  await openTheManagePage(page);
-  await page.getByTestId("manage-host-edit-conn-second").click();
-  await page.getByLabel("Address").fill("acme.example.com");
-
-  await expect(page.getByTestId("manage-host-bad-url-conn-second")).toBeVisible();
-  await expect(page.getByTestId("manage-host-save-conn-second")).toBeDisabled();
-});
-
-test("forgetting a host drops it from the roster and from storage", async ({ page }) => {
-  await seedTwoHosts(page);
-  await page.goto("/");
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
-
-  await openTheManagePage(page);
-  await page.getByTestId("manage-host-forget-conn-second").click();
-  await page.getByTestId("manage-host-forget-confirm-conn-second").click();
-
-  await expect(page.getByTestId("manage-host-conn-second")).toHaveCount(0);
-  await expect(switcher(page)).toHaveAttribute("data-host-count", "1");
-  expect((await storedProfiles(page)).map((p) => p.id)).toEqual(["conn-primary"]);
+  await expectHostMenuGone(page);
+  await expect(page.getByTestId("manage-hosts-page")).toHaveCount(0);
 });

--- a/frontend/test/e2e/sidebar-host-switcher.spec.ts
+++ b/frontend/test/e2e/sidebar-host-switcher.spec.ts
@@ -31,7 +31,7 @@ test.beforeEach(async ({ page }) => {
 /** Must match `companies/e2e_harness/company.toml`'s `[users] admins`. */
 const ADMIN_EMAIL = "harness-e2e@tinyhumans.ai";
 
-test("the sidebar owns the left edge, and its header switches hosts", async ({
+test("the sidebar owns the left edge, and its header names the company", async ({
   page,
   baseURL,
 }) => {
@@ -109,12 +109,29 @@ test("the sidebar owns the left edge, and its header switches hosts", async ({
     "the switcher is inside the sidebar, not a column of its own to the left of it",
   ).toBeGreaterThanOrEqual(sidebarBox!.x);
 
-  // Reachable from the keyboard, which the rail's unlabelled icon buttons
-  // effectively were not — and holding both seeded hosts, plus the way to add
-  // another that the rail's "+" used to be.
+  // And it is a nameplate, not a control. Two hosts are seeded above and it
+  // still opens nothing: the roster, "Add a host" and "Manage hosts" are hidden
+  // while the product is scoped to one company (`src/product-scope.ts`).
+  //
+  // Asserted after a click AND a keyboard Enter, because the trap this guards is
+  // a trigger that still opens — onto a menu with every group hidden, which is a
+  // chevron over an empty popup rather than a name.
+  await switcher.click();
   await switcher.focus();
   await page.keyboard.press("Enter");
-  await expect(page.getByTestId("host-row-switcher-spec-primary")).toBeVisible();
-  await expect(page.getByTestId("host-row-switcher-spec-second")).toBeVisible();
-  await expect(page.getByTestId("host-switcher-add")).toBeVisible();
+
+  await expect(page.locator('[role="menu"]')).toHaveCount(0);
+  await expect(page.getByTestId("host-row-switcher-spec-primary")).toHaveCount(0);
+  await expect(page.getByTestId("host-row-switcher-spec-second")).toHaveCount(0);
+  await expect(page.getByTestId("host-switcher-add")).toHaveCount(0);
+  await expect(page.getByTestId("host-switcher-manage")).toHaveCount(0);
+  await expect(page.getByTestId("switcher-new-company")).toHaveCount(0);
+
+  // It still names the company, and still reports the roster's health to a
+  // reader that cannot open it — the two things the trigger carried all along.
+  // The count includes the browser's own same-origin bootstrap alongside the two
+  // seeded here, so this asserts the signal survives rather than a exact total.
+  await expect(switcher).toHaveAttribute("data-host-count", /\d+/);
+  await expect(switcher).toHaveAttribute("data-worst-status", /\w+/);
+  await expect(switcher.locator("button")).toHaveCount(0);
 });

--- a/frontend/test/unit/connectors.test.ts
+++ b/frontend/test/unit/connectors.test.ts
@@ -215,10 +215,21 @@ describe("somebody with no host at all", () => {
     expect(copy.body).toContain("Choose where your company runs");
   });
 
-  it("offers the choice in both, rather than naming a control elsewhere", () => {
+  it("gives both a control, rather than naming one elsewhere", () => {
     // What this screen used to do was point at the switcher. A dead end that
     // describes its own exit is still a dead end.
-    expect(firstHostCopy(true).action).toBe("Choose where to run");
+    expect(firstHostCopy(true).action).toBeTruthy();
+    expect(firstHostCopy(false).action).toBeTruthy();
+  });
+
+  it("offers the desktop an action, not a choice of somewhere else to run", () => {
+    // One machine runs one host, so "where should this run" has a single answer
+    // there — and the body must stop offering the alternative it no longer has.
+    const copy = firstHostCopy(true);
+    expect(copy.action).toBe("Start the host on this computer");
+    expect(copy.body).not.toContain("somewhere else");
+    // The hub still chooses: it runs no host of its own, so the answer is
+    // genuinely elsewhere and the picker stays.
     expect(firstHostCopy(false).action).toBe("Choose where to run");
   });
 });

--- a/frontend/test/unit/inference-card-honesty.test.ts
+++ b/frontend/test/unit/inference-card-honesty.test.ts
@@ -144,13 +144,19 @@ describe("the Provider select shows the provider the host holds (issue #1737)", 
 
   it("rehydrates after a save rather than snapping back to the default", async () => {
     // The reported sequence: save under one provider, and the select goes on
-    // reading "Managed (TinyHumans)" while the header reads the saved one.
+    // reading the initializer's value while the header reads the saved one.
+    //
+    // Was staged from `managed`, which this console no longer offers as a route
+    // — its select row is the disabled "Not configured" stand-in and Save is
+    // withheld there, so the save under test could not fire. The defect was
+    // never about which two providers: it was the select not re-reading the
+    // host, which two offered providers exercise exactly as well.
     const client = stubClient(
-      [status({ provider: "managed" }), status({ provider: "openrouter" })],
+      [status({ provider: "openai_compatible" }), status({ provider: "openrouter" })],
       status({ provider: "openrouter" }),
     );
     await mount(client);
-    expect(providerSelect()).toBe("Managed (TinyHumans)");
+    expect(providerSelect()).toBe("Custom (OpenAI-compatible)");
 
     await act(async () => {
       (testId("inference-save") as HTMLButtonElement).click();
@@ -161,11 +167,15 @@ describe("the Provider select shows the provider the host holds (issue #1737)", 
   });
 
   it("names the key that belongs in the field, for the provider it is stored against", async () => {
-    // The managed brain is OpenRouter with the platform paying, so a key set
-    // here is sent to OpenRouter. This line asked for a TinyHumans key — true
-    // when `managed` was a provider of its own, and never updated when it
-    // stopped being one. It is what the reported 401 actually was.
-    await mount(stubClient([status({ provider: "managed" })]));
+    // This line asked for a TinyHumans key — true when `managed` was a provider
+    // of its own, and never updated when it stopped being one. It is what the
+    // reported 401 actually was.
+    //
+    // Asserted against OpenRouter rather than `managed`: the key field is
+    // withheld entirely for a route this console does not offer, so the note
+    // has no rendering there to check. What the test is for — the note naming
+    // the key of the provider it is stored against — is unchanged.
+    await mount(stubClient([status({ provider: "openrouter" })]));
     expect(testId("inference-key-note")?.textContent).toContain("an OpenRouter key");
   });
 });

--- a/frontend/test/unit/product-scope-hidden-surfaces.test.ts
+++ b/frontend/test/unit/product-scope-hidden-surfaces.test.ts
@@ -241,13 +241,25 @@ describe("Composio offers this company's own account and nothing else", () => {
     expect(find("composio-mode-byok")).not.toBeNull();
   });
 
-  it("still tells a company already on managed which route it is on", async () => {
-    // No tile can be marked Current for a route that is not rendered, so the
-    // card would otherwise read as "unconfigured" to a company that is working.
-    await mountComposio(composioStatus({ mode: "managed" }));
+  it("keeps a radio checked for a company on a route it does not offer", async () => {
+    // The a11y break this guards: with managed filtered out of the order array
+    // and a company still on it, `active` was false for every tile — the whole
+    // group reported `aria-checked="false"`, which states "nothing is chosen"
+    // rather than "this is not a route offered here".
+    await mountComposio(composioStatus({ mode: "managed", credentialSource: "none" }));
 
-    expect(find("composio-current-mode")).not.toBeNull();
-    expect(find("composio-current-mode")!.textContent).toContain("through OpenHuman");
+    const checked = document.querySelectorAll('[role="radio"][aria-checked="true"]');
+    expect(checked).toHaveLength(1);
+    expect(checked[0].getAttribute("data-testid")).toBe("composio-mode-unconfigured");
+  });
+
+  it("names nothing about the hidden route on the tile that stands in for it", async () => {
+    await mountComposio(composioStatus({ mode: "managed", credentialSource: "none" }));
+
+    const tile = find("composio-mode-unconfigured")!;
+    expect(tile.textContent).toContain("Not configured");
+    expect(tile.textContent).not.toContain("OpenHuman");
+    expect(container.textContent).not.toContain("OpenHuman-managed");
   });
 
   it("still lets a BYOK company clear its key, and does not name the hidden route", async () => {
@@ -325,17 +337,55 @@ describe("inference asks the operator to name a provider", () => {
     expect(options).toContain("OpenRouter");
   });
 
-  it("still labels a company whose stored provider is the hidden one", async () => {
-    // `LEGACY_MANAGED` resolves to the default provider on the host, so this
-    // company keeps working; the console must still say what it is on rather
-    // than printing the raw stored slug.
+  it("shows a value that is a real member of its own option set", async () => {
+    // The bug in one line: the trigger rendered a label out of the full
+    // descriptor table while the list was filtered, so the control displayed a
+    // provider none of its options matched.
     await mountInference(inferenceStatus({ provider: "managed", slug: "managed" }));
 
-    expect(container.textContent).toContain("Managed (TinyHumans)");
-    expect(container.textContent).not.toMatch(/\bmanaged\b(?![\s)])/);
-  });
-});
+    const trigger = document.querySelector("#inference-provider") as HTMLElement;
+    expect(trigger.textContent).toContain("Not configured");
+    expect(trigger.textContent).not.toContain("Managed (TinyHumans)");
 
+    await act(async () => {
+      trigger.click();
+      trigger.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+      trigger.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      trigger.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    });
+
+    const options = Array.from(document.querySelectorAll("[role='option']")).map((o) =>
+      o.textContent?.trim(),
+    );
+    expect(options.length, "the list did not open").toBeGreaterThan(0);
+    // Whatever the trigger says must be one of the rows below it.
+    expect(options).toContain("Not configured");
+    expect(options).not.toContain("Managed (TinyHumans)");
+  });
+
+  it("brands nothing on the card for a route it does not offer", async () => {
+    await mountInference(inferenceStatus({ provider: "managed", slug: "managed" }));
+
+    expect(find("inference-current-provider")!.textContent).toBe("Not configured");
+    expect(find("inference-not-configured")).not.toBeNull();
+    // No brand, no source word naming the route, and not the platform endpoint.
+    expect(container.textContent).not.toContain("Managed (TinyHumans)");
+    expect(container.textContent).not.toContain("api.tinyhumans.ai");
+  });
+
+  it("does not paint an unconfigured company as one of the offered providers", async () => {
+    // The other way to make the value a member is to quietly move it onto the
+    // first real option. That reads as a configured company and is a lie of the
+    // same size as the one being removed.
+    await mountInference(inferenceStatus({ provider: "managed", slug: "managed" }));
+
+    const trigger = document.querySelector("#inference-provider") as HTMLElement;
+    expect(trigger.textContent).not.toContain("OpenRouter");
+    expect((find("inference-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+
+});
 describe("the wizard's model step asks the operator to name a provider too", () => {
   it("does not offer the managed endpoint as the thing to think with", () => {
     // The wizard has its own provider list, and it is the FIRST screen of a

--- a/frontend/test/unit/product-scope-hidden-surfaces.test.ts
+++ b/frontend/test/unit/product-scope-hidden-surfaces.test.ts
@@ -1,0 +1,336 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { ComposioStatus } from "@/api/composio";
+import type { InferenceStatus } from "@/api/inference";
+import { HostSwitcher, hostSwitcherMenu } from "@/components/host-switcher";
+import { ComposioSection } from "@/views/connections/ComposioSection";
+import { InferenceSection } from "@/views/connections/InferenceSection";
+import { HostsProvider, type HostsValue } from "@/connections/HostsContext";
+import type { Connection, ConnectionId } from "@/connections/types";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+/**
+ * One company, and nothing else selectable.
+ *
+ * These pin the *absence* of controls, which is the only thing a hide can be
+ * checked by. Each fails against a tree where the matching flag in
+ * `product-scope.ts` is false — that is what makes them a test of the hide
+ * rather than of the layout that happens to be on screen.
+ */
+
+const CONNECTION: Connection = {
+  id: "c1" as ConnectionId,
+  defaultCompany: null,
+  label: "This computer",
+  baseUrl: "",
+  credential: { kind: "cookie" },
+  status: "live",
+  identity: null,
+  companies: [],
+  connector: { kind: "local" },
+};
+
+const SECOND: Connection = { ...CONNECTION, id: "c2" as ConnectionId, label: "Acme" };
+
+function hosts(connections: Connection[]): HostsValue {
+  return {
+    connections,
+    selected: connections[0]?.id ?? null,
+    onSelect: () => {},
+    onAdd: () => {},
+    localInstances: [],
+    onEditHost: () => {},
+    onRemoveHost: () => {},
+    hub: false,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+/** jsdom ships no `matchMedia`, and `SidebarProvider` reaches for it unguarded. */
+function stubMatchMedia() {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+beforeEach(() => {
+  stubMatchMedia();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function show(value: HostsValue, props: Record<string, unknown> = {}) {
+  await act(async () => {
+    root.render(
+      createElement(
+        SidebarProvider,
+        null,
+        createElement(
+          HostsProvider,
+          { value, children: null } as never,
+          createElement(HostSwitcher, {
+            // What the app shell actually renders (`app-shell.tsx`): the window
+            // title row, which is where an operator sees this.
+            variant: "titlebar",
+            companyName: "Acme",
+            companies: [
+              { id: "a", name: "Acme" },
+              { id: "b", name: "Other" },
+            ],
+            activeCompany: "a",
+            onSwitchCompany: () => {},
+            onCreateCompany: () => {},
+            canCreateCompany: true,
+            ...props,
+          } as never),
+        ),
+      ),
+    );
+  });
+}
+
+const find = (testId: string) =>
+  document.querySelector(`[data-testid="${testId}"]`) as HTMLElement | null;
+
+/**
+ * Press whatever the switcher put on screen, then look.
+ *
+ * Menu content is portalled and only mounts once the trigger is pressed, so an
+ * assertion made without this is vacuous — it passes against a tree that still
+ * has the whole roster, because the roster simply had not been opened yet.
+ */
+async function openWhateverExists() {
+  const trigger = container.querySelector("button");
+  if (!trigger) return;
+  await act(async () => {
+    trigger.click();
+    trigger.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+    trigger.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    trigger.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  });
+}
+
+describe("the company switcher is a label, not a menu", () => {
+  it("opens nothing, even with two hosts and two companies to offer", async () => {
+    await show(hosts([CONNECTION, SECOND]));
+
+    // The trigger still names the company — that is the whole surface now.
+    expect(container.textContent).toContain("Acme");
+    // Nothing to click at all: not a disabled control, not a chevron over an
+    // empty popup, no button element for a keyboard to land on.
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector("[aria-haspopup]")).toBeNull();
+    expect(container.querySelector("[aria-expanded]")).toBeNull();
+  });
+
+  it("offers no host roster, no way to add one and no way to manage one", async () => {
+    await show(hosts([CONNECTION, SECOND]));
+    await openWhateverExists();
+
+    expect(find("host-row-c1")).toBeNull();
+    expect(find("host-row-c2")).toBeNull();
+    expect(find("host-switcher-add")).toBeNull();
+    expect(find("host-switcher-manage")).toBeNull();
+  });
+
+  it("offers no company switching and no way to make another company", async () => {
+    await show(hosts([CONNECTION]));
+    await openWhateverExists();
+
+    expect(find("company-row-a")).toBeNull();
+    expect(find("company-row-b")).toBeNull();
+    expect(find("switcher-new-company")).toBeNull();
+    expect(container.textContent).not.toContain("All companies");
+  });
+
+  it("keeps the trigger a nameplate rather than a chevron over an empty popup", async () => {
+    // The trap this guards: `hostSwitcherMenu` still answers "any host at all
+    // opens a menu", and with every group hidden that would be a chevron over a
+    // popup with nothing in it. The switcher must not consult it alone.
+    expect(hostSwitcherMenu(1)).toBe(true);
+
+    await show(hosts([CONNECTION]));
+    await openWhateverExists();
+
+    // Nothing was openable, so nothing opened.
+    expect(document.querySelector("[role='menu']")).toBeNull();
+    expect(find("host-switcher-add")).toBeNull();
+  });
+});
+
+/**
+ * BYOK only, on both credential surfaces.
+ *
+ * The pair that matters: the managed route must not be *selectable*, and a
+ * company already on it must still be *legible*. Hiding a route by deleting its
+ * descriptor would satisfy the first and break the second — the label tables
+ * keep every route for exactly that reason.
+ */
+
+function composioStatus(over: Partial<ComposioStatus> = {}): ComposioStatus {
+  return {
+    inBuild: true,
+    granted: true,
+    credentialSource: "company",
+    mode: "managed",
+    backendUrl: "https://api.tinyhumans.ai",
+    toolkits: [],
+    openMode: true,
+    effectiveToolkits: [],
+    effectiveCatalog: [],
+    catalogSource: "manifest",
+    catalogNotice: null,
+    ...over,
+  } as ComposioStatus;
+}
+
+function composioClient(status: ComposioStatus) {
+  return {
+    scopeFor: (company: string | null) =>
+      company ? `/api/v1/companies/${company}` : "/api/v1/company",
+    get: async () => status,
+    put: async () => ({ status, note: "" }),
+    post: async () => ({ status, note: "" }),
+    del: async () => ({ status, note: "" }),
+  } as unknown as OpenCompanyClient;
+}
+
+async function mountComposio(status: ComposioStatus) {
+  await act(async () => {
+    root.render(
+      createElement(ComposioSection, {
+        client: composioClient(status),
+        company: "acme",
+        canManage: true,
+        onChanged: () => {},
+      }),
+    );
+  });
+}
+
+describe("Composio offers this company's own account and nothing else", () => {
+  it("does not offer the OpenHuman-managed route as a choice", async () => {
+    await mountComposio(composioStatus({ mode: "byok" }));
+
+    expect(find("composio-mode-managed")).toBeNull();
+    expect(find("composio-mode-byok")).not.toBeNull();
+  });
+
+  it("still tells a company already on managed which route it is on", async () => {
+    // No tile can be marked Current for a route that is not rendered, so the
+    // card would otherwise read as "unconfigured" to a company that is working.
+    await mountComposio(composioStatus({ mode: "managed" }));
+
+    expect(find("composio-current-mode")).not.toBeNull();
+    expect(find("composio-current-mode")!.textContent).toContain("through OpenHuman");
+  });
+
+  it("still lets a BYOK company clear its key, and does not name the hidden route", async () => {
+    // Clearing was reached by picking the managed tile. With no tile to pick, a
+    // company could rotate its key but never remove it — so the control has to
+    // stand on its own, without advertising where clearing lands.
+    await mountComposio(composioStatus({ mode: "byok" }));
+
+    expect(find("composio-clear-key")).not.toBeNull();
+    expect(container.textContent).not.toContain("use OpenHuman-managed");
+  });
+});
+
+function inferenceClient(status: InferenceStatus) {
+  return {
+    scopeFor: (company: string | null) =>
+      company ? `/api/v1/companies/${company}` : "/api/v1/company",
+    get: async (path: string) => (path.endsWith("/inference/models") ? [] : status),
+    put: async () => ({ status, note: "" }),
+    del: async () => ({ status, note: "" }),
+    post: async () => ({ status, note: "" }),
+  } as unknown as OpenCompanyClient;
+}
+
+function inferenceStatus(over: Partial<InferenceStatus> = {}): InferenceStatus {
+  return {
+    provider: "openrouter",
+    slug: "openrouter",
+    baseUrl: "https://openrouter.ai/api/v1",
+    models: {},
+    defaultTierModels: {},
+    source: "runtime",
+    keyConfigured: true,
+    cognition: "echo",
+    usageMetering: "none",
+    restartRequired: false,
+    harnessReachable: true,
+    canRebuildInPlace: true,
+    ...over,
+  };
+}
+
+async function mountInference(status: InferenceStatus) {
+  await act(async () => {
+    root.render(
+      createElement(InferenceSection, {
+        client: inferenceClient(status),
+        company: "acme",
+        canManage: true,
+      }),
+    );
+  });
+}
+
+describe("inference asks the operator to name a provider", () => {
+  it("does not offer the managed provider in the list", async () => {
+    await mountInference(inferenceStatus());
+
+    // The list is portalled and only mounts once the select is opened — asserted
+    // without this the test passes against a tree that still offers managed.
+    const trigger = document.querySelector("#inference-provider") as HTMLElement | null;
+    expect(trigger, "no provider select").toBeTruthy();
+    await act(async () => {
+      trigger!.click();
+      trigger!.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+      trigger!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      trigger!.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    });
+
+    const options = Array.from(document.querySelectorAll("[role='option']")).map((o) =>
+      o.textContent?.trim(),
+    );
+    expect(options.length, "the provider list did not open").toBeGreaterThan(0);
+    expect(options).not.toContain("Managed (TinyHumans)");
+    expect(options).toContain("OpenRouter");
+  });
+
+  it("still labels a company whose stored provider is the hidden one", async () => {
+    // `LEGACY_MANAGED` resolves to the default provider on the host, so this
+    // company keeps working; the console must still say what it is on rather
+    // than printing the raw stored slug.
+    await mountInference(inferenceStatus({ provider: "managed", slug: "managed" }));
+
+    expect(container.textContent).toContain("Managed (TinyHumans)");
+    expect(container.textContent).not.toMatch(/\bmanaged\b(?![\s)])/);
+  });
+});

--- a/frontend/test/unit/product-scope-hidden-surfaces.test.ts
+++ b/frontend/test/unit/product-scope-hidden-surfaces.test.ts
@@ -349,3 +349,22 @@ describe("the wizard's model step asks the operator to name a provider too", () 
     expect(INFERENCE_PROVIDERS.find((p) => p.id === "managed")?.label).toBe("TinyHumans");
   });
 });
+
+describe("the roster's keyboard shortcuts go with the roster", () => {
+  it("does not select a host on Cmd-1 when there is no roster to see", async () => {
+    // The listener is installed on `window` by the provider, not by the menu, so
+    // hiding the switcher does not remove it. Left live it would swallow the
+    // browser's own Cmd-1 and switch hosts with nothing on screen saying so.
+    const picked: string[] = [];
+    const value = { ...hosts([CONNECTION, SECOND]), onSelect: (id: string) => picked.push(id) };
+    await show(value as HostsValue);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "2", metaKey: true, bubbles: true }),
+      );
+    });
+
+    expect(picked).toEqual([]);
+  });
+});

--- a/frontend/test/unit/product-scope-hidden-surfaces.test.ts
+++ b/frontend/test/unit/product-scope-hidden-surfaces.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenCompanyClient } from "@/api/client";
 import type { ComposioStatus } from "@/api/composio";
 import type { InferenceStatus } from "@/api/inference";
+import { INFERENCE_PROVIDERS, SETUP_INFERENCE_OPTIONS } from "@/api/setup";
 import { HostSwitcher, hostSwitcherMenu } from "@/components/host-switcher";
 import { ComposioSection } from "@/views/connections/ComposioSection";
 import { InferenceSection } from "@/views/connections/InferenceSection";
@@ -332,5 +333,19 @@ describe("inference asks the operator to name a provider", () => {
 
     expect(container.textContent).toContain("Managed (TinyHumans)");
     expect(container.textContent).not.toMatch(/\bmanaged\b(?![\s)])/);
+  });
+});
+
+describe("the wizard's model step asks the operator to name a provider too", () => {
+  it("does not offer the managed endpoint as the thing to think with", () => {
+    // The wizard has its own provider list, and it is the FIRST screen of a
+    // first run — hiding the option only on the settings card would leave the
+    // managed route selectable at the one moment every operator passes through.
+    const offered = SETUP_INFERENCE_OPTIONS.map((option) => option.id);
+
+    expect(offered).not.toContain("managed");
+    expect(offered).toContain("openrouter");
+    // Still resolvable, so a host already reporting it keeps its label.
+    expect(INFERENCE_PROVIDERS.find((p) => p.id === "managed")?.label).toBe("TinyHumans");
   });
 });

--- a/frontend/test/unit/product-scope-hidden-surfaces.test.ts
+++ b/frontend/test/unit/product-scope-hidden-surfaces.test.ts
@@ -234,34 +234,35 @@ async function mountComposio(status: ComposioStatus) {
 }
 
 describe("Composio offers this company's own account and nothing else", () => {
-  it("does not offer the OpenHuman-managed route as a choice", async () => {
-    await mountComposio(composioStatus({ mode: "byok" }));
+  it("offers this company's own Composio key, and no route to pick between", async () => {
+    // With one route left there is nothing to choose, so the picker goes and the
+    // credential field for that route is what the operator lands on. A picker of
+    // one is not a choice; it is a click between the operator and the task.
+    await mountComposio(composioStatus({ mode: "managed", credentialSource: "none" }));
 
+    expect(document.querySelector("#composio-api-key")).not.toBeNull();
+    expect(document.querySelectorAll('[role="radiogroup"]')).toHaveLength(0);
     expect(find("composio-mode-managed")).toBeNull();
-    expect(find("composio-mode-byok")).not.toBeNull();
   });
 
-  it("keeps a radio checked for a company on a route it does not offer", async () => {
-    // The a11y break this guards: with managed filtered out of the order array
-    // and a company still on it, `active` was false for every tile — the whole
-    // group reported `aria-checked="false"`, which states "nothing is chosen"
-    // rather than "this is not a route offered here".
+  it("cannot leave a radiogroup with nothing checked, because there is none", async () => {
+    // The a11y break this replaces: managed filtered out of the order array with
+    // a company still on it left `active` false for every tile, so the whole
+    // group reported aria-checked="false". Removing the group removes the state.
     await mountComposio(composioStatus({ mode: "managed", credentialSource: "none" }));
 
+    const radios = document.querySelectorAll('[role="radio"]');
     const checked = document.querySelectorAll('[role="radio"][aria-checked="true"]');
-    expect(checked).toHaveLength(1);
-    expect(checked[0].getAttribute("data-testid")).toBe("composio-mode-unconfigured");
+    expect(radios.length === 0 || checked.length === 1).toBe(true);
   });
 
-  it("names nothing about the hidden route on the tile that stands in for it", async () => {
+  it("names nothing about the hidden route anywhere on the panel", async () => {
     await mountComposio(composioStatus({ mode: "managed", credentialSource: "none" }));
 
-    const tile = find("composio-mode-unconfigured")!;
-    expect(tile.textContent).toContain("Not configured");
-    expect(tile.textContent).not.toContain("OpenHuman");
-    expect(container.textContent).not.toContain("OpenHuman-managed");
+    expect(container.textContent).not.toContain("OpenHuman");
+    expect(container.textContent).not.toContain("TinyHumans");
+    expect(container.textContent).not.toContain("api.tinyhumans.ai");
   });
-
   it("still lets a BYOK company clear its key, and does not name the hidden route", async () => {
     // Clearing was reached by picking the managed tile. With no tile to pick, a
     // company could rotate its key but never remove it — so the control has to
@@ -344,8 +345,8 @@ describe("inference asks the operator to name a provider", () => {
     await mountInference(inferenceStatus({ provider: "managed", slug: "managed" }));
 
     const trigger = document.querySelector("#inference-provider") as HTMLElement;
-    expect(trigger.textContent).toContain("Not configured");
-    expect(trigger.textContent).not.toContain("Managed (TinyHumans)");
+    const shown = trigger.textContent ?? "";
+    expect(shown).not.toContain("Managed (TinyHumans)");
 
     await act(async () => {
       trigger.click();
@@ -354,15 +355,14 @@ describe("inference asks the operator to name a provider", () => {
       trigger.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
     });
 
-    const options = Array.from(document.querySelectorAll("[role='option']")).map((o) =>
-      o.textContent?.trim(),
+    const options = Array.from(document.querySelectorAll("[role='option']")).map(
+      (o) => o.textContent?.trim() ?? "",
     );
     expect(options.length, "the list did not open").toBeGreaterThan(0);
-    // Whatever the trigger says must be one of the rows below it.
-    expect(options).toContain("Not configured");
     expect(options).not.toContain("Managed (TinyHumans)");
+    // Whatever the trigger shows has to be one of the rows below it.
+    expect(options.some((label) => shown.includes(label))).toBe(true);
   });
-
   it("brands nothing on the card for a route it does not offer", async () => {
     await mountInference(inferenceStatus({ provider: "managed", slug: "managed" }));
 
@@ -373,19 +373,20 @@ describe("inference asks the operator to name a provider", () => {
     expect(container.textContent).not.toContain("api.tinyhumans.ai");
   });
 
-  it("does not paint an unconfigured company as one of the offered providers", async () => {
-    // The other way to make the value a member is to quietly move it onto the
-    // first real option. That reads as a configured company and is a lie of the
-    // same size as the one being removed.
+  it("leads an unconfigured company into a provider it can actually finish", async () => {
+    // Not an inert placeholder: the resting state has to be completable, or
+    // onboarding dead-ends on a row nobody can act on. The header still reports
+    // the company's real state, so proposing a provider in the form is an offer
+    // rather than a claim about what is configured.
     await mountInference(inferenceStatus({ provider: "managed", slug: "managed" }));
 
-    const trigger = document.querySelector("#inference-provider") as HTMLElement;
-    expect(trigger.textContent).not.toContain("OpenRouter");
-    expect((find("inference-save") as HTMLButtonElement).disabled).toBe(true);
+    expect(find("inference-current-provider")!.textContent).toBe("Not configured");
+    expect(document.querySelector("#inference-provider")?.textContent).toContain("OpenRouter");
+    expect(document.querySelector("#inference-key")).not.toBeNull();
+    expect((find("inference-save") as HTMLButtonElement).disabled).toBe(false);
   });
-
-
 });
+
 describe("the wizard's model step asks the operator to name a provider too", () => {
   it("does not offer the managed endpoint as the thing to think with", () => {
     // The wizard has its own provider list, and it is the FIRST screen of a

--- a/frontend/test/unit/product-scope-hidden-surfaces.test.ts
+++ b/frontend/test/unit/product-scope-hidden-surfaces.test.ts
@@ -9,6 +9,7 @@ import type { ComposioStatus } from "@/api/composio";
 import type { InferenceStatus } from "@/api/inference";
 import { INFERENCE_PROVIDERS, SETUP_INFERENCE_OPTIONS } from "@/api/setup";
 import { HostSwitcher, hostSwitcherMenu } from "@/components/host-switcher";
+import { canCreateCompanies } from "@/components/create-company-dialog";
 import { ComposioSection } from "@/views/connections/ComposioSection";
 import { InferenceSection } from "@/views/connections/InferenceSection";
 import { HostsProvider, type HostsValue } from "@/connections/HostsContext";
@@ -263,14 +264,21 @@ describe("Composio offers this company's own account and nothing else", () => {
     expect(container.textContent).not.toContain("TinyHumans");
     expect(container.textContent).not.toContain("api.tinyhumans.ai");
   });
-  it("still lets a BYOK company clear its key, and does not name the hidden route", async () => {
-    // Clearing was reached by picking the managed tile. With no tile to pick, a
-    // company could rotate its key but never remove it — so the control has to
-    // stand on its own, without advertising where clearing lands.
-    await mountComposio(composioStatus({ mode: "byok" }));
+  it("offers a BYOK company no control that would move it off its own account", async () => {
+    // Clearing a key is not "the key goes away". The host derives the route from
+    // whether one exists, so an empty write puts the company back on the route
+    // this console no longer offers — and a company with any credential there
+    // resumes acting through it, a different account billed differently.
+    //
+    // A button here could only say that, naming the route, or not say it, which
+    // is the switch happening silently. Rotating stays; removing does not.
+    await mountComposio(composioStatus({ mode: "byok", credentialSource: "company" }));
 
-    expect(find("composio-clear-key")).not.toBeNull();
+    expect(find("composio-clear-key")).toBeNull();
+    expect(container.textContent).not.toContain("Clear key");
     expect(container.textContent).not.toContain("use OpenHuman-managed");
+    // Rotation is still reachable, so a compromised key is still replaceable.
+    expect(container.textContent).toContain("Rotate key");
   });
 });
 
@@ -417,5 +425,30 @@ describe("the roster's keyboard shortcuts go with the roster", () => {
     });
 
     expect(picked).toEqual([]);
+  });
+});
+
+describe("company creation is gone from every trigger, not just the switcher", () => {
+  /**
+   * Four triggers reach one dialog: the switcher's "New company", the picker's
+   * own button, the picker's per-card Reset, the no-company screen, and
+   * Settings' "Reset / Start clean" — which archives and re-provisions through
+   * the same flow. Gating them one at a time is how three stayed live after the
+   * first was hidden, so the question is asked once, where they all ask it.
+   */
+  it("answers no at the funnel every trigger goes through", () => {
+    const withBearer = { carriesPlatformBearer: true } as unknown as OpenCompanyClient;
+
+    expect(canCreateCompanies(withBearer)).toBe(false);
+  });
+
+  it("stays no even for a client that could reach the routes", () => {
+    // The platform credential is the other half of the condition, and on its own
+    // it used to be the whole of it at two call sites.
+    const platform = { carriesPlatformBearer: true } as unknown as OpenCompanyClient;
+    const person = { carriesPlatformBearer: false } as unknown as OpenCompanyClient;
+
+    expect(canCreateCompanies(platform)).toBe(false);
+    expect(canCreateCompanies(person)).toBe(false);
   });
 });

--- a/frontend/test/unit/setup-wizard-company-identity.test.ts
+++ b/frontend/test/unit/setup-wizard-company-identity.test.ts
@@ -333,7 +333,7 @@ describe("whether a finished wizard seeds a template or a designed company", () 
     rosterEdited: false,
     template: TEMPLATE.id,
     credentialTested: false,
-    provider: "openrouter",
+    writesInference: true,
   };
 
   it("seeds the template an operator picked and did not edit", () => {
@@ -353,11 +353,17 @@ describe("whether a finished wizard seeds a template or a designed company", () 
     expect(shouldSeedTemplate({ ...picked, credentialTested: true })).toBe(false);
   });
 
-  it("still seeds the template when the tested provider is managed", () => {
-    // The designed submit omits inference for `managed`, so the designed path
-    // would trade the template's roster, belt and prompts for nothing at all.
+  it("still seeds the template when nothing will be written anyway", () => {
+    // The submit omits inference where the host already reaches it, or where the
+    // credential that passed was the house's rather than this operator's — so
+    // the designed path would trade the template's roster, belt and prompts for
+    // nothing at all.
+    //
+    // Asked as `writesInference`, not `provider === "managed"`. That literal
+    // answered the same question only while the model step adopted a provider it
+    // no longer offers, and went quietly wrong when it stopped.
     expect(
-      shouldSeedTemplate({ ...picked, credentialTested: true, provider: "managed" }),
+      shouldSeedTemplate({ ...picked, credentialTested: true, writesInference: false }),
     ).toBe(true);
   });
 

--- a/frontend/test/unit/setup-wizard-company-identity.test.ts
+++ b/frontend/test/unit/setup-wizard-company-identity.test.ts
@@ -155,7 +155,7 @@ async function pickTemplate(id: string) {
   });
 }
 
-/** model -> business -> sign-in (none) -> advanced -> review. */
+/** model -> business -> sign-in (none) -> review. */
 async function walkToReview(client: OpenCompanyClient, template: string | null) {
   await act(async () => {
     root.render(createElement(SetupWizard, { client, onDone: () => {} }));
@@ -171,7 +171,6 @@ async function walkToReview(client: OpenCompanyClient, template: string | null) 
   await act(async () => {
     (container.querySelector('[data-testid="auth-mode-none"]') as HTMLElement).click();
   });
-  await next(); // -> advanced (or account, on a host that signs people in)
   await next(); // -> review
 }
 
@@ -248,16 +247,15 @@ describe("what a finished wizard says the company is", () => {
     ).toBe(TEMPLATE.name);
 
     // Back to Business, a different template, forward again.
-    for (let i = 0; i < 3; i += 1) {
-      // review -> advanced -> sign-in -> business.
+    for (let i = 0; i < 2; i += 1) {
+      // review -> sign-in -> business.
       await act(async () => {
         button("Back").click();
       });
     }
     await pickTemplate(OTHER_TEMPLATE.id);
-    // business -> sign-in -> advanced -> review. The sign-in answer survives
-    // going back, so the address step stays absent.
-    await next();
+    // business -> sign-in -> review. The sign-in answer survives going back, so
+    // the address step stays absent.
     await next();
     await next();
     await act(async () => {
@@ -281,16 +279,15 @@ describe("what a finished wizard says the company is", () => {
     await walkToReview(client, TEMPLATE.id);
     await fill("setup-company-name", "Northwind Studio");
 
-    for (let i = 0; i < 3; i += 1) {
-      // review -> advanced -> sign-in -> business.
+    for (let i = 0; i < 2; i += 1) {
+      // review -> sign-in -> business.
       await act(async () => {
         button("Back").click();
       });
     }
     await pickTemplate(OTHER_TEMPLATE.id);
-    // business -> sign-in -> advanced -> review. The sign-in answer survives
-    // going back, so the address step stays absent.
-    await next();
+    // business -> sign-in -> review. The sign-in answer survives going back, so
+    // the address step stays absent.
     await next();
     await next();
     await act(async () => {

--- a/frontend/test/unit/setup-wizard-console-destination.test.ts
+++ b/frontend/test/unit/setup-wizard-console-destination.test.ts
@@ -152,7 +152,6 @@ async function finishNoSignIn() {
   await next(); // -> business
   await fill("setup-field-industry", "E-commerce — homeware");
   await next(); // -> sign-in (none preselected)
-  await next(); // -> advanced
   await next(); // -> review
   await settle();
   await click("setup-finish");
@@ -167,7 +166,6 @@ async function finishUnmailable() {
   await next(); // -> sign-in
   await next(); // -> account
   await fill("setup-field-email", "ada@example.com");
-  await next(); // -> advanced
   await next(); // -> review
   await settle();
   await click("setup-finish");

--- a/frontend/test/unit/setup-wizard-desktop-default.test.ts
+++ b/frontend/test/unit/setup-wizard-desktop-default.test.ts
@@ -166,17 +166,11 @@ describe("the sign-in a desktop install starts from", () => {
     // The consequence of the seeded answer, and the reason it is seeded: the
     // address step is gone from the bar before the operator has pressed
     // anything, rather than appearing and then being taken away.
-    expect(slots()).toEqual([
-      "step-power",
-      "step-business",
-      "step-signin",
-      "step-advanced",
-      "step-review",
-    ]);
+    expect(slots()).toEqual(["step-power", "step-business", "step-signin", "step-review"]);
 
     await next();
     expect(find("setup-field-email")).toBeNull();
-    expect(find("setup-advanced")).toBeTruthy();
+    expect(find("setup-advanced")).toBeNull();
   });
 
   it("still lets a desktop operator turn a sign-in on", async () => {

--- a/frontend/test/unit/setup-wizard-desktop-default.test.ts
+++ b/frontend/test/unit/setup-wizard-desktop-default.test.ts
@@ -115,6 +115,12 @@ function labelled(...wanted: string[]): HTMLButtonElement {
   return match as HTMLButtonElement;
 }
 
+/** The wizard's own progress line, e.g. `Review · step 4 of 4`. */
+function stepLabel(): string {
+  const match = container.textContent?.match(/(\w[\w -]*) · step \d+ of \d+/);
+  return match ? match[0] : "";
+}
+
 const next = async () =>
   act(async () => {
     labelled("Next", "Looks good").click();
@@ -169,6 +175,9 @@ describe("the sign-in a desktop install starts from", () => {
     expect(slots()).toEqual(["step-power", "step-business", "step-signin", "step-review"]);
 
     await next();
+    // Review, asserted first: both checks below are absences, and an absence on
+    // a screen the press never left says nothing at all.
+    expect(stepLabel(), "the press should have reached Review").toMatch(/^Review · step/);
     expect(find("setup-field-email")).toBeNull();
     expect(find("setup-advanced")).toBeNull();
   });

--- a/frontend/test/unit/setup-wizard-finish-gate.test.ts
+++ b/frontend/test/unit/setup-wizard-finish-gate.test.ts
@@ -484,3 +484,101 @@ describe("finishing setup with no companies on the host", () => {
   });
 
 });
+
+describe("a hosted tenant whose inference comes from the house", () => {
+  /**
+   * The regression this guards, in one line: testing the HOUSE credential must
+   * not store the provider selected beside it.
+   *
+   * On a hosted tenant the control plane injects the credential and the host
+   * reports itself ready on a route this step does not offer. The key box is
+   * optional there — that is the whole point of `onTheHouse` — so a blank-key
+   * test passes against the host's own credential. It says the house works, not
+   * that the selected provider does.
+   *
+   * The old guard was `provider !== "managed"`, which held only because the step
+   * adopted the host's provider verbatim. Once the step stopped adopting a route
+   * it does not offer, `provider` became a real one and that check stopped
+   * firing — writing `openrouter` at the managed endpoint with no key, over a
+   * configuration that was already working.
+   */
+  const hosted = () => ({
+    ...status(),
+    companies: [],
+    inference: {
+      ready: true,
+      provider: "managed",
+      base_url: "https://api.tinyhumans.ai/openai/v1",
+    },
+  });
+
+  function capturingClient(seen: { body?: unknown }): OpenCompanyClient {
+    const s = hosted();
+    return {
+      get: async () => s,
+      post: async (path: string, body: unknown) => {
+        if (path.includes("/inference/test")) {
+          // The house credential answers, because that is what an empty key
+          // probes on this host.
+          return { ok: true, baseUrl: s.inference.base_url, model: "some-model" };
+        }
+        if (path.includes("/setup/roster")) {
+          return { agents: [{ id: "ops", role: "Operations" }] };
+        }
+        seen.body = body;
+        return {
+          complete: true,
+          config_path: s.config_path,
+          restart_required: [],
+          seeded_company: null,
+        };
+      },
+    } as unknown as OpenCompanyClient;
+  }
+
+  it("stores no inference configuration when the key box was left empty", async () => {
+    const seen: { body?: unknown } = {};
+    await show(capturingClient(seen));
+
+    // Test the house credential with nothing typed — allowed here, and the
+    // reason this path exists at all.
+    await act(async () => {
+      (
+        container.querySelector('[data-testid="setup-test-connection"]') as HTMLElement
+      ).click();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(
+      container.querySelector('[data-testid="setup-test-ok"]'),
+      "the house credential should test clean",
+    ).toBeTruthy();
+
+    await next(); // -> business
+    await fill("setup-field-industry", "E-commerce — homeware");
+    await next(); // -> sign-in
+    await next(); // -> account
+    await fill("setup-field-email", "ada@example.com");
+    await next(); // -> review
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const finish = container.querySelector('[data-testid="setup-finish"]') as HTMLElement | null;
+    expect(finish, "the wizard should be able to finish").toBeTruthy();
+    await act(async () => {
+      finish!.click();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const body = seen.body as { company?: { inference?: unknown } } | undefined;
+    expect(body, "setup should have been applied").toBeTruthy();
+    expect(
+      body?.company?.inference ?? null,
+      "a house-credential pass must not be stored as this company's own provider",
+    ).toBeNull();
+  });
+});

--- a/frontend/test/unit/setup-wizard-finish-gate.test.ts
+++ b/frontend/test/unit/setup-wizard-finish-gate.test.ts
@@ -536,6 +536,44 @@ describe("a hosted tenant whose inference comes from the house", () => {
     } as unknown as OpenCompanyClient;
   }
 
+  it("does not lend the house credential to a provider the host will not send it to", async () => {
+    // `resolve_endpoint` inherits the injected credential for the managed choice
+    // and for OpenRouter without an endpoint override — and for nothing else,
+    // because pairing it with an arbitrary endpoint would leak it there. So a
+    // custom endpoint must ask for a key rather than hide the field and enable
+    // Test on nothing, which sent an unauthenticated probe that could only fail.
+    const seen: { body?: unknown } = {};
+    await show(capturingClient(seen));
+
+    // The house's credential is claimed on the default selection...
+    expect(
+      container.querySelector('[data-testid="setup-key-on-the-house"]'),
+      "OpenRouter with no override is the one selection the host will send it to",
+    ).toBeTruthy();
+
+    // ...and not on one the host refuses to forward it to.
+    const custom = container.querySelector(
+      '[data-testid="setup-provider-openai_compatible"]',
+    ) as HTMLElement | null;
+    expect(custom, "the model step should offer a custom endpoint").toBeTruthy();
+    await act(async () => {
+      custom!.click();
+    });
+
+    expect(
+      container.querySelector('[data-testid="setup-key-on-the-house"]'),
+      "a custom endpoint must not claim a credential the host will not send",
+    ).toBeNull();
+    expect(
+      container.querySelector("#setup-key"),
+      "so it has to ask for its own key",
+    ).toBeTruthy();
+    const test = container.querySelector(
+      '[data-testid="setup-test-connection"]',
+    ) as HTMLButtonElement | null;
+    expect(test?.disabled, "and Test must not run on a key nobody supplied").toBe(true);
+  });
+
   it("stores no inference configuration when the key box was left empty", async () => {
     const seen: { body?: unknown } = {};
     await show(capturingClient(seen));

--- a/frontend/test/unit/setup-wizard-finish-gate.test.ts
+++ b/frontend/test/unit/setup-wizard-finish-gate.test.ts
@@ -128,7 +128,7 @@ async function skipModel() {
   await next(); // -> business
 }
 
-/** model -> business -> sign-in -> account -> advanced -> review. */
+/** model -> business -> sign-in -> account -> review. */
 async function goToReview() {
   await skipModel();
   await fill("setup-field-industry", "E-commerce — homeware");
@@ -140,7 +140,6 @@ async function goToReview() {
   // The address is required on any host that asks people to sign in — leaving
   // it blank holds the wizard here, which is its own assertion below.
   await fill("setup-field-email", "ada@example.com");
-  await next(); // -> advanced
   await next(); // -> review
   // Entering Review kicks off the design call. Let it settle, or the assertions
   // below run against the spinner rather than the outcome.

--- a/frontend/test/unit/setup-wizard-mail-honesty.test.ts
+++ b/frontend/test/unit/setup-wizard-mail-honesty.test.ts
@@ -146,7 +146,6 @@ async function finish() {
   await next(); // -> sign-in
   await next(); // -> account
   await fill("setup-field-email", "ada@example.com");
-  await next(); // -> advanced
   await next(); // -> review
   await settle();
   await click("setup-finish");

--- a/frontend/test/unit/setup-wizard-step-order.test.ts
+++ b/frontend/test/unit/setup-wizard-step-order.test.ts
@@ -160,23 +160,23 @@ describe("where the sign-in question sits", () => {
     expect(find("setup-advanced")).toBeNull();
   });
 
-  it("no longer offers the mode a second time inside Advanced", async () => {
-    // Two controls for one setting, one of them behind copy telling you to
-    // press past it, is how the question ended up after its consequence.
+  it("has no Advanced step left to offer the mode a second time in", async () => {
+    // Advanced held one group — how this host runs — and hiding it leaves the
+    // step with nothing on it, so the step goes too rather than rendering blank.
     await show(clientWith(status()));
     await goToSignIn();
     await next(); // -> account
     await fill("setup-field-email", "ada@example.com");
-    await next(); // -> advanced
+    await next(); // -> review
 
-    expect(find("setup-advanced")).toBeTruthy();
+    expect(find("setup-advanced")).toBeNull();
     expect(find("auth-mode-email")).toBeNull();
     expect(find("field-auth_mode")).toBeNull();
   });
 });
 
 describe("a step this host does not need gets no slot", () => {
-  it("draws six steps on a host that asks people to sign in", async () => {
+  it("draws five steps on a host that asks people to sign in", async () => {
     await show(clientWith(status()));
     await goToSignIn();
 
@@ -185,30 +185,23 @@ describe("a step this host does not need gets no slot", () => {
       "step-business",
       "step-signin",
       "step-account",
-      "step-advanced",
       "step-review",
     ]);
-    expect(container.textContent).toContain("step 3 of 6");
+    expect(container.textContent).toContain("step 3 of 5");
   });
 
-  it("draws five, and never the address field, once no sign-in is chosen", async () => {
+  it("draws four, and never the address field, once no sign-in is chosen", async () => {
     await show(clientWith(status()));
     await goToSignIn();
     await click("auth-mode-none");
 
-    expect(slots()).toEqual([
-      "step-power",
-      "step-business",
-      "step-signin",
-      "step-advanced",
-      "step-review",
-    ]);
-    // The bar must renumber too: a five-step flow that says "of 6" is telling
+    expect(slots()).toEqual(["step-power", "step-business", "step-signin", "step-review"]);
+    // The bar must renumber too: a four-step flow that says "of 5" is telling
     // the operator about a screen they will never be shown.
-    expect(container.textContent).toContain("step 3 of 5");
+    expect(container.textContent).toContain("step 3 of 4");
 
     await next();
-    expect(find("setup-advanced")).toBeTruthy();
+    expect(find("setup-advanced")).toBeNull();
     expect(find("setup-field-email")).toBeNull();
   });
 });
@@ -227,7 +220,7 @@ describe("the position survives the list changing under it", () => {
     await show(clientWith(status()));
     await goToSignIn();
     await click("auth-mode-none");
-    await next(); // -> advanced, with no address step in the list
+    await next(); // -> review, with no address step in the list
     await back(); // -> sign-in
     expect(find("auth-mode-email")).toBeTruthy();
 

--- a/frontend/test/unit/setup-wizard-step-order.test.ts
+++ b/frontend/test/unit/setup-wizard-step-order.test.ts
@@ -98,6 +98,12 @@ function labelled(...wanted: string[]): HTMLButtonElement {
 }
 
 /** "Looks good" is the same control under a different word, on Advanced. */
+/** The wizard's own progress line, e.g. `Review · step 4 of 4`. */
+function stepLabel(): string {
+  const match = container.textContent?.match(/(\w[\w -]*) · step \d+ of \d+/);
+  return match ? match[0] : "";
+}
+
 const next = async () =>
   act(async () => {
     labelled("Next", "Looks good").click();
@@ -169,6 +175,14 @@ describe("where the sign-in question sits", () => {
     await fill("setup-field-email", "ada@example.com");
     await next(); // -> review
 
+    // Landed on Review, asserted before anything about what is absent. Without
+    // this the three checks below would also pass if the press had gone nowhere
+    // — a test that cannot fail for the reason it exists.
+    //
+    // Read off the step label rather than `setup-review`: entering Review kicks
+    // off the roster design, so the screen is its spinner first and the review
+    // body only once that settles. The label is true in both.
+    expect(stepLabel(), "the press should have reached Review").toMatch(/^Review · step/);
     expect(find("setup-advanced")).toBeNull();
     expect(find("auth-mode-email")).toBeNull();
     expect(find("field-auth_mode")).toBeNull();
@@ -201,6 +215,9 @@ describe("a step this host does not need gets no slot", () => {
     expect(container.textContent).toContain("step 3 of 4");
 
     await next();
+    // Review, not "wherever the press left us": absence proves nothing about a
+    // screen that never changed.
+    expect(stepLabel(), "the press should have reached Review").toMatch(/^Review · step/);
     expect(find("setup-advanced")).toBeNull();
     expect(find("setup-field-email")).toBeNull();
   });


### PR DESCRIPTION
## Summary

Scopes the console to one company per install: the OpenHuman-managed Composio
route and the managed inference provider are no longer offered, and the desktop
switcher becomes a static label.

**This is console-only. No Rust changed.** The server still reports
`provider: "managed"`, `ComposioMode::Managed` is untouched and still
`#[default]`, `LEGACY_MANAGED` still resolves to the default provider, and the
hosts registry is intact. Nothing was migrated and no stored value was rewritten.
Every switch lives in one file, `frontend/src/product-scope.ts`, so re-enabling a
surface is a single edit.

These are **replacements, not just hides** — hiding alone left first-run asking
for a credential the console can no longer use, and the inference card resting on
a row nobody could act on.

| Removed | Replaced by |
|---|---|
| Composio's "OpenHuman-managed" tile, and the TinyHumans account-key card the onboarding step embedded | The step now asks for this company's own Composio API key (`ak_…`) and connects providers with it |
| The managed inference provider | The card opens on OpenRouter with its key field and Save live |
| Host roster, "Add a host", "Manage hosts", company switching, "New company" | A static company nameplate |
| The desktop's four-way "where should this run" chooser | A single "Start the host on this computer" action |
| The wizard's Advanced → Host group | Nothing — the step held only that group, so the step goes too |

## API Or Behavior Changes

**No API changes.** No Rust, no route, no payload, no stored value.

**Behavior:**

- **On a hosted tenant the managed route genuinely runs, and after this change
  those operators cannot see what powers their company.** That is a deliberate
  product decision, not an oversight. The card reports "Not configured" — true of
  the tenant's own configuration, which is what `source` means — while the
  cognition line still says truthfully whether a brain is live.
- **The desktop switcher is a static label.** One company, no company creation,
  no host selection anywhere on the desktop. A hub keeps its picker, because a
  hub runs no host of its own and genuinely has to ask where a company runs.
- **A company already on a hidden setting keeps working.** Nothing is
  re-pointed: Composio's mode has exactly one writer, and it is the API-key
  write, so removing a tile fires no request.
- **Accessibility fix.** Composio's radiogroup reported `aria-checked="false"`
  on every radio once its stored route stopped being offered — the group claimed
  nothing was chosen. It now reports exactly one checked control.
- **Correctness fix.** The provider select displayed a value absent from its own
  options: the trigger read labels from the full descriptor table while the list
  was filtered. The displayed value is now always a member.
- A BYOK company can now clear its Composio key directly. That was previously
  reached by selecting the other tile, which no longer exists.
- The desktop's zero-host recovery no longer offers to run the company
  elsewhere, and the copy stops saying so.

**Two fixes of one shape, worth naming.** Both were a string comparison
encoding an assumption that a later change in this PR invalidated. Neither
started failing — both silently stopped matching, which is why neither surfaced
as a broken test.

Hiding the managed route meant the setup wizard stopped adopting a provider it
does not offer, so its `provider` became a real one instead of `"managed"`.
Two checks were quietly resting on it:

- `inference: … provider !== "managed"` decided whether to store inference on
  the new company. With the check no longer matching, testing the **house's**
  credential with an empty key wrote `openrouter` at the managed endpoint with
  no key, over a configuration that was already working. Found in review.
- `shouldSeedTemplate` ended on `input.provider === "managed"`, standing in for
  "nothing will be written anyway". With it no longer matching, a hosted tenant
  that picked a template would have taken the designed path and lost that
  template's roster, belt and prompts — in exchange for a credential the submit
  does not write. Found by sweeping for the same shape after the first.

Both now ask `writesInference`, and the seed decision is handed the very
condition the submit payload uses, so the two cannot answer differently again.

## Tests

- [x] `npm run typecheck` — pass
- [x] `npm run typecheck:unit` — pass
- [x] `npm run typecheck:e2e` — pass
- [x] `npx vitest run` — 487 files, 4495 tests, pass
- [x] `npx playwright test` over the nine touched specs — 24 passed
- [ ] `cargo fmt --all -- --check` — N/A, no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A, no Rust changed
- [ ] `cargo build --all-targets` — N/A, no Rust changed
- [ ] `cargo test` — N/A, no Rust changed

New assertions were checked against a tree with the switches off; 13 of the 14
fail there, so they test the change rather than the layout. The fourteenth is the
radiogroup invariant, which must hold either way.

Three wizard step-order cases pressed Next and then checked only that controls
were gone, with nothing to make them fail if the press went nowhere. Stalling
only the final press shows what they were worth: the wizard sat on
`You · step 4 of 5` while the test asserted Advanced was absent — true on that
step, and true all along. They now read the wizard's own progress line first.

The regression test for the first fix above fails without it, storing
`{ provider: 'openrouter', … }` where `null` is required.

Driven end to end in a browser against a local host: first-run wizard through to
a created company, the gate's integration step, Connections → Apps, and
Settings → Inference.

**Not verified: the desktop recovery action has never been driven in a packaged
Tauri shell.** A browser rig always takes the hub branch, so the single "start
the host on this computer" action is covered by its rendering and copy in a
faked-desktop runtime, not by a real start.

## Documentation

`docs/spec/runtime/desktop-instances.md` — corrected. It described the instance
at the data root seeding a starter company; commit `a37854eaf` reversed that and
the file was never updated. Every desktop instance now adopts what its root holds
and seeds nothing, which is why a fresh install reaches the wizard at all.

**Deferred, and named so a reviewer sees they were found rather than missed:**

- **Seven pre-existing controls with the same value-outside-its-options defect**,
  none caused by this change: the Search provider select, the Ledgers compose
  dialog's status select, three selects in the workflow create dialog (agent,
  channel, node kind), two in the node config fields, and the approval-tier
  radiogroup — which documents the hazard in its own comment and still leaves
  every tile unchecked. They are a separate defect class with their own blast
  radius and would make this branch unreviewable.
- **Retired e2e coverage**, written down in each spec file rather than deleted or
  skipped, each naming the switch that hid its entry point: host management,
  host-switch history, desktop local-instance CRUD, two connection-degrade rows,
  two connector-registry rows, and the desktop chooser's four cases. The largest
  loss is local-instance CRUD — the Tauri commands beneath it are untouched and
  still unit-tested in Rust; what is no longer exercised is the console wiring in
  front of them.
- The onboarding gate is a full-screen replacement with no inference step, so an
  operator must skip it to configure inference before the "run a workflow" step
  can succeed. Pre-existing ordering, unchanged here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop users can start the local host directly from the no-connection screen, with progress and error feedback.
  * Setup options now show only supported inference providers and available connection routes.
* **Changes**
  * Host and company-switching controls are hidden in single-company configurations.
  * Host settings and managed integrations are no longer shown where unavailable.
  * The setup wizard is shorter by omitting the Advanced step when no advanced options apply.
  * Updated first-run guidance clarifies how to restart the desktop host.
* **Documentation**
  * Clarified desktop setup, adoption, and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
