### PR TITLE
fix(console): repair frontend unit tests broken on main

### DIFF
--- a/frontend/src/components/create-company-dialog.tsx
+++ b/frontend/src/components/create-company-dialog.tsx
@@ -218,11 +218,8 @@ export function CreateCompanyDialog({
     setWallet("");
     setAuthMode("email");
     setPreflightFailed(false);
-    // Re-armed on every open, gated the same way the fetch effect below is:
-    // a client with no platform bearer never runs that fetch (its trigger
-    // is already disabled per `canCreateCompanies`), so nothing will ever
-    // resolve this — leaving it `true` would refuse every submit forever.
-    setPreflightPending(canCreateCompanies(client));
+    // Re-armed on every open, gated the same way the fetch effect below is.
+    setPreflightPending(client.carriesPlatformBearer);
     setPolicyMode(DEFAULT_POLICY_MODE);
     // Reset pre-seeds a fresh id rather than leaving this blank: the name
     // field above is pre-filled with the archived company's own name, and an
@@ -249,10 +246,11 @@ export function CreateCompanyDialog({
   // Read the host's sign-in mode on open, so the form asks for a wallet address
   // on a wallet-mode host and an admin email otherwise — and so a wallet-mode
   // refusal is caught in `submit` BEFORE the reset's archive leg, not after it.
-  // Only a platform bearer can reach the preflight; the triggers are already
-  // gated on that, so a client without one keeps the default email behaviour.
+  // Gated on the raw bearer, not `canCreateCompanies`: whether this client can
+  // reach the preflight route is independent of whether the product currently
+  // offers company creation at all.
   useEffect(() => {
-    if (!request || !canCreateCompanies(client)) return;
+    if (!request || !client.carriesPlatformBearer) return;
     let cancelled = false;
     client
       .provisioningInfo()


### PR DESCRIPTION
## Summary

Three frontend unit test files fail on a clean checkout of current `main` (verified against `d304ab8df` with a fresh `npm ci`). The `Console` CI job is path-filtered and skips on `main`, so none of this is caught by main's own CI — it only surfaces on PRs that happen to touch `frontend/`, which is why four currently-open PRs (#2086, #2087, #2088, #2091) are red for a reason that has nothing to do with their own diffs.

Root cause: `fix(console): gate company creation where every trigger asks, not per button` redefined `canCreateCompanies(client)` to also fold in the product-wide `COMPANY_SWITCHING_HIDDEN` flag (pinned `true`). That's the right call for trigger buttons — every entry point to company creation/reset should ask the same question. But `create-company-dialog.tsx` was also using `canCreateCompanies` for two purposes that have nothing to do with trigger visibility: seeding its own `preflightPending` state and gating its own provisioning-preflight fetch. Once that function started returning `false` unconditionally, an already-open dialog could never learn the host's sign-in mode — it silently stuck on the "email" default, unable to detect a wallet-mode host or a preflight failure, no matter what the client actually carries.

That widened gate also — correctly, per the same commit — hid the "Reset / Start clean" button in Settings and the no-company screen's "New company" trigger, both of which two other tests still asserted render unconditionally on `client.carriesPlatformBearer`.

## API Or Behavior Changes

**Product-side fix** (`frontend/src/components/create-company-dialog.tsx`): the dialog's internal preflight-fetch effect and its `preflightPending` seed now key on `client.carriesPlatformBearer` directly instead of `canCreateCompanies(client)`. Whether this client can reach the provisioning-preflight route is independent of whether the product currently *offers* company creation at all — that's a trigger-visibility question the triggers already ask before this dialog ever opens. No behavior changes for an operator today, since every trigger into this dialog is currently gated shut by `COMPANY_SWITCHING_HIDDEN` regardless; this only matters once that flag is ever flipped back, or for any future code path that opens the dialog directly.

**Test-side fixes** (no product code touched):
- `settings-lifecycle-reset-button.test.ts` — the Reset button's render gate (`onReset && platform && !archived`) now correctly folds in `COMPANY_SWITCHING_HIDDEN` via `canCreateCompanies`, per the intentional change above. This suite was written to test `LifecycleControls`'s own bearer/lifecycle contract in isolation (per its own docstring), so `COMPANY_SWITCHING_HIDDEN` is mocked back to `false` for this file rather than weakening or deleting any of its four render-gate cases.
- `connection-console-switch-known-status.test.ts` — same story: the no-company screen's "New company" trigger this test drives through to reach the create dialog is gated the same way, and is incidental to what the file actually pins (`switchCompany` skipping its redundant `client.status()` re-fetch after a create). Same mock, same reasoning.

## Tests

- [x] `npx vitest run` — 495 files / 4584 tests, all pass (was 7 failed / 4 passed across the two files named below before the fix; a third file, `connection-console-switch-known-status.test.ts`, was also silently broken by the same regression and is fixed here too)
- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npm run build`

No lint script exists in this repo.

## Documentation

None needed — this is a test-infrastructure fix plus a small internal gating correction, no public API or documented behavior changed.

## Follow-up (not fixed here)

`Console` CI is path-filtered and skips on `main` entirely, so a backend-only merge (like the one that introduced this regression) can silently break frontend unit tests and `main` stays green. That's the ratchet that let this land unnoticed until it started red-blocking unrelated PRs. Worth fixing separately — either running `Console` unconditionally on `main` pushes, or running it on every PR regardless of path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where company creation could remain stuck during preflight validation and prevent submissions for users with platform credentials.
  - Company creation requests now complete preflight validation correctly, including in configurations where company switching is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->