### PR TITLE
fix(desktop): pin the shipped updater key instead of forbidding one

### DIFF
--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -148,20 +148,52 @@ mod test {
         assert!(is_configured(A_REAL_PUBKEY));
     }
 
+    /// The updater public key this repository ships, installed when desktop
+    /// auto-update landed (`846913029`).
+    ///
+    /// Pinned here on purpose. A minisign **public** key is meant to be
+    /// distributed — it is what a shipped binary verifies a release against,
+    /// and it is inert without the private half, which stays an operator
+    /// secret — so carrying it is not the leak the pre-auto-update version of
+    /// this test was guarding against.
+    const SHIPPED_PUBKEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDcxMjNEREM2ODQ3NzA0MkMKUldRc0JIZUV4dDBqY1NnMnBmK21oc0xGdnBhNTl3djVGWWErWFJ0aG1IYkZJTWpVczJZUjBzcGIK";
+
+    /// The config carries the key this repository intends, and no other.
+    ///
+    /// # Why this replaced `the_shipped_placeholder_is_not_configured`
+    ///
+    /// That test asserted `tauri.conf.json` never carries a usable key, back
+    /// when the repository shipped a placeholder and the real key was injected
+    /// at release time. `846913029` installed the key deliberately, and the two
+    /// then contradicted each other: the `Desktop` lane went red on main and,
+    /// because pull-request CI builds the merge commit, on every open PR at
+    /// once — where it reads to each author as though their own branch broke
+    /// the desktop build.
+    ///
+    /// The old test invited exactly this edit: *"If this fails because somebody
+    /// pasted a real public key in, that is fine — but it has to be a
+    /// deliberate edit to this test, not a silent one to the config."* This is
+    /// that edit, and it keeps the half of the guarantee that still applies.
+    /// The point was never "no key"; it was "no *silent* change to the key", so
+    /// the assertion is now equality against a pinned constant. A rotation
+    /// still has to come here and say so, which is what the original was
+    /// protecting.
     #[test]
-    fn the_shipped_placeholder_is_not_configured() {
+    fn the_shipped_updater_key_is_the_intended_one() {
         let config: serde_json::Value =
             serde_json::from_str(include_str!("../tauri.conf.json")).unwrap();
         let pubkey = config["plugins"]["updater"]["pubkey"].as_str().unwrap();
 
-        // The config in this repository must never carry a usable key: the
-        // private half is an operator secret. If this fails because somebody
-        // pasted a real public key in, that is fine — but it has to be a
-        // deliberate edit to this test, not a silent one to the config.
         assert!(
-            !is_configured(pubkey),
-            "tauri.conf.json carries a real-looking updater pubkey ({pubkey}); \
-             the repository ships a placeholder and the key belongs in the release",
+            is_configured(pubkey),
+            "tauri.conf.json carries no usable updater pubkey ({pubkey}); \
+             a shipped desktop build cannot verify an update without one",
+        );
+        assert_eq!(
+            pubkey, SHIPPED_PUBKEY,
+            "the updater pubkey in tauri.conf.json changed; rotating it is fine, \
+             but update SHIPPED_PUBKEY in the same commit so the change is on \
+             the record rather than silent",
         );
     }
 


### PR DESCRIPTION
Unbreaks the `Desktop` lane, which is currently red on **main** and on **every open PR**.

## What's wrong

`src-tauri/src/update.rs::the_shipped_placeholder_is_not_configured` asserts `tauri.conf.json` never carries a usable updater pubkey. That was true while the repository shipped a placeholder and the real key was injected at release time.

`846913029` ("chore(desktop): install the updater's public signing key") installed the key deliberately when desktop auto-update landed. The config and the test have asserted opposite things ever since:

```
thread 'update::test::the_shipped_placeholder_is_not_configured'
  panicked at src/update.rs:161
  tauri.conf.json carries a real-looking updater pubkey (dW50cnVzdGVkIGNvbW1lbnQ6…)
  158 passed; 1 failed
```

## Why it looks like everyone's fault

`pull_request` CI builds the merge commit, so every open PR inherits main's contradiction and shows a red `Desktop` lane that has nothing to do with its own diff. For example on #2075:

```
git merge-base --is-ancestor 846913029 refs/pull/2075/merge  -> yes
git merge-base --is-ancestor 846913029 HEAD                  -> no
```

That branch still has `PLACEHOLDER-NOT-A-KEY-…`, yet its Desktop lane fails printing main's real key. Main's own run (`34050769896` @ `d304ab8d`) fails the identical test with the identical `158 passed; 1 failed`.

Worth knowing: a green tick on main is not evidence this is fixed — docs-only merges skip the lane entirely via `Changed areas`, so the run reports success without ever running it.

## The change

The old test named this remedy itself:

> If this fails because somebody pasted a real public key in, that is fine — but it has to be a deliberate edit to this test, not a silent one to the config.

This is that edit, keeping the half of the guarantee that still applies.

The point was never "no key" — a minisign **public** key is meant to be distributed, is what a shipped binary verifies a release against, and is inert without the private half, which stays an operator secret. The point was "no *silent* change to the key". So the assertion becomes equality against a pinned `SHIPPED_PUBKEY`, and a rotation still has to come to this file and say so.

Renamed to `the_shipped_updater_key_is_the_intended_one`, since the old name would now be a lie.

## Checks

- `cargo test --manifest-path src-tauri/Cargo.toml` — **159 passed, 0 failed** (was 158 / 1).
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` on `src-tauri` — clean.
- Verified the new assertion actually bites: swapping the configured key makes it fail with the "update SHIPPED_PUBKEY in the same commit" message, rather than passing vacuously.

## Not in scope

`Console E2E` and `Console E2E (live brain)` are also red across main and every PR, for a separate and un-diagnosed reason — filed as #2110.

cc @sanil-23, as the author of `846913029` — happy to close this if you would rather fix it differently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated updater configuration validation to verify that the shipped signing key matches the repository’s intended key.
  - Future signing-key rotations must update the corresponding validation in the same change, helping prevent mismatched updater configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->