### PR TITLE
Guard a chat-only turn's reply against leaked tool-call markup

### DIFF
--- a/src/harness/built_in/chat_only_guard.rs
+++ b/src/harness/built_in/chat_only_guard.rs
@@ -131,7 +131,9 @@ mod tests {
 
     #[test]
     fn guard_replaces_a_bare_tool_call_tag() {
-        let leaked = r#"<tool_call id="call_1">{"name":"workspace_search","arguments":{}}</tool_call>"#.to_string();
+        let leaked =
+            r#"<tool_call id="call_1">{"name":"workspace_search","arguments":{}}</tool_call>"#
+                .to_string();
         assert_eq!(guard_suppressed_reply(leaked), FALLBACK_REPLY);
     }
 
@@ -143,8 +145,8 @@ mod tests {
 
     #[test]
     fn guard_replaces_a_plain_text_function_call_marker() {
-        let leaked = r#"function_call:{"call":"read_ledger","arguments":{"ledger":"tasks"}}"#
-            .to_string();
+        let leaked =
+            r#"function_call:{"call":"read_ledger","arguments":{"ledger":"tasks"}}"#.to_string();
         assert_eq!(guard_suppressed_reply(leaked), FALLBACK_REPLY);
     }
 

--- a/src/harness/built_in/chat_only_guard.rs
+++ b/src/harness/built_in/chat_only_guard.rs
@@ -1,0 +1,166 @@
+//! Guarding a suppressed turn's reply against a text-shaped tool call it
+//! never had to begin with (#2094).
+//!
+//! ## The leak
+//!
+//! `is_chat_only_turn()` sets `overrides.suppress_tools = true`
+//! (`mod.rs:1282`, the #1725 cheap-reply fast path): the provider request
+//! carries an empty tool schema, so the model cannot enter the tool loop.
+//! Nothing else about the turn changes. The system prompt is built exactly
+//! once, on the turn that finds `self.history.is_empty()`
+//! (`vendor/openhuman` `core_turn.rs`, `build_system_prompt`), and every later
+//! turn — suppressed or not — reuses those bytes verbatim so the inference
+//! backend's KV-cache prefix survives; that reuse is stated as deliberate
+//! there ("only baked into the system prompt on the very first turn"). So the
+//! turn that decides to suppress tools cannot also rewrite the workspace /
+//! ledger / sandbox / skills tool briefs already frozen into that prompt
+//! without either rebuilding it every turn (paying the cache-invalidation cost
+//! of a suppressed turn onto every ordinary turn that follows it) or adding a
+//! per-turn system-prompt override to openhuman's `TurnOverrides` — a change
+//! to the vendored crate this repo only consumes, not a fix reachable from
+//! here. So the model is told at length about tools it does not have on the
+//! wire this turn, and does the obvious thing: writes the call out as text.
+//! That text becomes the entire reply the operator reads.
+//!
+//! ## Why this is not `native_salvage`
+//!
+//! [`super::native_salvage::recover_text_tool_calls`] keys on
+//! `authorized_tool_names`, which is empty on a suppressed turn *by
+//! construction* — see that function's own doc comment, which calls the
+//! resulting no-op deliberate: recovering a call this turn never authorized
+//! would execute an action the operator explicitly declined to pay for
+//! ("Just chatting"). This module is the opposite of recovery. It never
+//! parses a call out to run one — it only keeps one from reaching the
+//! operator verbatim. That also makes it a different defect from issue #2092
+//! and PR #2093: those are about a turn that *offered* tools and got a
+//! text-shaped call back anyway. This is about a turn that offered none and
+//! told the model otherwise in its prompt.
+//!
+//! ## Detection, deliberately coarse
+//!
+//! A genuine "Just chatting" answer has no structural reason to contain an
+//! XML-ish `<tool_call>` / `<tool_calls>` / `<invoke>` / `<function_call>`
+//! tag, or a `function_call:{…}` / `tool_call:{…}` text prefix (the shape
+//! [`super::native_salvage`]'s own docs show a real model once wrote in the
+//! authorized case) — those are markup that leaked out of the model's own
+//! tool-calling chat template, not English. So detection deliberately does
+//! not try to surgically excise a matched span and stitch the surrounding
+//! prose back together: on a turn this short (#1725's fast path never has
+//! much prose to save), a best-effort splice risks handing the operator a
+//! grammatically broken half-sentence, which is arguably worse than the bug.
+//! Instead, any match flags the *whole reply* as compromised and swaps in a
+//! short, honest line rather than fabricate a stitched answer.
+//!
+//! The pattern is intentionally wider than #105's
+//! [`super::tool_dispatcher::AttrTolerantXmlDispatcher`] normalization (which
+//! only widens the bare `<tool_call>` family so it can still be *executed*):
+//! nothing here executes what it finds, so there is no cost to also catching
+//! a model's own special-token wrapper around the keyword — the exact shape
+//! #2094 reproduced was `<｜｜DSML｜｜tool_calls>` /
+//! `<｜｜DSML｜｜invoke name="workspace_search">`, neither of which is the plain
+//! `<tool_call id="…">` attribute form #105 normalizes.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// An open or close tag whose name contains one of the tool-call family
+/// keywords, tolerant of a short run of filler characters immediately before
+/// the keyword (a model's own special-token wrapper, e.g. `｜｜DSML｜｜`) and of
+/// an attribute run after it. Matched case-insensitively.
+///
+/// Wider on purpose than #105's `TOOL_CALL_ATTR_OPEN_RE`: that pattern must
+/// stay narrow because a false positive there mangles a tag before the
+/// vendored parser sees it and can silently swallow a real call. A false
+/// positive here only ever swaps a paragraph of chat for [`FALLBACK_REPLY`],
+/// so the pattern can afford to catch more.
+static TAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)</?[^>\s]{0,32}(tool_calls?|tool-call|invoke|function_call)[^>]{0,64}>")
+        .expect("static tool-call tag pattern must compile")
+});
+
+/// The plain-text call marker family `native_salvage::CALL_MARKERS` recovers
+/// on an authorized turn (`function_call:{…}`, `tool_call:{…}`, …) — the same
+/// shape is still tool-call markup, not an answer, when nothing authorized it.
+static PLAIN_CALL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\b(function_call|functioncall|tool_calls?)\s*:\s*\{")
+        .expect("static plain-text call marker pattern must compile")
+});
+
+/// What the operator sees in place of leaked tool-call markup.
+const FALLBACK_REPLY: &str =
+    "I'd need to look that up — ask me again without \"Just chatting\" so I can use my tools.";
+
+/// If `reply` looks like a text-shaped tool call rather than a chat answer,
+/// replace it with [`FALLBACK_REPLY`]; otherwise return it untouched.
+///
+/// Callers must only apply this to the reply of a turn that actually ran with
+/// `suppress_tools` set (#1725) — the fallback assumes the turn had no tool
+/// available to satisfy the request, which is not a safe assumption about an
+/// ordinary tool-authorized turn's reply (that path is `native_salvage`'s, not
+/// this one).
+pub fn guard_suppressed_reply(reply: String) -> String {
+    if TAG_RE.is_match(&reply) || PLAIN_CALL_RE.is_match(&reply) {
+        tracing::warn!(
+            chars = reply.chars().count(),
+            "[harness] chat-only turn's reply looked like a text-shaped tool call; \
+             replacing it with a fallback instead of showing the operator raw markup (#2094)"
+        );
+        FALLBACK_REPLY.to_string()
+    } else {
+        reply
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact repro shape from #2094: a native model's own DSML-style
+    /// special-token wrapper around `tool_calls` / `invoke` / `parameter`.
+    #[test]
+    fn guard_replaces_the_reported_dsml_markup() {
+        let leaked = "\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}tool_calls>\n\
+             <\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}invoke name=\"workspace_search\">\n\
+             <\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}parameter name=\"query\" string=\"true\">team.md</\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}parameter>\n\
+             </\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}invoke>\n\
+             </\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}tool_calls>";
+        // Prefix the opening delimiter with `<` — the module docs' literal
+        // reproduces the report's copy/pasted markup, which already opens on
+        // the special glyphs; build the real tag text here instead of via a
+        // long raw string to keep the escapes legible.
+        let leaked = format!("<{leaked}");
+        assert_eq!(guard_suppressed_reply(leaked), FALLBACK_REPLY);
+    }
+
+    #[test]
+    fn guard_replaces_a_bare_tool_call_tag() {
+        let leaked = r#"<tool_call id="call_1">{"name":"workspace_search","arguments":{}}</tool_call>"#.to_string();
+        assert_eq!(guard_suppressed_reply(leaked), FALLBACK_REPLY);
+    }
+
+    #[test]
+    fn guard_replaces_an_invoke_tag() {
+        let leaked = r#"<invoke name="workspace_search">{"query":"team.md"}</invoke>"#.to_string();
+        assert_eq!(guard_suppressed_reply(leaked), FALLBACK_REPLY);
+    }
+
+    #[test]
+    fn guard_replaces_a_plain_text_function_call_marker() {
+        let leaked = r#"function_call:{"call":"read_ledger","arguments":{"ledger":"tasks"}}"#
+            .to_string();
+        assert_eq!(guard_suppressed_reply(leaked), FALLBACK_REPLY);
+    }
+
+    #[test]
+    fn guard_leaves_an_ordinary_chat_reply_untouched() {
+        let reply = "The growth desk is staffed by Priya and Sam.".to_string();
+        assert_eq!(guard_suppressed_reply(reply.clone()), reply);
+    }
+
+    #[test]
+    fn guard_leaves_empty_and_whitespace_replies_untouched() {
+        assert_eq!(guard_suppressed_reply(String::new()), "");
+        assert_eq!(guard_suppressed_reply("   \n".to_string()), "   \n");
+    }
+}

--- a/src/harness/built_in/chat_only_guard.rs
+++ b/src/harness/built_in/chat_only_guard.rs
@@ -120,16 +120,12 @@ mod tests {
     /// special-token wrapper around `tool_calls` / `invoke` / `parameter`.
     #[test]
     fn guard_replaces_the_reported_dsml_markup() {
-        let leaked = "\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}tool_calls>\n\
+        let leaked = "<\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}tool_calls>\n\
              <\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}invoke name=\"workspace_search\">\n\
              <\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}parameter name=\"query\" string=\"true\">team.md</\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}parameter>\n\
              </\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}invoke>\n\
-             </\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}tool_calls>";
-        // Prefix the opening delimiter with `<` — the module docs' literal
-        // reproduces the report's copy/pasted markup, which already opens on
-        // the special glyphs; build the real tag text here instead of via a
-        // long raw string to keep the escapes legible.
-        let leaked = format!("<{leaked}");
+             </\u{ff5c}\u{ff5c}DSML\u{ff5c}\u{ff5c}tool_calls>"
+            .to_string();
         assert_eq!(guard_suppressed_reply(leaked), FALLBACK_REPLY);
     }
 

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -1730,8 +1730,23 @@ impl CompanyAgent {
         // B-120). `reply?` here would have discarded `usages` on every hard
         // failure — a wall-clock ceiling, a provider fault, an auth error —
         // and those attempts had already burned every token they read back.
+        //
+        // Issue #2094: this turn's frozen-at-turn-1 system prompt still
+        // advertises tool briefs a `suppress_tools` turn's own request no
+        // longer carries, so the model can write a tool call out as text
+        // instead of answering — and `native_salvage` deliberately does not
+        // catch it (its `authorized_tool_names` is empty on exactly this turn
+        // shape, on purpose: recovering here would execute a call this turn
+        // never authorized). Guard the reply text itself before it reaches
+        // the operator. `overrides` is `Copy`, so reading it here — after
+        // being handed to `agent.set_next_turn_overrides` well above — is the
+        // same suppression this turn actually ran with, not a stale copy.
         let outcome = reply.map(|reply| TurnOutcome {
-            reply,
+            reply: if overrides.suppress_tools {
+                chat_only_guard::guard_suppressed_reply(reply)
+            } else {
+                reply
+            },
             steps,
             hit_iteration_cap,
             // This is the built_in harness, not the ACP fold — the only

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -47,7 +47,6 @@ pub mod build;
 pub mod capability_budget;
 #[cfg(feature = "chargebee")]
 pub mod chargebee;
-pub mod chat_seed;
 /// Guarding a chat-only (`suppress_tools`) turn's reply against the tool-call
 /// markup its frozen-at-turn-1 system prompt can still provoke, since that
 /// prompt still advertises tool briefs the turn's own tool schema no longer
@@ -55,6 +54,7 @@ pub mod chat_seed;
 /// inert on this same turn shape — see [`chat_only_guard`]'s module docs for
 /// why the two do not overlap.
 mod chat_only_guard;
+pub mod chat_seed;
 mod checkpoint;
 pub mod composio;
 /// Issue #410: how a Composio action catalogue is narrowed and rendered for an

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -48,6 +48,13 @@ pub mod capability_budget;
 #[cfg(feature = "chargebee")]
 pub mod chargebee;
 pub mod chat_seed;
+/// Guarding a chat-only (`suppress_tools`) turn's reply against the tool-call
+/// markup its frozen-at-turn-1 system prompt can still provoke, since that
+/// prompt still advertises tool briefs the turn's own tool schema no longer
+/// carries (#2094). Applied after [`native_salvage`], which is deliberately
+/// inert on this same turn shape — see [`chat_only_guard`]'s module docs for
+/// why the two do not overlap.
+mod chat_only_guard;
 mod checkpoint;
 pub mod composio;
 /// Issue #410: how a Composio action catalogue is narrowed and rendered for an


### PR DESCRIPTION
## Repro

Send a "Just chatting" message (`deliverable: "chat"` on `POST /api/v1/companies/{id}/chat`) that asks for something a tool would answer, e.g. "Search the workspace for team.md and tell me who sits on the growth desk." The entire reply the operator sees is raw tool-call markup, e.g.:

```
<｜｜DSML｜｜tool_calls>
<｜｜DSML｜｜invoke name="workspace_search">
<｜｜DSML｜｜parameter name="query" string="true">team.md</｜｜DSML｜｜parameter>
</｜｜DSML｜｜invoke>
</｜｜DSML｜｜tool_calls>
```

The identical message without the chat intent answers correctly.

## Mechanism

`crate::runtime::delegation::is_chat_only_turn()` sets `overrides.suppress_tools = true` in `src/harness/built_in/mod.rs:1282` (the #1725 cheap-reply fast path) — the provider request then carries an empty tool schema, so the model cannot enter the tool loop. That part works as intended.

What does not follow it is the **system prompt**. I confirmed (`vendor/openhuman` `core_turn.rs`, `build_system_prompt`) that the prompt is built exactly once, on the turn where `self.history.is_empty()`, and every later turn — suppressed or not — reuses those bytes verbatim so the inference backend's KV-cache prefix survives ("only baked into the system prompt on the very first turn... reused verbatim on every turn"). The workspace/ledger/sandbox/skills tool briefs (assembled in `src/harness/built_in/build.rs`, baked into `persona` and handed to `SystemPromptBuilder::for_subagent`) are part of that frozen prompt. So a chat-only turn's own prompt still tells the model at length about tools it does not have on the wire this turn, and the model writes the call out as text instead of answering. That text is the entire reply.

Nothing catches it downstream, correctly: `native_salvage::recover_text_tool_calls` keys on `authorized_tool_names`, which is empty on a suppressed turn by construction — recovering (and executing) there would run an action this turn deliberately did not authorize.

## Which fix, and why

**Fix (2)**, not fix (1). I verified fix (1) — dropping the tool briefs from the prompt on a suppressed turn — is not reachable from this repo alone: the prompt is built once per session and frozen into history specifically to preserve the KV-cache prefix (see `build_system_prompt`'s own doc comment). Making a `suppress_tools` turn skip or rewrite that already-frozen prompt would require either rebuilding the whole system prompt on every turn (paying every ordinary turn's cache-invalidation cost to save one suppressed turn some tokens) or adding a per-turn system-prompt override to openhuman's `TurnOverrides` — which has no such field today, and adding one is a change to the vendored `openhuman` crate, out of this repo's boundary. That is a large refactor, so per the issue's own fallback clause I implemented fix (2) instead.

Fix (2): on a turn that ran with `suppress_tools` set, guard the visible reply — if it looks like a text-shaped tool call (an XML-ish `<tool_call>`/`<tool_calls>`/`<invoke>`/`<function_call>` tag, or a `function_call:{…}`/`tool_call:{…}` text prefix), replace it outright with a short, honest line instead of showing the operator raw markup. It never parses out or executes anything — no recovered call ever runs on this path.

## Change

- `src/harness/built_in/chat_only_guard.rs` (new): `guard_suppressed_reply` — detects tool-call-shaped markup and swaps in a fallback reply. Full mechanism writeup and rationale for the (deliberately coarse, whole-reply) detection strategy live in the module doc comment.
- `src/harness/built_in/mod.rs:1731-1746` (approx, in `run_with_steer`): apply the guard to the reply exactly when `overrides.suppress_tools` was true for this turn, right before constructing `TurnOutcome`.
- `src/harness/built_in/mod.rs` module list: added the `chat_only_guard` module declaration/doc.

## Commands run (all from the worktree)

- `cargo fmt` — clean, no diffs beyond the new/edited files.
- `cargo clippy --lib --features openhuman -- -D warnings` — `Finished` with 0 errors (two pre-existing warnings shown are in the vendored `openhuman` crate, unrelated to this change).
- `cargo test --lib --features openhuman chat_only_guard` — `test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 6958 filtered out`.
- `cargo test --lib --features openhuman harness::built_in` — `test result: ok. 1491 passed; 0 failed; 0 ignored; 0 measured; 5473 filtered out` (regression check, no failures introduced).

## Adjacent work, not touched

Issue #2092 and PR #2093 (branch `native-salvage-dsml`) are about a turn that *offered* tools and got a text-shaped call back anyway — a different defect from this one, where the turn offered no tools at all. This branch does not include or depend on `native-salvage-dsml`'s changes, and does not alter `native_salvage.rs`'s behavior on an authorized turn.

Closes #2094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chat-only replies no longer display leaked tool-call markup.
  - Replies containing unsupported tool-call formats are replaced with a clear fallback message.
  - Ordinary, empty, and whitespace-only chat responses remain unchanged.
  - Improved handling covers multiple tool-call formats, including XML-like and plain-text markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->