### PR TITLE
fix(auth): scope the GraphQL read plane from the request, not the cookie jar

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1487,12 +1487,22 @@ export class OpenCompanyClient {
    * Deliberately untyped in `variables`/return shape: the caller (a page
    * author, indirectly) supplies an arbitrary document, so there is no fixed
    * response type to declare here the way every other method has one.
+   *
+   * Routed through {@link scope} like every REST call, so the company travels
+   * in the path. A document's own company argument is invisible to the host's
+   * auth layer, which runs before the body is read; naming it in the URL is
+   * what lets a browser holding a session per company on one origin be matched
+   * to the right one.
    */
   graphqlRequest(
     query: string,
     variables?: Record<string, unknown>,
+    company?: string | null,
   ): Promise<{ data?: unknown; errors?: unknown }> {
-    return this.request("POST", "/graphql", { query, variables });
+    return this.request("POST", `${this.scope(company)}/graphql`, {
+      query,
+      variables,
+    });
   }
 
   /**

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1499,9 +1499,21 @@ export class OpenCompanyClient {
     variables?: Record<string, unknown>,
     company?: string | null,
   ): Promise<{ data?: unknown; errors?: unknown }> {
-    return this.request("POST", `${this.scope(company)}/graphql`, {
-      query,
-      variables,
+    return this.request<{ data?: unknown; errors?: unknown }>(
+      "POST",
+      `${this.scope(company)}/graphql`,
+      { query, variables },
+    ).catch((err) => {
+      // A host predating the company-scoped route only serves bare `/graphql`
+      // and 404s on the scoped path — relevant to a hub/desktop console, whose
+      // hosts redeploy independently of it.
+      if (err instanceof ApiError && err.status === 404) {
+        return this.request<{ data?: unknown; errors?: unknown }>("POST", "/graphql", {
+          query,
+          variables,
+        });
+      }
+      throw err;
     });
   }
 

--- a/frontend/src/api/graphql.ts
+++ b/frontend/src/api/graphql.ts
@@ -46,8 +46,9 @@ export async function runQuery<T>(
   client: OpenCompanyClient,
   document: string,
   variables?: Record<string, unknown>,
+  company?: string | null,
 ): Promise<T> {
-  const response = await client.graphqlRequest(document, variables);
+  const response = await client.graphqlRequest(document, variables, company);
   const errors = Array.isArray(response?.errors)
     ? (response.errors as GraphQLErrorEntry[])
     : [];

--- a/frontend/src/api/graphql.ts
+++ b/frontend/src/api/graphql.ts
@@ -25,13 +25,33 @@ interface GraphQLErrorEntry {
   path?: (string | number)[];
 }
 
+/**
+ * Wire messages the read plane returns as bare codes, and what they mean to
+ * whoever is looking at the panel.
+ *
+ * A GraphQL error message is a protocol token, not prose. Rendering one
+ * verbatim puts a word like `unauthorized` on screen next to a retry that
+ * repeats the identical request and therefore fails identically — it names
+ * neither what went wrong nor what would fix it.
+ */
+const WIRE_MESSAGES: Record<string, string> = {
+  unauthorized: "Your session didn't cover this company. Sign in again to reload it.",
+  forbidden: "This company's data isn't visible to your account.",
+};
+
 /** Flattens an `errors` array into one operator-facing sentence. */
 function describe(errors: GraphQLErrorEntry[]): string {
   const messages = errors
     .map((e) => (typeof e?.message === "string" ? e.message : ""))
-    .filter(Boolean);
+    .filter(Boolean)
+    .map((m) => WIRE_MESSAGES[m] ?? m);
   if (messages.length === 0) return "the query was refused";
   return messages.join("; ");
+}
+
+/** Whether `errors` says the caller was refused rather than the query failed. */
+function isRefusal(errors: GraphQLErrorEntry[]): boolean {
+  return errors.some((e) => e?.message === "unauthorized" || e?.message === "forbidden");
 }
 
 /**
@@ -58,7 +78,10 @@ export async function runQuery<T>(
   // host considered this request and refused it, which is not the same as
   // something between the browser and the host giving up.
   if (errors.length > 0) {
-    throw new ApiError(200, "graphql_error", describe(errors), true);
+    // A distinct code, because a refusal and a failed read need different
+    // offers: retrying a refusal repeats it exactly.
+    const code = isRefusal(errors) ? "graphql_refused" : "graphql_error";
+    throw new ApiError(200, code, describe(errors), true);
   }
   if (response?.data === undefined || response.data === null) {
     throw new ApiError(200, "graphql_error", "the query returned no data", true);

--- a/frontend/src/api/observatory.ts
+++ b/frontend/src/api/observatory.ts
@@ -169,12 +169,12 @@ export async function fetchRunsForWorkflowRun(
   workflowRunId: string,
   limit = 50,
 ): Promise<ObservatoryRun[]> {
-  const data = await runQuery<RunsResult>(client, RUNS_QUERY, {
+  const data = await runQuery<RunsResult>(
+    client,
+    RUNS_QUERY,
+    { company, workflowRunId, taskId: null, limit },
     company,
-    workflowRunId,
-    taskId: null,
-    limit,
-  });
+  );
   return data.company?.agentRuns ?? [];
 }
 
@@ -184,12 +184,12 @@ export async function fetchRecentRuns(
   company: string,
   limit = 50,
 ): Promise<ObservatoryRun[]> {
-  const data = await runQuery<RunsResult>(client, RUNS_QUERY, {
+  const data = await runQuery<RunsResult>(
+    client,
+    RUNS_QUERY,
+    { company, workflowRunId: null, taskId: null, limit },
     company,
-    workflowRunId: null,
-    taskId: null,
-    limit,
-  });
+  );
   return data.company?.agentRuns ?? [];
 }
 
@@ -207,6 +207,6 @@ export async function fetchRun(
   company: string,
   id: string,
 ): Promise<ObservatoryRun | null> {
-  const data = await runQuery<RunResult>(client, RUN_QUERY, { company, id });
+  const data = await runQuery<RunResult>(client, RUN_QUERY, { company, id }, company);
   return data.company?.agentRun ?? null;
 }

--- a/frontend/src/views/observatory/ObservatoryView.tsx
+++ b/frontend/src/views/observatory/ObservatoryView.tsx
@@ -19,6 +19,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
 import {
   fetchRecentRuns,
   fetchRun,
@@ -59,7 +60,7 @@ type Load =
   | { phase: "loading" }
   | { phase: "ready"; runs: ObservatoryRun[] }
   | { phase: "unavailable" }
-  | { phase: "error"; message: string };
+  | { phase: "error"; message: string; retryable: boolean };
 
 export function ObservatoryView({ client, company, runId, eventTick }: Props) {
   const [load, setLoad] = useState<Load>({ phase: "loading" });
@@ -130,6 +131,7 @@ export function ObservatoryView({ client, company, runId, eventTick }: Props) {
           : {
               phase: "error",
               message: err instanceof Error ? err.message : "the read failed",
+              retryable: !(err instanceof ApiError && err.code === "graphql_refused"),
             },
       );
     }
@@ -237,9 +239,11 @@ export function ObservatoryView({ client, company, runId, eventTick }: Props) {
         <PageHeader title={runId ? "Run" : "Observatory"} />
         <div className="flex flex-col items-start gap-2 p-4">
           <p className="text-[var(--status-failed-text)] text-sm">{load.message}</p>
-          <Button variant="outline" size="sm" onClick={() => void reload()}>
-            Try again
-          </Button>
+          {load.retryable ? (
+            <Button variant="outline" size="sm" onClick={() => void reload()}>
+              Try again
+            </Button>
+          ) : null}
         </div>
       </div>
     );

--- a/frontend/test/unit/graphql-client.test.ts
+++ b/frontend/test/unit/graphql-client.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { runQuery } from "@/api/graphql";
+import { ApiError } from "@/api/types";
+
+/** A client that records what it was asked for and replays a canned answer. */
+function stub(response: { data?: unknown; errors?: unknown }) {
+  const calls: (string | null | undefined)[] = [];
+  const client = {
+    graphqlRequest: async (
+      _query: string,
+      _variables?: Record<string, unknown>,
+      company?: string | null,
+    ) => {
+      calls.push(company);
+      return response;
+    },
+  } as unknown as OpenCompanyClient;
+  return { client, calls };
+}
+
+/** Runs a document expected to be refused, and hands back the typed error. */
+async function refusalFrom(client: OpenCompanyClient): Promise<ApiError> {
+  try {
+    await runQuery(client, "{ company { id } }");
+  } catch (err) {
+    expect(err).toBeInstanceOf(ApiError);
+    return err as ApiError;
+  }
+  throw new Error("the query resolved when it should have been refused");
+}
+
+describe("the console's GraphQL entry point", () => {
+  it("carries the addressed company to the client", async () => {
+    const { client, calls } = stub({ data: { company: { id: "acme" } } });
+
+    await expect(runQuery(client, "{ company { id } }", { company: "acme" }, "acme")).resolves.toEqual({
+      company: { id: "acme" },
+    });
+    // The company travels beside the document, not only inside it: the host's
+    // auth layer runs before the body is read.
+    expect(calls).toEqual(["acme"]);
+  });
+
+  it("turns a refusal into a sentence and marks it unretryable", async () => {
+    const { client } = stub({ data: null, errors: [{ message: "unauthorized" }] });
+
+    const err = await refusalFrom(client);
+    expect(err.code).toBe("graphql_refused");
+    // The wire token must not reach the panel.
+    expect(err.message).not.toBe("unauthorized");
+    expect(err.message).toMatch(/sign in again/i);
+  });
+
+  it("names a forbidden read as a permission problem", async () => {
+    const { client } = stub({ data: null, errors: [{ message: "forbidden" }] });
+
+    const err = await refusalFrom(client);
+    expect(err.code).toBe("graphql_refused");
+    expect(err.message).toMatch(/isn't visible to your account/i);
+  });
+
+  it("leaves an ordinary resolver failure alone and retryable", async () => {
+    const { client } = stub({ data: null, errors: [{ message: "the store timed out" }] });
+
+    const err = await refusalFrom(client);
+    expect(err.code).toBe("graphql_error");
+    expect(err.message).toBe("the store timed out");
+  });
+});

--- a/frontend/test/unit/transport-seam.test.ts
+++ b/frontend/test/unit/transport-seam.test.ts
@@ -406,3 +406,47 @@ describe("a request deadline crossing the seam", () => {
     expect(typeof transport.seen.at(-1)!.timeoutMs).toBe("number");
   });
 });
+
+describe("graphqlRequest against a host predating the company-scoped route", () => {
+  it("retries bare /graphql when the scoped route 404s", async () => {
+    const t = new StubTransport((req) =>
+      req.url.endsWith("/api/v1/company/graphql")
+        ? { status: 404, text: "" }
+        : { text: '{"data":{"company":{"id":"acme"}}}' },
+    );
+    const client = clientOn(t, { baseUrl: "https://host.test" });
+
+    await expect(client.graphqlRequest("{ company { id } }")).resolves.toEqual({
+      data: { company: { id: "acme" } },
+    });
+    expect(t.seen.map((r) => r.url)).toEqual([
+      "https://host.test/api/v1/company/graphql",
+      "https://host.test/graphql",
+    ]);
+  });
+
+  it("carries the addressed company on the scoped attempt only", async () => {
+    const t = new StubTransport((req) =>
+      req.url.endsWith("/api/v1/companies/acme/graphql")
+        ? { status: 404, text: "" }
+        : { text: '{"data":{"company":{"id":"acme"}}}' },
+    );
+    const client = clientOn(t, { baseUrl: "https://host.test" });
+
+    await client.graphqlRequest("{ company { id } }", undefined, "acme");
+    expect(t.seen.map((r) => r.url)).toEqual([
+      "https://host.test/api/v1/companies/acme/graphql",
+      "https://host.test/graphql",
+    ]);
+  });
+
+  it("does not retry a refusal that is not a 404", async () => {
+    const t = new StubTransport(() => ({ status: 401, text: "" }));
+    const client = clientOn(t, { baseUrl: "https://host.test" });
+
+    await expect(client.graphqlRequest("{ company { id } }")).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(t.seen).toHaveLength(1);
+  });
+});

--- a/src/server/graphql/auth.rs
+++ b/src/server/graphql/auth.rs
@@ -170,14 +170,13 @@ pub fn resolve_claims(headers: &HeaderMap, state: &AppState) -> Result<GqlAuth, 
 /// Resolves the full principal: a valid session wins, else the machine
 /// credentials from [`resolve_claims`].
 ///
-/// `company` is the addressed company when the caller knows it (the REST
-/// routes, from the path or the sole registered company). Pass `None` when it
-/// is not knowable at resolution time — the GraphQL handler's company argument
-/// lives in the request body — and the carrier selects it: the cookie *name*,
-/// or the company embedded in the header value. With several session cookies
-/// present and no addressed company (only reachable in local dev, where one
-/// origin serves many companies) no user is resolved, because guessing which
-/// one the request meant would be worse than degrading.
+/// `company` is the addressed company when the caller knows it (the REST routes
+/// and the company-scoped GraphQL routes, from the `{id}` path param). Pass
+/// `None` on the alias forms and bare `/graphql`, where the carrier selects it:
+/// the company embedded in the header value, or the one session cookie naming a
+/// company **this host serves**. Several such cookies resolve no user, because
+/// guessing which one the request meant would be worse than degrading — the
+/// company-scoped routes are how a caller says which.
 ///
 /// A present-but-invalid session falls through to the bearer path rather than
 /// failing the request: a stale cookie must not brick an operator sharing the
@@ -402,7 +401,7 @@ async fn resolve_session(
     state: &AppState,
     company: Option<&CompanyId>,
 ) -> Option<UserPrincipal> {
-    let (company, token) = session_carrier(headers, company)?;
+    let (company, token) = session_carrier(headers, state, company)?;
     authenticate_session(state, company, &token).await
 }
 
@@ -417,8 +416,22 @@ async fn resolve_session(
 /// cookie rather than failing the request, matching the existing policy for a
 /// present-but-invalid cookie: a credential for somewhere else must not brick a
 /// request that had a valid one all along.
+///
+/// Without an addressed company the cookie jar is the only thing left to read,
+/// and it is scoped to the **origin** rather than to this host: a browser
+/// attaches every `oc_session_*` it holds for that hostname, and cookies ignore
+/// port, so a second host on the same machine — or a company since deleted, or
+/// a stray name any script on the origin can set — puts cookies here for
+/// companies this process has never served.
+///
+/// Only a company this host actually serves can be the one an unaddressed
+/// request meant, so the candidates are filtered to those first. Two survivors
+/// are genuinely ambiguous and resolve nobody; picking either would answer from
+/// a company the request never named. The company-scoped routes exist so a
+/// caller in that position can say which one it means.
 fn session_carrier(
     headers: &HeaderMap,
+    state: &AppState,
     company: Option<&CompanyId>,
 ) -> Option<(CompanyId, String)> {
     use crate::server::users::cookie::{
@@ -432,8 +445,6 @@ fn session_carrier(
     }
 
     let cookies = parse_cookies(headers);
-    // Resolve which company's cookie to read: the addressed one when known,
-    // else the sole session cookie present.
     match company {
         Some(id) => {
             let name = crate::server::users::cookie::session_cookie_name(id)?;
@@ -443,14 +454,15 @@ fn session_carrier(
             let mut sessions = cookies
                 .iter()
                 .filter_map(|(name, value)| {
-                    company_from_cookie_name(name).map(|id| (CompanyId::new(id), value.clone()))
+                    company_from_cookie_name(name).map(|id| (CompanyId::new(id), value))
                 })
+                .filter(|(id, _)| state.registry().get(id).is_some())
                 .collect::<Vec<_>>();
-            // Exactly one, or we cannot know which company was meant.
             if sessions.len() != 1 {
                 return None;
             }
-            Some(sessions.remove(0))
+            let (id, value) = sessions.remove(0);
+            Some((id, value.clone()))
         }
     }
 }

--- a/src/server/graphql/mod.rs
+++ b/src/server/graphql/mod.rs
@@ -54,10 +54,21 @@ pub fn sdl() -> String {
 ///
 /// `POST /graphql` serves queries; `GET /graphql` serves an embedded GraphiQL
 /// explorer for interactive use during development.
+///
+/// The same handler is also mounted through [`scoped`](crate::server::ops::scoped),
+/// giving `POST /api/v1/companies/{id}/graphql` alongside the
+/// `/api/v1/company/graphql` alias — the identical pair every REST route gets.
+/// A console addressing one of several companies on an origin names it in the
+/// path, exactly as it already does for REST, so the request says which company
+/// it means instead of the host inferring it.
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/graphql", post(graphql_handler))
         .route("/graphql", get(graphiql))
+        .merge(crate::server::ops::scoped(
+            "/graphql",
+            post(graphql_handler),
+        ))
 }
 
 /// The query root: the three top-level entry points into the read plane.
@@ -121,11 +132,13 @@ async fn graphql_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
     auth::MaybePeer(peer): auth::MaybePeer,
+    company: Option<axum::extract::Path<String>>,
     req: GraphQLRequest,
 ) -> GraphQLResponse {
-    // `None`: the company a query addresses lives in the request body, which is
-    // not available here, so a session cookie selects its own company by name.
-    let auth = match resolve_principal(&headers, &state, None, peer).await {
+    // Present on the `{id}` form, absent on the alias and on bare `/graphql`,
+    // where `resolve_principal` falls back to the sole registered company.
+    let addressed = company.map(|axum::extract::Path(id)| CompanyId::new(id));
+    let auth = match resolve_principal(&headers, &state, addressed.as_ref(), peer).await {
         Ok(auth) => auth,
         Err(_) => {
             let err = async_graphql::ServerError::new("unauthorized", None);

--- a/src/server/platform_auth.rs
+++ b/src/server/platform_auth.rs
@@ -406,7 +406,7 @@ pub(crate) fn forbidden() -> Response {
 ///
 /// The extractor resolves the addressed company from the `{id}` path param when
 /// present so a session cookie can be matched to it; on the single-company
-/// alias the sole session cookie selects itself.
+/// alias the registry's sole company is the addressed one.
 pub struct CompanyAuth(pub GqlAuth);
 
 impl FromRequestParts<AppState> for CompanyAuth {

--- a/src/server/users/auth_test.rs
+++ b/src/server/users/auth_test.rs
@@ -472,9 +472,198 @@ async fn a_session_cookie_cannot_reach_the_platform_plane() {
 }
 
 #[tokio::test]
+async fn a_second_session_cookie_does_not_hide_the_addressed_one() {
+    // A browser attaches every cookie for an origin, and cookies ignore port,
+    // so one browser holds a session per company ever signed into on that host
+    // — including companies this host has never heard of. None of that changes
+    // which company the request addresses.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, &["acme"]).await;
+    let token = seed_session(&state, "acme", UserRole::Member, UserStatus::Active).await;
+
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::header::COOKIE,
+        format!(
+            "{}; oc_session_ghost=stale; theme=dark",
+            cookie_header("acme", &token)
+        )
+        .parse()
+        .unwrap(),
+    );
+
+    // Unaddressed: the registry's sole company is the addressed one.
+    match resolve_principal(&headers, &state, None, None)
+        .await
+        .expect("a decoy cookie must not refuse the request")
+    {
+        GqlAuth::User(u) => assert_eq!(u.company, CompanyId::new("acme")),
+        other => panic!("expected a user, got {other:?}"),
+    }
+
+    // Addressed explicitly: same answer, by the same lookup.
+    match resolve_principal(&headers, &state, Some(&CompanyId::new("acme")), None)
+        .await
+        .expect("a decoy cookie must not refuse an addressed request")
+    {
+        GqlAuth::User(u) => assert_eq!(u.company, CompanyId::new("acme")),
+        other => panic!("expected a user, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn an_expired_cookie_beside_a_live_one_still_reads_as_ambiguous() {
+    // Both name companies this host serves, so both are candidates. Liveness is
+    // not consulted to break the tie: that would mean authenticating every
+    // cookie in the jar to decide which one the request meant, and the answer
+    // would still be a guess. The refusal is the conservative direction, and
+    // the company-scoped routes resolve it — see the test below.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, &["acme", "globex"]).await;
+    let live = seed_session(&state, "acme", UserRole::Member, UserStatus::Active).await;
+    let expired = seed_session(&state, "globex", UserRole::Member, UserStatus::Active).await;
+    let globex = CompanyId::new("globex");
+    let runtime = state.registry().get(&globex).unwrap();
+    let mut record = runtime
+        .sessions()
+        .find_by_token_hash(&globex, &sha256_hex(&expired))
+        .await
+        .unwrap()
+        .unwrap();
+    runtime
+        .sessions()
+        .delete(&globex, &record.id)
+        .await
+        .unwrap();
+    record.id = "s1-expired".into();
+    record.expires_at_millis = crate::ports::now_millis() - 1;
+    runtime.sessions().create(&globex, &record).await.unwrap();
+
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::header::COOKIE,
+        format!(
+            "{}; {}",
+            cookie_header("acme", &live),
+            cookie_header("globex", &expired)
+        )
+        .parse()
+        .unwrap(),
+    );
+    assert!(
+        resolve_principal(&headers, &state, None, None)
+            .await
+            .is_err(),
+        "two served companies in the jar stay ambiguous whatever their liveness"
+    );
+    // Naming the company is what resolves it, and the dead cookie is irrelevant.
+    match resolve_principal(&headers, &state, Some(&CompanyId::new("acme")), None)
+        .await
+        .unwrap()
+    {
+        GqlAuth::User(u) => assert_eq!(u.company, CompanyId::new("acme")),
+        other => panic!("expected a user, got {other:?}"),
+    }
+    // And the expired one authenticates nobody even when it is addressed.
+    assert!(
+        resolve_principal(&headers, &state, Some(&globex), None)
+            .await
+            .is_err(),
+        "an expired session must not authenticate its own company either"
+    );
+}
+
+#[tokio::test]
+async fn a_foreign_cookie_does_not_make_one_login_ambiguous() {
+    // Several companies served here, the caller signed into one of them, plus a
+    // cookie left by a company this host does not serve — a neighbouring host
+    // on the same hostname, or one since deleted. Only one candidate is real,
+    // so the request is not ambiguous and must still resolve.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, &["acme", "globex"]).await;
+    let token = seed_session(&state, "acme", UserRole::Member, UserStatus::Active).await;
+
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::header::COOKIE,
+        format!(
+            "{}; oc_session_elsewhere=stale",
+            cookie_header("acme", &token)
+        )
+        .parse()
+        .unwrap(),
+    );
+    match resolve_principal(&headers, &state, None, None)
+        .await
+        .expect("one served company plus a foreign cookie is not ambiguous")
+    {
+        GqlAuth::User(u) => assert_eq!(u.company, CompanyId::new("acme")),
+        other => panic!("expected a user, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn the_addressed_company_picks_its_cookie_out_of_a_shared_jar() {
+    // Two real companies on one origin, a live session for each. The address
+    // decides which one answers — never the jar's contents or its order.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, &["acme", "globex"]).await;
+    let acme = seed_session(&state, "acme", UserRole::Member, UserStatus::Active).await;
+    let globex = seed_session(&state, "globex", UserRole::Member, UserStatus::Active).await;
+
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::header::COOKIE,
+        format!(
+            "{}; {}",
+            cookie_header("acme", &acme),
+            cookie_header("globex", &globex)
+        )
+        .parse()
+        .unwrap(),
+    );
+
+    for name in ["acme", "globex"] {
+        match resolve_principal(&headers, &state, Some(&CompanyId::new(name)), None)
+            .await
+            .unwrap()
+        {
+            GqlAuth::User(u) => assert_eq!(u.company, CompanyId::new(name)),
+            other => panic!("expected a user, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn a_cookie_for_another_company_never_answers_for_the_addressed_one() {
+    // The jar holds a perfectly good session — for somewhere else. Reading it
+    // would answer from a company the request did not name.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, &["acme", "globex"]).await;
+    let globex = seed_session(&state, "globex", UserRole::Member, UserStatus::Active).await;
+
+    assert!(
+        resolve_principal(
+            &headers_with_cookie("globex", &globex),
+            &state,
+            Some(&CompanyId::new("acme")),
+            None,
+        )
+        .await
+        .is_err(),
+        "globex's session must not authenticate a request addressing acme"
+    );
+}
+
+#[tokio::test]
 async fn without_an_addressed_company_a_lone_cookie_selects_its_own() {
-    // The GraphQL path: the company lives in the request body, so the cookie
-    // name is the only signal.
+    // The unaddressed forms — bare `/graphql` and the `/api/v1/company`
+    // aliases. The host serves one company, so that is the one addressed.
     let home_dir = home();
     let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme"]).await;
@@ -491,8 +680,9 @@ async fn without_an_addressed_company_a_lone_cookie_selects_its_own() {
 
 #[tokio::test]
 async fn without_an_addressed_company_ambiguous_cookies_resolve_no_user() {
-    // Two companies' sessions in one jar (only reachable in local dev). Picking
-    // one would be a guess; degrade instead.
+    // Several companies registered, so no unaddressed request can name one.
+    // Picking from the jar would be a guess; degrade instead. The console
+    // addresses these hosts through the `{id}` routes.
     let home_dir = home();
     let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme", "globex"]).await;

--- a/src/server/users/cookie.rs
+++ b/src/server/users/cookie.rs
@@ -18,9 +18,11 @@
 //! session for company A — same origin, same cookie name, last write wins.
 //! Naming the cookie `oc_session_<company>` keeps them independent.
 //!
-//! It also gives the GraphQL handler a way to find the company: the resolver's
-//! company argument lives in the request *body*, which is unavailable when
-//! extractors run, but the cookie name carries it.
+//! The name is how a cookie is *looked up* once the request has established
+//! which company it addresses. It is not how that company is decided: the jar
+//! belongs to the origin and holds one cookie per company signed into on it, so
+//! reading a company out of it would answer from whichever the browser happened
+//! to send rather than the one the request named.
 //!
 //! ## Why the name is validated
 //!


### PR DESCRIPTION
## Summary

The GraphQL read plane resolved the caller's company from the browser's cookie
jar rather than from the request. `graphql_handler` passed `None` as the
addressed company, so `session_carrier` fell back to reading "the one session
cookie present" — counting every cookie whose name matched `oc_session_*`.

That set belongs to the **origin**, not to this host. A browser attaches every
such cookie for the hostname; cookies ignore port; and the suffix after the
prefix was never validated against anything. So a second OpenCompany host on the
same machine, a company since deleted, or any script on the origin could add a
name, push the count past one, and the request would resolve no user at all. The
console then rendered a bare `unauthorized` to a signed-in admin.

Reachability splits sharply. Near zero on hosted tenants, which get per-tenant
hostnames and therefore separate jars. Automatic for any self-hosted host serving
more than one company, and for any developer running two hosts on `localhost`.

Two changes, at the seam and in front of it:

- **The unaddressed fallback now filters candidates to companies this host
  actually serves before counting them.** Two survivors stay genuinely ambiguous
  and still resolve nobody, so nothing is loosened. This is one `.filter` and it
  also repairs the `/api/v1/company/*` alias routes, which reached the same code
  path and failed the same way.
- **The read plane is now mounted on the company-scoped routes** the REST surface
  already uses (`/api/v1/companies/{id}/graphql` plus the `/api/v1/company`
  alias), and the console addresses it through the same `scope()` helper as every
  other call. A query's own company argument lives in the request body, which the
  auth layer cannot see before it runs; the path is where a caller can say which
  company it means. This is what makes two real sessions on one origin work
  rather than merely refuse.

Deliberately **not** done: picking the first cookie, or relaxing the ambiguity
check. Either would convert a visible refusal into a silent read of the wrong
company. A query still cannot answer for a company the caller did not scope to —
verified below.

Also fixes the console half: a GraphQL error message is a protocol token, and
rendering `unauthorized` verbatim beside a "Try again" that repeats the identical
request told the operator neither what broke nor what would fix it.

## API Or Behavior Changes

- **New routes**: `POST /api/v1/companies/{id}/graphql` and
  `POST /api/v1/company/graphql`. Bare `POST /graphql` and the GraphiQL explorer
  at `GET /graphql` are unchanged and still served.
- **Session resolution on unaddressed routes** (bare `/graphql`, the
  `/api/v1/company/*` aliases, `GET /api/v1/companies`): a session cookie naming
  a company this host does not serve is now ignored instead of counted. Requests
  that previously failed on such a cookie now succeed; nothing that previously
  succeeded now fails. Two cookies for two served companies still resolve no
  user, as before.
- **Console**: `graphqlRequest` and `runQuery` take an optional company and route
  through the existing scope helper. `runQuery` raises `ApiError` with code
  `graphql_refused` (rather than `graphql_error`) for `unauthorized`/`forbidden`,
  carrying a sentence instead of the wire token; the observatory offers "Try
  again" only for failures a retry could fix.
- No schema change, no store change, no migration.

## Tests

Reproduced first on a running build, both halves. A signed-in **admin** with a
valid session got `200` from REST and `unauthorized` from GraphQL in the same
request pair from the same page, and the observatory rendered the bare word. The
trigger is exactly **two or more cookies matching `oc_session_<nonempty>`**,
regardless of validity or whether the company exists — unrelated cookies and an
empty suffix do not count, and the self-describing header carrier was never
affected.

Verified after the fix on a single-company host and a two-company host:

| Case | Before | After |
|---|---|---|
| no session cookie | refused | refused |
| one valid | ok | ok |
| one valid + decoy for a company not on this host | **refused** | ok |
| one valid + three decoys | **refused** | ok |
| multi-company host, one valid login | ok | ok (guarded by a test) |
| multi-company host, two valid logins, unaddressed | refused | refused |
| multi-company host, two valid logins, scoped route | n/a | each answers its own |
| expired cookie beside a live one | refused | refused (scoped route works) |
| valid cookie for a company the caller did not scope to | refused | refused |
| session revoked server-side, cookie still held | refused | refused |
| scoped to A, query asks for B, holding a valid B cookie | n/a | `forbidden` |

The last row is the one that matters: scoping to one company and querying another
returns `forbidden` even while holding a live cookie for the second, and
`{ companies { id } }` on a scoped route lists only the scoped company.

Commands run locally, each unpiped with its own exit code:

- [x] `cargo fmt --all -- --check` — 0
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` — 0
- [x] `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings` — 0
- [x] `cargo check --all-features` — 0
- [x] `cargo test --features openhuman,mcp,composio --lib server::users::auth_test` — 23 passed, 0 failed
- [x] `npm run typecheck` / `typecheck:unit` / `typecheck:e2e` — 0
- [x] `npx vitest run` — 4578 passed, 10 failed in 4 files
- [x] `npm run build` — 0
- [x] Manual verification on a local build (ports 8605 single-company, 8606 two-company)

N/A: `cargo build --all-targets` — `cargo check --all-features` plus the two
clippy lanes (which build all targets) cover the same compile surface.

The 10 vitest failures are pre-existing on `main` and unrelated — company
create/reset, wallet mode, lifecycle reset, connection console switch. Confirmed
by reverting the four changed frontend sources and re-running those four files:
identical 10 failures.

The two new positive cases are red-proofed. Reverting `graphql/auth.rs` alone and
re-running the suite fails exactly
`a_second_session_cookie_does_not_hide_the_addressed_one` and
`a_foreign_cookie_does_not_make_one_login_ambiguous`, both with `Unauthorized`.
The cross-company refusal tests pass against both old and new code, which is the
point — they pin what must not change.

## Documentation

Module docs corrected where they stated the old rule as the design: the cookie
module claimed the cookie name was how the GraphQL handler *finds* the company
(it is how a cookie is looked up once the company is known), and
`resolve_principal` / `CompanyAuth` described the single-cookie fallback. No
separate spec file covers this path.

### Related finding, not fixed here

`src/server/a2a.rs` resolves a company for `@handle` requests by falling back to
the sole registered company **while discarding the handle the request named** —
the one place found in a sweep of ambient scope resolution where a client-supplied
identifier is dropped rather than checked, in front of a path that runs a cycle
and journals into whichever company it picked. Different subsystem and different
change; called out so it is not lost.
