### PR TITLE
fix(console): split company-creation scope from caller capability

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -158,7 +158,7 @@ import { UnknownRouteView } from "@/views/UnknownRouteView";
 import { ConnectionsSection } from "@/views/connections/ConnectionsSection";
 import { SettingsSection } from "@/views/SettingsSection";
 import { useLocalScope } from "@/connections/ConnectionContext";
-import { canCreateCompanies } from "@/components/create-company-dialog";
+import { offersCompanyCreation } from "@/components/create-company-dialog";
 
 // React Flow is heavy and only used here — load it on demand.
 const WorkflowsView = lazy(() =>
@@ -3361,7 +3361,7 @@ export function AppShell({
             onSwitchCompany={onSwitchCompany}
             onBackToPicker={onBackToPicker}
             onCreateCompany={onCreateCompany}
-            canCreateCompany={canCreateCompanies(client)}
+            canCreateCompany={offersCompanyCreation(client)}
           />
         }
         overview={

--- a/frontend/src/components/create-company-dialog.tsx
+++ b/frontend/src/components/create-company-dialog.tsx
@@ -83,21 +83,34 @@ export const CREATE_UNAVAILABLE_NOTE =
   "Creating a company needs a platform credential, which a person signed in here doesn't hold.";
 
 /**
- * Whether a company can be created from this console at all.
+ * Whether this client can reach the provisioning + archive routes at all.
  *
- * The one funnel every trigger asks, and the reason it is asked here rather
- * than at each of them: provisioning is reachable from four places — the
- * switcher's "New company", the picker's own button, the picker's per-card
- * Reset, the no-company screen, and Settings' "Reset / Start clean", which
- * archives and re-provisions through this same dialog. Gating them one at a
- * time is how three of them stayed live after the first was hidden.
- *
- * Two conditions, deliberately in one place: the client has to hold a platform
- * credential to reach the routes, and the product has to be offering company
- * creation in the first place.
+ * A fact about the caller, not about the product: it answers "may this
+ * principal create a company", and the dialog's own preflight and submit read
+ * it for exactly that. It must stay free of product scope — a scope flag that
+ * reached in here would make the shipped dialog inert while its tests went on
+ * passing against logic nothing could run.
  */
 export function canCreateCompanies(client: OpenCompanyClient): boolean {
-  return !COMPANY_SWITCHING_HIDDEN && client.carriesPlatformBearer;
+  return client.carriesPlatformBearer;
+}
+
+/**
+ * Whether a company-creation entry point should render.
+ *
+ * The presentation half, asked once where every trigger already asks: creation
+ * is reachable from the switcher's "New company", the picker's own button, the
+ * picker's per-card Reset, the no-company screen, and Settings' "Reset / Start
+ * clean" — which archives and re-provisions through this same dialog. Gating
+ * them one at a time is how four stayed live after the first was hidden.
+ *
+ * Separate from {@link canCreateCompanies} on purpose. "Do we offer this in
+ * this product configuration" and "may this caller do it" are different
+ * questions, and answering both with one predicate is what turned a hidden
+ * button into a disabled code path.
+ */
+export function offersCompanyCreation(client: OpenCompanyClient): boolean {
+  return !COMPANY_SWITCHING_HIDDEN && canCreateCompanies(client);
 }
 
 interface Props {

--- a/frontend/src/views/ConnectionConsole.tsx
+++ b/frontend/src/views/ConnectionConsole.tsx
@@ -19,7 +19,7 @@ import {
   CREATE_UNAVAILABLE_NOTE,
   CreateCompanyDialog,
   type CreateCompanyRequest,
-  canCreateCompanies,
+  offersCompanyCreation,
 } from "@/components/create-company-dialog";
 import { ConsoleChrome } from "@/components/host-switcher";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -296,7 +296,7 @@ export function ConnectionConsole({
   // reset the operator's archived company has to be left, both of which are this
   // component's job.
   const [createRequest, setCreateRequest] = useState<CreateCompanyRequest | null>(null);
-  const canCreate = canCreateCompanies(client);
+  const canCreate = offersCompanyCreation(client);
 
   // Whichever companies the current phase knows about, so a create can drop the
   // operator into the new one alongside the rest.

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -52,7 +52,7 @@ import { useLocalScope } from "@/connections/ConnectionContext";
 import { forgetSession } from "@/connections/registry";
 import type { ConnectionId } from "@/connections/types";
 import { lifecycleAffordances } from "@/lib/lifecycle-controls";
-import { canCreateCompanies } from "@/components/create-company-dialog";
+import { offersCompanyCreation } from "@/components/create-company-dialog";
 import { personName } from "@/lib/person";
 
 interface Props {
@@ -328,7 +328,7 @@ export function LifecycleControls({
   // company and re-provisions it through the same dialog "New company" opens, so
   // it is company creation wearing another label and has to answer the same
   // question the other triggers do.
-  const platform = canCreateCompanies(client);
+  const platform = offersCompanyCreation(client);
   const { actions, explainPlatformOnly, explainPlatformSuspended, archived } =
     lifecycleAffordances(state, platform);
   const offers = (action: LifecycleAction) => actions.includes(action);

--- a/frontend/test/e2e/desktop-connections.spec.ts
+++ b/frontend/test/e2e/desktop-connections.spec.ts
@@ -152,29 +152,6 @@ async function asDesktop(page: Page, config: BridgeConfig) {
                 ? null
                 : { baseUrl: cfg.embedded, dataDir: "/tmp/e2e-desktop" };
             }
-            case "oc_local_instances": {
-              // The roster a current console asks first — `App` only falls back to
-              // `oc_embedded` when this command is absent, which is not what a
-              // packaged shell answers. Mirrors `cfg.embedded`: one running
-              // instance when there is a host, none when there is not, so a
-              // machine with nothing running is still a machine that can start
-              // one — not a shell predating the roster.
-              if (cfg.discoveryDelayMs) {
-                await new Promise((resolve) => setTimeout(resolve, cfg.discoveryDelayMs));
-              }
-              return cfg.embedded === null
-                ? []
-                : [
-                    {
-                      id: "default",
-                      label: "This computer",
-                      dataDir: "/tmp/e2e-desktop",
-                      running: true,
-                      baseUrl: cfg.embedded,
-                      instanceId: "default",
-                    },
-                  ];
-            }
             case "oc_request": {
               const id = args.connectionId as string;
               // Only ever a host `oc_connect` accepted, so no second check is

--- a/frontend/test/e2e/desktop-connections.spec.ts
+++ b/frontend/test/e2e/desktop-connections.spec.ts
@@ -152,6 +152,29 @@ async function asDesktop(page: Page, config: BridgeConfig) {
                 ? null
                 : { baseUrl: cfg.embedded, dataDir: "/tmp/e2e-desktop" };
             }
+            case "oc_local_instances": {
+              // The roster a current console asks first — `App` only falls back to
+              // `oc_embedded` when this command is absent, which is not what a
+              // packaged shell answers. Mirrors `cfg.embedded`: one running
+              // instance when there is a host, none when there is not, so a
+              // machine with nothing running is still a machine that can start
+              // one — not a shell predating the roster.
+              if (cfg.discoveryDelayMs) {
+                await new Promise((resolve) => setTimeout(resolve, cfg.discoveryDelayMs));
+              }
+              return cfg.embedded === null
+                ? []
+                : [
+                    {
+                      id: "default",
+                      label: "This computer",
+                      dataDir: "/tmp/e2e-desktop",
+                      running: true,
+                      baseUrl: cfg.embedded,
+                      instanceId: "default",
+                    },
+                  ];
+            }
             case "oc_request": {
               const id = args.connectionId as string;
               // Only ever a host `oc_connect` accepted, so no second check is

--- a/frontend/test/unit/connection-console-switch-known-status.test.ts
+++ b/frontend/test/unit/connection-console-switch-known-status.test.ts
@@ -8,24 +8,6 @@ import type { OpenCompanyClient } from "@/api/client";
 import type { AppSpec, CompanyStatus } from "@/api/types";
 import { HostsProvider } from "@/connections/HostsContext";
 
-// The company-creation funnel is closed at the product level:
-// `canCreateCompanies` is `!COMPANY_SWITCHING_HIDDEN && carriesPlatformBearer`
-// (#2074), and with the flag set it answers `false` for every client — so the
-// dialog and the Reset button this file renders never mount, and every case
-// here fails on an element that cannot exist.
-//
-// The flag is neutralised rather than the tests skipped, because what they
-// cover is not the funnel. It is the dialog's own behaviour once open — the
-// wallet field, the preflight race, the pre-archive guard, the lifecycle
-// disable — and that code still ships and can still regress. The *gate* has its
-// own coverage in `product-scope-hidden-surfaces.test.ts`, which pins the
-// absence directly and is where a change to the hide belongs.
-vi.mock("@/product-scope", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/product-scope")>()),
-  COMPANY_SWITCHING_HIDDEN: false,
-}));
-
-
 /**
  * Codex review on #1828 (PR comment 3864628314): `switchCompany`'s only
  * caller that already holds fresh data for the company it is entering —

--- a/frontend/test/unit/connection-console-switch-known-status.test.ts
+++ b/frontend/test/unit/connection-console-switch-known-status.test.ts
@@ -144,62 +144,36 @@ afterEach(() => {
   container.remove();
 });
 
-describe("a create provisioning a company whose follow-up status lookup would fail", () => {
-  it("still lands the operator in the fresh company, without re-fetching what the create already returned", async () => {
-    const provisioned = company("co-fresh1", "Fresh Co");
-    const { client, statusSpy } = stubClient(provisioned);
+/**
+ * Retired with the trigger it drove.
+ *
+ * It covered the landing after a create: the operator ends up inside the
+ * fresh company, and the console does not re-fetch a status the create call
+ * already returned — the point being that a follow-up lookup which fails must
+ * not strand them outside a company that exists.
+ *
+ * It reached that through the no-company screen's "New company" button, and
+ * no company-creation trigger renders while the product does not offer it
+ * (`src/product-scope.ts`). The picker's own button is gated the same way, so
+ * there is no second way in to re-point this at.
+ *
+ * Deliberately not re-pointed at the handler directly: driving
+ * `onCompanyCreated` below the trigger would keep this green while the shipped
+ * path renders nothing to reach it. The handler is untouched; turning the flag
+ * off restores the trigger and this case.
+ */
+
+describe("the no-company screen while the product offers no company creation", () => {
+  it("shows no way to create one", async () => {
+    // What replaces the retired case above: the trigger it drove is the thing
+    // under test now, and its absence is asserted where the case used to press
+    // it. A platform-scoped client is used deliberately — the caller *could*
+    // create a company, and it is product scope that withholds the control.
+    const { client } = stubClient(company("co-fresh1", "Fresh Co"));
 
     await show(client);
     await settle();
 
-    // A configured host with zero companies lands on "no-company" — the
-    // lightest phase with a reachable "New company" trigger.
-    const trigger = container.querySelector<HTMLButtonElement>('[data-testid="no-company-new"]');
-    expect(trigger, "no-company-new trigger not found").toBeTruthy();
-    await act(async () => {
-      trigger!.click();
-    });
-
-    // The dialog renders through a Radix portal into `document.body`, not
-    // into `container` — matching `create-company-reset-fresh-id.test.ts`'s
-    // `[data-slot="dialog-content"]` queries.
-    const nameInput = document.querySelector<HTMLInputElement>("#create-company-name");
-    expect(nameInput, "create-company-name field not found").toBeTruthy();
-    const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
-    await act(async () => {
-      setValue.call(nameInput, "Fresh Co");
-      nameInput!.dispatchEvent(new Event("input", { bubbles: true }));
-    });
-
-    // Required after codex review comment 3864885200 — unrelated to what
-    // this file pins (skipping the redundant status lookup), so the submit
-    // needs one filled in first or validation blocks it before provisioning.
-    const adminInput = document.querySelector<HTMLInputElement>("#create-company-admin");
-    expect(adminInput, "create-company-admin field not found").toBeTruthy();
-    await act(async () => {
-      setValue.call(adminInput, "ceo@fresh.test");
-      adminInput!.dispatchEvent(new Event("input", { bubbles: true }));
-    });
-
-    const submit = Array.from(
-      document.querySelectorAll<HTMLButtonElement>('[data-slot="dialog-content"] button'),
-    ).find((b) => b.textContent?.trim() === "Create company");
-    expect(submit, 'no "Create company" button found').toBeTruthy();
-    await act(async () => {
-      submit!.click();
-    });
-    await settle();
-
-    // Never the generic connection-error screen — a transient failure on a
-    // lookup nothing needed should not surface at all.
-    expect(container.querySelector('[data-testid="connection-error"]')).toBeNull();
-
-    const phase = container.querySelector('[data-testid="console-phase"]');
-    expect(phase, "console phase never rendered").toBeTruthy();
-    expect(phase!.getAttribute("data-company")).toBe("co-fresh1");
-    // Populated from the status the create call already returned, not a
-    // second fetch — which is exactly what the assertion below proves.
-    expect(phase!.getAttribute("data-status-id")).toBe("co-fresh1");
-    expect(statusSpy).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="no-company-new"]')).toBeNull();
   });
 });

--- a/frontend/test/unit/product-scope-hidden-surfaces.test.ts
+++ b/frontend/test/unit/product-scope-hidden-surfaces.test.ts
@@ -9,7 +9,7 @@ import type { ComposioStatus } from "@/api/composio";
 import type { InferenceStatus } from "@/api/inference";
 import { INFERENCE_PROVIDERS, SETUP_INFERENCE_OPTIONS } from "@/api/setup";
 import { HostSwitcher, hostSwitcherMenu } from "@/components/host-switcher";
-import { canCreateCompanies } from "@/components/create-company-dialog";
+import { canCreateCompanies, offersCompanyCreation } from "@/components/create-company-dialog";
 import { ComposioSection } from "@/views/connections/ComposioSection";
 import { InferenceSection } from "@/views/connections/InferenceSection";
 import { HostsProvider, type HostsValue } from "@/connections/HostsContext";
@@ -437,18 +437,23 @@ describe("company creation is gone from every trigger, not just the switcher", (
    * first was hidden, so the question is asked once, where they all ask it.
    */
   it("answers no at the funnel every trigger goes through", () => {
-    const withBearer = { carriesPlatformBearer: true } as unknown as OpenCompanyClient;
-
-    expect(canCreateCompanies(withBearer)).toBe(false);
-  });
-
-  it("stays no even for a client that could reach the routes", () => {
-    // The platform credential is the other half of the condition, and on its own
-    // it used to be the whole of it at two call sites.
     const platform = { carriesPlatformBearer: true } as unknown as OpenCompanyClient;
     const person = { carriesPlatformBearer: false } as unknown as OpenCompanyClient;
 
-    expect(canCreateCompanies(platform)).toBe(false);
+    expect(offersCompanyCreation(platform)).toBe(false);
+    expect(offersCompanyCreation(person)).toBe(false);
+  });
+
+  it("leaves the caller's own capability alone", () => {
+    // Product scope decides whether an entry point renders. Whether this
+    // principal may create a company is a different question, and the dialog's
+    // preflight and submit read it — so a scope flag reaching in there would
+    // make the shipped path inert while its tests passed against logic nothing
+    // could run.
+    const platform = { carriesPlatformBearer: true } as unknown as OpenCompanyClient;
+    const person = { carriesPlatformBearer: false } as unknown as OpenCompanyClient;
+
+    expect(canCreateCompanies(platform)).toBe(true);
     expect(canCreateCompanies(person)).toBe(false);
   });
 });

--- a/frontend/test/unit/settings-lifecycle-reset-button.test.ts
+++ b/frontend/test/unit/settings-lifecycle-reset-button.test.ts
@@ -9,24 +9,6 @@ import type { OpenCompanyClient } from "@/api/client";
 import type { CompanyStatus } from "@/api/types";
 import { LifecycleControls } from "@/views/SettingsView";
 
-// The company-creation funnel is closed at the product level:
-// `canCreateCompanies` is `!COMPANY_SWITCHING_HIDDEN && carriesPlatformBearer`
-// (#2074), and with the flag set it answers `false` for every client — so the
-// dialog and the Reset button this file renders never mount, and every case
-// here fails on an element that cannot exist.
-//
-// The flag is neutralised rather than the tests skipped, because what they
-// cover is not the funnel. It is the dialog's own behaviour once open — the
-// wallet field, the preflight race, the pre-archive guard, the lifecycle
-// disable — and that code still ships and can still regress. The *gate* has its
-// own coverage in `product-scope-hidden-surfaces.test.ts`, which pins the
-// absence directly and is where a change to the hide belongs.
-vi.mock("@/product-scope", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/product-scope")>()),
-  COMPANY_SWITCHING_HIDDEN: false,
-}));
-
-
 /**
  * The Reset / Start clean button (#1807, SettingsView.tsx `LifecycleControls`)
  * had no render test of its own — tinysweeper flagged the gap (PR comment

--- a/frontend/test/unit/settings-lifecycle-reset-button.test.ts
+++ b/frontend/test/unit/settings-lifecycle-reset-button.test.ts
@@ -110,12 +110,16 @@ async function render(client: OpenCompanyClient, lifecycle: string, onReset?: ()
 }
 
 describe("the Reset / Start clean button's render gate", () => {
-  it("renders when the client is platform-scoped, the company is live, and onReset is given", async () => {
+  it("is left out while the product does not offer company creation", async () => {
+    // Reset archives this company and provisions a replacement through the same
+    // dialog "New company" opens — it is company creation wearing another
+    // label, so it answers the same presentation question the other four
+    // triggers do (`offersCompanyCreation`).
     await render(clientWith(true), "running", () => {});
-    expect(resetButton()).not.toBeUndefined();
+    expect(resetButton()).toBeUndefined();
   });
 
-  it("is left out when onReset is not given (mirrors the `canCreateCompanies` gate upstream)", async () => {
+  it("is left out when onReset is not given (mirrors the `offersCompanyCreation` gate upstream)", async () => {
     await render(clientWith(true), "running", undefined);
     expect(resetButton()).toBeUndefined();
   });
@@ -131,35 +135,19 @@ describe("the Reset / Start clean button's render gate", () => {
   });
 });
 
-describe("the Reset / Start clean button's click wiring", () => {
-  it("calls the onReset callback it was given", async () => {
-    const onReset = vi.fn();
-    await render(clientWith(true), "running", onReset);
-    const btn = resetButton();
-    expect(btn).not.toBeUndefined();
-    await act(async () => {
-      btn?.click();
-    });
-    expect(onReset).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("the Reset / Start clean button while another lifecycle action is in flight", () => {
-  it("disables alongside Pause/Resume/Suspend/Archive, not just its own click", async () => {
-    const onReset = vi.fn();
-    // `hang: true` — the in-flight `pause` call never resolves, so `busy`
-    // stays true for the duration of this test, the same window the operator
-    // sees between a click and the host's response.
-    await render(clientWith(true, true), "running", onReset);
-    const pause = [...container.querySelectorAll("button")].find((b) =>
-      b.textContent?.includes("Pause"),
-    );
-    expect(pause, "a running, platform-scoped company must offer Pause").not.toBeUndefined();
-    await act(async () => {
-      pause?.click();
-    });
-    const btn = resetButton();
-    expect(btn, "Reset stays rendered while another action is busy").not.toBeUndefined();
-    expect(btn?.disabled, "Reset must disable with the rest of the row").toBe(true);
-  });
-});
+/**
+ * Two cases retired with the control's entry point.
+ *
+ * They covered the button's click wiring — that it calls the `onReset` it was
+ * given — and that it disables alongside Pause/Resume/Suspend/Archive while any
+ * lifecycle action is in flight, rather than only guarding its own click.
+ *
+ * Both need the button on screen, and it does not render while the product does
+ * not offer company creation (`src/product-scope.ts`). The wiring and the
+ * disabled rule are untouched in `LifecycleControls`; turning the flag off
+ * restores the control and both cases.
+ *
+ * Not re-pointed at `LifecycleControls` directly: that would test the component
+ * below the gate, leaving these green while the shipped path renders nothing —
+ * which is the false pass this branch has produced before.
+ */


### PR DESCRIPTION
## Summary

Main is red: `Console (current Node, advisory)` fails on ten unit tests. This
fixes it.

A previous change hid company creation by folding the product-scope flag into
`canCreateCompanies`. That predicate had two callers of different kinds — the
buttons that offer creation, and the dialog's own preflight and submit, which
read it as a permission check. Gating it therefore did not only hide five
buttons; it made the shipped dialog inert, and took six passing tests down with
it because they exercise logic that still exists and still ships.

They are different questions:

- **Product scope** — does this configuration offer company creation? A
  presentation decision. Now `offersCompanyCreation`, asked by every trigger:
  the switcher's "New company", the picker's own button, the picker's per-card
  Reset, the no-company screen, and Settings' "Reset / Start clean", which
  archives and re-provisions through the same dialog.
- **Capability** — may this caller create a company? A fact about the principal.
  Stays `canCreateCompanies`, read by the dialog exactly as before.

Keeping them apart is what stops a scope flag silently changing runtime
behaviour, and what makes flipping the scope back restore a control that is
still tested and still works.

Rebased onto current `main` (this branch was cut before it), which pulled in
three unrelated e2e failures against the code this now builds on. Fixed below,
alongside the original ten.

## API Or Behavior Changes

No API changes. No Rust.

- The create/reset dialog behaves as it did before creation was hidden: its
  preflight arms and its submit runs for a caller that holds a platform
  credential. Nothing about the hiding changes — no creation trigger renders.
- No change to which entry points are hidden. The same five are gated; they now
  ask a predicate that means what they need it to mean.
- `CompanyPicker`'s company *switching* is deliberately untouched and out of
  scope here. With the switcher gone, an install that genuinely holds two
  companies still enters the picker automatically from the company count, and
  hiding it would strand that install with no way in. That needs a product
  answer, not a flag flip.

## Tests

- [x] `npm run typecheck` — pass
- [x] `npm run typecheck:unit` — pass
- [x] `npm run typecheck:e2e` — pass
- [x] `npx vitest run` — 495 files, 4582 tests, pass
- [x] `npx playwright test connections-authority desktop-connections workflow-selection-persists` — 9 passed (one retired, see below)
- [ ] `cargo fmt --all -- --check` — N/A, no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A, no Rust changed
- [ ] `cargo build --all-targets` — N/A, no Rust changed
- [ ] `cargo test` — N/A, no Rust changed

All ten unit failures on main are addressed, and the split is what does it
rather than the tests being rewritten around the failure:

- **Four `create-company-wallet-mode` and two `create-company-dialog-preflight-race`
  cases pass untouched.** The dialog reads the caller's capability again, so the
  logic they cover runs again. Verified red on main alone and green here.
- **Three `settings-lifecycle-reset-button` cases**: the render gate inverts to
  assert the button is hidden — Reset is company creation wearing another label.
  The click-wiring and busy-disabled cases are retired, with the reason recorded
  in the file.
- **One `connection-console-switch-known-status` case** drove the no-company
  screen's trigger; retired the same way, and the assertion replacing it is the
  absence of the button it used to press.

The retired cases were deliberately not re-pointed at `LifecycleControls` or at
the create handler directly. Testing below the gate would leave them green while
the shipped path renders nothing to reach — the false pass this work has
produced before, so it is worth not repeating to recover three tests.

Three Playwright specs went red after the rebase, none of them from this
branch's own diff:

- **`desktop-connections.spec.ts:420`** — a fixture gap, not a product defect.
  The added case needs the desktop's local-instance roster (`canStartHere`),
  but the file's shared `asDesktop` stub only ever answered `oc_embedded`, so
  every case in the file ran the pre-roster fallback path. Fixed by mirroring
  `cfg.embedded` into `oc_local_instances` as well, the same shape
  `desktop-embedded-identity.spec.ts` already uses for a roster-aware shell.
  The other five cases in the file pass unchanged.
- **`connections-authority.spec.ts:145`** — a stale invariant. It asserted
  `#company-credential` as the Apps page's always-on admin write surface, but
  that card stopped rendering for anyone once the managed Composio route was
  hidden (`COMPOSIO_MANAGED_HIDDEN`) — a change that landed after this spec was
  last touched. Repointed at the by-slug connect hatch, which is gated on
  `canManage` the same way and still renders on a default-feature host; its
  absence for a member is already asserted two rows above in the sibling test,
  so the pair now actually distinguishes the two roles.
- **`workflow-selection-persists.spec.ts:176`** — a real loss of subject, not a
  stale assertion. It drove a company switch through the host switcher's
  "Companies" menu, which no longer opens: `showCompanies` reads
  `COMPANY_SWITCHING_HIDDEN`, true on this build, and `onSwitchCompany` is
  wired nowhere else. Retired with the reason in the file rather than skipped;
  the route-clearing behaviour it proved stays covered at the unit level
  (`connection-console-switch-known-status.test.ts`), and turning the flag off
  restores both the menu and this case.

## Documentation

None needed — no operator-visible behaviour changes beyond restoring the
dialog's internals, and the reasoning lives beside the two predicates.

Also worth a reviewer's attention, found while fixing the earlier round and
already on main: the setup wizard seeded the host's own `base_url` into the form
for providers that take no URL field, where it later read as a tenant endpoint
override — which is exactly what withholds the injected platform credential
(`resolve_endpoint`). It is now seeded only where the provider takes one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chat remains available while navigating between sections, preserving the selected channel.
  - Chat and team agent links can open directly in edit mode.
  - Finance navigation now uses the section-level navigation rail.
  - Signing out from the profile menu now clears the active session.

- **Bug Fixes**
  - Company creation and lifecycle reset controls now appear only when supported and authorized.
  - Policy and domain settings are now restricted according to the user’s permissions.
  - Settings explain when administrator access is required for pause and resume actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->