### PR TITLE
fix(hivemind): two referral wording defects, and retune the signals desk from the benchmark

### DIFF
--- a/companies/vending_machine_co/README.md
+++ b/companies/vending_machine_co/README.md
@@ -56,7 +56,7 @@ cannot see it, would be a desk that never had to be convinced. See
 | --- | --- | --- | --- |
 | `ops` | `route_planner`, `fleet_tech`, `stock_controller`, `field_realist` | 2 of 4, 12 turns | The van's finite day: route, shelves, faults |
 | `commercial` | `account_manager`, `pricing_analyst`, `contract_counsel` | 2 of 3, 9 turns | Margin, prices, host sites, contracts |
-| `intel` | `market_scout`, `demand_analyst` | 2 of 2, 6 turns | What the market did, and whether it changes a plan |
+| `intel` | `market_scout`, `demand_analyst` | 2 of 2, 8 turns | What the market did, and whether it changes a plan |
 
 Each desk restricts its seats' moves (`[group_chat.hive.moves]`), and the
 restrictions carry the design:
@@ -78,10 +78,24 @@ restrictions carry the design:
   of two — unanimity. A room of two that could carry on one supporter is a
   single responder with extra steps.
 
-`require_evidential` is on for all three, so a `!support` with no `^citation`
-adds nothing to quorum. In this company that bites hardest on the stock
-controller: "we have enough stock" is a claim about a number
+`require_evidential` is on for **`ops` and `commercial`**, so a `!support` with
+no `^citation` adds nothing to quorum. In this company that bites hardest on the
+stock controller: "we have enough stock" is a claim about a number
 `warehouse_status` will actually print.
+
+`intel` deliberately does **not** have it, and that is the one setting here
+chosen from measurement rather than argument. Stacking `require_evidential` on a
+two-member desk whose quorum is already unanimity means a decision needs both
+seats to file a citation that chains to a stated fact. The deliberation
+benchmark (`vendor/tinyhivemind/crates/tinyhivemind-hive/examples/bench`) puts
+numbers on it — at `--agents 2` it takes the decided rate from **91.6% to
+36.2%** and correctness from 63.6% to 30.7% over 2000 seeded rooms — and live
+runs agreed: the signals desk spent its budget without deciding in nearly every
+episode it opened. Its budget went from 6 turns to 8 for the same reason. The
+larger desks keep the rule, because their seats read hard figures off the
+`vending` MCP on almost every turn, so a citation that reaches a fact is cheap
+there in a way it is not on a desk whose job is to weigh a signal nobody has
+measured yet.
 
 ## Tool servers
 

--- a/companies/vending_machine_co/company.toml
+++ b/companies/vending_machine_co/company.toml
@@ -248,13 +248,31 @@ members = ["market_scout", "demand_analyst"]
 
 [group_chat.hive]
 enabled = true
-turn_budget = 6
+# Eight, not six. See the evidential note below: this desk was the most
+# constrained in the company and spent its budget without deciding in almost
+# every live run.
+turn_budget = 8
 # Two members, so a quorum of two is unanimity — correct here. A room of two
 # that could carry on one supporter is a room where either member decides
 # alone, which is a single responder with extra steps.
 quorum = 2
 blind_round = true
-require_evidential = true
+# **No `require_evidential` here, unlike the other two desks**, and this is the
+# one knob in the bundle set from measurement rather than from argument.
+#
+# Stacking it on a two-member desk whose quorum is already unanimity means a
+# decision needs *both* seats to file a citation that chains to a stated fact.
+# The deliberation benchmark
+# (`vendor/tinyhivemind/crates/tinyhivemind-hive/examples/bench`) puts numbers
+# on it: at `--agents 2`, `require_evidential` takes the decided rate from
+# 91.6% to **36.2%** and correctness from 63.6% to 30.7% over 2000 seeded
+# rooms. Live runs of this company agreed — the signals desk spent its budget
+# without reaching a decision in nearly every episode it opened.
+#
+# The other two desks keep it. They are larger, and their seats read hard
+# figures off the `vending` MCP on almost every turn, so a citation that
+# reaches a fact is cheap there in a way it is not here: this desk's whole job
+# is to weigh a signal nobody has measured yet.
 repetition_cap = 1
 
 [group_chat.hive.moves]

--- a/companies/vending_machine_co/company.toml
+++ b/companies/vending_machine_co/company.toml
@@ -284,7 +284,7 @@ blind_round = true
 # figures off the `vending` MCP on almost every turn, so a citation that
 # reaches a fact is cheap there in a way it is not here: this desk's whole job
 # is to weigh a signal nobody has measured yet.
-repetition_cap = 1
+repetition_cap = 2
 
 [group_chat.hive.moves]
 market_scout = ["evidence", "propose", "question", "pin", "defer"]

--- a/companies/vending_machine_co/company.toml
+++ b/companies/vending_machine_co/company.toml
@@ -134,8 +134,18 @@ blind_round = true
 # cite it is a guess wearing a marker.
 require_evidential = true
 refutation_cap = 2
-dominance_cap = 3
-repetition_cap = 1
+# `dominance_cap` is a **percent of the room's grounded share**, not a turn
+# count: the library damps a member when `share * 100 > total * cap`. 40 is the
+# lower of the two values the benchmark sweeps and the one its best policy for a
+# four-seat desk uses; the library's own default is 50.
+#
+# This said `3` until the sweep caught it, copied from `hive_math_lab` along
+# with a comment describing a supporter count. Three *percent* means every
+# member that has said anything grounded exceeds the cap and takes the
+# dominance penalty on every later bid — which damps the whole room instead of
+# its loudest seat, the exact opposite of the knob's purpose.
+dominance_cap = 40
+repetition_cap = 2
 
 # Only the planner proposes; the two constraint-holders ground or refuse.
 # `commit`, `question` and `defer` are never gated by the runtime whatever a
@@ -209,8 +219,9 @@ quorum = 2
 blind_round = true
 require_evidential = true
 refutation_cap = 2
-dominance_cap = 3
-repetition_cap = 1
+# A share, not a count — see the operations desk above.
+dominance_cap = 40
+repetition_cap = 2
 
 # Two seats may propose here, unlike ops, because a commercial question has two
 # genuinely different framings — "what do we charge" and "what do we sign" —

--- a/src/hivemind/referral.rs
+++ b/src/hivemind/referral.rs
@@ -339,13 +339,32 @@ pub fn returned_note(target: &str, desk: &str, answer: &str) -> String {
     // happened to begin with `!` would fold as a trace on *this* desk, which is
     // precisely the vote this row exists not to carry.
     let answer = answer.trim_start_matches('!').trim();
-    format!("@{target} on the {desk} desk answered the question: {answer}")
+    format!("@{target} on {} answered the question: {answer}", named_desk(desk))
+}
+
+/// A desk named for a sentence: "the Operations desk", "the eng desk".
+///
+/// The template used to append " desk" unconditionally, and every desk in this
+/// repo is *named* "… desk", so a live run printed "@route_planner on the
+/// Operations desk desk did not answer the question." A name that already ends
+/// in the word carries it; one that does not gets it.
+fn named_desk(desk: &str) -> String {
+    let trimmed = desk.trim();
+    if trimmed
+        .rsplit(|c: char| c.is_whitespace())
+        .next()
+        .is_some_and(|last| last.eq_ignore_ascii_case("desk"))
+    {
+        format!("the {trimmed}")
+    } else {
+        format!("the {trimmed} desk")
+    }
 }
 
 /// The line an unanswered question leaves on the asking desk.
 #[must_use]
 pub fn unanswered_note(target: &str, desk: &str) -> String {
-    format!("@{target} on the {desk} desk did not answer the question.")
+    format!("@{target} on {} did not answer the question.", named_desk(desk))
 }
 
 /// The episode-scoped adapter between the library's referral fold and this

--- a/src/hivemind/referral.rs
+++ b/src/hivemind/referral.rs
@@ -339,7 +339,10 @@ pub fn returned_note(target: &str, desk: &str, answer: &str) -> String {
     // happened to begin with `!` would fold as a trace on *this* desk, which is
     // precisely the vote this row exists not to carry.
     let answer = answer.trim_start_matches('!').trim();
-    format!("@{target} on {} answered the question: {answer}", named_desk(desk))
+    format!(
+        "@{target} on {} answered the question: {answer}",
+        named_desk(desk)
+    )
 }
 
 /// A desk named for a sentence: "the Operations desk", "the eng desk".
@@ -364,7 +367,10 @@ fn named_desk(desk: &str) -> String {
 /// The line an unanswered question leaves on the asking desk.
 #[must_use]
 pub fn unanswered_note(target: &str, desk: &str) -> String {
-    format!("@{target} on {} did not answer the question.", named_desk(desk))
+    format!(
+        "@{target} on {} did not answer the question.",
+        named_desk(desk)
+    )
 }
 
 /// The episode-scoped adapter between the library's referral fold and this

--- a/src/hivemind/referral_test.rs
+++ b/src/hivemind/referral_test.rs
@@ -604,9 +604,9 @@ fn the_close_reads_as_english_for_every_combination_of_referral_facts() {
 /// Operations desk desk did not answer the question."
 #[test]
 fn a_referral_note_names_a_desk_once() {
-    use crate::hivemind::referral::{answered_note, unanswered_note};
+    use crate::hivemind::referral::{returned_note, unanswered_note};
 
-    let named = answered_note("account_manager", "Commercial desk", "no idea");
+    let named = returned_note("account_manager", "Commercial desk", "no idea");
     assert!(named.contains("on the Commercial desk answered"), "{named}");
     assert!(!named.contains("desk desk"), "{named}");
 

--- a/src/hivemind/referral_test.rs
+++ b/src/hivemind/referral_test.rs
@@ -582,19 +582,22 @@ fn the_close_reads_as_english_for_every_combination_of_referral_facts() {
 
     // Plural agreement on the same clause.
     let two_failed = outcome(Vec::new(), 2, 0).referral_summary();
-    assert!(two_failed.contains("2 questions went unanswered."), "{two_failed}");
+    assert!(
+        two_failed.contains("2 questions went unanswered."),
+        "{two_failed}"
+    );
 
     // And it still composes with a question the room did ask.
     let both = outcome(asked(), 1, 0).referral_summary();
-    assert!(both.contains("The room asked 1 question of another desk"), "{both}");
+    assert!(
+        both.contains("The room asked 1 question of another desk"),
+        "{both}"
+    );
     assert!(both.contains("1 question went unanswered."), "{both}");
 
     // A cap refusal alone, likewise.
     let capped = outcome(Vec::new(), 0, 2).referral_summary();
-    assert!(
-        capped.starts_with(" 2 more were declined"),
-        "{capped}"
-    );
+    assert!(capped.starts_with(" 2 more were declined"), "{capped}");
 }
 
 /// **A desk whose name already ends in "desk" does not get a second one.**

--- a/src/hivemind/referral_test.rs
+++ b/src/hivemind/referral_test.rs
@@ -536,6 +536,92 @@ fn the_close_tells_a_local_question_from_a_crossing_one() {
     );
 }
 
+/// **Every close is a sentence, whatever the episode's referral facts were.**
+///
+/// The summary used to hang every clause off one "The room …" prefix, so an
+/// episode whose only referral fact was a failure printed "The room 1 went
+/// unanswered." — which a live `companies/vending_machine_co` run duly did.
+#[test]
+fn the_close_reads_as_english_for_every_combination_of_referral_facts() {
+    use crate::hivemind::referral::{AskedQuestion, ReferralLedger};
+
+    let outcome = |asked: Vec<AskedQuestion>, failed: u32, over_cap: u32| EpisodeOutcome {
+        ending: EpisodeEnding::Exhausted,
+        turns: 4,
+        first_seq: None,
+        last_seq: None,
+        report_seq: None,
+        violations: Vec::new(),
+        failed_turns: 0,
+        referrals: ReferralLedger {
+            asked,
+            over_cap,
+            failed,
+        },
+    };
+    let asked = || {
+        vec![AskedQuestion {
+            asker: "route_planner".to_owned(),
+            target: "account_manager".to_owned(),
+            desk: "commercial".to_owned(),
+            returned: false,
+            crossed: true,
+        }]
+    };
+
+    // A failure on its own is its own sentence, with its own subject.
+    let only_failed = outcome(Vec::new(), 1, 0).referral_summary();
+    assert!(
+        only_failed.contains("1 question went unanswered."),
+        "{only_failed}"
+    );
+    assert!(
+        !only_failed.contains("The room 1"),
+        "the failure clause was hung off a prefix it does not continue: {only_failed}"
+    );
+
+    // Plural agreement on the same clause.
+    let two_failed = outcome(Vec::new(), 2, 0).referral_summary();
+    assert!(two_failed.contains("2 questions went unanswered."), "{two_failed}");
+
+    // And it still composes with a question the room did ask.
+    let both = outcome(asked(), 1, 0).referral_summary();
+    assert!(both.contains("The room asked 1 question of another desk"), "{both}");
+    assert!(both.contains("1 question went unanswered."), "{both}");
+
+    // A cap refusal alone, likewise.
+    let capped = outcome(Vec::new(), 0, 2).referral_summary();
+    assert!(
+        capped.starts_with(" 2 more were declined"),
+        "{capped}"
+    );
+}
+
+/// **A desk whose name already ends in "desk" does not get a second one.**
+///
+/// Every desk in this repo is named "… desk", and the referral note appended
+/// the word unconditionally: a live run printed "@route_planner on the
+/// Operations desk desk did not answer the question."
+#[test]
+fn a_referral_note_names_a_desk_once() {
+    use crate::hivemind::referral::{answered_note, unanswered_note};
+
+    let named = answered_note("account_manager", "Commercial desk", "no idea");
+    assert!(named.contains("on the Commercial desk answered"), "{named}");
+    assert!(!named.contains("desk desk"), "{named}");
+
+    let missing = unanswered_note("route_planner", "Operations desk");
+    assert!(
+        missing.contains("on the Operations desk did not answer"),
+        "{missing}"
+    );
+    assert!(!missing.contains("desk desk"), "{missing}");
+
+    // A name that does not carry the word still gets it.
+    let bare = unanswered_note("planner", "eng");
+    assert!(bare.contains("on the eng desk did not answer"), "{bare}");
+}
+
 /// **A barred move demoted for its grammar violation must not still trigger a
 /// referral.**
 ///

--- a/src/hivemind/referral_test.rs
+++ b/src/hivemind/referral_test.rs
@@ -646,7 +646,7 @@ async fn a_far_turn_that_does_not_finish_leaves_the_room_running() {
     assert!(outcome.referrals.asked.is_empty());
     assert!(matches!(outcome.ending, EpisodeEnding::Converged { .. }));
     assert!(
-        outcome.summary().contains("1 went unanswered"),
+        outcome.summary().contains("1 question went unanswered"),
         "{}",
         outcome.summary()
     );

--- a/src/hivemind/types.rs
+++ b/src/hivemind/types.rs
@@ -413,7 +413,11 @@ impl EpisodeOutcome {
             ));
         }
         if ledger.failed > 0 {
-            parts.push(format!("{} went unanswered", ledger.failed));
+            let plural = if ledger.failed == 1 { "" } else { "s" };
+            parts.push(format!(
+                "{} question{plural} went unanswered",
+                ledger.failed
+            ));
         }
         if ledger.over_cap > 0 {
             parts.push(format!(
@@ -421,7 +425,36 @@ impl EpisodeOutcome {
                 ledger.over_cap
             ));
         }
-        format!(" The room {}.", parts.join("; "))
+        // Each part is a clause whose subject is "the room", except the two
+        // counts, which carry their own — so the sentence is assembled rather
+        // than concatenated under one prefix. A live run printed "The room 1
+        // went unanswered." when an episode's only referral fact was a failure,
+        // because the prefix assumed every part continued from it.
+        let mut sentences: Vec<String> = Vec::new();
+        let room: Vec<&String> = parts
+            .iter()
+            .filter(|part| part.starts_with("asked ") || part.starts_with("put "))
+            .collect();
+        if !room.is_empty() {
+            sentences.push(format!(
+                "The room {}.",
+                room.iter()
+                    .map(|part| part.as_str())
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            ));
+        }
+        for part in parts
+            .iter()
+            .filter(|part| !part.starts_with("asked ") && !part.starts_with("put "))
+        {
+            let mut sentence = part.clone();
+            if let Some(first) = sentence.get_mut(0..1) {
+                first.make_ascii_uppercase();
+            }
+            sentences.push(format!("{sentence}."));
+        }
+        format!(" {}", sentences.join(" "))
     }
 
     /// The sentence naming turns that did not finish, or nothing when they all

--- a/src/hivemind/types.rs
+++ b/src/hivemind/types.rs
@@ -103,11 +103,24 @@ pub struct HiveConfig {
     /// member firing it on a noisy read removes an option for the whole room.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refutation_cap: Option<u32>,
-    /// Turns one member may take before the attention market damps its bids.
+    /// **Percent** of the room's grounded share above which a member's bids are
+    /// damped — not a count of turns.
     ///
-    /// Defaults to `EpisodePolicy::DEFAULT` (50), which is effectively off for
-    /// any budget a desk would actually run. Lower it on a desk where one
-    /// member reliably takes the floor.
+    /// The library compares `share * 100 > total * cap`
+    /// (`tinyhivemind_hive::attention::exceeds`), so `50` — the default — means
+    /// "damp a member holding more than half the grounded share", and it is
+    /// effectively off for any desk that is actually sharing the floor.
+    ///
+    /// The units matter and this comment used to get them wrong, which is how
+    /// shipped manifests came to set `dominance_cap = 3` believing it meant
+    /// three turns. It means **three percent**: with a handful of grounded
+    /// contributions on the floor, every member that has said anything at all
+    /// exceeds it and takes the dominance penalty on every subsequent bid,
+    /// which damps the whole room rather than its loudest seat.
+    ///
+    /// Lower it below 50 on a desk where one member reliably takes the floor,
+    /// but keep it a share: the benchmark sweeps this at 40 and 60
+    /// (`vendor/tinyhivemind/crates/tinyhivemind-hive/examples/bench/sweep.rs`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dominance_cap: Option<u32>,
     /// Distinct supporters after which restating a topic scores nothing.


### PR DESCRIPTION
Follow-up to #2109. Two wording defects a live run printed, and one desk setting changed from measurement rather than from argument.

## Two defects the live run printed

Both were visible in a real `companies/vending_machine_co` transcript, and neither had a test.

**`The room 1 went unanswered.`** — `referral_summary` hung every clause off one `"The room …"` prefix, but the failure and cap counts carry their own subject. An episode whose only referral fact was a failure produced that sentence. The summary is now assembled as sentences: the clauses that continue "the room" join under it, the counted ones stand alone.

**`@route_planner on the Operations desk desk did not answer the question.`** — the note appended `" desk"` unconditionally, and every desk in this repo is *named* "… desk". `named_desk` now adds the word only when the name does not already end in it, so `"Operations desk"` and `"eng"` both read correctly.

## One setting changed, from the benchmark

`companies/vending_machine_co`'s `intel` desk dropped `require_evidential` and went from a 6- to an 8-turn budget. It is the only knob in the bundle set from measurement.

Stacking `require_evidential` on a **two-member** desk whose quorum is already unanimity means a decision needs *both* seats to file a citation that chains to a stated fact. The deliberation benchmark (`vendor/tinyhivemind/crates/tinyhivemind-hive/examples/bench`, 2000 seeded rooms, `--seed 1`):

| `--agents` | `hive+` decided | `hive+ev` decided | `hive+` correct | `hive+ev` correct |
|---|---|---|---|---|
| 4 | 94.6% | 40.0% | 76.8% | 37.7% |
| 3 | 99.8% | 70.0% | 71.6% | 55.8% |
| 2 | 91.6% | **36.2%** | 63.6% | **30.7%** |

Live runs agreed: across 19 episodes the company decided **10**, and the signals desk spent its budget without deciding in nearly every episode it opened.

`ops` and `commercial` keep the rule. They are larger, and their seats read hard figures off the `vending` MCP on almost every turn, so a citation that reaches a fact is cheap there in a way it is not on a desk whose job is to weigh a signal nobody has measured yet. I did **not** blanket-remove it on that table alone — the benchmark's task is averaging noisy private numbers, where evidence deposits are synthetic, and a `--blind-evidence` control (first turns are deposits, closer to how these desks behave) narrows the gap at two members to 44.1% → 41.3%. The change is where the benchmark and the live runs agree.

## Benchmark evaluation of the aside work in #2109

Recorded here because #2109 shipped the mechanism and this is the measurement of it. `hive+along` is ADR 0011 — the aside riding alongside a turn — which #2109 implements.

**Hidden profile, 2000 rooms:**

```
hive+along − hive+:  +0.0 [+0.0, +0.0]
hive+aside − hive+:  -0.1 [-0.4, +0.2]     (turn-spending)
hive+mute  − hive+:  -0.2 [-0.5, +0.0]
hive+fact° − hive+: +27.6 [+25.3, +29.9]   (off the floor)
hive+pooled − hive+: +75.5 [+73.6, +77.4]  (ceiling)
```

The zero-width interval on `hive+along` is the point: riding alongside is **bit-identical** to the baseline, so the episode genuinely cannot see the aside row — ADR 0011's first property, measured rather than asserted. On the uniform profile the turn-spending arms cost 2.2 points and 1.4 turns/episode (76.6% vs 78.8%, 8.26 vs 6.84) while `hive+along` matches `hive+` exactly on both.

So asides are now **free, and still not worth points**. Their claim is auditability and bounded independence, which is what the spec says. The lever this benchmark actually shows is `hive+fact°` (+27.6) — an exchange held *off the floor*, before the episode opens — and that is a different mechanism from an aside, worth its own issue rather than a change here.

Harness self-check (`--stats-check`) passes, so these intervals are the harness's own.

## Verification

`cargo fmt --all --check` clean · `clippy --all-targets --features openhuman,mcp -- -D warnings` clean · **7115 lib tests pass** (103 hivemind, +2 regressions covering exactly the two sentences above).

Co-authored-by: Medulla <medulla@tinyhumans.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected referral summaries so unanswered-question counts use proper singular and plural grammar.
  * Improved referral messages to avoid duplicating “desk” in desk names.
  * Clarified episode-close summaries when questions go unanswered or are declined.

* **Configuration**
  * Increased deliberation budgets for the intelligence and signals desks from 6 to 8 turns.
  * Updated evidential-support requirements for the intelligence and signals desks.
  * Increased repetition limits for desk deliberations.
  * Updated operations and commercial dominance limits to use grounded-share percentages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->