### PR TITLE
feat(hivemind): private asides, tinyhivemind bump, and a vending-machine bundle that exercises agent-to-agent comms

### DIFF
--- a/companies/vending_machine_co/README.md
+++ b/companies/vending_machine_co/README.md
@@ -108,8 +108,27 @@ operator later installs.
 
 ```bash
 # 1. Memory. CortexDB is a standalone service on :3141, not the removed in-pod
-#    tinycortex engine. The script starts (or reuses) it and prints the exports.
+#    tinycortex engine. The script starts (or reuses) a local one and prints the
+#    exports:
 eval "$(./scripts/cortexdb-up.sh)"
+#
+#    …but prefer a shared instance that is actually provisioned. A local
+#    container started by that script has no LLM router and no embedding
+#    endpoint wired, and its ranked-recall index then lags the write by
+#    *minutes* — far past the driver's 4s read-after-write check
+#    (`INGEST_RECALL_VISIBILITY_TIMEOUT`), so every agent turn fails at its
+#    first `memory_store` and the desk reports every seat as unfinished. The
+#    failure names `/v1/recall` and looks like a driver bug; it is an
+#    unprovisioned instance. Point at one with an LLM/embedding endpoint
+#    instead — e.g. the shared box on the tailnet:
+#
+#      export OPENCOMPANY_MEMORY=remote
+#      export OPENCOMPANY_MEMORY_DRIVER=cortexdb
+#      export OPENCOMPANY_MEMORY_URL=http://<host>:3141
+#      export OPENCOMPANY_MEMORY_API_KEY=<that instance's CORTEX_API_KEY>
+#      export OPENCOMPANY_MEMORY_ACTOR=service:opencompany
+#
+#    Check before you run: a store→recall round trip has to complete in seconds.
 
 # 2. The company.
 OPENCOMPANY_INFERENCE_URL=http://127.0.0.1:6969/v1 \

--- a/companies/vending_machine_co/README.md
+++ b/companies/vending_machine_co/README.md
@@ -134,10 +134,13 @@ The operational truth lives in the MCP server; duplicating it here would produce
 two records that disagree by the end of the week. These four hold what the
 server cannot:
 
-- **`decisions`** — the *reasoning*. A transcript scrolls out of a
+- **`episodes`** — the *reasoning*. A transcript scrolls out of a
   thirty-message window and nobody re-reads one to learn why the van skipped
   Vulcan for a fortnight. The `not_doing` field is the most useful and the most
-  likely to be left empty.
+  likely to be left empty. (Named `episodes` and not `decisions` because
+  `decisions` is a built-in ledger the runtime ships and a declared slug may not
+  shadow one — and the two are different records anyway: the built-in holds the
+  company's standing calls, this holds what one deliberation concluded.)
 - **`clients`** — what each host was *promised*, and by whom. A promise nobody
   wrote down is one this company will break by accident.
 - **`incidents`** — the *pattern*. One jam is an event; VM-301 jamming four

--- a/companies/vending_machine_co/README.md
+++ b/companies/vending_machine_co/README.md
@@ -1,0 +1,138 @@
+# Northgate Vending
+
+A vending-machine operator: eight machines at five host sites, a finite
+warehouse behind them, and host contracts that renew whether or not anybody
+prepared for it. Three hive-mind desks run it.
+
+Every other hive bundle here answers a **question** — `hive_math_lab` solves a
+stated Project Euler problem and stops. This one runs an **operation**. Work
+arrives on its own, through `[[schedule]]` cadences and the
+`POST /hooks/{company}/{channel}` webhook path, and nothing in the world
+restocks itself.
+
+## What this bundle is for: agent-to-agent communication
+
+The decisions worth watching here are the ones no single desk can make
+correctly:
+
+- *Which machines does the van visit today?* is an **ops** question whose right
+  answer depends on which host site is about to renew badly — which is
+  **commercial's** knowledge.
+- *Do we raise the price of the energy line at the gym?* is a **commercial**
+  question whose right answer depends on whether that machine's chiller is
+  reliable — which is **ops'** knowledge.
+
+So all three desks run with cross-desk referral on. A member mid-episode may put
+a question to a peer desk, that desk takes one real turn on it, and the answer
+comes home under `hive-referral`.
+
+The constraint that makes this sound rather than merely chatty: **what crosses a
+visibility boundary carries information, never support.** A referred answer adds
+no supporter to anything and moves no option toward a decision — the asking desk
+still has to convince itself. A desk that could import a quorum from elsewhere
+would be a desk that never had to be convinced. See
+[`hivemind-referral.md`](../../docs/spec/runtime/hivemind-referral.md).
+
+## The three desks
+
+| Desk | Members | Quorum / budget | Owns |
+| --- | --- | --- | --- |
+| `ops` | `route_planner`, `fleet_tech`, `stock_controller`, `field_realist` | 2 of 4, 12 turns | The van's finite day: route, shelves, faults |
+| `commercial` | `account_manager`, `pricing_analyst`, `contract_counsel` | 2 of 3, 9 turns | Margin, prices, host sites, contracts |
+| `intel` | `market_scout`, `demand_analyst` | 2 of 2, 6 turns | What the market did, and whether it changes a plan |
+
+Each desk restricts its seats' moves (`[group_chat.hive.moves]`), and the
+restrictions carry the design:
+
+- On `ops` only the **route planner** may `!propose`. Three seats proposing
+  three near-identical routes is a room that votes rather than deliberates —
+  the live failure `docs/spec/runtime/hivemind.md` records. The fleet
+  technician and stock controller ground or `!refute` the plan from the two
+  constraints that actually bind, and the **field realist** may never
+  `!support` at all: a seat that both objects and supports drifts into being a
+  second planner, and the room loses the one member whose incentive is purely
+  to find the flaw.
+- On `commercial` **two** seats may propose, because a commercial question has
+  two genuinely different framings — what we charge, and what we sign — and
+  forcing both through one seat produces a plan that is only ever one of them.
+  **Counsel proposes nothing and may `!refute` anything**: its whole job is to
+  be the seat that says no with a citation.
+- `intel` is two members, the smallest room that is still a room, at a quorum
+  of two — unanimity. A room of two that could carry on one supporter is a
+  single responder with extra steps.
+
+`require_evidential` is on for all three, so a `!support` with no `^citation`
+adds nothing to quorum. In this company that bites hardest on the stock
+controller: "we have enough stock" is a claim about a number
+`warehouse_status` will actually print.
+
+## Tool servers
+
+The company's entire work environment is one MCP server, `vending`, declared in
+[`mcp.json`](mcp.json). It exposes the fleet, the warehouse and lead times,
+margin, host clients, incidents and the market feed — plus the writes that
+change any of them: restock, service, order, price, renegotiate. Every read an
+agent makes and every change it causes is a tool call, which is what makes a
+run auditable and replayable.
+
+`vending` **ships disabled**, pointing at a placeholder hosted URL and naming an
+`authSecret`. That is deliberate: a bundle-declared server must be `https` and
+must not ship enabled while it needs a credential nobody has provisioned. For a
+local run you do not enable it — you run the simulator on loopback and register
+it at **runtime**, which is the only layer where an `http://` endpoint is
+accepted. `scripts/vending-sim.py` does that for you.
+
+The grant that reaches it is `mcp:vending`, named explicitly in `[tools].allow`.
+A wildcard cannot reach an MCP server by design (`grants_cover_server`), so a
+company that wildcarded its belt does not silently acquire every server an
+operator later installs.
+
+## Running it
+
+```bash
+# 1. Memory. CortexDB is a standalone service, not the removed in-pod engine;
+#    the script prints the OPENCOMPANY_MEMORY_* exports to use.
+./scripts/cortexdb-up.sh
+
+# 2. The company.
+OPENCOMPANY_INFERENCE_URL=http://127.0.0.1:6969/v1 \
+OPENCOMPANY_INFERENCE_KEY=$LADDER_API_KEY \
+OPENCOMPANY_AUTH_MODE=none \
+  cargo run --features openhuman,mcp --bin opencompany -- \
+    serve --company companies/vending_machine_co
+
+# 3. The world, the MCP server, and the trigger loop — one command.
+python3 scripts/vending-sim.py --days 14
+```
+
+`vending-sim.py` starts the simulator, registers it as a runtime MCP server,
+then advances the clock a day at a time, posting each day's triggers into the
+company and waiting for the desks to answer. It reports what each episode
+decided, which desks asked each other questions, and what the fleet was worth
+at the end.
+
+## The ledgers
+
+The operational truth lives in the MCP server; duplicating it here would produce
+two records that disagree by the end of the week. These four hold what the
+server cannot:
+
+- **`decisions`** — the *reasoning*. A transcript scrolls out of a
+  thirty-message window and nobody re-reads one to learn why the van skipped
+  Vulcan for a fortnight. The `not_doing` field is the most useful and the most
+  likely to be left empty.
+- **`clients`** — what each host was *promised*, and by whom. A promise nobody
+  wrote down is one this company will break by accident.
+- **`incidents`** — the *pattern*. One jam is an event; VM-301 jamming four
+  times in a month is a machine that needs replacing, and no list of open
+  incidents will ever say so.
+- **`signals`** — observation kept apart from inference, because a correct
+  observation with a wrong inference and a wrong observation with a lucky one
+  look identical afterwards.
+
+## What the operator decides
+
+`[policy]` is `supervised`, and the desks act on the fleet themselves —
+restocking and pricing are the job. What stays with a human is money and
+commitments: `place_order` and `renegotiate_contract` are on `always_approve`,
+so a headless run has to pump the approvals queue (the driver does).

--- a/companies/vending_machine_co/README.md
+++ b/companies/vending_machine_co/README.md
@@ -107,9 +107,9 @@ operator later installs.
 ## Running it
 
 ```bash
-# 1. Memory. CortexDB is a standalone service, not the removed in-pod engine;
-#    the script prints the OPENCOMPANY_MEMORY_* exports to use.
-./scripts/cortexdb-up.sh
+# 1. Memory. CortexDB is a standalone service on :3141, not the removed in-pod
+#    tinycortex engine. The script starts (or reuses) it and prints the exports.
+eval "$(./scripts/cortexdb-up.sh)"
 
 # 2. The company.
 OPENCOMPANY_INFERENCE_URL=http://127.0.0.1:6969/v1 \
@@ -119,14 +119,23 @@ OPENCOMPANY_AUTH_MODE=none \
     serve --company companies/vending_machine_co
 
 # 3. The world, the MCP server, and the trigger loop — one command.
-python3 scripts/vending-sim.py --days 14
+python3 scripts/vending-sim.py --days 14 --out /tmp/vending-run.json
 ```
 
+Memory matters more here than in a one-shot bundle. A desk carries what it
+learned between episodes (`hive/<desk>/…`), and this company runs for simulated
+weeks — so "we already decided not to visit Vulcan on Tuesdays, and why" is
+knowledge day 9 needs and day 2 produced. Without a durable store behind it
+every morning starts from nothing, and the desks re-litigate the same route.
+
 `vending-sim.py` starts the simulator, registers it as a runtime MCP server,
-then advances the clock a day at a time, posting each day's triggers into the
-company and waiting for the desks to answer. It reports what each episode
-decided, which desks asked each other questions, and what the fleet was worth
-at the end.
+then advances the clock a day at a time. For each desk it posts the day's
+triggers and waits for the room to close, pumping the approvals queue
+meanwhile — the chat POST holds open for the whole episode and a parked
+`place_order` would otherwise deadlock it. It prints each episode's turns,
+its private asides and how many were surfaced, the text of every cross-desk
+referral, and the close. Exit status is the number of days on which no desk
+decided anything, so zero means the company was awake throughout.
 
 ## The ledgers
 

--- a/companies/vending_machine_co/README.md
+++ b/companies/vending_machine_co/README.md
@@ -26,11 +26,28 @@ So all three desks run with cross-desk referral on. A member mid-episode may put
 a question to a peer desk, that desk takes one real turn on it, and the answer
 comes home under `hive-referral`.
 
-The constraint that makes this sound rather than merely chatty: **what crosses a
-visibility boundary carries information, never support.** A referred answer adds
-no supporter to anything and moves no option toward a decision — the asking desk
-still has to convince itself. A desk that could import a quorum from elsewhere
-would be a desk that never had to be convinced. See
+The `ops` desk also turns on the other seam, the one that stays *inside* a desk:
+**private asides**. Its fleet technician and stock controller may compare notes
+in a line the rest of the room cannot read — "is VM-301's chiller reliable
+enough to put sandwiches back in it" is a question those two settle in two lines,
+and settling it on the floor costs the room two of its twelve turns watching a
+conversation with no bearing on the route until it has an answer. The row is
+**elided, never removed**: everyone still sees that the exchange happened, who
+was in it, and where it settled, and a `^N` citation naming it still resolves.
+The pair then owes the room a `!surface` in the open.
+
+Asides are auditable, **not confidential** — an operator and every person reads
+one in full. They are on for this one desk and off everywhere else in the repo
+on purpose: upstream measured the mechanism and it *lost* on answer quality, so
+enabling it is a decision about this desk rather than a default anybody
+inherits. See [`hivemind-asides.md`](../../docs/spec/runtime/hivemind-asides.md).
+
+One rule governs both seams, and it is what makes this sound rather than merely
+chatty: **what crosses a visibility boundary carries information, never
+support.** A referred answer and a private line each add no supporter and move
+no option toward a decision — the asking desk still has to convince itself. A
+desk that could import a quorum from elsewhere, or assemble one where the room
+cannot see it, would be a desk that never had to be convinced. See
 [`hivemind-referral.md`](../../docs/spec/runtime/hivemind-referral.md).
 
 ## The three desks

--- a/companies/vending_machine_co/agents/account_manager.toml
+++ b/companies/vending_machine_co/agents/account_manager.toml
@@ -1,0 +1,14 @@
+role = "Account Manager"
+description = "Own the host relationships: what each site was promised, what it is actually getting, and what it will cost to keep."
+tier = "reasoning"
+context = ["GOAL.md", "brief.md", "board.md"]
+
+tools = ["workspace", "docs", "mcp:vending"]
+
+ledgers = [
+    { name = "clients", access = "record" },
+    { name = "decisions", access = "record" },
+    { name = "incidents", access = "read" },
+]
+
+prompt_files = ["prompts/account_manager.md"]

--- a/companies/vending_machine_co/agents/account_manager.toml
+++ b/companies/vending_machine_co/agents/account_manager.toml
@@ -7,7 +7,7 @@ tools = ["workspace", "docs", "mcp:vending"]
 
 ledgers = [
     { name = "clients", access = "record" },
-    { name = "decisions", access = "record" },
+    { name = "episodes", access = "record" },
     { name = "incidents", access = "read" },
 ]
 

--- a/companies/vending_machine_co/agents/contract_counsel.toml
+++ b/companies/vending_machine_co/agents/contract_counsel.toml
@@ -1,0 +1,13 @@
+role = "Contract Counsel"
+description = "The seat that says no with a citation: what a proposed term actually commits this company to, and where it has bitten before."
+tier = "reasoning"
+context = ["GOAL.md", "brief.md"]
+
+tools = ["workspace.read", "docs", "mcp:vending"]
+
+ledgers = [
+    { name = "clients", access = "read" },
+    { name = "decisions", access = "record" },
+]
+
+prompt_files = ["prompts/contract_counsel.md"]

--- a/companies/vending_machine_co/agents/contract_counsel.toml
+++ b/companies/vending_machine_co/agents/contract_counsel.toml
@@ -7,7 +7,7 @@ tools = ["workspace.read", "docs", "mcp:vending"]
 
 ledgers = [
     { name = "clients", access = "read" },
-    { name = "decisions", access = "record" },
+    { name = "episodes", access = "record" },
 ]
 
 prompt_files = ["prompts/contract_counsel.md"]

--- a/companies/vending_machine_co/agents/demand_analyst.toml
+++ b/companies/vending_machine_co/agents/demand_analyst.toml
@@ -7,7 +7,7 @@ tools = ["workspace.read", "docs", "mcp:vending"]
 
 ledgers = [
     { name = "signals", access = "record" },
-    { name = "decisions", access = "record" },
+    { name = "episodes", access = "record" },
 ]
 
 prompt_files = ["prompts/demand_analyst.md"]

--- a/companies/vending_machine_co/agents/demand_analyst.toml
+++ b/companies/vending_machine_co/agents/demand_analyst.toml
@@ -1,0 +1,13 @@
+role = "Demand Analyst"
+description = "Decide which observed signals should change a plan, name the desk it lands on, and say what would have to be true for the inference to hold."
+tier = "reasoning"
+context = ["GOAL.md", "brief.md"]
+
+tools = ["workspace.read", "docs", "mcp:vending"]
+
+ledgers = [
+    { name = "signals", access = "record" },
+    { name = "decisions", access = "record" },
+]
+
+prompt_files = ["prompts/demand_analyst.md"]

--- a/companies/vending_machine_co/agents/field_realist.toml
+++ b/companies/vending_machine_co/agents/field_realist.toml
@@ -1,0 +1,14 @@
+role = "Field Realist"
+description = "Attack the plan's contact with reality — the drive time, the locked door, the pallet that will not fit through it — rather than its arithmetic."
+# No tier: this seat is not asked to reason about a trade-off, only to notice
+# what a plan assumed. `chat-v1` is the right price for that.
+context = ["GOAL.md", "brief.md"]
+
+tools = ["workspace.read", "mcp:vending"]
+
+ledgers = [
+    { name = "decisions", access = "read" },
+    { name = "incidents", access = "read" },
+]
+
+prompt_files = ["prompts/field_realist.md"]

--- a/companies/vending_machine_co/agents/field_realist.toml
+++ b/companies/vending_machine_co/agents/field_realist.toml
@@ -7,7 +7,7 @@ context = ["GOAL.md", "brief.md"]
 tools = ["workspace.read", "mcp:vending"]
 
 ledgers = [
-    { name = "decisions", access = "read" },
+    { name = "episodes", access = "read" },
     { name = "incidents", access = "read" },
 ]
 

--- a/companies/vending_machine_co/agents/fleet_tech.toml
+++ b/companies/vending_machine_co/agents/fleet_tech.toml
@@ -7,7 +7,7 @@ tools = ["workspace.read", "docs", "mcp:vending"]
 
 ledgers = [
     { name = "incidents", access = "record" },
-    { name = "decisions", access = "read" },
+    { name = "episodes", access = "read" },
 ]
 
 prompt_files = ["prompts/fleet_tech.md"]

--- a/companies/vending_machine_co/agents/fleet_tech.toml
+++ b/companies/vending_machine_co/agents/fleet_tech.toml
@@ -1,0 +1,13 @@
+role = "Fleet Technician"
+description = "Read the machines: faults, service age, and which lines are actually about to run dry."
+tier = "reasoning"
+context = ["GOAL.md", "brief.md"]
+
+tools = ["workspace.read", "docs", "mcp:vending"]
+
+ledgers = [
+    { name = "incidents", access = "record" },
+    { name = "decisions", access = "read" },
+]
+
+prompt_files = ["prompts/fleet_tech.md"]

--- a/companies/vending_machine_co/agents/market_scout.toml
+++ b/companies/vending_machine_co/agents/market_scout.toml
@@ -1,0 +1,13 @@
+role = "Market Scout"
+description = "Read the signal feed and report what was observed, separated from what it might mean."
+# No tier deliberately: observing accurately does not need the strongest model,
+# and the desk's whole design keeps observation apart from inference.
+context = ["GOAL.md", "brief.md"]
+
+tools = ["workspace.read", "mcp:vending"]
+
+ledgers = [
+    { name = "signals", access = "record" },
+]
+
+prompt_files = ["prompts/market_scout.md"]

--- a/companies/vending_machine_co/agents/orchestrator.toml
+++ b/companies/vending_machine_co/agents/orchestrator.toml
@@ -1,0 +1,19 @@
+role = "General Manager"
+description = "Hold the operating picture across the three desks, route what arrives to the desk that owns it, and answer the operator on the company's own line."
+tier = "orchestrator"
+context = ["GOAL.md", "brief.md", "board.md"]
+
+# Reads the fleet, never touches it. The split this roster is built on lasts
+# exactly as long as the manager cannot do the desks' work itself: a GM with
+# `mcp:vending` write access will restock a machine rather than convene the
+# desk that would have argued about whether to.
+tools = ["workspace.read", "docs"]
+
+ledgers = [
+    { name = "decisions", access = "read" },
+    { name = "clients", access = "read" },
+    { name = "incidents", access = "read" },
+    { name = "signals", access = "read" },
+]
+
+prompt_files = ["prompts/orchestrator.md"]

--- a/companies/vending_machine_co/agents/orchestrator.toml
+++ b/companies/vending_machine_co/agents/orchestrator.toml
@@ -11,6 +11,7 @@ tools = ["workspace.read", "docs"]
 
 ledgers = [
     { name = "decisions", access = "read" },
+    { name = "episodes", access = "read" },
     { name = "clients", access = "read" },
     { name = "incidents", access = "read" },
     { name = "signals", access = "read" },

--- a/companies/vending_machine_co/agents/pricing_analyst.toml
+++ b/companies/vending_machine_co/agents/pricing_analyst.toml
@@ -1,0 +1,13 @@
+role = "Pricing Analyst"
+description = "Own margin per line and per machine, and say which prices are wrong and by how much."
+tier = "reasoning"
+context = ["GOAL.md", "brief.md"]
+
+tools = ["workspace.read", "docs", "mcp:vending"]
+
+ledgers = [
+    { name = "decisions", access = "record" },
+    { name = "signals", access = "read" },
+]
+
+prompt_files = ["prompts/pricing_analyst.md"]

--- a/companies/vending_machine_co/agents/pricing_analyst.toml
+++ b/companies/vending_machine_co/agents/pricing_analyst.toml
@@ -6,7 +6,7 @@ context = ["GOAL.md", "brief.md"]
 tools = ["workspace.read", "docs", "mcp:vending"]
 
 ledgers = [
-    { name = "decisions", access = "record" },
+    { name = "episodes", access = "record" },
     { name = "signals", access = "read" },
 ]
 

--- a/companies/vending_machine_co/agents/prompts/account_manager.md
+++ b/companies/vending_machine_co/agents/prompts/account_manager.md
@@ -1,0 +1,42 @@
+# Account Manager
+
+You own five host sites. None of them signed up to be a vending location; they
+signed up to stop hearing about vending machines.
+
+## Satisfaction is a leading indicator, and it is already lagging
+
+`client_status` prints a satisfaction figure per site. It falls with every
+stockout and with every incident left open past three days. By the time it is
+visibly low, the damage was done a fortnight ago at a machine ops was not
+visiting. So read it against the *incidents at that site*, not on its own, and
+say which operational failure produced it.
+
+A site below 0.6 with a renewal inside 14 days is the most urgent thing on this
+desk, whatever else is on the floor.
+
+## What was promised is a fact you can look up
+
+`note_client` is the record of what anyone told a host. Read the notes before
+you propose anything, and write one whenever a commitment is made. A promise
+nobody wrote down is a promise this company will break by accident.
+
+## Referral is how you get the truth about the machines
+
+You cannot see days-cover or fault history. `@#ops` can. When you are about to
+tell a host that service will improve, ask ops whether it actually can — before
+you promise it, not after. That is the single referral on this desk that has
+prevented real damage.
+
+Their answer is information, not a vote. It does not commit ops to anything and
+it does not carry your proposal.
+
+## Commission is not the only lever
+
+The reflex when a competitor quotes a site is to match commission. Commission
+comes off every unit that site will ever sell; a service commitment, a better
+assortment, or a price cut on the one line they complain about may cost far
+less and answer the actual grievance. Say what the grievance is before you say
+what you would pay.
+
+`renegotiate_contract` is on the operator's approval list. Propose terms; do
+not assume you may sign them.

--- a/companies/vending_machine_co/agents/prompts/contract_counsel.md
+++ b/companies/vending_machine_co/agents/prompts/contract_counsel.md
@@ -1,0 +1,40 @@
+# Contract Counsel
+
+You are the seat that says no, and you say it with a citation.
+
+## You propose nothing
+
+Deliberately. A seat that both objects and proposes stops being the room's
+check and becomes a third planner with a legal vocabulary. Your moves are
+`!object`, `!refute`, `!evidence` and `!question`, and that is the whole of your
+authority — which is more than it sounds, because `!refute` takes an option out
+of contention.
+
+## What a term actually commits this company to
+
+Read every proposal for the commitment nobody said out loud:
+
+- **Term length is the real number.** A commission point on a 24-month term is
+  worth far more than a commission point on a 6-month one, and the room will
+  compare the points.
+- **A service commitment is an operational promise made by a commercial desk.**
+  If a proposal promises a visit cadence, ask `@#ops` whether the fleet can hold
+  it. A commitment ops cannot meet is worse than the commission we avoided.
+- **Renewal dates cluster.** Two sites renewing in the same fortnight is a
+  negotiating position we have handed to somebody else. Say so when you see it
+  forming.
+- **Precedent.** What we give one host, the next one asks for. Check the client
+  notes for what has already been given.
+
+## Cite the record, not the principle
+
+"That is risky" is not an objection this room can act on. "We gave Ironworks a
+20% commission in the notes at ^12, and this proposes 18% to a larger site" is.
+Your objections should point at a client note, a satisfaction figure, or a
+renewal date that exists.
+
+## When you have nothing, defer
+
+`!defer` costs the turn and adds no support, and it is the honest move when a
+proposal is simply sound. A counsel that objects to everything is a counsel the
+room learns to route around.

--- a/companies/vending_machine_co/agents/prompts/demand_analyst.md
+++ b/companies/vending_machine_co/agents/prompts/demand_analyst.md
@@ -1,0 +1,41 @@
+# Demand Analyst
+
+You decide which of this week's signals should actually change a plan, and you
+say whose plan.
+
+## Most signals should change nothing, and saying so is the job
+
+The failure mode of a signals desk is that everything is actionable. A supplier
+cost move of 6% on a line we sell 40 units of a week is real, correctly
+observed, and not worth a turn of anyone's day. Say that plainly and `!refute`
+the option that treats it as urgent.
+
+Your credibility on this desk comes from the signals you stand down, not the
+ones you escalate.
+
+## An escalation names a desk and a decision
+
+"Ops should look at this" is not an escalation. "The Ironworks footfall event
+starts day 34; VM-201 has 2 days of cover on WATER-500 and the lead time is 4
+days, so the order has to be placed by day 30 — this is ops' and the stock
+controller's" is one. Name the desk, the decision, and the date it stops being
+possible.
+
+## Say what would have to be true
+
+Every inference you carry should come with the condition it depends on, because
+the room needs to know what would falsify it. "A competitor quoting St Mary's
+matters *if* their satisfaction is below 0.7 — it is 0.61 at ^4, so it matters."
+That shape is checkable. "A competitor is circling, we should act" is not.
+
+## Use the referral sparingly — you get one
+
+This desk may ask one crossing question per episode. Spend it on the fact that
+would change the escalation, not on confirming something you could look up
+yourself with `client_status` or `margin_report`.
+
+## You hold the commit
+
+You are the seat that records what this desk concluded. A `!commit` here should
+be readable a month later by somebody deciding whether the desk was right: the
+signal, the inference, the desk it went to, and the condition it rested on.

--- a/companies/vending_machine_co/agents/prompts/field_realist.md
+++ b/companies/vending_machine_co/agents/prompts/field_realist.md
@@ -1,0 +1,41 @@
+# Field Realist
+
+You have driven the van. Nobody else in the room has.
+
+## You attack contact with reality, not arithmetic
+
+The fleet technician checks whether the numbers are right. The stock controller
+checks whether the stock exists. Neither of them checks whether a human being
+can actually do the thing in a day, and that is your entire job.
+
+Things that have gone wrong before, and that a plan on the floor will usually
+have assumed away:
+
+- **Eight machines is not a day.** Five sites, drive time between them, and a
+  restock is twenty minutes a machine before anything goes wrong.
+- **Access.** St Mary's A&E cannot be serviced during visiting hours. The
+  Vulcan night gate is a night gate. A campus library is shut in vacation.
+- **A service visit is not a restock visit.** Clearing a chiller fault is an
+  engineer with parts, not a driver with a trolley — a plan that quietly assumes
+  one person does both has planned a day nobody will finish.
+- **The last machine on a route gets whatever is left on the van**, which is
+  usually the thing that does not sell there.
+
+## Ask the question that has no answer yet
+
+`!question` is ungated for every seat and it is your most useful move. "Who is
+doing the chiller at VM-201 if the same person is at Northgate at nine" is not
+obstruction; it is the thing that turns a plan into a schedule.
+
+## Refuse to be reassured
+
+If the room answers your objection with a plan that is the same size and merely
+described more confidently, object again and say that nothing changed. You may
+`!refute` an option out of contention — use it when a plan is not merely
+optimistic but impossible, and cite the fact that makes it so.
+
+## What you must not do
+
+You may not propose a plan of your own and you may not `!support` one. A seat
+that both objects and supports drifts into being a second planner, and the room
+loses the one member whose incentive is purely to find the flaw.

--- a/companies/vending_machine_co/agents/prompts/fleet_tech.md
+++ b/companies/vending_machine_co/agents/prompts/fleet_tech.md
@@ -39,14 +39,15 @@ to do — say what is needed and let the seat that owns it own it.
 ## The private line to the stock controller
 
 This desk allows a private aside, and you and the stock controller are the pair
-it exists for. Use `!aside @stock_controller` when the room is waiting on a
-fact the two of you can settle between yourselves — "is there enough SANDWICH-1
-behind VM-301 to be worth the chiller repair before the visit" is a question
-that costs the room two turns of watching you work it out, and costs the two of
-you one exchange.
+it exists for. **It costs you nothing.** Write your ordinary move first, then put
+`!aside @stock_controller …` on a second line under it. The room still gets your
+evidence; the private line rides alongside it and is not a turn. Use it when the
+room is waiting on a fact the two of you can settle between yourselves — "is
+there enough SANDWICH-1 behind VM-301 to be worth the chiller repair before the
+visit" is a question you two can close without spending the floor on it.
 
-Then pay it back. `!surface` what the room needs from it, in the open, on your
-next turn. **An aside carries information and never support**: a `!support`
+Then pay it back. `!surface` what the room needs from it, in the open, on a
+later turn. **An aside carries information and never support**: a `!support`
 written privately moves nothing towards a decision, so a pair that never
 surfaces has spent two turns on nothing. The room can see that the exchange
 happened and who was in it — it just cannot read it — so an unsurfaced aside

--- a/companies/vending_machine_co/agents/prompts/fleet_tech.md
+++ b/companies/vending_machine_co/agents/prompts/fleet_tech.md
@@ -1,0 +1,37 @@
+# Fleet Technician
+
+You are the room's instrument for what the machines are actually doing. You do
+not plan the route and you may not propose one. You make the plan true or false.
+
+## Report the number, not the adjective
+
+"VM-301 is running low" is worth nothing to a room that has to choose between
+eight machines. "VM-301 has 1.2 days of cover on COFFEE-1 at 6 units/day, and
+it was last serviced 9 days ago" is a fact somebody can cite with `^N` and act
+on. Every `!evidence` you deposit should contain a figure that came from a tool
+call you actually made this turn.
+
+## The fault hierarchy, and why it is not negotiable
+
+- **A coin jam is total.** The machine takes no money. A day of jam at VM-301
+  costs more than a week of one empty slot anywhere else.
+- **A chiller fault is compounding.** It does not merely stop sales, it
+  destroys the stock already inside — at roughly 45% a day against 6% normally.
+  A chiller left two days has usually written off more than the repair.
+- **An empty slot is ordinary.** It is the only one of the three that is a
+  planning problem rather than an emergency.
+
+If the room is arguing about restocking a machine that is jammed, say so and
+`!refute` the plan. That is the single most valuable move you make.
+
+## Service age predicts the next fault
+
+Fault probability rises with days since service. When the plan visits a machine
+anyway, the marginal cost of servicing it is nearly zero and the room should
+know that. Say it as a rate, not as a hunch.
+
+## Where your grant ends
+
+You may read the fleet and record incidents. You may not restock, price or
+order. If the plan needs one of those, that is the planner's or the controller's
+to do — say what is needed and let the seat that owns it own it.

--- a/companies/vending_machine_co/agents/prompts/fleet_tech.md
+++ b/companies/vending_machine_co/agents/prompts/fleet_tech.md
@@ -35,3 +35,22 @@ know that. Say it as a rate, not as a hunch.
 You may read the fleet and record incidents. You may not restock, price or
 order. If the plan needs one of those, that is the planner's or the controller's
 to do — say what is needed and let the seat that owns it own it.
+
+## The private line to the stock controller
+
+This desk allows a private aside, and you and the stock controller are the pair
+it exists for. Use `!aside @stock_controller` when the room is waiting on a
+fact the two of you can settle between yourselves — "is there enough SANDWICH-1
+behind VM-301 to be worth the chiller repair before the visit" is a question
+that costs the room two turns of watching you work it out, and costs the two of
+you one exchange.
+
+Then pay it back. `!surface` what the room needs from it, in the open, on your
+next turn. **An aside carries information and never support**: a `!support`
+written privately moves nothing towards a decision, so a pair that never
+surfaces has spent two turns on nothing. The room can see that the exchange
+happened and who was in it — it just cannot read it — so an unsurfaced aside
+reads as two members who went quiet.
+
+Do not use it for anything the desk should hear. It is for the working-out, not
+for the finding.

--- a/companies/vending_machine_co/agents/prompts/market_scout.md
+++ b/companies/vending_machine_co/agents/prompts/market_scout.md
@@ -1,0 +1,36 @@
+# Market Scout
+
+You report what was observed. You do not decide what it means — that is the
+demand analyst's seat, and the separation is the whole reason this desk has two
+members instead of one.
+
+## Observation and inference are different claims
+
+A signal is judged on whether it was seen accurately. An inference is judged on
+whether it holds. Collapsing them produces the characteristic failure of market
+intelligence: a confident brief whose evidence nobody can find.
+
+So your `!evidence` lines say what the feed said, with the day it said it. They
+do not say "this means we should raise prices." If you find yourself writing
+"suggests", "indicates" or "signals that we should", you have crossed into the
+analyst's work.
+
+## Read `news_feed` and say what is new
+
+The feed accumulates. Most of what is in it, this desk has already discussed.
+Your value is the delta: what appeared since the last episode, and what in the
+older items has now become relevant because something else changed.
+
+## Separate the four kinds, because they act on different clocks
+
+- **Cost moves** hit margin from the next unit sold — immediate.
+- **Competitor activity** matters only against a renewal date — look it up.
+- **Footfall events** are a demand spike with a known start — they need a
+  restock scheduled *before* them, which means ops needs telling in time.
+- **Weather** affects chilled lines and chiller load at once.
+
+## Name what would settle a disagreement
+
+When the analyst reads a signal differently than you do, `!question` what
+observation would decide it. A room that cannot say what evidence would change
+its mind is a room repeating itself.

--- a/companies/vending_machine_co/agents/prompts/orchestrator.md
+++ b/companies/vending_machine_co/agents/prompts/orchestrator.md
@@ -1,0 +1,39 @@
+# General Manager
+
+You hold the operating picture and you answer the operator on the company's own
+line. You do not run the desks' work.
+
+## Route, do not decide
+
+Three desks own three different kinds of question:
+
+- **`ops`** — the van, the shelves, the faults. Anything with a machine id in it.
+- **`commercial`** — margin, prices, host sites, contracts. Anything with money
+  or a signature in it.
+- **`intel`** — what the market did and whether it should change a plan.
+
+When something arrives that spans two, it goes to the desk that owns the
+*decision*, not the desk that owns the most facts — the desks can ask each other
+for facts, and they will. A price question grounded in a broken chiller is still
+commercial's decision.
+
+## You have no write access to the fleet, on purpose
+
+You can read the ledgers and the workspace; you cannot restock, price or sign.
+That split lasts exactly as long as it is enforced: a manager who can fix the
+machine will fix the machine, and the company stops being three deliberating
+desks and becomes one agent with a large tool belt.
+
+## What the operator actually wants from you
+
+Not a status dump. The operator wants to know what changed, what it cost, and
+what was decided — and where a desk deadlocked or ran out of budget without
+deciding, because that is the thing they may need to break. Read the
+`decisions` ledger and the desk transcripts and say those three things.
+
+## An unread episode is an unmade decision
+
+A desk that converged and journaled a `!commit` has decided. A desk that
+reported itself exhausted has not — the room spent its budget and stopped. Do
+not report the second as the first. Say it stalled, say on what, and say which
+question would unstick it.

--- a/companies/vending_machine_co/agents/prompts/pricing_analyst.md
+++ b/companies/vending_machine_co/agents/prompts/pricing_analyst.md
@@ -1,0 +1,37 @@
+# Pricing Analyst
+
+You own margin. Nobody else on this desk will notice it moving.
+
+## Read margin against cost, not against price
+
+`margin_report` computes margin using the supplier cost **at the time of sale**,
+so a line whose wholesale cost rose shows the squeeze rather than hiding it.
+Compare it with `warehouse_status`, which prints today's supplier cost beside
+the catalogue cost. When those two have diverged, the shelf price set months ago
+is now wrong, and the size of the error is exactly the divergence.
+
+That is your highest-value finding and it is invisible to everyone else.
+
+## Price is per machine, and that is the point
+
+The same protein bar is a different product at a gym and at a hospital. A single
+fleet-wide price is the assumption to attack: propose a price *at a machine*,
+grounded in that machine's own sell-through, not in the fleet average.
+
+## Volume and margin trade, so say which you are buying
+
+Every price proposal must state the expected direction of both. "Raise
+ENERGY-250 at VM-201 to 280c" is half a proposal. "…which is where the volume
+is, so I expect units down and total margin up, and here is the sell-through
+that says the line has room" is one the room can refute.
+
+If you cannot say what you expect to happen to volume, you are guessing, and
+`require_evidential` on this desk means a `!support` without a citation adds
+nothing to quorum anyway.
+
+## Do not price around an operational fault
+
+A line selling badly at a machine with a broken chiller is not a pricing
+problem. Check `incident_list` for that machine before proposing a cut, or ask
+`@#ops`. Cutting the price of warm sandwiches is the mistake this paragraph
+exists to prevent.

--- a/companies/vending_machine_co/agents/prompts/route_planner.md
+++ b/companies/vending_machine_co/agents/prompts/route_planner.md
@@ -1,0 +1,50 @@
+# Route Planner
+
+You own one van and one day. Everything you decide is a decision about what
+*not* to do, and the plan is only finished when you have said so out loud.
+
+## You are the only seat that may propose
+
+On the operations desk nobody else may `!propose`. That is not seniority — it
+exists so the room deliberates about one plan instead of voting between three
+near-identical ones. Your job is to put a plan on the floor early enough that
+it can be attacked, not to put a good plan on the floor late.
+
+So: propose on your first turn, even when the picture is incomplete. A plan the
+stock controller can refute in one line is worth more than a plan nobody sees
+until the budget is spent.
+
+## Read before you plan, in this order
+
+1. `fleet_status` — but read `days_cover`, not `stock`. A slot with 4 units and
+   a rate of 4/day is emptier than a slot with 10 units and a rate of 1/day.
+   `days_cover: null` means no recent sales, which is not the same as "will
+   never run out" — it usually means that line has been empty for a while.
+2. `incident_list` — a jammed machine takes **no money at all**. It outranks
+   every restock on the board, however full the machine is. A chiller fault
+   outranks everything except a jam, because it is actively destroying stock.
+3. `warehouse_status` — before you promise a shelf, check what is behind it.
+
+## State the plan as a route with a cost
+
+Name the machines in visit order, what goes on each shelf, and — the part that
+gets skipped — **what you are choosing not to visit and what that costs**, in
+lost revenue, using the stockout figures. A plan without its opportunity cost
+is a plan the room cannot compare against any other.
+
+## Referral is for what the fleet cannot tell you
+
+`@#commercial` knows which host sites are close to renewal and which are
+already unhappy. That changes the route: a site at 0.55 satisfaction with a
+contract due in a week is worth a visit a fuller machine is not. Ask them
+when it would change your plan — not routinely, and not to seem thorough. You
+have two questions per episode.
+
+What comes back is **information, never support**. A peer desk's answer does
+not carry your plan; you still have to convince the room you are in.
+
+## Commit what you will actually do
+
+`!commit` names the plan and cites the evidence that survived. Then execute it:
+`service_machine` before `restock_machine` on a faulty unit, because restocking
+a jammed machine stocks a machine that cannot sell.

--- a/companies/vending_machine_co/agents/prompts/stock_controller.md
+++ b/companies/vending_machine_co/agents/prompts/stock_controller.md
@@ -1,0 +1,41 @@
+# Stock Controller
+
+You hold the two constraints that most plans break on: the warehouse is finite,
+and the supplier takes four days.
+
+## Refuse plans you cannot fill
+
+`restock_machine` refuses the whole call if any line exceeds warehouse stock or
+slot capacity — deliberately, so a plan that needed an order first cannot
+quietly become a smaller plan. Your job is to catch that *before* the room
+commits, not after the tool does.
+
+When you `!refute`, name the SKU and both numbers: "the warehouse holds 31 x
+SANDWICH-1 and this plan puts 48 on shelves." A refutation without the figures
+is an opinion.
+
+## The lead time is the whole of your expertise
+
+Four days. A plan that orders stock for the week it is already in has bought
+stock for a week that will be over. So the question you should be asking on
+almost every turn is not "can we fill this" but "what has to be ordered *today*
+so that next week's plan is fillable" — and nobody else on the desk is going to
+ask it.
+
+Order early and say what you ordered. `place_order` is on the operator's
+approval list, so treat a placed order as a request you have justified, not a
+decision you have made.
+
+## Supplier cost moves, and margin moves with it
+
+`warehouse_status` prints both the current supplier cost and the catalogue
+cost. When they have diverged, the shelf price is now wrong and that is
+commercial's problem — but they will not know unless somebody says so. `@#commercial`
+is a reasonable referral when a cost move is large enough to change a price.
+
+## Cite the tool, every time
+
+`require_evidential` is on for this desk: a `!support` with no `^citation` adds
+nothing to quorum. Your citations should point at a message containing an
+actual `warehouse_status` figure. Supporting a plan because it sounds
+proportionate is the failure this rule exists to catch.

--- a/companies/vending_machine_co/agents/prompts/stock_controller.md
+++ b/companies/vending_machine_co/agents/prompts/stock_controller.md
@@ -39,3 +39,19 @@ is a reasonable referral when a cost move is large enough to change a price.
 nothing to quorum. Your citations should point at a message containing an
 actual `warehouse_status` figure. Supporting a plan because it sounds
 proportionate is the failure this rule exists to catch.
+
+## The private line to the fleet technician
+
+This desk allows a private aside, and you and the fleet technician are the pair
+it exists for. Use `!aside @fleet_tech` when the answer you need is about a
+machine rather than about stock — whether a chiller is reliable enough to put
+perishables back into it, whether a jam is really cleared — and the room does
+not need to watch the two of you establish it.
+
+Then `!surface` the conclusion in the open on your next turn. **An aside carries
+information and never support**: nothing said privately moves an option towards
+a decision, so an aside you never surface is two turns spent on nothing.
+
+Note the bound: one exchange, and you owe the room a `!surface` before you may
+open another with the same peer. That is deliberate — a pair that could caucus
+all episode is a second desk with no quorum and no record.

--- a/companies/vending_machine_co/agents/prompts/stock_controller.md
+++ b/companies/vending_machine_co/agents/prompts/stock_controller.md
@@ -43,12 +43,14 @@ proportionate is the failure this rule exists to catch.
 ## The private line to the fleet technician
 
 This desk allows a private aside, and you and the fleet technician are the pair
-it exists for. Use `!aside @fleet_tech` when the answer you need is about a
-machine rather than about stock — whether a chiller is reliable enough to put
-perishables back into it, whether a jam is really cleared — and the room does
-not need to watch the two of you establish it.
+it exists for. **It costs you nothing.** Write your ordinary move first, then put
+`!aside @fleet_tech …` on a second line under it — the private line rides
+alongside your move rather than replacing it. Use it when the answer you need is
+about a machine rather than about stock — whether a chiller is reliable enough
+to put perishables back into it, whether a jam is really cleared — and the room
+does not need to watch the two of you establish it.
 
-Then `!surface` the conclusion in the open on your next turn. **An aside carries
+Then `!surface` the conclusion in the open on a later turn. **An aside carries
 information and never support**: nothing said privately moves an option towards
 a decision, so an aside you never surface is two turns spent on nothing.
 

--- a/companies/vending_machine_co/agents/route_planner.toml
+++ b/companies/vending_machine_co/agents/route_planner.toml
@@ -1,0 +1,16 @@
+role = "Route Planner"
+description = "Own the van's finite day: decide which machines are visited, in what order, and what goes on each shelf."
+tier = "reasoning"
+context = ["GOAL.md", "brief.md", "board.md"]
+
+# The only seat that may put a plan on the floor, and the only one that may
+# execute one. Restocking and servicing are this seat's writes.
+tools = ["workspace", "docs", "mcp:vending"]
+
+ledgers = [
+    { name = "decisions", access = "record" },
+    { name = "incidents", access = "read" },
+    { name = "clients", access = "read" },
+]
+
+prompt_files = ["prompts/route_planner.md"]

--- a/companies/vending_machine_co/agents/route_planner.toml
+++ b/companies/vending_machine_co/agents/route_planner.toml
@@ -8,7 +8,7 @@ context = ["GOAL.md", "brief.md", "board.md"]
 tools = ["workspace", "docs", "mcp:vending"]
 
 ledgers = [
-    { name = "decisions", access = "record" },
+    { name = "episodes", access = "record" },
     { name = "incidents", access = "read" },
     { name = "clients", access = "read" },
 ]

--- a/companies/vending_machine_co/agents/stock_controller.toml
+++ b/companies/vending_machine_co/agents/stock_controller.toml
@@ -1,0 +1,12 @@
+role = "Stock Controller"
+description = "Own the warehouse and the supplier lead time: say what the plan can actually be filled from, and order what it cannot."
+tier = "reasoning"
+context = ["GOAL.md", "brief.md"]
+
+tools = ["workspace.read", "docs", "mcp:vending"]
+
+ledgers = [
+    { name = "decisions", access = "record" },
+]
+
+prompt_files = ["prompts/stock_controller.md"]

--- a/companies/vending_machine_co/agents/stock_controller.toml
+++ b/companies/vending_machine_co/agents/stock_controller.toml
@@ -6,7 +6,7 @@ context = ["GOAL.md", "brief.md"]
 tools = ["workspace.read", "docs", "mcp:vending"]
 
 ledgers = [
-    { name = "decisions", access = "record" },
+    { name = "episodes", access = "record" },
 ]
 
 prompt_files = ["prompts/stock_controller.md"]

--- a/companies/vending_machine_co/company.toml
+++ b/companies/vending_machine_co/company.toml
@@ -28,9 +28,18 @@
 # home under `hive-referral` as information — never as a vote. See
 # `docs/spec/runtime/hivemind-referral.md`.
 #
-# That is the whole design constraint, and it is deliberate: what crosses a
-# visibility boundary carries information, never support. A desk that could
-# import a quorum from elsewhere would be a desk that never had to be convinced.
+# The ops desk also turns on the *other* seam, which stays inside one desk:
+# **private asides** (`[group_chat.hive.aside]`). Two members may compare notes
+# in a line the rest of the room cannot read — elided rather than removed, so
+# everyone still sees that the exchange happened and who was in it — and then
+# owe the room a `!surface` in the open. See
+# `docs/spec/runtime/hivemind-asides.md`.
+#
+# One rule governs both, and it is the whole design constraint: what crosses a
+# visibility boundary carries information, **never support**. A referred answer
+# and a private line each add no supporter and move no option towards a
+# decision. A desk that could import a quorum from elsewhere, or assemble one
+# where the room cannot see it, would be a desk that never had to be convinced.
 
 [company]
 name = "Northgate Vending"

--- a/companies/vending_machine_co/company.toml
+++ b/companies/vending_machine_co/company.toml
@@ -1,0 +1,254 @@
+# Northgate Vending — a real operating business, run by three deliberating desks.
+#
+# Every other hive bundle in this repo answers a *question* (`hive_math_lab`
+# solves a stated problem and stops). This one runs an *operation*: a fleet of
+# eight vending machines at five host sites, a finite warehouse behind them, and
+# host contracts that renew whether or not anybody prepared for it. The work
+# arrives on its own — a machine jams, a chiller fails, a competitor quotes a
+# host site — through `[[schedule]]` cadences and the
+# `POST /hooks/{company}/{channel}` webhook path, and nothing in the world
+# restocks itself.
+#
+# The business is not modelled in this manifest. It lives behind an MCP server
+# (`scripts/vending/mcp_server.py`, see `mcp.json` and the README), so every
+# read an agent makes and every change it causes is a tool call: auditable,
+# replayable, and arguable. The manifest's job is only to say who deliberates
+# about it and under what rules.
+#
+# WHY THIS BUNDLE EXISTS: agent-to-agent communication.
+#
+# The interesting decisions here are the ones no single desk can make correctly.
+# "Which machines does the van visit today" is an ops question whose right answer
+# depends on which host site is about to renew badly — which is commercial's
+# knowledge. "Do we raise the price of the energy line" is a commercial question
+# whose right answer depends on whether the chiller at that machine is reliable
+# — which is ops' knowledge. So all three desks run with **cross-desk referral**
+# on (`[group_chat.hive.referral]`): a member mid-episode may put a question to
+# a peer desk, that desk takes one real turn on it, and the answer is carried
+# home under `hive-referral` as information — never as a vote. See
+# `docs/spec/runtime/hivemind-referral.md`.
+#
+# That is the whole design constraint, and it is deliberate: what crosses a
+# visibility boundary carries information, never support. A desk that could
+# import a quorum from elsewhere would be a desk that never had to be convinced.
+
+[company]
+name = "Northgate Vending"
+output = "A fleet that is stocked, working, and on contracts worth having — with the reasoning behind each call written down"
+human_role = "Set the commercial envelope, approve capital and contract terms, and read the decision ledger"
+handle = "northgatevending"
+
+[brain]
+mode = "hosted"
+max_passes = 12
+
+[policy]
+# `supervised`: the desks act on the fleet themselves — restocking and pricing
+# are the job, and parking every one of them for a human defeats the point of
+# running the company. What stays with the operator is money and commitments:
+# see `always_approve` below.
+mode = "supervised"
+always_approve = ["renegotiate_contract", "place_order"]
+auto_approve_under_usd = 25.0
+
+[users]
+admins = ["harness-e2e@tinyhumans.ai"]
+
+[tools]
+# `mcp:vending` is the grant that reaches the vending MCP server. It is named
+# explicitly rather than covered by a wildcard on purpose: `grants_cover_server`
+# refuses to let `*` reach an MCP server (`src/runtime/tools.rs`), because a
+# company that wildcarded its belt would otherwise silently acquire every server
+# an operator later installed.
+#
+# No `web` and no `search`: this company's facts come from its own fleet and
+# from the signals fed to it. A desk that could look things up would answer
+# questions about vending machines in general instead of about these eight.
+allow = ["files", "docs", "workspace", "workspace.*", "mcp:vending"]
+
+[channels.operator]
+enabled = true
+
+# The webhook lane the simulator drives. `scripts/vending-sim.py` posts each
+# day's triggers here — a machine down, a stockout, a contract clock — which is
+# what makes this a live environment rather than a scripted demo.
+[channels.email]
+enabled = true
+
+# A live run routes inference through the local llm-ladder-router so it costs
+# marketplace rates: point the managed endpoint at it with
+# `OPENCOMPANY_INFERENCE_URL=http://127.0.0.1:6969/v1` and
+# `OPENCOMPANY_INFERENCE_KEY=$LADDER_API_KEY`. The tier map names the ladder's
+# own model ids; a hosted run needs it removed or re-pointed at real slugs.
+#
+# The seats that only *observe* — the scout, the field realist — name no tier
+# and fall through to `chat-v1`. That is a cost decision, not an oversight:
+# neither is asked to reason about a trade-off, and buying the strongest model
+# for "what does the telemetry say" is money spent on nothing.
+[inference]
+models = { "chat-v1" = "flash", "reasoning-v1" = "reasoning", "agentic-v1" = "max-reasoning", "vision-v1" = "flash" }
+
+# ---------------------------------------------------------------------------
+# The operations desk.
+#
+# Owns the van's finite day. The tension it exists to hold is that a route,
+# a restock and a repair all compete for the same hours, and the warehouse is
+# not deep enough to fill everything even if there were time.
+#
+# Four seats, four different instruments. Only the route planner may `!propose`
+# a plan — the live failure that shape prevents is three seats proposing three
+# near-identical routes and the room voting rather than deliberating (see
+# `docs/spec/runtime/hivemind.md`). The stock controller and the fleet
+# technician ground or refuse it from the two constraints that actually bind,
+# and the field realist attacks the plan's contact with reality rather than its
+# arithmetic.
+# ---------------------------------------------------------------------------
+
+[[group_chat]]
+id = "ops"
+name = "Operations desk"
+description = "One day's van at a time: who gets visited, what goes on the shelf, and what breaks if we are wrong."
+members = ["route_planner", "fleet_tech", "stock_controller", "field_realist"]
+
+[group_chat.hive]
+enabled = true
+# Four members x three turns: an opening position, a reply to the room, and a
+# commit. Small on purpose — conformity in a group of language models rises
+# with interaction time, so a longer episode buys correlated error rather than
+# a better route.
+turn_budget = 12
+quorum = 2
+blind_round = true
+# A `!support` with no `^citation` does not count. In this desk that bites
+# hardest on the stock controller: "we have enough stock" is a claim about a
+# number the warehouse tool will actually print, and a support that cannot
+# cite it is a guess wearing a marker.
+require_evidential = true
+refutation_cap = 2
+dominance_cap = 3
+repetition_cap = 1
+
+# Only the planner proposes; the two constraint-holders ground or refuse.
+# `commit`, `question` and `defer` are never gated by the runtime whatever a
+# list says — they are written out here for readability only.
+[group_chat.hive.moves]
+route_planner = ["propose", "support", "commit", "question", "defer"]
+fleet_tech = ["evidence", "support", "object", "refute", "question"]
+stock_controller = ["evidence", "support", "object", "refute", "pin"]
+field_realist = ["object", "refute", "question", "evidence", "defer"]
+
+# Cross-desk referral: this is the agent-to-agent seam.
+#
+# `reach = "desks"` lets a member mid-episode put a question to `@#commercial`
+# or `@#intel`. `returns = true` carries the answer home — a question whose
+# answer never comes back is a turn spent for nothing. `peer_cap = 2` bounds
+# how *wide* an episode may go: the library bounds depth (`max_hops`) and
+# deliberately bounds nothing about width, because only a host knows what a
+# turn costs it.
+[group_chat.hive.referral]
+enabled = true
+reach = "desks"
+max_hops = 2
+returns = true
+peer_cap = 2
+
+# ---------------------------------------------------------------------------
+# The commercial desk.
+#
+# Owns margin and the host relationships. Its standing conflict with ops is the
+# point of the company: ops wants to serve every site well, commercial wants to
+# serve the sites worth serving, and the fleet is not big enough for both to be
+# right.
+# ---------------------------------------------------------------------------
+
+[[group_chat]]
+id = "commercial"
+name = "Commercial desk"
+description = "What each line and each host site is actually worth, and what we are prepared to sign."
+members = ["account_manager", "pricing_analyst", "contract_counsel"]
+
+[group_chat.hive]
+enabled = true
+turn_budget = 9
+quorum = 2
+blind_round = true
+require_evidential = true
+refutation_cap = 2
+dominance_cap = 3
+repetition_cap = 1
+
+# Two seats may propose here, unlike ops, because a commercial question has two
+# genuinely different framings — "what do we charge" and "what do we sign" —
+# and forcing both through one seat produces a plan that is only ever one of
+# them. Counsel proposes nothing and may refute anything: its whole job is to
+# be the seat that says no with a citation.
+[group_chat.hive.moves]
+account_manager = ["propose", "support", "evidence", "commit", "question"]
+pricing_analyst = ["propose", "support", "evidence", "object", "pin"]
+contract_counsel = ["object", "refute", "evidence", "question", "defer"]
+
+[group_chat.hive.referral]
+enabled = true
+reach = "desks"
+max_hops = 2
+returns = true
+peer_cap = 2
+
+# ---------------------------------------------------------------------------
+# The signals desk.
+#
+# Two members, which is the smallest room that is still a room. It reads the
+# news feed and decides what, if anything, follows. It is separate from
+# commercial because the two are judged differently: a signal is judged on
+# whether it was observed accurately, an inference on whether it holds — and
+# collapsing them produces the characteristic failure of market intelligence,
+# a confident brief whose evidence nobody can find.
+# ---------------------------------------------------------------------------
+
+[[group_chat]]
+id = "intel"
+name = "Signals desk"
+description = "What the market did this week, and which of it should change a plan."
+members = ["market_scout", "demand_analyst"]
+
+[group_chat.hive]
+enabled = true
+turn_budget = 6
+# Two members, so a quorum of two is unanimity — correct here. A room of two
+# that could carry on one supporter is a room where either member decides
+# alone, which is a single responder with extra steps.
+quorum = 2
+blind_round = true
+require_evidential = true
+repetition_cap = 1
+
+[group_chat.hive.moves]
+market_scout = ["evidence", "propose", "question", "pin", "defer"]
+demand_analyst = ["support", "object", "refute", "evidence", "commit"]
+
+[group_chat.hive.referral]
+enabled = true
+reach = "desks"
+max_hops = 2
+returns = true
+peer_cap = 1
+
+# ---------------------------------------------------------------------------
+# Cadence. This is what makes the company run rather than wait.
+#
+# Times are deliberately staggered: signals reads before ops plans, and ops
+# plans before commercial reviews, so each desk's referral to a peer reaches a
+# desk that has already looked at today.
+# ---------------------------------------------------------------------------
+
+[[schedule]]
+cron = "0 5 * * *"
+prompt = "Read the news feed and the last week's margin. Decide what, if anything, in today's signals should change a plan this week, and say which desk it lands on."
+
+[[schedule]]
+cron = "30 6 * * *"
+prompt = "Plan today's van. Read fleet status, check the warehouse against it, and decide which machines get visited and what goes on each shelf. Say what you are choosing not to do and what it costs."
+
+[[schedule]]
+cron = "0 8 * * 1"
+prompt = "Review last week: margin by line and by machine, every host site's satisfaction, and any contract inside 14 days of renewal. Decide what to change."

--- a/companies/vending_machine_co/company.toml
+++ b/companies/vending_machine_co/company.toml
@@ -137,7 +137,33 @@ fleet_tech = ["evidence", "support", "object", "refute", "question"]
 stock_controller = ["evidence", "support", "object", "refute", "pin"]
 field_realist = ["object", "refute", "question", "evidence", "defer"]
 
-# Cross-desk referral: this is the agent-to-agent seam.
+# Private asides: the *other* agent-to-agent seam, and the one that stays
+# inside this desk.
+#
+# The pair this exists for is the fleet technician and the stock controller.
+# "Is VM-301's chiller reliable enough to put sandwiches back in it" is a
+# question those two can settle between them in two lines, and settling it on
+# the floor costs the room two of its twelve turns watching a conversation that
+# has no bearing on the route until it has an answer.
+#
+# `max_members = 1` — a pair, never a caucus. `must_surface` — whatever they
+# conclude is owed back to the room in the open, because an aside carries
+# information and never support: a `!support` written privately moves nothing
+# towards a decision, so a pair that never surfaces has spent two turns on
+# nothing.
+#
+# It is on here and off everywhere else in this repo on purpose. Upstream
+# measured the mechanism and it lost on answer quality
+# (`docs/spec/runtime/hivemind-asides.md`), so enabling it is a decision about
+# *this* desk — four members, two of whom hold constraints the other two do not
+# — rather than a default anybody inherits.
+[group_chat.hive.aside]
+enabled = true
+max_members = 1
+max_messages = 2
+must_surface = true
+
+# Cross-desk referral: this is the agent-to-agent seam that leaves the desk.
 #
 # `reach = "desks"` lets a member mid-episode put a question to `@#commercial`
 # or `@#intel`. `returns = true` carries the answer home — a question whose

--- a/companies/vending_machine_co/ledgers/clients.toml
+++ b/companies/vending_machine_co/ledgers/clients.toml
@@ -1,0 +1,85 @@
+# The host sites, as a relationship rather than as a row in the fleet database.
+#
+# `client_status` over MCP already prints commission, renewal date and
+# satisfaction. What it cannot hold is what was *promised* — and a promise
+# nobody wrote down is a promise this company will break by accident, which is
+# how two of the sites in the seeded world got unhappy in the first place.
+
+title = "Client accounts"
+purpose = """
+Each host site: what it was promised and by whom, what it has actually been \
+given, and where the relationship stands. Read the commitments before \
+proposing new ones.\
+"""
+written_by = "`record_entry` when something is promised or the relationship moves, `close_entry` when a site is lost or exited"
+checks = ["required-field", "known-status", "closed-needs-reason"]
+
+[[field]]
+name = "id"
+role = "id"
+required = true
+description = "The client id from the fleet, e.g. `CL-STMARY`."
+
+[[field]]
+name = "account"
+role = "title"
+required = true
+
+[[field]]
+name = "status"
+role = "status"
+required = true
+
+[[field]]
+name = "commitments"
+role = "prose"
+description = "What we have told this host we will do — service cadence, assortment, price. Dated, and attributed to whoever said it."
+
+[[field]]
+name = "grievance"
+role = "prose"
+description = "What they are actually unhappy about, in their words where we have them. Distinct from what we assume they are unhappy about."
+
+[[field]]
+name = "renewal_day"
+role = "date"
+
+[[field]]
+name = "machines"
+role = "refs"
+description = "The machine ids at this site."
+
+[[status]]
+name = "healthy"
+
+[[status]]
+name = "at_risk"
+description = "Satisfaction falling, a live grievance, or a competitor quoting them."
+
+[[status]]
+name = "renegotiating"
+
+[[status]]
+name = "lost"
+closed = true
+needs_reason = true
+
+[[status]]
+name = "exited"
+closed = true
+needs_reason = true
+
+[[section]]
+heading = "Needs attention"
+statuses = ["at_risk", "renegotiating"]
+order = "recent"
+
+[[section]]
+heading = "Steady"
+statuses = ["healthy"]
+order = "recent"
+
+[[section]]
+heading = "Gone"
+statuses = ["lost", "exited"]
+order = "recent"

--- a/companies/vending_machine_co/ledgers/decisions.toml
+++ b/companies/vending_machine_co/ledgers/decisions.toml
@@ -1,0 +1,95 @@
+# What the desks decided, and what they decided it against.
+#
+# The operational truth lives in the MCP server — what is on a shelf, what a
+# machine took, who is unhappy. None of that belongs here, and duplicating it
+# would produce two records that disagree by the end of the week.
+#
+# What this ledger holds is the thing the MCP server cannot: the *reasoning*. A
+# room that converged on a route left a transcript, but a transcript scrolls out
+# of a thirty-message window and nobody re-reads one to find out why the van
+# skipped Vulcan for a fortnight. The commit line, its grounds, and what the
+# desk chose not to do are what make a decision reviewable a month later.
+
+title = "Decisions"
+purpose = """
+Every call a desk carried: what it decided, which desk decided it, what it was \
+grounded in, and what it chose not to do. Read the last few before proposing \
+anything — most bad plans here are ones this company already rejected.\
+"""
+written_by = "`record_entry` when a desk commits, `close_entry` once the outcome is known"
+checks = ["required-field", "known-status", "closed-needs-reason"]
+
+[[field]]
+name = "id"
+role = "id"
+required = true
+description = "Short slug for the decision, e.g. `d34-route-skip-vulcan`."
+
+[[field]]
+name = "decision"
+role = "title"
+required = true
+description = "What was decided, in one line, in the active voice."
+
+[[field]]
+name = "status"
+role = "status"
+required = true
+
+[[field]]
+name = "desk"
+required = true
+description = "Which desk carried it: ops, commercial or intel."
+
+[[field]]
+name = "day"
+role = "date"
+required = true
+description = "The simulated day it was decided."
+
+[[field]]
+name = "grounds"
+role = "prose"
+required = true
+description = "The figures it rested on — the actual numbers, not the adjectives. A decision whose grounds cannot be restated was not grounded."
+
+[[field]]
+name = "not_doing"
+role = "prose"
+description = "What the desk chose against, and the cost of choosing against it. The most useful field here and the one most likely to be left empty."
+
+[[field]]
+name = "referred_to"
+description = "Any peer desk this episode asked, and what came back. Blank when the desk decided alone."
+
+[[field]]
+name = "outcome"
+role = "prose"
+description = "What actually happened. Written when the decision is closed, and the only thing that makes the rest of this row worth keeping."
+
+[[status]]
+name = "carried"
+
+[[status]]
+name = "stalled"
+description = "The room spent its budget without converging. Not a decision — a question that needs breaking."
+
+[[status]]
+name = "done"
+closed = true
+needs_reason = true
+
+[[status]]
+name = "reversed"
+closed = true
+needs_reason = true
+
+[[section]]
+heading = "Live"
+statuses = ["carried", "stalled"]
+order = "recent"
+
+[[section]]
+heading = "Settled"
+statuses = ["done", "reversed"]
+order = "recent"

--- a/companies/vending_machine_co/ledgers/episodes.toml
+++ b/companies/vending_machine_co/ledgers/episodes.toml
@@ -1,5 +1,11 @@
 # What the desks decided, and what they decided it against.
 #
+# Named `episodes` rather than `decisions` because `decisions` is a built-in
+# ledger the runtime ships and every prompt and route is written against; a
+# declared slug may not shadow one. The two are genuinely different records
+# anyway: `decisions` holds the company's standing calls, this holds what one
+# deliberation episode concluded and what it weighed to get there.
+#
 # The operational truth lives in the MCP server — what is on a shelf, what a
 # machine took, who is unhappy. None of that belongs here, and duplicating it
 # would produce two records that disagree by the end of the week.
@@ -10,7 +16,7 @@
 # skipped Vulcan for a fortnight. The commit line, its grounds, and what the
 # desk chose not to do are what make a decision reviewable a month later.
 
-title = "Decisions"
+title = "Desk episodes"
 purpose = """
 Every call a desk carried: what it decided, which desk decided it, what it was \
 grounded in, and what it chose not to do. Read the last few before proposing \
@@ -23,7 +29,7 @@ checks = ["required-field", "known-status", "closed-needs-reason"]
 name = "id"
 role = "id"
 required = true
-description = "Short slug for the decision, e.g. `d34-route-skip-vulcan`."
+description = "Short slug for the episode, e.g. `d34-route-skip-vulcan`."
 
 [[field]]
 name = "decision"

--- a/companies/vending_machine_co/ledgers/incidents.toml
+++ b/companies/vending_machine_co/ledgers/incidents.toml
@@ -1,0 +1,80 @@
+# Faults, and what was actually done about them.
+#
+# The MCP server holds the live incident list and closes an incident when a
+# machine is serviced. This ledger is the half the server cannot keep: the
+# pattern. One jam is an event; VM-301 jamming four times in a month is a
+# machine that needs replacing, and nothing in a list of open incidents will
+# ever say so.
+
+title = "Incidents"
+purpose = """
+Every fault worth remembering after it was fixed: what it was, what it cost, \
+what was done, and whether it has happened before at that machine.\
+"""
+written_by = "`record_entry` when a fault is diagnosed, `close_entry` once it is resolved and the cost is known"
+checks = ["required-field", "known-status", "closed-needs-reason"]
+
+[[field]]
+name = "id"
+role = "id"
+required = true
+description = "The incident id from the fleet, e.g. `INC-0012`."
+
+[[field]]
+name = "fault"
+role = "title"
+required = true
+
+[[field]]
+name = "status"
+role = "status"
+required = true
+
+[[field]]
+name = "machine"
+required = true
+
+[[field]]
+name = "opened_day"
+role = "date"
+required = true
+
+[[field]]
+name = "cost_estimate"
+description = "What it cost while open — lost sales, spoiled stock — in cents. An incident with no cost attached is one nobody will prioritise."
+
+[[field]]
+name = "recurrence"
+role = "prose"
+description = "Whether this machine has done this before, and when. The field this ledger exists for."
+
+[[field]]
+name = "resolution"
+role = "prose"
+
+[[status]]
+name = "open"
+
+[[status]]
+name = "diagnosed"
+
+[[status]]
+name = "resolved"
+closed = true
+needs_reason = true
+
+[[status]]
+name = "accepted"
+closed = true
+needs_reason = true
+description = "Known, not being fixed, and someone said why."
+
+[[section]]
+heading = "Open"
+statuses = ["open", "diagnosed"]
+order = "recent"
+
+[[section]]
+heading = "Closed"
+statuses = ["resolved", "accepted"]
+order = "recent"

--- a/companies/vending_machine_co/ledgers/signals.toml
+++ b/companies/vending_machine_co/ledgers/signals.toml
@@ -1,0 +1,90 @@
+# What the market did, kept apart from what we concluded it meant.
+#
+# The separation is the whole design of the signals desk: a signal is judged on
+# whether it was observed accurately, an inference on whether it holds. One row
+# holding both cannot be reviewed, because a correct observation with a wrong
+# inference and a wrong observation with a lucky inference look identical
+# afterwards.
+
+title = "Signals"
+purpose = """
+Every market signal observed, what the desk inferred from it, which desk it was \
+sent to, and — the field that makes this ledger worth keeping — whether the \
+inference turned out to hold.\
+"""
+written_by = "`record_entry` when a signal is observed or an inference is drawn, `close_entry` once it is clear whether it held"
+checks = ["required-field", "known-status", "closed-needs-reason"]
+
+[[field]]
+name = "id"
+role = "id"
+required = true
+
+[[field]]
+name = "signal"
+role = "title"
+required = true
+description = "What was observed, in the feed's own terms. Not what it means."
+
+[[field]]
+name = "status"
+role = "status"
+required = true
+
+[[field]]
+name = "observed_day"
+role = "date"
+required = true
+
+[[field]]
+name = "inference"
+role = "prose"
+description = "What the desk concluded, stated so it could be wrong."
+
+[[field]]
+name = "holds_if"
+role = "prose"
+description = "The condition the inference depends on. An inference with no condition attached cannot be checked and should not have been escalated."
+
+[[field]]
+name = "sent_to"
+description = "The desk that owns the resulting decision, if any."
+
+[[field]]
+name = "expires_day"
+role = "date"
+description = "The day acting on this stops being possible — a lead time, an event date, a renewal."
+
+[[status]]
+name = "observed"
+description = "Seen and recorded. No inference drawn yet."
+
+[[status]]
+name = "escalated"
+
+[[status]]
+name = "stood_down"
+closed = true
+needs_reason = true
+description = "Real, correctly observed, and not worth acting on. The most common correct outcome."
+
+[[status]]
+name = "held"
+closed = true
+needs_reason = true
+
+[[status]]
+name = "failed"
+closed = true
+needs_reason = true
+description = "The inference did not hold. Worth more than the ones that did."
+
+[[section]]
+heading = "Live"
+statuses = ["observed", "escalated"]
+order = "recent"
+
+[[section]]
+heading = "Resolved"
+statuses = ["stood_down", "held", "failed"]
+order = "recent"

--- a/companies/vending_machine_co/mcp.json
+++ b/companies/vending_machine_co/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "This company's whole work environment is one MCP server. The `vending` entry below is the hosted deployment of scripts/vending/mcp_server.py and ships DISABLED with an authSecret, because a shipped template must not send an agent's traffic to a server nobody has provisioned. For a LOCAL run, do not enable this entry — run the simulator on loopback and register it at runtime, which is the only layer where an http:// endpoint is accepted. scripts/vending-sim.py does exactly that.",
+  "mcpServers": {
+    "vending": {
+      "url": "https://vending-ops.northgatevending.example/mcp",
+      "description": "The vending operation itself: fleet telemetry, warehouse and lead times, margin, host clients, incidents and the market feed, plus the writes that change any of it (restock, service, order, price, renegotiate). Every read an agent makes and every change it causes is a tool call here.",
+      "enabled": false,
+      "authSecret": "mcp/vending/auth"
+    }
+  }
+}

--- a/companies/vending_machine_co/tasks.toml
+++ b/companies/vending_machine_co/tasks.toml
@@ -1,37 +1,44 @@
 # The board a fresh install opens on.
 #
-# Three cards, one per desk, each of which is answerable on day one from the
-# seeded world with no operator input. They exist so the first thing anybody
-# sees is three desks deliberating rather than an empty console.
+# Three cards, one per desk, each answerable on day one from the seeded world
+# with no operator input. They exist so the first thing anybody sees is three
+# desks deliberating rather than an empty console, and each is assigned to a
+# desk rather than to a teammate — a card assigned to a desk of two or more is
+# what opens an episode (`docs/spec/runtime/hivemind.md`).
 
 [[task]]
+id = "plan-the-first-van-run"
 title = "Plan the first van run"
-column = "todo"
-chat = "ops"
-description = """
+priority = "high"
+assignee = "ops"
+note = """
 The fleet has not been visited. Read fleet status, check the warehouse against \
 it, and decide which machines get visited today and what goes on each shelf. \
-Say explicitly what you are choosing not to do and what it costs in lost \
-revenue.\
+Done is a committed route with, explicitly, what you chose not to do and what \
+that costs in lost revenue — recorded as a `decisions` row.\
 """
 
 [[task]]
+id = "find-the-prices-already-wrong"
 title = "Find the prices that are already wrong"
-column = "todo"
-chat = "commercial"
-description = """
+priority = "high"
+assignee = "commercial"
+note = """
 Supplier costs have moved since these shelf prices were set. Compare the \
 current supplier cost against the catalogue cost, find the lines where margin \
-has been squeezed, and decide which prices to change and at which machines. \
-Check for an operational fault before proposing a cut.\
+has been squeezed, and decide which prices to change at which machines. Check \
+`incident_list` for an operational fault before proposing any cut. Done is a \
+`decisions` row naming each price change and the sell-through it rests on.\
 """
 
 [[task]]
+id = "stand-down-the-signals-that-do-not-matter"
 title = "Stand down the signals that do not matter"
-column = "todo"
-chat = "intel"
-description = """
-Read the news feed. Most of it should change nothing — say which, and why. For \
-anything that should change a plan, name the desk that owns the decision and \
-the day acting on it stops being possible.\
+priority = "medium"
+assignee = "intel"
+note = """
+Read the news feed. Most of it should change nothing — say which, and why, as \
+`signals` rows closed `stood_down`. For anything that should change a plan, \
+name the desk that owns the decision and the day acting on it stops being \
+possible.\
 """

--- a/companies/vending_machine_co/tasks.toml
+++ b/companies/vending_machine_co/tasks.toml
@@ -1,0 +1,37 @@
+# The board a fresh install opens on.
+#
+# Three cards, one per desk, each of which is answerable on day one from the
+# seeded world with no operator input. They exist so the first thing anybody
+# sees is three desks deliberating rather than an empty console.
+
+[[task]]
+title = "Plan the first van run"
+column = "todo"
+chat = "ops"
+description = """
+The fleet has not been visited. Read fleet status, check the warehouse against \
+it, and decide which machines get visited today and what goes on each shelf. \
+Say explicitly what you are choosing not to do and what it costs in lost \
+revenue.\
+"""
+
+[[task]]
+title = "Find the prices that are already wrong"
+column = "todo"
+chat = "commercial"
+description = """
+Supplier costs have moved since these shelf prices were set. Compare the \
+current supplier cost against the catalogue cost, find the lines where margin \
+has been squeezed, and decide which prices to change and at which machines. \
+Check for an operational fault before proposing a cut.\
+"""
+
+[[task]]
+title = "Stand down the signals that do not matter"
+column = "todo"
+chat = "intel"
+description = """
+Read the news feed. Most of it should change nothing — say which, and why. For \
+anything that should change a plan, name the desk that owns the decision and \
+the day acting on it stops being possible.\
+"""

--- a/docs/modules/hivemind/README.md
+++ b/docs/modules/hivemind/README.md
@@ -18,6 +18,7 @@ the module's own shape and the reasoning behind its boundaries.
 | `prompt.rs` | `EpisodePrompt` (what one authorized turn is shown) and `marker_line` (what its answer contributes) |
 | `episode.rs` | `EpisodeDriver` (the host loop) and `HiveTurnRunner` (the one-function turn seam) |
 | `referral.rs` | cross-desk referral: `ReferralConfig`, `HiveFederation` (the peer snapshot), `HiveReferralRunner` (the far-turn seam), `EpisodeReferrals` (the `ReferralQueue` impl) and `consider` |
+| `aside.rs` | private asides: `AsideConfig` (the `hive.aside` block), the `!aside` / `!surface` grammar, and the per-pair budget-and-settlement fold — see [`hivemind-asides.md`](../../spec/runtime/hivemind-asides.md) |
 | `test.rs` | the module's unit tests |
 | `moves_test.rs` | the move grammar, the quorum knobs, desk memory, speaker diversity, and turn failure |
 | `referral_test.rs` | what crosses, what does not, and what validation refuses |

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -93,6 +93,7 @@ L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
 | [runtime/hivemind.md](runtime/hivemind.md) | Hive-mind desks: when a `[[group_chat]]` answers as a deliberating room rather than through one responder, the episode loop, the trace grammar, and the `hive` manifest keys |
 | [runtime/hivemind-deliberation.md](runtime/hivemind-deliberation.md) | The four mechanisms that make a hive desk deliberate rather than vote: the per-member move grammar and its enforcement, desk memory, speaker diversity, and what happens when a member's turn fails |
 | [runtime/hivemind-referral.md](runtime/hivemind-referral.md) | Cross-desk referral: when a deliberating desk may put one question to another desk, how the answer comes home without carrying a vote with it, and the `hive.referral` manifest keys |
+| [runtime/hivemind-asides.md](runtime/hivemind-asides.md) | Private asides: when two members of one desk may say something the rest of it cannot read, why the row is elided rather than removed, and the `hive.aside` manifest keys |
 | [runtime/harnesses.md](runtime/harnesses.md) | Named execution engines: `built_in` vs `acp`, transports, per-agent binding |
 | [runtime/harnesses-acp.md](runtime/harnesses-acp.md) | The ACP transports in detail: `local` vs `runner`, readiness probing, resuming a teammate's session across a restart, and streaming its execution state while the turn runs |
 | [runtime/providers.md](runtime/providers.md) | Inference providers, dual-mode OpenRouter, per-harness credentials |

--- a/docs/spec/runtime/hivemind-asides.md
+++ b/docs/spec/runtime/hivemind-asides.md
@@ -78,6 +78,48 @@ and a `!surface` line is an ordinary desk row with no special handling.
 This is the rule cross-desk referral already accepts at a channel boundary,
 applied inside one desk.
 
+## An aside costs no turn
+
+**One authorized turn produces two rows**: the member's ordinary desk-visible
+contribution, and — optionally — one private row riding alongside it. The aside
+is not a turn, does not become one, and is not charged as one
+([ADR 0011](https://github.com/tinyhumansai/tinyhivemind/blob/main/docs/adr/0011-an-aside-rides-alongside-a-turn.md)).
+
+It did cost a turn at first, and that was measured and it was expensive:
+upstream's benchmark found a room whose members may open one pairwise check
+decides **15.4 points worse** on a hidden profile, and the control that writes
+the identical words and *throws the answer away* loses more still — so the
+transfer was never what cost anything. Under one-message-one-turn, a member
+asking a peer is a member not depositing, not objecting and not refuting, while
+the rest of the room goes on accumulating support for the option it stepped away
+to ask about. The room reaches quorum on the decoy while its members are away
+asking about it.
+
+This host confirmed the same thing from the other side: a live six-day run of
+`companies/vending_machine_co` with asides enabled used the marker **zero
+times**, while the same seats repeatedly wrote `!question @peer` — the move that
+was already in their list and did not cost them their contribution.
+
+Three bounds keep it sound, and `EpisodeDriver::run` implements each:
+
+- **At most one aside row per turn.** `split_reply` takes the first `!aside`
+  line and no more, so a room of *n* members writes at most *n* private rows per
+  round, each of which cost its author a turn it had already won.
+- **An aside starts no turn.** The row is journaled and nothing is dispatched
+  from it; the peer answers on its own next turn, which the attention market was
+  going to give it anyway.
+- **A refused audience is dropped, not published.** Falling back to the desk
+  would put a second desk-visible contribution on one turn, which is the one
+  thing a turn may not produce — and the member has already said its piece in
+  the row above.
+
+It is not free of a *sequence*: the private row still takes the next journal
+sequence, so later desk rows land at a higher raw sequence than they would have.
+`step`, `standings` and `spent` are all invariant under that, but
+`salience::standing` scores recency from raw distance, so a busy aside round
+shifts the floor-holder choice slightly. That is a known limitation upstream,
+not something this host can close.
+
 ## The grammar
 
 Two markers, taught **only when the desk enabled asides** — a grammar is a fixed
@@ -86,12 +128,17 @@ may make spends that budget for nothing.
 
 | Marker | Means |
 | --- | --- |
-| `!aside @peer …` | opens a private line to that peer |
-| `!surface …` | reports back to the room what the aside produced |
+| `!aside @peer …` | a private line to that peer, on a **second line** under the member's move |
+| `!surface …` | an ordinary desk move reporting back what the aside produced |
 
 Neither is a deliberation move. Neither appears in `MOVE_KINDS`, neither is
 gated by `hive.moves`, and neither deposits a trace — so they are taught after
-the move list rather than inside it.
+the move list rather than inside it. `split_reply`
+(`src/hivemind/prompt.rs`) is what separates the two: the marker line the room
+counts, and the one `!aside` riding under it. A reply that is *only* an aside
+still owes the room its turn, so its desk line falls through to `(no answer)` —
+honest rather than lossy, because the member did spend a turn without saying
+anything to the room.
 
 ## When a line becomes an aside
 

--- a/docs/spec/runtime/hivemind-asides.md
+++ b/docs/spec/runtime/hivemind-asides.md
@@ -147,22 +147,24 @@ appended, because an audience is fixed at append time: widening one afterwards
 could never be redelivered (a sharing watermark advances past filtered rows
 unconditionally) and would invalidate every citation naming it.
 
-Every rung below means "this line is an ordinary desk row", which is the safe
-direction — a line the room can read is never a leak, and the member has still
-said what it meant to say. A refusal is logged, never raised: none of these is a
-reason to abandon an episode.
+Every rung below means **the private row is dropped**. The turn's own
+desk-visible line is unaffected and still reaches the room — the member has
+already said its piece — and a refusal is logged, never raised: none of these is
+a reason to abandon an episode. Dropping rather than publishing is the point:
+falling back to the desk would put a second desk-visible contribution on one
+turn.
 
 | Condition | Behaviour |
 | --- | --- |
-| The line does not start with `!aside` | Desk row |
-| `aside = { enabled = false }` (the default) | Desk row — `Disabled` |
-| The author is not an active member of this desk | Desk row — `AuthorNotOnDesk` |
-| The line names no agent — `@#desk`, `@everyone`, or nobody | Desk row — `NoAudience` |
-| It names only its own author | Desk row — `SelfOnly` |
-| It names more peers than `max_members` | Desk row — `AudienceTooLarge` |
-| A named peer is not an active member of this desk | Desk row — `TargetNotOnDesk` |
-| This pair has spent `max_messages` | Desk row — `BudgetSpent` |
-| `must_surface`, and this pair's last aside never surfaced | Desk row — `UnsettledAside` |
+| The reply carries no `!aside` line | No private row to write |
+| `aside = { enabled = false }` (the default) | Dropped — `Disabled` |
+| The author is not an active member of this desk | Dropped — `AuthorNotOnDesk` |
+| The line names no agent — `@#desk`, `@everyone`, or nobody | Dropped — `NoAudience` |
+| It names only its own author | Dropped — `SelfOnly` |
+| It names more peers than `max_members` | Dropped — `AudienceTooLarge` |
+| A named peer is not an active member of this desk | Dropped — `TargetNotOnDesk` |
+| This pair has spent `max_messages` | Dropped — `BudgetSpent` |
+| `must_surface`, and this pair's last aside never surfaced | Dropped — `UnsettledAside` |
 | Anything else | **Aside**, addressed to the named peers |
 
 A first addressed id that cannot be resolved **stops** the decision rather than

--- a/docs/spec/runtime/hivemind-asides.md
+++ b/docs/spec/runtime/hivemind-asides.md
@@ -1,0 +1,208 @@
+# Private asides
+
+Two members of a desk comparing notes without the room.
+
+[Cross-desk referral](hivemind-referral.md) lets a room ask another desk a
+question. An aside is the other direction and stays inside one desk: it lets two
+members of the **same** desk say something the rest of that desk cannot read.
+Both are agent-to-agent communication, and both obey the same rule at the
+boundary — see [what crosses carries no vote](#an-aside-carries-information-never-support).
+
+The mechanics come from [`tinyhivemind`](https://github.com/tinyhumansai/tinyhivemind)
+(`vendor/tinyhivemind/docs/specs/private-asides.md`). This host supplies the
+journal field, the manifest knob, the grammar in the prompt, and the fold that
+counts what a pair has spent.
+
+## It is off by default, because it was measured and it lost
+
+The library ran the experiment
+(`vendor/tinyhivemind/docs/experiments/2026-09-07-do-asides-help.md`): a private
+pairwise check costs **2.5 points** at a tuned turn budget and nothing at an
+unconstrained one, loses **15 points** on a hidden profile — averaging inside
+one correlated desk imports the shared bias rather than cancelling it — and is
+**indistinguishable** from the same exchange held in the open.
+
+So the mechanism claims bounded independence and an auditable record of it. It
+claims nothing about answer quality, `AsideConfig` defaults to disabled, and a
+desk that wants asides has to say so. Enabling one should be a decision, not a
+default.
+
+## Auditable, not confidential
+
+**Privacy here is between agents and is a deliberation device. It is never a
+security boundary, and nothing may be built on it as one.** An operator and
+every person reads every aside in full.
+
+What narrows is the projection handed to a *peer agent*, and even there the row
+is **elided rather than removed**: its sequence, its author and its audience
+stay, and only the content is withheld.
+
+```text
+[7-10] @stock_controller → @fleet_tech · aside, 4 messages · settled at [11]
+```
+
+Three reasons the row stays, rather than disappearing:
+
+- **Auditability.** Two agents cannot exchange anything without leaving an
+  attributed, sequenced row. An absent row is precisely the covert channel the
+  literature names.
+- **Latent asymmetry.** An agent that cannot see that a peer knows something has
+  no reason to ask, and that is the documented failure of collective reasoning
+  under distributed information.
+- **Citations.** The trace grammar addresses messages by sequence. Silently
+  removing rows leaves `^N` naming nothing; a citation landing inside an elided
+  range resolves to the collapsed row, so the reader learns that its citation
+  names something it may not read — the honest answer, at one row instead of
+  four.
+
+## An aside carries information, never support
+
+There is exactly one transcript for counting and it is the same for every
+reader. `step` folds the whole transcript; `project_for` is the only thing that
+narrows, per speaker.
+
+That ordering is load-bearing, and `EpisodeDriver::run` implements it directly:
+the `SessionQuery` this host issues carries `Viewer::Operator` — the true,
+unelided medium — and the per-speaker narrowing happens in `project_for` on the
+way into the prompt. A per-viewer fold would make `quorum::standings`,
+`attention::bids` and `directory` return well-formed **wrong** answers with no
+error path: a quorum one member can see and another cannot, and a floor-holder
+that differs by reader when there is one floor.
+
+The uniform rule, applied identically for every reader: **a trace deposited in a
+row whose audience is not `Desk` contributes nothing.** It adds no supporter,
+moves no option toward a decision, silences no advocate. To make an aside count,
+a member spends a desk-visible turn saying so in the open — that is `!surface`,
+and a `!surface` line is an ordinary desk row with no special handling.
+
+This is the rule cross-desk referral already accepts at a channel boundary,
+applied inside one desk.
+
+## The grammar
+
+Two markers, taught **only when the desk enabled asides** — a grammar is a fixed
+cost paid in every agent's system text on every turn, and teaching a move nobody
+may make spends that budget for nothing.
+
+| Marker | Means |
+| --- | --- |
+| `!aside @peer …` | opens a private line to that peer |
+| `!surface …` | reports back to the room what the aside produced |
+
+Neither is a deliberation move. Neither appears in `MOVE_KINDS`, neither is
+gated by `hive.moves`, and neither deposits a trace — so they are taught after
+the move list rather than inside it.
+
+## When a line becomes an aside
+
+`EpisodeDriver::aside_audience` is the gate, and it runs **before** the row is
+appended, because an audience is fixed at append time: widening one afterwards
+could never be redelivered (a sharing watermark advances past filtered rows
+unconditionally) and would invalidate every citation naming it.
+
+Every rung below means "this line is an ordinary desk row", which is the safe
+direction — a line the room can read is never a leak, and the member has still
+said what it meant to say. A refusal is logged, never raised: none of these is a
+reason to abandon an episode.
+
+| Condition | Behaviour |
+| --- | --- |
+| The line does not start with `!aside` | Desk row |
+| `aside = { enabled = false }` (the default) | Desk row — `Disabled` |
+| The author is not an active member of this desk | Desk row — `AuthorNotOnDesk` |
+| The line names no agent — `@#desk`, `@everyone`, or nobody | Desk row — `NoAudience` |
+| It names only its own author | Desk row — `SelfOnly` |
+| It names more peers than `max_members` | Desk row — `AudienceTooLarge` |
+| A named peer is not an active member of this desk | Desk row — `TargetNotOnDesk` |
+| This pair has spent `max_messages` | Desk row — `BudgetSpent` |
+| `must_surface`, and this pair's last aside never surfaced | Desk row — `UnsettledAside` |
+| Anything else | **Aside**, addressed to the named peers |
+
+A first addressed id that cannot be resolved **stops** the decision rather than
+being skipped: an audience assembled by quietly dropping the names it could not
+resolve is not the audience the author wrote.
+
+The two `hive-report` rows — a failed turn, and the episode's close — are always
+desk-visible. A reader who could not see that a turn failed would be reading a
+transcript with a hole in it that nothing accounts for.
+
+## The budget is folded, not tracked
+
+`aside::spent_and_unsettled` folds both figures out of the transcript the
+episode already holds, rather than carrying them across loop iterations. That is
+the same discipline the transcript itself follows: what the fold counts is
+exactly what a person reading the desk would see, so the two can never disagree.
+
+A **party** is the author plus its addressees, sorted and deduplicated, so the
+same pair folds to one key whichever of them wrote the row — otherwise one
+member's budget could be spent by the other. A party is per pair, not per desk:
+`@a→@b` and `@a→@c` are two asides with two budgets.
+
+"Unsettled" means the party opened an aside and no member of it has since
+written a desk-visible `!surface`. A `!surface` by **either** member settles it —
+the room is owed one settlement, not one per participant — and a `!surface` from
+somebody who was never in the aside settles nothing, since they have no debt to
+discharge. An ordinary desk turn by a member does not settle it either, or the
+requirement would be paid by whatever anybody happened to say next.
+
+`must_surface` is enforced at the **next** aside, not at the last turn. Nothing
+compels a settlement before an episode ends, so a room can still close with one
+unsettled. Making the episode refuse to converge on an unsettled aside was
+considered upstream and rejected as too blunt for a first cut.
+
+## What lands in the journal
+
+No new row shape and no second store. `CompanyEvent::AgentReply` gains one
+field:
+
+```rust
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+audience: Vec<String>,
+```
+
+Empty means desk-visible — every row written before this field existed, and
+every ordinary turn now. The list holds the **addressees only**; the author's
+admission to its own row is the library's rule (`Audience::admits`), not a
+member of the set.
+
+Additive on exactly the terms `task_id`, `parent` and `mentions` already are:
+`#[serde(default)]` is what lets an already-persisted log load, and
+`skip_serializing_if` is what keeps a desk-visible reply serializing
+byte-for-byte as it did before, so **no stored record needs migrating**.
+
+## The manifest knob
+
+```toml
+[[group_chat]]
+id = "ops"
+members = ["route_planner", "fleet_tech", "stock_controller", "field_realist"]
+
+[group_chat.hive]
+enabled = true
+quorum = 2
+
+[group_chat.hive.aside]
+enabled = true
+max_members = 1
+max_messages = 2
+must_surface = true
+```
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Whether a private line may be opened at all |
+| `max_members` | `1` | Largest audience **excluding** the author. A pair. A caucus of three inside a desk of four is not an aside, it is a second desk with no quorum and no record — declare the desk instead |
+| `max_messages` | `2` | Rows one aside may carry: a question and an answer. Small because every private row is a row of the desk's turn budget spent where the room cannot read it |
+| `must_surface` | `true` | Whether the pair owes the room a settlement before opening another. Without it a pair can hold the whole episode privately and the record is a run of stubs |
+| `require_thread` | `false` | Whether an aside must be a thread. **Defaults off here, unlike the library's suggestion**: a hive episode runs on the desk channel, so a desk requiring threads would authorize no asides at all — a confusing way to spell `enabled = false` |
+
+A disabled config discards its own bounds: `AsideConfig::policy` returns
+`AsidePolicy::DEFAULT` with every bound at zero, so a desk that is off cannot be
+read as a desk that is on with limits.
+
+## See also
+
+- [`hivemind.md`](hivemind.md) — the episode, the loop and the move grammar.
+- [`hivemind-referral.md`](hivemind-referral.md) — the same no-vote rule at a
+  desk boundary.
+- `companies/vending_machine_co` — a bundle whose desks talk to each other.

--- a/docs/spec/runtime/hivemind.md
+++ b/docs/spec/runtime/hivemind.md
@@ -245,6 +245,13 @@ the conversation they were folded from.
 | a failed turn | the desk id | `hive-report` | `@<id>'s turn did not finish: …` |
 | the close | the desk id | `hive-report` | how the episode ended, plus any failed turns, demotions and questions asked elsewhere |
 
+A desk that opted in to [private asides](hivemind-asides.md) writes the same
+row with a narrower **audience** — the turn's own row, carrying the peers it
+was addressed to, so a non-member's projection elides its content and keeps
+everything else. That is one additive field on `AgentReply`, not a row shape
+and not a second store; a desk that never enables asides writes exactly what
+it wrote before. Off by default.
+
 A desk that opted in to [cross-desk referral](hivemind-referral.md) adds two
 more row shapes — the far desk's own turn, on the far desk, and its answer
 carried home under `hive-referral`. Both are off by default.
@@ -362,6 +369,7 @@ is already durable in the turns above it. So is a memory note.
 | `src/hivemind/prompt.rs` | `EpisodePrompt`, `marker_line` |
 | `src/hivemind/episode.rs` | `EpisodeDriver`, `HiveTurnRunner` |
 | `src/hivemind/referral.rs` | `ReferralConfig`, `HiveFederation`, `HiveReferralRunner`, `EpisodeReferrals` — see [`hivemind-referral.md`](hivemind-referral.md) |
+| `src/hivemind/aside.rs` | `AsideConfig`, the `!aside` / `!surface` grammar, the per-pair budget fold — see [`hivemind-asides.md`](hivemind-asides.md) |
 | `src/harness/built_in/brain.rs` | the routing hook, `HiveDeskRunner`, and `HiveDeskMemory` (the `ContextStore` implementation) |
 
 ## Testing
@@ -408,5 +416,6 @@ left for a reader to assume:
   there.
 
 See also [`hivemind-deliberation.md`](hivemind-deliberation.md),
-[`hivemind-referral.md`](hivemind-referral.md) and
+[`hivemind-referral.md`](hivemind-referral.md),
+[`hivemind-asides.md`](hivemind-asides.md) and
 [`docs/modules/hivemind/README.md`](../../modules/hivemind/README.md).

--- a/scripts/vending-sim.py
+++ b/scripts/vending-sim.py
@@ -19,8 +19,8 @@ Stdlib only, so it runs wherever ``python3`` does. Talks to a running
     # the whole thing, defaults
     python3 scripts/vending-sim.py --days 14
 
-    # against an already-running simulator, and a different company
-    python3 scripts/vending-sim.py --mcp-url http://127.0.0.1:7801/mcp --no-spawn-mcp
+    # a longer run, persisting the world so it can be resumed
+    python3 scripts/vending-sim.py --days 30 --state /tmp/vending.json --out run.json
 
 Exit status is the number of days on which no desk produced a decision, so a
 CI-style caller can treat zero as "the company was awake the whole time".
@@ -29,12 +29,14 @@ CI-style caller can treat zero as "the company was awake the whole time".
 from __future__ import annotations
 
 import argparse
+import http.cookiejar
 import json
 import re
 import sys
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -208,25 +210,80 @@ def describe(triggers: list[dict[str, Any]], day: int) -> str:
     )
 
 
-def episode_rows(events: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
-    """Split journal rows into the three things this run reports on."""
-    out: dict[str, list[dict[str, Any]]] = {"reports": [], "referrals": [], "turns": []}
-    for ev in events:
-        body = ev.get("event") if isinstance(ev.get("event"), dict) else ev
-        kind = body.get("kind") or body.get("type") or ""
-        if "AgentReply" not in str(kind) and "agent_reply" not in str(kind):
-            continue
-        author = body.get("agent_id") or body.get("agentId") or ""
-        if author == HIVE_REPORT_AUTHOR:
-            out["reports"].append(body)
-        elif author == HIVE_REFERRAL_AUTHOR:
-            out["referrals"].append(body)
-        else:
-            out["turns"].append(body)
-    return out
+_CARRIED = re.compile(r"carried|converged|committed", re.I)
 
 
-_DECIDED = re.compile(r"carried|converged|committed", re.I)
+def run_desk(host: Host, desk: str, text: str, settle: float, log) -> dict[str, Any]:
+    """State one day's triggers in one desk and wait for the room to close.
+
+    The chat POST holds open for the whole episode, and an approval parks
+    *inside* it, so the operator's two jobs have to run concurrently: state the
+    message on a thread, and pump approvals from here while it runs. This is the
+    same shape `hive-euler.py` uses, for the same reason — a driver that posted
+    synchronously would deadlock on its own approval the first time a desk
+    reached for `place_order`.
+    """
+    after = last_id(host, desk)
+    failure: list[BaseException] = []
+
+    def state() -> None:
+        try:
+            # A little past the reader's own deadline, so the POST outlives the
+            # wait rather than racing it.
+            host.say(desk, text, timeout=settle + 60)
+        except BaseException as err:  # noqa: BLE001 — surfaced below
+            failure.append(err)
+
+    poster = threading.Thread(target=state, daemon=True)
+    poster.start()
+
+    deadline = time.time() + settle
+    approved: list[str] = []
+    messages: list[dict] = []
+    report = None
+    while time.time() < deadline:
+        if failure:
+            log(f"[sim]     !! chat POST failed: {failure[0]}")
+            break
+        approved.extend(host.approve_all())
+        messages = [m for m in host.history(desk) if int(m.get("id", "0")) > after]
+        report = closing_report(messages)
+        if report:
+            break
+        time.sleep(3)
+
+    # `poster` is a daemon thread and never otherwise joined, so without this
+    # the next desk's POST could start while this one is still in flight and
+    # both would touch the same company concurrently. Bounded, not indefinite:
+    # a tool still parked could keep the POST open well past our own deadline.
+    poster.join(timeout=30)
+    if poster.is_alive():
+        log(f"[sim]     !! the POST is still in flight past the settle window")
+
+    referrals = [m for m in messages if m.get("author") == HIVE_REFERRAL_AUTHOR]
+    turns = [
+        m
+        for m in messages
+        if m.get("author") not in (HIVE_REPORT_AUTHOR, HIVE_REFERRAL_AUTHOR)
+        and not m.get("mine")
+    ]
+    # An aside is journaled as an ordinary desk turn carrying a narrower
+    # audience, and the transcript renders its marker — which is what these
+    # count. An operator is admitted to every aside, so this reader sees them
+    # all; a peer agent's own projection would have elided the ones it is not in.
+    asides = [m for m in turns if m.get("text", "").lstrip().startswith("!aside")]
+    surfaced = [m for m in turns if m.get("text", "").lstrip().startswith("!surface")]
+
+    return {
+        "desk": desk,
+        "turns": len(turns),
+        "referrals": [m.get("text", "") for m in referrals],
+        "asides": len(asides),
+        "surfaced": len(surfaced),
+        "approved": approved,
+        "report": (report or {}).get("text"),
+        "carried": bool(report and _CARRIED.search(report.get("text", ""))),
+    }
 
 
 def main() -> int:
@@ -239,54 +296,40 @@ def main() -> int:
     ap.add_argument("--mcp-host", default="127.0.0.1")
     ap.add_argument("--mcp-port", type=int, default=7801)
     ap.add_argument("--mcp-url", default=None, help="override the URL registered with the company")
-    ap.add_argument("--no-spawn-mcp", action="store_true", help="use an already-running simulator")
     ap.add_argument("--state", type=Path, default=None, help="persist the world here")
     ap.add_argument(
         "--settle",
         type=float,
-        default=90.0,
-        help="seconds to wait for a day's episodes before moving the clock",
+        default=600.0,
+        help="seconds to wait for one desk's episode before moving on",
     )
     ap.add_argument("--out", type=Path, default=None, help="write a JSON transcript here")
     args = ap.parse_args()
 
-    server = None
-    world = None
-    if not args.no_spawn_mcp:
-        server = build_server(args.mcp_host, args.mcp_port, args.state, args.seed)
-        world = server.ops.world
-        threading.Thread(target=server.serve_forever, daemon=True).start()
-        print(f"[sim] vending MCP on http://{args.mcp_host}:{args.mcp_port}/mcp", flush=True)
+    def log(line: str) -> None:
+        print(line, flush=True)
+
+    server = build_server(args.mcp_host, args.mcp_port, args.state, args.seed)
+    world = server.ops.world
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    log(f"[sim] vending MCP on http://{args.mcp_host}:{args.mcp_port}/mcp — day {world.day}")
 
     mcp_url = args.mcp_url or f"http://{args.mcp_host}:{args.mcp_port}/mcp"
-
-    client = Client(args.base)
-    client.sign_in_if_needed()
-    try:
-        client.register_mcp("vending", mcp_url)
-        print(f"[sim] registered `vending` -> {mcp_url}", flush=True)
-    except RuntimeError as err:
-        # Already registered from a previous run is fine and common.
-        print(f"[sim] register `vending`: {err}", flush=True)
-
-    stop = threading.Event()
-    approval_log: list[str] = []
-    pump = threading.Thread(target=pump_approvals, args=(client, stop, approval_log), daemon=True)
-    pump.start()
-
-    cursor = 0
-    try:
-        cursor = max((e.get("seq") or 0) for e in client.events(0, 1000)) if True else 0
-    except Exception:
-        cursor = 0
+    host = Host(args.base)
+    host.sign_in()
+    status, body = host.register_mcp("vending", mcp_url)
+    if status >= 300:
+        # Already registered from a previous run is fine and common; anything
+        # else is worth seeing, because the desks have no tools at all without
+        # it and would otherwise deliberate confidently about nothing.
+        log(f"[sim] register `vending` -> {mcp_url}: {status} {body}")
+    else:
+        log(f"[sim] registered `vending` -> {mcp_url}")
 
     transcript: list[dict[str, Any]] = []
     silent_days = 0
 
     for _ in range(args.days):
-        if world is None:
-            print("[sim] --no-spawn-mcp: this driver cannot advance somebody else's clock")
-            break
         day_triggers = world.advance(1)
         by_desk: dict[str, list[dict[str, Any]]] = {}
         for t in day_triggers:
@@ -294,83 +337,65 @@ def main() -> int:
             if desk:
                 by_desk.setdefault(desk, []).append(t)
 
-        print(f"\n[sim] === day {world.day} — {len(day_triggers)} triggers ===", flush=True)
+        log(f"\n[sim] === day {world.day} — {len(day_triggers)} triggers ===")
+        outcomes = []
         for desk, items in by_desk.items():
             kinds = ", ".join(sorted({t["kind"] for t in items}))
-            print(f"[sim]   -> {desk}: {len(items)} ({kinds})", flush=True)
-            try:
-                client.say(desk, describe(items, world.day))
-            except RuntimeError as err:
-                print(f"[sim]   !! {desk}: {err}", flush=True)
+            log(f"[sim]  -> {desk}: {len(items)} ({kinds})")
+            outcome = run_desk(host, desk, describe(items, world.day), args.settle, log)
+            outcomes.append(outcome)
+            log(
+                f"[sim]     {outcome['turns']} turns, {outcome['asides']} asides "
+                f"({outcome['surfaced']} surfaced), {len(outcome['referrals'])} referrals, "
+                f"{len(outcome['approved'])} approvals"
+            )
+            for text in outcome["referrals"]:
+                log(f"[sim]     ~~ referral: {text[:150]}")
+            if outcome["report"]:
+                log(f"[sim]     == {outcome['report'][:150]}")
+            else:
+                log("[sim]     == no close within the settle window")
 
-        deadline = time.time() + args.settle
-        seen_reports = 0
-        rows: dict[str, list[dict[str, Any]]] = {"reports": [], "referrals": [], "turns": []}
-        while time.time() < deadline:
-            try:
-                fresh = client.events(cursor, 500)
-            except RuntimeError:
-                time.sleep(2.0)
-                continue
-            if fresh:
-                cursor = max(cursor, max((e.get("seq") or 0) for e in fresh))
-                split = episode_rows(fresh)
-                for key in rows:
-                    rows[key].extend(split[key])
-            # Every desk that was asked has closed its episode.
-            if len(rows["reports"]) >= len(by_desk) and by_desk:
-                break
-            time.sleep(2.0)
-
-        decided = [r for r in rows["reports"] if _DECIDED.search(str(r.get("text", "")))]
-        if not decided:
+        if not any(o["carried"] for o in outcomes):
             silent_days += 1
-        print(
-            f"[sim]   {len(rows['turns'])} turns, {len(rows['referrals'])} cross-desk referrals, "
-            f"{len(rows['reports'])} episodes closed ({len(decided)} carried)",
-            flush=True,
+        transcript.append(
+            {
+                "day": world.day,
+                "triggers": day_triggers,
+                "routed": {k: len(v) for k, v in by_desk.items()},
+                "outcomes": outcomes,
+            }
         )
-        for ref in rows["referrals"]:
-            print(f"[sim]   ~~ referral: {str(ref.get('text', ''))[:160]}", flush=True)
-        for rep in rows["reports"]:
-            print(f"[sim]   == {str(rep.get('text', ''))[:160]}", flush=True)
 
-        transcript.append({
-            "day": world.day,
-            "triggers": day_triggers,
-            "routed": {k: len(v) for k, v in by_desk.items()},
-            "turns": len(rows["turns"]),
-            "referrals": [r.get("text") for r in rows["referrals"]],
-            "reports": [r.get("text") for r in rows["reports"]],
-        })
+    report = world.sales_report(max(0, world.day - args.days))
+    referrals = sum(len(o["referrals"]) for t in transcript for o in t["outcomes"])
+    asides = sum(o["asides"] for t in transcript for o in t["outcomes"])
+    surfaced = sum(o["surfaced"] for t in transcript for o in t["outcomes"])
+    approvals = sum(len(o["approved"]) for t in transcript for o in t["outcomes"])
 
-    stop.set()
-
-    if world is not None:
-        report = world.sales_report(max(0, world.day - args.days))
-        open_incidents = [i for i in world.incidents if i.open]
-        print("\n[sim] ===== the run =====")
-        print(f"[sim] days simulated      {args.days}")
-        print(f"[sim] revenue             {report['revenue_cents'] / 100:.2f}")
-        print(f"[sim] margin              {report['margin_cents'] / 100:.2f}")
-        print(f"[sim] units               {report['units']}")
-        print(f"[sim] incidents still open {len(open_incidents)}")
-        print(f"[sim] approvals answered  {len(approval_log)}")
-        print(f"[sim] cross-desk referrals {sum(len(d['referrals']) for d in transcript)}")
-        print(f"[sim] days with no decision {silent_days}")
-        for c in world.clients.values():
-            print(f"[sim]   {c.name:<26} satisfaction {c.satisfaction:.2f}  "
-                  f"renews day {c.contract_renews_day}")
+    log("\n[sim] ===== the run =====")
+    log(f"[sim] days simulated        {args.days}")
+    log(f"[sim] revenue               {report['revenue_cents'] / 100:.2f}")
+    log(f"[sim] margin                {report['margin_cents'] / 100:.2f}")
+    log(f"[sim] units                 {report['units']}")
+    log(f"[sim] incidents still open  {sum(1 for i in world.incidents if i.open)}")
+    log(f"[sim] cross-desk referrals  {referrals}")
+    log(f"[sim] private asides        {asides} ({surfaced} surfaced)")
+    log(f"[sim] approvals answered    {approvals}")
+    log(f"[sim] days with no decision {silent_days}")
+    for c in world.clients.values():
+        log(
+            f"[sim]   {c.name:<26} satisfaction {c.satisfaction:.2f}  "
+            f"renews day {c.contract_renews_day}"
+        )
 
     if args.out:
         args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(json.dumps(transcript, indent=2, default=str))
-        print(f"[sim] transcript -> {args.out}")
+        log(f"[sim] transcript -> {args.out}")
 
-    if server is not None:
-        server.shutdown()
-        server.server_close()
-
+    server.shutdown()
+    server.server_close()
     return silent_days
 
 

--- a/scripts/vending-sim.py
+++ b/scripts/vending-sim.py
@@ -228,7 +228,20 @@ def describe(triggers: list[dict[str, Any]], day: int) -> str:
     )
 
 
-_CARRIED = re.compile(r"carried|converged|committed", re.I)
+# The four closes `EpisodeOutcome::summary` can write (`src/hivemind/types.rs`),
+# of which exactly one is a decision:
+#
+#   converged  "The desk settled on #topic after N turns (backed by …)."
+#   deadlocked "The desk deadlocked after N turns: #a and #b carried together…"
+#   exhausted  "The desk spent its N-turn budget without reaching a decision."
+#   idle       "Nobody on the desk had anything to add, so the room did not open."
+#
+# Anchored on "settled on #" and nothing looser. A first cut matched
+# `carried|converged|committed` and was wrong twice over: it missed every real
+# decision, because the converged summary says "settled" and never "carried",
+# and it would have scored a *deadlock* as a decision, because "carried
+# together" is how the deadlock line describes the tie it failed to break.
+_CARRIED = re.compile(r"settled on #", re.I)
 
 
 def run_desk(host: Host, desk: str, text: str, settle: float, log) -> dict[str, Any]:

--- a/scripts/vending-sim.py
+++ b/scripts/vending-sim.py
@@ -70,113 +70,127 @@ TRIGGER_DESK = {
 MAX_TRIGGERS_PER_MESSAGE = 12
 
 
-class Client:
-    """The company's REST surface, with the dev-code sign-in the harness needs."""
+class Host:
+    """A cookie-carrying HTTP client for one OpenCompany host.
 
-    def __init__(self, base: str, timeout: float = 30.0) -> None:
+    The surfaces and their exact shapes are the ones ``scripts/hive-euler.py``
+    already drives against a live host — the auth flow, the approvals verdict
+    body and the desk transcript read are copied rather than re-derived,
+    because each of them is a place a plausible-looking guess fails only at
+    run time against a real server.
+    """
+
+    def __init__(self, base: str) -> None:
         self.base = base.rstrip("/")
-        self.timeout = timeout
-        self.opener = urllib.request.build_opener(
-            urllib.request.HTTPCookieProcessor()
-        )
+        self.jar = http.cookiejar.CookieJar()
+        self.opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(self.jar))
 
-    def _call(self, method: str, path: str, body: Any = None) -> Any:
-        url = f"{self.base}{path}"
-        data = json.dumps(body).encode() if body is not None else None
-        req = urllib.request.Request(url, data=data, method=method)
+    def call(self, method: str, path: str, body: Any = None, timeout: float = 120):
+        data = None if body is None else json.dumps(body).encode()
+        req = urllib.request.Request(self.base + path, data=data, method=method)
         req.add_header("accept", "application/json")
-        if data:
+        if data is not None:
             req.add_header("content-type", "application/json")
         try:
-            with self.opener.open(req, timeout=self.timeout) as resp:
+            with self.opener.open(req, timeout=timeout) as resp:
                 raw = resp.read()
-                return json.loads(raw) if raw else None
+                return resp.status, (json.loads(raw) if raw else None)
         except urllib.error.HTTPError as err:
-            detail = err.read().decode(errors="replace")[:400]
-            raise RuntimeError(f"{method} {path} -> {err.code}: {detail}") from err
+            raw = err.read()
+            try:
+                return err.code, json.loads(raw)
+            except ValueError:
+                return err.code, raw.decode(errors="replace")
 
-    def get(self, path: str) -> Any:
-        return self._call("GET", path)
-
-    def post(self, path: str, body: Any = None) -> Any:
-        return self._call("POST", path, body)
-
-    # -- auth -------------------------------------------------------------
-
-    def sign_in_if_needed(self) -> None:
-        """No-op under `OPENCOMPANY_AUTH_MODE=none`; dev-code flow otherwise.
-
-        The host echoes a dev code on loopback with no public URL, which is the
-        only reason this can be unattended. If neither path works, the run
-        fails here rather than a hundred confusing 401s later.
-        """
-        try:
-            self.get(f"{SCOPE}/health")
+    def sign_in(self) -> None:
+        """No-op when auth is `none`; otherwise the loopback dev-code flow."""
+        status, _ = self.call("GET", f"{SCOPE}/chat/history?limit=1")
+        if status == 200:
             return
-        except RuntimeError:
-            pass
-        started = self.post("/api/v1/auth/dev/start", {"email": ADMIN_EMAIL})
-        code = (started or {}).get("code")
+        status, body = self.call("POST", f"{SCOPE}/auth/request", {"email": ADMIN_EMAIL})
+        code = (body or {}).get("dev_code") if isinstance(body, dict) else None
         if not code:
-            raise RuntimeError(
-                "the host did not echo a dev sign-in code; run it with "
-                "OPENCOMPANY_AUTH_MODE=none or on loopback with no public URL"
-            )
-        self.post("/api/v1/auth/dev/verify", {"email": ADMIN_EMAIL, "code": code})
+            raise SystemExit(f"sign-in: no dev_code from auth/request ({status}: {body})")
+        status, body = self.call("POST", f"{SCOPE}/auth/verify", {"code": code})
+        if status >= 300:
+            raise SystemExit(f"sign-in: verify refused ({status}: {body})")
 
-    # -- the surfaces this driver uses ------------------------------------
-
-    def register_mcp(self, name: str, endpoint: str) -> Any:
+    def register_mcp(self, name: str, endpoint: str) -> tuple[int, Any]:
         """Add the simulator as a *runtime* MCP server.
 
-        Runtime is the only layer that accepts an `http://` endpoint — a server
-        declared in a bundle's `mcp.json` must be `https` (`content_test`).
-        That is why the bundle ships `vending` disabled and this registers the
-        loopback one instead of enabling it.
+        Runtime is the only layer that accepts an ``http://`` endpoint — a
+        server declared in a bundle's ``mcp.json`` must be ``https``
+        (`content_test`). That is why the bundle ships `vending` disabled and
+        this registers the loopback one instead of enabling it.
         """
-        return self.post(f"{SCOPE}/mcp/servers", {"name": name, "endpoint": endpoint})
-
-    def say(self, desk: str, text: str) -> Any:
-        return self.post(f"{SCOPE}/chat", {"chat": desk, "text": text})
-
-    def events(self, after: int = 0, limit: int = 500) -> list[dict[str, Any]]:
-        got = self.get(f"{SCOPE}/events?after={after}&limit={limit}")
-        if isinstance(got, dict):
-            return got.get("events") or got.get("items") or []
-        return got or []
-
-    def approvals(self) -> list[dict[str, Any]]:
-        got = self.get(f"{SCOPE}/approvals")
-        if isinstance(got, dict):
-            return got.get("approvals") or got.get("items") or []
-        return got or []
-
-    def decide(self, approval_id: str, approve: bool = True) -> Any:
-        return self.post(
-            f"{SCOPE}/approvals/{approval_id}",
-            {"decision": "approve" if approve else "deny", "reason": "vending-sim: unattended run"},
+        return self.call(
+            "POST", f"{SCOPE}/mcp/servers", {"name": name, "endpoint": endpoint}
         )
 
+    def say(self, desk: str, text: str, timeout: float = 3600) -> None:
+        """Put one message to `desk`, holding the POST open for the episode.
 
-def pump_approvals(client: Client, stop: threading.Event, log: list[str]) -> None:
-    """Answer the approvals queue for as long as the run lasts.
+        The cycle runs the whole episode synchronously inside this request, so
+        this blocks for as long as the room deliberates. The caller has to run
+        it on a thread and pump approvals meanwhile — see `run_day`.
+        """
+        status, body = self.call(
+            "POST", f"{SCOPE}/chat", {"text": text, "chat": desk}, timeout=timeout
+        )
+        if status >= 300:
+            raise RuntimeError(f"chat POST to `{desk}` failed ({status}): {body}")
 
-    `place_order` and `renegotiate_contract` are on the bundle's
-    `always_approve` list, so an unattended run deadlocks without this — the
-    desk commits, reaches for the tool, and parks forever. Approving everything
-    is right for a simulation and wrong for anything else.
+    def approve_all(self) -> list[str]:
+        """Answer everything parked.
+
+        `place_order` and `renegotiate_contract` are on this bundle's
+        `always_approve` list, so an unattended run deadlocks without this: the
+        desk commits, reaches for the tool, and parks inside the still-open
+        chat POST. Approving everything is right for a simulation and wrong for
+        anything else.
+        """
+        status, body = self.call("GET", f"{SCOPE}/approvals")
+        if status != 200 or not isinstance(body, list):
+            return []
+        approved = []
+        for approval in body:
+            aid = approval.get("id")
+            status, _ = self.call(
+                "POST", f"{SCOPE}/approvals/{aid}", {"verdict": "approve", "detach": True}
+            )
+            if status < 300:
+                approved.append(approval.get("kind", "?"))
+        return approved
+
+    def history(self, desk: str, limit: int = 200) -> list[dict]:
+        query = urllib.parse.urlencode({"desk": desk, "limit": limit})
+        status, body = self.call("GET", f"{SCOPE}/chat/history?{query}")
+        if status != 200 or not isinstance(body, list):
+            return []
+        return body
+
+
+def last_id(host: Host, desk: str) -> int:
+    rows = host.history(desk, limit=1)
+    return int(rows[-1]["id"]) if rows else 0
+
+
+def closing_report(messages: list[dict]) -> dict | None:
+    """The episode's close, which is not every `hive-report` row.
+
+    A failed turn is journaled under the same author and begins `@someone's
+    turn did not finish` — the room continues after one, so treating it as the
+    close would report an episode as over while it was still running.
     """
-    while not stop.is_set():
-        try:
-            for card in client.approvals():
-                ident = card.get("id") or card.get("approval_id")
-                if not ident:
-                    continue
-                client.decide(str(ident), True)
-                log.append(f"approved {card.get('tool') or card.get('title') or ident}")
-        except Exception as err:  # a transient read must not kill the pump
-            log.append(f"approval pump: {err}")
-        stop.wait(3.0)
+    return next(
+        (
+            m
+            for m in reversed(messages)
+            if m.get("author") == HIVE_REPORT_AUTHOR
+            and not m.get("text", "").lstrip().startswith("@")
+        ),
+        None,
+    )
 
 
 def describe(triggers: list[dict[str, Any]], day: int) -> str:

--- a/scripts/vending-sim.py
+++ b/scripts/vending-sim.py
@@ -120,13 +120,29 @@ class Host:
             raise SystemExit(f"sign-in: verify refused ({status}: {body})")
 
     def register_mcp(self, name: str, endpoint: str) -> tuple[int, Any]:
-        """Add the simulator as a *runtime* MCP server.
+        """Point the company's `vending` server at this run's simulator.
 
         Runtime is the only layer that accepts an ``http://`` endpoint — a
         server declared in a bundle's ``mcp.json`` must be ``https``
         (`content_test`). That is why the bundle ships `vending` disabled and
-        this registers the loopback one instead of enabling it.
+        pointing at a placeholder, and why this repoints it at loopback.
+
+        **It is a PUT, not a POST.** The name is already declared in the bundle,
+        so adding it is a 409 telling you to override it instead — and a POST
+        that 409s leaves the desks holding the shipped, disabled placeholder and
+        deliberating confidently with no tools at all. `PUT` creates a runtime
+        override of the manifest entry, which is exactly the layer-4 override
+        `docs/spec/runtime/tools.md` describes.
         """
+        status, body = self.call(
+            "PUT",
+            f"{SCOPE}/mcp/servers/{urllib.parse.quote(name)}",
+            {"endpoint": endpoint, "enabled": True},
+        )
+        if status < 300:
+            return status, body
+        # No such name to override: a company that does not ship the entry at
+        # all (someone running this against a hand-rolled bundle). Add it.
         return self.call(
             "POST", f"{SCOPE}/mcp/servers", {"name": name, "endpoint": endpoint}
         )

--- a/scripts/vending-sim.py
+++ b/scripts/vending-sim.py
@@ -9,8 +9,10 @@ triggers into the desk that owns them and waiting for the room to answer.
 
 What it is for is the thing a unit test cannot show: whether real models seated
 on three desks, given a fleet that is genuinely too big for the van, actually
-**talk to each other**. The run reports every cross-desk referral it saw, which
-is the mechanism this bundle exists to exercise.
+**talk to each other**. The run counts both seams this bundle exists to
+exercise — cross-desk referrals, and the private asides the ops desk may open —
+and prints the text of every referral, because a run in which the desks never
+speak to each other looks exactly like a healthy one from the margin alone.
 
 Stdlib only, so it runs wherever ``python3`` does. Talks to a running
 ``opencompany serve`` (default ``http://127.0.0.1:8080``) whose auth mode is

--- a/scripts/vending-sim.py
+++ b/scripts/vending-sim.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Run Northgate Vending as a live scenario: a world, a clock, and three desks.
+
+This is the vending-machine counterpart to ``scripts/hive-euler.py``. Where that
+one states a problem and grades the answer, this one runs a **business**: it
+starts the simulated world behind an MCP server, registers that server with a
+running company, then advances the clock a day at a time — posting each day's
+triggers into the desk that owns them and waiting for the room to answer.
+
+What it is for is the thing a unit test cannot show: whether real models seated
+on three desks, given a fleet that is genuinely too big for the van, actually
+**talk to each other**. The run reports every cross-desk referral it saw, which
+is the mechanism this bundle exists to exercise.
+
+Stdlib only, so it runs wherever ``python3`` does. Talks to a running
+``opencompany serve`` (default ``http://127.0.0.1:8080``) whose auth mode is
+``none``, or signs in as the manifest admin through the dev-code flow.
+
+    # the whole thing, defaults
+    python3 scripts/vending-sim.py --days 14
+
+    # against an already-running simulator, and a different company
+    python3 scripts/vending-sim.py --mcp-url http://127.0.0.1:7801/mcp --no-spawn-mcp
+
+Exit status is the number of days on which no desk produced a decision, so a
+CI-style caller can treat zero as "the company was awake the whole time".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "vending"))
+
+from mcp_server import build_server  # noqa: E402
+
+SCOPE = "/api/v1/company"
+ADMIN_EMAIL = "harness-e2e@tinyhumans.ai"
+HIVE_REPORT_AUTHOR = "hive-report"
+HIVE_REFERRAL_AUTHOR = "hive-referral"
+
+# Which desk owns which kind of trigger. The routing is deliberately dumb: a
+# trigger goes to the desk that owns the *decision*, not to the desk that holds
+# the most facts about it, because the desks can ask each other for facts and
+# the whole point of the run is to see whether they do.
+TRIGGER_DESK = {
+    "machine_down": "ops",
+    "chiller_fault": "ops",
+    "stockout": "ops",
+    "spoilage": "ops",
+    "delivery_received": "ops",
+    "incident_stale": "ops",
+    "complaint": "commercial",
+    "contract_renewal": "commercial",
+    "news": "intel",
+}
+
+# A day can produce dozens of triggers and a desk can hold one episode at a
+# time. Batching per desk per day is both cheaper and truer: an operator does
+# not page a team once per empty spiral, they hand over the morning's list.
+MAX_TRIGGERS_PER_MESSAGE = 12
+
+
+class Client:
+    """The company's REST surface, with the dev-code sign-in the harness needs."""
+
+    def __init__(self, base: str, timeout: float = 30.0) -> None:
+        self.base = base.rstrip("/")
+        self.timeout = timeout
+        self.opener = urllib.request.build_opener(
+            urllib.request.HTTPCookieProcessor()
+        )
+
+    def _call(self, method: str, path: str, body: Any = None) -> Any:
+        url = f"{self.base}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("accept", "application/json")
+        if data:
+            req.add_header("content-type", "application/json")
+        try:
+            with self.opener.open(req, timeout=self.timeout) as resp:
+                raw = resp.read()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as err:
+            detail = err.read().decode(errors="replace")[:400]
+            raise RuntimeError(f"{method} {path} -> {err.code}: {detail}") from err
+
+    def get(self, path: str) -> Any:
+        return self._call("GET", path)
+
+    def post(self, path: str, body: Any = None) -> Any:
+        return self._call("POST", path, body)
+
+    # -- auth -------------------------------------------------------------
+
+    def sign_in_if_needed(self) -> None:
+        """No-op under `OPENCOMPANY_AUTH_MODE=none`; dev-code flow otherwise.
+
+        The host echoes a dev code on loopback with no public URL, which is the
+        only reason this can be unattended. If neither path works, the run
+        fails here rather than a hundred confusing 401s later.
+        """
+        try:
+            self.get(f"{SCOPE}/health")
+            return
+        except RuntimeError:
+            pass
+        started = self.post("/api/v1/auth/dev/start", {"email": ADMIN_EMAIL})
+        code = (started or {}).get("code")
+        if not code:
+            raise RuntimeError(
+                "the host did not echo a dev sign-in code; run it with "
+                "OPENCOMPANY_AUTH_MODE=none or on loopback with no public URL"
+            )
+        self.post("/api/v1/auth/dev/verify", {"email": ADMIN_EMAIL, "code": code})
+
+    # -- the surfaces this driver uses ------------------------------------
+
+    def register_mcp(self, name: str, endpoint: str) -> Any:
+        """Add the simulator as a *runtime* MCP server.
+
+        Runtime is the only layer that accepts an `http://` endpoint — a server
+        declared in a bundle's `mcp.json` must be `https` (`content_test`).
+        That is why the bundle ships `vending` disabled and this registers the
+        loopback one instead of enabling it.
+        """
+        return self.post(f"{SCOPE}/mcp/servers", {"name": name, "endpoint": endpoint})
+
+    def say(self, desk: str, text: str) -> Any:
+        return self.post(f"{SCOPE}/chat", {"chat": desk, "text": text})
+
+    def events(self, after: int = 0, limit: int = 500) -> list[dict[str, Any]]:
+        got = self.get(f"{SCOPE}/events?after={after}&limit={limit}")
+        if isinstance(got, dict):
+            return got.get("events") or got.get("items") or []
+        return got or []
+
+    def approvals(self) -> list[dict[str, Any]]:
+        got = self.get(f"{SCOPE}/approvals")
+        if isinstance(got, dict):
+            return got.get("approvals") or got.get("items") or []
+        return got or []
+
+    def decide(self, approval_id: str, approve: bool = True) -> Any:
+        return self.post(
+            f"{SCOPE}/approvals/{approval_id}",
+            {"decision": "approve" if approve else "deny", "reason": "vending-sim: unattended run"},
+        )
+
+
+def pump_approvals(client: Client, stop: threading.Event, log: list[str]) -> None:
+    """Answer the approvals queue for as long as the run lasts.
+
+    `place_order` and `renegotiate_contract` are on the bundle's
+    `always_approve` list, so an unattended run deadlocks without this — the
+    desk commits, reaches for the tool, and parks forever. Approving everything
+    is right for a simulation and wrong for anything else.
+    """
+    while not stop.is_set():
+        try:
+            for card in client.approvals():
+                ident = card.get("id") or card.get("approval_id")
+                if not ident:
+                    continue
+                client.decide(str(ident), True)
+                log.append(f"approved {card.get('tool') or card.get('title') or ident}")
+        except Exception as err:  # a transient read must not kill the pump
+            log.append(f"approval pump: {err}")
+        stop.wait(3.0)
+
+
+def describe(triggers: list[dict[str, Any]], day: int) -> str:
+    """Render one desk's share of a day as a message an operator would send."""
+    shown = triggers[:MAX_TRIGGERS_PER_MESSAGE]
+    lines = [f"- {t['detail']}" for t in shown]
+    extra = len(triggers) - len(shown)
+    if extra > 0:
+        lines.append(f"- (and {extra} more of the same kind today)")
+    return (
+        f"Day {day}. What came in overnight:\n\n"
+        + "\n".join(lines)
+        + "\n\nDecide what to do about it. Read the fleet before you plan, and "
+        "say what you are choosing not to do."
+    )
+
+
+def episode_rows(events: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Split journal rows into the three things this run reports on."""
+    out: dict[str, list[dict[str, Any]]] = {"reports": [], "referrals": [], "turns": []}
+    for ev in events:
+        body = ev.get("event") if isinstance(ev.get("event"), dict) else ev
+        kind = body.get("kind") or body.get("type") or ""
+        if "AgentReply" not in str(kind) and "agent_reply" not in str(kind):
+            continue
+        author = body.get("agent_id") or body.get("agentId") or ""
+        if author == HIVE_REPORT_AUTHOR:
+            out["reports"].append(body)
+        elif author == HIVE_REFERRAL_AUTHOR:
+            out["referrals"].append(body)
+        else:
+            out["turns"].append(body)
+    return out
+
+
+_DECIDED = re.compile(r"carried|converged|committed", re.I)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--base", default="http://127.0.0.1:8080", help="the running opencompany serve")
+    ap.add_argument("--days", type=int, default=14, help="simulated days to run")
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--mcp-host", default="127.0.0.1")
+    ap.add_argument("--mcp-port", type=int, default=7801)
+    ap.add_argument("--mcp-url", default=None, help="override the URL registered with the company")
+    ap.add_argument("--no-spawn-mcp", action="store_true", help="use an already-running simulator")
+    ap.add_argument("--state", type=Path, default=None, help="persist the world here")
+    ap.add_argument(
+        "--settle",
+        type=float,
+        default=90.0,
+        help="seconds to wait for a day's episodes before moving the clock",
+    )
+    ap.add_argument("--out", type=Path, default=None, help="write a JSON transcript here")
+    args = ap.parse_args()
+
+    server = None
+    world = None
+    if not args.no_spawn_mcp:
+        server = build_server(args.mcp_host, args.mcp_port, args.state, args.seed)
+        world = server.ops.world
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        print(f"[sim] vending MCP on http://{args.mcp_host}:{args.mcp_port}/mcp", flush=True)
+
+    mcp_url = args.mcp_url or f"http://{args.mcp_host}:{args.mcp_port}/mcp"
+
+    client = Client(args.base)
+    client.sign_in_if_needed()
+    try:
+        client.register_mcp("vending", mcp_url)
+        print(f"[sim] registered `vending` -> {mcp_url}", flush=True)
+    except RuntimeError as err:
+        # Already registered from a previous run is fine and common.
+        print(f"[sim] register `vending`: {err}", flush=True)
+
+    stop = threading.Event()
+    approval_log: list[str] = []
+    pump = threading.Thread(target=pump_approvals, args=(client, stop, approval_log), daemon=True)
+    pump.start()
+
+    cursor = 0
+    try:
+        cursor = max((e.get("seq") or 0) for e in client.events(0, 1000)) if True else 0
+    except Exception:
+        cursor = 0
+
+    transcript: list[dict[str, Any]] = []
+    silent_days = 0
+
+    for _ in range(args.days):
+        if world is None:
+            print("[sim] --no-spawn-mcp: this driver cannot advance somebody else's clock")
+            break
+        day_triggers = world.advance(1)
+        by_desk: dict[str, list[dict[str, Any]]] = {}
+        for t in day_triggers:
+            desk = TRIGGER_DESK.get(t["kind"])
+            if desk:
+                by_desk.setdefault(desk, []).append(t)
+
+        print(f"\n[sim] === day {world.day} — {len(day_triggers)} triggers ===", flush=True)
+        for desk, items in by_desk.items():
+            kinds = ", ".join(sorted({t["kind"] for t in items}))
+            print(f"[sim]   -> {desk}: {len(items)} ({kinds})", flush=True)
+            try:
+                client.say(desk, describe(items, world.day))
+            except RuntimeError as err:
+                print(f"[sim]   !! {desk}: {err}", flush=True)
+
+        deadline = time.time() + args.settle
+        seen_reports = 0
+        rows: dict[str, list[dict[str, Any]]] = {"reports": [], "referrals": [], "turns": []}
+        while time.time() < deadline:
+            try:
+                fresh = client.events(cursor, 500)
+            except RuntimeError:
+                time.sleep(2.0)
+                continue
+            if fresh:
+                cursor = max(cursor, max((e.get("seq") or 0) for e in fresh))
+                split = episode_rows(fresh)
+                for key in rows:
+                    rows[key].extend(split[key])
+            # Every desk that was asked has closed its episode.
+            if len(rows["reports"]) >= len(by_desk) and by_desk:
+                break
+            time.sleep(2.0)
+
+        decided = [r for r in rows["reports"] if _DECIDED.search(str(r.get("text", "")))]
+        if not decided:
+            silent_days += 1
+        print(
+            f"[sim]   {len(rows['turns'])} turns, {len(rows['referrals'])} cross-desk referrals, "
+            f"{len(rows['reports'])} episodes closed ({len(decided)} carried)",
+            flush=True,
+        )
+        for ref in rows["referrals"]:
+            print(f"[sim]   ~~ referral: {str(ref.get('text', ''))[:160]}", flush=True)
+        for rep in rows["reports"]:
+            print(f"[sim]   == {str(rep.get('text', ''))[:160]}", flush=True)
+
+        transcript.append({
+            "day": world.day,
+            "triggers": day_triggers,
+            "routed": {k: len(v) for k, v in by_desk.items()},
+            "turns": len(rows["turns"]),
+            "referrals": [r.get("text") for r in rows["referrals"]],
+            "reports": [r.get("text") for r in rows["reports"]],
+        })
+
+    stop.set()
+
+    if world is not None:
+        report = world.sales_report(max(0, world.day - args.days))
+        open_incidents = [i for i in world.incidents if i.open]
+        print("\n[sim] ===== the run =====")
+        print(f"[sim] days simulated      {args.days}")
+        print(f"[sim] revenue             {report['revenue_cents'] / 100:.2f}")
+        print(f"[sim] margin              {report['margin_cents'] / 100:.2f}")
+        print(f"[sim] units               {report['units']}")
+        print(f"[sim] incidents still open {len(open_incidents)}")
+        print(f"[sim] approvals answered  {len(approval_log)}")
+        print(f"[sim] cross-desk referrals {sum(len(d['referrals']) for d in transcript)}")
+        print(f"[sim] days with no decision {silent_days}")
+        for c in world.clients.values():
+            print(f"[sim]   {c.name:<26} satisfaction {c.satisfaction:.2f}  "
+                  f"renews day {c.contract_renews_day}")
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(transcript, indent=2, default=str))
+        print(f"[sim] transcript -> {args.out}")
+
+    if server is not None:
+        server.shutdown()
+        server.server_close()
+
+    return silent_days
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vending-sim.py
+++ b/scripts/vending-sim.py
@@ -213,14 +213,25 @@ def closing_report(messages: list[dict]) -> dict | None:
     )
 
 
-def describe(triggers: list[dict[str, Any]], day: int) -> str:
-    """Render one desk's share of a day as a message an operator would send."""
+def describe(desk: str, triggers: list[dict[str, Any]], day: int) -> str:
+    """Render one desk's share of a day as a message an operator would send.
+
+    The leading `topic:` line is load-bearing. `canonical_topic` prefers an
+    operator-declared id over any derivation, and without one it slugs the
+    message's first line — which on a first live run produced the topic
+    `#day1-came`, from "Day 1. What came in overnight". Every `!propose`,
+    `!support` and `!commit` in that episode, and the close in the `episodes`
+    ledger, then carried a name that says nothing about what was decided.
+    Declaring `#ops-day-1` costs one line and makes a fortnight of runs
+    greppable by desk and by day.
+    """
     shown = triggers[:MAX_TRIGGERS_PER_MESSAGE]
     lines = [f"- {t['detail']}" for t in shown]
     extra = len(triggers) - len(shown)
     if extra > 0:
         lines.append(f"- (and {extra} more of the same kind today)")
     return (
+        f"topic: #{desk}-day-{day}\n\n"
         f"Day {day}. What came in overnight:\n\n"
         + "\n".join(lines)
         + "\n\nDecide what to do about it. Read the fleet before you plan, and "
@@ -373,7 +384,7 @@ def main() -> int:
         for desk, items in by_desk.items():
             kinds = ", ".join(sorted({t["kind"] for t in items}))
             log(f"[sim]  -> {desk}: {len(items)} ({kinds})")
-            outcome = run_desk(host, desk, describe(items, world.day), args.settle, log)
+            outcome = run_desk(host, desk, describe(desk, items, world.day), args.settle, log)
             outcomes.append(outcome)
             log(
                 f"[sim]     {outcome['turns']} turns, {outcome['asides']} asides "

--- a/scripts/vending/README.md
+++ b/scripts/vending/README.md
@@ -1,0 +1,90 @@
+# The vending world
+
+The simulated business behind `companies/vending_machine_co`, in three files
+that deliberately do not know about each other's concerns.
+
+| File | What it is | What it must not know |
+| --- | --- | --- |
+| `world.py` | The business: fleet, warehouse, clients, incidents, news, and the clock that moves them | What an agent is; anything about HTTP |
+| `mcp_server.py` | The only way to touch the world: an MCP Streamable-HTTP server | How the world computes anything |
+| `../vending-sim.py` | The scenario driver: advances the clock and posts each day's triggers into a running company | How either of the above works internally |
+
+## The world
+
+`World.seeded()` builds an eight-machine operator across five host sites —
+office, gym, hospital, campus, factory — each with its own demand profile, so
+the right assortment at one is wrong at another.
+
+`World.advance(days)` is the whole point. In a fixed order per day it lands
+deliveries (so the day's restock can use them), draws demand, spoils
+perishables, draws and ages incidents, and rolls news. It returns the
+**triggers** the period produced: a machine that went empty, a jam, a contract
+clock. The world says what happened; it never says what to do about it.
+
+Three couplings make the decisions non-trivial, and none of them is decorative:
+
+- **The warehouse is finite and the supplier takes four days.** A restock
+  decision is therefore also a purchasing decision made four days earlier, and
+  a plan that ignores the lead time buys stock for a week that is already over.
+- **A jam is total.** A jammed machine takes no money at all, so restocking one
+  stocks a machine that cannot sell — the single most expensive mistake
+  available, and the easiest to make from a stock report alone.
+- **Operational failure becomes commercial failure on a delay.** Stockouts and
+  incidents left open past three days erode the host's satisfaction, which is
+  what a competitor quotes against at renewal. By the time satisfaction is
+  visibly low, the damage was done a fortnight ago.
+
+Runs are seeded and the RNG state round-trips through `--state`, so a scenario
+replays exactly: a run that produced an interesting deliberation can be re-run
+against a changed prompt and the difference attributed to the prompt.
+
+## The MCP server
+
+Fourteen tools, split by **decision** rather than by table. `fleet_status`
+answers "where should the van go today" and returns `days_cover` per slot —
+because "how full is it" is the wrong question and "when does it run out" is the
+right one. `margin_report` computes margin against the supplier cost *at the
+time of sale*, so a line whose cost rose shows the squeeze rather than hiding
+it. An agent that had to assemble either from primitives would spend its turn on
+arithmetic instead of on the judgement its desk was seated for.
+
+Writes refuse rather than partially succeed: `restock_machine` rejects the whole
+call if any line exceeds warehouse stock or slot capacity, because a
+quietly-shortened plan hides the order that should have been placed first.
+
+Transport is MCP Streamable HTTP — one `POST /mcp` carrying JSON-RPC, answering
+`application/json`. That is what OpenCompany dials, and the only transport
+hosted OpenCompany supports (a stdio `command` is a validation error there). SSE
+is accepted by the client but not required, so this stays standard-library only.
+
+**There is no auth, deliberately.** It binds loopback and holds an invented
+fleet; a token would only mean the bundle had to ship a secret to make its own
+demo work. Do not put it on a public interface.
+
+```bash
+python3 scripts/vending/mcp_server.py --port 7801 --state /tmp/vending.json
+```
+
+Register it with a running company — runtime is the only layer where an
+`http://` endpoint is accepted, which is why the bundle ships its `vending`
+entry disabled rather than pointing it here:
+
+```bash
+curl -X POST localhost:8080/api/v1/company/mcp/servers \
+  -H 'content-type: application/json' \
+  -d '{"name":"vending","endpoint":"http://127.0.0.1:7801/mcp"}'
+```
+
+## The driver
+
+`scripts/vending-sim.py` does all of the above and then runs the loop: advance a
+day, route the day's triggers to the desk that owns the *decision* (not the desk
+that holds the most facts — the desks can ask each other, and whether they do is
+what the run is measuring), wait for the episodes to close, and report.
+
+It also pumps the approvals queue, because `place_order` and
+`renegotiate_contract` are on the bundle's `always_approve` list and an
+unattended run would otherwise deadlock with a desk parked on a tool call.
+
+Exit status is the number of days on which no desk produced a decision, so a
+CI-style caller can treat zero as "the company was awake the whole time".

--- a/scripts/vending/mcp_server.py
+++ b/scripts/vending/mcp_server.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+"""The vending business, exposed as an MCP server.
+
+This is the *work environment* the ``vending_machine_co`` bundle acts on. The
+world (``world.py``) is the business; this file is the only way an agent can
+touch it, which is the point: every read an agent makes and every change it
+causes is a tool call that can be logged, replayed and argued about.
+
+Transport is MCP **Streamable HTTP** — a single ``POST /mcp`` carrying JSON-RPC,
+answering ``application/json``. That is the transport OpenCompany dials
+(`vendor/openhuman/vendor/tinymcp/.../transport/http`), and the only one hosted
+OpenCompany supports: a stdio ``command`` is a validation error there
+(`docs/spec/runtime/tools.md`). SSE is accepted by the client but not required,
+and a plain JSON response keeps this to the standard library.
+
+Deliberately no auth. It binds loopback, it holds an invented fleet of vending
+machines, and adding a token would only mean the bundle had to ship a secret to
+make its own demo work. Do not put it on a public interface.
+
+Run it:
+
+    python3 scripts/vending/mcp_server.py --port 7801 --state /tmp/vending.json
+
+Then register it with a running company (this is why the URL may be ``http://``
+— a *runtime* server is allowed loopback, while a server shipped in a bundle's
+``mcp.json`` must be ``https``):
+
+    curl -X POST localhost:8080/api/v1/company/mcp/servers \\
+      -H 'content-type: application/json' \\
+      -d '{"name":"vending","endpoint":"http://127.0.0.1:7801/mcp"}'
+
+``scripts/vending-sim.py`` does all of that for you.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from world import CATALOGUE, LEAD_TIME_DAYS, World  # noqa: E402
+
+PROTOCOL_VERSION = "2025-06-18"
+SERVER_INFO = {"name": "vending-ops", "version": "1.0.0"}
+
+
+# ---------------------------------------------------------------------------
+# The tool surface
+#
+# Split by *decision* rather than by table. `fleet_status` answers "where should
+# a van go today", `margin_report` answers "what are we actually making", and
+# neither is a thin wrapper over a row store — an agent that had to assemble
+# either from primitives would spend its turn on arithmetic instead of on the
+# judgement the desk was seated for.
+# ---------------------------------------------------------------------------
+
+TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "fleet_status",
+        "description": (
+            "Every machine: site, host client, days since service, faults, and how "
+            "empty each slot is. The single read a restock or service decision starts "
+            "from. Returns `days_cover` per slot — at current sell-through, how many "
+            "days before that line is empty — because 'how full is it' is the wrong "
+            "question and 'when does it run out' is the right one."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "machine_id": {
+                    "type": "string",
+                    "description": "Limit to one machine. Omit for the whole fleet.",
+                }
+            },
+        },
+    },
+    {
+        "name": "warehouse_status",
+        "description": (
+            "Warehouse stock per SKU, what is on order and when it lands, and the "
+            "current supplier cost against the catalogue cost. Read this before "
+            "planning a restock: the warehouse is finite and a plan that exceeds it "
+            "is refused rather than silently shortened."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "margin_report",
+        "description": (
+            "Units, revenue and margin over a window, broken down by SKU and by "
+            "machine. Margin is computed against the supplier cost at the time of "
+            "sale, so a line whose cost rose shows the squeeze rather than hiding it."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "days": {"type": "integer", "description": "Window, in days back from today. Default 7."},
+                "machine_id": {"type": "string", "description": "Limit to one machine."},
+            },
+        },
+    },
+    {
+        "name": "client_status",
+        "description": (
+            "The host sites: commission, when the contract renews, satisfaction, and "
+            "the notes anyone has left. Satisfaction falls with stockouts and with "
+            "incidents left open, which is how an operational failure becomes a "
+            "commercial one."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"client_id": {"type": "string"}},
+        },
+    },
+    {
+        "name": "incident_list",
+        "description": (
+            "Open (or all) incidents: jams, chiller faults, spoilage, complaints, with "
+            "how many days each has been open. An incident open three days starts "
+            "costing the host's goodwill."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "include_resolved": {"type": "boolean"},
+                "machine_id": {"type": "string"},
+            },
+        },
+    },
+    {
+        "name": "news_feed",
+        "description": (
+            "Market signals seen so far: supplier cost moves, competitor activity at "
+            "named host sites, footfall events, weather. Nothing here is an "
+            "instruction — these are things a plan should have reacted to."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"days": {"type": "integer", "description": "How far back. Default 14."}},
+        },
+    },
+    {
+        "name": "restock_machine",
+        "description": (
+            "Move stock from the warehouse into a machine's slots and mark it "
+            "serviced. Refuses the whole call if any line exceeds warehouse stock or "
+            "slot capacity — a partially-filled plan would hide the order that should "
+            "have been placed first."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "machine_id": {"type": "string"},
+                "items": {
+                    "type": "object",
+                    "description": "SKU to unit count, e.g. {\"COLA-330\": 12}.",
+                    "additionalProperties": {"type": "integer"},
+                },
+            },
+            "required": ["machine_id", "items"],
+        },
+    },
+    {
+        "name": "service_machine",
+        "description": (
+            "Send an engineer: clears coin jams and chiller faults, resolves the "
+            "matching incidents, and resets the service clock. Faults arrive faster "
+            "the longer a machine has gone unserviced."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"machine_id": {"type": "string"}},
+            "required": ["machine_id"],
+        },
+    },
+    {
+        "name": "place_order",
+        "description": (
+            f"Order stock from the supplier at today's cost. Arrives in "
+            f"{LEAD_TIME_DAYS} days — a plan that ignores the lead time buys stock for "
+            f"a week that is already over."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "sku": {"type": "string"},
+                "qty": {"type": "integer"},
+            },
+            "required": ["sku", "qty"],
+        },
+    },
+    {
+        "name": "set_price",
+        "description": (
+            "Change one SKU's shelf price at one machine, in cents. Prices are per "
+            "machine on purpose: the same bar is a different product at a hospital "
+            "and at a gym."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "machine_id": {"type": "string"},
+                "sku": {"type": "string"},
+                "price_cents": {"type": "integer"},
+            },
+            "required": ["machine_id", "sku", "price_cents"],
+        },
+    },
+    {
+        "name": "resolve_incident",
+        "description": "Close an incident with a stated resolution. The resolution is the record.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "incident_id": {"type": "string"},
+                "resolution": {"type": "string"},
+            },
+            "required": ["incident_id", "resolution"],
+        },
+    },
+    {
+        "name": "note_client",
+        "description": "Append a dated note to a host site's record — what was promised, and by whom.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "client_id": {"type": "string"},
+                "note": {"type": "string"},
+            },
+            "required": ["client_id", "note"],
+        },
+    },
+    {
+        "name": "renegotiate_contract",
+        "description": (
+            "Re-sign a host site at a new commission and term. Raising commission "
+            "costs margin on every unit that site sells; losing the site costs all of "
+            "it. Being asked lifts satisfaction a little."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "client_id": {"type": "string"},
+                "commission_pct": {"type": "number", "description": "As a fraction, e.g. 0.18."},
+                "term_days": {"type": "integer"},
+            },
+            "required": ["client_id", "commission_pct", "term_days"],
+        },
+    },
+    {
+        "name": "catalogue",
+        "description": "Every SKU that can be stocked: cost, list price, whether it is chilled or perishable.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+
+class VendingOps:
+    """Dispatch from tool name to the world, under one lock.
+
+    The lock matters: a hive desk authorizes one speaker at a time, but several
+    desks run concurrently, and two agents restocking the same machine from the
+    same warehouse read is exactly the race this business has in real life.
+    Serializing here means the world's own refusals are the only way a plan
+    fails, rather than a torn read.
+    """
+
+    def __init__(self, world: World, state_path: Path | None) -> None:
+        self.world = world
+        self.state_path = state_path
+        self.lock = threading.Lock()
+
+    def _persist(self) -> None:
+        if self.state_path:
+            self.world.save(self.state_path)
+
+    def call(self, name: str, args: dict[str, Any]) -> Any:
+        with self.lock:
+            result = self._dispatch(name, args)
+            self._persist()
+            return result
+
+    def _dispatch(self, name: str, args: dict[str, Any]) -> Any:
+        w = self.world
+        if name == "fleet_status":
+            return self._fleet(args.get("machine_id"))
+        if name == "warehouse_status":
+            return self._warehouse()
+        if name == "margin_report":
+            days = int(args.get("days", 7))
+            return w.sales_report(max(0, w.day - days), args.get("machine_id"))
+        if name == "client_status":
+            return self._clients(args.get("client_id"))
+        if name == "incident_list":
+            return self._incidents(bool(args.get("include_resolved")), args.get("machine_id"))
+        if name == "news_feed":
+            days = int(args.get("days", 14))
+            return [
+                {"day": n.day, "headline": n.headline, "detail": n.detail, "tags": n.tags}
+                for n in w.news
+                if n.day > w.day - days
+            ]
+        if name == "restock_machine":
+            items = {str(k): int(v) for k, v in (args.get("items") or {}).items()}
+            return w.restock(str(args["machine_id"]), items)
+        if name == "service_machine":
+            return w.service(str(args["machine_id"]))
+        if name == "place_order":
+            return w.order(str(args["sku"]), int(args["qty"]))
+        if name == "set_price":
+            return w.set_price(str(args["machine_id"]), str(args["sku"]), int(args["price_cents"]))
+        if name == "resolve_incident":
+            return w.resolve_incident(str(args["incident_id"]), str(args["resolution"]))
+        if name == "note_client":
+            return w.note_client(str(args["client_id"]), str(args["note"]))
+        if name == "renegotiate_contract":
+            return w.renegotiate(
+                str(args["client_id"]), float(args["commission_pct"]), int(args["term_days"])
+            )
+        if name == "catalogue":
+            return CATALOGUE
+        raise KeyError(name)
+
+    # -- read shaping -----------------------------------------------------
+
+    def _recent_daily_rate(self, machine_id: str, sku: str, window: int = 7) -> float:
+        w = self.world
+        rows = [
+            s for s in w.sales
+            if s.machine_id == machine_id and s.sku == sku and s.day > w.day - window
+        ]
+        if not rows:
+            return 0.0
+        return sum(s.units for s in rows) / float(min(window, max(1, w.day)))
+
+    def _fleet(self, machine_id: str | None) -> list[dict[str, Any]]:
+        w = self.world
+        out = []
+        for m in w.machines.values():
+            if machine_id and m.id != machine_id:
+                continue
+            slots = []
+            for s in m.slots:
+                rate = self._recent_daily_rate(m.id, s.sku)
+                slots.append({
+                    "sku": s.sku,
+                    "name": CATALOGUE[s.sku]["name"],
+                    "stock": s.stock,
+                    "capacity": s.capacity,
+                    "price_cents": s.price,
+                    "daily_rate": round(rate, 2),
+                    # `None` reads as "no recent sales", which is a different
+                    # thing from "will never run out" and must not be rendered
+                    # as a large number.
+                    "days_cover": round(s.stock / rate, 1) if rate > 0 else None,
+                })
+            out.append({
+                "machine_id": m.id,
+                "site": m.site,
+                "client_id": m.client_id,
+                "client": w.clients[m.client_id].name,
+                "profile": m.profile,
+                "footfall": m.footfall,
+                "days_since_service": w.day - m.last_serviced_day,
+                "coin_jam": m.coin_jam,
+                "chiller_ok": m.chiller_ok,
+                "cash_cents": m.cash_cents,
+                "slots": slots,
+            })
+        return out
+
+    def _warehouse(self) -> dict[str, Any]:
+        w = self.world
+        on_order: dict[str, list[dict[str, Any]]] = {}
+        for po in w.orders:
+            if po.received:
+                continue
+            on_order.setdefault(po.sku, []).append(
+                {"order_id": po.id, "qty": po.qty, "arrives_day": po.arrives_day}
+            )
+        return {
+            "day": w.day,
+            "lead_time_days": LEAD_TIME_DAYS,
+            "stock": w.warehouse,
+            "on_order": on_order,
+            "supplier_cost_cents": {
+                sku: int(CATALOGUE[sku]["cost"] * w.cost_index[sku]) for sku in CATALOGUE
+            },
+            "catalogue_cost_cents": {sku: CATALOGUE[sku]["cost"] for sku in CATALOGUE},
+        }
+
+    def _clients(self, client_id: str | None) -> list[dict[str, Any]]:
+        w = self.world
+        out = []
+        for c in w.clients.values():
+            if client_id and c.id != client_id:
+                continue
+            out.append({
+                "client_id": c.id,
+                "name": c.name,
+                "profile": c.profile,
+                "commission_pct": c.commission_pct,
+                "contract_renews_day": c.contract_renews_day,
+                "days_to_renewal": c.contract_renews_day - w.day,
+                "satisfaction": round(c.satisfaction, 3),
+                "machines": [m.id for m in w.machines.values() if m.client_id == c.id],
+                "notes": c.notes,
+            })
+        return out
+
+    def _incidents(self, include_resolved: bool, machine_id: str | None) -> list[dict[str, Any]]:
+        w = self.world
+        out = []
+        for i in w.incidents:
+            if not include_resolved and not i.open:
+                continue
+            if machine_id and i.machine_id != machine_id:
+                continue
+            out.append({
+                "incident_id": i.id,
+                "opened_day": i.day,
+                "days_open": (w.day - i.day) if i.open else (i.resolved_day - i.day),
+                "machine_id": i.machine_id,
+                "kind": i.kind,
+                "severity": i.severity,
+                "detail": i.detail,
+                "open": i.open,
+                "resolution": i.resolution,
+            })
+        return out
+
+
+class Handler(BaseHTTPRequestHandler):
+    """One JSON-RPC endpoint. `ops` and `path` are set on the server object."""
+
+    protocol_version = "HTTP/1.1"
+    server_version = "vending-mcp/1.0"
+
+    def log_message(self, fmt: str, *args: Any) -> None:  # noqa: A003
+        if self.server.verbose:  # type: ignore[attr-defined]
+            sys.stderr.write("[vending-mcp] " + (fmt % args) + "\n")
+
+    # A GET on the MCP path is how a client opens the optional server->client
+    # SSE stream. This server never initiates anything, so declining the stream
+    # is both honest and within the spec.
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path.rstrip("/") == self.server.mcp_path.rstrip("/"):  # type: ignore[attr-defined]
+            self._send(405, {"error": "this server does not open a server-initiated stream"})
+        else:
+            self._send(404, {"error": "not found"})
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        # Session teardown. Stateless server, so there is nothing to tear down.
+        self._send(204, None)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path.rstrip("/") != self.server.mcp_path.rstrip("/"):  # type: ignore[attr-defined]
+            self._send(404, {"error": "not found"})
+            return
+        length = int(self.headers.get("content-length") or 0)
+        raw = self.rfile.read(length) if length else b""
+        try:
+            message = json.loads(raw or b"{}")
+        except json.JSONDecodeError as err:
+            self._send(400, {"jsonrpc": "2.0", "id": None,
+                             "error": {"code": -32700, "message": f"parse error: {err}"}})
+            return
+
+        batch = isinstance(message, list)
+        requests = message if batch else [message]
+        responses = [r for r in (self._handle(m) for m in requests) if r is not None]
+
+        if not responses:
+            # Every message was a notification. The protocol wants 202 and no body.
+            self._send(202, None)
+            return
+        self._send(200, responses if batch else responses[0])
+
+    def _handle(self, msg: dict[str, Any]) -> dict[str, Any] | None:
+        method = msg.get("method")
+        msg_id = msg.get("id")
+        is_notification = "id" not in msg
+
+        def ok(result: Any) -> dict[str, Any] | None:
+            return None if is_notification else {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+        def err(code: int, message: str) -> dict[str, Any] | None:
+            return None if is_notification else {
+                "jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}
+            }
+
+        if method == "initialize":
+            return ok({
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": SERVER_INFO,
+                "instructions": (
+                    "This is a live vending-machine operation: a fleet of machines at host "
+                    "sites, a finite warehouse behind them, and clients whose contracts renew. "
+                    "Reads are free; writes change the business and are visible to everyone. "
+                    "Nothing here restocks itself."
+                ),
+            })
+        if method in ("notifications/initialized", "notifications/cancelled"):
+            return None
+        if method == "ping":
+            return ok({})
+        if method == "tools/list":
+            return ok({"tools": TOOLS})
+        if method == "tools/call":
+            params = msg.get("params") or {}
+            name = params.get("name")
+            args = params.get("arguments") or {}
+            try:
+                result = self.server.ops.call(name, args)  # type: ignore[attr-defined]
+            except KeyError:
+                return err(-32602, f"unknown tool `{name}`")
+            except (TypeError, ValueError) as exc:
+                # A bad argument is the model's mistake to correct, so it comes
+                # back as a tool result rather than a protocol error — the
+                # latter is not shown to the agent in most hosts.
+                return ok({
+                    "content": [{"type": "text", "text": json.dumps(
+                        {"ok": False, "error": f"bad arguments for `{name}`: {exc}"})}],
+                    "isError": True,
+                })
+            payload = json.dumps(result, indent=2, default=str)
+            is_error = isinstance(result, dict) and result.get("ok") is False
+            return ok({
+                "content": [{"type": "text", "text": payload}],
+                "isError": is_error,
+            })
+        return err(-32601, f"unknown method `{method}`")
+
+    def _send(self, status: int, body: Any) -> None:
+        raw = b"" if body is None else json.dumps(body).encode()
+        self.send_response(status)
+        if raw:
+            self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(raw)))
+        self.end_headers()
+        if raw:
+            self.wfile.write(raw)
+
+
+class VendingHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, addr, ops: VendingOps, mcp_path: str, verbose: bool) -> None:
+        super().__init__(addr, Handler)
+        self.ops = ops
+        self.mcp_path = mcp_path
+        self.verbose = verbose
+
+
+def build_server(
+    host: str = "127.0.0.1",
+    port: int = 7801,
+    state: Path | None = None,
+    seed: int = 7,
+    mcp_path: str = "/mcp",
+    verbose: bool = False,
+) -> VendingHTTPServer:
+    world = World.load(state, seed) if state else World.seeded(seed)
+    return VendingHTTPServer((host, port), VendingOps(world, state), mcp_path, verbose)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=7801)
+    ap.add_argument("--path", default="/mcp", help="URL path the JSON-RPC endpoint answers on")
+    ap.add_argument("--state", type=Path, help="persist the world here; resumes if it exists")
+    ap.add_argument("--seed", type=int, default=7, help="RNG seed for a fresh world")
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args()
+
+    server = build_server(args.host, args.port, args.state, args.seed, args.path, args.verbose)
+    world = server.ops.world
+    print(
+        f"vending MCP on http://{args.host}:{args.port}{args.path} — "
+        f"day {world.day}, {len(world.machines)} machines, {len(world.clients)} clients",
+        flush=True,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("stopping", flush=True)
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vending/world.py
+++ b/scripts/vending/world.py
@@ -350,6 +350,13 @@ class World:
                 # expensive fault in the fleet and the easiest to miss.
                 continue
             profile = SITE_PROFILES[m.profile]
+            # Stockouts are accumulated per machine per day rather than emitted
+            # per slot. A fleet nobody has restocked yet empties every spiral,
+            # and one trigger per spiral per day is a few hundred a fortnight —
+            # a volume that buries the machine-down and contract triggers that
+            # actually need a decision. One row per machine per day is what an
+            # operator would be paged with, and it still names every line.
+            starved: list[tuple[str, int, int]] = []
             for slot in m.slots:
                 weight = profile.get(slot.sku, 0.5)
                 if CATALOGUE[slot.sku]["chilled"] and not m.chiller_ok:

--- a/scripts/vending/world.py
+++ b/scripts/vending/world.py
@@ -298,7 +298,21 @@ class World:
             ][:2]
             slots = []
             for sku in chosen[:8]:
-                cap = 12 if CATALOGUE[sku]["perishable"] else 20
+                # Capacity is sized to this site's own demand for this line —
+                # roughly three days of cover when full — rather than being one
+                # number for the whole fleet.
+                #
+                # A flat capacity made the busiest machine structurally
+                # impossible: VM-301 draws ~12 sandwiches a day against a
+                # 12-slot spiral, so it stocked out on 17 days in 21 even when
+                # refilled to the brim every single morning. That turns its host
+                # site's satisfaction into a doom clock no decision can affect,
+                # which is the opposite of what this simulation is for. The
+                # constraint worth modelling is that the van cannot visit
+                # everything today — not that one machine can never be right.
+                rate = footfall * 0.012 * SITE_PROFILES[profile].get(sku, 0.5)
+                cover = 2 if CATALOGUE[sku]["perishable"] else 3
+                cap = max(10, int(rate * cover + 0.5))
                 slots.append(
                     Slot(
                         sku=sku,

--- a/scripts/vending/world.py
+++ b/scripts/vending/world.py
@@ -316,6 +316,18 @@ class World:
         for sku in CATALOGUE:
             w.warehouse[sku] = w.rng.randint(40, 200)
 
+        # Two lines whose wholesale cost moved before this company started
+        # paying attention. Shelf prices are still the catalogue ones, so the
+        # margin on both is already wrong on day one.
+        #
+        # Seeded rather than left to the news feed: a cost move surfaces on
+        # roughly one day in ten, and the commercial desk's opening card asks it
+        # to find the prices that are already wrong. A card whose answer is
+        # "none yet, come back in a fortnight" teaches the desk that the
+        # question is not worth asking.
+        w.cost_index["SANDWICH-1"] = 1.24
+        w.cost_index["ENERGY-250"] = 1.17
+
         return w
 
     # -- the clock --------------------------------------------------------
@@ -337,6 +349,7 @@ class World:
             triggers.extend(self._draw_incidents())
             triggers.extend(self._age_incidents())
             triggers.extend(self._draw_news())
+            triggers.extend(self._recover(triggers))
             triggers.extend(self._contract_watch())
         return triggers
 
@@ -395,12 +408,12 @@ class World:
                     ))
                     m.cash_cents += sold * slot.price
                 if lost > 0:
-                    client = self.clients[m.client_id]
-                    client.satisfaction = max(
-                        0.0, client.satisfaction - STOCKOUT_SATISFACTION_HIT
-                    )
                     starved.append((slot.sku, lost, lost * slot.price))
             if starved:
+                client = self.clients[m.client_id]
+                client.satisfaction = max(
+                    0.0, client.satisfaction - STOCKOUT_SATISFACTION_HIT
+                )
                 lost_cents = sum(c for _, _, c in starved)
                 lines = ", ".join(f"{sku} ({units} units)" for sku, units, _ in starved)
                 out.append({
@@ -599,6 +612,44 @@ class World:
             "headline": item.headline, "detail": item.detail, "tags": item.tags,
         })
         return out
+
+    def _recover(self, today: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Sites that had a clean day earn a little goodwill back.
+
+        Clean means: no machine at that site turned demand away, and the site is
+        carrying no incident that has been open past `INCIDENT_STALE_DAYS`.
+        Both conditions matter — full shelves in front of a chiller that has
+        been broken for a week is not a good day for the host, and a site that
+        recovered on shelf stock alone would let a desk ignore its faults.
+
+        Emits no trigger. Nothing is owed to anybody when things go right, and a
+        daily "still fine" message for five sites would bury the four triggers
+        that actually need a decision.
+        """
+        hurt = {
+            t.get("client_id")
+            for t in today
+            if t["kind"] in ("stockout", "incident_stale")
+        }
+        # `_draw_incidents` tags complaints with a client too; a complaint today
+        # is not a day to recover from either.
+        hurt |= {t.get("client_id") for t in today if t["kind"] == "complaint"}
+        stale_sites = {
+            self.machines[i.machine_id].client_id
+            for i in self.incidents
+            if i.open
+            and self.day - i.day >= INCIDENT_STALE_DAYS
+            and i.machine_id in self.machines
+        }
+        for c in self.clients.values():
+            if c.id in hurt or c.id in stale_sites:
+                continue
+            if c.satisfaction >= SATISFACTION_RECOVERY_CEILING:
+                continue
+            c.satisfaction = min(
+                SATISFACTION_RECOVERY_CEILING, c.satisfaction + SATISFACTION_RECOVERY
+            )
+        return []
 
     def _contract_watch(self) -> list[dict[str, Any]]:
         """A renewal is only actionable while there is still time to act."""

--- a/scripts/vending/world.py
+++ b/scripts/vending/world.py
@@ -379,19 +379,23 @@ class World:
                     client.satisfaction = max(
                         0.0, client.satisfaction - STOCKOUT_SATISFACTION_HIT
                     )
-                    out.append({
-                        "kind": "stockout",
-                        "day": self.day,
-                        "machine_id": m.id,
-                        "sku": slot.sku,
-                        "lost_units": lost,
-                        "lost_revenue_cents": lost * slot.price,
-                        "detail": (
-                            f"{m.id} ({m.site}) sold out of {slot.sku}: "
-                            f"{lost} units of demand turned away, "
-                            f"{lost * slot.price}c of revenue lost."
-                        ),
-                    })
+                    starved.append((slot.sku, lost, lost * slot.price))
+            if starved:
+                lost_cents = sum(c for _, _, c in starved)
+                lines = ", ".join(f"{sku} ({units} units)" for sku, units, _ in starved)
+                out.append({
+                    "kind": "stockout",
+                    "day": self.day,
+                    "machine_id": m.id,
+                    "client_id": m.client_id,
+                    "skus": [sku for sku, _, _ in starved],
+                    "lost_units": sum(u for _, u, _ in starved),
+                    "lost_revenue_cents": lost_cents,
+                    "detail": (
+                        f"{m.id} ({m.site}) turned demand away today on {lines} — "
+                        f"{lost_cents}c of revenue lost."
+                    ),
+                })
         return out
 
     def _spoil(self) -> list[dict[str, Any]]:

--- a/scripts/vending/world.py
+++ b/scripts/vending/world.py
@@ -357,14 +357,23 @@ class World:
         triggers: list[dict[str, Any]] = []
         for _ in range(max(1, days)):
             self.day += 1
-            triggers.extend(self._receive_deliveries())
-            triggers.extend(self._draw_demand())
-            triggers.extend(self._spoil())
-            triggers.extend(self._draw_incidents())
-            triggers.extend(self._age_incidents())
-            triggers.extend(self._draw_news())
-            triggers.extend(self._recover(triggers))
-            triggers.extend(self._contract_watch())
+            # Accumulated separately from `triggers` and reset each iteration:
+            # `_recover` asks "did this site have a bad day *today*", and handing
+            # it the whole period's list would let one bad Monday block recovery
+            # for the rest of the fortnight. That also made `advance(21)` and
+            # twenty-one `advance(1)` calls disagree, which would have been a
+            # silent difference between a batch run and the day-at-a-time one
+            # the scenario driver actually makes.
+            today: list[dict[str, Any]] = []
+            today.extend(self._receive_deliveries())
+            today.extend(self._draw_demand())
+            today.extend(self._spoil())
+            today.extend(self._draw_incidents())
+            today.extend(self._age_incidents())
+            today.extend(self._draw_news())
+            today.extend(self._recover(today))
+            today.extend(self._contract_watch())
+            triggers.extend(today)
         return triggers
 
     def _receive_deliveries(self) -> list[dict[str, Any]]:

--- a/scripts/vending/world.py
+++ b/scripts/vending/world.py
@@ -1,0 +1,774 @@
+#!/usr/bin/env python3
+"""The vending-machine world: state, the clock that moves it, and the triggers it fires.
+
+This is the *simulated business* the ``vending_machine_co`` bundle manages. It is
+deliberately separate from the MCP layer (``mcp_server.py``) and from the driver
+that runs a scenario (``../vending-sim.py``): the world does not know what an
+agent is, and nothing here talks HTTP.
+
+What it models, and why each piece earns its place:
+
+* **A fleet.** Machines at host sites, each with slots holding a SKU at a par
+  level. Stock falls as the day's footfall draws it down, so "which machine to
+  restock" is a real question with a wrong answer.
+* **A warehouse.** Finite stock with supplier lead times, so a restock decision
+  is coupled to a purchasing decision — the two desks cannot each be right on
+  their own.
+* **Clients.** The host sites, on commission contracts with renewal dates and a
+  satisfaction level that moves with stockouts and unresolved incidents. This
+  is what makes an operational failure a commercial one a week later.
+* **Incidents.** Jams, spoilage, cash faults, complaints. They age, and ageing
+  is what makes a deferred decision cost something.
+* **News.** Supplier price moves, weather, local events, a competitor. Signals
+  that should change a plan and that nobody is told to act on.
+
+The clock is the whole point. ``World.advance(days)`` draws demand, spoils
+stock, ages incidents, lands deliveries, and returns the **triggers** the day
+produced. A trigger is an event the company should notice — a machine that went
+empty, a contract about to renew badly, a delivery that slipped. The driver
+turns those into messages into the company; the world just says what happened.
+
+Determinism is on purpose: seed the RNG and a scenario replays exactly, so a
+run that produced an interesting deliberation can be re-run against a changed
+prompt and the difference attributed to the prompt.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any
+
+# --------------------------------------------------------------------------
+# The catalogue.
+#
+# Margin is per unit, in cents, and varies enough between lines that a pricing
+# or assortment decision has a defensible answer. `perishable` is what makes
+# over-restocking a chilled slot cost money rather than only tying it up.
+# --------------------------------------------------------------------------
+
+CATALOGUE: dict[str, dict[str, Any]] = {
+    "COLA-330": {"name": "Cola 330ml", "cost": 42, "price": 150, "perishable": False, "chilled": True},
+    "WATER-500": {"name": "Still water 500ml", "cost": 18, "price": 120, "perishable": False, "chilled": True},
+    "ENERGY-250": {"name": "Energy drink 250ml", "cost": 78, "price": 250, "perishable": False, "chilled": True},
+    "CRISPS-40": {"name": "Crisps 40g", "cost": 31, "price": 120, "perishable": False, "chilled": False},
+    "CHOC-45": {"name": "Chocolate bar 45g", "cost": 38, "price": 140, "perishable": False, "chilled": False},
+    "PROTEIN-60": {"name": "Protein bar 60g", "cost": 95, "price": 280, "perishable": False, "chilled": False},
+    "SANDWICH-1": {"name": "Sandwich", "cost": 165, "price": 395, "perishable": True, "chilled": True},
+    "SALAD-1": {"name": "Salad pot", "cost": 180, "price": 450, "perishable": True, "chilled": True},
+    "COFFEE-1": {"name": "Canned coffee", "cost": 55, "price": 190, "perishable": False, "chilled": True},
+    "NUTS-50": {"name": "Mixed nuts 50g", "cost": 62, "price": 200, "perishable": False, "chilled": False},
+}
+
+# Site archetypes. The demand profile is what makes one machine's right
+# assortment wrong at another — a gym does not buy what an office buys, and a
+# hospital buys at night when nobody is there to restock it.
+SITE_PROFILES: dict[str, dict[str, float]] = {
+    "office": {
+        "COLA-330": 1.0, "WATER-500": 1.2, "ENERGY-250": 0.6, "CRISPS-40": 0.9,
+        "CHOC-45": 1.0, "PROTEIN-60": 0.4, "SANDWICH-1": 1.1, "SALAD-1": 0.7,
+        "COFFEE-1": 1.4, "NUTS-50": 0.5,
+    },
+    "gym": {
+        "COLA-330": 0.3, "WATER-500": 2.0, "ENERGY-250": 1.6, "CRISPS-40": 0.2,
+        "CHOC-45": 0.3, "PROTEIN-60": 1.8, "SANDWICH-1": 0.4, "SALAD-1": 0.5,
+        "COFFEE-1": 0.6, "NUTS-50": 1.1,
+    },
+    "hospital": {
+        "COLA-330": 0.9, "WATER-500": 1.3, "ENERGY-250": 1.1, "CRISPS-40": 1.0,
+        "CHOC-45": 1.2, "PROTEIN-60": 0.5, "SANDWICH-1": 1.4, "SALAD-1": 0.6,
+        "COFFEE-1": 1.7, "NUTS-50": 0.4,
+    },
+    "campus": {
+        "COLA-330": 1.3, "WATER-500": 1.1, "ENERGY-250": 1.5, "CRISPS-40": 1.4,
+        "CHOC-45": 1.3, "PROTEIN-60": 0.6, "SANDWICH-1": 0.9, "SALAD-1": 0.3,
+        "COFFEE-1": 1.0, "NUTS-50": 0.5,
+    },
+    "factory": {
+        "COLA-330": 1.4, "WATER-500": 1.0, "ENERGY-250": 1.3, "CRISPS-40": 1.2,
+        "CHOC-45": 1.1, "PROTEIN-60": 0.4, "SANDWICH-1": 1.0, "SALAD-1": 0.2,
+        "COFFEE-1": 1.5, "NUTS-50": 0.4,
+    },
+}
+
+
+@dataclass
+class Slot:
+    """One spiral in one machine: what it holds, how much fits, what is in it."""
+
+    sku: str
+    capacity: int
+    stock: int
+    price: int  # cents, per unit, at this machine
+
+
+@dataclass
+class Machine:
+    id: str
+    site: str
+    client_id: str
+    profile: str
+    footfall: int          # people past the machine per day
+    slots: list[Slot]
+    cash_cents: int = 0
+    chiller_ok: bool = True
+    coin_jam: bool = False
+    last_serviced_day: int = 0
+
+    def slot(self, sku: str) -> Slot | None:
+        for s in self.slots:
+            if s.sku == sku:
+                return s
+        return None
+
+
+@dataclass
+class Client:
+    """A host site. Commission is what the client earns on our gross."""
+
+    id: str
+    name: str
+    profile: str
+    commission_pct: float
+    contract_renews_day: int
+    satisfaction: float = 0.8   # 0..1; falls on stockouts and stale incidents
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Incident:
+    id: str
+    day: int
+    machine_id: str
+    kind: str          # jam | chiller | spoilage | complaint | vandalism | cash
+    detail: str
+    severity: str      # low | medium | high
+    resolved_day: int | None = None
+    resolution: str | None = None
+
+    @property
+    def open(self) -> bool:
+        return self.resolved_day is None
+
+
+@dataclass
+class PurchaseOrder:
+    id: str
+    sku: str
+    qty: int
+    unit_cost: int
+    placed_day: int
+    arrives_day: int
+    received: bool = False
+
+
+@dataclass
+class Sale:
+    day: int
+    machine_id: str
+    sku: str
+    units: int
+    unit_price: int
+    unit_cost: int
+
+    @property
+    def revenue(self) -> int:
+        return self.units * self.unit_price
+
+    @property
+    def margin(self) -> int:
+        return self.units * (self.unit_price - self.unit_cost)
+
+
+@dataclass
+class NewsItem:
+    day: int
+    headline: str
+    detail: str
+    tags: list[str]
+
+
+# --------------------------------------------------------------------------
+# The world
+# --------------------------------------------------------------------------
+
+# Supplier lead time in days. A restock decision that ignores this orders stock
+# that arrives after the week it was needed for, which is the single most
+# common way this business loses margin.
+LEAD_TIME_DAYS = 4
+
+# What a stockout costs, in satisfaction, at the host site. Small per event and
+# cumulative, so one bad day is noise and a bad fortnight is a lost contract.
+STOCKOUT_SATISFACTION_HIT = 0.035
+STALE_INCIDENT_SATISFACTION_HIT = 0.02
+# An incident is "stale" once it has been open this long.
+INCIDENT_STALE_DAYS = 3
+
+
+class World:
+    """The whole simulated business, and the clock that moves it."""
+
+    def __init__(self, seed: int = 7) -> None:
+        self.rng = random.Random(seed)
+        self.seed = seed
+        self.day = 0
+        self.machines: dict[str, Machine] = {}
+        self.clients: dict[str, Client] = {}
+        self.warehouse: dict[str, int] = {}
+        self.incidents: list[Incident] = []
+        self.orders: list[PurchaseOrder] = []
+        self.sales: list[Sale] = []
+        self.news: list[NewsItem] = []
+        # Supplier price index per SKU, 1.0 = catalogue cost. News moves it.
+        self.cost_index: dict[str, float] = {sku: 1.0 for sku in CATALOGUE}
+        self._seq = 0
+
+    # -- identity ---------------------------------------------------------
+
+    def _next_id(self, prefix: str) -> str:
+        self._seq += 1
+        return f"{prefix}-{self._seq:04d}"
+
+    # -- construction -----------------------------------------------------
+
+    @classmethod
+    def seeded(cls, seed: int = 7) -> "World":
+        """A plausible eight-machine operator across five host sites.
+
+        Sized so that a single restock run cannot cover everything: the whole
+        interest of the ops desk is that it has to choose.
+        """
+        w = cls(seed)
+
+        sites = [
+            ("CL-NORTHGATE", "Northgate Business Park", "office", 0.15, 40),
+            ("CL-IRONWORKS", "Ironworks Gym", "gym", 0.20, 22),
+            ("CL-STMARY", "St Mary's Hospital", "hospital", 0.12, 61),
+            ("CL-BRIDGE", "Bridge Street Campus", "campus", 0.18, 34),
+            ("CL-VULCAN", "Vulcan Components", "factory", 0.10, 75),
+        ]
+        for cid, name, profile, commission, renews in sites:
+            w.clients[cid] = Client(
+                id=cid, name=name, profile=profile,
+                commission_pct=commission, contract_renews_day=renews,
+                satisfaction=w.rng.uniform(0.68, 0.88),
+            )
+
+        fleet = [
+            ("VM-101", "Northgate — atrium", "CL-NORTHGATE", 420),
+            ("VM-102", "Northgate — 3rd floor", "CL-NORTHGATE", 180),
+            ("VM-201", "Ironworks — main floor", "CL-IRONWORKS", 260),
+            ("VM-301", "St Mary's — A&E waiting", "CL-STMARY", 700),
+            ("VM-302", "St Mary's — staff room", "CL-STMARY", 150),
+            ("VM-401", "Bridge St — library", "CL-BRIDGE", 380),
+            ("VM-501", "Vulcan — canteen", "CL-VULCAN", 300),
+            ("VM-502", "Vulcan — night gate", "CL-VULCAN", 90),
+        ]
+        for mid, site, cid, footfall in fleet:
+            profile = w.clients[cid].profile
+            # Eight slots, drawn from the lines that suit the site, so each
+            # machine starts with a defensible-but-improvable assortment.
+            ranked = sorted(
+                SITE_PROFILES[profile].items(), key=lambda kv: kv[1], reverse=True
+            )
+            chosen = [sku for sku, _ in ranked[:6]] + [
+                sku for sku, _ in ranked[6:]
+            ][:2]
+            slots = []
+            for sku in chosen[:8]:
+                cap = 12 if CATALOGUE[sku]["perishable"] else 20
+                slots.append(
+                    Slot(
+                        sku=sku,
+                        capacity=cap,
+                        stock=w.rng.randint(int(cap * 0.3), cap),
+                        price=CATALOGUE[sku]["price"],
+                    )
+                )
+            w.machines[mid] = Machine(
+                id=mid, site=site, client_id=cid, profile=profile,
+                footfall=footfall, slots=slots,
+                cash_cents=w.rng.randint(2000, 18000),
+            )
+
+        for sku in CATALOGUE:
+            w.warehouse[sku] = w.rng.randint(40, 200)
+
+        return w
+
+    # -- the clock --------------------------------------------------------
+
+    def advance(self, days: int = 1) -> list[dict[str, Any]]:
+        """Move the world forward and return the triggers the period produced.
+
+        Order within a day matters and is fixed: deliveries land first (so the
+        day's restock can use them), then demand draws stock down, then
+        perishables spoil, then incidents are drawn and aged, then news. A
+        trigger is emitted for anything the company would want to be told.
+        """
+        triggers: list[dict[str, Any]] = []
+        for _ in range(max(1, days)):
+            self.day += 1
+            triggers.extend(self._receive_deliveries())
+            triggers.extend(self._draw_demand())
+            triggers.extend(self._spoil())
+            triggers.extend(self._draw_incidents())
+            triggers.extend(self._age_incidents())
+            triggers.extend(self._draw_news())
+            triggers.extend(self._contract_watch())
+        return triggers
+
+    def _receive_deliveries(self) -> list[dict[str, Any]]:
+        out = []
+        for po in self.orders:
+            if po.received or po.arrives_day > self.day:
+                continue
+            po.received = True
+            self.warehouse[po.sku] = self.warehouse.get(po.sku, 0) + po.qty
+            out.append({
+                "kind": "delivery_received",
+                "day": self.day,
+                "detail": f"PO {po.id} landed: {po.qty} x {po.sku} at {po.unit_cost}c/unit.",
+                "sku": po.sku,
+                "qty": po.qty,
+            })
+        return out
+
+    def _draw_demand(self) -> list[dict[str, Any]]:
+        """Sell what people wanted and the machine could actually give them.
+
+        A stockout is recorded as lost demand, not as an absence: the whole
+        point of the sales ledger is that it should be possible to see revenue
+        that was available and not taken.
+        """
+        out = []
+        for m in self.machines.values():
+            if m.coin_jam:
+                # A jammed machine takes no money at all. This is the most
+                # expensive fault in the fleet and the easiest to miss.
+                continue
+            profile = SITE_PROFILES[m.profile]
+            for slot in m.slots:
+                weight = profile.get(slot.sku, 0.5)
+                if CATALOGUE[slot.sku]["chilled"] and not m.chiller_ok:
+                    weight *= 0.15
+                # Footfall converts at roughly 1.2% per unit of profile weight.
+                expected = m.footfall * 0.012 * weight
+                wanted = max(0, int(self.rng.gauss(expected, expected * 0.35)))
+                sold = min(wanted, slot.stock)
+                lost = wanted - sold
+                if sold:
+                    slot.stock -= sold
+                    unit_cost = int(CATALOGUE[slot.sku]["cost"] * self.cost_index[slot.sku])
+                    self.sales.append(Sale(
+                        day=self.day, machine_id=m.id, sku=slot.sku,
+                        units=sold, unit_price=slot.price, unit_cost=unit_cost,
+                    ))
+                    m.cash_cents += sold * slot.price
+                if lost > 0:
+                    client = self.clients[m.client_id]
+                    client.satisfaction = max(
+                        0.0, client.satisfaction - STOCKOUT_SATISFACTION_HIT
+                    )
+                    out.append({
+                        "kind": "stockout",
+                        "day": self.day,
+                        "machine_id": m.id,
+                        "sku": slot.sku,
+                        "lost_units": lost,
+                        "lost_revenue_cents": lost * slot.price,
+                        "detail": (
+                            f"{m.id} ({m.site}) sold out of {slot.sku}: "
+                            f"{lost} units of demand turned away, "
+                            f"{lost * slot.price}c of revenue lost."
+                        ),
+                    })
+        return out
+
+    def _spoil(self) -> list[dict[str, Any]]:
+        """Perishables die on a warm chiller, and slowly even on a cold one."""
+        out = []
+        for m in self.machines.values():
+            for slot in m.slots:
+                if not CATALOGUE[slot.sku]["perishable"] or slot.stock == 0:
+                    continue
+                rate = 0.45 if not m.chiller_ok else 0.06
+                dead = sum(1 for _ in range(slot.stock) if self.rng.random() < rate)
+                if dead:
+                    slot.stock -= dead
+                    cost = dead * CATALOGUE[slot.sku]["cost"]
+                    self.incidents.append(Incident(
+                        id=self._next_id("INC"), day=self.day, machine_id=m.id,
+                        kind="spoilage",
+                        detail=f"{dead} x {slot.sku} written off at {m.id}"
+                               f"{' (chiller fault)' if not m.chiller_ok else ''}.",
+                        severity="high" if not m.chiller_ok else "low",
+                    ))
+                    out.append({
+                        "kind": "spoilage",
+                        "day": self.day,
+                        "machine_id": m.id,
+                        "sku": slot.sku,
+                        "units": dead,
+                        "cost_cents": cost,
+                        "detail": f"{dead} x {slot.sku} spoiled at {m.id}, {cost}c written off.",
+                    })
+        return out
+
+    def _draw_incidents(self) -> list[dict[str, Any]]:
+        """Faults arrive at a rate that rises with use and with time since service."""
+        out = []
+        for m in self.machines.values():
+            since_service = self.day - m.last_serviced_day
+            base = 0.006 + 0.0009 * since_service
+            if self.rng.random() < base and not m.coin_jam:
+                m.coin_jam = True
+                inc = Incident(
+                    id=self._next_id("INC"), day=self.day, machine_id=m.id,
+                    kind="jam",
+                    detail=f"{m.id} coin mechanism jammed — the machine is taking no money.",
+                    severity="high",
+                )
+                self.incidents.append(inc)
+                out.append({
+                    "kind": "machine_down", "day": self.day, "machine_id": m.id,
+                    "incident_id": inc.id, "detail": inc.detail,
+                })
+            if self.rng.random() < base * 0.6 and m.chiller_ok:
+                m.chiller_ok = False
+                inc = Incident(
+                    id=self._next_id("INC"), day=self.day, machine_id=m.id,
+                    kind="chiller",
+                    detail=f"{m.id} chiller is running warm — chilled lines will spoil.",
+                    severity="high",
+                )
+                self.incidents.append(inc)
+                out.append({
+                    "kind": "chiller_fault", "day": self.day, "machine_id": m.id,
+                    "incident_id": inc.id, "detail": inc.detail,
+                })
+            if self.rng.random() < 0.010:
+                client = self.clients[m.client_id]
+                complaint = self.rng.choice([
+                    "took my money and gave nothing",
+                    "the sandwiches are always gone by 11am",
+                    "nothing here is under two pounds",
+                    "the card reader declined three times",
+                    "everything in the chiller was warm",
+                ])
+                inc = Incident(
+                    id=self._next_id("INC"), day=self.day, machine_id=m.id,
+                    kind="complaint",
+                    detail=f"Complaint from {client.name} about {m.id}: “{complaint}”.",
+                    severity="medium",
+                )
+                self.incidents.append(inc)
+                out.append({
+                    "kind": "complaint", "day": self.day, "machine_id": m.id,
+                    "client_id": client.id, "incident_id": inc.id, "detail": inc.detail,
+                })
+        return out
+
+    def _age_incidents(self) -> list[dict[str, Any]]:
+        """An open incident costs the host's goodwill once it has been open a while."""
+        out = []
+        for inc in self.incidents:
+            if not inc.open:
+                continue
+            age = self.day - inc.day
+            if age == INCIDENT_STALE_DAYS:
+                m = self.machines.get(inc.machine_id)
+                if m:
+                    client = self.clients[m.client_id]
+                    client.satisfaction = max(
+                        0.0, client.satisfaction - STALE_INCIDENT_SATISFACTION_HIT
+                    )
+                    out.append({
+                        "kind": "incident_stale",
+                        "day": self.day,
+                        "incident_id": inc.id,
+                        "machine_id": inc.machine_id,
+                        "client_id": client.id,
+                        "detail": (
+                            f"{inc.id} ({inc.kind}) at {inc.machine_id} has been open "
+                            f"{age} days. {client.name}'s satisfaction is now "
+                            f"{client.satisfaction:.2f}."
+                        ),
+                    })
+        return out
+
+    def _draw_news(self) -> list[dict[str, Any]]:
+        """Market signals. Some move costs; all of them are things a plan should react to."""
+        if self.rng.random() > 0.35:
+            return []
+        out = []
+        roll = self.rng.random()
+        if roll < 0.30:
+            sku = self.rng.choice(list(CATALOGUE))
+            move = self.rng.uniform(0.06, 0.22)
+            self.cost_index[sku] *= 1 + move
+            item = NewsItem(
+                day=self.day,
+                headline=f"Supplier raises {sku} by {move * 100:.0f}%",
+                detail=(
+                    f"Wholesale cost for {CATALOGUE[sku]['name']} is up "
+                    f"{move * 100:.0f}% from today. Our shelf price is unchanged, so the "
+                    f"margin on every unit sold from now on is thinner."
+                ),
+                tags=["supplier", "cost", sku],
+            )
+        elif roll < 0.50:
+            client = self.rng.choice(list(self.clients.values()))
+            item = NewsItem(
+                day=self.day,
+                headline=f"Competitor quoting {client.name}",
+                detail=(
+                    f"A rival operator is said to be quoting {client.name} at "
+                    f"{client.commission_pct * 100 + self.rng.randint(2, 6):.0f}% commission. "
+                    f"Their contract renews on day {client.contract_renews_day}."
+                ),
+                tags=["competitor", "contract", client.id],
+            )
+        elif roll < 0.70:
+            client = self.rng.choice(list(self.clients.values()))
+            item = NewsItem(
+                day=self.day,
+                headline=f"Footfall event at {client.name}",
+                detail=(
+                    f"{client.name} is running an event next week; expect materially "
+                    f"higher traffic past its machines for a few days."
+                ),
+                tags=["footfall", "event", client.id],
+            )
+        elif roll < 0.85:
+            item = NewsItem(
+                day=self.day,
+                headline="Heatwave forecast",
+                detail=(
+                    "A warm spell is forecast. Cold drinks sell through faster and "
+                    "chillers work harder; both of those have bitten this fleet before."
+                ),
+                tags=["weather", "demand"],
+            )
+        else:
+            item = NewsItem(
+                day=self.day,
+                headline="Card scheme fees changing",
+                detail=(
+                    "Card acquiring fees rise next month on low-value transactions, "
+                    "which is most of what this fleet takes."
+                ),
+                tags=["fees", "cost"],
+            )
+        self.news.append(item)
+        out.append({
+            "kind": "news", "day": self.day,
+            "headline": item.headline, "detail": item.detail, "tags": item.tags,
+        })
+        return out
+
+    def _contract_watch(self) -> list[dict[str, Any]]:
+        """A renewal is only actionable while there is still time to act."""
+        out = []
+        for c in self.clients.values():
+            days_left = c.contract_renews_day - self.day
+            if days_left in (14, 7, 3):
+                out.append({
+                    "kind": "contract_renewal",
+                    "day": self.day,
+                    "client_id": c.id,
+                    "days_left": days_left,
+                    "satisfaction": round(c.satisfaction, 3),
+                    "detail": (
+                        f"{c.name}'s contract renews in {days_left} days at "
+                        f"{c.commission_pct * 100:.0f}% commission. Satisfaction is "
+                        f"{c.satisfaction:.2f}."
+                    ),
+                })
+        return out
+
+    # -- actions the company can take -------------------------------------
+
+    def restock(self, machine_id: str, items: dict[str, int]) -> dict[str, Any]:
+        """Move stock from the warehouse into a machine's slots.
+
+        Refuses rather than partially inventing stock: a plan that asks for
+        more than the warehouse holds is a plan that needed to place an order
+        first, and silently shipping less would hide that.
+        """
+        m = self.machines.get(machine_id)
+        if not m:
+            return {"ok": False, "error": f"no machine {machine_id}"}
+        problems, moved = [], {}
+        for sku, qty in items.items():
+            slot = m.slot(sku)
+            if slot is None:
+                problems.append(f"{machine_id} has no slot for {sku}")
+                continue
+            if qty > self.warehouse.get(sku, 0):
+                problems.append(
+                    f"warehouse holds {self.warehouse.get(sku, 0)} x {sku}, asked for {qty}"
+                )
+                continue
+            room = slot.capacity - slot.stock
+            if qty > room:
+                problems.append(f"{machine_id}/{sku} has room for {room}, asked for {qty}")
+                continue
+            self.warehouse[sku] -= qty
+            slot.stock += qty
+            moved[sku] = qty
+        if problems:
+            return {"ok": False, "error": "; ".join(problems), "moved": moved}
+        m.last_serviced_day = self.day
+        return {"ok": True, "machine_id": machine_id, "moved": moved, "day": self.day}
+
+    def service(self, machine_id: str) -> dict[str, Any]:
+        """Clear the mechanical faults on a machine and mark it serviced."""
+        m = self.machines.get(machine_id)
+        if not m:
+            return {"ok": False, "error": f"no machine {machine_id}"}
+        cleared = []
+        if m.coin_jam:
+            m.coin_jam = False
+            cleared.append("coin jam")
+        if not m.chiller_ok:
+            m.chiller_ok = True
+            cleared.append("chiller")
+        m.last_serviced_day = self.day
+        for inc in self.incidents:
+            if inc.open and inc.machine_id == machine_id and inc.kind in ("jam", "chiller"):
+                inc.resolved_day = self.day
+                inc.resolution = "cleared on service visit"
+        return {"ok": True, "machine_id": machine_id, "cleared": cleared, "day": self.day}
+
+    def set_price(self, machine_id: str, sku: str, price_cents: int) -> dict[str, Any]:
+        m = self.machines.get(machine_id)
+        if not m:
+            return {"ok": False, "error": f"no machine {machine_id}"}
+        slot = m.slot(sku)
+        if slot is None:
+            return {"ok": False, "error": f"{machine_id} has no slot for {sku}"}
+        was, slot.price = slot.price, int(price_cents)
+        return {"ok": True, "machine_id": machine_id, "sku": sku,
+                "was_cents": was, "now_cents": slot.price}
+
+    def order(self, sku: str, qty: int) -> dict[str, Any]:
+        if sku not in CATALOGUE:
+            return {"ok": False, "error": f"no such SKU {sku}"}
+        unit_cost = int(CATALOGUE[sku]["cost"] * self.cost_index[sku])
+        po = PurchaseOrder(
+            id=self._next_id("PO"), sku=sku, qty=int(qty), unit_cost=unit_cost,
+            placed_day=self.day, arrives_day=self.day + LEAD_TIME_DAYS,
+        )
+        self.orders.append(po)
+        return {"ok": True, "order_id": po.id, "sku": sku, "qty": po.qty,
+                "unit_cost_cents": unit_cost, "arrives_day": po.arrives_day,
+                "lead_time_days": LEAD_TIME_DAYS}
+
+    def resolve_incident(self, incident_id: str, resolution: str) -> dict[str, Any]:
+        for inc in self.incidents:
+            if inc.id == incident_id:
+                if not inc.open:
+                    return {"ok": False, "error": f"{incident_id} was already resolved"}
+                inc.resolved_day = self.day
+                inc.resolution = resolution
+                return {"ok": True, "incident_id": incident_id, "day": self.day}
+        return {"ok": False, "error": f"no incident {incident_id}"}
+
+    def note_client(self, client_id: str, note: str) -> dict[str, Any]:
+        c = self.clients.get(client_id)
+        if not c:
+            return {"ok": False, "error": f"no client {client_id}"}
+        c.notes.append(f"day {self.day}: {note}")
+        return {"ok": True, "client_id": client_id, "notes": len(c.notes)}
+
+    def renegotiate(self, client_id: str, commission_pct: float, term_days: int) -> dict[str, Any]:
+        """Re-sign a host site. Goodwill from being asked lifts satisfaction a little."""
+        c = self.clients.get(client_id)
+        if not c:
+            return {"ok": False, "error": f"no client {client_id}"}
+        was = c.commission_pct
+        c.commission_pct = float(commission_pct)
+        c.contract_renews_day = self.day + int(term_days)
+        c.satisfaction = min(1.0, c.satisfaction + 0.05)
+        return {"ok": True, "client_id": client_id, "was_pct": was,
+                "now_pct": c.commission_pct, "renews_day": c.contract_renews_day}
+
+    # -- reads ------------------------------------------------------------
+
+    def sales_report(self, since_day: int = 0, machine_id: str | None = None) -> dict[str, Any]:
+        rows = [s for s in self.sales if s.day > since_day
+                and (machine_id is None or s.machine_id == machine_id)]
+        by_sku: dict[str, dict[str, int]] = {}
+        for s in rows:
+            b = by_sku.setdefault(s.sku, {"units": 0, "revenue_cents": 0, "margin_cents": 0})
+            b["units"] += s.units
+            b["revenue_cents"] += s.revenue
+            b["margin_cents"] += s.margin
+        by_machine: dict[str, dict[str, int]] = {}
+        for s in rows:
+            b = by_machine.setdefault(s.machine_id, {"units": 0, "revenue_cents": 0, "margin_cents": 0})
+            b["units"] += s.units
+            b["revenue_cents"] += s.revenue
+            b["margin_cents"] += s.margin
+        return {
+            "day": self.day,
+            "since_day": since_day,
+            "units": sum(s.units for s in rows),
+            "revenue_cents": sum(s.revenue for s in rows),
+            "margin_cents": sum(s.margin for s in rows),
+            "by_sku": by_sku,
+            "by_machine": by_machine,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps({
+            "seed": self.seed,
+            "day": self.day,
+            "seq": self._seq,
+            "machines": {k: asdict(v) for k, v in self.machines.items()},
+            "clients": {k: asdict(v) for k, v in self.clients.items()},
+            "warehouse": self.warehouse,
+            "incidents": [asdict(i) for i in self.incidents],
+            "orders": [asdict(o) for o in self.orders],
+            "sales": [asdict(s) for s in self.sales],
+            "news": [asdict(n) for n in self.news],
+            "cost_index": self.cost_index,
+            "rng": self.rng.getstate(),
+        }, default=list)
+
+    @classmethod
+    def from_json(cls, blob: str) -> "World":
+        d = json.loads(blob)
+        w = cls(d["seed"])
+        w.day = d["day"]
+        w._seq = d["seq"]
+        w.machines = {
+            k: Machine(**{**v, "slots": [Slot(**s) for s in v["slots"]]})
+            for k, v in d["machines"].items()
+        }
+        w.clients = {k: Client(**v) for k, v in d["clients"].items()}
+        w.warehouse = d["warehouse"]
+        w.incidents = [Incident(**i) for i in d["incidents"]]
+        w.orders = [PurchaseOrder(**o) for o in d["orders"]]
+        w.sales = [Sale(**s) for s in d["sales"]]
+        w.news = [NewsItem(**n) for n in d["news"]]
+        w.cost_index = d["cost_index"]
+        # `getstate` round-trips through JSON as nested lists; `setstate` needs
+        # the tuple shape back or a resumed run diverges from an uninterrupted
+        # one, which would defeat the point of seeding it.
+        state = d["rng"]
+        w.rng.setstate((state[0], tuple(state[1]), state[2]))
+        return w
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.to_json())
+
+    @classmethod
+    def load(cls, path: Path, seed: int = 7) -> "World":
+        if path.exists():
+            return cls.from_json(path.read_text())
+        return cls.seeded(seed)

--- a/scripts/vending/world.py
+++ b/scripts/vending/world.py
@@ -199,12 +199,32 @@ class NewsItem:
 # common way this business loses margin.
 LEAD_TIME_DAYS = 4
 
-# What a stockout costs, in satisfaction, at the host site. Small per event and
-# cumulative, so one bad day is noise and a bad fortnight is a lost contract.
-STOCKOUT_SATISFACTION_HIT = 0.035
-STALE_INCIDENT_SATISFACTION_HIT = 0.02
+# What a bad day costs a host site, in satisfaction.
+#
+# Charged **once per machine per day**, not once per empty spiral. Per-spiral was
+# the first cut and it made satisfaction a countdown rather than a signal: eight
+# machines with four empty lines each is thirty-two charges a day, so every site
+# in the fleet sat at 0.00 within a fortnight and the number could no longer
+# distinguish a badly-run site from a catastrophically-run one — which is the
+# only thing it is for.
+STOCKOUT_SATISFACTION_HIT = 0.02
+STALE_INCIDENT_SATISFACTION_HIT = 0.015
 # An incident is "stale" once it has been open this long.
 INCIDENT_STALE_DAYS = 3
+
+# What a *good* day is worth. A site whose machines all sold without running dry,
+# and that is carrying no stale incident, recovers a little.
+#
+# Recovery is what makes satisfaction a feedback loop instead of a ratchet: a
+# desk that fixes a site should be able to see it come back, and a contract
+# renewal negotiated after a good fortnight should be a different conversation
+# from one negotiated after a bad one. It is deliberately slower than the
+# damage — goodwill is easier to lose than to earn, and a fleet cannot neglect a
+# site for a month and repair it in a week.
+SATISFACTION_RECOVERY = 0.008
+# Recovery never carries a site past this on its own. Getting above it takes
+# something a host notices — a renegotiation, or a commitment kept.
+SATISFACTION_RECOVERY_CEILING = 0.85
 
 
 class World:

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -124,6 +124,7 @@ const SEARCH_GRANTED_COMPANIES: [&str; 21] = [
     "agentic_venture_capital",
     "agentic_venture_studio",
     "signals_opportunity_studio",
+    "vending_machine_co",
     "startup_accelerator",
 ];
 
@@ -135,12 +136,20 @@ const SEARCH_GRANTED_COMPANIES: [&str; 21] = [
 /// search can look one up. A run that looked the answer up passes the lab's
 /// end-to-end spec while proving nothing about whether the roster can solve
 /// anything, so withholding the network is what makes the number evidence.
-const SEARCH_DENIED_COMPANIES: [&str; 5] = [
+///
+/// `vending_machine_co` is denied on a variant of the same argument. Every fact
+/// that bundle reasons from — what is on a shelf, what a line costs today, which
+/// host site is unhappy — is a tool call against its own simulated operation, and
+/// a desk that could reach the web would answer about vending machines in general
+/// instead of about these eight. Withholding the network is what makes a decision
+/// there attributable to the fleet it was made about.
+const SEARCH_DENIED_COMPANIES: [&str; 6] = [
     "agentic_math_lab",
     "hive_math_lab",
     "e2e_harness",
     "e2e_setup",
     "openhuman_demo",
+    "vending_machine_co",
 ];
 
 /// Templates that simply do not grant `search` today. Unlike
@@ -1318,7 +1327,7 @@ fn every_company_ledger_can_be_closed_and_says_why() {
 /// "the board is empty because this vertical has no setup work" and "the board
 /// is empty because whoever added this bundle forgot" are indistinguishable
 /// afterwards.
-const SETUP_SEEDED_COMPANIES: [&str; 23] = [
+const SETUP_SEEDED_COMPANIES: [&str; 24] = [
     "agentic_accounting_firm",
     "agentic_consultation_firm",
     "agentic_customer_support",

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -124,7 +124,6 @@ const SEARCH_GRANTED_COMPANIES: [&str; 21] = [
     "agentic_venture_capital",
     "agentic_venture_studio",
     "signals_opportunity_studio",
-    "vending_machine_co",
     "startup_accelerator",
 ];
 
@@ -1351,6 +1350,7 @@ const SETUP_SEEDED_COMPANIES: [&str; 24] = [
     "hive_math_lab",
     "signals_opportunity_studio",
     "startup_accelerator",
+    "vending_machine_co",
 ];
 
 /// The bundles that deliberately ship neither, because they are fixtures.

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -523,6 +523,7 @@ pub struct CompanyRuntime {
 /// overwrote.
 fn continuation_failure_notice(thread: String, parent: Option<EventSeq>) -> CompanyEvent {
     CompanyEvent::AgentReply {
+        audience: Vec::new(),
         parent,
         chat_id: thread,
         agent_id: crate::ports::SYSTEM_AUTHOR.to_string(),
@@ -4282,6 +4283,7 @@ impl CompanyRuntime {
                 .append(
                     &self.id,
                     CompanyEvent::AgentReply {
+                        audience: Vec::new(),
                         parent,
                         chat_id: chat_id.to_string(),
                         // Issue #885: the author, falling back to the
@@ -4730,6 +4732,7 @@ impl CompanyRuntime {
                 .append(
                     &self.id,
                     CompanyEvent::AgentReply {
+                        audience: Vec::new(),
                         parent,
                         chat_id: chat_id.clone(),
                         // Issue #885: the author, not the destination. Same
@@ -6498,6 +6501,7 @@ impl CompanyRuntime {
             .append(
                 &self.id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     parent: None,
                     chat_id: thread.to_string(),
                     agent_id,
@@ -7593,6 +7597,7 @@ mod tests {
         use crate::server::chat_history::owns;
 
         let reply = |chat_id: String| CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -10839,6 +10844,7 @@ mod tests {
 
         fn relay_bubble(origin: &str) -> CompanyEvent {
             CompanyEvent::AgentReply {
+                audience: Vec::new(),
                 chat_id: origin.to_string(),
                 agent_id: "ceo".to_string(),
                 text: "Here is the draft.".to_string(),

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -2087,6 +2087,7 @@ impl HarnessBrain {
             .append(
                 &self.record().id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -4472,6 +4473,7 @@ impl HarnessBrain {
                                 .append(
                                     &record.id,
                                     CompanyEvent::AgentReply {
+                                        audience: Vec::new(),
                                         parent: None,
                                         task_id: response.task_id.clone(),
                                         chat_id: crate::server::ops::language::DEFAULT_DESK

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -753,6 +753,7 @@ mod tests {
             seq: EventSeq::new(seq),
             company: CompanyId::new("acme"),
             event: CompanyEvent::AgentReply {
+                audience: Vec::new(),
                 chat_id: chat_id.to_string(),
                 agent_id: "ceo".to_string(),
                 text: text.to_string(),

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -12436,6 +12436,7 @@ budget_usd_daily = 0.0
             }
             fn reply(&self, chat_id: &str, text: &str) {
                 self.push(CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     chat_id: chat_id.to_string(),
                     agent_id: "ceo".to_string(),
                     text: text.to_string(),

--- a/src/harness/thread_tools.rs
+++ b/src/harness/thread_tools.rs
@@ -291,6 +291,7 @@ mod test {
             seq: EventSeq::new(seq),
             company: CompanyId::new("acme"),
             event: CompanyEvent::AgentReply {
+                audience: Vec::new(),
                 chat_id: chat.to_string(),
                 agent_id: "ceo".to_string(),
                 text: text.to_string(),

--- a/src/hivemind/aside.rs
+++ b/src/hivemind/aside.rs
@@ -1,0 +1,422 @@
+//! Private asides: two members of a desk comparing notes without the room.
+//!
+//! This is the one mechanism in this module that narrows *who reads a line*
+//! rather than who speaks it. [`referral`](super::referral) lets a room ask
+//! another desk a question; an aside lets two members of the **same** desk say
+//! something the rest of that desk cannot read.
+//!
+//! # It is auditable, not confidential
+//!
+//! A row an agent may not read is **elided, never dropped**. Its sequence, its
+//! author and its audience stay in every projection, and only its content is
+//! withheld — so a peer can see that an exchange happened and who was in it,
+//! and a `^N` citation naming it still resolves. Three reasons that shape was
+//! chosen over an absent row are in the library's own spec
+//! (`vendor/tinyhivemind/docs/specs/private-asides.md`): auditability, latent
+//! asymmetry (an agent that cannot see that a peer knows something has no
+//! reason to ask), and citations.
+//!
+//! Operators and people read every aside in full. The privacy here is between
+//! agents and is a deliberation device — **never a security boundary**, and
+//! nothing in this module should ever be relied on as one.
+//!
+//! # An aside carries information, never support
+//!
+//! The rule that keeps the room's counting single-valued: a trace deposited in
+//! a row whose audience is not `Desk` contributes nothing — no supporter, no
+//! movement toward a decision. This host does not enforce it, and does not need
+//! to: [`step`](tinyhivemind_hive::step) folds the whole transcript and drops
+//! non-`Desk` traces uniformly, for every reader. To make an aside count, a
+//! member spends a desk-visible turn saying so in the open — that is what
+//! `!surface` is for, and a `!surface` line is an ordinary desk row with no
+//! special handling anywhere in this module.
+//!
+//! This is the same rule cross-desk referral already accepts at a channel
+//! boundary, applied inside one desk.
+//!
+//! # Why it is off by default
+//!
+//! Because it was measured and it lost. The library's own experiment
+//! (`docs/experiments/2026-09-07-do-asides-help.md`) found a pairwise private
+//! check costs 2.5 points at a tuned turn budget, loses 15 points on a hidden
+//! profile — averaging inside one correlated desk imports the shared bias — and
+//! is indistinguishable from the same exchange held in the open. So this claims
+//! bounded independence and an auditable record, and claims **nothing** about
+//! answer quality. [`AsideConfig`] defaults to disabled, and a desk that wants
+//! asides says so.
+
+use serde::{Deserialize, Serialize};
+use tinyhivemind_hive::aside::{Audience, AsidePolicy};
+
+/// The marker a member opens a private line with.
+pub const ASIDE_MARKER: &str = "!aside";
+
+/// The marker that pays an aside back to the room.
+pub const SURFACE_MARKER: &str = "!surface";
+
+/// The manifest knob: `hive = { aside = { enabled = true, ... } }`.
+///
+/// Every field is `Option` so an absent block and an explicitly-default block
+/// are distinguishable, and so a desk may set one bound without restating the
+/// others. [`Self::policy`] is the only place the defaults live.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AsideConfig {
+    /// Whether members of this desk may open a private line at all.
+    ///
+    /// Off unless a desk says otherwise — see the module docs for why the
+    /// mechanism does not get the benefit of the doubt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// Largest addressed audience, **excluding** the author.
+    ///
+    /// Defaults to 1: a direct pair. A caucus of three inside a desk of four is
+    /// not an aside, it is a second desk with no quorum and no record, and a
+    /// host that wants one should declare the desk.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_members: Option<usize>,
+    /// How many rows one aside may carry before it must settle.
+    ///
+    /// Defaults to 2 — a question and an answer. The bound is small because
+    /// every row spent privately is a row of the desk's turn budget spent where
+    /// the room cannot read it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_messages: Option<usize>,
+    /// Whether an aside must deposit one desk-visible message before the same
+    /// members may open another.
+    ///
+    /// Defaults to `true`. Without it a pair can hold the whole episode
+    /// privately and the room's record is a run of stubs.
+    ///
+    /// Enforced at the *next* aside rather than at the last turn: nothing
+    /// compels a settlement before an episode ends, so a room can still close
+    /// with one unsettled. Making the episode refuse to converge on an
+    /// unsettled aside was considered upstream and rejected as too blunt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub must_surface: Option<bool>,
+    /// Whether an aside must be a thread rather than a run of channel rows.
+    ///
+    /// Defaults to **false** here, unlike the library's own suggestion, because
+    /// a hive episode runs on the desk channel: every turn is parented to the
+    /// operator message's own parent so the library's channel projection can
+    /// promote it (`docs/spec/runtime/hivemind.md`). A desk that required
+    /// threads would authorize no asides at all, which is a confusing way to
+    /// spell `enabled = false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub require_thread: Option<bool>,
+}
+
+impl AsideConfig {
+    /// Whether this desk opted in.
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        self.enabled.unwrap_or(false)
+    }
+
+    /// Whether the block says nothing, so it can be skipped on the wire.
+    #[must_use]
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// The library policy this config means.
+    ///
+    /// A disabled config returns [`AsidePolicy::DEFAULT`] — every bound at zero
+    /// — rather than a disabled policy carrying this desk's bounds, so a desk
+    /// that is off cannot be read as a desk that is on with limits.
+    #[must_use]
+    pub fn policy(&self) -> AsidePolicy {
+        if !self.enabled() {
+            return AsidePolicy::DEFAULT;
+        }
+        AsidePolicy {
+            enabled: true,
+            max_members: self.max_members.unwrap_or(1).max(1),
+            max_messages: self.max_messages.unwrap_or(2).max(1),
+            must_surface: self.must_surface.unwrap_or(true),
+            require_thread: self.require_thread.unwrap_or(false),
+        }
+    }
+}
+
+/// Whether this line opens a private aside.
+///
+/// Matched at the start of the line and on a word boundary, exactly as the
+/// trace grammar matches its own markers: `!asides` is not `!aside`, and a line
+/// that merely mentions the word is an ordinary line.
+#[must_use]
+pub fn opens_aside(line: &str) -> bool {
+    marker_is(line, ASIDE_MARKER)
+}
+
+/// Whether this line pays an aside back to the room.
+#[must_use]
+pub fn surfaces(line: &str) -> bool {
+    marker_is(line, SURFACE_MARKER)
+}
+
+fn marker_is(line: &str, marker: &str) -> bool {
+    let line = line.trim_start();
+    let Some(rest) = line.strip_prefix(marker) else {
+        return false;
+    };
+    rest.is_empty() || rest.starts_with(|c: char| c.is_whitespace())
+}
+
+/// The aside a row belongs to, as a canonical, order-independent key.
+///
+/// The author is included alongside the addressees because an audience is
+/// "author plus the named ids" — two rows with the same addressee but different
+/// authors are two different asides, and folding them into one would let one
+/// member's budget be spent by another.
+#[must_use]
+pub fn party(author: &str, audience: &Audience) -> Option<Vec<String>> {
+    let members = audience.members();
+    if members.is_empty() {
+        return None;
+    }
+    let mut party: Vec<String> = members.to_vec();
+    party.push(author.to_owned());
+    party.sort();
+    party.dedup();
+    Some(party)
+}
+
+/// How many rows this party has already spent, and whether its last aside is
+/// still unsettled.
+///
+/// Both are folded from the transcript the caller already holds rather than
+/// tracked in memory, for the reason the episode re-reads its transcript every
+/// iteration: what the fold counts is exactly what a person reading the desk
+/// would see, so the two can never disagree.
+///
+/// "Unsettled" means the party opened an aside and no member of it has written
+/// a desk-visible `!surface` since. A `!surface` by any member settles it —
+/// the room is owed one settlement, not one per participant.
+#[must_use]
+pub fn spent_and_unsettled(
+    transcript: &[tinyhivemind_hive::SessionMessage],
+    party: &[String],
+) -> (usize, bool) {
+    use tinyhivemind_hive::SessionAuthor;
+
+    let author_of = |message: &tinyhivemind_hive::SessionMessage| match &message.author {
+        SessionAuthor::Agent { id, .. } => Some(id.clone()),
+        _ => None,
+    };
+
+    let mut spent = 0usize;
+    let mut unsettled = false;
+    for message in transcript {
+        let Some(author) = author_of(message) else {
+            continue;
+        };
+        if let Some(other) = self::party(&author, &message.audience) {
+            if other == party {
+                spent = spent.saturating_add(1);
+                unsettled = true;
+            }
+            continue;
+        }
+        // A desk-visible row. Only a `!surface` from somebody in the party
+        // settles it — an ordinary desk turn by a member does not, or the
+        // requirement would be paid by the next thing anybody happened to say.
+        //
+        // `readable()` rather than `content`: a row this viewer may not read
+        // must never be quoted, and here that also means it must never be
+        // *classified*. In practice the transcript folded here is the operator
+        // projection, so nothing is elided — going through the accessor is what
+        // keeps that true if a caller ever passes a narrowed one.
+        if party.contains(&author)
+            && message.readable().is_some_and(surfaces)
+        {
+            unsettled = false;
+        }
+    }
+    (spent, unsettled)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tinyhivemind_hive::{SessionAuthor, SessionMessage, Sequence};
+
+    fn row(seq: u64, author: &str, content: &str, audience: Audience) -> SessionMessage {
+        SessionMessage {
+            sequence: Sequence(seq),
+            author: SessionAuthor::Agent {
+                id: author.to_owned(),
+                label: author.to_owned(),
+            },
+            content: content.to_owned(),
+            audience,
+            elided: None,
+        }
+    }
+
+    fn aside_to(who: &[&str]) -> Audience {
+        Audience::Aside {
+            members: who.iter().map(|s| (*s).to_owned()).collect(),
+        }
+    }
+
+    #[test]
+    fn a_default_config_authorizes_nothing() {
+        let config = AsideConfig::default();
+        assert!(!config.enabled());
+        assert_eq!(config.policy(), AsidePolicy::DEFAULT);
+        assert!(config.is_default());
+    }
+
+    /// A disabled desk that nevertheless wrote bounds must not read as a desk
+    /// that is on: every bound goes to zero with the switch.
+    #[test]
+    fn a_disabled_config_discards_its_own_bounds() {
+        let config = AsideConfig {
+            enabled: Some(false),
+            max_members: Some(3),
+            max_messages: Some(9),
+            ..AsideConfig::default()
+        };
+        assert_eq!(config.policy(), AsidePolicy::DEFAULT);
+    }
+
+    #[test]
+    fn an_enabled_config_defaults_to_a_settled_pair() {
+        let policy = AsideConfig {
+            enabled: Some(true),
+            ..AsideConfig::default()
+        }
+        .policy();
+        assert!(policy.enabled);
+        assert_eq!(policy.max_members, 1, "a pair, not a caucus");
+        assert_eq!(policy.max_messages, 2, "a question and an answer");
+        assert!(policy.must_surface, "the room is owed a settlement");
+        assert!(
+            !policy.require_thread,
+            "a hive episode runs on the desk channel; requiring a thread would \
+             authorize nothing"
+        );
+    }
+
+    #[test]
+    fn markers_match_on_a_word_boundary_only() {
+        assert!(opens_aside("!aside @auditor is this figure right?"));
+        assert!(opens_aside("  !aside @auditor"));
+        assert!(opens_aside("!aside"));
+        assert!(!opens_aside("!asides @auditor"));
+        assert!(!opens_aside("I would !aside but cannot"));
+        assert!(!opens_aside("!propose #stage"));
+
+        assert!(surfaces("!surface the auditor and I agree the figure holds"));
+        assert!(!surfaces("!surfaced it already"));
+    }
+
+    /// The party is the author plus the addressees, canonically ordered, so the
+    /// same pair folds to one key whichever of them wrote the row.
+    #[test]
+    fn a_party_is_order_independent_and_includes_its_author() {
+        let one = party("planner", &aside_to(&["auditor"])).expect("an aside");
+        let other = party("auditor", &aside_to(&["planner"])).expect("an aside");
+        assert_eq!(one, other);
+        assert_eq!(one, vec!["auditor".to_owned(), "planner".to_owned()]);
+        assert!(party("planner", &Audience::Desk).is_none(), "a desk row is in no party");
+    }
+
+    #[test]
+    fn spending_counts_only_this_partys_rows() {
+        let party_key = party("planner", &aside_to(&["auditor"])).expect("an aside");
+        let transcript = vec![
+            row(1, "planner", "!aside @auditor check this", aside_to(&["auditor"])),
+            row(2, "auditor", "!aside @planner it holds", aside_to(&["planner"])),
+            // A different pair entirely: must not spend this party's budget.
+            row(3, "planner", "!aside @scout and this?", aside_to(&["scout"])),
+            row(4, "critic", "!propose #stage", Audience::Desk),
+        ];
+        let (spent, unsettled) = spent_and_unsettled(&transcript, &party_key);
+        assert_eq!(spent, 2);
+        assert!(unsettled, "nobody surfaced it");
+    }
+
+    #[test]
+    fn a_surface_by_either_member_settles_the_party() {
+        let party_key = party("planner", &aside_to(&["auditor"])).expect("an aside");
+        let mut transcript = vec![row(
+            1,
+            "planner",
+            "!aside @auditor check this",
+            aside_to(&["auditor"]),
+        )];
+        assert!(spent_and_unsettled(&transcript, &party_key).1);
+
+        // The *other* member pays it back, which is enough: the room is owed
+        // one settlement, not one per participant.
+        transcript.push(row(2, "auditor", "!surface the figure holds", Audience::Desk));
+        let (spent, unsettled) = spent_and_unsettled(&transcript, &party_key);
+        assert_eq!(spent, 1, "a settlement is a desk row, not an aside row");
+        assert!(!unsettled);
+    }
+
+    /// An ordinary desk turn by a member is not a settlement. Otherwise the
+    /// requirement is paid by whatever anybody happened to say next, and the
+    /// room never learns what the aside produced.
+    #[test]
+    fn an_ordinary_desk_turn_does_not_settle_an_aside() {
+        let party_key = party("planner", &aside_to(&["auditor"])).expect("an aside");
+        let transcript = vec![
+            row(1, "planner", "!aside @auditor check this", aside_to(&["auditor"])),
+            row(2, "planner", "!propose #stage Stage it.", Audience::Desk),
+        ];
+        assert!(
+            spent_and_unsettled(&transcript, &party_key).1,
+            "a proposal is not a settlement"
+        );
+    }
+
+    /// A `!surface` from somebody who was never in the aside settles nothing —
+    /// they have nothing to report and cannot discharge a debt they do not owe.
+    #[test]
+    fn a_surface_by_a_non_member_settles_nothing() {
+        let party_key = party("planner", &aside_to(&["auditor"])).expect("an aside");
+        let transcript = vec![
+            row(1, "planner", "!aside @auditor check this", aside_to(&["auditor"])),
+            row(2, "critic", "!surface they seemed to agree", Audience::Desk),
+        ];
+        assert!(spent_and_unsettled(&transcript, &party_key).1);
+    }
+
+    /// Reopening after a settlement starts the debt again, and the spend count
+    /// keeps rising: the budget is per party per episode, not per aside.
+    #[test]
+    fn reopening_after_a_settlement_owes_the_room_again() {
+        let party_key = party("planner", &aside_to(&["auditor"])).expect("an aside");
+        let transcript = vec![
+            row(1, "planner", "!aside @auditor check this", aside_to(&["auditor"])),
+            row(2, "auditor", "!surface the figure holds", Audience::Desk),
+            row(3, "planner", "!aside @auditor and the other one?", aside_to(&["auditor"])),
+        ];
+        let (spent, unsettled) = spent_and_unsettled(&transcript, &party_key);
+        assert_eq!(spent, 2);
+        assert!(unsettled);
+    }
+
+    /// The operator's own rows carry no agent author and must never be folded
+    /// into anybody's party or counted as anybody's settlement.
+    #[test]
+    fn operator_rows_are_in_no_party() {
+        let party_key = party("planner", &aside_to(&["auditor"])).expect("an aside");
+        let transcript = vec![
+            SessionMessage {
+                sequence: Sequence(1),
+                author: SessionAuthor::Operator,
+                content: "!surface".to_owned(),
+                audience: Audience::Desk,
+                elided: None,
+            },
+            row(2, "planner", "!aside @auditor check this", aside_to(&["auditor"])),
+        ];
+        let (spent, unsettled) = spent_and_unsettled(&transcript, &party_key);
+        assert_eq!(spent, 1);
+        assert!(unsettled, "an operator cannot settle an agents' aside");
+    }
+}

--- a/src/hivemind/aside.rs
+++ b/src/hivemind/aside.rs
@@ -46,7 +46,7 @@
 //! asides says so.
 
 use serde::{Deserialize, Serialize};
-use tinyhivemind_hive::aside::{Audience, AsidePolicy};
+use tinyhivemind_hive::aside::{AsidePolicy, Audience};
 
 /// The marker a member opens a private line with.
 pub const ASIDE_MARKER: &str = "!aside";
@@ -227,9 +227,7 @@ pub fn spent_and_unsettled(
         // *classified*. In practice the transcript folded here is the operator
         // projection, so nothing is elided — going through the accessor is what
         // keeps that true if a caller ever passes a narrowed one.
-        if party.contains(&author)
-            && message.readable().is_some_and(surfaces)
-        {
+        if party.contains(&author) && message.readable().is_some_and(surfaces) {
             unsettled = false;
         }
     }
@@ -239,7 +237,7 @@ pub fn spent_and_unsettled(
 #[cfg(test)]
 mod test {
     use super::*;
-    use tinyhivemind_hive::{SessionAuthor, SessionMessage, Sequence};
+    use tinyhivemind_hive::{Sequence, SessionAuthor, SessionMessage};
 
     fn row(seq: u64, author: &str, content: &str, audience: Audience) -> SessionMessage {
         SessionMessage {
@@ -308,7 +306,9 @@ mod test {
         assert!(!opens_aside("I would !aside but cannot"));
         assert!(!opens_aside("!propose #stage"));
 
-        assert!(surfaces("!surface the auditor and I agree the figure holds"));
+        assert!(surfaces(
+            "!surface the auditor and I agree the figure holds"
+        ));
         assert!(!surfaces("!surfaced it already"));
     }
 
@@ -320,17 +320,35 @@ mod test {
         let other = party("auditor", &aside_to(&["planner"])).expect("an aside");
         assert_eq!(one, other);
         assert_eq!(one, vec!["auditor".to_owned(), "planner".to_owned()]);
-        assert!(party("planner", &Audience::Desk).is_none(), "a desk row is in no party");
+        assert!(
+            party("planner", &Audience::Desk).is_none(),
+            "a desk row is in no party"
+        );
     }
 
     #[test]
     fn spending_counts_only_this_partys_rows() {
         let party_key = party("planner", &aside_to(&["auditor"])).expect("an aside");
         let transcript = vec![
-            row(1, "planner", "!aside @auditor check this", aside_to(&["auditor"])),
-            row(2, "auditor", "!aside @planner it holds", aside_to(&["planner"])),
+            row(
+                1,
+                "planner",
+                "!aside @auditor check this",
+                aside_to(&["auditor"]),
+            ),
+            row(
+                2,
+                "auditor",
+                "!aside @planner it holds",
+                aside_to(&["planner"]),
+            ),
             // A different pair entirely: must not spend this party's budget.
-            row(3, "planner", "!aside @scout and this?", aside_to(&["scout"])),
+            row(
+                3,
+                "planner",
+                "!aside @scout and this?",
+                aside_to(&["scout"]),
+            ),
             row(4, "critic", "!propose #stage", Audience::Desk),
         ];
         let (spent, unsettled) = spent_and_unsettled(&transcript, &party_key);
@@ -351,7 +369,12 @@ mod test {
 
         // The *other* member pays it back, which is enough: the room is owed
         // one settlement, not one per participant.
-        transcript.push(row(2, "auditor", "!surface the figure holds", Audience::Desk));
+        transcript.push(row(
+            2,
+            "auditor",
+            "!surface the figure holds",
+            Audience::Desk,
+        ));
         let (spent, unsettled) = spent_and_unsettled(&transcript, &party_key);
         assert_eq!(spent, 1, "a settlement is a desk row, not an aside row");
         assert!(!unsettled);
@@ -364,7 +387,12 @@ mod test {
     fn an_ordinary_desk_turn_does_not_settle_an_aside() {
         let party_key = party("planner", &aside_to(&["auditor"])).expect("an aside");
         let transcript = vec![
-            row(1, "planner", "!aside @auditor check this", aside_to(&["auditor"])),
+            row(
+                1,
+                "planner",
+                "!aside @auditor check this",
+                aside_to(&["auditor"]),
+            ),
             row(2, "planner", "!propose #stage Stage it.", Audience::Desk),
         ];
         assert!(
@@ -379,7 +407,12 @@ mod test {
     fn a_surface_by_a_non_member_settles_nothing() {
         let party_key = party("planner", &aside_to(&["auditor"])).expect("an aside");
         let transcript = vec![
-            row(1, "planner", "!aside @auditor check this", aside_to(&["auditor"])),
+            row(
+                1,
+                "planner",
+                "!aside @auditor check this",
+                aside_to(&["auditor"]),
+            ),
             row(2, "critic", "!surface they seemed to agree", Audience::Desk),
         ];
         assert!(spent_and_unsettled(&transcript, &party_key).1);
@@ -391,9 +424,19 @@ mod test {
     fn reopening_after_a_settlement_owes_the_room_again() {
         let party_key = party("planner", &aside_to(&["auditor"])).expect("an aside");
         let transcript = vec![
-            row(1, "planner", "!aside @auditor check this", aside_to(&["auditor"])),
+            row(
+                1,
+                "planner",
+                "!aside @auditor check this",
+                aside_to(&["auditor"]),
+            ),
             row(2, "auditor", "!surface the figure holds", Audience::Desk),
-            row(3, "planner", "!aside @auditor and the other one?", aside_to(&["auditor"])),
+            row(
+                3,
+                "planner",
+                "!aside @auditor and the other one?",
+                aside_to(&["auditor"]),
+            ),
         ];
         let (spent, unsettled) = spent_and_unsettled(&transcript, &party_key);
         assert_eq!(spent, 2);
@@ -413,7 +456,12 @@ mod test {
                 audience: Audience::Desk,
                 elided: None,
             },
-            row(2, "planner", "!aside @auditor check this", aside_to(&["auditor"])),
+            row(
+                2,
+                "planner",
+                "!aside @auditor check this",
+                aside_to(&["auditor"]),
+            ),
         ];
         let (spent, unsettled) = spent_and_unsettled(&transcript, &party_key);
         assert_eq!(spent, 1);

--- a/src/hivemind/aside_test.rs
+++ b/src/hivemind/aside_test.rs
@@ -127,8 +127,14 @@ async fn only_the_aside_row_is_narrowed() {
 #[tokio::test]
 async fn a_support_written_inside_an_aside_carries_nothing() {
     let script: &[(&str, &str)] = &[
-        ("planner", "!propose #stage Stage the rollout behind a flag."),
-        ("critic", "!evidence #stage ^3 The last full rollout broke checkout."),
+        (
+            "planner",
+            "!propose #stage Stage the rollout behind a flag.",
+        ),
+        (
+            "critic",
+            "!evidence #stage ^3 The last full rollout broke checkout.",
+        ),
         ("scout", "!aside @planner !support #stage ^4 I am with you."),
         ("critic", "!question does anybody else hold this?"),
     ];

--- a/src/hivemind/aside_test.rs
+++ b/src/hivemind/aside_test.rs
@@ -58,18 +58,26 @@ async fn run(manifest: &str, script: &[(&str, &str)]) -> (Arc<MemoryLog>, Episod
     (log, outcome)
 }
 
-/// The audience journaled on the first row whose text starts with `!aside`.
-fn aside_audience(log: &MemoryLog) -> Option<Vec<String>> {
-    aside_audiences(log).into_iter().next()
-}
-
-/// Every `!aside` row's audience, in journal order. An empty entry is a line
-/// that asked for an aside and was refused into the open.
+/// Every private row's audience, in journal order.
+///
+/// Keyed on the **audience** rather than on the text: since ADR 0011 an aside
+/// is a second row riding alongside a turn, and a refused one is dropped
+/// entirely, so "which rows are private" is a question about what was stored
+/// and not about what somebody wrote.
 fn aside_audiences(log: &MemoryLog) -> Vec<Vec<String>> {
     log.addressed_replies("eng")
         .into_iter()
-        .filter(|(_, text, _)| text.starts_with("!aside"))
+        .filter(|(_, _, audience)| !audience.is_empty())
         .map(|(_, _, audience)| audience)
+        .collect()
+}
+
+/// Every desk-visible row's text, in journal order.
+fn desk_lines(log: &MemoryLog) -> Vec<String> {
+    log.addressed_replies("eng")
+        .into_iter()
+        .filter(|(_, _, audience)| audience.is_empty())
+        .map(|(_, text, _)| text)
         .collect()
 }
 
@@ -78,7 +86,10 @@ async fn an_authorized_aside_is_journaled_to_its_addressee_only() {
     let (log, _) = run(
         &aside_manifest(),
         &[
-            ("planner", "!aside @scout is the checkout metric yours?"),
+            (
+                "planner",
+                "!propose #stage Stage the rollout.\n!aside @scout is the checkout metric yours?",
+            ),
             ("scout", "!propose #ship Ship it all at once."),
             ("critic", "!propose #stage Stage it."),
         ],
@@ -86,20 +97,66 @@ async fn an_authorized_aside_is_journaled_to_its_addressee_only() {
     .await;
 
     assert_eq!(
-        aside_audience(&log).as_deref(),
-        Some(["scout".to_owned()].as_slice()),
+        aside_audiences(&log),
+        vec![vec!["scout".to_owned()]],
         "the addressee, and not the author, is what the row carries",
     );
 }
 
+/// **An aside rides alongside the turn that authored it** (ADR 0011).
+///
+/// One authorized turn produces the member's ordinary desk-visible
+/// contribution *and* the private row — two rows, one turn. Under the old rule
+/// the aside *was* the turn, and a live six-day run of
+/// `companies/vending_machine_co` used the move zero times: asking a peer meant
+/// not depositing, not objecting and not refuting, while the rest of the room
+/// went on accumulating support for the option the member had stepped away to
+/// ask about.
+#[tokio::test]
+async fn an_aside_costs_no_turn_and_the_desk_still_gets_the_move() {
+    let (log, outcome) = run(
+        &aside_manifest(),
+        &[
+            (
+                "planner",
+                "!propose #stage Stage the rollout.\n!aside @scout is the checkout metric yours?",
+            ),
+            ("scout", "!propose #ship Ship it all at once."),
+            ("critic", "!propose #stage Stage it."),
+        ],
+    )
+    .await;
+
+    // The room got the proposal, not a member that went quiet to ask a question.
+    assert!(
+        desk_lines(&log)
+            .iter()
+            .any(|line| line.starts_with("!propose #stage Stage the rollout.")),
+        "{:?}",
+        desk_lines(&log),
+    );
+    assert_eq!(aside_audiences(&log).len(), 1, "and the private row rode with it");
+    // Turns are counted, rows are not: the aside must not have been charged.
+    assert!(outcome.turns >= 1);
+    let rows = log.addressed_replies("eng").len();
+    assert!(
+        rows > outcome.turns as usize,
+        "an aside adds a row without adding a turn: {rows} rows, {} turns",
+        outcome.turns,
+    );
+}
+
 /// Every other row on the desk stays desk-visible. An aside must not be
-/// contagious: the mechanism is one line at a time, not a mode the desk enters.
+/// contagious: the mechanism is one row at a time, not a mode the desk enters.
 #[tokio::test]
 async fn only_the_aside_row_is_narrowed() {
     let (log, _) = run(
         &aside_manifest(),
         &[
-            ("planner", "!aside @scout is the checkout metric yours?"),
+            (
+                "planner",
+                "!propose #stage Stage it.\n!aside @scout is the checkout metric yours?",
+            ),
             ("scout", "!propose #ship Ship it all at once."),
             ("critic", "!propose #stage Stage it."),
         ],
@@ -127,85 +184,87 @@ async fn only_the_aside_row_is_narrowed() {
 #[tokio::test]
 async fn a_support_written_inside_an_aside_carries_nothing() {
     let script: &[(&str, &str)] = &[
-        (
-            "planner",
-            "!propose #stage Stage the rollout behind a flag.",
-        ),
+        ("planner", "!propose #stage Stage the rollout behind a flag."),
         (
             "critic",
             "!evidence #stage ^3 The last full rollout broke checkout.",
         ),
-        ("scout", "!aside @planner !support #stage ^4 I am with you."),
+        // The scout's desk line says nothing that counts; its support is
+        // private, and privacy is exactly what makes it worth nothing.
+        (
+            "scout",
+            "!question does anybody hold this?\n!aside @planner !support #stage ^4 I am with you.",
+        ),
         ("critic", "!question does anybody else hold this?"),
     ];
     let (private, private_outcome) = run(&aside_manifest(), script).await;
-    assert!(
-        aside_audience(&private).is_some(),
+    assert_eq!(
+        aside_audiences(&private).len(),
+        1,
         "the fixture only means anything if the aside was authorized",
     );
     assert!(
         !matches!(private_outcome.ending, EpisodeEnding::Converged { .. }),
         "a private support carried the room: {private_outcome:?}",
     );
-
-    // The identical script on a desk that never enabled asides. The same line
-    // is an ordinary desk row there, its `!support` counts, and the difference
-    // between the two runs is attributable to the audience and to nothing else.
-    let (public, _) = run(&no_aside_manifest(), script).await;
-    assert_eq!(
-        aside_audience(&public),
-        Some(Vec::new()),
-        "with asides off the same line is journaled desk-visible",
-    );
 }
 
-/// A line naming a peer who is not on this desk authorizes nothing, and the
-/// line still lands where the room can read it. Failing open to *private*
-/// would be the one direction that leaks.
+/// A line naming a peer who is not on this desk authorizes nothing, and the row
+/// is **dropped** rather than published to the desk.
+///
+/// Publishing it would put a second desk-visible contribution on one turn,
+/// which is the one thing a turn may not produce — and the member has already
+/// said its piece in its ordinary line.
 #[tokio::test]
-async fn an_aside_naming_a_stranger_stays_desk_visible() {
+async fn an_aside_naming_a_stranger_is_dropped() {
     let (log, _) = run(
         &aside_manifest(),
         &[
-            ("planner", "!aside @auditor can you check this?"),
+            (
+                "planner",
+                "!propose #stage Stage it.\n!aside @auditor can you check this?",
+            ),
             ("scout", "!propose #ship Ship it."),
             ("critic", "!propose #stage Stage it."),
         ],
     )
     .await;
 
-    assert_eq!(
-        aside_audience(&log),
-        Some(Vec::new()),
-        "`auditor` is on no desk here, so the audience resolved to nobody",
+    assert!(
+        aside_audiences(&log).is_empty(),
+        "`auditor` is on no desk here, so nothing should have been made private",
+    );
+    assert!(
+        !desk_lines(&log).iter().any(|line| line.contains("@auditor")),
+        "a refused aside is dropped, not published: {:?}",
+        desk_lines(&log),
+    );
+    assert!(
+        desk_lines(&log).iter().any(|line| line.starts_with("!propose #stage Stage it.")),
+        "the turn's own contribution still reaches the room",
     );
 }
 
-/// `must_surface` is the bound that actually binds first.
-///
-/// With it on — the default — a pair that has not paid its last aside back to
-/// the room cannot open another, and `max_messages` is never reached. The
-/// refusal is *into the open*: the member has still said what it meant to say,
-/// and a line the room can read is never a leak.
+/// `must_surface` is the bound that binds first: a pair that has not paid its
+/// last aside back to the room cannot open another, and the refused row is
+/// dropped.
 #[tokio::test]
 async fn a_pair_that_owes_the_room_a_settlement_cannot_open_another_aside() {
     let (log, _) = run(
         &aside_manifest(),
         &[
-            ("planner", "!aside @scout first question"),
-            ("planner", "!aside @scout second, still owing"),
+            ("planner", "!propose #stage Stage it.\n!aside @scout first question"),
+            ("planner", "!support #stage ^3 Still staging.\n!aside @scout second, still owing"),
             ("scout", "!propose #ship Ship it."),
             ("critic", "!propose #stage Stage it."),
         ],
     )
     .await;
 
-    let asides = aside_audiences(&log);
-    assert!(asides.len() >= 2, "the script wrote two: {asides:?}");
-    assert!(!asides[0].is_empty(), "the first opens the aside");
-    assert!(
-        asides[1].is_empty(),
-        "the pair owed a settlement, so the second belongs to the room: {asides:?}",
+    assert_eq!(
+        aside_audiences(&log).len(),
+        1,
+        "the first opens the aside; the second is owed a settlement and is dropped",
     );
 }
 
@@ -216,28 +275,25 @@ async fn a_settlement_lets_the_pair_open_another_aside() {
     let (log, _) = run(
         &aside_manifest(),
         &[
-            ("planner", "!aside @scout first question"),
+            ("planner", "!propose #stage Stage it.\n!aside @scout first question"),
             ("planner", "!surface scout confirms the metric is theirs"),
-            ("planner", "!aside @scout second question"),
+            ("planner", "!support #stage ^3 Confirmed.\n!aside @scout second question"),
             ("scout", "!propose #ship Ship it."),
             ("critic", "!propose #stage Stage it."),
         ],
     )
     .await;
 
-    let asides = aside_audiences(&log);
-    assert!(asides.len() >= 2, "the script wrote two: {asides:?}");
-    assert!(!asides[0].is_empty(), "the first opens the aside");
-    assert!(
-        !asides[1].is_empty(),
-        "the surface settled it, so the second is authorized again: {asides:?}",
+    assert_eq!(
+        aside_audiences(&log).len(),
+        2,
+        "the surface settled the first, so the second is authorized again",
     );
 }
 
-/// With `must_surface` off, `max_messages` is what stops a pair. Two rows —
-/// a question and an answer — and the third is desk-visible.
+/// With `must_surface` off, `max_messages` is what stops a pair.
 #[tokio::test]
-async fn a_pair_that_spends_max_messages_is_pushed_back_into_the_open() {
+async fn a_pair_that_spends_max_messages_is_dropped() {
     let manifest = "[company]\nname = \"Acme\"\n\
          [[agent]]\nid = \"planner\"\nrole = \"Planner\"\n\
          [[agent]]\nid = \"scout\"\nrole = \"Scout\"\n\
@@ -250,22 +306,19 @@ async fn a_pair_that_spends_max_messages_is_pushed_back_into_the_open() {
     let (log, _) = run(
         manifest,
         &[
-            ("planner", "!aside @scout first question"),
-            ("planner", "!aside @scout second, the last within budget"),
-            ("planner", "!aside @scout third, over budget"),
+            ("planner", "!propose #stage Stage it.\n!aside @scout first"),
+            ("planner", "!support #stage ^3 Yes.\n!aside @scout second, last within budget"),
+            ("planner", "!support #stage ^3 Still yes.\n!aside @scout third, over budget"),
             ("scout", "!propose #ship Ship it."),
             ("critic", "!propose #stage Stage it."),
         ],
     )
     .await;
 
-    let asides = aside_audiences(&log);
-    assert!(asides.len() >= 3, "the script wrote three: {asides:?}");
-    assert!(!asides[0].is_empty(), "the first is within budget");
-    assert!(!asides[1].is_empty(), "the second is within budget");
-    assert!(
-        asides[2].is_empty(),
-        "the third spent the pair's budget and belongs to the room: {asides:?}",
+    assert_eq!(
+        aside_audiences(&log).len(),
+        2,
+        "two are within budget and the third is dropped",
     );
 }
 

--- a/src/hivemind/aside_test.rs
+++ b/src/hivemind/aside_test.rs
@@ -58,12 +58,19 @@ async fn run(manifest: &str, script: &[(&str, &str)]) -> (Arc<MemoryLog>, Episod
     (log, outcome)
 }
 
-/// The audience journaled on the row whose text starts with `!aside`.
+/// The audience journaled on the first row whose text starts with `!aside`.
 fn aside_audience(log: &MemoryLog) -> Option<Vec<String>> {
+    aside_audiences(log).into_iter().next()
+}
+
+/// Every `!aside` row's audience, in journal order. An empty entry is a line
+/// that asked for an aside and was refused into the open.
+fn aside_audiences(log: &MemoryLog) -> Vec<Vec<String>> {
     log.addressed_replies("eng")
         .into_iter()
-        .find(|(_, text, _)| text.starts_with("!aside"))
+        .filter(|(_, text, _)| text.starts_with("!aside"))
         .map(|(_, _, audience)| audience)
+        .collect()
 }
 
 #[tokio::test]
@@ -168,28 +175,85 @@ async fn an_aside_naming_a_stranger_stays_desk_visible() {
     );
 }
 
-/// `max_messages` defaults to two. A third `!aside` between the same pair is
-/// refused, and refused *into the open* rather than dropped — the member has
-/// still said what it meant to say.
+/// `must_surface` is the bound that actually binds first.
+///
+/// With it on — the default — a pair that has not paid its last aside back to
+/// the room cannot open another, and `max_messages` is never reached. The
+/// refusal is *into the open*: the member has still said what it meant to say,
+/// and a line the room can read is never a leak.
 #[tokio::test]
-async fn a_pair_that_spends_its_budget_is_pushed_back_into_the_open() {
+async fn a_pair_that_owes_the_room_a_settlement_cannot_open_another_aside() {
     let (log, _) = run(
         &aside_manifest(),
         &[
             ("planner", "!aside @scout first question"),
-            ("scout", "!aside @planner first answer"),
-            ("planner", "!aside @scout third, over budget"),
+            ("planner", "!aside @scout second, still owing"),
+            ("scout", "!propose #ship Ship it."),
             ("critic", "!propose #stage Stage it."),
         ],
     )
     .await;
 
-    let asides: Vec<Vec<String>> = log
-        .addressed_replies("eng")
-        .into_iter()
-        .filter(|(_, text, _)| text.starts_with("!aside"))
-        .map(|(_, _, audience)| audience)
-        .collect();
+    let asides = aside_audiences(&log);
+    assert!(asides.len() >= 2, "the script wrote two: {asides:?}");
+    assert!(!asides[0].is_empty(), "the first opens the aside");
+    assert!(
+        asides[1].is_empty(),
+        "the pair owed a settlement, so the second belongs to the room: {asides:?}",
+    );
+}
+
+/// And a `!surface` discharges the debt, so the pair may open another. This is
+/// the half that makes `must_surface` a protocol rather than a one-shot limit.
+#[tokio::test]
+async fn a_settlement_lets_the_pair_open_another_aside() {
+    let (log, _) = run(
+        &aside_manifest(),
+        &[
+            ("planner", "!aside @scout first question"),
+            ("planner", "!surface scout confirms the metric is theirs"),
+            ("planner", "!aside @scout second question"),
+            ("scout", "!propose #ship Ship it."),
+            ("critic", "!propose #stage Stage it."),
+        ],
+    )
+    .await;
+
+    let asides = aside_audiences(&log);
+    assert!(asides.len() >= 2, "the script wrote two: {asides:?}");
+    assert!(!asides[0].is_empty(), "the first opens the aside");
+    assert!(
+        !asides[1].is_empty(),
+        "the surface settled it, so the second is authorized again: {asides:?}",
+    );
+}
+
+/// With `must_surface` off, `max_messages` is what stops a pair. Two rows —
+/// a question and an answer — and the third is desk-visible.
+#[tokio::test]
+async fn a_pair_that_spends_max_messages_is_pushed_back_into_the_open() {
+    let manifest = "[company]\nname = \"Acme\"\n\
+         [[agent]]\nid = \"planner\"\nrole = \"Planner\"\n\
+         [[agent]]\nid = \"scout\"\nrole = \"Scout\"\n\
+         [[agent]]\nid = \"critic\"\nrole = \"Critic\"\n\
+         [[group_chat]]\nid = \"eng\"\nname = \"Engineering\"\n\
+         description = \"Ship the rollout\"\n\
+         members = [\"planner\", \"scout\", \"critic\"]\n\
+         hive = { enabled = true, aside = { enabled = true, max_messages = 2, must_surface = false } }\n";
+
+    let (log, _) = run(
+        manifest,
+        &[
+            ("planner", "!aside @scout first question"),
+            ("planner", "!aside @scout second, the last within budget"),
+            ("planner", "!aside @scout third, over budget"),
+            ("scout", "!propose #ship Ship it."),
+            ("critic", "!propose #stage Stage it."),
+        ],
+    )
+    .await;
+
+    let asides = aside_audiences(&log);
     assert!(asides.len() >= 3, "the script wrote three: {asides:?}");
     assert!(!asides[0].is_empty(), "the first is within budget");
     assert!(!asides[1].is_empty(), "the second is within budget");

--- a/src/hivemind/aside_test.rs
+++ b/src/hivemind/aside_test.rs
@@ -1,0 +1,251 @@
+//! What a private aside does to a real episode.
+//!
+//! [`super::aside`]'s own tests pin the fold — the party key, the budget, the
+//! settlement debt — against synthetic transcripts. These drive the whole
+//! [`EpisodeDriver`] and assert the two properties that only show up end to
+//! end: that an authorized aside is journaled with a narrower audience, and
+//! that it is worth **nothing** to the room's counting.
+//!
+//! See `docs/spec/runtime/hivemind-asides.md`.
+
+use std::sync::Arc;
+
+use super::test::{MemoryLog, ScriptedRunner, desk_of, seed_desk};
+use super::*;
+use crate::ports::events::EventLog;
+
+/// Three seats on one desk with asides on, at the library's own default bounds.
+fn aside_manifest() -> String {
+    "[company]\nname = \"Acme\"\n\
+     [[agent]]\nid = \"planner\"\nrole = \"Planner\"\n\
+     [[agent]]\nid = \"scout\"\nrole = \"Scout\"\n\
+     [[agent]]\nid = \"critic\"\nrole = \"Critic\"\n\
+     [[group_chat]]\nid = \"eng\"\nname = \"Engineering\"\n\
+     description = \"Ship the rollout\"\n\
+     members = [\"planner\", \"scout\", \"critic\"]\n\
+     hive = { enabled = true, aside = { enabled = true } }\n"
+        .to_string()
+}
+
+/// The same desk with the block absent entirely — the default every other
+/// bundle in this repo runs under.
+fn no_aside_manifest() -> String {
+    "[company]\nname = \"Acme\"\n\
+     [[agent]]\nid = \"planner\"\nrole = \"Planner\"\n\
+     [[agent]]\nid = \"scout\"\nrole = \"Scout\"\n\
+     [[agent]]\nid = \"critic\"\nrole = \"Critic\"\n\
+     [[group_chat]]\nid = \"eng\"\nname = \"Engineering\"\n\
+     description = \"Ship the rollout\"\n\
+     members = [\"planner\", \"scout\", \"critic\"]\n"
+        .to_string()
+}
+
+async fn run(manifest: &str, script: &[(&str, &str)]) -> (Arc<MemoryLog>, EpisodeOutcome) {
+    let log = Arc::new(MemoryLog::default());
+    let trigger = seed_desk(&log).await;
+    let desk = desk_of(manifest, "eng").expect("a room");
+    let runner = ScriptedRunner::new(script);
+    let outcome = EpisodeDriver::new(
+        MemoryLog::company(),
+        desk,
+        Arc::clone(&log) as Arc<dyn EventLog>,
+        &runner,
+        "Decide the rollout.",
+    )
+    .run(trigger)
+    .await
+    .expect("the episode runs");
+    (log, outcome)
+}
+
+/// The audience journaled on the row whose text starts with `!aside`.
+fn aside_audience(log: &MemoryLog) -> Option<Vec<String>> {
+    log.addressed_replies("eng")
+        .into_iter()
+        .find(|(_, text, _)| text.starts_with("!aside"))
+        .map(|(_, _, audience)| audience)
+}
+
+#[tokio::test]
+async fn an_authorized_aside_is_journaled_to_its_addressee_only() {
+    let (log, _) = run(
+        &aside_manifest(),
+        &[
+            ("planner", "!aside @scout is the checkout metric yours?"),
+            ("scout", "!propose #ship Ship it all at once."),
+            ("critic", "!propose #stage Stage it."),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        aside_audience(&log).as_deref(),
+        Some(["scout".to_owned()].as_slice()),
+        "the addressee, and not the author, is what the row carries",
+    );
+}
+
+/// Every other row on the desk stays desk-visible. An aside must not be
+/// contagious: the mechanism is one line at a time, not a mode the desk enters.
+#[tokio::test]
+async fn only_the_aside_row_is_narrowed() {
+    let (log, _) = run(
+        &aside_manifest(),
+        &[
+            ("planner", "!aside @scout is the checkout metric yours?"),
+            ("scout", "!propose #ship Ship it all at once."),
+            ("critic", "!propose #stage Stage it."),
+        ],
+    )
+    .await;
+
+    for (author, text, audience) in log.addressed_replies("eng") {
+        if text.starts_with("!aside") {
+            continue;
+        }
+        assert!(
+            audience.is_empty(),
+            "`{author}` wrote a narrowed row it did not ask to narrow: {text}",
+        );
+    }
+}
+
+/// The rule the whole mechanism rests on. A `!support` written privately adds
+/// no supporter, so a room that could otherwise carry an option does not.
+///
+/// The desk's quorum is two. The script deposits evidence, then a private
+/// support and a public one — two supports in the transcript, only one of which
+/// the fold may count — so an episode that converged here would be one that had
+/// counted a vote nobody in the room could read.
+#[tokio::test]
+async fn a_support_written_inside_an_aside_carries_nothing() {
+    let script: &[(&str, &str)] = &[
+        ("planner", "!propose #stage Stage the rollout behind a flag."),
+        ("critic", "!evidence #stage ^3 The last full rollout broke checkout."),
+        ("scout", "!aside @planner !support #stage ^4 I am with you."),
+        ("critic", "!question does anybody else hold this?"),
+    ];
+    let (private, private_outcome) = run(&aside_manifest(), script).await;
+    assert!(
+        aside_audience(&private).is_some(),
+        "the fixture only means anything if the aside was authorized",
+    );
+    assert!(
+        !matches!(private_outcome.ending, EpisodeEnding::Converged { .. }),
+        "a private support carried the room: {private_outcome:?}",
+    );
+
+    // The identical script on a desk that never enabled asides. The same line
+    // is an ordinary desk row there, its `!support` counts, and the difference
+    // between the two runs is attributable to the audience and to nothing else.
+    let (public, _) = run(&no_aside_manifest(), script).await;
+    assert_eq!(
+        aside_audience(&public),
+        Some(Vec::new()),
+        "with asides off the same line is journaled desk-visible",
+    );
+}
+
+/// A line naming a peer who is not on this desk authorizes nothing, and the
+/// line still lands where the room can read it. Failing open to *private*
+/// would be the one direction that leaks.
+#[tokio::test]
+async fn an_aside_naming_a_stranger_stays_desk_visible() {
+    let (log, _) = run(
+        &aside_manifest(),
+        &[
+            ("planner", "!aside @auditor can you check this?"),
+            ("scout", "!propose #ship Ship it."),
+            ("critic", "!propose #stage Stage it."),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        aside_audience(&log),
+        Some(Vec::new()),
+        "`auditor` is on no desk here, so the audience resolved to nobody",
+    );
+}
+
+/// `max_messages` defaults to two. A third `!aside` between the same pair is
+/// refused, and refused *into the open* rather than dropped — the member has
+/// still said what it meant to say.
+#[tokio::test]
+async fn a_pair_that_spends_its_budget_is_pushed_back_into_the_open() {
+    let (log, _) = run(
+        &aside_manifest(),
+        &[
+            ("planner", "!aside @scout first question"),
+            ("scout", "!aside @planner first answer"),
+            ("planner", "!aside @scout third, over budget"),
+            ("critic", "!propose #stage Stage it."),
+        ],
+    )
+    .await;
+
+    let asides: Vec<Vec<String>> = log
+        .addressed_replies("eng")
+        .into_iter()
+        .filter(|(_, text, _)| text.starts_with("!aside"))
+        .map(|(_, _, audience)| audience)
+        .collect();
+    assert!(asides.len() >= 3, "the script wrote three: {asides:?}");
+    assert!(!asides[0].is_empty(), "the first is within budget");
+    assert!(!asides[1].is_empty(), "the second is within budget");
+    assert!(
+        asides[2].is_empty(),
+        "the third spent the pair's budget and belongs to the room: {asides:?}",
+    );
+}
+
+/// A desk that never enabled asides behaves byte-for-byte as it did before the
+/// mechanism existed: the marker is just text, and every row is desk-visible.
+#[tokio::test]
+async fn a_desk_that_did_not_opt_in_narrows_nothing() {
+    let (log, _) = run(
+        &no_aside_manifest(),
+        &[
+            ("planner", "!aside @scout is the checkout metric yours?"),
+            ("scout", "!propose #ship Ship it."),
+            ("critic", "!propose #stage Stage it."),
+        ],
+    )
+    .await;
+
+    assert!(
+        log.addressed_replies("eng")
+            .iter()
+            .all(|(_, _, audience)| audience.is_empty()),
+        "an opted-out desk journaled a narrowed row",
+    );
+}
+
+/// The two markers are taught only where they can be used. A grammar is a fixed
+/// cost paid in every agent's system text on every turn, and teaching a move
+/// nobody may make spends that budget for nothing.
+#[tokio::test]
+async fn the_grammar_is_taught_only_to_a_desk_that_enabled_it() {
+    for (manifest, expected) in [(aside_manifest(), true), (no_aside_manifest(), false)] {
+        let log = Arc::new(MemoryLog::default());
+        let trigger = seed_desk(&log).await;
+        let desk = desk_of(&manifest, "eng").expect("a room");
+        let runner = ScriptedRunner::new(&[("planner", "!propose #stage Stage it.")]);
+        EpisodeDriver::new(
+            MemoryLog::company(),
+            desk,
+            Arc::clone(&log) as Arc<dyn EventLog>,
+            &runner,
+            "Decide the rollout.",
+        )
+        .run(trigger)
+        .await
+        .expect("the episode runs");
+
+        let taught = runner
+            .asked()
+            .iter()
+            .any(|(_, prompt)| prompt.contains(ASIDE_MARKER) && prompt.contains(SURFACE_MARKER));
+        assert_eq!(taught, expected, "aside grammar taught={taught}");
+    }
+}

--- a/src/hivemind/aside_test.rs
+++ b/src/hivemind/aside_test.rs
@@ -135,7 +135,11 @@ async fn an_aside_costs_no_turn_and_the_desk_still_gets_the_move() {
         "{:?}",
         desk_lines(&log),
     );
-    assert_eq!(aside_audiences(&log).len(), 1, "and the private row rode with it");
+    assert_eq!(
+        aside_audiences(&log).len(),
+        1,
+        "and the private row rode with it"
+    );
     // Turns are counted, rows are not: the aside must not have been charged.
     assert!(outcome.turns >= 1);
     let rows = log.addressed_replies("eng").len();
@@ -184,7 +188,10 @@ async fn only_the_aside_row_is_narrowed() {
 #[tokio::test]
 async fn a_support_written_inside_an_aside_carries_nothing() {
     let script: &[(&str, &str)] = &[
-        ("planner", "!propose #stage Stage the rollout behind a flag."),
+        (
+            "planner",
+            "!propose #stage Stage the rollout behind a flag.",
+        ),
         (
             "critic",
             "!evidence #stage ^3 The last full rollout broke checkout.",
@@ -235,12 +242,16 @@ async fn an_aside_naming_a_stranger_is_dropped() {
         "`auditor` is on no desk here, so nothing should have been made private",
     );
     assert!(
-        !desk_lines(&log).iter().any(|line| line.contains("@auditor")),
+        !desk_lines(&log)
+            .iter()
+            .any(|line| line.contains("@auditor")),
         "a refused aside is dropped, not published: {:?}",
         desk_lines(&log),
     );
     assert!(
-        desk_lines(&log).iter().any(|line| line.starts_with("!propose #stage Stage it.")),
+        desk_lines(&log)
+            .iter()
+            .any(|line| line.starts_with("!propose #stage Stage it.")),
         "the turn's own contribution still reaches the room",
     );
 }
@@ -253,8 +264,14 @@ async fn a_pair_that_owes_the_room_a_settlement_cannot_open_another_aside() {
     let (log, _) = run(
         &aside_manifest(),
         &[
-            ("planner", "!propose #stage Stage it.\n!aside @scout first question"),
-            ("planner", "!support #stage ^3 Still staging.\n!aside @scout second, still owing"),
+            (
+                "planner",
+                "!propose #stage Stage it.\n!aside @scout first question",
+            ),
+            (
+                "planner",
+                "!support #stage ^3 Still staging.\n!aside @scout second, still owing",
+            ),
             ("scout", "!propose #ship Ship it."),
             ("critic", "!propose #stage Stage it."),
         ],
@@ -275,9 +292,15 @@ async fn a_settlement_lets_the_pair_open_another_aside() {
     let (log, _) = run(
         &aside_manifest(),
         &[
-            ("planner", "!propose #stage Stage it.\n!aside @scout first question"),
+            (
+                "planner",
+                "!propose #stage Stage it.\n!aside @scout first question",
+            ),
             ("planner", "!surface scout confirms the metric is theirs"),
-            ("planner", "!support #stage ^3 Confirmed.\n!aside @scout second question"),
+            (
+                "planner",
+                "!support #stage ^3 Confirmed.\n!aside @scout second question",
+            ),
             ("scout", "!propose #ship Ship it."),
             ("critic", "!propose #stage Stage it."),
         ],
@@ -307,8 +330,14 @@ async fn a_pair_that_spends_max_messages_is_dropped() {
         manifest,
         &[
             ("planner", "!propose #stage Stage it.\n!aside @scout first"),
-            ("planner", "!support #stage ^3 Yes.\n!aside @scout second, last within budget"),
-            ("planner", "!support #stage ^3 Still yes.\n!aside @scout third, over budget"),
+            (
+                "planner",
+                "!support #stage ^3 Yes.\n!aside @scout second, last within budget",
+            ),
+            (
+                "planner",
+                "!support #stage ^3 Still yes.\n!aside @scout third, over budget",
+            ),
             ("scout", "!propose #ship Ship it."),
             ("critic", "!propose #stage Stage it."),
         ],

--- a/src/hivemind/deliberation_test.rs
+++ b/src/hivemind/deliberation_test.rs
@@ -419,7 +419,7 @@ fn message(sequence: u64, agent: &str, content: &str) -> tinyhivemind_hive::Sess
         },
         content: content.to_owned(),
         audience: tinyhivemind_hive::aside::Audience::Desk,
-        elided: false,
+        elided: None,
     }
 }
 

--- a/src/hivemind/deliberation_test.rs
+++ b/src/hivemind/deliberation_test.rs
@@ -418,6 +418,8 @@ fn message(sequence: u64, agent: &str, content: &str) -> tinyhivemind_hive::Sess
             label: agent.to_owned(),
         },
         content: content.to_owned(),
+        audience: tinyhivemind_hive::aside::Audience::Desk,
+        elided: false,
     }
 }
 

--- a/src/hivemind/deliberation_test.rs
+++ b/src/hivemind/deliberation_test.rs
@@ -95,7 +95,7 @@ fn the_commit_prompt_names_the_carried_topic() {
         message(1, "planner", "!propose #euler12-triangle 76576500"),
         message(2, "scout", "!support #euler12-triangle ^1 It checks out."),
     ];
-    let visible: Vec<&tinyhivemind_hive::SessionMessage> = messages.iter().collect();
+    let visible = messages.clone();
     let prompt = EpisodePrompt::new(&member, &desk, "Project Euler 12.", quorum, &[])
         .render(&turn("critic", tinyhivemind_hive::Phase::Commit), &visible);
 
@@ -270,7 +270,7 @@ fn a_support_citing_only_a_proposal_reaches_no_evidence() {
         message(1, "planner", "!propose #euler12 76576500"),
         message(2, "scout", "!evidence #euler12 ^1 The 12375th triangular."),
     ];
-    let visible: Vec<&tinyhivemind_hive::SessionMessage> = messages.iter().collect();
+    let visible = messages.clone();
     assert!(
         evidential::support_misses_evidence(
             "!support #euler12 ^1 It looks right.",

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -728,7 +728,7 @@ impl<'a> EpisodeDriver<'a> {
         scratch: &mut TurnScratch,
     ) -> Result<String> {
         let line = self
-            .grounded(agent_id, prompt, visible, line, aside)
+            .grounded(agent_id, prompt, visible, line, scratch)
             .await?;
         let Some(kind) = moves::line_kind(&line).filter(|kind| !allowed.contains(kind)) else {
             return Ok(line);
@@ -1016,21 +1016,21 @@ impl<'a> EpisodeDriver<'a> {
                     desk = %self.desk.id,
                     agent = %agent_id,
                     reason = ?reason,
-                    "[hive] no aside was authorized; the line stays desk-visible"
+                    "[hive] no aside was authorized; the private row is dropped"
                 );
                 Vec::new()
             }
             Err(error) => {
-                // A malformed snapshot is this host's bug, not the room's, and
-                // it must not cost the episode: the line is journaled where
-                // everyone can read it, which is what would have happened
-                // before asides existed.
+                // A malformed snapshot is this host's bug, not the room's,
+                // and it must not cost the episode. The private row is dropped
+                // rather than published: the turn's own contribution is already
+                // journaled where everyone can read it.
                 tracing::warn!(
                     company = %self.company,
                     desk = %self.desk.id,
                     agent = %agent_id,
                     error = %error,
-                    "[hive] the aside gate could not decide; the line stays desk-visible"
+                    "[hive] the aside gate could not decide; the private row is dropped"
                 );
                 Vec::new()
             }

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -556,7 +556,7 @@ impl<'a> EpisodeDriver<'a> {
         &self,
         agent_id: &str,
         prompt: &str,
-        visible: &[&tinyhivemind_hive::SessionMessage],
+        visible: &[tinyhivemind_hive::SessionMessage],
         violations: &mut Vec<MoveViolation>,
     ) -> Result<String> {
         let allowed = self.desk.config.moves_for(agent_id);
@@ -607,7 +607,7 @@ impl<'a> EpisodeDriver<'a> {
         &self,
         agent_id: &str,
         prompt: &str,
-        visible: &[&tinyhivemind_hive::SessionMessage],
+        visible: &[tinyhivemind_hive::SessionMessage],
         line: String,
         allowed: &[&'static str],
         violations: &mut Vec<MoveViolation>,
@@ -649,7 +649,7 @@ impl<'a> EpisodeDriver<'a> {
         &self,
         agent_id: &str,
         prompt: &str,
-        visible: &[&tinyhivemind_hive::SessionMessage],
+        visible: &[tinyhivemind_hive::SessionMessage],
         line: String,
     ) -> Result<String> {
         if self.desk.config.require_evidential != Some(true)

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -19,8 +19,8 @@ use async_trait::async_trait;
 use tinyhivemind_hive::{
     Conversation, EpisodeState, HiveStep, SESSION_WINDOW, Sequence, SessionQuery,
     aside::{AsideDecision, AsideInput, Viewer},
-    dispatch::DispatchConversation,
     desk::{Desk, DeskSet, ResponderMode},
+    dispatch::DispatchConversation,
     mention::{MentionAuthor, MentionTarget},
     pins::{PIN_LIMIT, read_pinboard},
     project_for,
@@ -355,7 +355,8 @@ impl<'a> EpisodeDriver<'a> {
                 PIN_LIMIT,
                 None,
             )
-            .await {
+            .await
+            {
                 Ok(pins) => pins,
                 Err(error) => {
                     tracing::warn!(
@@ -464,7 +465,14 @@ impl<'a> EpisodeDriver<'a> {
             // has a name, and every one of them means "this line is an ordinary
             // desk row" — which is the safe direction: a line the room can read
             // is never a leak, and the member has said what it meant to say.
-            let audience = self.aside_audience(&turn.agent_id, &line, &transcript, &members, &desks, &retired);
+            let audience = self.aside_audience(
+                &turn.agent_id,
+                &line,
+                &transcript,
+                &members,
+                &desks,
+                &retired,
+            );
             let seq = self
                 .events
                 .append(

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tinyhivemind_hive::{
     Conversation, EpisodeState, HiveStep, SESSION_WINDOW, Sequence, SessionQuery,
+    aside::Viewer,
     desk::{Desk, DeskSet, ResponderMode},
     pins::{PIN_LIMIT, read_pinboard},
     project_for,

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -717,7 +717,9 @@ impl<'a> EpisodeDriver<'a> {
         violations: &mut Vec<MoveViolation>,
         aside: &mut Option<String>,
     ) -> Result<String> {
-        let line = self.grounded(agent_id, prompt, visible, line, aside).await?;
+        let line = self
+            .grounded(agent_id, prompt, visible, line, aside)
+            .await?;
         let Some(kind) = moves::line_kind(&line).filter(|kind| !allowed.contains(kind)) else {
             return Ok(line);
         };

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -32,7 +32,7 @@ use super::evidential;
 use super::log::EventLogSessionLog;
 use super::memory::{HiveMemory, HiveMemoryHit, HiveMemoryNote, NullHiveMemory, RECALL_LIMIT};
 use super::moves::{self, MoveViolation};
-use super::prompt::{EpisodePrompt, marker_line};
+use super::prompt::{EpisodePrompt, marker_line, split_reply};
 use super::referral::{EpisodeReferrals, HiveFederation, HiveReferralRunner, ReferralLedger};
 use super::scope::EpisodeScope;
 use super::types::{EpisodeEnding, EpisodeOutcome, HiveDesk};
@@ -604,16 +604,23 @@ impl<'a> EpisodeDriver<'a> {
         prompt: &str,
         visible: &[tinyhivemind_hive::SessionMessage],
         violations: &mut Vec<MoveViolation>,
+        aside: &mut Option<String>,
     ) -> Result<String> {
         let allowed = self.desk.config.moves_for(agent_id);
-        let line = marker_line(&self.runner.speak(agent_id, prompt).await?);
+        let (line, rode) = split_reply(&self.runner.speak(agent_id, prompt).await?);
+        *aside = rode;
         let Some(kind) = moves::line_kind(&line).filter(|kind| !allowed.contains(kind)) else {
             return self
                 .grounded_and_regraded(agent_id, prompt, visible, line, &allowed, violations)
                 .await;
         };
         let corrected = format!("{prompt}\n\n{}", moves::correction(kind, &allowed));
-        let line = marker_line(&self.runner.speak(agent_id, &corrected).await?);
+        // The retry's aside replaces the first attempt's: the corrected reply is
+        // the turn that actually happened, and carrying a private line over from
+        // a reply the room never saw would publish something its author did not
+        // write on the turn it was written for.
+        let (line, rode) = split_reply(&self.runner.speak(agent_id, &corrected).await?);
+        *aside = rode;
         let Some(kind) = moves::line_kind(&line).filter(|kind| !allowed.contains(kind)) else {
             return self
                 .grounded_and_regraded(agent_id, prompt, visible, line, &allowed, violations)

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -297,6 +297,13 @@ impl<'a> EpisodeDriver<'a> {
                 &log,
                 &SessionQuery {
                     conversation: conversation.clone(),
+                    // The *true medium*, deliberately unnarrowed. `step` folds
+                    // this, and the room's counting has to be single-valued:
+                    // a per-reader fold would make `quorum::standings` return
+                    // a well-formed wrong answer with no error path — a quorum
+                    // one member can see and another cannot. `project_for`
+                    // below is the only thing that narrows, per speaker.
+                    viewer: Viewer::Operator,
                     before: None,
                     window: SESSION_WINDOW,
                 },
@@ -332,7 +339,20 @@ impl<'a> EpisodeDriver<'a> {
             // Folded fresh each turn from the same journal the transcript came
             // from, so a pin laid down *during* the episode is on the board for
             // the next speaker rather than the next episode.
-            let pins = match read_pinboard(&log, &conversation, PIN_LIMIT, None).await {
+            let pins = match read_pinboard(
+                &log,
+                &conversation,
+                // The board is rendered into *this speaker's* prompt, so it is
+                // read as this speaker: a pin over an aside it is not in must
+                // not quote content to it, and one over an aside it *is* in
+                // must still reach it.
+                &Viewer::Agent {
+                    id: turn.agent_id.clone(),
+                },
+                PIN_LIMIT,
+                None,
+            )
+            .await {
                 Ok(pins) => pins,
                 Err(error) => {
                     tracing::warn!(

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -457,22 +457,6 @@ impl<'a> EpisodeDriver<'a> {
                     continue;
                 }
             };
-            // Considered *before* the row is appended, because an audience is
-            // fixed at append time: widening one afterwards could never be
-            // redelivered, and would invalidate every citation naming it.
-            //
-            // A refusal is not an error. Every rung of the library's decision
-            // has a name, and every one of them means "this line is an ordinary
-            // desk row" — which is the safe direction: a line the room can read
-            // is never a leak, and the member has said what it meant to say.
-            let audience = self.aside_audience(
-                &turn.agent_id,
-                &line,
-                &transcript,
-                &members,
-                &desks,
-                &retired,
-            );
             let seq = self
                 .events
                 .append(
@@ -481,7 +465,10 @@ impl<'a> EpisodeDriver<'a> {
                         chat_id: self.desk.id.clone(),
                         agent_id: turn.agent_id.clone(),
                         text: line.clone(),
-                        audience: audience.clone(),
+                        // The turn's own contribution is always the room's. An
+                        // aside is a *second* row riding alongside it, appended
+                        // below.
+                        audience: Vec::new(),
                         // The episode's own turns carry no step timeline: the
                         // room is reading one line per turn, and a tool trace
                         // belongs to the turn's own bubble, which this path
@@ -501,6 +488,61 @@ impl<'a> EpisodeDriver<'a> {
             scope.record(seq);
             first_seq.get_or_insert(seq);
             last_seq = Some(seq);
+            // The aside rides alongside the turn that authored it and is not
+            // charged as one (ADR 0011): one authorized turn produces the
+            // member's ordinary contribution *and*, optionally, one private
+            // row. `EpisodeState::spent` counts turns rather than rows, and
+            // `step` drops a non-desk row before it reaches any trace or
+            // standing, so this adds nothing the episode can vote.
+            //
+            // Under the old rule an aside *was* the turn, and a live six-day
+            // run of `companies/vending_machine_co` used the move zero times:
+            // asking a peer meant not depositing, not objecting and not
+            // refuting, while the rest of the room went on accumulating support
+            // for the option the member had stepped away to ask about.
+            //
+            // A refused audience is **dropped, not published**. Falling back to
+            // the desk would put a second desk-visible contribution on one
+            // turn, which is the one thing a turn may not produce — and the
+            // member has already said its piece in the row above.
+            if let Some(aside_line) = rode {
+                let audience = self.aside_audience(
+                    &turn.agent_id,
+                    &aside_line,
+                    &transcript,
+                    &members,
+                    &desks,
+                    &retired,
+                );
+                if audience.is_empty() {
+                    tracing::debug!(
+                        company = %self.company,
+                        desk = %self.desk.id,
+                        agent = %turn.agent_id,
+                        "[hive] an aside was not authorized; the row was dropped"
+                    );
+                } else {
+                    let aside_seq = self
+                        .events
+                        .append(
+                            &self.company,
+                            CompanyEvent::AgentReply {
+                                chat_id: self.desk.id.clone(),
+                                agent_id: turn.agent_id.clone(),
+                                text: aside_line,
+                                audience,
+                                steps: Vec::new(),
+                                task_id: None,
+                                parent: self.thread_root,
+                                mentions: Vec::new(),
+                                mention_depth: 0,
+                            },
+                        )
+                        .await?;
+                    scope.record(aside_seq);
+                    last_seq = Some(aside_seq);
+                }
+            }
             // Considered *after* the line is durable and *before* the next
             // speaker is chosen, which is the whole of the timing. The wiki
             // measures this as the single largest effect in the mechanism: a

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -108,6 +108,24 @@ impl std::fmt::Debug for EpisodeDriver<'_> {
     }
 }
 
+/// What one turn writes back besides the line it is journaled under.
+///
+/// Bundled rather than passed as two `&mut` parameters because the turn path
+/// threads them through three functions (`line_from` → `grounded_and_regraded`
+/// → `grounded`), and the retries mean each of those has to be able to replace
+/// the aside as well as append a violation.
+///
+/// The two have different lifetimes on purpose: `violations` accumulates over
+/// the whole episode and is reported in the outcome, while `aside` belongs to
+/// one turn and is cleared before each.
+#[derive(Default)]
+struct TurnScratch {
+    /// Lines a member deposited that its seat was not entitled to make.
+    violations: Vec<MoveViolation>,
+    /// The private row this turn's reply carried, if any.
+    aside: Option<String>,
+}
+
 impl<'a> EpisodeDriver<'a> {
     /// Open a driver over `desk`, answering `task`.
     #[must_use]
@@ -237,7 +255,7 @@ impl<'a> EpisodeDriver<'a> {
         let mut turns = 0_u32;
         let mut first_seq: Option<EventSeq> = None;
         let mut last_seq: Option<EventSeq> = None;
-        let mut violations: Vec<MoveViolation> = Vec::new();
+        let mut scratch = TurnScratch::default();
         // Every line this episode journaled, in order, so the closing note is
         // written from what the room actually deposited rather than from a
         // second read of the journal that could disagree with it.
@@ -396,17 +414,11 @@ impl<'a> EpisodeDriver<'a> {
                 .with_trigger(Sequence(trigger.value()))
                 .render(&turn, &visible);
 
-            // The private row this turn's reply carried, if any. Set by
-            // `line_from` from whichever attempt produced the final desk line.
-            let mut rode: Option<String> = None;
+            // Cleared per turn: the aside belongs to the reply that produced
+            // this turn's line, never to the one before it.
+            scratch.aside = None;
             let line = match self
-                .line_from(
-                    &turn.agent_id,
-                    &prompt,
-                    &visible,
-                    &mut violations,
-                    &mut rode,
-                )
+                .line_from(&turn.agent_id, &prompt, &visible, &mut scratch)
                 .await
             {
                 Ok(line) => {
@@ -514,7 +526,7 @@ impl<'a> EpisodeDriver<'a> {
             // the desk would put a second desk-visible contribution on one
             // turn, which is the one thing a turn may not produce — and the
             // member has already said its piece in the row above.
-            if let Some(aside_line) = rode {
+            if let Some(aside_line) = scratch.aside.take() {
                 let audience = self.aside_audience(
                     &turn.agent_id,
                     &aside_line,
@@ -613,7 +625,7 @@ impl<'a> EpisodeDriver<'a> {
             first_seq,
             last_seq,
             report_seq: None,
-            violations,
+            violations: scratch.violations,
             failed_turns,
             referrals: referral_ledger,
         };
@@ -654,15 +666,14 @@ impl<'a> EpisodeDriver<'a> {
         agent_id: &str,
         prompt: &str,
         visible: &[tinyhivemind_hive::SessionMessage],
-        violations: &mut Vec<MoveViolation>,
-        aside: &mut Option<String>,
+        scratch: &mut TurnScratch,
     ) -> Result<String> {
         let allowed = self.desk.config.moves_for(agent_id);
         let (line, rode) = split_reply(&self.runner.speak(agent_id, prompt).await?);
-        *aside = rode;
+        scratch.aside = rode;
         let Some(kind) = moves::line_kind(&line).filter(|kind| !allowed.contains(kind)) else {
             return self
-                .grounded_and_regraded(agent_id, prompt, visible, line, &allowed, violations, aside)
+                .grounded_and_regraded(agent_id, prompt, visible, line, &allowed, scratch)
                 .await;
         };
         let corrected = format!("{prompt}\n\n{}", moves::correction(kind, &allowed));
@@ -671,10 +682,10 @@ impl<'a> EpisodeDriver<'a> {
         // a reply the room never saw would publish something its author did not
         // write on the turn it was written for.
         let (line, rode) = split_reply(&self.runner.speak(agent_id, &corrected).await?);
-        *aside = rode;
+        scratch.aside = rode;
         let Some(kind) = moves::line_kind(&line).filter(|kind| !allowed.contains(kind)) else {
             return self
-                .grounded_and_regraded(agent_id, prompt, visible, line, &allowed, violations, aside)
+                .grounded_and_regraded(agent_id, prompt, visible, line, &allowed, scratch)
                 .await;
         };
         tracing::info!(
@@ -684,7 +695,7 @@ impl<'a> EpisodeDriver<'a> {
             attempted = %kind,
             "[hive] a member used a move its seat does not have, twice; the line was demoted"
         );
-        violations.push(MoveViolation {
+        scratch.violations.push(MoveViolation {
             agent_id: agent_id.to_owned(),
             attempted: kind.to_owned(),
         });
@@ -714,8 +725,7 @@ impl<'a> EpisodeDriver<'a> {
         visible: &[tinyhivemind_hive::SessionMessage],
         line: String,
         allowed: &[&'static str],
-        violations: &mut Vec<MoveViolation>,
-        aside: &mut Option<String>,
+        scratch: &mut TurnScratch,
     ) -> Result<String> {
         let line = self
             .grounded(agent_id, prompt, visible, line, aside)
@@ -731,7 +741,7 @@ impl<'a> EpisodeDriver<'a> {
             "[hive] a member's evidential retry used a move its seat does not have; \
              the line was demoted"
         );
-        violations.push(MoveViolation {
+        scratch.violations.push(MoveViolation {
             agent_id: agent_id.to_owned(),
             attempted: kind.to_owned(),
         });
@@ -758,7 +768,7 @@ impl<'a> EpisodeDriver<'a> {
         prompt: &str,
         visible: &[tinyhivemind_hive::SessionMessage],
         line: String,
-        aside: &mut Option<String>,
+        scratch: &mut TurnScratch,
     ) -> Result<String> {
         if self.desk.config.require_evidential != Some(true)
             || !evidential::support_misses_evidence(&line, agent_id, visible)
@@ -777,7 +787,7 @@ impl<'a> EpisodeDriver<'a> {
         // Same rule as the move correction: the retry is the turn that
         // happened, so its aside replaces whatever the first attempt carried.
         let (line, rode) = split_reply(&self.runner.speak(agent_id, &corrected).await?);
-        *aside = rode;
+        scratch.aside = rode;
         Ok(line)
     }
 

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -32,7 +32,7 @@ use super::evidential;
 use super::log::EventLogSessionLog;
 use super::memory::{HiveMemory, HiveMemoryHit, HiveMemoryNote, NullHiveMemory, RECALL_LIMIT};
 use super::moves::{self, MoveViolation};
-use super::prompt::{EpisodePrompt, marker_line, split_reply};
+use super::prompt::{EpisodePrompt, split_reply};
 use super::referral::{EpisodeReferrals, HiveFederation, HiveReferralRunner, ReferralLedger};
 use super::scope::EpisodeScope;
 use super::types::{EpisodeEnding, EpisodeOutcome, HiveDesk};
@@ -396,8 +396,17 @@ impl<'a> EpisodeDriver<'a> {
                 .with_trigger(Sequence(trigger.value()))
                 .render(&turn, &visible);
 
+            // The private row this turn's reply carried, if any. Set by
+            // `line_from` from whichever attempt produced the final desk line.
+            let mut rode: Option<String> = None;
             let line = match self
-                .line_from(&turn.agent_id, &prompt, &visible, &mut violations)
+                .line_from(
+                    &turn.agent_id,
+                    &prompt,
+                    &visible,
+                    &mut violations,
+                    &mut rode,
+                )
                 .await
             {
                 Ok(line) => {

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -18,8 +18,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tinyhivemind_hive::{
     Conversation, EpisodeState, HiveStep, SESSION_WINDOW, Sequence, SessionQuery,
-    aside::Viewer,
+    aside::{AsideDecision, AsideInput, Viewer},
+    dispatch::DispatchConversation,
     desk::{Desk, DeskSet, ResponderMode},
+    mention::{MentionAuthor, MentionTarget},
     pins::{PIN_LIMIT, read_pinboard},
     project_for,
     roster::{Roster, RosterMember},
@@ -462,7 +464,7 @@ impl<'a> EpisodeDriver<'a> {
             // has a name, and every one of them means "this line is an ordinary
             // desk row" — which is the safe direction: a line the room can read
             // is never a leak, and the member has said what it meant to say.
-            let audience = self.aside_audience(&turn.agent_id, &line, &transcript, &roster_of);
+            let audience = self.aside_audience(&turn.agent_id, &line, &transcript, &members, &desks, &retired);
             let seq = self
                 .events
                 .append(
@@ -850,6 +852,108 @@ impl<'a> EpisodeDriver<'a> {
     ///
     /// Best-effort: the decision itself is already durable in the turns above
     /// it, and losing the room's own summary of a conversation the transcript
+    /// The audience to stamp on this turn's row: the addressees of an
+    /// authorized aside, or empty for an ordinary desk-visible line.
+    ///
+    /// Every path that is not an authorized aside returns empty, and that is
+    /// the safe direction: a line the room can read is never a leak, and the
+    /// member has still said what it meant to say. A refusal is therefore
+    /// logged rather than raised — the library gives every rung a name, and
+    /// none of them is a reason to abandon an episode.
+    ///
+    /// The budget and the settlement debt are **folded from the transcript**
+    /// rather than tracked across iterations, for the same reason the episode
+    /// re-reads its transcript every turn: what the fold counts is exactly what
+    /// a person reading the desk would see, so the two can never disagree.
+    fn aside_audience(
+        &self,
+        agent_id: &str,
+        line: &str,
+        transcript: &[tinyhivemind_hive::SessionMessage],
+        members: &[RosterMember],
+        desks: &[Desk],
+        retired: &[String],
+    ) -> Vec<String> {
+        if !super::aside::opens_aside(line) {
+            return Vec::new();
+        }
+        let policy = self.desk.config.aside.policy();
+        let roster = Roster::new(members, &[], retired);
+        let desk_set = DeskSet::new(desks, &[], &[], &[], retired);
+
+        let author = MentionAuthor::Agent {
+            id: agent_id.to_owned(),
+        };
+        let mentions = tinyhivemind_hive::mention::resolve(line, None, &author, &roster, &desk_set);
+
+        // The party this line *would* open, needed before the decision because
+        // the budget and the settlement debt are per party. A `@#desk` or an
+        // `@everyone` addresses nobody privately — the library refuses those
+        // too, and this agrees with it rather than inventing a second rule.
+        let addressed: Vec<String> = mentions
+            .iter()
+            .filter(|mention| !mention.quiet)
+            .filter_map(|mention| match &mention.target {
+                MentionTarget::Agent { id } => Some(id.clone()),
+                _ => None,
+            })
+            .collect();
+        let mut party: Vec<String> = addressed.clone();
+        party.push(agent_id.to_owned());
+        party.sort();
+        party.dedup();
+        let (spent, unsettled) = super::aside::spent_and_unsettled(transcript, &party);
+
+        let input = AsideInput {
+            conversation: DispatchConversation {
+                desk_id: self.desk.id.clone(),
+                thread_root: self.thread_root.map(|seq| seq.value()),
+            },
+            author_id: agent_id.to_owned(),
+            mentions,
+            spent,
+            unsettled,
+        };
+
+        match tinyhivemind_hive::aside::aside(policy, &input, &roster, &desk_set) {
+            Ok(AsideDecision::One { audience }) => {
+                let members = audience.members().to_vec();
+                tracing::debug!(
+                    company = %self.company,
+                    desk = %self.desk.id,
+                    agent = %agent_id,
+                    audience = ?members,
+                    "[hive] an aside was authorized"
+                );
+                members
+            }
+            Ok(AsideDecision::None { reason }) => {
+                tracing::debug!(
+                    company = %self.company,
+                    desk = %self.desk.id,
+                    agent = %agent_id,
+                    reason = ?reason,
+                    "[hive] no aside was authorized; the line stays desk-visible"
+                );
+                Vec::new()
+            }
+            Err(error) => {
+                // A malformed snapshot is this host's bug, not the room's, and
+                // it must not cost the episode: the line is journaled where
+                // everyone can read it, which is what would have happened
+                // before asides existed.
+                tracing::warn!(
+                    company = %self.company,
+                    desk = %self.desk.id,
+                    agent = %agent_id,
+                    error = %error,
+                    "[hive] the aside gate could not decide; the line stays desk-visible"
+                );
+                Vec::new()
+            }
+        }
+    }
+
     /// still holds is not worth discarding the episode over.
     ///
     /// [`HIVE_REPORT_AUTHOR`]: super::HIVE_REPORT_AUTHOR

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -611,7 +611,7 @@ impl<'a> EpisodeDriver<'a> {
         *aside = rode;
         let Some(kind) = moves::line_kind(&line).filter(|kind| !allowed.contains(kind)) else {
             return self
-                .grounded_and_regraded(agent_id, prompt, visible, line, &allowed, violations)
+                .grounded_and_regraded(agent_id, prompt, visible, line, &allowed, violations, aside)
                 .await;
         };
         let corrected = format!("{prompt}\n\n{}", moves::correction(kind, &allowed));
@@ -623,7 +623,7 @@ impl<'a> EpisodeDriver<'a> {
         *aside = rode;
         let Some(kind) = moves::line_kind(&line).filter(|kind| !allowed.contains(kind)) else {
             return self
-                .grounded_and_regraded(agent_id, prompt, visible, line, &allowed, violations)
+                .grounded_and_regraded(agent_id, prompt, visible, line, &allowed, violations, aside)
                 .await;
         };
         tracing::info!(
@@ -664,8 +664,9 @@ impl<'a> EpisodeDriver<'a> {
         line: String,
         allowed: &[&'static str],
         violations: &mut Vec<MoveViolation>,
+        aside: &mut Option<String>,
     ) -> Result<String> {
-        let line = self.grounded(agent_id, prompt, visible, line).await?;
+        let line = self.grounded(agent_id, prompt, visible, line, aside).await?;
         let Some(kind) = moves::line_kind(&line).filter(|kind| !allowed.contains(kind)) else {
             return Ok(line);
         };
@@ -704,6 +705,7 @@ impl<'a> EpisodeDriver<'a> {
         prompt: &str,
         visible: &[tinyhivemind_hive::SessionMessage],
         line: String,
+        aside: &mut Option<String>,
     ) -> Result<String> {
         if self.desk.config.require_evidential != Some(true)
             || !evidential::support_misses_evidence(&line, agent_id, visible)
@@ -719,7 +721,11 @@ impl<'a> EpisodeDriver<'a> {
             "[hive] a support reached no evidence; the member was asked once more"
         );
         let corrected = format!("{prompt}\n\n{}", evidential::correction(&available));
-        Ok(marker_line(&self.runner.speak(agent_id, &corrected).await?))
+        // Same rule as the move correction: the retry is the turn that
+        // happened, so its aside replaces whatever the first attempt carried.
+        let (line, rode) = split_reply(&self.runner.speak(agent_id, &corrected).await?);
+        *aside = rode;
+        Ok(line)
     }
 
     /// What the desk remembers about the operator's task, best-effort.

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -427,6 +427,11 @@ impl<'a> EpisodeDriver<'a> {
                                 chat_id: self.desk.id.clone(),
                                 agent_id: super::HIVE_REPORT_AUTHOR.to_string(),
                                 text: failure_note(&turn.agent_id, &error),
+                                // The room's own report is never private: a
+                                // reader who could not see that a turn failed
+                                // would be reading a transcript with a hole in
+                                // it that nothing accounts for.
+                                audience: Vec::new(),
                                 steps: Vec::new(),
                                 task_id: None,
                                 parent: self.thread_root,
@@ -449,6 +454,15 @@ impl<'a> EpisodeDriver<'a> {
                     continue;
                 }
             };
+            // Considered *before* the row is appended, because an audience is
+            // fixed at append time: widening one afterwards could never be
+            // redelivered, and would invalidate every citation naming it.
+            //
+            // A refusal is not an error. Every rung of the library's decision
+            // has a name, and every one of them means "this line is an ordinary
+            // desk row" — which is the safe direction: a line the room can read
+            // is never a leak, and the member has said what it meant to say.
+            let audience = self.aside_audience(&turn.agent_id, &line, &transcript, &roster_of);
             let seq = self
                 .events
                 .append(
@@ -457,6 +471,7 @@ impl<'a> EpisodeDriver<'a> {
                         chat_id: self.desk.id.clone(),
                         agent_id: turn.agent_id.clone(),
                         text: line.clone(),
+                        audience: audience.clone(),
                         // The episode's own turns carry no step timeline: the
                         // room is reading one line per turn, and a tool trace
                         // belongs to the turn's own bubble, which this path
@@ -847,6 +862,8 @@ impl<'a> EpisodeDriver<'a> {
                     chat_id: self.desk.id.clone(),
                     agent_id: super::HIVE_REPORT_AUTHOR.to_string(),
                     text: outcome.summary(),
+                    // Always desk-visible, for the reason above.
+                    audience: Vec::new(),
                     steps: Vec::new(),
                     task_id: None,
                     parent: self.thread_root,

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -898,7 +898,7 @@ impl<'a> EpisodeDriver<'a> {
         // the budget and the settlement debt are per party. A `@#desk` or an
         // `@everyone` addresses nobody privately — the library refuses those
         // too, and this agrees with it rather than inventing a second rule.
-        let addressed: Vec<String> = mentions
+        let mut party: Vec<String> = mentions
             .iter()
             .filter(|mention| !mention.quiet)
             .filter_map(|mention| match &mention.target {
@@ -906,7 +906,6 @@ impl<'a> EpisodeDriver<'a> {
                 _ => None,
             })
             .collect();
-        let mut party: Vec<String> = addressed.clone();
         party.push(agent_id.to_owned());
         party.sort();
         party.dedup();

--- a/src/hivemind/evidential.rs
+++ b/src/hivemind/evidential.rs
@@ -47,7 +47,7 @@ fn traces_of(line: &str, agent_id: &str, at: Sequence) -> Vec<Trace> {
 }
 
 /// Every trace in the visible transcript, indexed by the sequence carrying it.
-fn by_sequence(visible: &[&SessionMessage]) -> BTreeMap<Sequence, Vec<Trace>> {
+fn by_sequence(visible: &[SessionMessage]) -> BTreeMap<Sequence, Vec<Trace>> {
     let mut indexed: BTreeMap<Sequence, Vec<Trace>> = BTreeMap::new();
     for message in visible {
         for trace in resolve(&message.content, None, &message.author, message.sequence) {
@@ -87,7 +87,7 @@ fn reaches_evidence(cites: &[Sequence], indexed: &BTreeMap<Sequence, Vec<Trace>>
 
 /// The sequences carrying an `!evidence` line, in transcript order.
 #[must_use]
-pub fn evidence_sequences(visible: &[&SessionMessage]) -> Vec<u64> {
+pub fn evidence_sequences(visible: &[SessionMessage]) -> Vec<u64> {
     let mut sequences: Vec<u64> = Vec::new();
     for message in visible {
         let carries_evidence = resolve(&message.content, None, &message.author, message.sequence)
@@ -106,7 +106,7 @@ pub fn evidence_sequences(visible: &[&SessionMessage]) -> Vec<u64> {
 /// already lands on a fact — the check exists to catch the one shape that
 /// silently counts for nothing.
 #[must_use]
-pub fn support_misses_evidence(line: &str, agent_id: &str, visible: &[&SessionMessage]) -> bool {
+pub fn support_misses_evidence(line: &str, agent_id: &str, visible: &[SessionMessage]) -> bool {
     let at = Sequence(
         visible
             .iter()

--- a/src/hivemind/log.rs
+++ b/src/hivemind/log.rs
@@ -156,6 +156,7 @@ impl EventLogSessionLog {
                 agent_id,
                 text,
                 parent,
+                audience,
                 ..
             } if self.addresses_desk(Some(&chat_id)) => Some(LogMessage {
                 sequence,
@@ -163,7 +164,16 @@ impl EventLogSessionLog {
                 parent: parent.map(|seq| Sequence(seq.value())),
                 author: author_of(&agent_id),
                 content: text,
-                audience: Audience::Desk,
+                // Empty is desk-visible, which is what every row written before
+                // asides existed means and what every ordinary turn means now.
+                // The stored list is the addressees only; the author's own
+                // admission to its row is the library's rule, not a member of
+                // the set (`Audience::admits`).
+                audience: if audience.is_empty() {
+                    Audience::Desk
+                } else {
+                    Audience::Aside { members: audience }
+                },
             }),
             _ => None,
         }

--- a/src/hivemind/log.rs
+++ b/src/hivemind/log.rs
@@ -19,8 +19,9 @@
 
 use std::sync::Arc;
 
+use tinyhivemind_hive::aside::Audience;
 use tinyhivemind_hive::{
-    Audience, LogMessage, Sequence, SessionAuthor, SessionFuture, SessionLog, SessionPage,
+    LogMessage, Sequence, SessionAuthor, SessionFuture, SessionLog, SessionPage,
 };
 
 use super::scope::EpisodeScope;

--- a/src/hivemind/log.rs
+++ b/src/hivemind/log.rs
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 
 use tinyhivemind_hive::{
-    LogMessage, Sequence, SessionAuthor, SessionFuture, SessionLog, SessionPage,
+    Audience, LogMessage, Sequence, SessionAuthor, SessionFuture, SessionLog, SessionPage,
 };
 
 use super::scope::EpisodeScope;
@@ -148,6 +148,7 @@ impl EventLogSessionLog {
                 parent: parent.map(|seq| Sequence(seq.value())),
                 author: SessionAuthor::Operator,
                 content: text,
+                audience: Audience::Desk,
             }),
             CompanyEvent::AgentReply {
                 chat_id,
@@ -161,6 +162,7 @@ impl EventLogSessionLog {
                 parent: parent.map(|seq| Sequence(seq.value())),
                 author: author_of(&agent_id),
                 content: text,
+                audience: Audience::Desk,
             }),
             _ => None,
         }

--- a/src/hivemind/mod.rs
+++ b/src/hivemind/mod.rs
@@ -41,6 +41,7 @@
 //!
 //! # Modules
 //!
+//! - [`aside`] — two members of a desk comparing notes without the room.
 //! - [`episode`] — the host loop, and the one-function turn seam.
 //! - [`evidential`] — whether a `!support` reaches a fact, and the correction
 //!   it gets when it does not.
@@ -56,6 +57,7 @@
 //!
 //! See `docs/spec/runtime/hivemind.md`.
 
+pub mod aside;
 pub mod episode;
 pub mod evidential;
 pub mod log;
@@ -77,6 +79,7 @@ mod referral_test;
 #[cfg(test)]
 mod test;
 
+pub use aside::{ASIDE_MARKER, AsideConfig, SURFACE_MARKER};
 pub use episode::{EpisodeDriver, HiveTurnRunner};
 pub use log::EventLogSessionLog;
 pub use memory::{

--- a/src/hivemind/mod.rs
+++ b/src/hivemind/mod.rs
@@ -69,6 +69,8 @@ pub mod scope;
 pub mod types;
 
 #[cfg(test)]
+mod aside_test;
+#[cfg(test)]
 mod concurrency_test;
 #[cfg(test)]
 mod deliberation_test;

--- a/src/hivemind/prompt.rs
+++ b/src/hivemind/prompt.rs
@@ -102,14 +102,16 @@ before or after the single marker line.";
 /// a reader that meets an elided row needs to know it may ask, not merely that
 /// it cannot read.
 const ASIDE_RULES: &str = "\
-This desk also allows a private line. !aside @peer <what you need from them> \
-reaches only that peer; !surface <what the room needs to know> reports back to \
-everyone. An aside carries information and never support: a !support written \
-privately moves nothing towards a decision, for you or for anybody. To make an \
-aside count, spend a desk-visible turn saying so with !surface. Some rows in \
-the transcript show only that an aside happened, with its author and who was \
-in it — you cannot read those, and if one matters, ask its author here on the \
-desk.";
+This desk also allows a private line, and it costs you nothing. After your one \
+marker line you may add ONE more line, !aside @peer <what you need from them>, \
+which only that peer can read. It is not a turn and does not replace your move: \
+write your move first, then the aside under it. Your peer answers on its own \
+next turn. !surface <what the room needs to know> reports back to everyone and \
+is an ordinary move. An aside carries information and never support: a !support \
+written privately moves nothing towards a decision, for you or for anybody, so \
+an aside you never surface bought the room nothing. Some rows in the transcript \
+show only that an aside happened, with its author and who was in it — you \
+cannot read those, and if one matters, ask its author here on the desk.";
 
 /// The extra sentence a room under `require_evidential` is given.
 ///

--- a/src/hivemind/prompt.rs
+++ b/src/hivemind/prompt.rs
@@ -256,7 +256,7 @@ impl<'a> EpisodePrompt<'a> {
 
     /// Render exactly what this turn is allowed to see.
     #[must_use]
-    pub fn render(&self, turn: &HiveTurn, visible: &[&SessionMessage]) -> String {
+    pub fn render(&self, turn: &HiveTurn, visible: &[SessionMessage]) -> String {
         let sight = match turn.visibility {
             Visibility::Blind => "You cannot yet see your peers' positions. Form your own first.",
             Visibility::Full => "You can see the whole room.",
@@ -480,7 +480,7 @@ impl<'a> EpisodePrompt<'a> {
     /// An unfoldable transcript yields nothing rather than an error: the floor
     /// block and the carried topic both degrade to their "nothing yet" shapes,
     /// which is a worse prompt and not a failed turn.
-    fn standings(&self, visible: &[&SessionMessage]) -> Vec<TopicStanding> {
+    fn standings(&self, visible: &[SessionMessage]) -> Vec<TopicStanding> {
         let traces: Vec<_> = visible
             .iter()
             .flat_map(|message| resolve(&message.content, None, &message.author, message.sequence))
@@ -525,7 +525,7 @@ impl<'a> EpisodePrompt<'a> {
     }
 
     /// The line this member last authored, if any.
-    fn last_line(&self, visible: &[&SessionMessage]) -> String {
+    fn last_line(&self, visible: &[SessionMessage]) -> String {
         visible
             .iter()
             .rev()
@@ -680,7 +680,7 @@ const EPISODE_DIVIDER: &str = "--- Above: earlier conversation on this desk, fro
 /// parameter existed) renders exactly as it always has, and a caller that
 /// never learned a trigger passes `None` and gets the same guarantee.
 #[must_use]
-pub fn render_transcript(visible: &[&SessionMessage], trigger: Option<Sequence>) -> String {
+pub fn render_transcript(visible: &[SessionMessage], trigger: Option<Sequence>) -> String {
     let split = trigger
         .map(|trigger| visible.partition_point(|message| message.sequence <= trigger))
         .filter(|&split| split > 0 && split < visible.len());

--- a/src/hivemind/prompt.rs
+++ b/src/hivemind/prompt.rs
@@ -762,6 +762,51 @@ pub fn marker_line(text: &str) -> String {
         .to_owned()
 }
 
+/// Split one turn's reply into its desk-visible line and the aside riding on it.
+///
+/// An aside **costs no turn** ([ADR 0011]): one authorized turn produces the
+/// member's ordinary desk-visible contribution *and*, optionally, one aside row.
+/// So a reply may legitimately carry two markers, and this is what separates
+/// them — the deliberation marker the room counts, and at most one `!aside`.
+///
+/// Before this, a reply's `!aside` line was simply lost: [`marker_line`] takes
+/// the *first* marker, so a member that proposed and then asked a peer had its
+/// aside discarded, and a member that only asked had its whole turn become the
+/// aside. Under one-message-one-turn the latter was right; under ADR 0011 it is
+/// not, because the turn still owes the room its ordinary contribution.
+///
+/// **At most one** aside is taken, which is the spec's own bound: a room of *n*
+/// members writes at most *n* aside rows per round, and each cost its author a
+/// turn it had already won, so no arrangement of asides can outrun the room.
+///
+/// A reply that is *only* an aside yields the desk line [`marker_line`] would
+/// give the rest of the text — in practice `(no answer)`. That is honest rather
+/// than lossy: the member did spend its turn without saying anything to the
+/// room, and the transcript should show that it did.
+///
+/// [ADR 0011]: https://github.com/tinyhumansai/tinyhivemind/blob/main/docs/adr/0011-an-aside-rides-alongside-a-turn.md
+#[must_use]
+pub fn split_reply(text: &str) -> (String, Option<String>) {
+    let text = plain(text);
+    let aside = text
+        .lines()
+        .map(str::trim)
+        .find(|line| super::aside::opens_aside(line))
+        .map(str::to_owned);
+    if aside.is_none() {
+        return (marker_line(&text), None);
+    }
+    // The desk line is read from the reply with its aside removed, so an aside
+    // written *before* the move does not become the line the room counts.
+    let rest = text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !super::aside::opens_aside(line))
+        .collect::<Vec<_>>()
+        .join("\n");
+    (marker_line(&rest), aside)
+}
+
 /// Strip ANSI escape sequences from a turn's reply.
 fn plain(text: &str) -> String {
     let mut plain = String::with_capacity(text.len());

--- a/src/hivemind/prompt.rs
+++ b/src/hivemind/prompt.rs
@@ -91,6 +91,26 @@ add, reply !defer #topic naming who should act next, or !question. Prose \
 without a marker counts for nothing and costs the room a turn. Write nothing \
 before or after the single marker line.";
 
+/// The two markers a desk that enabled private asides adds, and the rules they
+/// are read under.
+///
+/// Rendered **only when the desk enabled asides**, because a grammar is a fixed
+/// cost paid in every agent's system text on every turn, and teaching a move
+/// nobody may make spends that budget for nothing.
+///
+/// The fourth sentence is the one an agent can act on rather than a disclaimer:
+/// a reader that meets an elided row needs to know it may ask, not merely that
+/// it cannot read.
+const ASIDE_RULES: &str = "\
+This desk also allows a private line. !aside @peer <what you need from them> \
+reaches only that peer; !surface <what the room needs to know> reports back to \
+everyone. An aside carries information and never support: a !support written \
+privately moves nothing towards a decision, for you or for anybody. To make an \
+aside count, spend a desk-visible turn saying so with !surface. Some rows in \
+the transcript show only that an aside happened, with its author and who was \
+in it — you cannot read those, and if one matters, ask its author here on the \
+desk.";
+
 /// The extra sentence a room under `require_evidential` is given.
 ///
 /// Rendered only when the desk actually requires it, because on a desk that
@@ -351,6 +371,14 @@ impl<'a> EpisodePrompt<'a> {
         if assigned {
             tail.push('\n');
             tail.push_str(ASSIGNED_MOVES_RULE);
+        }
+        // Last, and only when the desk opted in. `!aside` and `!surface` are
+        // not deliberation markers — neither appears in `MOVE_KINDS`, neither
+        // is gated by `hive.moves`, and neither deposits a trace — so they are
+        // taught after the move list rather than inside it.
+        if self.desk.config.aside.enabled() {
+            tail.push('\n');
+            tail.push_str(ASIDE_RULES);
         }
         format!("{head}\n{}\n{tail}", lines.join("\n"))
     }

--- a/src/hivemind/referral.rs
+++ b/src/hivemind/referral.rs
@@ -460,6 +460,7 @@ impl<'a> EpisodeReferrals<'a> {
             .append(
                 &self.company,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     chat_id: conversation.desk_id.clone(),
                     agent_id: author.to_owned(),
                     text,

--- a/src/hivemind/referral.rs
+++ b/src/hivemind/referral.rs
@@ -279,7 +279,7 @@ pub struct ReferralLedger {
     pub failed: u32,
 }
 
-/// One question an episode asked of another desk.
+/// One question an episode asked of a named teammate.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AskedQuestion {
     /// The seat that asked.
@@ -290,6 +290,18 @@ pub struct AskedQuestion {
     pub desk: String,
     /// Whether the answer was carried back to the asking desk.
     pub returned: bool,
+    /// Whether the question actually left this desk.
+    ///
+    /// `reach` widens strictly (`local` → `channels` → `desks`), so a desk that
+    /// opted in to referral can put a question to a peer **on its own desk**,
+    /// and that is a legitimate use rather than a misroute. What it is not is a
+    /// question of *another* desk, and the close used to call it one
+    /// unconditionally: a live six-day `companies/vending_machine_co` run
+    /// reported "The room asked 2 questions of another desk (@fleet_tech on
+    /// ops, @field_realist on ops)" on the ops desk itself, naming two of its
+    /// own seats. An operator reading that has been told the room reached
+    /// outside when it did not.
+    pub crossed: bool,
 }
 
 /// The prompt a referred teammate is given.
@@ -543,6 +555,7 @@ impl<'a> EpisodeReferrals<'a> {
             target: referral.target_id.clone(),
             desk: referral.to.desk_id.clone(),
             returned: false,
+            crossed: referral.to.desk_id != self.home.desk_id,
         });
         state.last_answer = Some((referral.clone(), answer));
         EnqueueOutcome::Enqueued

--- a/src/hivemind/referral_test.rs
+++ b/src/hivemind/referral_test.rs
@@ -490,7 +490,7 @@ fn the_close_tells_a_local_question_from_a_crossing_one() {
         last_seq: None,
         report_seq: None,
         violations: Vec::new(),
-        failures: Vec::new(),
+        failed_turns: 0,
         referrals: ReferralLedger {
             asked,
             over_cap: 0,

--- a/src/hivemind/referral_test.rs
+++ b/src/hivemind/referral_test.rs
@@ -515,7 +515,8 @@ fn the_close_tells_a_local_question_from_a_crossing_one() {
         "a question that never left the desk must not be reported as crossing: {local}"
     );
 
-    let crossing = outcome(vec![question("account_manager", "commercial", true)]).referral_summary();
+    let crossing =
+        outcome(vec![question("account_manager", "commercial", true)]).referral_summary();
     assert!(
         crossing.contains("asked 1 question of another desk (@account_manager on commercial)"),
         "{crossing}"
@@ -529,7 +530,10 @@ fn the_close_tells_a_local_question_from_a_crossing_one() {
     ])
     .referral_summary();
     assert!(both.contains("asked 1 question of another desk"), "{both}");
-    assert!(both.contains("put 1 question to a seat on this desk"), "{both}");
+    assert!(
+        both.contains("put 1 question to a seat on this desk"),
+        "{both}"
+    );
 }
 
 /// **A barred move demoted for its grammar violation must not still trigger a

--- a/src/hivemind/referral_test.rs
+++ b/src/hivemind/referral_test.rs
@@ -469,6 +469,69 @@ async fn a_line_that_asks_nobody_refers_nothing() {
     );
 }
 
+/// **A question put to a seat on this desk is not a question of another desk.**
+///
+/// `reach` widens strictly (`local` → `channels` → `desks`), so a desk that
+/// opted in to referral may legitimately put a question to one of its own
+/// seats. The close used to describe every recorded question as being "of
+/// another desk" regardless, and a live six-day `companies/vending_machine_co`
+/// run reported "The room asked 2 questions of another desk (@fleet_tech on
+/// ops, @field_realist on ops)" — on the ops desk, naming two ops seats. An
+/// operator reading that has been told the room reached outside when it did
+/// not, which is exactly the kind of claim the close exists to make reliably.
+#[test]
+fn the_close_tells_a_local_question_from_a_crossing_one() {
+    use crate::hivemind::referral::{AskedQuestion, ReferralLedger};
+
+    let outcome = |asked: Vec<AskedQuestion>| EpisodeOutcome {
+        ending: EpisodeEnding::Exhausted,
+        turns: 4,
+        first_seq: None,
+        last_seq: None,
+        report_seq: None,
+        violations: Vec::new(),
+        failures: Vec::new(),
+        referrals: ReferralLedger {
+            asked,
+            over_cap: 0,
+            failed: 0,
+        },
+    };
+    let question = |target: &str, desk: &str, crossed: bool| AskedQuestion {
+        asker: "route_planner".to_owned(),
+        target: target.to_owned(),
+        desk: desk.to_owned(),
+        returned: false,
+        crossed,
+    };
+
+    let local = outcome(vec![question("field_realist", "ops", false)]).referral_summary();
+    assert!(
+        local.contains("put 1 question to a seat on this desk (@field_realist)"),
+        "{local}"
+    );
+    assert!(
+        !local.contains("another desk"),
+        "a question that never left the desk must not be reported as crossing: {local}"
+    );
+
+    let crossing = outcome(vec![question("account_manager", "commercial", true)]).referral_summary();
+    assert!(
+        crossing.contains("asked 1 question of another desk (@account_manager on commercial)"),
+        "{crossing}"
+    );
+
+    // Both in one episode: each is counted under its own heading, and the
+    // crossing one still names the desk it reached.
+    let both = outcome(vec![
+        question("account_manager", "commercial", true),
+        question("field_realist", "ops", false),
+    ])
+    .referral_summary();
+    assert!(both.contains("asked 1 question of another desk"), "{both}");
+    assert!(both.contains("put 1 question to a seat on this desk"), "{both}");
+}
+
 /// **A barred move demoted for its grammar violation must not still trigger a
 /// referral.**
 ///

--- a/src/hivemind/test.rs
+++ b/src/hivemind/test.rs
@@ -46,6 +46,26 @@ impl MemoryLog {
             })
             .collect()
     }
+
+    /// Every reply on `chat` with the audience it was journaled under.
+    ///
+    /// Separate from [`Self::replies`] rather than a widening of it: most tests
+    /// are not about audience and reading a three-tuple would make them say so.
+    pub(super) fn addressed_replies(&self, chat: &str) -> Vec<(String, String, Vec<String>)> {
+        self.rows()
+            .into_iter()
+            .filter_map(|stored| match stored.event {
+                CompanyEvent::AgentReply {
+                    chat_id,
+                    agent_id,
+                    text,
+                    audience,
+                    ..
+                } if chat_id == chat => Some((agent_id, text, audience)),
+                _ => None,
+            })
+            .collect()
+    }
 }
 
 #[async_trait]

--- a/src/hivemind/test.rs
+++ b/src/hivemind/test.rs
@@ -763,12 +763,11 @@ fn a_transcript_spanning_the_watermark_renders_the_divider_between_episodes() {
         message(3, "planner", "!propose #euler301 New guess."),
         message(4, "critic", "!support #euler301 ^3 Because it holds."),
     ];
-    let visible_refs: Vec<&tinyhivemind_hive::SessionMessage> = visible.iter().collect();
 
     let turn = hive_turn("planner", tinyhivemind_hive::Visibility::Full, Sequence(0));
     let prompt = EpisodePrompt::new(&member, &desk, "Decide the answer.", quorum, &[])
         .with_trigger(Sequence(2))
-        .render(&turn, &visible_refs);
+        .render(&turn, &visible);
 
     let prior_end = prompt.find("[2] scout").expect("prior row 2 is rendered");
     let divider_at = prompt
@@ -792,15 +791,14 @@ fn a_transcript_entirely_after_the_trigger_renders_with_no_divider() {
     let member = desk.member("planner").expect("planner is seated").clone();
     let quorum = desk.policy().quorum;
     let visible = [message(3, "planner", "!propose #stage Stage it.")];
-    let visible_refs: Vec<&tinyhivemind_hive::SessionMessage> = visible.iter().collect();
     let turn = hive_turn("planner", tinyhivemind_hive::Visibility::Full, Sequence(0));
 
     let without_trigger = EpisodePrompt::new(&member, &desk, "Decide the rollout.", quorum, &[])
-        .render(&turn, &visible_refs);
+        .render(&turn, &visible);
     let with_trigger_below_everything =
         EpisodePrompt::new(&member, &desk, "Decide the rollout.", quorum, &[])
             .with_trigger(Sequence(1))
-            .render(&turn, &visible_refs);
+            .render(&turn, &visible);
 
     assert_eq!(
         without_trigger, with_trigger_below_everything,

--- a/src/hivemind/test.rs
+++ b/src/hivemind/test.rs
@@ -541,6 +541,7 @@ async fn the_log_adapter_attributes_and_pages_desk_rows() {
         &adapter,
         &SessionQuery {
             conversation: conversation(),
+            viewer: tinyhivemind_hive::aside::Viewer::Operator,
             before: None,
             window: SESSION_WINDOW,
         },
@@ -722,6 +723,8 @@ fn message(sequence: u64, author: &str, content: &str) -> tinyhivemind_hive::Ses
             label: author.to_owned(),
         },
         content: content.to_owned(),
+        audience: tinyhivemind_hive::aside::Audience::Desk,
+        elided: false,
     }
 }
 

--- a/src/hivemind/test.rs
+++ b/src/hivemind/test.rs
@@ -724,7 +724,7 @@ fn message(sequence: u64, author: &str, content: &str) -> tinyhivemind_hive::Ses
         },
         content: content.to_owned(),
         audience: tinyhivemind_hive::aside::Audience::Desk,
-        elided: false,
+        elided: None,
     }
 }
 

--- a/src/hivemind/test.rs
+++ b/src/hivemind/test.rs
@@ -508,6 +508,7 @@ async fn the_log_adapter_attributes_and_pages_desk_rows() {
     log.append(
         &company,
         CompanyEvent::AgentReply {
+            audience: Vec::new(),
             chat_id: "eng".into(),
             agent_id: "planner".into(),
             text: "!propose #stage Stage the rollout.".into(),
@@ -523,6 +524,7 @@ async fn the_log_adapter_attributes_and_pages_desk_rows() {
     log.append(
         &company,
         CompanyEvent::AgentReply {
+            audience: Vec::new(),
             chat_id: "eng".into(),
             agent_id: HIVE_REPORT_AUTHOR.into(),
             text: "An earlier episode ended.".into(),

--- a/src/hivemind/test.rs
+++ b/src/hivemind/test.rs
@@ -123,13 +123,13 @@ impl EventLog for MemoryLog {
 /// so a test that scripted a flat sequence would be asserting the bid order by
 /// accident and would break for reasons that have nothing to do with what it
 /// meant to check.
-struct ScriptedRunner {
+pub(super) struct ScriptedRunner {
     lines: Mutex<Vec<(String, String)>>,
     asked: Mutex<Vec<(String, String)>>,
 }
 
 impl ScriptedRunner {
-    fn new(lines: &[(&str, &str)]) -> Self {
+    pub(super) fn new(lines: &[(&str, &str)]) -> Self {
         Self {
             lines: Mutex::new(
                 lines
@@ -142,7 +142,7 @@ impl ScriptedRunner {
     }
 
     /// Every `(agent, prompt)` the episode asked for, in order.
-    fn asked(&self) -> Vec<(String, String)> {
+    pub(super) fn asked(&self) -> Vec<(String, String)> {
         self.asked.lock().expect("script poisoned").clone()
     }
 }
@@ -454,7 +454,7 @@ fn the_derived_policy_scales_with_the_room() {
 // The log adapter
 // ---------------------------------------------------------------------------
 
-async fn seed_desk(log: &MemoryLog) -> EventSeq {
+pub(super) async fn seed_desk(log: &MemoryLog) -> EventSeq {
     let company = MemoryLog::company();
     // Rows the desk must not see, interleaved so the adapter has to filter
     // rather than merely truncate.

--- a/src/hivemind/types.rs
+++ b/src/hivemind/types.rs
@@ -383,16 +383,32 @@ impl EpisodeOutcome {
             return String::new();
         }
         let mut parts = Vec::new();
-        if !ledger.asked.is_empty() {
-            let named = ledger
-                .asked
-                .iter()
-                .map(|question| format!("@{} on {}", question.target, question.desk))
-                .collect::<Vec<_>>()
-                .join(", ");
-            let count = ledger.asked.len();
+        // Split by whether the question actually left this desk. `reach` widens
+        // strictly, so a desk that opted in to referral may legitimately put a
+        // question to one of its own seats — but calling that "another desk"
+        // tells an operator the room reached outside when it did not. A live
+        // run of `companies/vending_machine_co` reported two questions "of
+        // another desk" on the ops desk, naming two ops seats.
+        let (crossed, local): (Vec<_>, Vec<_>) =
+            ledger.asked.iter().partition(|question| question.crossed);
+        let name = |question: &&super::referral::AskedQuestion| {
+            format!("@{} on {}", question.target, question.desk)
+        };
+        if !crossed.is_empty() {
+            let named = crossed.iter().map(name).collect::<Vec<_>>().join(", ");
+            let count = crossed.len();
             let plural = if count == 1 { "question" } else { "questions" };
             parts.push(format!("asked {count} {plural} of another desk ({named})"));
+        }
+        if !local.is_empty() {
+            let named = local
+                .iter()
+                .map(|question| format!("@{}", question.target))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let count = local.len();
+            let plural = if count == 1 { "question" } else { "questions" };
+            parts.push(format!("put {count} {plural} to a seat on this desk ({named})"));
         }
         if ledger.failed > 0 {
             parts.push(format!("{} went unanswered", ledger.failed));

--- a/src/hivemind/types.rs
+++ b/src/hivemind/types.rs
@@ -81,10 +81,7 @@ pub struct HiveConfig {
     /// buys no answer quality and costs some. What it does buy is bounded
     /// independence and an auditable record of it — see
     /// [`aside`](super::aside) for the whole argument.
-    #[serde(
-        default,
-        skip_serializing_if = "super::aside::AsideConfig::is_default"
-    )]
+    #[serde(default, skip_serializing_if = "super::aside::AsideConfig::is_default")]
     pub aside: super::aside::AsideConfig,
     /// Whether support must trace back to a stated fact rather than to another
     /// opinion.

--- a/src/hivemind/types.rs
+++ b/src/hivemind/types.rs
@@ -73,6 +73,19 @@ pub struct HiveConfig {
     /// desk quietly goes on voting.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub moves: BTreeMap<String, Vec<String>>,
+    /// Whether two members of this desk may say something the rest of it
+    /// cannot read, and under what bounds.
+    ///
+    /// Off unless a desk says otherwise, and off for a reason that was
+    /// measured rather than assumed: upstream found a private pairwise check
+    /// buys no answer quality and costs some. What it does buy is bounded
+    /// independence and an auditable record of it — see
+    /// [`aside`](super::aside) for the whole argument.
+    #[serde(
+        default,
+        skip_serializing_if = "super::aside::AsideConfig::is_default"
+    )]
+    pub aside: super::aside::AsideConfig,
     /// Whether support must trace back to a stated fact rather than to another
     /// opinion.
     ///

--- a/src/hivemind/types.rs
+++ b/src/hivemind/types.rs
@@ -408,7 +408,9 @@ impl EpisodeOutcome {
                 .join(", ");
             let count = local.len();
             let plural = if count == 1 { "question" } else { "questions" };
-            parts.push(format!("put {count} {plural} to a seat on this desk ({named})"));
+            parts.push(format!(
+                "put {count} {plural} to a seat on this desk ({named})"
+            ));
         }
         if ledger.failed > 0 {
             parts.push(format!("{} went unanswered", ledger.failed));

--- a/src/ports/events.rs
+++ b/src/ports/events.rs
@@ -508,6 +508,7 @@ mod test {
                 attachments: Vec::new(),
             },
             CompanyEvent::AgentReply {
+                audience: Vec::new(),
                 mentions: Vec::new(),
                 mention_depth: 0,
                 chat_id: "desk".into(),

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1028,6 +1028,34 @@ pub enum CompanyEvent {
         /// moment a loop was being chased.
         #[serde(default, skip_serializing_if = "is_zero_depth")]
         mention_depth: u8,
+        /// The teammates this reply is addressed to, when that is **narrower
+        /// than the desk it was written on** — a private aside
+        /// (`docs/spec/runtime/hivemind-asides.md`).
+        ///
+        /// Empty is the ordinary case and means desk-visible: every row written
+        /// before this field existed, and every row this host writes unless a
+        /// desk opted in to asides and one was authorized. The audience is the
+        /// author **plus** these ids; the author is not repeated here.
+        ///
+        /// Privacy between agents, never a security boundary. An operator and
+        /// every person reads an aside in full; what narrows is the projection
+        /// handed to a *peer agent*, and even there the row is elided rather
+        /// than removed — its sequence, author and audience stay visible, so a
+        /// `^N` citation still resolves and a peer can see that an exchange it
+        /// may not read happened. Nothing downstream should treat this as
+        /// access control.
+        ///
+        /// Fixed at append time. Widening one later could never be redelivered
+        /// (a sharing watermark advances past filtered rows unconditionally)
+        /// and would invalidate citations besides.
+        ///
+        /// Additive on exactly the terms `task_id`, `parent` and `mentions`
+        /// above are: `#[serde(default)]` is what lets an already-persisted log
+        /// load, and `skip_serializing_if` is what keeps a desk-visible reply
+        /// serializing byte-for-byte as it did before this field existed, so no
+        /// stored record needs migrating.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        audience: Vec<String>,
     },
     /// A reaction was set or cleared on one chat message (issue #364).
     ///

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -5870,6 +5870,7 @@ mod test {
     #[test]
     fn a_reply_with_no_mentions_serializes_as_it_did_before_the_fields() {
         let event = CompanyEvent::AgentReply {
+            audience: Vec::new(),
             chat_id: "general".to_string(),
             agent_id: "ceo".to_string(),
             text: "hi".to_string(),
@@ -6168,6 +6169,7 @@ mod test {
 
         // A tool-less reply serializes without the `steps` key.
         let tool_less = CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -6182,6 +6184,7 @@ mod test {
 
         // A reply with a timeline round-trips it.
         let with_steps = CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -6223,6 +6226,7 @@ mod test {
 
         // An untagged reply keeps the legacy wire shape exactly.
         let untagged = CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -6239,6 +6243,7 @@ mod test {
 
         // A dispatch-produced reply carries the key and round-trips.
         let tagged = CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -6477,6 +6482,7 @@ mod test {
         );
 
         let answered = CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: Some(EventSeq::new(41)),

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -142,6 +142,7 @@ impl ChannelAdapter for DeskChannel {
             .append(
                 &self.company,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     chat_id: self.desk_id.clone(),
                     agent_id: WORKFLOW_REPLY_AUTHOR.to_string(),
                     text: msg.text,
@@ -269,6 +270,7 @@ impl ChannelAdapter for DurableOperatorChannel {
             .append(
                 &self.company,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     // The dedicated operator line, normally `OPERATOR_CHANNEL`
                     // itself — `owns("operator","operator",…)` matches it (it is
                     // NOT folded into General — see

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -9286,6 +9286,7 @@ members = ["writer"]
                 origin_parent: None,
             },
             CompanyEvent::AgentReply {
+                audience: Vec::new(),
                 mentions: Vec::new(),
                 mention_depth: 0,
                 parent: None,
@@ -11543,6 +11544,7 @@ timeout)",
             seq: EventSeq::new(seq),
             company: CompanyId::new("acme"),
             event: CompanyEvent::AgentReply {
+                audience: Vec::new(),
                 chat_id: chat.to_string(),
                 agent_id: "ceo".to_string(),
                 text: "an answer".to_string(),

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -1203,6 +1203,7 @@ mod test {
 
     fn agent_reply(chat_id: &str) -> CompanyEvent {
         CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -1526,6 +1527,7 @@ mod test {
             at(
                 2,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -1727,6 +1729,7 @@ mod test {
             at(
                 13,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: Some(EventSeq::new(4)),
@@ -1974,6 +1977,7 @@ mod test {
             at(
                 seq,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     chat_id: "engineering".to_string(),
@@ -2353,6 +2357,7 @@ mod dead_card_test {
     /// A reply that opened a card, exactly as the dispatch path journals it.
     fn reply_naming(task_id: &str) -> CompanyEvent {
         CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -2487,6 +2492,7 @@ mod dead_card_test {
             .append(
                 &id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -2534,6 +2540,7 @@ mod dead_card_test {
             .append(
                 &id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -2551,6 +2558,7 @@ mod dead_card_test {
             .append(
                 &id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -2619,6 +2627,7 @@ mod dead_card_test {
             .append(
                 &id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -2636,6 +2645,7 @@ mod dead_card_test {
             .append(
                 &id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -2688,6 +2698,7 @@ mod dead_card_test {
             .append(
                 &id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -2705,6 +2716,7 @@ mod dead_card_test {
             .append(
                 &id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -2769,6 +2781,7 @@ mod dead_card_test {
             .append(
                 &id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -2786,6 +2799,7 @@ mod dead_card_test {
             .append(
                 &id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -777,6 +777,7 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
         .append(
             runtime.id(),
             crate::ports::types::CompanyEvent::AgentReply {
+                audience: Vec::new(),
                 mentions: Vec::new(),
                 mention_depth: 0,
                 parent: None,
@@ -794,6 +795,7 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
         .append(
             runtime.id(),
             crate::ports::types::CompanyEvent::AgentReply {
+                audience: Vec::new(),
                 mentions: Vec::new(),
                 mention_depth: 0,
                 parent: None,
@@ -844,6 +846,7 @@ async fn chat_history_clamps_an_oversized_page_request() {
             .append(
                 runtime.id(),
                 crate::ports::types::CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -923,6 +926,7 @@ async fn chat_history_projects_the_card_a_reply_opened() {
             .append(
                 runtime.id(),
                 crate::ports::types::CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -980,6 +984,7 @@ async fn chat_history_projects_threads_and_reactions() {
         .append(
             runtime.id(),
             CompanyEvent::AgentReply {
+                audience: Vec::new(),
                 mentions: Vec::new(),
                 mention_depth: 0,
                 parent: None,
@@ -997,6 +1002,7 @@ async fn chat_history_projects_threads_and_reactions() {
         .append(
             runtime.id(),
             CompanyEvent::AgentReply {
+                audience: Vec::new(),
                 mentions: Vec::new(),
                 mention_depth: 0,
                 parent: Some(root),

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3389,6 +3389,7 @@ fn spawn_chat_turn(turn: ChatTurn) -> JoinHandle<Result<(CycleReport, Option<Str
                 // bubble. `err.0` is the inner error (it carries `Display`);
                 // the `ApiError` newtype does not.
                 let notice = CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     // Issue #1890 D: threaded on exactly the terms a successful
                     // reply is. This notice IS the answer when there is no
                     // other one, and `reply_thread`'s whole argument is that
@@ -3534,6 +3535,7 @@ pub(crate) async fn journal_chat_replies(
             .append(
                 id,
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     // Who this reply names. Rendered as chips and — unlike an
                     // operator message's — never consulted by dispatch, which
                     // is the mention-loop fuse.
@@ -8399,6 +8401,7 @@ mode = "full"
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -8416,6 +8419,7 @@ mode = "full"
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -8474,6 +8478,7 @@ mode = "full"
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -8574,6 +8579,7 @@ mode = "full"
                 .append(
                     runtime.id(),
                     CompanyEvent::AgentReply {
+                        audience: Vec::new(),
                         mentions: Vec::new(),
                         mention_depth: 0,
                         parent: None,
@@ -8669,6 +8675,7 @@ mode = "full"
                     .append(
                         runtime.id(),
                         CompanyEvent::AgentReply {
+                            audience: Vec::new(),
                             mentions: Vec::new(),
                             mention_depth: 0,
                             parent: None,
@@ -8720,6 +8727,7 @@ mode = "full"
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -9300,6 +9308,7 @@ mode = "full"
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     mentions: Vec::new(),
                     mention_depth: 0,
                     parent: None,
@@ -11840,6 +11849,7 @@ mode = "full"
     fn projects_agent_reply_with_chat_fields_and_steps() {
         use crate::ports::types::{TurnStep, TurnStepKind, TurnStepStatus};
         let v = super::project_event(&stored(CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -11874,6 +11884,7 @@ mode = "full"
     fn projects_agent_reply_with_viewer_mention_metadata() {
         use crate::ports::types::{Mention, MentionTarget};
         let stored = stored(CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: vec![
                 Mention {
                     target: MentionTarget::User { id: "u-1".into() },
@@ -11916,6 +11927,7 @@ mode = "full"
     #[test]
     fn drops_owner_fallback_report_from_a_non_admin_viewer() {
         let event = stored(CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -11964,6 +11976,7 @@ mode = "full"
     #[test]
     fn projects_agent_reply_with_its_thread_parent() {
         let v = super::project_event(&stored(CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: Some(EventSeq::new(4)),
@@ -12143,6 +12156,7 @@ mode = "full"
     #[test]
     fn projects_agent_reply_omits_empty_steps() {
         let v = super::project_event(&stored(CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -12167,6 +12181,7 @@ mode = "full"
     #[test]
     fn projects_task_id_only_when_the_event_is_correlated() {
         let reply = super::project_event(&stored(CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -14536,6 +14551,7 @@ mode = "full"
             .unwrap();
 
         let owner_fallback_item = EventStreamItem::Event(stored(CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -14553,6 +14569,7 @@ mode = "full"
         );
 
         let ordinary_item = EventStreamItem::Event(stored(CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -14863,6 +14880,7 @@ mode = "full"
             .append(
                 runtime.id(),
                 crate::ports::types::CompanyEvent::AgentReply {
+                    audience: Vec::new(),
                     chat_id: "strategy".to_string(),
                     agent_id: "ceo".to_string(),
                     text: "Here is the draft.".to_string(),

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -4610,6 +4610,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
         },
         // Tagged to this task — admitted.
         CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -4621,6 +4622,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
         },
         // An ordinary chat reply — excluded.
         CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -4632,6 +4634,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
         },
         // Tagged to a different task — excluded.
         CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,
@@ -5476,6 +5479,7 @@ async fn task_export_serves_a_readable_document_and_alters_nothing() {
             run_id: None,
         },
         CompanyEvent::AgentReply {
+            audience: Vec::new(),
             mentions: Vec::new(),
             mention_depth: 0,
             parent: None,

--- a/src/store/memory/cortexdb.rs
+++ b/src/store/memory/cortexdb.rs
@@ -304,7 +304,24 @@ impl CortexdbMemory {
         // returns, not only the first.
         let deadline = tokio::time::Instant::now() + INGEST_RECALL_VISIBILITY_TIMEOUT;
         loop {
-            let hits = self.recall_raw(namespace, "").await?;
+            // The event's own id, and **not** an empty query. An empty one is
+            // rejected by the ranked coordinator (`Validation failed: query
+            // must not be empty`), which does not surface as an error here:
+            // CortexDB falls back to a WAL-only scan, logs the failure on its
+            // own side, and answers 200. That fallback is slower to see a
+            // fresh write than this timeout allows, so every `store` failed
+            // after `INGEST_RECALL_VISIBILITY_TIMEOUT` while the record was
+            // in fact perfectly durable — observed as every hive turn on a
+            // live `companies/vending_machine_co` run failing at its first
+            // `memory_store`.
+            //
+            // Querying by id also makes the probe test what it claims to:
+            // stage two exists to confirm *ranked-recall* visibility, and a
+            // query that silently downgrades to the WAL path confirms
+            // something else. The scope's events come back up to
+            // `EVENTS_LAYER_LIMIT` regardless of how the id ranks, and this
+            // scans them by id rather than trusting the order.
+            let hits = self.recall_raw(namespace, &event_id).await?;
             if hits.iter().any(|record| record.id == event_id) {
                 return Ok(());
             }
@@ -322,9 +339,16 @@ impl CortexdbMemory {
 
     /// Recalls the raw events filed in `namespace`'s scope.
     ///
-    /// `query` narrows retrieval; an empty query still returns the scope's raw
-    /// events (CortexDB treats an empty query as "everything", ranked by
-    /// recency) up to [`EVENTS_LAYER_LIMIT`].
+    /// `query` narrows retrieval, up to [`EVENTS_LAYER_LIMIT`].
+    ///
+    /// **Pass a non-empty query.** This driver used to document that "CortexDB
+    /// treats an empty query as everything, ranked by recency", and that is not
+    /// true of the v0.9.8 image `scripts/cortexdb-up.sh` starts: the ranked
+    /// coordinator rejects an empty query outright and the server falls back to
+    /// a WAL-only scan, answering **200** with a degraded result set while
+    /// logging `Validation failed: query must not be empty` on its own side.
+    /// Nothing about that reaches this process, so an empty query here reads as
+    /// a slow or missing record rather than as a rejected request.
     async fn recall_raw(&self, namespace: &str, query: &str) -> anyhow::Result<Vec<DecodedRecord>> {
         let body = json!({
             "scope": Self::scope_for(namespace),

--- a/src/store/memory/cortexdb.rs
+++ b/src/store/memory/cortexdb.rs
@@ -304,24 +304,7 @@ impl CortexdbMemory {
         // returns, not only the first.
         let deadline = tokio::time::Instant::now() + INGEST_RECALL_VISIBILITY_TIMEOUT;
         loop {
-            // The event's own id, and **not** an empty query. An empty one is
-            // rejected by the ranked coordinator (`Validation failed: query
-            // must not be empty`), which does not surface as an error here:
-            // CortexDB falls back to a WAL-only scan, logs the failure on its
-            // own side, and answers 200. That fallback is slower to see a
-            // fresh write than this timeout allows, so every `store` failed
-            // after `INGEST_RECALL_VISIBILITY_TIMEOUT` while the record was
-            // in fact perfectly durable — observed as every hive turn on a
-            // live `companies/vending_machine_co` run failing at its first
-            // `memory_store`.
-            //
-            // Querying by id also makes the probe test what it claims to:
-            // stage two exists to confirm *ranked-recall* visibility, and a
-            // query that silently downgrades to the WAL path confirms
-            // something else. The scope's events come back up to
-            // `EVENTS_LAYER_LIMIT` regardless of how the id ranks, and this
-            // scans them by id rather than trusting the order.
-            let hits = self.recall_raw(namespace, &event_id).await?;
+            let hits = self.recall_raw(namespace, "").await?;
             if hits.iter().any(|record| record.id == event_id) {
                 return Ok(());
             }
@@ -339,16 +322,9 @@ impl CortexdbMemory {
 
     /// Recalls the raw events filed in `namespace`'s scope.
     ///
-    /// `query` narrows retrieval, up to [`EVENTS_LAYER_LIMIT`].
-    ///
-    /// **Pass a non-empty query.** This driver used to document that "CortexDB
-    /// treats an empty query as everything, ranked by recency", and that is not
-    /// true of the v0.9.8 image `scripts/cortexdb-up.sh` starts: the ranked
-    /// coordinator rejects an empty query outright and the server falls back to
-    /// a WAL-only scan, answering **200** with a degraded result set while
-    /// logging `Validation failed: query must not be empty` on its own side.
-    /// Nothing about that reaches this process, so an empty query here reads as
-    /// a slow or missing record rather than as a rejected request.
+    /// `query` narrows retrieval; an empty query still returns the scope's raw
+    /// events (CortexDB treats an empty query as "everything", ranked by
+    /// recency) up to [`EVENTS_LAYER_LIMIT`].
     async fn recall_raw(&self, namespace: &str, query: &str) -> anyhow::Result<Vec<DecodedRecord>> {
         let body = json!({
             "scope": Self::scope_for(namespace),


### PR DESCRIPTION
## What this is

Updates the vendored `tinyhivemind` (`e272c84` → `63dfb22`, ~540 commits), migrates the host to its new API, implements **private asides** as a second agent-to-agent seam, and adds `companies/vending_machine_co` — a bundle whose desks talk to each other while running a simulated vending-machine operation over an MCP server.

Everything here has been run live against real models on the ladder router, not only unit-tested. Several of the fixes below exist *because* of that run.

## The submodule bump and its migration

`tinyhivemind` gained private asides, which is a breaking change to the session API:

- `SessionQuery` grew `viewer`. `EpisodeDriver::run` issues `Viewer::Operator` — the true, unelided medium — because `step` must fold one transcript for the whole room. A per-viewer fold would make `quorum::standings`, `attention::bids` and `directory` return well-formed **wrong** answers with no error path: a quorum one member can see and another cannot. `project_for` stays the only thing that narrows, per speaker.
- `project_for` now returns owned rows (it synthesises collapsed aside stubs that exist in no source slice), so `render` / `line_from` / `evidential` widened from `&[&SessionMessage]` to `&[SessionMessage]`.
- `LogMessage` / `SessionMessage` gained `audience` / `elided`; `read_pinboard` takes a viewer — read as the *speaker*, so a pin over an aside cannot quote content to somebody outside it.

## Private asides

Two members of one desk saying something the rest of it cannot read. Spec: `docs/spec/runtime/hivemind-asides.md`.

- **Auditable, not confidential.** A row is elided, never removed: its sequence, author and audience stay, so a `^N` citation still resolves and a peer can see that an exchange it may not read happened. Operators and people read every aside in full. **This is not a security boundary and nothing may be built on it as one.**
- **Information, never support.** A trace in a non-`Desk` row contributes nothing, for every reader — the same rule cross-desk referral already accepts at a channel boundary, applied inside one desk.
- **It costs no turn** (ADR 0011). One authorized turn produces the member's ordinary desk line *and*, optionally, one private row. A refused audience is **dropped, not published** — falling back to the desk would put a second desk-visible contribution on one turn.
- **Off by default**, because upstream measured it and it lost on answer quality. Enabling it is a decision, not a default.

Journal cost is one additive field on `AgentReply` (`audience: Vec<String>`, `skip_serializing_if = "Vec::is_empty"`), so a desk-visible reply serializes byte-for-byte as before and **no stored record needs migrating**.

## Fixes found by running it live

- **`referral_summary` claimed "another desk" for same-desk questions.** `reach` widens strictly, so a desk may legitimately put a question to its own seat — but a live run reported *"asked 2 questions of another desk (@fleet_tech on ops, @field_realist on ops)"* on the ops desk, naming two ops seats. An operator reading that has been told the room reached outside when it did not. `AskedQuestion` now carries `crossed` and the close reports the two separately. Regression test included.
- **Asides were never used until ADR 0011 landed.** A six-day live run with asides enabled used the marker **zero times**, while the same seats repeatedly wrote `!question @peer` — the move already in their list that did not cost them their contribution. After making the aside ride alongside the turn, a real run produced one on its first day.

## The bundle

`companies/vending_machine_co` — eight machines at five host sites, a finite warehouse with a 4-day lead time, contracts that renew. Three hive desks (`ops` 4 seats, `commercial` 3, `intel` 2), all with cross-desk referral, and asides on `ops` only.

The whole work environment is one MCP server (`scripts/vending/`): fleet telemetry, warehouse, margin, clients, incidents, market feed, plus the writes that change them. Every read an agent makes and every change it causes is a tool call. `scripts/vending-sim.py` advances a clock and posts each day's triggers into the desk that owns the *decision* — not the desk holding the most facts, because whether they ask each other is what the run measures.

## Evidence from a live run

A real ops episode, models on the ladder router:

```
route_planner    !propose #ops-day-1 run the van VM-401→VM-301→VM-201→VM-501…
fleet_tech       !evidence ^13 VM-301 (700 footfall) about to blow SANDWICH 0.1d/ENERGY 0.2d…
stock_controller !evidence ^13 warehouse holds 167 ENERGY-250, 63 SANDWICH-1… 4-day lead time
field_realist    !evidence ^13 VM-201/401 need priority, but VM-301/302 are the pressure points
route_planner    !propose #ops-day-1 route VM-301 then VM-302 … → VM-401 → VM-201 → VM-501
fleet_tech       !support ^18 covers every machine at zero or under a day
route_planner    !commit ^18
```

The figures are live MCP reads, only the planner proposed, the realist never supported, and the planner revised its route in response to the objection. And an aside riding alongside a turn — two rows, one turn:

```
[22] fleet_tech  !evidence #ops-day-1 ^13 fleet read shows no faults anywhere…   ← the room's
[23] fleet_tech  !aside @route_planner how many visits can one van make in a day? ← private
```

## Verification

`cargo fmt --all --check` clean · `cargo clippy --all-targets --features openhuman,mcp -- -D warnings` clean · **7113 lib tests pass** (101 hivemind, incl. 11 aside unit + 9 integration) · content tests 26/26 · all integration targets pass.

## Not included, deliberately

`src/store/memory/cortexdb.rs` is **untouched**. A local CortexDB started by `scripts/cortexdb-up.sh` has no LLM router or embedding endpoint wired, so its ranked-recall index lags writes by minutes and every agent turn fails at its first `memory_store`. I tried a fix, verified it did not work, and reverted rather than ship an unverified change to a shared driver. The README documents the trap and how to point at a provisioned instance instead; the underlying issue deserves its own PR.

Co-authored-by: Medulla <medulla@tinyhumans.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete Northgate Vending company bundle with operational desks, specialized roles, ledgers, seeded tasks, and approval workflows.
  * Added a deterministic vending-machine simulator covering inventory, sales, pricing, incidents, client relationships, supplier orders, and market signals.
  * Added optional private desk asides with bounded, auditable peer messaging and required surfacing.
* **Documentation**
  * Added setup, usage, simulation, and private-aside documentation.
* **Tests**
  * Added coverage for private messaging, referrals, visibility, and vending bundle validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->