### PR TITLE
fix(console): pin the create/reset flow against the build that offers it

### DIFF
--- a/frontend/test/unit/connection-console-switch-known-status.test.ts
+++ b/frontend/test/unit/connection-console-switch-known-status.test.ts
@@ -9,6 +9,32 @@ import type { AppSpec, CompanyStatus } from "@/api/types";
 import { HostsProvider } from "@/connections/HostsContext";
 
 /**
+ * These exercise the create/reset flow itself, so they need the build where the
+ * product offers it.
+ *
+ * `canCreateCompanies` is `!COMPANY_SWITCHING_HIDDEN && carriesPlatformBearer`
+ * (b8a3e2e97), and `COMPANY_SWITCHING_HIDDEN` ships `true` — so in the shipped
+ * tree every trigger below is hidden and the dialog's own preflight never runs.
+ * Left unmocked, these files would assert against controls the product
+ * deliberately does not render, which is what broke them: they would be pinning
+ * the flag rather than the flow.
+ *
+ * The *hide* is not weakened by this. It has its own coverage, deliberately
+ * unmocked, in `product-scope-hidden-surfaces.test.ts` ("company creation is
+ * gone from every trigger, not just the switcher"), which is where a regression
+ * in the gate belongs. What is left here is the flow underneath it — including
+ * the #1894 pre-archive guard, whose whole job is to keep a reset from
+ * archiving a company before it knows the replacement has a usable admin. That
+ * logic is still in the tree and still worth failing a build over the day the
+ * flag flips back.
+ */
+vi.mock("@/product-scope", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/product-scope")>()),
+  COMPANY_SWITCHING_HIDDEN: false,
+}));
+
+
+/**
  * Codex review on #1828 (PR comment 3864628314): `switchCompany`'s only
  * caller that already holds fresh data for the company it is entering —
  * `onCompanyCreated`, right after a create or reset provisions the

--- a/frontend/test/unit/create-company-dialog-preflight-race.test.ts
+++ b/frontend/test/unit/create-company-dialog-preflight-race.test.ts
@@ -9,6 +9,32 @@ import type { CompanyStatus, ProvisioningInfo } from "@/api/types";
 import { CreateCompanyDialog } from "@/components/create-company-dialog";
 
 /**
+ * These exercise the create/reset flow itself, so they need the build where the
+ * product offers it.
+ *
+ * `canCreateCompanies` is `!COMPANY_SWITCHING_HIDDEN && carriesPlatformBearer`
+ * (b8a3e2e97), and `COMPANY_SWITCHING_HIDDEN` ships `true` — so in the shipped
+ * tree every trigger below is hidden and the dialog's own preflight never runs.
+ * Left unmocked, these files would assert against controls the product
+ * deliberately does not render, which is what broke them: they would be pinning
+ * the flag rather than the flow.
+ *
+ * The *hide* is not weakened by this. It has its own coverage, deliberately
+ * unmocked, in `product-scope-hidden-surfaces.test.ts` ("company creation is
+ * gone from every trigger, not just the switcher"), which is where a regression
+ * in the gate belongs. What is left here is the flow underneath it — including
+ * the #1894 pre-archive guard, whose whole job is to keep a reset from
+ * archiving a company before it knows the replacement has a usable admin. That
+ * logic is still in the tree and still worth failing a build over the day the
+ * flag flips back.
+ */
+vi.mock("@/product-scope", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/product-scope")>()),
+  COMPANY_SWITCHING_HIDDEN: false,
+}));
+
+
+/**
  * Codex review on #1943 (PR comment 3894416362): on a wallet-mode host with a
  * slow or pending provisioning preflight, the dialog used to open with its
  * name already filled and the submit button enabled while `authMode` still

--- a/frontend/test/unit/create-company-wallet-mode.test.ts
+++ b/frontend/test/unit/create-company-wallet-mode.test.ts
@@ -13,6 +13,32 @@ import {
 } from "@/components/create-company-dialog";
 
 /**
+ * These exercise the create/reset flow itself, so they need the build where the
+ * product offers it.
+ *
+ * `canCreateCompanies` is `!COMPANY_SWITCHING_HIDDEN && carriesPlatformBearer`
+ * (b8a3e2e97), and `COMPANY_SWITCHING_HIDDEN` ships `true` — so in the shipped
+ * tree every trigger below is hidden and the dialog's own preflight never runs.
+ * Left unmocked, these files would assert against controls the product
+ * deliberately does not render, which is what broke them: they would be pinning
+ * the flag rather than the flow.
+ *
+ * The *hide* is not weakened by this. It has its own coverage, deliberately
+ * unmocked, in `product-scope-hidden-surfaces.test.ts` ("company creation is
+ * gone from every trigger, not just the switcher"), which is where a regression
+ * in the gate belongs. What is left here is the flow underneath it — including
+ * the #1894 pre-archive guard, whose whole job is to keep a reset from
+ * archiving a company before it knows the replacement has a usable admin. That
+ * logic is still in the tree and still worth failing a build over the day the
+ * flag flips back.
+ */
+vi.mock("@/product-scope", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/product-scope")>()),
+  COMPANY_SWITCHING_HIDDEN: false,
+}));
+
+
+/**
  * The wallet-mode create/reset flow (issues #1914, #1894).
  *
  * The dialog reads a provisioning preflight on open. On a wallet-mode host it

--- a/frontend/test/unit/settings-lifecycle-reset-button.test.ts
+++ b/frontend/test/unit/settings-lifecycle-reset-button.test.ts
@@ -10,6 +10,32 @@ import type { CompanyStatus } from "@/api/types";
 import { LifecycleControls } from "@/views/SettingsView";
 
 /**
+ * These exercise the create/reset flow itself, so they need the build where the
+ * product offers it.
+ *
+ * `canCreateCompanies` is `!COMPANY_SWITCHING_HIDDEN && carriesPlatformBearer`
+ * (b8a3e2e97), and `COMPANY_SWITCHING_HIDDEN` ships `true` — so in the shipped
+ * tree every trigger below is hidden and the dialog's own preflight never runs.
+ * Left unmocked, these files would assert against controls the product
+ * deliberately does not render, which is what broke them: they would be pinning
+ * the flag rather than the flow.
+ *
+ * The *hide* is not weakened by this. It has its own coverage, deliberately
+ * unmocked, in `product-scope-hidden-surfaces.test.ts` ("company creation is
+ * gone from every trigger, not just the switcher"), which is where a regression
+ * in the gate belongs. What is left here is the flow underneath it — including
+ * the #1894 pre-archive guard, whose whole job is to keep a reset from
+ * archiving a company before it knows the replacement has a usable admin. That
+ * logic is still in the tree and still worth failing a build over the day the
+ * flag flips back.
+ */
+vi.mock("@/product-scope", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/product-scope")>()),
+  COMPANY_SWITCHING_HIDDEN: false,
+}));
+
+
+/**
  * The Reset / Start clean button (#1807, SettingsView.tsx `LifecycleControls`)
  * had no render test of its own — tinysweeper flagged the gap (PR comment
  * 3879183959) against the repo's "every behavior change gets a focused test"


### PR DESCRIPTION
## Summary

`main` has been red on the `Console` job since b8a3e2e97 — `npm test` reports `4 failed | 492 passed`, ten failures across four files. This is not a flake and not runner contention; it reproduces on a clean `npm ci` and locally.

b8a3e2e97 ("gate company creation where every trigger asks, not per button") moved company creation behind one funnel — `canCreateCompanies` became `!COMPANY_SWITCHING_HIDDEN && client.carriesPlatformBearer` — and added the test that pins the hide. What it did not do is update the four older files that assert the *presence* of the controls it had just hidden:

| File | What broke |
|---|---|
| `settings-lifecycle-reset-button` | Reset / Start clean no longer renders |
| `create-company-wallet-mode` | the dialog's preflight no longer runs, so the wallet field never appears |
| `create-company-dialog-preflight-race` | same preflight, so submit is never held |
| `connection-console-switch-known-status` | the no-company New trigger is gone, and the test opens the dialog through it |

`COMPANY_SWITCHING_HIDDEN` ships `true`, so `canCreateCompanies` is `false` for every client. Note this reaches past trigger visibility: `create-company-dialog.tsx` also consults it internally to arm and run the provisioning preflight, which is why two of these files fail on field-level assertions rather than on a missing button.

## The fix

Those four premises are now *unreachable* rather than wrong — the flow they cover is still in the tree, it is just not offered in the shipped build. So each file declares the configuration it needs (`COMPANY_SWITCHING_HIDDEN: false`, other exports untouched via `importOriginal`) instead of asserting against one the product does not ship.

**This does not weaken the hide.** That has its own deliberately-unmocked coverage in `product-scope-hidden-surfaces.test.ts` — "company creation is gone from every trigger, not just the switcher", added by b8a3e2e97 itself — which is where a regression in the gate belongs, and which still passes untouched. I ran it alongside these four to confirm.

What the four keep testing is the flow underneath the gate, including the #1894 pre-archive guard, whose whole job is to stop a reset archiving a company before it knows the replacement has a usable admin. Getting to green by deleting them would have thrown away coverage of a data-loss path that is still live code.

I considered the alternative — splitting `canCreateCompanies` into a product-scope predicate for triggers and a capability-only one for the dialog's internals — and did not do it. With the flag `true` no trigger renders so the dialog never opens, and with it `false` the two predicates are identical; the conflation is inert in production either way. That would be changing shipped code to suit the tests.

**No production code changes.** The gate behaves as intended.

## API Or Behavior Changes

None. Test-only.

## Tests

No Rust changed, so the cargo lanes were not run for this diff.

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:unit` — clean
- [x] `npm test` — **495 files, 4584 tests, 0 failures** (was `4 failed | 492 passed`)

## Documentation

None needed — no behaviour or API change.

---

Found while opening #2118, whose `Console` job is red for this reason and nothing of its own. Once this lands I'll rebase that one; it should go green with no changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for company creation and reset workflows.
  - Verified provisioning preflight behavior while checks are pending and after completion.
  - Added coverage for wallet mode, lifecycle reset controls, click behavior, and in-progress states.
  - Confirmed that company-switching controls remain hidden in the shipped experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->