### PR TITLE
The migration delta, and the blocker it turns out to sit behind

### DIFF
--- a/docs/spec/runtime/memory-engine-cortex.md
+++ b/docs/spec/runtime/memory-engine-cortex.md
@@ -348,9 +348,39 @@ opencompany-manager: create, inject `OPENCOMPANY_MEMORY_*` alongside the existin
 waits on a real per-instance figure from Cortex.
 
 **Phase 3 — migration.** `opencompany memory migrate --to cortex` over the
-Portability family. The existing runbook in `memory-engine.md` applies unchanged;
-its per-tenant-credential caution is satisfied by the instance-per-tenant
-topology. Hosted-target enumeration cost still applies.
+Portability family. The generic procedure in
+[`memory-engine.md`](memory-engine.md#switching-engines--the-operator-runbook)
+holds; four things are specific to Cortex and one of them is a blocker.
+
+**The target engine has to exist, and for an existing company it does not.**
+`ensure_cortex` runs inside `provision`, and `ensure_running` calls `provision`
+only when the workload's StatefulSet is *absent*. Parking scales to zero and
+keeps it. So a company created before Cortex was switched on never gets an
+engine, no matter how many times it wakes — and migration has a prerequisite
+with no path behind it. Closing that is the first task of this phase, not a
+detail of it: either provisioning learns to add an engine to a running tenant,
+or the operator re-provisions deliberately.
+
+**The driver id is `cortex`, not `cortexdb`.** They are two adapters for the
+same service and both are accepted targets; the manager injects `cortex`, so
+that is what a migration onto a provisioned engine names. `cortexdb` sends
+`X-Cortex-Actor` and this one does not.
+
+**This does not use CortexDB's own export.** Migration reads through the
+driver's Portability family — `namespace_summaries` then paged `get` — so it
+moves host entries. `POST /v1/export` is a different, engine-native dump of
+events plus derived records, and is what the backup path uses. Do not reach for
+one expecting the other.
+
+**Budget for the write cost.** Each record is an append plus a wait for
+read-after-write visibility, and the adapter waits on both the scope listing and
+ranked recall because they become ready seconds apart. That is per record, so a
+migration's runtime is set by record count rather than bytes. Pause the company
+first, as the generic runbook says, and expect the copy to dominate the outage.
+
+The runbook's per-tenant-credential caution is satisfied by construction here:
+instance-per-tenant means the source credential can only see one company's
+records.
 
 **Phase 4 — revisit the derived layers.** Previously gated on upstream defects
 being fixed; per the [Correction](#correction-2026-09-04) it is now gated on

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -330,7 +330,9 @@ comes first.
    seam and is refused by name — for those, `opencompany export` reads the
    live engine (base backend plus memory overlay, operator facts included)
    and is the capture tool. Target drivers are the hosted engines
-   `supermemory`, `mem0`, `cognee` and `cortexdb`.
+   `supermemory`, `mem0`, `cognee`, `cortexdb` and `cortex`. Hosted tenants run
+   **`cortex`** — the manager injects that id at provision — so a migration onto
+   a provisioned engine names `cortex`, not `cortexdb`.
 
    Two hosted-deployment cautions. The copy is **engine-level**: every
    namespace the source credential can see crosses, which is exactly right


### PR DESCRIPTION
#1936's last deliverable. The generic switching runbook holds; writing the
Cortex-specific part surfaced something that is not a detail.

## An existing company cannot be migrated onto Cortex today

It has no engine to migrate *to*. `ensure_cortex` runs inside `provision`, and
`ensure_running` calls `provision` only when the workload's StatefulSet is
**absent** — parking scales to zero and keeps it. So a company created before
Cortex was switched on never gets an engine however often it wakes.

The migration this deliverable describes therefore has a prerequisite with
nothing behind it. It is recorded as the **first task of Phase 3** rather than
buried inside it: either provisioning learns to add an engine to a running
tenant, or the operator re-provisions deliberately.

## Three corrections that would have bitten an operator

**The target driver is `cortex`, not `cortexdb`.** They are two adapters for the
same service — `cortexdb` sends `X-Cortex-Actor`, `cortex` is the dialect
`tinymemory-remote` ships — and the manager injects **`cortex`** at provision.
The runbook's target list named only `cortexdb`, so the documented command was
wrong for every hosted tenant. Fixed in `memory-engine.md` too.

**Migration does not use CortexDB's `/v1/export`.** It reads through the driver's
Portability family (`namespace_summaries`, then paged `get`), moving host
entries. `/v1/export` is an engine-native dump of events plus derived records and
belongs to the backup path (ocm#64). Easy to conflate now that both exist, and
reaching for one expecting the other would produce a migration that silently
moved the wrong shape of data.

**The cost is per record, not per byte.** Every write is an append plus a wait
for read-after-write visibility, on two read paths that become ready seconds
apart. Runtime is set by record count, and the copy dominates the outage window
the generic runbook already tells you to open.

## Unchanged

The per-tenant-credential caution is satisfied by construction under
instance-per-tenant: a source credential can only see one company's records.

Docs only. Refs #1936.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded Cortex migration guidance with prerequisites, driver identification, data portability behavior, runtime considerations, and credential cautions.
  - Added Cortex as a supported hosted migration target.
  - Clarified that hosted tenants use the `cortex` driver identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->