### PR TITLE
fix(console): gate the Search, Hosting, Domain and SMTP write forms to admins

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -13,6 +13,7 @@
 // still the right trade where the alternative is no console at all.
 
 import type { OpenCompanyClient } from "./client";
+import { ApiError } from "./types";
 
 /** What a company may call a user. */
 export type UserRole = "admin" | "member";
@@ -240,6 +241,23 @@ export async function loginWithPassword(
 /** Who the current session belongs to; throws 401 when signed out. */
 export async function me(client: OpenCompanyClient, company: string | null): Promise<Me> {
   return client.get<Me>(`${client.scopeFor(company)}/auth/me`);
+}
+
+/**
+ * Whether {@link me} failed because there is confirmedly no session, rather
+ * than for some other reason.
+ *
+ * A caller falling back to a platform bearer's own authority on *any* {@link
+ * me} failure (codex review) would also fall back on a network error, a
+ * timeout, or a `5xx` — none of which mean "no session"; a member's session
+ * could still be live and would still take precedence on the host. The
+ * host's own `no_session()` answers `401` with `code: "unauthorized"` from
+ * its own `{error, code}` envelope, which {@link ApiError.fromHost}
+ * distinguishes from a `401` (or any other status) synthesised between the
+ * browser and the host giving up before reaching it at all.
+ */
+export function hasNoSession(err: unknown): boolean {
+  return err instanceof ApiError && err.fromHost && err.status === 401 && err.code === "unauthorized";
 }
 
 /** Sets or replaces the signed-in user's own password. */

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -248,7 +248,7 @@ export async function me(client: OpenCompanyClient, company: string | null): Pro
  * than for some other reason.
  *
  * A caller falling back to a platform bearer's own authority on *any* {@link
- * me} failure (codex review) would also fall back on a network error, a
+ * me} failure would also fall back on a network error, a
  * timeout, or a `5xx` — none of which mean "no session"; a member's session
  * could still be live and would still take precedence on the host. The
  * host's own `no_session()` answers `401` with `code: "unauthorized"` from

--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -340,7 +340,7 @@ export function DomainCard({ client, company }: Props) {
         // host will actually authorize on. A network error, a timeout, or a
         // `5xx` is not that confirmation — a member's session could still be
         // live and still take precedence on the host — so those stay
-        // non-admin rather than assuming the bearer wins (codeRabbit review).
+        // non-admin rather than assuming the bearer wins.
         admin = client.carriesPlatformBearer && hasNoSession(err);
       }
       if (live) setCanManage(admin);
@@ -695,7 +695,7 @@ export function SmtpCard({ client, company }: Props) {
         // error, a timeout, or a `5xx` is not that confirmation — a
         // member's session could still be live and still take precedence
         // on the host — so those stay non-admin rather than assuming the
-        // bearer wins (codeRabbit review).
+        // bearer wins.
         admin = client.carriesPlatformBearer && hasNoSession(err);
       }
       if (live) setCanManage(admin);

--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -1,7 +1,18 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, Copy, Globe, Loader2, Mail, ShieldAlert, TriangleAlert, X } from "lucide-react";
+import {
+  Check,
+  Copy,
+  Globe,
+  Info,
+  Loader2,
+  Mail,
+  ShieldAlert,
+  TriangleAlert,
+  X,
+} from "lucide-react";
 import { toast } from "sonner";
 
+import { me as fetchMe } from "@/api/auth";
 import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import {
@@ -14,7 +25,7 @@ import {
   verifyDomain,
 } from "@/api/domain";
 import { getSmtp, saveSmtp, type SmtpSecurity, type SmtpStatus, testSmtp } from "@/api/smtp";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -92,10 +103,16 @@ function isUnwired(err: unknown): boolean {
  *
  * Neither feature is ready, so `DomainSettings` renders `ComingSoon` previews
  * and mounts neither card. `DomainCard` and `SmtpCard` below are exported and
- * otherwise unchanged: their host-backed guarantees are still covered by
- * `test/unit/domain-settings-host-backed.test.ts`, which renders them
- * directly, so switching the feature on is putting them back into the two
- * slots below rather than rebuilding them out of the git history.
+ * otherwise unchanged except for the admin gate on their own write controls
+ * (`PUT …/domain`, `PUT …/smtp` and `POST …/smtp/test` all take
+ * `AdminScopedCompany` on the host, `POST …/domain/verify` stays open to a
+ * member on purpose): their host-backed guarantees, gate included, are still
+ * covered by `test/unit/domain-settings-host-backed.test.ts`, which renders
+ * them directly, so switching the feature on is putting them back into the
+ * two slots below rather than rebuilding them out of the git history. Each
+ * card resolves its own `canManage`, the way `HostingView` and `SearchView`
+ * resolve the same question, since neither has a mounted parent to resolve it
+ * once and pass down while this gate stands.
  */
 export function DomainSettings(_props: Props) {
   return (
@@ -296,6 +313,7 @@ function SmtpPreview() {
  * from and written to the host, and none of it is cached in the browser.
  */
 export function DomainCard({ client, company }: Props) {
+  const [canManage, setCanManage] = useState(false);
   const [status, setStatus] = useState<DomainStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -305,6 +323,22 @@ export function DomainCard({ client, company }: Props) {
   // the operator is looking at the Verify button when they learn this, and a
   // notice that vanishes leaves them clicking a button that cannot work.
   const [verifyUnwired, setVerifyUnwired] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      let admin = false;
+      try {
+        admin = (await fetchMe(client, company)).role === "admin";
+      } catch {
+        // No user plane on this host, or not signed in — treat as non-admin.
+      }
+      if (live) setCanManage(admin);
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -397,30 +431,55 @@ export function DomainCard({ client, company }: Props) {
             <Loader2 className="size-4 animate-spin" /> Loading domain…
           </p>
         ) : !configured ? (
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <Input
-              value={draft}
-              data-testid="domain-input"
-              // The card title is the only thing naming this field, and a
-              // screen reader does not read it as the input's name. The
-              // placeholder is an example, not a label — it disappears on the
-              // first keystroke, which is exactly when it would be needed.
-              aria-label="Custom domain"
-              onChange={(e) => setDraft(e.target.value)}
-              placeholder="mail.acme.com"
-              onKeyDown={(e) => e.key === "Enter" && void connect()}
-            />
-            <Button
-              className="shrink-0"
-              disabled={busy}
-              onClick={() => void connect()}
-              data-testid="domain-add"
-            >
-              Add domain
-            </Button>
-          </div>
+          canManage ? (
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                value={draft}
+                data-testid="domain-input"
+                // The card title is the only thing naming this field, and a
+                // screen reader does not read it as the input's name. The
+                // placeholder is an example, not a label — it disappears on the
+                // first keystroke, which is exactly when it would be needed.
+                aria-label="Custom domain"
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="mail.acme.com"
+                onKeyDown={(e) => e.key === "Enter" && void connect()}
+              />
+              <Button
+                className="shrink-0"
+                disabled={busy}
+                onClick={() => void connect()}
+                data-testid="domain-add"
+              >
+                Add domain
+              </Button>
+            </div>
+          ) : (
+            <>
+              <Alert data-testid="domain-read-only">
+                <Info className="size-4" />
+                <AlertTitle>Only an admin can add this company&apos;s domain</AlertTitle>
+                <AlertDescription>
+                  A domain is the company&rsquo;s mail identity, so an admin sets it.
+                </AlertDescription>
+              </Alert>
+              <p className="text-sm text-muted-foreground">No custom domain configured.</p>
+            </>
+          )
         ) : (
           <>
+            {!canManage && (
+              <Alert data-testid="domain-read-only">
+                <Info className="size-4" />
+                <AlertTitle>Only an admin can change this company&apos;s domain</AlertTitle>
+                <AlertDescription>
+                  A domain is the company&rsquo;s mail identity, so an admin sets and removes it.
+                  You can see what is configured, and verifying its DNS records is open to
+                  everyone.
+                </AlertDescription>
+              </Alert>
+            )}
+
             <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border p-3">
               <span className="inline-flex items-center gap-2 font-mono text-sm">
                 <Globe className="size-4 text-muted-foreground" />
@@ -439,15 +498,17 @@ export function DomainCard({ client, company }: Props) {
                     <span className="size-1.5 rounded-full bg-status-blocked" /> Pending
                   </Badge>
                 )}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={busy}
-                  onClick={() => void remove()}
-                  data-testid="domain-remove"
-                >
-                  Remove
-                </Button>
+                {canManage && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() => void remove()}
+                    data-testid="domain-remove"
+                  >
+                    Remove
+                  </Button>
+                )}
               </div>
             </div>
 
@@ -600,11 +661,28 @@ function CopyCell({ value }: { value: string }) {
  * is what holds that property while nothing renders the card.
  */
 export function SmtpCard({ client, company }: Props) {
+  const [canManage, setCanManage] = useState(false);
   const [status, setStatus] = useState<SmtpStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [testUnwired, setTestUnwired] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      let admin = false;
+      try {
+        admin = (await fetchMe(client, company)).role === "admin";
+      } catch {
+        // No user plane on this host, or not signed in — treat as non-admin.
+      }
+      if (live) setCanManage(admin);
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
 
   const [host, setHost] = useState("");
   const [port, setPort] = useState("587");
@@ -733,6 +811,32 @@ export function SmtpCard({ client, company }: Props) {
           <p className="flex items-center gap-2 text-sm text-muted-foreground">
             <Loader2 className="size-4 animate-spin" /> Loading email settings…
           </p>
+        ) : !canManage ? (
+          <>
+            <Alert data-testid="smtp-read-only">
+              <Info className="size-4" />
+              <AlertTitle>Only an admin can change this company&apos;s email settings</AlertTitle>
+              <AlertDescription>
+                These credentials are the address the company sends mail as, so an admin sets
+                them. You can see what is configured.
+              </AlertDescription>
+            </Alert>
+            {status?.configured ? (
+              <dl className="grid gap-2 text-sm sm:grid-cols-2" data-testid="smtp-summary">
+                <SummaryRow label="SMTP host" value={status.host} />
+                <SummaryRow label="Port" value={status.port !== undefined ? String(status.port) : undefined} />
+                <SummaryRow
+                  label="Security"
+                  value={status.security ? SECURITY_LABELS[status.security] : undefined}
+                />
+                <SummaryRow label="Username" value={status.username} />
+                <SummaryRow label="From name" value={status.from_name} />
+                <SummaryRow label="From email" value={status.from_email} />
+              </dl>
+            ) : (
+              <p className="text-sm text-muted-foreground">No email settings configured.</p>
+            )}
+          </>
         ) : (
           <>
             <div className="grid gap-4 sm:grid-cols-2">
@@ -873,6 +977,16 @@ function Field({
       <Label htmlFor={id}>{label}</Label>
       {children}
       {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+/** One read-only field in the SMTP summary a non-admin sees instead of the form. */
+function SummaryRow({ label, value }: { label: string; value: string | undefined }) {
+  return (
+    <div>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="font-mono">{value || "—"}</dd>
     </div>
   );
 }

--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
-import { me as fetchMe } from "@/api/auth";
+import { hasNoSession, me as fetchMe } from "@/api/auth";
 import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import {
@@ -330,18 +330,18 @@ export function DomainCard({ client, company }: Props) {
       let admin = false;
       try {
         admin = (await fetchMe(client, company)).role === "admin";
-      } catch {
+      } catch (err) {
         // `resolve_principal` on the host tries a human session first and
         // only falls back to the platform/tenant bearer when none is
         // present — a hub console can carry both, and `PUT …/domain` is
         // AdminScopedCompany, which admits that machine principal
-        // unconditionally once it has addressed this company. So `/auth/me`
-        // failing outright (no session at all) means the bearer is what the
-        // host will actually authorize on; `/auth/me` succeeding with a
-        // member role — even with a bearer also present — means the host
-        // resolved that member and will 403 the same as with no bearer,
-        // which the `try` above already handles correctly.
-        admin = client.carriesPlatformBearer;
+        // unconditionally once it has addressed this company. So a
+        // *confirmed* absence of any session means the bearer is what the
+        // host will actually authorize on. A network error, a timeout, or a
+        // `5xx` is not that confirmation — a member's session could still be
+        // live and still take precedence on the host — so those stay
+        // non-admin rather than assuming the bearer wins (codeRabbit review).
+        admin = client.carriesPlatformBearer && hasNoSession(err);
       }
       if (live) setCanManage(admin);
     })();
@@ -684,19 +684,19 @@ export function SmtpCard({ client, company }: Props) {
       let admin = false;
       try {
         admin = (await fetchMe(client, company)).role === "admin";
-      } catch {
+      } catch (err) {
         // `resolve_principal` on the host tries a human session first and
         // only falls back to the platform/tenant bearer when none is
         // present — a hub console can carry both, and `PUT …/smtp` and
         // `POST …/smtp/test` are AdminScopedCompany, which admits that
         // machine principal unconditionally once it has addressed this
-        // company. So `/auth/me` failing outright (no session at all) means
-        // the bearer is what the host will actually authorize on;
-        // `/auth/me` succeeding with a member role — even with a bearer
-        // also present — means the host resolved that member and will 403
-        // the same as with no bearer, which the `try` above already
-        // handles correctly.
-        admin = client.carriesPlatformBearer;
+        // company. So a *confirmed* absence of any session means the
+        // bearer is what the host will actually authorize on. A network
+        // error, a timeout, or a `5xx` is not that confirmation — a
+        // member's session could still be live and still take precedence
+        // on the host — so those stay non-admin rather than assuming the
+        // bearer wins (codeRabbit review).
+        admin = client.carriesPlatformBearer && hasNoSession(err);
       }
       if (live) setCanManage(admin);
     })();

--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -325,22 +325,23 @@ export function DomainCard({ client, company }: Props) {
   const [verifyUnwired, setVerifyUnwired] = useState(false);
 
   useEffect(() => {
-    // A platform or tenant bearer has no human session for `/auth/me` to
-    // return, but `PUT …/domain` is `AdminScopedCompany` on the host, which
-    // admits that machine principal unconditionally once it has addressed
-    // this company. Asking `/auth/me` anyway would read the missing session
-    // as "not an admin" and hide a form whose write would in fact succeed.
-    if (client.carriesPlatformBearer) {
-      setCanManage(true);
-      return;
-    }
     let live = true;
     void (async () => {
       let admin = false;
       try {
         admin = (await fetchMe(client, company)).role === "admin";
       } catch {
-        // No user plane on this host, or not signed in — treat as non-admin.
+        // `resolve_principal` on the host tries a human session first and
+        // only falls back to the platform/tenant bearer when none is
+        // present — a hub console can carry both, and `PUT …/domain` is
+        // AdminScopedCompany, which admits that machine principal
+        // unconditionally once it has addressed this company. So `/auth/me`
+        // failing outright (no session at all) means the bearer is what the
+        // host will actually authorize on; `/auth/me` succeeding with a
+        // member role — even with a bearer also present — means the host
+        // resolved that member and will 403 the same as with no bearer,
+        // which the `try` above already handles correctly.
+        admin = client.carriesPlatformBearer;
       }
       if (live) setCanManage(admin);
     })();
@@ -678,23 +679,24 @@ export function SmtpCard({ client, company }: Props) {
   const [testUnwired, setTestUnwired] = useState(false);
 
   useEffect(() => {
-    // A platform or tenant bearer has no human session for `/auth/me` to
-    // return, but `PUT …/smtp` and `POST …/smtp/test` are `AdminScopedCompany`
-    // on the host, which admits that machine principal unconditionally once it
-    // has addressed this company. Asking `/auth/me` anyway would read the
-    // missing session as "not an admin" and hide a form whose write would in
-    // fact succeed.
-    if (client.carriesPlatformBearer) {
-      setCanManage(true);
-      return;
-    }
     let live = true;
     void (async () => {
       let admin = false;
       try {
         admin = (await fetchMe(client, company)).role === "admin";
       } catch {
-        // No user plane on this host, or not signed in — treat as non-admin.
+        // `resolve_principal` on the host tries a human session first and
+        // only falls back to the platform/tenant bearer when none is
+        // present — a hub console can carry both, and `PUT …/smtp` and
+        // `POST …/smtp/test` are AdminScopedCompany, which admits that
+        // machine principal unconditionally once it has addressed this
+        // company. So `/auth/me` failing outright (no session at all) means
+        // the bearer is what the host will actually authorize on;
+        // `/auth/me` succeeding with a member role — even with a bearer
+        // also present — means the host resolved that member and will 403
+        // the same as with no bearer, which the `try` above already
+        // handles correctly.
+        admin = client.carriesPlatformBearer;
       }
       if (live) setCanManage(admin);
     })();

--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -325,6 +325,15 @@ export function DomainCard({ client, company }: Props) {
   const [verifyUnwired, setVerifyUnwired] = useState(false);
 
   useEffect(() => {
+    // A platform or tenant bearer has no human session for `/auth/me` to
+    // return, but `PUT …/domain` is `AdminScopedCompany` on the host, which
+    // admits that machine principal unconditionally once it has addressed
+    // this company. Asking `/auth/me` anyway would read the missing session
+    // as "not an admin" and hide a form whose write would in fact succeed.
+    if (client.carriesPlatformBearer) {
+      setCanManage(true);
+      return;
+    }
     let live = true;
     void (async () => {
       let admin = false;
@@ -669,6 +678,16 @@ export function SmtpCard({ client, company }: Props) {
   const [testUnwired, setTestUnwired] = useState(false);
 
   useEffect(() => {
+    // A platform or tenant bearer has no human session for `/auth/me` to
+    // return, but `PUT …/smtp` and `POST …/smtp/test` are `AdminScopedCompany`
+    // on the host, which admits that machine principal unconditionally once it
+    // has addressed this company. Asking `/auth/me` anyway would read the
+    // missing session as "not an admin" and hide a form whose write would in
+    // fact succeed.
+    if (client.carriesPlatformBearer) {
+      setCanManage(true);
+      return;
+    }
     let live = true;
     void (async () => {
       let admin = false;

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -292,9 +292,11 @@ export function HostingView({ client, company }: Props) {
                 already stored — a build without the tools, or a manifest that
                 has not granted `hosting` yet. A member gets that distinction
                 back here rather than reading a stored credential as absent. */}
-            {!canManage && status.apiKeyConfigured ? (
+            {!canManage && (status.apiKeyConfigured || status.team) ? (
               <p className="text-xs text-muted-foreground" data-testid="hosting-credential-status">
-                An API token is stored{status.team ? `, scoped to ${status.team}` : ""}.
+                {status.apiKeyConfigured
+                  ? `An API token is stored${status.team ? `, scoped to ${status.team}` : ""}.`
+                  : `Scoped to ${status.team}, but no API token is stored yet.`}
               </p>
             ) : null}
 

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -287,6 +287,17 @@ export function HostingView({ client, company }: Props) {
               ) : null}
             </div>
 
+            {/* `connected` folds three independent flags into one boolean, so
+                "Not connected yet" above can be true even with a token
+                already stored — a build without the tools, or a manifest that
+                has not granted `hosting` yet. A member gets that distinction
+                back here rather than reading a stored credential as absent. */}
+            {!canManage && status.apiKeyConfigured ? (
+              <p className="text-xs text-muted-foreground" data-testid="hosting-credential-status">
+                An API token is stored{status.team ? `, scoped to ${status.team}` : ""}.
+              </p>
+            ) : null}
+
             {canManage && (
               <div className={cn("grid gap-4 sm:grid-cols-2", SETTINGS_FIELD_COLUMN)}>
                 <div className="space-y-2">

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -124,7 +124,7 @@ export function HostingView({ client, company }: Props) {
         // host will actually authorize on. A network error, a timeout, or a
         // `5xx` is not that confirmation — a member's session could still be
         // live and still take precedence on the host — so those stay
-        // non-admin rather than assuming the bearer wins (codeRabbit review).
+        // non-admin rather than assuming the bearer wins.
         admin = client.carriesPlatformBearer && hasNoSession(err);
       }
       if (live) setCanManage(admin);
@@ -181,9 +181,9 @@ export function HostingView({ client, company }: Props) {
   }
 
   /*
-    Hoisted above the state conditionals for the same reason as `SearchView`'s
-    (codex review, #1785) — this page is the other half of that copy-paste
-    pair, and had the same two unnamed states.
+    Hoisted above the state conditionals for the same reason as `SearchView`'s —
+    this page is the other half of that copy-paste pair, and had the same two
+    unnamed states.
   */
   const header = (
     <PageHeader

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -109,6 +109,15 @@ export function HostingView({ client, company }: Props) {
   }, [client, company]);
 
   useEffect(() => {
+    // A platform or tenant bearer has no human session for `/auth/me` to
+    // return, but `PUT …/hosting` is `AdminScopedCompany` on the host, which
+    // admits that machine principal unconditionally once it has addressed
+    // this company. Asking `/auth/me` anyway would read the missing session
+    // as "not an admin" and hide a form whose write would in fact succeed.
+    if (client.carriesPlatformBearer) {
+      setCanManage(true);
+      return;
+    }
     let live = true;
     void (async () => {
       let admin = false;

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -109,22 +109,23 @@ export function HostingView({ client, company }: Props) {
   }, [client, company]);
 
   useEffect(() => {
-    // A platform or tenant bearer has no human session for `/auth/me` to
-    // return, but `PUT …/hosting` is `AdminScopedCompany` on the host, which
-    // admits that machine principal unconditionally once it has addressed
-    // this company. Asking `/auth/me` anyway would read the missing session
-    // as "not an admin" and hide a form whose write would in fact succeed.
-    if (client.carriesPlatformBearer) {
-      setCanManage(true);
-      return;
-    }
     let live = true;
     void (async () => {
       let admin = false;
       try {
         admin = (await fetchMe(client, company)).role === "admin";
       } catch {
-        // No user plane on this host, or not signed in — treat as non-admin.
+        // `resolve_principal` on the host tries a human session first and
+        // only falls back to the platform/tenant bearer when none is
+        // present — a hub console can carry both, and `PUT …/hosting` is
+        // AdminScopedCompany, which admits that machine principal
+        // unconditionally once it has addressed this company. So `/auth/me`
+        // failing outright (no session at all) means the bearer is what the
+        // host will actually authorize on; `/auth/me` succeeding with a
+        // member role — even with a bearer also present — means the host
+        // resolved that member and will 403 the same as with no bearer,
+        // which the `try` above already handles correctly.
+        admin = client.carriesPlatformBearer;
       }
       if (live) setCanManage(admin);
     })();

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, Loader2, TriangleAlert } from "lucide-react";
+import { Check, Info, Loader2, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -13,7 +13,7 @@ import type { OpenCompanyClient } from "@/api/client";
 import { PageHeader } from "@/components/page-header";
 import { cn } from "@/lib/utils";
 import { SETTINGS_FIELD_COLUMN } from "@/views/settings-pages";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { GrantNamespace } from "@/components/grant-namespace";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -246,6 +246,17 @@ export function HostingView({ client, company }: Props) {
           />
         ) : null}
 
+        {!canManage && (
+          <Alert data-testid="hosting-read-only">
+            <Info className="size-4" />
+            <AlertTitle>Only an admin can change this company&apos;s hosting connection</AlertTitle>
+            <AlertDescription>
+              A deployment publishes files under this account and a database is a bill it pays,
+              so an admin connects it. You can see what is configured.
+            </AlertDescription>
+          </Alert>
+        )}
+
         <Card>
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
@@ -266,74 +277,78 @@ export function HostingView({ client, company }: Props) {
               ) : null}
             </div>
 
-            <div className={cn("grid gap-4 sm:grid-cols-2", SETTINGS_FIELD_COLUMN)}>
-              <div className="space-y-2">
-                <Label htmlFor="hosting-key">API token</Label>
-                <Input
-                  id="hosting-key"
-                  data-testid="hosting-api-key"
-                  type="password"
-                  autoComplete="off"
-                  placeholder={
-                    status.apiKeyConfigured ? "Configured — type to replace" : "vercel_…"
-                  }
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
-                />
-                <p className="text-xs text-muted-foreground">
-                  Create one at vercel.com → Account Settings → Tokens. Stored
-                  write-only: it is never shown again, here or anywhere else.
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="hosting-team">Team (optional)</Label>
-                <Input
-                  id="hosting-team"
-                  data-testid="hosting-team"
-                  placeholder="team_…"
-                  value={team}
-                  onChange={(e) => setTeam(e.target.value)}
-                />
-                <p className="text-xs text-muted-foreground">
-                  The team or organization to deploy under. Leave empty for a
-                  personal account.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-2">
-              <Button onClick={() => void onSave()} disabled={busy} data-testid="hosting-save">
-                {busy ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
-                Save
-              </Button>
-              {status.apiKeyConfigured ? (
-                <AlertDialog>
-                  <AlertDialogTrigger
-                    render={
-                      <Button variant="outline" disabled={busy} data-testid="hosting-clear">
-                        Disconnect
-                      </Button>
+            {canManage && (
+              <div className={cn("grid gap-4 sm:grid-cols-2", SETTINGS_FIELD_COLUMN)}>
+                <div className="space-y-2">
+                  <Label htmlFor="hosting-key">API token</Label>
+                  <Input
+                    id="hosting-key"
+                    data-testid="hosting-api-key"
+                    type="password"
+                    autoComplete="off"
+                    placeholder={
+                      status.apiKeyConfigured ? "Configured — type to replace" : "vercel_…"
                     }
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
                   />
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Disconnect {status.provider}?</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        This clears the write-only hosting token and team setting. They cannot be
-                        recovered; reconnect with a new token before teammates can deploy again.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction variant="destructive" onClick={() => void onClear()}>
-                        Disconnect hosting
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              ) : null}
-            </div>
+                  <p className="text-xs text-muted-foreground">
+                    Create one at vercel.com → Account Settings → Tokens. Stored
+                    write-only: it is never shown again, here or anywhere else.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="hosting-team">Team (optional)</Label>
+                  <Input
+                    id="hosting-team"
+                    data-testid="hosting-team"
+                    placeholder="team_…"
+                    value={team}
+                    onChange={(e) => setTeam(e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    The team or organization to deploy under. Leave empty for a
+                    personal account.
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {canManage && (
+              <div className="flex items-center gap-2">
+                <Button onClick={() => void onSave()} disabled={busy} data-testid="hosting-save">
+                  {busy ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                  Save
+                </Button>
+                {status.apiKeyConfigured ? (
+                  <AlertDialog>
+                    <AlertDialogTrigger
+                      render={
+                        <Button variant="outline" disabled={busy} data-testid="hosting-clear">
+                          Disconnect
+                        </Button>
+                      }
+                    />
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Disconnect {status.provider}?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This clears the write-only hosting token and team setting. They cannot be
+                          recovered; reconnect with a new token before teammates can deploy again.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction variant="destructive" onClick={() => void onClear()}>
+                          Disconnect hosting
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                ) : null}
+              </div>
+            )}
           </CardContent>
         </Card>
 

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -8,7 +8,7 @@ import {
   saveHosting,
   type HostingStatus,
 } from "@/api/hosting";
-import { me as fetchMe } from "@/api/auth";
+import { hasNoSession, me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { PageHeader } from "@/components/page-header";
 import { cn } from "@/lib/utils";
@@ -114,18 +114,18 @@ export function HostingView({ client, company }: Props) {
       let admin = false;
       try {
         admin = (await fetchMe(client, company)).role === "admin";
-      } catch {
+      } catch (err) {
         // `resolve_principal` on the host tries a human session first and
         // only falls back to the platform/tenant bearer when none is
         // present — a hub console can carry both, and `PUT …/hosting` is
         // AdminScopedCompany, which admits that machine principal
-        // unconditionally once it has addressed this company. So `/auth/me`
-        // failing outright (no session at all) means the bearer is what the
-        // host will actually authorize on; `/auth/me` succeeding with a
-        // member role — even with a bearer also present — means the host
-        // resolved that member and will 403 the same as with no bearer,
-        // which the `try` above already handles correctly.
-        admin = client.carriesPlatformBearer;
+        // unconditionally once it has addressed this company. So a
+        // *confirmed* absence of any session means the bearer is what the
+        // host will actually authorize on. A network error, a timeout, or a
+        // `5xx` is not that confirmation — a member's session could still be
+        // live and still take precedence on the host — so those stay
+        // non-admin rather than assuming the bearer wins (codeRabbit review).
+        admin = client.carriesPlatformBearer && hasNoSession(err);
       }
       if (live) setCanManage(admin);
     })();

--- a/frontend/src/views/SearchView.tsx
+++ b/frontend/src/views/SearchView.tsx
@@ -140,7 +140,7 @@ export function SearchView({ client, company }: Props) {
         // host will actually authorize on. A network error, a timeout, or a
         // `5xx` is not that confirmation — a member's session could still be
         // live and still take precedence on the host — so those stay
-        // non-admin rather than assuming the bearer wins (codeRabbit review).
+        // non-admin rather than assuming the bearer wins.
         admin = client.carriesPlatformBearer && hasNoSession(err);
       }
       if (live) setCanManage(admin);
@@ -203,7 +203,7 @@ export function SearchView({ client, company }: Props) {
   }
 
   /*
-    Hoisted above the state conditionals (codex review, #1785). Both early
+    Hoisted above the state conditionals. Both early
     returns used to run before the header, so the page had no `h1` while it
     loaded and — because the read is not retried — none at all once it failed.
     The error state is the one that matters: it is terminal, so a screen reader

--- a/frontend/src/views/SearchView.tsx
+++ b/frontend/src/views/SearchView.tsx
@@ -125,22 +125,23 @@ export function SearchView({ client, company }: Props) {
   }, [client, company]);
 
   useEffect(() => {
-    // A platform or tenant bearer has no human session for `/auth/me` to
-    // return, but `PUT …/search` is `AdminScopedCompany` on the host, which
-    // admits that machine principal unconditionally once it has addressed
-    // this company. Asking `/auth/me` anyway would read the missing session
-    // as "not an admin" and hide a form whose write would in fact succeed.
-    if (client.carriesPlatformBearer) {
-      setCanManage(true);
-      return;
-    }
     let live = true;
     void (async () => {
       let admin = false;
       try {
         admin = (await fetchMe(client, company)).role === "admin";
       } catch {
-        // No user plane on this host, or not signed in — treat as non-admin.
+        // `resolve_principal` on the host tries a human session first and
+        // only falls back to the platform/tenant bearer when none is
+        // present — a hub console can carry both, and `PUT …/search` is
+        // AdminScopedCompany, which admits that machine principal
+        // unconditionally once it has addressed this company. So `/auth/me`
+        // failing outright (no session at all) means the bearer is what the
+        // host will actually authorize on; `/auth/me` succeeding with a
+        // member role — even with a bearer also present — means the host
+        // resolved that member and will 403 the same as with no bearer,
+        // which the `try` above already handles correctly.
+        admin = client.carriesPlatformBearer;
       }
       if (live) setCanManage(admin);
     })();

--- a/frontend/src/views/SearchView.tsx
+++ b/frontend/src/views/SearchView.tsx
@@ -3,7 +3,7 @@ import { Check, Info, Loader2, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 
 import { clearSearch, getSearch, saveSearch, type SearchStatus } from "@/api/search";
-import { me as fetchMe } from "@/api/auth";
+import { hasNoSession, me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { PageHeader } from "@/components/page-header";
 import { cn } from "@/lib/utils";
@@ -130,18 +130,18 @@ export function SearchView({ client, company }: Props) {
       let admin = false;
       try {
         admin = (await fetchMe(client, company)).role === "admin";
-      } catch {
+      } catch (err) {
         // `resolve_principal` on the host tries a human session first and
         // only falls back to the platform/tenant bearer when none is
         // present — a hub console can carry both, and `PUT …/search` is
         // AdminScopedCompany, which admits that machine principal
-        // unconditionally once it has addressed this company. So `/auth/me`
-        // failing outright (no session at all) means the bearer is what the
-        // host will actually authorize on; `/auth/me` succeeding with a
-        // member role — even with a bearer also present — means the host
-        // resolved that member and will 403 the same as with no bearer,
-        // which the `try` above already handles correctly.
-        admin = client.carriesPlatformBearer;
+        // unconditionally once it has addressed this company. So a
+        // *confirmed* absence of any session means the bearer is what the
+        // host will actually authorize on. A network error, a timeout, or a
+        // `5xx` is not that confirmation — a member's session could still be
+        // live and still take precedence on the host — so those stay
+        // non-admin rather than assuming the bearer wins (codeRabbit review).
+        admin = client.carriesPlatformBearer && hasNoSession(err);
       }
       if (live) setCanManage(admin);
     })();

--- a/frontend/src/views/SearchView.tsx
+++ b/frontend/src/views/SearchView.tsx
@@ -383,6 +383,18 @@ export function SearchView({ client, company }: Props) {
               </div>
             )}
 
+            {!canManage && provider === "searxng" && endpoint ? (
+              <div className="space-y-2">
+                <Label htmlFor="search-endpoint-readonly">Instance URL</Label>
+                <p id="search-endpoint-readonly" data-testid="search-endpoint-readonly" className="text-sm">
+                  {endpoint}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  The address your SearXNG instance answers on. Every teammate search goes there.
+                </p>
+              </div>
+            ) : null}
+
             {canManage && (
               <div className="flex items-center gap-2">
                 <Button onClick={() => void onSave()} disabled={busy} data-testid="search-save">

--- a/frontend/src/views/SearchView.tsx
+++ b/frontend/src/views/SearchView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, Loader2, TriangleAlert } from "lucide-react";
+import { Check, Info, Loader2, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 
 import { clearSearch, getSearch, saveSearch, type SearchStatus } from "@/api/search";
@@ -8,7 +8,7 @@ import type { OpenCompanyClient } from "@/api/client";
 import { PageHeader } from "@/components/page-header";
 import { cn } from "@/lib/utils";
 import { SETTINGS_FIELD_COLUMN } from "@/views/settings-pages";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { GrantNamespace } from "@/components/grant-namespace";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -275,6 +275,17 @@ export function SearchView({ client, company }: Props) {
           />
         ) : null}
 
+        {!canManage && (
+          <Alert data-testid="search-read-only">
+            <Info className="size-4" />
+            <AlertTitle>Only an admin can change this company&apos;s search provider</AlertTitle>
+            <AlertDescription>
+              Search queries leave this host under whichever provider is selected, so an admin
+              chooses it. You can see what is configured.
+            </AlertDescription>
+          </Alert>
+        )}
+
         <Card>
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
@@ -297,85 +308,89 @@ export function SearchView({ client, company }: Props) {
               ) : null}
             </div>
 
-            <div className={cn("grid gap-4 sm:grid-cols-2", SETTINGS_FIELD_COLUMN)}>
-              <div className="space-y-2">
-                <Label htmlFor="search-provider">Provider</Label>
-                <Select
-                  value={provider}
-                  onValueChange={(v) => v && setProvider(String(v))}
-                  items={labels}
-                >
-                  <SelectTrigger id="search-provider" data-testid="search-provider">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {status.supportedProviders.map((slug) => (
-                      <SelectItem key={slug} value={slug}>
-                        {PROVIDERS[slug]?.label ?? slug}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-muted-foreground">
-                  {PROVIDERS[provider]?.help ?? ""}
-                </p>
+            {canManage && (
+              <div className={cn("grid gap-4 sm:grid-cols-2", SETTINGS_FIELD_COLUMN)}>
+                <div className="space-y-2">
+                  <Label htmlFor="search-provider">Provider</Label>
+                  <Select
+                    value={provider}
+                    onValueChange={(v) => v && setProvider(String(v))}
+                    items={labels}
+                  >
+                    <SelectTrigger id="search-provider" data-testid="search-provider">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {status.supportedProviders.map((slug) => (
+                        <SelectItem key={slug} value={slug}>
+                          {PROVIDERS[slug]?.label ?? slug}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    {PROVIDERS[provider]?.help ?? ""}
+                  </p>
+                </div>
+
+                {byo && provider !== "searxng" ? (
+                  <div className="space-y-2">
+                    <Label htmlFor="search-key">API key</Label>
+                    <Input
+                      id="search-key"
+                      data-testid="search-api-key"
+                      type="password"
+                      autoComplete="off"
+                      placeholder={
+                        status.apiKeyConfigured ? "Configured — type to replace" : "sk_…"
+                      }
+                      value={apiKey}
+                      onChange={(e) => setApiKey(e.target.value)}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Stored write-only: it is never shown again, here or anywhere
+                      else. Searches are billed to this account, not to us.
+                    </p>
+                  </div>
+                ) : null}
+
+                {provider === "searxng" ? (
+                  <div className="space-y-2">
+                    <Label htmlFor="search-endpoint">Instance URL</Label>
+                    <Input
+                      id="search-endpoint"
+                      data-testid="search-endpoint"
+                      placeholder="https://searx.example.com"
+                      value={endpoint}
+                      onChange={(e) => setEndpoint(e.target.value)}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      The address your SearXNG instance answers on. Every teammate
+                      search goes there, so it has to be reachable from this host.
+                    </p>
+                  </div>
+                ) : null}
               </div>
+            )}
 
-              {byo && provider !== "searxng" ? (
-                <div className="space-y-2">
-                  <Label htmlFor="search-key">API key</Label>
-                  <Input
-                    id="search-key"
-                    data-testid="search-api-key"
-                    type="password"
-                    autoComplete="off"
-                    placeholder={
-                      status.apiKeyConfigured ? "Configured — type to replace" : "sk_…"
-                    }
-                    value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Stored write-only: it is never shown again, here or anywhere
-                    else. Searches are billed to this account, not to us.
-                  </p>
-                </div>
-              ) : null}
-
-              {provider === "searxng" ? (
-                <div className="space-y-2">
-                  <Label htmlFor="search-endpoint">Instance URL</Label>
-                  <Input
-                    id="search-endpoint"
-                    data-testid="search-endpoint"
-                    placeholder="https://searx.example.com"
-                    value={endpoint}
-                    onChange={(e) => setEndpoint(e.target.value)}
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    The address your SearXNG instance answers on. Every teammate
-                    search goes there, so it has to be reachable from this host.
-                  </p>
-                </div>
-              ) : null}
-            </div>
-
-            <div className="flex items-center gap-2">
-              <Button onClick={() => void onSave()} disabled={busy} data-testid="search-save">
-                {busy ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
-                Save
-              </Button>
-              {status.provider !== "managed" ? (
-                <Button
-                  variant="outline"
-                  onClick={() => void onClear()}
-                  disabled={busy}
-                  data-testid="search-clear"
-                >
-                  Use managed search
+            {canManage && (
+              <div className="flex items-center gap-2">
+                <Button onClick={() => void onSave()} disabled={busy} data-testid="search-save">
+                  {busy ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                  Save
                 </Button>
-              ) : null}
-            </div>
+                {status.provider !== "managed" ? (
+                  <Button
+                    variant="outline"
+                    onClick={() => void onClear()}
+                    disabled={busy}
+                    data-testid="search-clear"
+                  >
+                    Use managed search
+                  </Button>
+                ) : null}
+              </div>
+            )}
           </CardContent>
         </Card>
 

--- a/frontend/src/views/SearchView.tsx
+++ b/frontend/src/views/SearchView.tsx
@@ -125,6 +125,15 @@ export function SearchView({ client, company }: Props) {
   }, [client, company]);
 
   useEffect(() => {
+    // A platform or tenant bearer has no human session for `/auth/me` to
+    // return, but `PUT …/search` is `AdminScopedCompany` on the host, which
+    // admits that machine principal unconditionally once it has addressed
+    // this company. Asking `/auth/me` anyway would read the missing session
+    // as "not an admin" and hide a form whose write would in fact succeed.
+    if (client.carriesPlatformBearer) {
+      setCanManage(true);
+      return;
+    }
     let live = true;
     void (async () => {
       let admin = false;

--- a/frontend/test/unit/credential-clear-confirm.test.ts
+++ b/frontend/test/unit/credential-clear-confirm.test.ts
@@ -34,7 +34,7 @@ let container: HTMLDivElement;
 let root: Root;
 
 /**
- * `get` answers `/auth/me` as an admin: since issue #403 `HostingView` resolves
+ * `get` answers `/auth/me` as an admin: `HostingView` resolves
  * the viewer's role before offering its write controls at all, and a client
  * with no `get` left every call rejecting, which resolved as a non-admin and
  * hid the very Disconnect button this suite exists to click.

--- a/frontend/test/unit/credential-clear-confirm.test.ts
+++ b/frontend/test/unit/credential-clear-confirm.test.ts
@@ -33,8 +33,20 @@ const { HostingView } = await import("@/views/HostingView");
 let container: HTMLDivElement;
 let root: Root;
 
+/**
+ * `get` answers `/auth/me` as an admin: since issue #403 `HostingView` resolves
+ * the viewer's role before offering its write controls at all, and a client
+ * with no `get` left every call rejecting, which resolved as a non-admin and
+ * hid the very Disconnect button this suite exists to click.
+ */
 function client(): OpenCompanyClient {
-  return { scopeFor: () => "/api/v1/company" } as unknown as OpenCompanyClient;
+  return {
+    scopeFor: () => "/api/v1/company",
+    get: (path: string) =>
+      path.endsWith("/auth/me")
+        ? Promise.resolve({ id: "u1", email: "a@b.c", role: "admin", company: "acme" })
+        : Promise.reject(new Error(`unexpected get ${path}`)),
+  } as unknown as OpenCompanyClient;
 }
 
 function button(label: string): HTMLButtonElement {

--- a/frontend/test/unit/domain-settings-host-backed.test.ts
+++ b/frontend/test/unit/domain-settings-host-backed.test.ts
@@ -92,12 +92,30 @@ interface Calls {
  *
  * Routed on the path rather than on call order: the two cards mount
  * independently and nothing guarantees which read resolves first.
+ *
+ * `/auth/me` answers as an admin by default, matching `HostingView`'s own
+ * fixture convention: since issue #403 this page resolves the viewer's role to
+ * decide whether to offer the write forms at all, and a client that fell
+ * through to the SMTP branch for every unmatched path — as this one used to —
+ * would resolve every test here as a non-admin by accident.
  */
-function fakeClient(overrides: { domain?: unknown; smtp?: unknown } = {}) {
+function fakeClient(
+  overrides: { domain?: unknown; smtp?: unknown } = {},
+  role: "admin" | "member" = "admin",
+) {
   const calls: Calls = { put: [], post: [] };
   const client = {
     scopeFor: () => "/api/v1/companies/acme",
     get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return Promise.resolve({
+          id: "u1",
+          email: "a@b.c",
+          role,
+          company: "acme",
+          hasPassword: true,
+        });
+      }
       const answer = path.endsWith("/domain")
         ? (overrides.domain ?? DOMAIN_STATUS)
         : (overrides.smtp ?? SMTP_STATUS);
@@ -370,5 +388,84 @@ describe("the domain card's writes", () => {
 
     expect(calls.put).toHaveLength(1);
     expect(calls.put[0].body).toEqual({ domain: "" });
+  });
+});
+
+/**
+ * `PUT …/domain`, `PUT …/smtp` and `POST …/smtp/test` all take
+ * `AdminScopedCompany` on the host — neither card read that before this fix,
+ * so a member saw both forms enabled and learned only after a 403 toast that
+ * pasting a credential was never going to work. `POST …/domain/verify` stays
+ * `ScopedCompany` deliberately: it re-checks DNS for a domain only an admin
+ * could have set, so Verify is asserted open to a member, not gated.
+ */
+describe("authority: the write forms, not the reads (issue #1785 audit)", () => {
+  it("hides the domain add/remove controls from a member, and still lets them verify", async () => {
+    const { client, calls } = fakeClient({}, "member");
+    await show(client);
+
+    expect(at("domain-read-only")?.textContent).toContain("Only an admin");
+    expect(at("domain-remove")).toBeNull();
+
+    // The read stays intact: the domain and its pending state are still on
+    // screen, not a blank card.
+    expect(container.textContent).toContain("mail.acme.com");
+
+    // Verify is deliberately open to a member — it changes nothing an admin
+    // did not already set, and re-checks DNS the member could already read.
+    await click("domain-verify");
+    expect(calls.post).toHaveLength(1);
+    expect(calls.post[0].path).toContain("/domain/verify");
+  });
+
+  it("offers no add form to a member on an unconfigured domain, but still names the reason", async () => {
+    const { client } = fakeClient(
+      { domain: { domain: "", verified: false, records: [] } },
+      "member",
+    );
+    await show(client);
+
+    expect(at("domain-input")).toBeNull();
+    expect(at("domain-read-only")?.textContent).toContain("Only an admin");
+    expect(container.textContent).toContain("No custom domain configured");
+  });
+
+  it("offers an admin the domain add/remove controls, with no read-only notice", async () => {
+    const { client } = fakeClient({}, "admin");
+    await show(client);
+
+    expect(at("domain-read-only")).toBeNull();
+    expect(at("domain-remove")).not.toBeNull();
+  });
+
+  it("hides the SMTP credential form and Test from a member, and shows the read summary instead", async () => {
+    const { client, calls } = fakeClient({}, "member");
+    await show(client);
+
+    expect(at("smtp-read-only")?.textContent).toContain("Only an admin");
+    expect(at("smtp-host")).toBeNull();
+    expect(at("smtp-password")).toBeNull();
+    expect(at("smtp-save")).toBeNull();
+    expect(at("smtp-test")).toBeNull();
+
+    // Not a blank card: the non-secret configuration is still readable.
+    const summary = at("smtp-summary");
+    expect(summary?.textContent).toContain("smtp.postmarkapp.com");
+    expect(summary?.textContent).toContain("hello@mail.acme.com");
+    // And never the password — there is no field on the host response that
+    // could carry it, so there is nothing here to leak either.
+    expect(summary?.textContent).not.toContain("SECRET");
+
+    expect(calls.put).toHaveLength(0);
+    expect(calls.post).toHaveLength(0);
+  });
+
+  it("offers an admin the SMTP form and Test, with no read-only notice", async () => {
+    const { client } = fakeClient({}, "admin");
+    await show(client);
+
+    expect(at("smtp-read-only")).toBeNull();
+    expect(at("smtp-host")).not.toBeNull();
+    expect((at("smtp-save") as HTMLButtonElement | null)?.disabled).toBe(false);
   });
 });

--- a/frontend/test/unit/domain-settings-host-backed.test.ts
+++ b/frontend/test/unit/domain-settings-host-backed.test.ts
@@ -95,7 +95,7 @@ interface Calls {
  * independently and nothing guarantees which read resolves first.
  *
  * `/auth/me` answers as an admin by default, matching `HostingView`'s own
- * fixture convention: since issue #403 this page resolves the viewer's role to
+ * fixture convention: this page resolves the viewer's role to
  * decide whether to offer the write forms at all, and a client that fell
  * through to the SMTP branch for every unmatched path — as this one used to —
  * would resolve every test here as a non-admin by accident. `session: "none"`
@@ -410,7 +410,7 @@ describe("the domain card's writes", () => {
  * `ScopedCompany` deliberately: it re-checks DNS for a domain only an admin
  * could have set, so Verify is asserted open to a member, not gated.
  */
-describe("authority: the write forms, not the reads (issue #1785 audit)", () => {
+describe("authority: the write forms, not the reads", () => {
   it("hides the domain add/remove controls from a member, and still lets them verify", async () => {
     const { client, calls } = fakeClient({}, "member");
     await show(client);
@@ -497,7 +497,7 @@ describe("authority: the write forms, not the reads (issue #1785 audit)", () => 
   it("stays read-only on both cards on an ambiguous /auth/me failure, even with a bearer present", async () => {
     // A network error, a timeout, or a 5xx is not a confirmed absence of a
     // session — a member's session could still be live and would still take
-    // precedence on the host (coderabbit review).
+    // precedence on the host.
     const { client } = fakeClient({}, "error", true);
     await show(client);
 
@@ -510,7 +510,7 @@ describe("authority: the write forms, not the reads (issue #1785 audit)", () => 
   it("defers to a member session on both cards even when a platform bearer is also present", async () => {
     // A hub console can carry both credentials at once (`authHeaders`), and
     // resolve_principal tries the session first — so a bearer must never
-    // paper over a member's own 403 (codex review).
+    // paper over a member's own 403.
     const { client } = fakeClient({}, "member", true);
     await show(client);
 

--- a/frontend/test/unit/domain-settings-host-backed.test.ts
+++ b/frontend/test/unit/domain-settings-host-backed.test.ts
@@ -97,11 +97,15 @@ interface Calls {
  * fixture convention: since issue #403 this page resolves the viewer's role to
  * decide whether to offer the write forms at all, and a client that fell
  * through to the SMTP branch for every unmatched path — as this one used to —
- * would resolve every test here as a non-admin by accident.
+ * would resolve every test here as a non-admin by accident. `session: "none"`
+ * makes `/auth/me` reject, the way it does for an unauthenticated or
+ * bearer-only caller. `carriesPlatformBearer` is independent of it — a hub
+ * console can carry a bearer alongside a real session (`authHeaders`'s own
+ * doc comment).
  */
 function fakeClient(
   overrides: { domain?: unknown; smtp?: unknown } = {},
-  role: "admin" | "member" = "admin",
+  session: "admin" | "member" | "none" = "admin",
   carriesPlatformBearer = false,
 ) {
   const calls: Calls = { put: [], post: [] };
@@ -110,13 +114,15 @@ function fakeClient(
     carriesPlatformBearer,
     get: (path: string) => {
       if (path.endsWith("/auth/me")) {
-        return Promise.resolve({
-          id: "u1",
-          email: "a@b.c",
-          role,
-          company: "acme",
-          hasPassword: true,
-        });
+        return session === "none"
+          ? Promise.reject(new Error("no session"))
+          : Promise.resolve({
+              id: "u1",
+              email: "a@b.c",
+              role: session,
+              company: "acme",
+              hasPassword: true,
+            });
       }
       const answer = path.endsWith("/domain")
         ? (overrides.domain ?? DOMAIN_STATUS)
@@ -471,20 +477,40 @@ describe("authority: the write forms, not the reads (issue #1785 audit)", () => 
     expect((at("smtp-save") as HTMLButtonElement | null)?.disabled).toBe(false);
   });
 
-  it("offers a platform bearer both write forms without calling /auth/me", async () => {
+  it("offers a bearer-only caller both write forms once /auth/me finds no session", async () => {
     // `PUT …/domain`, `PUT …/smtp` and `POST …/smtp/test` are all
     // `AdminScopedCompany`, which admits a bearer that has addressed this
-    // company unconditionally — it has no human session for `/auth/me` to
-    // return, so resolving canManage through that route alone would hide a
-    // write both cards' own backend would let through.
-    const { client } = fakeClient({}, "member", true);
-    const getSpy = vi.spyOn(client, "get");
+    // company unconditionally once `/auth/me` finds no human session to
+    // resolve instead.
+    const { client } = fakeClient({}, "none", true);
     await show(client);
 
     expect(at("domain-read-only")).toBeNull();
     expect(at("domain-remove")).not.toBeNull();
     expect(at("smtp-read-only")).toBeNull();
     expect(at("smtp-host")).not.toBeNull();
-    expect(getSpy.mock.calls.some(([path]) => String(path).endsWith("/auth/me"))).toBe(false);
+  });
+
+  it("defers to a member session on both cards even when a platform bearer is also present", async () => {
+    // A hub console can carry both credentials at once (`authHeaders`), and
+    // resolve_principal tries the session first — so a bearer must never
+    // paper over a member's own 403 (codex review).
+    const { client } = fakeClient({}, "member", true);
+    await show(client);
+
+    expect(at("domain-read-only")?.textContent).toContain("Only an admin");
+    expect(at("domain-remove")).toBeNull();
+    expect(at("smtp-read-only")?.textContent).toContain("Only an admin");
+    expect(at("smtp-host")).toBeNull();
+  });
+
+  it("defers to an admin session on both cards when a platform bearer is also present", async () => {
+    const { client } = fakeClient({}, "admin", true);
+    await show(client);
+
+    expect(at("domain-read-only")).toBeNull();
+    expect(at("domain-remove")).not.toBeNull();
+    expect(at("smtp-read-only")).toBeNull();
+    expect(at("smtp-host")).not.toBeNull();
   });
 });

--- a/frontend/test/unit/domain-settings-host-backed.test.ts
+++ b/frontend/test/unit/domain-settings-host-backed.test.ts
@@ -102,10 +102,12 @@ interface Calls {
 function fakeClient(
   overrides: { domain?: unknown; smtp?: unknown } = {},
   role: "admin" | "member" = "admin",
+  carriesPlatformBearer = false,
 ) {
   const calls: Calls = { put: [], post: [] };
   const client = {
     scopeFor: () => "/api/v1/companies/acme",
+    carriesPlatformBearer,
     get: (path: string) => {
       if (path.endsWith("/auth/me")) {
         return Promise.resolve({
@@ -467,5 +469,22 @@ describe("authority: the write forms, not the reads (issue #1785 audit)", () => 
     expect(at("smtp-read-only")).toBeNull();
     expect(at("smtp-host")).not.toBeNull();
     expect((at("smtp-save") as HTMLButtonElement | null)?.disabled).toBe(false);
+  });
+
+  it("offers a platform bearer both write forms without calling /auth/me", async () => {
+    // `PUT …/domain`, `PUT …/smtp` and `POST …/smtp/test` are all
+    // `AdminScopedCompany`, which admits a bearer that has addressed this
+    // company unconditionally — it has no human session for `/auth/me` to
+    // return, so resolving canManage through that route alone would hide a
+    // write both cards' own backend would let through.
+    const { client } = fakeClient({}, "member", true);
+    const getSpy = vi.spyOn(client, "get");
+    await show(client);
+
+    expect(at("domain-read-only")).toBeNull();
+    expect(at("domain-remove")).not.toBeNull();
+    expect(at("smtp-read-only")).toBeNull();
+    expect(at("smtp-host")).not.toBeNull();
+    expect(getSpy.mock.calls.some(([path]) => String(path).endsWith("/auth/me"))).toBe(false);
   });
 });

--- a/frontend/test/unit/domain-settings-host-backed.test.ts
+++ b/frontend/test/unit/domain-settings-host-backed.test.ts
@@ -4,6 +4,7 @@ import { act, createElement, Fragment } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 
 /**
@@ -98,14 +99,16 @@ interface Calls {
  * decide whether to offer the write forms at all, and a client that fell
  * through to the SMTP branch for every unmatched path — as this one used to —
  * would resolve every test here as a non-admin by accident. `session: "none"`
- * makes `/auth/me` reject, the way it does for an unauthenticated or
- * bearer-only caller. `carriesPlatformBearer` is independent of it — a hub
- * console can carry a bearer alongside a real session (`authHeaders`'s own
- * doc comment).
+ * rejects the way the host's own `no_session()` does — a real `ApiError` from
+ * its `{error, code}` envelope — for an unauthenticated or bearer-only caller.
+ * `session: "error"` rejects with a plain network-style error: not a
+ * confirmed absence of a session, so it must not be read as one.
+ * `carriesPlatformBearer` is independent of it — a hub console can carry a
+ * bearer alongside a real session (`authHeaders`'s own doc comment).
  */
 function fakeClient(
   overrides: { domain?: unknown; smtp?: unknown } = {},
-  session: "admin" | "member" | "none" = "admin",
+  session: "admin" | "member" | "none" | "error" = "admin",
   carriesPlatformBearer = false,
 ) {
   const calls: Calls = { put: [], post: [] };
@@ -114,15 +117,15 @@ function fakeClient(
     carriesPlatformBearer,
     get: (path: string) => {
       if (path.endsWith("/auth/me")) {
-        return session === "none"
-          ? Promise.reject(new Error("no session"))
-          : Promise.resolve({
-              id: "u1",
-              email: "a@b.c",
-              role: session,
-              company: "acme",
-              hasPassword: true,
-            });
+        if (session === "none") return Promise.reject(new ApiError(401, "unauthorized", "not signed in", true));
+        if (session === "error") return Promise.reject(new Error("network down"));
+        return Promise.resolve({
+          id: "u1",
+          email: "a@b.c",
+          role: session,
+          company: "acme",
+          hasPassword: true,
+        });
       }
       const answer = path.endsWith("/domain")
         ? (overrides.domain ?? DOMAIN_STATUS)
@@ -489,6 +492,19 @@ describe("authority: the write forms, not the reads (issue #1785 audit)", () => 
     expect(at("domain-remove")).not.toBeNull();
     expect(at("smtp-read-only")).toBeNull();
     expect(at("smtp-host")).not.toBeNull();
+  });
+
+  it("stays read-only on both cards on an ambiguous /auth/me failure, even with a bearer present", async () => {
+    // A network error, a timeout, or a 5xx is not a confirmed absence of a
+    // session — a member's session could still be live and would still take
+    // precedence on the host (coderabbit review).
+    const { client } = fakeClient({}, "error", true);
+    await show(client);
+
+    expect(at("domain-read-only")?.textContent).toContain("Only an admin");
+    expect(at("domain-remove")).toBeNull();
+    expect(at("smtp-read-only")?.textContent).toContain("Only an admin");
+    expect(at("smtp-host")).toBeNull();
   });
 
   it("defers to a member session on both cards even when a platform bearer is also present", async () => {

--- a/frontend/test/unit/hosting-view-branches.test.ts
+++ b/frontend/test/unit/hosting-view-branches.test.ts
@@ -207,6 +207,23 @@ describe("HostingView authority (issue #1785 copy-paste pair)", () => {
     expect(at("hosting-view")?.textContent).toContain("vercel");
   });
 
+  it("tells a member a token is stored even when connected collapses that with a build/grant gap", async () => {
+    // `connected` folds apiKeyConfigured, granted and inBuild into one flag,
+    // so a stored token with the manifest not yet granting `hosting` reads as
+    // "Not connected yet" — indistinguishable, for a member reading only that
+    // summary, from no token ever having been saved (codex review).
+    await show(clientWith({ ...HOSTING_OK, granted: false }, "member"));
+
+    expect(at("hosting-connected")).toBeNull();
+    expect(at("hosting-credential-status")?.textContent).toContain("An API token is stored");
+  });
+
+  it("names the team scope in the member's credential-status line when one is set", async () => {
+    await show(clientWith({ ...HOSTING_OK, granted: false, team: "team_abc" }, "member"));
+
+    expect(at("hosting-credential-status")?.textContent).toContain("team_abc");
+  });
+
   it("offers an admin every control, with no read-only notice", async () => {
     await show(clientWith(HOSTING_OK, "admin"));
 

--- a/frontend/test/unit/hosting-view-branches.test.ts
+++ b/frontend/test/unit/hosting-view-branches.test.ts
@@ -36,9 +36,14 @@ const HOSTING_OK = {
  * control, and a client that rejected every `GET` alike would leave every test
  * here asserting a non-admin's view by accident. `role` makes that explicit.
  */
-function clientWith(answer: unknown, role: "admin" | "member" = "admin"): OpenCompanyClient {
+function clientWith(
+  answer: unknown,
+  role: "admin" | "member" = "admin",
+  carriesPlatformBearer = false,
+): OpenCompanyClient {
   return {
     scopeFor: () => "/api/v1/companies/acme",
+    carriesPlatformBearer,
     get: (path: string) =>
       path.endsWith("/auth/me")
         ? Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme", hasPassword: true })
@@ -200,5 +205,15 @@ describe("HostingView authority (issue #1785 copy-paste pair)", () => {
     expect(at("hosting-api-key")).not.toBeNull();
     expect(at("hosting-team")).not.toBeNull();
     expect((at("hosting-save") as HTMLButtonElement | null)?.disabled).toBe(false);
+  });
+
+  it("offers a platform bearer every control without calling /auth/me", async () => {
+    const client = clientWith(HOSTING_OK, "member", true);
+    const getSpy = vi.spyOn(client, "get");
+    await show(client);
+
+    expect(at("hosting-read-only")).toBeNull();
+    expect(at("hosting-api-key")).not.toBeNull();
+    expect(getSpy.mock.calls.some(([path]) => String(path).endsWith("/auth/me"))).toBe(false);
   });
 });

--- a/frontend/test/unit/hosting-view-branches.test.ts
+++ b/frontend/test/unit/hosting-view-branches.test.ts
@@ -224,6 +224,19 @@ describe("HostingView authority", () => {
     expect(at("hosting-credential-status")?.textContent).toContain("team_abc");
   });
 
+  it("shows the saved team scope to a member even before a token is ever stored", async () => {
+    // An admin can save the team field on its own — `put_hosting` persists it
+    // independently of the API key — so `apiKeyConfigured` can be false while
+    // `team` is already set. Gating the status line on the token alone would
+    // hide the only team display from a member in that state.
+    await show(clientWith({ ...HOSTING_OK, apiKeyConfigured: false, team: "team_abc" }, "member"));
+
+    expect(at("hosting-connected")).toBeNull();
+    const status = at("hosting-credential-status")?.textContent ?? "";
+    expect(status).toContain("team_abc");
+    expect(status).not.toContain("An API token is stored");
+  });
+
   it("offers an admin every control, with no read-only notice", async () => {
     await show(clientWith(HOSTING_OK, "admin"));
 

--- a/frontend/test/unit/hosting-view-branches.test.ts
+++ b/frontend/test/unit/hosting-view-branches.test.ts
@@ -172,3 +172,33 @@ describe("HostingView status surfaces", () => {
     expect(at("hosting-save")).not.toBeNull();
   });
 });
+
+describe("HostingView authority (issue #1785 copy-paste pair)", () => {
+  it("offers a member the credential fields, and no way to submit them", async () => {
+    // The provider picker's sibling defect: the API token field, the team
+    // field and Save were rendered enabled for a member, and the host refuses
+    // `PUT …/hosting` with a 403 whatever the console shows. Presence, not
+    // enabledness — matching `connections-authority.spec.ts`.
+    await show(clientWith(HOSTING_OK, "member"));
+
+    expect(at("hosting-read-only")?.textContent).toContain("Only an admin");
+    expect(at("hosting-api-key")).toBeNull();
+    expect(at("hosting-team")).toBeNull();
+    expect(at("hosting-save")).toBeNull();
+    expect(at("hosting-clear")).toBeNull();
+
+    // A member is not shown a blank page: the current connection state is
+    // still on screen.
+    expect(at("hosting-connected")).not.toBeNull();
+    expect(at("hosting-view")?.textContent).toContain("vercel");
+  });
+
+  it("offers an admin every control, with no read-only notice", async () => {
+    await show(clientWith(HOSTING_OK, "admin"));
+
+    expect(at("hosting-read-only")).toBeNull();
+    expect(at("hosting-api-key")).not.toBeNull();
+    expect(at("hosting-team")).not.toBeNull();
+    expect((at("hosting-save") as HTMLButtonElement | null)?.disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/hosting-view-branches.test.ts
+++ b/frontend/test/unit/hosting-view-branches.test.ts
@@ -187,7 +187,7 @@ describe("HostingView status surfaces", () => {
   });
 });
 
-describe("HostingView authority (issue #1785 copy-paste pair)", () => {
+describe("HostingView authority", () => {
   it("offers a member the credential fields, and no way to submit them", async () => {
     // The provider picker's sibling defect: the API token field, the team
     // field and Save were rendered enabled for a member, and the host refuses
@@ -211,7 +211,7 @@ describe("HostingView authority (issue #1785 copy-paste pair)", () => {
     // `connected` folds apiKeyConfigured, granted and inBuild into one flag,
     // so a stored token with the manifest not yet granting `hosting` reads as
     // "Not connected yet" — indistinguishable, for a member reading only that
-    // summary, from no token ever having been saved (codex review).
+    // summary, from no token ever having been saved.
     await show(clientWith({ ...HOSTING_OK, granted: false }, "member"));
 
     expect(at("hosting-connected")).toBeNull();
@@ -243,7 +243,7 @@ describe("HostingView authority (issue #1785 copy-paste pair)", () => {
   it("stays read-only on an ambiguous /auth/me failure, even with a bearer present", async () => {
     // A network error, a timeout, or a 5xx is not a confirmed absence of a
     // session — a member's session could still be live and would still take
-    // precedence on the host (coderabbit review).
+    // precedence on the host.
     await show(clientWith(HOSTING_OK, "error", true));
 
     expect(at("hosting-read-only")?.textContent).toContain("Only an admin");
@@ -253,7 +253,7 @@ describe("HostingView authority (issue #1785 copy-paste pair)", () => {
   it("defers to a member session even when a platform bearer is also present", async () => {
     // A hub console can carry both credentials at once (`authHeaders`), and
     // resolve_principal tries the session first — so a bearer must never
-    // paper over a member's own 403 (codex review).
+    // paper over a member's own 403.
     await show(clientWith(HOSTING_OK, "member", true));
 
     expect(at("hosting-read-only")?.textContent).toContain("Only an admin");

--- a/frontend/test/unit/hosting-view-branches.test.ts
+++ b/frontend/test/unit/hosting-view-branches.test.ts
@@ -34,22 +34,27 @@ const HOSTING_OK = {
  * `/auth/me` is answered separately, and as an admin by default: since #1796
  * this page resolves the viewer's role to decide whether to offer the grant
  * control, and a client that rejected every `GET` alike would leave every test
- * here asserting a non-admin's view by accident. `role` makes that explicit.
+ * here asserting a non-admin's view by accident. `session: "none"` makes
+ * `/auth/me` reject, the way it does for an unauthenticated or bearer-only
+ * caller. `carriesPlatformBearer` is independent of it — a hub console can
+ * carry a bearer alongside a real session (`authHeaders`'s own doc comment).
  */
 function clientWith(
   answer: unknown,
-  role: "admin" | "member" = "admin",
+  session: "admin" | "member" | "none" = "admin",
   carriesPlatformBearer = false,
 ): OpenCompanyClient {
   return {
     scopeFor: () => "/api/v1/companies/acme",
     carriesPlatformBearer,
-    get: (path: string) =>
-      path.endsWith("/auth/me")
-        ? Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme", hasPassword: true })
-        : answer instanceof Error
-          ? Promise.reject(answer)
-          : Promise.resolve(answer ?? HOSTING_OK),
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return session === "none"
+          ? Promise.reject(new Error("no session"))
+          : Promise.resolve({ id: "u1", email: "a@b.c", role: session, company: "acme", hasPassword: true });
+      }
+      return answer instanceof Error ? Promise.reject(answer) : Promise.resolve(answer ?? HOSTING_OK);
+    },
   } as unknown as OpenCompanyClient;
 }
 
@@ -207,13 +212,27 @@ describe("HostingView authority (issue #1785 copy-paste pair)", () => {
     expect((at("hosting-save") as HTMLButtonElement | null)?.disabled).toBe(false);
   });
 
-  it("offers a platform bearer every control without calling /auth/me", async () => {
-    const client = clientWith(HOSTING_OK, "member", true);
-    const getSpy = vi.spyOn(client, "get");
-    await show(client);
+  it("offers a bearer-only caller every control once /auth/me finds no session", async () => {
+    await show(clientWith(HOSTING_OK, "none", true));
 
     expect(at("hosting-read-only")).toBeNull();
     expect(at("hosting-api-key")).not.toBeNull();
-    expect(getSpy.mock.calls.some(([path]) => String(path).endsWith("/auth/me"))).toBe(false);
+  });
+
+  it("defers to a member session even when a platform bearer is also present", async () => {
+    // A hub console can carry both credentials at once (`authHeaders`), and
+    // resolve_principal tries the session first — so a bearer must never
+    // paper over a member's own 403 (codex review).
+    await show(clientWith(HOSTING_OK, "member", true));
+
+    expect(at("hosting-read-only")?.textContent).toContain("Only an admin");
+    expect(at("hosting-api-key")).toBeNull();
+  });
+
+  it("defers to an admin session when a platform bearer is also present", async () => {
+    await show(clientWith(HOSTING_OK, "admin", true));
+
+    expect(at("hosting-read-only")).toBeNull();
+    expect(at("hosting-api-key")).not.toBeNull();
   });
 });

--- a/frontend/test/unit/hosting-view-branches.test.ts
+++ b/frontend/test/unit/hosting-view-branches.test.ts
@@ -4,6 +4,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import { HostingView } from "@/views/HostingView";
 
@@ -34,14 +35,17 @@ const HOSTING_OK = {
  * `/auth/me` is answered separately, and as an admin by default: since #1796
  * this page resolves the viewer's role to decide whether to offer the grant
  * control, and a client that rejected every `GET` alike would leave every test
- * here asserting a non-admin's view by accident. `session: "none"` makes
- * `/auth/me` reject, the way it does for an unauthenticated or bearer-only
- * caller. `carriesPlatformBearer` is independent of it — a hub console can
- * carry a bearer alongside a real session (`authHeaders`'s own doc comment).
+ * here asserting a non-admin's view by accident. `session: "none"` rejects the
+ * way the host's own `no_session()` does — a real `ApiError` from its
+ * `{error, code}` envelope — for an unauthenticated or bearer-only caller.
+ * `session: "error"` rejects with a plain network-style error: not a
+ * confirmed absence of a session, so it must not be read as one.
+ * `carriesPlatformBearer` is independent of it — a hub console can carry a
+ * bearer alongside a real session (`authHeaders`'s own doc comment).
  */
 function clientWith(
   answer: unknown,
-  session: "admin" | "member" | "none" = "admin",
+  session: "admin" | "member" | "none" | "error" = "admin",
   carriesPlatformBearer = false,
 ): OpenCompanyClient {
   return {
@@ -49,9 +53,9 @@ function clientWith(
     carriesPlatformBearer,
     get: (path: string) => {
       if (path.endsWith("/auth/me")) {
-        return session === "none"
-          ? Promise.reject(new Error("no session"))
-          : Promise.resolve({ id: "u1", email: "a@b.c", role: session, company: "acme", hasPassword: true });
+        if (session === "none") return Promise.reject(new ApiError(401, "unauthorized", "not signed in", true));
+        if (session === "error") return Promise.reject(new Error("network down"));
+        return Promise.resolve({ id: "u1", email: "a@b.c", role: session, company: "acme", hasPassword: true });
       }
       return answer instanceof Error ? Promise.reject(answer) : Promise.resolve(answer ?? HOSTING_OK);
     },
@@ -217,6 +221,16 @@ describe("HostingView authority (issue #1785 copy-paste pair)", () => {
 
     expect(at("hosting-read-only")).toBeNull();
     expect(at("hosting-api-key")).not.toBeNull();
+  });
+
+  it("stays read-only on an ambiguous /auth/me failure, even with a bearer present", async () => {
+    // A network error, a timeout, or a 5xx is not a confirmed absence of a
+    // session — a member's session could still be live and would still take
+    // precedence on the host (coderabbit review).
+    await show(clientWith(HOSTING_OK, "error", true));
+
+    expect(at("hosting-read-only")?.textContent).toContain("Only an admin");
+    expect(at("hosting-api-key")).toBeNull();
   });
 
   it("defers to a member session even when a platform bearer is also present", async () => {

--- a/frontend/test/unit/search-view-branches.test.ts
+++ b/frontend/test/unit/search-view-branches.test.ts
@@ -9,7 +9,7 @@ import type { OpenCompanyClient } from "@/api/client";
 import { SearchView } from "@/views/SearchView";
 
 /**
- * `SearchView` is `HostingView`'s copy-paste sibling (codex review, #1785),
+ * `SearchView` is `HostingView`'s copy-paste sibling,
  * and carried the same authority gap: the provider picker, the API key field
  * and Save rendered enabled for a member, with nothing that read `canManage`
  * — the page's own footer sentence names the reason the choice is an
@@ -88,7 +88,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("SearchView authority (issue #1785 copy-paste pair)", () => {
+describe("SearchView authority", () => {
   it("offers a member the current provider, and no way to change it", async () => {
     await show(clientWith(SEARCH_OK, "member"));
 
@@ -121,7 +121,7 @@ describe("SearchView authority (issue #1785 copy-paste pair)", () => {
   it("stays read-only on an ambiguous /auth/me failure, even with a bearer present", async () => {
     // A network error, a timeout, or a 5xx is not a confirmed absence of a
     // session — a member's session could still be live and would still take
-    // precedence on the host (coderabbit review).
+    // precedence on the host.
     await show(clientWith(SEARCH_OK, "error", true));
 
     expect(at("search-read-only")?.textContent).toContain("Only an admin");
@@ -131,7 +131,7 @@ describe("SearchView authority (issue #1785 copy-paste pair)", () => {
   it("defers to a member session even when a platform bearer is also present", async () => {
     // A hub console can carry both credentials at once (`authHeaders`), and
     // resolve_principal tries the session first — so a bearer must never
-    // paper over a member's own 403 (codex review).
+    // paper over a member's own 403.
     await show(clientWith(SEARCH_OK, "member", true));
 
     expect(at("search-read-only")?.textContent).toContain("Only an admin");
@@ -148,8 +148,7 @@ describe("SearchView authority (issue #1785 copy-paste pair)", () => {
   it("hides the editable SearXNG endpoint field from a member, but shows it read-only", async () => {
     // The endpoint is non-secret and identifies where every teammate search
     // leaves the host — a member auditing that must not find only "SearXNG"
-    // with the actual address hidden alongside the write control (codex
-    // review).
+    // with the actual address hidden alongside the write control.
     await show(
       clientWith(
         { ...SEARCH_OK, provider: "searxng", effectiveProvider: "searxng", endpoint: "https://searx.acme.com" },

--- a/frontend/test/unit/search-view-branches.test.ts
+++ b/frontend/test/unit/search-view-branches.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { SearchView } from "@/views/SearchView";
+
+/**
+ * `SearchView` is `HostingView`'s copy-paste sibling (codex review, #1785),
+ * and carried the same authority gap: the provider picker, the API key field
+ * and Save rendered enabled for a member, with nothing that read `canManage`
+ * — the page's own footer sentence names the reason the choice is an
+ * administrator's, and the form above it did not act on it. The host refuses
+ * `PUT …/search` with a 403 whatever the console shows.
+ */
+
+const SEARCH_OK = {
+  provider: "brave",
+  effectiveProvider: "brave",
+  apiKeyConfigured: true,
+  endpoint: null,
+  needsApiKey: false,
+  needsEndpoint: false,
+  granted: true,
+  inBuild: true,
+  supportedProviders: ["managed", "brave", "exa", "searxng"],
+};
+
+/**
+ * A client answering the search read with a value or a rejection.
+ *
+ * `/auth/me` is answered separately, and as an admin by default — matching
+ * `HostingView`'s own fixture — since this page resolves the viewer's role to
+ * decide whether to offer the write form.
+ */
+function clientWith(answer: unknown, role: "admin" | "member" = "admin"): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: (path: string) =>
+      path.endsWith("/auth/me")
+        ? Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme", hasPassword: true })
+        : answer instanceof Error
+          ? Promise.reject(answer)
+          : Promise.resolve(answer ?? SEARCH_OK),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(SearchView, { client, company: "acme" }));
+  });
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("SearchView authority (issue #1785 copy-paste pair)", () => {
+  it("offers a member the current provider, and no way to change it", async () => {
+    await show(clientWith(SEARCH_OK, "member"));
+
+    expect(at("search-read-only")?.textContent).toContain("Only an admin");
+    expect(at("search-provider")).toBeNull();
+    expect(at("search-api-key")).toBeNull();
+    expect(at("search-endpoint")).toBeNull();
+    expect(at("search-save")).toBeNull();
+    expect(at("search-clear")).toBeNull();
+
+    // Not a blank page: the effective provider is still on screen.
+    expect(at("search-view")?.textContent).toContain("Brave Search");
+  });
+
+  it("offers an admin every control, with no read-only notice", async () => {
+    await show(clientWith(SEARCH_OK, "admin"));
+
+    expect(at("search-read-only")).toBeNull();
+    expect(at("search-provider")).not.toBeNull();
+    expect((at("search-save") as HTMLButtonElement | null)?.disabled).toBe(false);
+  });
+
+  it("hides the SearXNG endpoint field from a member too, same as the API key", async () => {
+    await show(
+      clientWith(
+        { ...SEARCH_OK, provider: "searxng", effectiveProvider: "searxng", endpoint: "https://searx.acme.com" },
+        "member",
+      ),
+    );
+
+    expect(at("search-endpoint")).toBeNull();
+    // The effective provider is still readable — a member is told what is
+    // configured, just not handed the field that would change it.
+    expect(at("search-view")?.textContent).toContain("SearXNG");
+  });
+});

--- a/frontend/test/unit/search-view-branches.test.ts
+++ b/frontend/test/unit/search-view-branches.test.ts
@@ -33,23 +33,28 @@ const SEARCH_OK = {
  *
  * `/auth/me` is answered separately, and as an admin by default — matching
  * `HostingView`'s own fixture — since this page resolves the viewer's role to
- * decide whether to offer the write form. `carriesPlatformBearer` defaults to
- * `false`, matching a browser session authenticating by cookie.
+ * decide whether to offer the write form. `session: "none"` makes `/auth/me`
+ * reject, the way it does for an unauthenticated or bearer-only caller.
+ * `carriesPlatformBearer` defaults to `false`, matching a browser session
+ * authenticating by cookie; a hub console can carry it alongside a real
+ * session (`authHeaders`'s own doc comment), so the two are independent here.
  */
 function clientWith(
   answer: unknown,
-  role: "admin" | "member" = "admin",
+  session: "admin" | "member" | "none" = "admin",
   carriesPlatformBearer = false,
 ): OpenCompanyClient {
   return {
     scopeFor: () => "/api/v1/companies/acme",
     carriesPlatformBearer,
-    get: (path: string) =>
-      path.endsWith("/auth/me")
-        ? Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme", hasPassword: true })
-        : answer instanceof Error
-          ? Promise.reject(answer)
-          : Promise.resolve(answer ?? SEARCH_OK),
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return session === "none"
+          ? Promise.reject(new Error("no session"))
+          : Promise.resolve({ id: "u1", email: "a@b.c", role: session, company: "acme", hasPassword: true });
+      }
+      return answer instanceof Error ? Promise.reject(answer) : Promise.resolve(answer ?? SEARCH_OK);
+    },
   } as unknown as OpenCompanyClient;
 }
 
@@ -102,14 +107,28 @@ describe("SearchView authority (issue #1785 copy-paste pair)", () => {
     expect((at("search-save") as HTMLButtonElement | null)?.disabled).toBe(false);
   });
 
-  it("offers a platform bearer every control without calling /auth/me", async () => {
-    const client = clientWith(SEARCH_OK, "member", true);
-    const getSpy = vi.spyOn(client, "get");
-    await show(client);
+  it("offers a bearer-only caller every control once /auth/me finds no session", async () => {
+    await show(clientWith(SEARCH_OK, "none", true));
 
     expect(at("search-read-only")).toBeNull();
     expect(at("search-provider")).not.toBeNull();
-    expect(getSpy.mock.calls.some(([path]) => String(path).endsWith("/auth/me"))).toBe(false);
+  });
+
+  it("defers to a member session even when a platform bearer is also present", async () => {
+    // A hub console can carry both credentials at once (`authHeaders`), and
+    // resolve_principal tries the session first — so a bearer must never
+    // paper over a member's own 403 (codex review).
+    await show(clientWith(SEARCH_OK, "member", true));
+
+    expect(at("search-read-only")?.textContent).toContain("Only an admin");
+    expect(at("search-provider")).toBeNull();
+  });
+
+  it("defers to an admin session when a platform bearer is also present", async () => {
+    await show(clientWith(SEARCH_OK, "admin", true));
+
+    expect(at("search-read-only")).toBeNull();
+    expect(at("search-provider")).not.toBeNull();
   });
 
   it("hides the SearXNG endpoint field from a member too, same as the API key", async () => {

--- a/frontend/test/unit/search-view-branches.test.ts
+++ b/frontend/test/unit/search-view-branches.test.ts
@@ -33,11 +33,17 @@ const SEARCH_OK = {
  *
  * `/auth/me` is answered separately, and as an admin by default — matching
  * `HostingView`'s own fixture — since this page resolves the viewer's role to
- * decide whether to offer the write form.
+ * decide whether to offer the write form. `carriesPlatformBearer` defaults to
+ * `false`, matching a browser session authenticating by cookie.
  */
-function clientWith(answer: unknown, role: "admin" | "member" = "admin"): OpenCompanyClient {
+function clientWith(
+  answer: unknown,
+  role: "admin" | "member" = "admin",
+  carriesPlatformBearer = false,
+): OpenCompanyClient {
   return {
     scopeFor: () => "/api/v1/companies/acme",
+    carriesPlatformBearer,
     get: (path: string) =>
       path.endsWith("/auth/me")
         ? Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme", hasPassword: true })
@@ -94,6 +100,16 @@ describe("SearchView authority (issue #1785 copy-paste pair)", () => {
     expect(at("search-read-only")).toBeNull();
     expect(at("search-provider")).not.toBeNull();
     expect((at("search-save") as HTMLButtonElement | null)?.disabled).toBe(false);
+  });
+
+  it("offers a platform bearer every control without calling /auth/me", async () => {
+    const client = clientWith(SEARCH_OK, "member", true);
+    const getSpy = vi.spyOn(client, "get");
+    await show(client);
+
+    expect(at("search-read-only")).toBeNull();
+    expect(at("search-provider")).not.toBeNull();
+    expect(getSpy.mock.calls.some(([path]) => String(path).endsWith("/auth/me"))).toBe(false);
   });
 
   it("hides the SearXNG endpoint field from a member too, same as the API key", async () => {

--- a/frontend/test/unit/search-view-branches.test.ts
+++ b/frontend/test/unit/search-view-branches.test.ts
@@ -145,7 +145,11 @@ describe("SearchView authority (issue #1785 copy-paste pair)", () => {
     expect(at("search-provider")).not.toBeNull();
   });
 
-  it("hides the SearXNG endpoint field from a member too, same as the API key", async () => {
+  it("hides the editable SearXNG endpoint field from a member, but shows it read-only", async () => {
+    // The endpoint is non-secret and identifies where every teammate search
+    // leaves the host — a member auditing that must not find only "SearXNG"
+    // with the actual address hidden alongside the write control (codex
+    // review).
     await show(
       clientWith(
         { ...SEARCH_OK, provider: "searxng", effectiveProvider: "searxng", endpoint: "https://searx.acme.com" },
@@ -154,8 +158,7 @@ describe("SearchView authority (issue #1785 copy-paste pair)", () => {
     );
 
     expect(at("search-endpoint")).toBeNull();
-    // The effective provider is still readable — a member is told what is
-    // configured, just not handed the field that would change it.
+    expect(at("search-endpoint-readonly")?.textContent).toBe("https://searx.acme.com");
     expect(at("search-view")?.textContent).toContain("SearXNG");
   });
 });

--- a/frontend/test/unit/search-view-branches.test.ts
+++ b/frontend/test/unit/search-view-branches.test.ts
@@ -4,6 +4,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import { SearchView } from "@/views/SearchView";
 
@@ -33,15 +34,18 @@ const SEARCH_OK = {
  *
  * `/auth/me` is answered separately, and as an admin by default — matching
  * `HostingView`'s own fixture — since this page resolves the viewer's role to
- * decide whether to offer the write form. `session: "none"` makes `/auth/me`
- * reject, the way it does for an unauthenticated or bearer-only caller.
+ * decide whether to offer the write form. `session: "none"` rejects the way
+ * the host's own `no_session()` does — a real `ApiError` from its
+ * `{error, code}` envelope — for an unauthenticated or bearer-only caller.
+ * `session: "error"` rejects with a plain network-style error: not a
+ * confirmed absence of a session, so it must not be read as one.
  * `carriesPlatformBearer` defaults to `false`, matching a browser session
  * authenticating by cookie; a hub console can carry it alongside a real
  * session (`authHeaders`'s own doc comment), so the two are independent here.
  */
 function clientWith(
   answer: unknown,
-  session: "admin" | "member" | "none" = "admin",
+  session: "admin" | "member" | "none" | "error" = "admin",
   carriesPlatformBearer = false,
 ): OpenCompanyClient {
   return {
@@ -49,9 +53,9 @@ function clientWith(
     carriesPlatformBearer,
     get: (path: string) => {
       if (path.endsWith("/auth/me")) {
-        return session === "none"
-          ? Promise.reject(new Error("no session"))
-          : Promise.resolve({ id: "u1", email: "a@b.c", role: session, company: "acme", hasPassword: true });
+        if (session === "none") return Promise.reject(new ApiError(401, "unauthorized", "not signed in", true));
+        if (session === "error") return Promise.reject(new Error("network down"));
+        return Promise.resolve({ id: "u1", email: "a@b.c", role: session, company: "acme", hasPassword: true });
       }
       return answer instanceof Error ? Promise.reject(answer) : Promise.resolve(answer ?? SEARCH_OK);
     },
@@ -112,6 +116,16 @@ describe("SearchView authority (issue #1785 copy-paste pair)", () => {
 
     expect(at("search-read-only")).toBeNull();
     expect(at("search-provider")).not.toBeNull();
+  });
+
+  it("stays read-only on an ambiguous /auth/me failure, even with a bearer present", async () => {
+    // A network error, a timeout, or a 5xx is not a confirmed absence of a
+    // session — a member's session could still be live and would still take
+    // precedence on the host (coderabbit review).
+    await show(clientWith(SEARCH_OK, "error", true));
+
+    expect(at("search-read-only")?.textContent).toContain("Only an admin");
+    expect(at("search-provider")).toBeNull();
   });
 
   it("defers to a member session even when a platform bearer is also present", async () => {


### PR DESCRIPTION
## Summary

Four console surfaces rendered their write controls **enabled for a member**, with the backend's
403 as the only thing stopping the write. On Search and Hosting the cost is that a teammate
learns this only after pasting a live credential into a form that was never going to work.

- **Search** (`SearchView`) — provider picker, API key, endpoint, Save, Clear
- **Hosting** (`HostingView`) — API token, team field, Save, Disconnect
- **Domain** (`domain-settings`) — Add/Remove domain
- **SMTP** (`domain-settings`) — the whole credential form and Test

Search and Hosting are a known copy-paste pair; the code's own comment says so. Domain and SMTP
were not previously identified: `domain-settings.tsx` had **zero** role logic anywhere, despite
the host requiring admin for the domain write and for both the SMTP write and its test.

Search is the sharpest of the four, because the page prints the rule it is breaking directly
under the enabled control: *"Search queries leave this host … which is the reason the choice is an
administrator's and not a teammate's."*

`canManage` was already computed in `SearchView` for its `GrantNamespace` and simply never applied
to the form. This uses the existing `use-can-manage` hook and the `Alert` + `AlertTitle` read-only
notice convention already used by `InferenceView`, `OAuthView` and `McpServersView` — no new
mechanism.

**Verify DNS is deliberately left open to members.** `POST …/domain/verify` is `ScopedCompany` on
the host, so gating it in the console would make the page lie in the other direction.

Nothing is hidden. A member still sees the current provider, connection state and the non-secret
SMTP fields — never the password — so the page stays honest about what is configured while
refusing the write it cannot perform.

## API Or Behavior Changes

Console-only; no route, request or response changed. Behaviour change for a member: write controls
on these four surfaces now render disabled with a notice, instead of enabled and then failing with
a 403 after a credential has been typed. Admins are unaffected.

## Tests

Every authority assertion was observed failing against the pre-fix components before being
trusted. The pre-fix files were restored from out-of-tree copies rather than `git checkout`, and
the fixed versions diffed byte-for-byte before committing.

- `frontend/test/unit/search-view-branches.test.ts` (new) — member sees the notice and no
  picker/key/Save but still sees the current provider; admin sees every control and no notice.
- `frontend/test/unit/hosting-view-branches.test.ts` — same coverage added for Hosting.
- `frontend/test/unit/domain-settings-host-backed.test.ts` — member-vs-admin for both Domain and
  SMTP, and an assertion that Verify DNS stays available to a member.
- `frontend/test/unit/credential-clear-confirm.test.ts` — its `client()` stub had no `get()` at
  all, so once the gate landed it resolved `HostingView` as non-admin and silently hid the
  Disconnect button the test clicks. Fixture repaired; it was hiding the regression it existed to
  catch.

Commands run locally, unpiped:

- [x] `npm run typecheck` — 0
- [x] `npm run typecheck:unit` — 0
- [x] `npm run typecheck:e2e` — 0
- [x] `npx vitest run` — 0 · 497 files, 4598 tests passed
- [ ] N/A: `cargo fmt` / `clippy` / `build` / `test` — no Rust changed

### Known intermittent flake — not from this change

`npx vitest run` exits **1 on some runs and 0 on others**, always with the same cause: two
`TypeError: client.post is not a function` uncaught exceptions attributed to
`test/unit/workflow-id-derivation.test.ts`. It is a `WorkflowCreateDialog` debounce timer firing
after that file has finished, so the count varies with timing and the process exit code varies
with it. **No test fails in either case** — 497 files and 4598 tests pass every run.

This reproduces on a clean checkout of base `40659a3fa` with the same signature and the same two
occurrences, and nothing in this PR touches `WorkflowCreateDialog`, `workflow-id-derivation`, or
any workflow code. Flagging it because a reviewer seeing a red vitest lane on this PR should not
attribute it here; it deserves its own fix.

## Documentation

None needed. The read-only notices state the rule on the page where it applies.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access Controls**
  * Restricted domain, SMTP, hosting, and search configuration changes to administrators.
  * Non-admins now see read-only summaries and permission notices.
  * DNS verification remains available to non-admins.
  * Administrative save, remove, disconnect, and credential actions remain available to administrators.

* **Bug Fixes**
  * Prevented non-admin users from editing provider settings, hosting credentials, domains, or SMTP configuration.
  * Improved handling of uncertain sign-in status to avoid incorrectly exposing editing controls.
  * Added coverage for administrator and non-administrator settings behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->