### PR TITLE
fix(workspace): hand the column to the note at mobile width

### DIFF
--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -1133,6 +1133,9 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
   async function open(id: string) {
     await flush();
     setOpenId(id);
+    // Below `md` the two panes share one column, so opening a note has to hand
+    // it over; above `md` both are shown regardless and this is inert.
+    setShowExplorer(false);
     setMode("read");
     setDraft(null);
     setSaveState("idle");
@@ -1558,9 +1561,12 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
         id="workspace-explorer"
         className={cn(
           "min-w-0 shrink-0 flex-col overflow-hidden bg-card/40 md:flex",
+          // Full width while it owns the column; the resizable width only
+          // applies once the note pane is beside it.
+          "w-full md:w-(--workspace-list-width)",
           showExplorer ? "flex" : "hidden",
         )}
-        style={{ width: listWidth }}
+        style={{ "--workspace-list-width": `${listWidth}px` } as CSSProperties}
       >
         <div className="flex items-center gap-1 border-b px-2 py-2">
           <span className="flex-1 px-1 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
@@ -1753,7 +1759,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
           "relative w-1.5 shrink-0 touch-none cursor-col-resize bg-border outline-none transition-colors select-none motion-reduce:transition-none",
           "hover:bg-primary/50 focus-visible:bg-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
           resizingList && "bg-primary/70",
-          showExplorer ? "hidden md:block" : "hidden",
+          "hidden md:block",
         )}
         onPointerDown={(e) => {
           if (e.button !== 0) return;

--- a/frontend/test/e2e/workspace-mobile-note.spec.ts
+++ b/frontend/test/e2e/workspace-mobile-note.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * A note opened at phone width has to be readable.
+ *
+ * The workspace is two panes — explorer, then the note — and below `md` only
+ * one of them can have the column. Which one is a piece of state that opening a
+ * note has to move: the explorer keeps the column until a note is picked, and
+ * the note takes it from there. When that state never moves, tapping a note
+ * plays an animation and leaves the operator on the list, with the note itself
+ * laid out at zero by zero.
+ *
+ * Measured rather than asserted on class names: `toBeVisible()` alone passes on
+ * a `display:none` ancestor's child in some arrangements, and the failure here
+ * is precisely a box with no area.
+ */
+
+const PHONE = { width: 386, height: 800 };
+const DESKTOP = { width: 1280, height: 900 };
+
+test.beforeEach(async ({ page }) => {
+  // The first-run tour renders over the console and swallows clicks.
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+async function openWorkspace(page: Page) {
+  await page.goto("/#/workspace");
+  await page.reload();
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await skip.waitFor({ state: "visible", timeout: 15_000 }).catch(() => {});
+  if (await skip.isVisible()) await skip.click();
+  await expect(page.getByTestId("workspace-tree")).toBeVisible({ timeout: 30_000 });
+}
+
+/** Tap the seeded `standards` note in the tree. */
+async function openSeededNote(page: Page) {
+  await page
+    .getByTestId("workspace-tree")
+    .getByTestId("workspace-tree-name")
+    .filter({ hasText: "standards" })
+    .first()
+    .click();
+}
+
+/** The note body's rendered box, or `null` where it has none. */
+async function noteBox(page: Page) {
+  return page.getByTestId("workspace-note").boundingBox();
+}
+
+test("a note opened at phone width renders with area", async ({ page }) => {
+  await page.setViewportSize(PHONE);
+  await openWorkspace(page);
+  await openSeededNote(page);
+
+  const box = await noteBox(page);
+  expect(box, "the note pane must lay out at phone width").not.toBeNull();
+  expect(box!.width).toBeGreaterThan(200);
+  expect(box!.height).toBeGreaterThan(40);
+  await expect(page.getByTestId("workspace-note")).toContainText("House conventions");
+});
+
+test("the note survives a width round trip", async ({ page }) => {
+  // Narrow, wide, narrow again. A one-shot layout race would recover on the
+  // second narrow; a collapse does not.
+  await page.setViewportSize(PHONE);
+  await openWorkspace(page);
+  await openSeededNote(page);
+  const first = await noteBox(page);
+
+  await page.setViewportSize(DESKTOP);
+  const wide = await noteBox(page);
+
+  await page.setViewportSize(PHONE);
+  const again = await noteBox(page);
+
+  for (const [label, box] of [
+    ["first narrow", first],
+    ["wide", wide],
+    ["narrow again", again],
+  ] as const) {
+    expect(box, `${label}: the note must have a box`).not.toBeNull();
+    expect(box!.width, `${label}: the note must have width`).toBeGreaterThan(200);
+    expect(box!.height, `${label}: the note must have height`).toBeGreaterThan(40);
+  }
+});
+
+test("the explorer is reachable again after opening a note at phone width", async ({ page }) => {
+  // Taking the column is only correct if it can be handed back — otherwise the
+  // fix trades an unreadable note for an unreachable list.
+  await page.setViewportSize(PHONE);
+  await openWorkspace(page);
+  await openSeededNote(page);
+
+  await page.getByRole("button", { name: "Toggle explorer" }).click();
+  await expect(page.getByTestId("workspace-tree")).toBeVisible();
+});
+
+test("both panes still share the column on a desktop viewport", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await openWorkspace(page);
+  await openSeededNote(page);
+
+  await expect(page.getByTestId("workspace-tree")).toBeVisible();
+  const box = await noteBox(page);
+  expect(box).not.toBeNull();
+  expect(box!.width).toBeGreaterThan(200);
+});


### PR DESCRIPTION
## Summary

At phone width, tapping a workspace note left the operator looking at the list
with the note laid out at **no size at all** — `boundingBox()` returns `null`,
not a small box. The note was unreadable and there was no way to reach it.

Below `md` the explorer and the note share one column, and `showExplorer`
decides which of them gets it. That flag is initialised `true` and **nothing
ever set it to `false`** — `open()` set the note id, the mode, and the draft,
but not this. So the note pane kept `hidden md:flex` and stayed `display:none`
at every width under 768px, on every note, forever.

The second half is why it felt inescapable: the in-pane **Toggle explorer**
control is rendered *inside the note pane*, so the one control that could have
handed the column over was itself inside the element that was hidden.

Opening a note now takes the column. Above `md` both panes are shown regardless
of the flag, so the change is inert there — verified below.

Two consequences had to be fixed with it:

- The **resizer** keyed off `showExplorer`, so with the flag now false on
  desktop it would have vanished the moment a note was opened. It is
  `hidden md:block` outright, which is what it always meant.
- The explorer took its resizable desktop width (256px) even when it owned the
  whole column, wasting a third of a 386px screen. It is full-width while it
  owns the column and keeps the resizable width from `md` up.

### Why column takeover rather than a sheet

The console already answers this. `InboxView` is the same master/detail shape at
the same breakpoint and does exactly this: `setMobilePane("read")` on selection,
with a Back control to hand the column back. Workspace had the same state
(`showExplorer`) and the same back control (**Toggle explorer**) — it simply
never moved the state. This aligns the two rather than introducing a third
pattern.

### Sibling sweep

Not a shared layout primitive — every master/detail surface here is hand-rolled,
so this is fixed where it lives. Enumerated:

| Surface | Mechanism | Mobile handling | Collapses at 386px? |
|---|---|---|---|
| `WorkspaceView` | flex + `showExplorer` | state existed, never set on open | **Yes — fixed here** |
| `InboxView` | flex + `mobilePane` | set on selection + Back | No — the working precedent |
| `PagesView:262` | list `hidden … md:flex`, detail always `flex` | none | Detail stays readable, but the **page list is unreachable** below `md` — a real sibling with a different failure (navigation, not readability). Not fixed here; it needs its own interaction decision. |
| `ChatView:2255` | `hidden lg:flex` members pane | deliberate, documented in-file | No (auxiliary pane; also held by another PR) |
| `WorkflowsView:3468` | `!hidden sm:!block` minimap | deliberate | No — decorative overlay, not a content pane |
| `window-title-bar:93`, `app-shell:3475` | `hidden lg:flex` / `hidden md:block` | deliberate chrome trim | No |

Settings, People/Team and the ledger surfaces carry no hidden-pane pattern at
all (Team uses responsive grid columns), so there is nothing of this shape to
fix there.

## API Or Behavior Changes

- Opening a workspace note below 768px now shows the note instead of staying on
  the explorer. **Toggle explorer** returns to the list.
- No change at or above 768px: both panes and the resizer behave exactly as
  before.
- No host or API change.

## Tests

`frontend/test/e2e/workspace-mobile-note.spec.ts` (new, 4 cases) at a real
386×800 Playwright viewport — not an iframe, and not device emulation.

Reproduced on **unmodified `main`** before any fix was written, which is also
the red proof:

```
3 failed, 1 passed
  ✗ a note opened at phone width renders with area
      → "the note pane must lay out at phone width"
        expect(received).not.toBeNull()   Received: null
  ✗ the note survives a width round trip
  ✗ the explorer is reachable again after opening a note at phone width
      → timed out waiting for "Toggle explorer" (it is inside the hidden pane)
  ✓ both panes still share the column on a desktop viewport
```

After the fix: **4 passed**. The desktop case passing both before and after is
the non-regression pin.

Measured on a local running build (debug binary serving the built console):

| Viewport | `workspace-note` before | after |
|---|---|---|
| 386 × 800 | `null` — no layout box | **360 × 364** |
| 900 × 800 | — | 396 × 316 |
| 1400 (live browser) | 672 × 268 | 672 × 268 — unchanged |

At 1400px with a note open, the explorer is still 256×683 and the resizer still
renders at 6×683 (`display: block`) — the regression the resizer change exists
to prevent.

The round-trip case narrows, widens and narrows again, which is what separates a
genuine collapse from a one-shot layout race.

Gates (each run separately, own exit code): `typecheck` 0 · `typecheck:unit` 0 ·
`typecheck:e2e` 0 · `vitest run` 4574 passed · `build` 0.

`vitest` is byte-identical to the `main` baseline — same 10 failures in the same
4 files (company create/reset, wallet mode, lifecycle reset), pre-existing and
untouched here. This branch adds no unit tests, so the passed count is unchanged
at 4574.

## Documentation

None needed — no spec or module surface changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace note and explorer behavior on small screens so opening a note displays it in the available single-column layout.
  * Preserved side-by-side note and explorer layouts on larger screens.
  * Improved workspace resizing and explorer toggling across different viewport sizes.

* **Tests**
  * Added end-to-end coverage for note rendering, viewport resizing, explorer toggling, and desktop layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->