### PR TITLE
chore(desktop): install the updater's public signing key

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
   "plugins": {
     "updater": {
       "active": true,
-      "pubkey": "PLACEHOLDER-NOT-A-KEY-see-docs-spec-runtime-desktop-updates-md",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDcxMjNEREM2ODQ3NzA0MkMKUldRc0JIZUV4dDBqY1NnMnBmK21oc0xGdnBhNTl3djVGWWErWFJ0aG1IYkZJTWpVczJZUjBzcGIK",
       "endpoints": [
         "https://github.com/tinyhumansai/opencompany/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Summary

#2066 shipped the desktop updater with a placeholder public key:

```json
"pubkey": "PLACEHOLDER-NOT-A-KEY-see-docs-spec-runtime-desktop-updates-md"
```

`scripts/release/assert-updater-configured.sh` refuses any signed release while that is in place — correctly, since an application built with it could never verify an update, and immutable releases mean that cannot be repaired after publishing. So **no DMG release can currently be published at all**, which is how this was found.

This installs the real public half. The keypair was generated once with `tauri signer generate`, passphrase-protected as `docs/spec/runtime/desktop-updates.md` requires; the private half and its passphrase are the `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` repository secrets and appear nowhere in this tree.

## Why committed rather than injected from a variable

Considered and rejected:

- **It is not a secret.** The pubkey ships inside every DMG, so externalising it hides it from this repository and from nobody else.
- **The trust root belongs in the tag.** Checking out a release should tell you which key that build accepts updates from. Injected at build time, that fact lives only in workflow logs.
- **Reproducibility.** Two builds of one commit could otherwise trust different keys depending on a variable's value at the time.
- **The guard would weaken.** `assert-updater-configured.sh` reads this file; if the real value came from elsewhere, the guard would be validating something the build no longer uses — passing on a placeholder while the binary trusted whatever the variable said.

OpenHuman resolved it the same way and records the reasoning in its `build-desktop.yml`: *"The minisign pubkey is baked into the static `tauri.conf.json`, not injected from secrets; only the private key still has to come from secrets."*

## This value is effectively permanent

Clients verify against the key compiled into the build they are already running, so rotating it strands every install on its current version — they would need to download a new DMG by hand. v0.1.1 shipped with no `plugins.updater` block at all, so nothing trusts a key yet and this one starts clean.

The private key must therefore be backed up, not regenerated. Losing it means no existing install can ever be updated again.

## Verification

`assert-updater-configured.sh` — the exact script the release guard runs — passes against this tree:

```
[updater] src-tauri/tauri.conf.json carries a minisign public key and a signing secret is present.
```

The config still parses, `active: true`, one endpoint, 152-character key (same length as OpenHuman's).

## Follow-up

The `v0.1.2` tag currently points at `edbfdda72`, which predates this commit and so still carries the placeholder. It needs moving onto the merge of this PR before a release is cut — nothing depends on it yet, since no GitHub Release exists for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the application’s update configuration with a valid signing key, enabling verification of desktop update packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->