### PR TITLE
feat(console): sign out from General settings

### DIFF
--- a/frontend/src/api/transport/desktop.ts
+++ b/frontend/src/api/transport/desktop.ts
@@ -140,6 +140,43 @@ export function adoptSessionIntoCore(id: string, session: string): Promise<void>
 }
 
 /**
+ * Drops this machine's stored session for a connection — the sign-out leg of
+ * {@link adoptSessionIntoCore}.
+ *
+ * Local only, and deliberately so: the host's own session record is revoked by
+ * `auth/logout` before this runs, and `oc_forget_device` is documented as not
+ * touching it. Signing out on this machine must not reach into another one.
+ *
+ * Sequenced behind whatever is parked under this id for the same reason the
+ * adoption is: a forget that overtook an in-flight `oc_connect` would be undone
+ * by the registration landing after it, leaving the keychain holding a session
+ * the person has already signed out of.
+ *
+ * Rejects on failure rather than swallowing it, again like the adoption: a
+ * credential that could not be cleared is something the person signing out has
+ * to be told about, not a surprise sign-in on the next launch. The parked
+ * promise is the settled-either-way one so nothing resurfaces.
+ */
+export function forgetSessionInCore(id: string): Promise<void> {
+  const desktop = tauriCore();
+  if (!desktop) return Promise.resolve();
+  const previous = registrations.get(id) ?? Promise.resolve();
+  const forgotten = previous.then(() =>
+    desktop.invoke<void>("oc_forget_device", { connectionId: id }),
+  );
+  registrations.set(
+    id,
+    forgotten.then(
+      () => undefined,
+      (error: unknown) => {
+        console.error(`[desktop] could not forget the session for ${id}`, error);
+      },
+    ),
+  );
+  return forgotten;
+}
+
+/**
  * Drops a host from the core.
  *
  * Sequenced after any registration still in flight. This and

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -27,6 +27,7 @@ import type { Transport } from "@/api/transport";
 import {
   closeSshTunnel,
   forgetConnection,
+  forgetSessionInCore,
   openSshTunnel,
   adoptSessionIntoCore,
   registerConnection,
@@ -719,6 +720,41 @@ export async function adoptSession(id: ConnectionId, session: string): Promise<v
     return;
   }
   adoptCredential(id, { kind: "session", value: session });
+}
+
+/**
+ * Signs this connection out, locally — the other half of {@link adoptSession}.
+ *
+ * The host's session record is revoked by `auth/logout` before this is called;
+ * this is what makes the console stop *acting* signed in. Three things, in the
+ * order they have to happen:
+ *
+ * 1. The core forgets its keychain entry, on the desktop. Left in place, the
+ *    next launch's `oc_connect` would present a token the host has already
+ *    revoked and the row would come back as a mysterious refusal rather than
+ *    as a clean sign-in screen. Awaited, so a keychain that refused the
+ *    deletion surfaces to the person signing out instead of ambushing them
+ *    later — the same reason `adoptSession` awaits its write.
+ * 2. The credential goes back to `cookie`, which is what a connection that has
+ *    never signed in carries. This also drops the token out of the profile
+ *    store, so a reload does not resurrect it. A no-op for the same-origin
+ *    browser case, where the credential already *is* the (now-cleared) cookie.
+ * 3. The row is marked `unauthenticated`, which is the state `ConnectionConsole`
+ *    renders the sign-in screen from. Set here rather than left to the next
+ *    401 so the console changes the moment the person asks it to, without a
+ *    round trip they would watch it fail.
+ *
+ * Per connection, like every other status write here: signing out of one host
+ * leaves the others exactly as they were.
+ */
+export async function forgetSession(id: ConnectionId): Promise<void> {
+  if (isDesktopRuntime()) {
+    await forgetSessionInCore(id);
+  }
+  adoptCredential(id, { kind: "cookie" });
+  // After the reseat, not before: `adoptCredential` rebuilds the record from
+  // the one it found, so a status written first would be copied back over.
+  patch(id, { status: "unauthenticated" });
 }
 
 /**

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -3,6 +3,7 @@ import {
   Compass,
   Flag,
   Globe,
+  LogOut,
   Pause,
   Play,
   Power,
@@ -13,6 +14,7 @@ import {
 import { toast } from "sonner";
 
 import type { LifecycleAction, OpenCompanyClient } from "@/api/client";
+import { fetchAuthConfig, logout, me as fetchMe, type Me } from "@/api/auth";
 import { memoryEngine, type MemoryEngineState } from "@/api/memory";
 import { ApiError } from "@/api/types";
 import { PageHeader } from "@/components/page-header";
@@ -47,8 +49,11 @@ import { withHostParam } from "@/hooks/use-host-route";
 import { restartTour } from "@/tour/state";
 import { preloadTour } from "@/tour/TourController";
 import { useLocalScope } from "@/connections/ConnectionContext";
+import { forgetSession } from "@/connections/registry";
+import type { ConnectionId } from "@/connections/types";
 import { lifecycleAffordances } from "@/lib/lifecycle-controls";
 import { canCreateCompanies } from "@/components/create-company-dialog";
+import { personName } from "@/lib/person";
 
 interface Props {
   client: OpenCompanyClient;
@@ -146,6 +151,15 @@ export function SettingsView({ client, company, feed, onFlag, onResetCompany }: 
             </InfoRow>
           </CardContent>
         </Card>
+
+        {/* Account.
+
+            Beside Connection on purpose: that card says where this console is
+            pointed, and this one says who it is pointed as. Signing out is the
+            one control on this page that ends the session rather than changing
+            the company, so it sits with the identity it ends rather than among
+            the company controls below. */}
+        <AccountCard client={client} company={company} connectionId={scope.connection} />
 
         <MemoryEngineCard client={client} company={company} />
 
@@ -452,6 +466,132 @@ function ConfirmAction({
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+  );
+}
+
+/**
+ * Who this console is signed in as, and the way to stop being them.
+ *
+ * Renders nothing at all on a company with no sign-in (`mode: "none"` — the
+ * desktop's default, where the principal is resolved from the request rather
+ * than from a session). There is genuinely no account there: `auth/logout`
+ * refuses with `auth_mode`, and there would be no sign-in screen to land on
+ * afterwards. A card that named a local owner and offered a button whose only
+ * outcome is an error would be worse than the silence.
+ *
+ * Renders nothing while `me` is still in flight or has 401'd either, for the
+ * same reason `ProfileRow` does: a card whose whole content is an identity has
+ * nothing to say without one.
+ *
+ * Exported for the same reason `LifecycleControls` is: rendering the whole
+ * `SettingsView` to assert on one card would drag in
+ * `ExternalHarnesses`/`PolicySettings`/`DomainSettings` and every route they
+ * fetch, none of which this behaviour touches (`settings-sign-out.test.ts`).
+ */
+export function AccountCard({
+  client,
+  company,
+  connectionId,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  connectionId: ConnectionId;
+}) {
+  const [me, setMe] = useState<Me | null>(null);
+  const [hasSignIn, setHasSignIn] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    // Keyed by the scope they were fetched for, and cleared first — the same
+    // rule `ProfileRow` follows. A company switch must not leave the previous
+    // company's person on screen above a Sign out scoped to the new one.
+    setMe(null);
+    setHasSignIn(false);
+    void fetchMe(client, company)
+      .then((who) => {
+        if (live) setMe(who);
+      })
+      // A 401, or a company with no `me` to read. Not worth a toast on a
+      // settings card: the card simply does not appear.
+      .catch(() => {});
+    void fetchAuthConfig(client, company)
+      .then((config) => {
+        if (live) setHasSignIn(config.mode !== "none");
+      })
+      .catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
+
+  /**
+   * Ends the session, and puts the console back on its sign-in screen.
+   *
+   * Both legs matter, in this order:
+   *
+   * 1. `auth/logout` revokes the session server-side and clears the cookie. It
+   *    has to go first, while the credential still authenticates — a console
+   *    that forgot its token and then asked would be asking anonymously, and
+   *    the session would outlive the sign-out on the host.
+   * 2. `forgetSession` drops whatever this machine was carrying (a cross-origin
+   *    token, a desktop keychain entry) and marks the connection
+   *    `unauthenticated`, which is the state `ConnectionConsole` renders
+   *    `Login` from. Without it this page would sit here, signed out, until
+   *    some later request happened to 401.
+   *
+   * A failing first leg reports and stays put rather than signing out locally
+   * anyway: a console on its sign-in screen while the host still honours the
+   * session it believes it revoked is the worse of the two states, and only one
+   * of them is something the person can see and retry from.
+   */
+  async function signOut() {
+    setSigningOut(true);
+    try {
+      await logout(client, company);
+      await forgetSession(connectionId);
+    } catch (error) {
+      setSigningOut(false);
+      toast.error(error instanceof Error ? error.message : "Couldn't sign out.");
+    }
+    // No `finally`: a sign-out that succeeded has already replaced this whole
+    // subtree with the sign-in screen, and clearing the flag on an unmounted
+    // component is a React warning about a button nobody can see.
+  }
+
+  if (!hasSignIn || !me || typeof me !== "object" || !("email" in me)) return null;
+
+  return (
+    <Card data-testid="settings-account">
+      <CardHeader>
+        <CardTitle className="text-base">Account</CardTitle>
+        <CardDescription>Who this console is signed in as.</CardDescription>
+        <CardAction>
+          <Button
+            variant="outline"
+            disabled={signingOut}
+            data-testid="settings-sign-out"
+            onClick={() => void signOut()}
+          >
+            <LogOut className="size-4" /> Sign out
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="space-y-0 divide-y">
+        <InfoRow label="Signed in as">
+          <span className="text-sm">{personName(me)}</span>
+        </InfoRow>
+        {/* The address beside the name rather than instead of it: the name may
+            be a display name somebody chose, and the address is what the roster
+            and every invite are keyed on. */}
+        <InfoRow label="Email">
+          <span className="font-mono text-xs">{me.email}</span>
+        </InfoRow>
+        <InfoRow label="Role">
+          <span className="text-sm capitalize">{me.role}</span>
+        </InfoRow>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/frontend/test/unit/settings-sign-out.test.ts
+++ b/frontend/test/unit/settings-sign-out.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { AuthMode, Me } from "@/api/auth";
+import type { OpenCompanyClient } from "@/api/client";
+import { addConnection, getConnection, resetConnections } from "@/connections/registry";
+import type { ConnectionId } from "@/connections/types";
+import { AccountCard } from "@/views/SettingsView";
+
+/**
+ * Signing out, from General settings' Account card.
+ *
+ * Two facts, and they are separate:
+ *
+ * - The card exists only where signing out means something. A `none`-mode
+ *   company resolves its principal from the request, so `/auth/me` answers and
+ *   an identity is there to render — but `auth/logout` refuses with
+ *   `auth_mode` and there is no sign-in screen to land on. A card with a button
+ *   whose only outcome is an error is worse than no card.
+ * - Pressing it revokes the session *and* puts the connection back to
+ *   `unauthenticated`, which is the state `ConnectionConsole` renders `Login`
+ *   from. Only doing the first would leave the console drawing a signed-out
+ *   company's shell until some later request happened to 401.
+ */
+
+function meFor(company: string): Me {
+  return {
+    id: `${company}-me`,
+    email: `ada@${company}.test`,
+    displayName: "Ada Lovelace",
+    role: "admin",
+    company,
+    hasPassword: false,
+    mustChangePassword: false,
+  };
+}
+
+function host(mode: AuthMode, logoutFails = false) {
+  const posts: string[] = [];
+  const client = {
+    scopeFor: (company: string | null) =>
+      company === null ? "/api/v1/company" : `/api/v1/companies/${company}`,
+    get: async (path: string) => {
+      if (path.endsWith("/auth/config")) {
+        return { mode, passwords: mode === "email", magicLink: true };
+      }
+      return meFor("alpha");
+    },
+    post: async (path: string) => {
+      posts.push(path);
+      if (logoutFails) throw new Error("the host could not be reached");
+      return { ok: true };
+    },
+  } as unknown as OpenCompanyClient;
+  return { client, posts };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let connectionId: ConnectionId;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(AccountCard, { client, company: "alpha", connectionId }));
+  });
+}
+
+function signOutButton(): HTMLButtonElement | null {
+  return container.querySelector('[data-testid="settings-sign-out"]');
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  localStorage.clear();
+  resetConnections();
+  connectionId = addConnection({ baseUrl: "https://acme.example" });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  resetConnections();
+  localStorage.clear();
+});
+
+describe("the Account card in General settings", () => {
+  it("names who you are signed in as, and offers Sign out", async () => {
+    const { client } = host("email");
+    await show(client);
+    expect(container.textContent).toContain("Ada Lovelace");
+    expect(container.textContent).toContain("ada@alpha.test");
+    expect(signOutButton()).toBeTruthy();
+  });
+
+  it("renders nothing on a company with no sign-in", async () => {
+    const { client } = host("none");
+    await show(client);
+    expect(container.querySelector('[data-testid="settings-account"]')).toBeNull();
+  });
+
+  it("revokes the session and hands the connection back to the sign-in screen", async () => {
+    const { client, posts } = host("email");
+    await show(client);
+
+    await act(async () => {
+      signOutButton()?.click();
+    });
+
+    expect(posts).toEqual(["/api/v1/companies/alpha/auth/logout"]);
+    // What `ConnectionConsole` reads to draw `Login` instead of the shell.
+    expect(getConnection(connectionId)?.status).toBe("unauthenticated");
+    // And nothing is carried forward for a reload to sign back in with.
+    expect(getConnection(connectionId)?.credential).toEqual({ kind: "cookie" });
+  });
+
+  it("stays signed in when the host refuses the logout", async () => {
+    const { client } = host("email", true);
+    await show(client);
+
+    await act(async () => {
+      signOutButton()?.click();
+    });
+
+    // The local credential must survive a failed revoke: dropping it would put
+    // this console on a sign-in screen while the host still honours the session.
+    expect(getConnection(connectionId)?.status).not.toBe("unauthenticated");
+    expect(signOutButton()?.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The console could sign a person in and never sign them out. A session ended only by expiring, by an admin revoking it from People, or by clearing cookies — so a shared or borrowed machine had no way to leave a company.

This adds an **Account** card to General settings, between Connection and Lifecycle: that card says where this console is pointed, this one says who it is pointed as, and carries **Sign out**.

Signing out revokes the session server-side first, while the credential still authenticates, then clears whatever this machine was carrying — a cross-origin token, or the desktop core's keychain entry via the already-registered-but-unused `oc_forget_device` — and marks the connection `unauthenticated`, which is the state `ConnectionConsole` already renders `Login` from. Ordering matters both ways: a console that forgot its token and *then* asked would be asking anonymously and the session would outlive the sign-out on the host, and a failed revoke reports and stays put rather than signing out locally anyway — a console on its sign-in screen while the host still honours the session it believes it revoked is the worse of the two states, and only one of them is something a person can see and retry from.

The card renders nothing on a company with no sign-in (`mode: "none"`, the desktop's default). The principal there is resolved from the request rather than from a session, so `/auth/me` answers with the local owner and an identity is there to draw — but `auth/logout` refuses with `auth_mode` and there is no sign-in screen to land on, so the control would be a button whose only outcome is an error.

**Deliberately does not touch running work.** A chat turn is a process-local `tokio::spawn` owned by the host and serialised on the per-company cycle mutex (`runtime/turn_sweep.rs`); the console is only a viewer over SSE. Sessions are per-user, so halting inference on sign-out would let one person closing their laptop stop work the rest of the company depends on. Pause, the emergency stop, and `POST …/workflows/runs/{id}/cancel` remain the controls that stop work. The SSE stream and its 30-second reconciliation timer are torn down on the way out, because `AppShell` unmounts when the connection flips — so there is no retry storm against a revoked session.

## API Or Behavior Changes

- New console affordance only. No new HTTP routes: `POST …/auth/logout` and `GET …/auth/config` already existed and are unchanged.
- New frontend exports: `forgetSession` (`connections/registry.ts`), `forgetSessionInCore` (`api/transport/desktop.ts`), and `AccountCard` (`views/SettingsView.tsx`, exported for its test the same way `LifecycleControls` is).
- Wires the existing `oc_forget_device` Tauri command, which was registered in `lib.rs` but called by nothing.

## Tests

No Rust changed, so the cargo lanes were not run for this diff.

- [x] `npm run typecheck` (`tsc -b`) — clean
- [x] `npm run typecheck:unit` — clean
- [x] `npm test` — `test/unit/settings-sign-out.test.ts` passes (4 cases: the identity is named; the card is absent in `none` mode; sign-out posts the logout and leaves the connection `unauthenticated` with the credential cleared; a refused logout leaves the local credential intact)

Also verified by hand against a local `opencompany serve`: signed in over a magic link, opened Settings → Sign out, landed on the sign-in screen; `auth/me` then answers 401 with no cookie left, and a reload stays signed out. Against a second host in `mode = "none"`, General settings renders normally with no Account card and no Sign out.

⚠️ **The `Console` job is red on this branch, and not because of this change.** `npm test` reports `4 failed | 492 passed` — 10 failures across `settings-lifecycle-reset-button`, `create-company-wallet-mode`, `create-company-dialog-preflight-race` and `connection-console-switch-known-status`. The new `settings-sign-out` test is in the 492 that pass, and all three typecheck steps pass.

Those 10 are pre-existing on `main`, from b8a3e2e97 ("gate company creation where every trigger asks, not per button"). That commit routes the picker's New-company button, the per-card Reset, the no-company trigger and Settings' Reset / Start clean through `canCreateCompanies()` — which is `!COMPANY_SWITCHING_HIDDEN && client.carriesPlatformBearer`, and `COMPANY_SWITCHING_HIDDEN` is `true` in `product-scope.ts`. So those controls no longer render, while the tests still assert that they do; the commit's own file list (`create-company-dialog.tsx`, `SettingsView.tsx`, `app-shell.tsx`) maps one-to-one onto the four failing files. It landed on 2026-09-04, three days before this branch was cut off `efecd6061`, which contains it.

I confirmed the isolation locally as well: reverting this diff against an unchanged dependency tree reproduces exactly the same 10 failures. This change touches `LifecycleControls`' file but not that component — it only adds `AccountCard` and its render site.

Happy to fix those 10 in a separate PR (they need either the gate relaxed for a non-platform client or the tests taught about it) and rebase this one on top, if that's the preference — I left it out of this diff rather than mixing an unrelated fix into a sign-out change.

## Documentation

No docs change. This adds a console control over existing routes; `docs/spec/runtime/users.md` describes the auth modes and session lifecycle, both of which are unchanged.
