### PR TITLE
fix(runtime): install git in the runtime image for workspace checkpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,8 +145,9 @@ FROM debian:bookworm-slim AS runtime
 # files must be present to load the binary). No-ops for the small builds.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       ca-certificates curl libssl3 \
+       ca-certificates curl git libssl3 \
        libx11-6 libxi6 libxtst6 libxrandr2 libxcb1 libxkbcommon0 \
+    && git --version \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

The workspace checkpoint feature shells out to `git` at runtime. `src/harness/built_in/checkpoint.rs` runs `git init` / `git add` / `git commit` / `git log` after every tool call when `workspace_git_enabled` is on, and the flag is threaded into the company builder at `src/bin/opencompany.rs:579`. The runtime stage of the Dockerfile installs `ca-certificates`, `curl` and `libssl3` but **not** `git`, so checkpointing fails at runtime with `git: command not found` — even though `build.rs` only needs git at compile time.

## Change

Add `git` to the runtime-stage `apt-get install` list and verify it with `git --version` in the same RUN layer (fails the build early if the package ever disappears).

## Evidence

Isolated runtime-stage container smoke on an idle node (not a full application E2E, no Rust build):

| Stage | Result |
|---|---|
| BEFORE (runtime stage, unpatched) | `git: command not found`, checkpoint flow exits 127 |
| AFTER (runtime stage, +git) | `git version 2.39.5`, full `init`/`add`/`commit`/`log` sequence OK, exit 0 |

`git` is not pulled in transitively by the runtime deps (`ca-certificates curl libssl3 libx11-6 libxi6 libxtst6 libxrandr2 libxcb1 libxkbcommon0`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added Git to the runtime environment.
  - Added an installation verification step to confirm Git is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->