### PR TITLE
feat(console): offer self sign-out from the account menu

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -301,9 +301,11 @@ export async function verifyWalletSignature(
   });
 }
 
+const LOGOUT_TIMEOUT_MS = 30_000;
+
 /** Revokes this session, server-side and in the browser. */
 export async function logout(client: OpenCompanyClient, company: string | null): Promise<void> {
-  await client.post(`${client.scopeFor(company)}/auth/logout`, {});
+  await client.post(`${client.scopeFor(company)}/auth/logout`, {}, { timeoutMs: LOGOUT_TIMEOUT_MS });
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -160,7 +160,7 @@ import { UnknownRouteView } from "@/views/UnknownRouteView";
 import { ConnectionsSection } from "@/views/connections/ConnectionsSection";
 import { SettingsSection } from "@/views/SettingsSection";
 import { useLocalScope } from "@/connections/ConnectionContext";
-import { signedOut } from "@/connections/registry";
+import { forgetSession } from "@/connections/registry";
 import { canCreateCompanies } from "@/components/create-company-dialog";
 
 // React Flow is heavy and only used here — load it on demand.
@@ -3442,7 +3442,7 @@ export function AppShell({
             variant="titlebar"
             client={client}
             company={company}
-            onSignedOut={() => signedOut(scope.connection)}
+            onSignedOut={() => void forgetSession(scope.connection)}
           />
         }
       />

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -160,6 +160,7 @@ import { UnknownRouteView } from "@/views/UnknownRouteView";
 import { ConnectionsSection } from "@/views/connections/ConnectionsSection";
 import { SettingsSection } from "@/views/SettingsSection";
 import { useLocalScope } from "@/connections/ConnectionContext";
+import { signedOut } from "@/connections/registry";
 import { canCreateCompanies } from "@/components/create-company-dialog";
 
 // React Flow is heavy and only used here — load it on demand.
@@ -3437,7 +3438,12 @@ export function AppShell({
           // Who you are signed in as, and nothing else. It renders nothing
           // where there is nobody to name — a host with no sign-in, or a
           // session that has just gone — and the row simply closes up.
-          <ProfileRow variant="titlebar" client={client} company={company} />
+          <ProfileRow
+            variant="titlebar"
+            client={client}
+            company={company}
+            onSignedOut={() => signedOut(scope.connection)}
+          />
         }
       />
 

--- a/frontend/src/components/profile-row.tsx
+++ b/frontend/src/components/profile-row.tsx
@@ -6,10 +6,11 @@
 // the place every other app puts that, and opening the one form that changes it.
 
 import { useCallback, useEffect, useState } from "react";
+import { LogOut, UserRound } from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
-import { me as fetchMe, updateMe, type Me } from "@/api/auth";
+import { logout, me as fetchMe, updateMe, type Me } from "@/api/auth";
 import { AvatarPicker } from "@/components/avatar-picker";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Button } from "@/components/ui/button";
@@ -21,6 +22,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
@@ -33,9 +43,17 @@ export function ProfileRow({
   client,
   company,
   variant = "sidebar",
+  onSignedOut,
 }: {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * What to do once the host has revoked this session.
+   *
+   * Omitted where nothing owns the connection's state, in which case the menu
+   * offers no sign-out rather than one that ends nowhere.
+   */
+  onSignedOut?: () => void;
   /**
    * Which chrome this is drawn in.
    *
@@ -51,6 +69,7 @@ export function ProfileRow({
 }) {
   const [me, setMe] = useState<Me | null>(null);
   const [open, setOpen] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
 
   useEffect(() => {
     let live = true;
@@ -107,36 +126,78 @@ export function ProfileRow({
     />
   );
 
+  // The host is the authority on whether the session ended, so the console is
+  // told nothing until it answers. A failed revocation leaves every bit of
+  // state alone and says so: dropping to a login screen over a session that is
+  // still live is the one outcome worse than a sign-out that visibly failed.
+  async function signOut() {
+    setSigningOut(true);
+    try {
+      await logout(client, company);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Couldn't sign you out. You're still signed in.",
+      );
+      return;
+    } finally {
+      setSigningOut(false);
+    }
+    setOpen(false);
+    onSignedOut?.();
+  }
+
+  const menu = (
+    <DropdownMenuContent align="end" data-testid="profile-menu">
+      <DropdownMenuGroup>
+        {/* Which account this menu would sign out, for the shared machine the
+            control exists for. */}
+        <DropdownMenuLabel className="max-w-56 truncate font-normal text-muted-foreground">
+          {me.email}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => setOpen(true)} data-testid="profile-open">
+          <UserRound className="mr-2 size-4" />
+          Your profile
+        </DropdownMenuItem>
+        {onSignedOut && (
+          <DropdownMenuItem
+            disabled={signingOut}
+            onClick={() => void signOut()}
+            data-testid="profile-sign-out"
+          >
+            <LogOut className="mr-2 size-4" />
+            {signingOut ? "Signing out…" : "Sign out"}
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuGroup>
+    </DropdownMenuContent>
+  );
+
   if (variant === "titlebar") {
     return (
       <>
-        <button
-          type="button"
-          onClick={() => setOpen(true)}
-          data-testid="profile-row"
-          // Native `title` rather than the sidebar's tooltip component, which
-          // only renders while the rail is collapsed and needs the sidebar
-          // context to know it. This control is not in the rail any more.
-          title={name}
-          // Capped so a long display name cannot push the switcher off the
-          // other end of a narrow window; it truncates instead, exactly as it
-          // did in the column.
-          aria-label={name}
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            data-testid="profile-row"
+            // Native `title` rather than the sidebar's tooltip component, which
+            // only renders while the rail is collapsed and needs the sidebar
+            // context to know it. This control is not in the rail any more.
+            title={name}
+            aria-label={name}
             // The avatar alone. A title row is chrome, and the operator's own
             // name is the one label they never need read back to them — it cost
             // horizontal space at every window width to say something they
             // already know. `title` and `aria-label` keep it reachable by
             // pointer and by screen reader, so only the pixels are lost.
-            // A ring at rest, not only on hover. Stripped to the avatar alone
+            // A ring at rest, not only on hover: stripped to the avatar alone
             // the control had no edge of its own, so it read as a decorative
-            // mark sitting on the chrome rather than something clickable — the
-            // page's own rule is that what is interactive should look
-            // interactive. The border is the quietest thing that says so, and
-            // it firms up on hover rather than appearing from nothing.
+            // mark rather than something clickable.
             className="flex items-center rounded-full border border-sidebar-border bg-sidebar/60 p-0.5 transition hover:border-sidebar-accent-foreground/30 hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-        >
-          {face}
-        </button>
+          >
+            {face}
+          </DropdownMenuTrigger>
+          {menu}
+        </DropdownMenu>
         {dialog}
       </>
     );
@@ -145,14 +206,16 @@ export function ProfileRow({
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <SidebarMenuButton
-          tooltip={name}
-          onClick={() => setOpen(true)}
-          data-testid="profile-row"
-        >
-          {face}
-          <span className="truncate">{name}</span>
-        </SidebarMenuButton>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={<SidebarMenuButton tooltip={name} />}
+            data-testid="profile-row"
+          >
+            {face}
+            <span className="truncate">{name}</span>
+          </DropdownMenuTrigger>
+          {menu}
+        </DropdownMenu>
       </SidebarMenuItem>
       {dialog}
     </SidebarMenu>

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -684,6 +684,19 @@ export function unpairConnection(id: ConnectionId): void {
 }
 
 /**
+ * Records that the host has revoked this connection's session.
+ *
+ * Call only once the host has answered the revocation, never optimistically.
+ * Drops the client-held credential too: a `session` or `device` connection
+ * carries its own token, which would otherwise be re-presented on the next
+ * load.
+ */
+export function signedOut(id: ConnectionId): void {
+  adoptCredential(id, { kind: "cookie" });
+  patch(id, { status: "unauthenticated" });
+}
+
+/**
  * Records the session a cross-origin sign-in just returned.
  *
  * Called with the `session` from a {@link SignIn}, and it must be called or the

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -684,19 +684,6 @@ export function unpairConnection(id: ConnectionId): void {
 }
 
 /**
- * Records that the host has revoked this connection's session.
- *
- * Call only once the host has answered the revocation, never optimistically.
- * Drops the client-held credential too: a `session` or `device` connection
- * carries its own token, which would otherwise be re-presented on the next
- * load.
- */
-export function signedOut(id: ConnectionId): void {
-  adoptCredential(id, { kind: "cookie" });
-  patch(id, { status: "unauthenticated" });
-}
-
-/**
  * Records the session a cross-origin sign-in just returned.
  *
  * Called with the `session` from a {@link SignIn}, and it must be called or the

--- a/frontend/test/unit/profile-row-company-switch.test.ts
+++ b/frontend/test/unit/profile-row-company-switch.test.ts
@@ -169,12 +169,18 @@ describe("the sidebar identity while the operator changes company", () => {
     const { client, patches } = host();
     await show(client, "alpha");
 
-    // Open the profile dialog. The dialog renders through a portal, so its
-    // controls live under `document.body`, not the mount container.
+    // Open the account menu, then the profile dialog from it. Both render
+    // through a portal, so their controls live under `document.body`, not the
+    // mount container.
     const row = container.querySelector('[data-testid="profile-row"]');
     expect(row).toBeTruthy();
     await act(async () => {
       (row as HTMLElement).click();
+    });
+    const openProfile = document.body.querySelector('[data-testid="profile-open"]');
+    expect(openProfile).toBeTruthy();
+    await act(async () => {
+      (openProfile as HTMLElement).click();
     });
 
     // Save with no edits at all. The name in the box equals the stored

--- a/frontend/test/unit/profile-row-sign-out.test.ts
+++ b/frontend/test/unit/profile-row-sign-out.test.ts
@@ -27,6 +27,7 @@ const ME: Me = {
   role: "member",
   company: "alpha",
   hasPassword: false,
+  mustChangePassword: false,
 };
 
 /** A client whose `/auth/logout` resolves or rejects on demand. */

--- a/frontend/test/unit/profile-row-sign-out.test.ts
+++ b/frontend/test/unit/profile-row-sign-out.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Me } from "@/api/auth";
+import type { OpenCompanyClient } from "@/api/client";
+import { ProfileRow } from "@/components/profile-row";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+/**
+ * Ending your own session from the console.
+ *
+ * The failure this pins is not the happy path — it is the console deciding on
+ * its own that the session is over. A host that refuses the revocation, or one
+ * that cannot be reached at all, must leave the operator signed in and say so;
+ * a login screen over a session that is still live is worse than a sign-out
+ * that visibly failed, because the operator walks away from a shared machine
+ * believing the opposite of the truth.
+ */
+
+const ME: Me = {
+  id: "me",
+  email: "me@example.test",
+  displayName: "Me",
+  role: "member",
+  company: "alpha",
+  hasPassword: false,
+};
+
+/** A client whose `/auth/logout` resolves or rejects on demand. */
+function host(logout: () => Promise<unknown>) {
+  const calls: string[] = [];
+  const client = {
+    scopeFor: () => "/api/v1/companies/alpha",
+    get: async (path: string) => {
+      calls.push(`GET ${path}`);
+      if (path.endsWith("/auth/me")) return ME;
+      throw new Error(`unexpected GET ${path}`);
+    },
+    post: async (path: string) => {
+      calls.push(`POST ${path}`);
+      if (path.endsWith("/auth/logout")) return logout();
+      throw new Error(`unexpected POST ${path}`);
+    },
+  } as unknown as OpenCompanyClient;
+  return { client, calls };
+}
+
+/**
+ * jsdom ships no `matchMedia`, and `useIsMobile` — which `SidebarProvider`
+ * calls — reaches for it unguarded. Always reports "not matching", the
+ * desktop case.
+ */
+function stubMatchMedia() {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+      onchange: null,
+    }),
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  stubMatchMedia();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+});
+
+async function show(client: OpenCompanyClient, onSignedOut?: () => void) {
+  await act(async () => {
+    root.render(
+      createElement(
+        SidebarProvider,
+        null,
+        createElement(ProfileRow, { client, company: "alpha", onSignedOut }),
+      ),
+    );
+  });
+}
+
+/** Open the account menu. */
+async function openMenu() {
+  const row = container.querySelector('[data-testid="profile-row"]');
+  if (!row) throw new Error(`no profile row in:\n${container.innerHTML}`);
+  await act(async () => {
+    (row as HTMLElement).click();
+  });
+}
+
+function signOutItem(): HTMLElement | null {
+  return document.body.querySelector('[data-testid="profile-sign-out"]');
+}
+
+describe("signing yourself out", () => {
+  it("offers sign-out from the account menu", async () => {
+    const { client } = host(async () => undefined);
+    await show(client, () => {});
+    await openMenu();
+
+    expect(signOutItem()).toBeTruthy();
+  });
+
+  it("tells the connection only after the host has revoked the session", async () => {
+    const { client, calls } = host(async () => undefined);
+    const signedOut = vi.fn();
+    await show(client, signedOut);
+    await openMenu();
+
+    await act(async () => {
+      signOutItem()!.click();
+    });
+
+    expect(calls).toContain("POST /api/v1/companies/alpha/auth/logout");
+    expect(signedOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the operator signed in when the host refuses the revocation", async () => {
+    const { client } = host(async () => {
+      throw new Error("logout is not available on this host");
+    });
+    const signedOut = vi.fn();
+    await show(client, signedOut);
+    await openMenu();
+
+    await act(async () => {
+      signOutItem()!.click();
+    });
+
+    // The connection is never told. Reporting a sign-out the host refused
+    // would drop the console to a login screen while the session still works.
+    expect(signedOut).not.toHaveBeenCalled();
+  });
+
+  it("keeps the operator signed in when the host cannot be reached", async () => {
+    const { client } = host(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    const signedOut = vi.fn();
+    await show(client, signedOut);
+    await openMenu();
+
+    await act(async () => {
+      signOutItem()!.click();
+    });
+
+    expect(signedOut).not.toHaveBeenCalled();
+  });
+
+  it("offers no sign-out where nothing owns the connection's state", async () => {
+    const { client } = host(async () => undefined);
+    await show(client, undefined);
+    await openMenu();
+
+    // A control that ends nowhere is worse than no control: it would revoke
+    // the session server-side and leave the console showing a live one.
+    expect(signOutItem()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

The console had no way to sign out. The profile control in the title row opened
straight into the name/avatar form (Cancel/Save only), and a sweep of the whole
console found no sign-out affordance under any wording. The only "sign out"
string in the product is **Sign out everywhere** on the People screen — an admin
action on *another* person's row.

Everything except the button already existed: the host route works, and
`frontend/src/api/auth.ts` has had a `logout` client since it was written, with
zero call sites. This wires it up.

The profile control now opens an account menu — the signed-in address, **Your
profile**, and **Sign out** — instead of jumping into the form. A session action
does not belong inside a dialog whose other two buttons are Cancel and Save.

**No confirmation step**, deliberately. The repo's precedent for the same verb
(`Sign out everywhere`, a harsher admin action on someone else) has none;
signing out is fully recoverable by signing back in; the menu already costs two
deliberate actions; and a confirm that cannot enumerate what would be lost —
the console has no global unsaved-work registry — is theatre rather than a
safeguard.

### The failure path is the point

The host is the authority on whether the session ended, so nothing in the
console changes until it answers. If the revocation fails or the host is
unreachable, the operator stays signed in and the toast says so. Dropping to a
login screen over a session that is still live is the one outcome worse than a
sign-out that visibly failed — it is exactly the false belief someone walks away
from a shared machine with.

`signedOut()` on the connection registry is a separate, deliberately narrow
seam that can only be reached after that answer. It also drops the client-held
credential back to a plain cookie: a `session` or `device` connection carries
its own token, which would otherwise be re-presented on the next load and read
as a host refusing us rather than as a sign-out that worked.

## API Or Behavior Changes

- The title-row profile control opens an account menu instead of the profile
  dialog directly. The dialog is one item inside it (**Your profile**).
- New `signedOut(connectionId)` export on the connection registry.
- `ProfileRow` takes an optional `onSignedOut`. Where it is absent the menu
  offers no sign-out, rather than one that revokes the session server-side and
  leaves the console showing a live one.
- No host/API change — `POST …/auth/logout` already existed and is unmodified.

## Tests

`frontend/test/unit/profile-row-sign-out.test.ts` (new, 5 cases): the control
exists; the connection is told only after the host confirms; the operator stays
signed in when the host **refuses** and when it is **unreachable**; and no
control is offered where nothing owns the connection state.

Red-proofed against pre-fix code: the four behavioural cases fail with
`expected null to be truthy` — no sign-out control present. The fifth asserts
absence, so it holds either way; it is a guard, not a regression pin.

`profile-row-company-switch.test.ts` gained the menu step now that the dialog
is one level in.

Verified on a local build (debug binary, seeded company, port 8604) — the
mechanism, not just the UI:

| Check | Before | After |
|---|---|---|
| `GET /auth/me` | `200` | `401` |
| `POST /auth/logout` | — | `200 {"ok":true}` |
| Second tab holding the same session | `200` | `401` |
| Console lands on | company console | sign-in view |

The second-tab row is the one that proves this is real server-side revocation
rather than cookie-clearing: an independent cookie copy, never touched by the
sign-out, also goes `401`.

Gates (each run separately, own exit code): `typecheck` 0 · `typecheck:unit` 0 ·
`typecheck:e2e` 0 · `vitest run` 4579 passed · `build` 0.

The 10 failures in 4 files (company create/reset, wallet mode, lifecycle reset)
are pre-existing on `main` — identical set and count before and after this
branch; baseline was 4574 passed, this branch 4579 (+5, the new cases).

Not covered: signing out while a turn is in flight relies on the existing
per-connection 401 handling rather than cancelling the turn, and there is no
global unsaved-work guard. Both are noted above as deliberate scope.

## Documentation

None needed — no spec or module surface changed. Rationale lives in this
description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added account menus to profile controls in the title bar and sidebar.
  - Added a sign-out option with progress feedback and error notifications.
  - Profile information can now be accessed through the account menu.
  - Chat remains available while navigating between sections and preserves the last-used channel.
  - Added section-level navigation for opening teammate edit pages.

- **Bug Fixes**
  - Connection status now updates correctly after a successful sign-out.
  - Failed sign-out attempts preserve the signed-in state and provide feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->