### PR TITLE
fix(acp): bind a session to the connection that opened it, and cap and expire it

### DIFF
--- a/src-tauri/src/embedded.rs
+++ b/src-tauri/src/embedded.rs
@@ -270,11 +270,11 @@ pub async fn start_with(
     // this sweeper from its own `async_main`, which the embedded host never
     // runs, so nothing here ever reclaimed an idle ACP session — they and
     // their per-connection and host-wide cap slots piled up for the life of
-    // the process (codex review). `AppState::spawn_acp_session_sweeper` is a
+    // the process. `AppState::spawn_acp_session_sweeper` is a
     // no-op in a build without the `acp` feature — this crate's own default
     // dependency features don't include it (`Cargo.toml`), only the
     // release/CI feature set does, and this call site has to compile and do
-    // the right thing either way (codex review, round two).
+    // the right thing either way.
     //
     // Never notified: `Drop` aborts the task directly, matching how `server`
     // below is already stopped, rather than plumbing a second shutdown path
@@ -286,8 +286,7 @@ pub async fn start_with(
             // The sweeper was already running (an infinite loop with no other
             // shutdown path here), so a failed bind must abort it explicitly
             // or it outlives this whole attempt — one more sweeper leaked per
-            // retry a caller makes after a busy-port failure (coderabbit
-            // review).
+            // retry a caller makes after a busy-port failure.
             sweeper.abort();
             return Err(error);
         }

--- a/src-tauri/src/embedded.rs
+++ b/src-tauri/src/embedded.rs
@@ -280,7 +280,18 @@ pub async fn start_with(
     // below is already stopped, rather than plumbing a second shutdown path
     // through a struct that otherwise has none.
     let sweeper = state.spawn_acp_session_sweeper(std::sync::Arc::new(tokio::sync::Notify::new()));
-    let (address, serving) = opencompany::server::bind("127.0.0.1:0", state).await?;
+    let (address, serving) = match opencompany::server::bind("127.0.0.1:0", state).await {
+        Ok(bound) => bound,
+        Err(error) => {
+            // The sweeper was already running (an infinite loop with no other
+            // shutdown path here), so a failed bind must abort it explicitly
+            // or it outlives this whole attempt — one more sweeper leaked per
+            // retry a caller makes after a busy-port failure (coderabbit
+            // review).
+            sweeper.abort();
+            return Err(error);
+        }
+    };
     let server = tokio::spawn(async move {
         if let Err(error) = serving.run().await {
             tracing::error!(%error, "the embedded host stopped");

--- a/src-tauri/src/embedded.rs
+++ b/src-tauri/src/embedded.rs
@@ -36,6 +36,7 @@ pub struct EmbeddedHost {
     /// Dropping it would release the root while this process kept writing.
     _instance: EmbeddedInstance,
     server: tokio::task::JoinHandle<()>,
+    sweeper: tokio::task::JoinHandle<()>,
 }
 
 impl EmbeddedHost {
@@ -71,6 +72,7 @@ impl Drop for EmbeddedHost {
         // The task owns the listener; aborting it closes the port. Without this
         // a restarted embedded host would leak a listener per restart.
         self.server.abort();
+        self.sweeper.abort();
     }
 }
 
@@ -264,12 +266,23 @@ pub async fn start_with(
             .collect::<Vec<_>>(),
     };
 
+    // Captured before `state` moves into `bind`: the standalone binary spawns
+    // this sweeper from its own `async_main`, which the embedded host never
+    // runs, so nothing here ever reclaimed an idle ACP session — they and
+    // their per-connection and host-wide cap slots piled up for the life of
+    // the process (codex review).
+    let acp_sessions = state.acp_sessions();
     let (address, serving) = opencompany::server::bind("127.0.0.1:0", state).await?;
     let server = tokio::spawn(async move {
         if let Err(error) = serving.run().await {
             tracing::error!(%error, "the embedded host stopped");
         }
     });
+    // Never notified: `Drop` aborts the task directly, matching how `server`
+    // above is already stopped, rather than plumbing a second shutdown path
+    // through a struct that otherwise has none.
+    let sweeper = opencompany::server::acp::SessionSweeper::new(acp_sessions)
+        .spawn(std::sync::Arc::new(tokio::sync::Notify::new()));
 
     tracing::info!(
         %address,
@@ -284,6 +297,7 @@ pub async fn start_with(
         companies,
         _instance: instance,
         server,
+        sweeper,
     })
 }
 

--- a/src-tauri/src/embedded.rs
+++ b/src-tauri/src/embedded.rs
@@ -266,23 +266,26 @@ pub async fn start_with(
             .collect::<Vec<_>>(),
     };
 
-    // Captured before `state` moves into `bind`: the standalone binary spawns
+    // Called before `state` moves into `bind`: the standalone binary spawns
     // this sweeper from its own `async_main`, which the embedded host never
     // runs, so nothing here ever reclaimed an idle ACP session — they and
     // their per-connection and host-wide cap slots piled up for the life of
-    // the process (codex review).
-    let acp_sessions = state.acp_sessions();
+    // the process (codex review). `AppState::spawn_acp_session_sweeper` is a
+    // no-op in a build without the `acp` feature — this crate's own default
+    // dependency features don't include it (`Cargo.toml`), only the
+    // release/CI feature set does, and this call site has to compile and do
+    // the right thing either way (codex review, round two).
+    //
+    // Never notified: `Drop` aborts the task directly, matching how `server`
+    // below is already stopped, rather than plumbing a second shutdown path
+    // through a struct that otherwise has none.
+    let sweeper = state.spawn_acp_session_sweeper(std::sync::Arc::new(tokio::sync::Notify::new()));
     let (address, serving) = opencompany::server::bind("127.0.0.1:0", state).await?;
     let server = tokio::spawn(async move {
         if let Err(error) = serving.run().await {
             tracing::error!(%error, "the embedded host stopped");
         }
     });
-    // Never notified: `Drop` aborts the task directly, matching how `server`
-    // above is already stopped, rather than plumbing a second shutdown path
-    // through a struct that otherwise has none.
-    let sweeper = opencompany::server::acp::SessionSweeper::new(acp_sessions)
-        .spawn(std::sync::Arc::new(tokio::sync::Notify::new()));
 
     tracing::info!(
         %address,

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1327,13 +1327,13 @@ mod tests {
         let state = AppState::new(AppConfig::default());
         let shutdown = Arc::new(tokio::sync::Notify::new());
         let handle = state.spawn_acp_session_sweeper(Arc::clone(&shutdown));
-        // Give the spawned task its first poll before notifying: `notify_waiters`
-        // wakes only a task already registered as waiting, not one still
-        // pending its first `.await` — the same race declined as out of scope
-        // for the sweeper itself (coderabbit review), worked around here so
-        // this test does not depend on it.
-        tokio::task::yield_now().await;
-        shutdown.notify_waiters();
+        // `notify_one`, not `notify_waiters`: this test is the only holder of
+        // `shutdown` and the sweeper its only waiter, and unlike
+        // `notify_waiters`, `notify_one` stores a permit for a task that has
+        // not registered as waiting yet — so this cannot lose the
+        // notification to the same scheduling race declined as out of scope
+        // for the sweeper's own shutdown convention (coderabbit review).
+        shutdown.notify_one();
         tokio::time::timeout(std::time::Duration::from_secs(5), handle)
             .await
             .expect("the sweeper task must stop once notified, in every build")

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1320,7 +1320,7 @@ mod tests {
     /// point of the facade: an embedder linking this crate as a library
     /// (`src-tauri/src/embedded.rs`) cannot know at its own compile time
     /// whether this crate's default dependency features happened to include
-    /// `acp` (codex review), so the call site must never need a `cfg` of its
+    /// `acp`, so the call site must never need a `cfg` of its
     /// own to stay buildable.
     #[tokio::test]
     async fn spawn_acp_session_sweeper_is_always_callable_and_stoppable() {
@@ -1331,8 +1331,7 @@ mod tests {
         // `shutdown` and the sweeper its only waiter, and unlike
         // `notify_waiters`, `notify_one` stores a permit for a task that has
         // not registered as waiting yet — so this cannot lose the
-        // notification to the same scheduling race declined as out of scope
-        // for the sweeper's own shutdown convention (coderabbit review).
+        // notification to a scheduling race.
         shutdown.notify_one();
         tokio::time::timeout(std::time::Duration::from_secs(5), handle)
             .await

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -654,6 +654,40 @@ impl AppState {
         Arc::clone(&self.acp_sessions)
     }
 
+    /// Starts the process-wide ACP-session sweeper, reclaiming sessions idle
+    /// past their TTL. A no-op join handle when this build lacks the `acp`
+    /// feature.
+    ///
+    /// Always compiled and always callable, unlike [`Self::acp_sessions`] —
+    /// so an embedder linking this crate as a library (the desktop host,
+    /// `src-tauri/src/embedded.rs`) can call this the same way whether or not
+    /// its own default dependency features happen to include `acp`, rather
+    /// than needing `#[cfg(feature = "acp")]` of its own — which would need a
+    /// same-named feature declared on that crate purely to gate a `cfg`, and
+    /// this crate's own `acp`/`composio` are deliberately *not* forwarded
+    /// that way (see `src-tauri/Cargo.toml`'s comment on why: keeping its
+    /// `Cargo.lock` byte-identical between the default and release feature
+    /// sets is what lets a release still build `--locked`). The standalone
+    /// binary's own `spawn_acp_session_sweeper` mirrors this one line for
+    /// line; it stays `#[cfg(feature = "acp")]` there because it is not
+    /// compiled by anything but this crate itself.
+    #[cfg(feature = "acp")]
+    pub fn spawn_acp_session_sweeper(
+        &self,
+        shutdown: Arc<tokio::sync::Notify>,
+    ) -> tokio::task::JoinHandle<()> {
+        crate::server::acp::SessionSweeper::new(self.acp_sessions()).spawn(shutdown)
+    }
+
+    /// See the feature-enabled [`Self::spawn_acp_session_sweeper`] above.
+    #[cfg(not(feature = "acp"))]
+    pub fn spawn_acp_session_sweeper(
+        &self,
+        _shutdown: Arc<tokio::sync::Notify>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async {})
+    }
+
     /// This host's in-place runtime rebuilder, when one is wired.
     pub fn rebuilder(&self) -> Option<Arc<dyn crate::runtime::RuntimeRebuilder>> {
         self.rebuilder.clone()
@@ -1280,6 +1314,30 @@ mod tests {
     #[test]
     fn workspace_git_checkpoints_default_off() {
         assert!(!AppConfig::default().workspace_git_enabled);
+    }
+
+    /// Callable and finite in every build, `acp` feature or not — the whole
+    /// point of the facade: an embedder linking this crate as a library
+    /// (`src-tauri/src/embedded.rs`) cannot know at its own compile time
+    /// whether this crate's default dependency features happened to include
+    /// `acp` (codex review), so the call site must never need a `cfg` of its
+    /// own to stay buildable.
+    #[tokio::test]
+    async fn spawn_acp_session_sweeper_is_always_callable_and_stoppable() {
+        let state = AppState::new(AppConfig::default());
+        let shutdown = Arc::new(tokio::sync::Notify::new());
+        let handle = state.spawn_acp_session_sweeper(Arc::clone(&shutdown));
+        // Give the spawned task its first poll before notifying: `notify_waiters`
+        // wakes only a task already registered as waiting, not one still
+        // pending its first `.await` — the same race declined as out of scope
+        // for the sweeper itself (coderabbit review), worked around here so
+        // this test does not depend on it.
+        tokio::task::yield_now().await;
+        shutdown.notify_waiters();
+        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+            .await
+            .expect("the sweeper task must stop once notified, in every build")
+            .expect("the sweeper task must not panic");
     }
 
     fn bound_to(bind: &str) -> AppConfig {

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -804,6 +804,17 @@ fn spawn_presence_sweeper(state: &AppState, shutdown: &Arc<Notify>) -> tokio::ta
         .spawn(shutdown.clone())
 }
 
+/// Starts the process-wide ACP-session sweep: reclaims sessions idle past
+/// their TTL. Mirrors [`spawn_presence_sweeper`] — host-global state, not
+/// scoped to a registered company.
+#[cfg(feature = "acp")]
+fn spawn_acp_session_sweeper(
+    state: &AppState,
+    shutdown: &Arc<Notify>,
+) -> tokio::task::JoinHandle<()> {
+    opencompany::server::acp::SessionSweeper::new(state.acp_sessions()).spawn(shutdown.clone())
+}
+
 /// Starts a company's IMAP mailbox poller as a background task, if the
 /// platform injected mailbox credentials for this tenant.
 ///
@@ -2469,6 +2480,8 @@ async fn async_main() -> Result<()> {
             // after boot — which the per-company scheduler spawn above does not.
             scheduler_handles.push(spawn_maintenance_ticker(&state, &shutdown));
             scheduler_handles.push(spawn_presence_sweeper(&state, &shutdown));
+            #[cfg(feature = "acp")]
+            scheduler_handles.push(spawn_acp_session_sweeper(&state, &shutdown));
 
             // Issue #1845: the week-1 nudge, process-wide and always started —
             // same reasoning as the workflow scheduler and maintenance ticker

--- a/src/server/acp/approvals.rs
+++ b/src/server/acp/approvals.rs
@@ -36,36 +36,43 @@
 
 use serde_json::{Value, json};
 
-/// A session-level notification telling a client an effect was parked.
+/// The bare `SessionUpdate` for a parked effect.
+///
+/// Split from the notification envelope the same way [`super::map`] splits
+/// [`from_turn_stream`](super::map::from_turn_stream) from
+/// [`notification`](super::map::notification): a `session/prompt` **result**
+/// carries update objects in its `updates` array, while a pushed
+/// `session/update` carries one inside a JSON-RPC envelope. Offering only the
+/// envelope made the result path embed a whole notification as an array
+/// element, so a client switching on `sessionUpdate` — which every sibling
+/// element answers — found nothing on that one.
 ///
 /// Carries the approval id, because that is what the client resolves against
-/// over REST. Sent as `_meta` on a `session/update` rather than as a new
-/// protocol method: a conforming client that has never heard of OpenCompany
-/// ignores it, which is exactly what `_meta` is for.
-pub fn parked_notification(session_id: &str, approval_id: &str, summary: &str) -> Value {
+/// over REST. Sent as `_meta` rather than as a new protocol method: a
+/// conforming client that has never heard of OpenCompany ignores it, which is
+/// exactly what `_meta` is for.
+pub fn parked_update(approval_id: &str, summary: &str) -> Value {
     json!({
-        "jsonrpc": "2.0",
-        "method": "session/update",
-        "params": {
-            "sessionId": session_id,
-            "update": {
-                // No ACP variant means "a human must decide something". The
-                // closest honest carrier is a session-info update whose `_meta`
-                // says what actually happened.
-                "sessionUpdate": "session_info_update",
-                "_meta": {
-                    "opencompany/approval": {
-                        "id": approval_id,
-                        "summary": summary,
-                        // Where to resolve it. Told rather than assumed: a
-                        // third-party ACP client has no reason to know this
-                        // host's REST shape.
-                        "resolve": "POST /api/v1/companies/{company}/approvals/{id}",
-                    }
-                },
-            },
+        // No ACP variant means "a human must decide something". The closest
+        // honest carrier is a session-info update whose `_meta` says what
+        // actually happened.
+        "sessionUpdate": "session_info_update",
+        "_meta": {
+            "opencompany/approval": {
+                "id": approval_id,
+                "summary": summary,
+                // Where to resolve it. Told rather than assumed: a third-party
+                // ACP client has no reason to know this host's REST shape.
+                "resolve": "POST /api/v1/companies/{company}/approvals/{id}",
+            }
         },
     })
+}
+
+/// [`parked_update`] wrapped in the `session/update` notification envelope, for
+/// a transport that pushes frames mid-turn rather than returning them.
+pub fn parked_notification(session_id: &str, approval_id: &str, summary: &str) -> Value {
+    super::map::notification(session_id, parked_update(approval_id, summary))
 }
 
 #[cfg(test)]

--- a/src/server/acp/approvals.rs
+++ b/src/server/acp/approvals.rs
@@ -1,6 +1,5 @@
-//! Approvals, in both directions — which are not the same shape.
-//!
-//! ## Outbound: this host does **not** implement `session/request_permission`
+//! Approvals, outbound: this host does **not** implement
+//! `session/request_permission`.
 //!
 //! ACP's permission model assumes a turn that *suspends*: the agent asks, the
 //! client answers, the same tool call proceeds. This host's approvals do not
@@ -19,37 +18,23 @@
 //! `session/request_permission` could be issued, and implementing one would
 //! mean it either never fires or fires against a turn that has ended.
 //!
-//! Instead a park is surfaced as `_meta` on the tool call (see
-//! [`map`](super::map)) plus a session-level notification carrying the approval
-//! id, and the client resolves it over the existing REST surface — which the
-//! desktop already has, because it runs the same console.
+//! Instead a park is surfaced as a session-level notification carrying the
+//! approval id ([`parked_notification`]), and the client resolves it over the
+//! existing REST surface — which the desktop already has, because it runs the
+//! same console.
 //!
-//! ## Inbound: this direction genuinely *is* synchronous
+//! ## Inbound is a separate, already-answered question
 //!
-//! When this host is the ACP **client** — driving a runner, or a local harness
-//! that really does suspend, as `claude-agent-acp` does — a
-//! `session/request_permission` arrives as a request and must be answered.
-//! [`PendingPermissions`] holds it while a human decides.
-//!
-//! Stated plainly, because it reads as an inconsistency until you see why:
-//! **this host is a synchronous permission client and an asynchronous
-//! permission server.** That is not a design preference; it is what the two
-//! engines actually do.
-
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+//! When this host is the ACP **client** — `src-tauri/src/acp/client.rs`
+//! driving a locally-installed harness — an inbound `session/request_permission`
+//! is answered synchronously by a `ClientHandler` implementation there, not
+//! held for a human. `LocalAcpAgent`'s production handler (`AutoApprovingFiles`)
+//! trusts the harness's own permission-mode config and auto-approves whatever
+//! it still asks about; there is no queued, human-in-the-loop path on that
+//! side today. A held-request TTL is meaningless without something that ever
+//! holds a request, so this module carries none.
 
 use serde_json::{Value, json};
-
-/// How long an inbound permission request is held before it is answered for the
-/// person who never came back.
-///
-/// A bound is not optional. The request is a live JSON-RPC call holding a
-/// socket, and a harness blocked on it is blocked forever — so an unanswered
-/// prompt would pin a runner and its worktree indefinitely. Long enough for
-/// someone to notice a notification and decide; short enough that a laptop
-/// closed at the wrong moment frees the runner the same day.
-pub const PERMISSION_TTL_MILLIS: u64 = 30 * 60 * 1000;
 
 /// A session-level notification telling a client an effect was parked.
 ///
@@ -83,125 +68,9 @@ pub fn parked_notification(session_id: &str, approval_id: &str, summary: &str) -
     })
 }
 
-/// How a held permission request was answered.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PermissionOutcome {
-    /// A person chose an option.
-    Selected,
-    /// Nobody answered in time. ACP's own `cancelled` outcome, which a harness
-    /// already knows how to handle — unlike a synthetic refusal, which it would
-    /// report to the model as a decision someone made.
-    TimedOut,
-}
-
-/// One inbound `session/request_permission` awaiting a human.
-#[derive(Clone, Debug)]
-pub struct HeldPermission {
-    pub request_id: String,
-    pub session_id: String,
-    pub asked_at_millis: u64,
-    /// The option ids the agent offered. An answer must be one of these.
-    pub options: Vec<String>,
-}
-
-impl HeldPermission {
-    fn expired(&self, now_millis: u64) -> bool {
-        now_millis.saturating_sub(self.asked_at_millis) >= PERMISSION_TTL_MILLIS
-    }
-}
-
-/// Inbound permission requests this host is holding open.
-#[derive(Debug, Default)]
-pub struct PendingPermissions {
-    held: Mutex<HashMap<String, HeldPermission>>,
-}
-
-impl PendingPermissions {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn hold(&self, permission: HeldPermission) {
-        self.held
-            .lock()
-            .expect("pending permissions poisoned")
-            .insert(permission.request_id.clone(), permission);
-    }
-
-    pub fn get(&self, request_id: &str) -> Option<HeldPermission> {
-        self.held
-            .lock()
-            .expect("pending permissions poisoned")
-            .get(request_id)
-            .cloned()
-    }
-
-    /// Answers a held request with an option the agent offered.
-    ///
-    /// Refuses an option that was never offered. Echoing back an arbitrary id
-    /// would be answering a question the agent did not ask, and a harness that
-    /// cannot match it may do anything from erroring to picking a default.
-    pub fn resolve(&self, request_id: &str, option_id: &str) -> Option<Value> {
-        let mut held = self.held.lock().expect("pending permissions poisoned");
-        let permission = held.get(request_id)?;
-        if !permission.options.iter().any(|o| o == option_id) {
-            return None;
-        }
-        held.remove(request_id);
-        Some(json!({
-            "outcome": { "outcome": "selected", "optionId": option_id }
-        }))
-    }
-
-    /// Answers everything nobody came back for, freeing whatever was blocked.
-    ///
-    /// Returns `(request_id, response)` pairs for the caller to send.
-    pub fn expire(&self, now_millis: u64) -> Vec<(String, Value)> {
-        let mut held = self.held.lock().expect("pending permissions poisoned");
-        let stale: Vec<String> = held
-            .iter()
-            .filter(|(_, p)| p.expired(now_millis))
-            .map(|(id, _)| id.clone())
-            .collect();
-        stale
-            .into_iter()
-            .map(|id| {
-                held.remove(&id);
-                // ACP's own cancellation outcome, not a synthetic rejection: a
-                // harness told "rejected" reports a decision to the model that
-                // nobody made.
-                (id, json!({ "outcome": { "outcome": "cancelled" } }))
-            })
-            .collect()
-    }
-
-    pub fn len(&self) -> usize {
-        self.held
-            .lock()
-            .expect("pending permissions poisoned")
-            .len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
-/// Shared with the ACP client lane.
-pub type SharedPermissions = Arc<PendingPermissions>;
-
 #[cfg(test)]
 mod test {
     use super::*;
-
-    fn held(id: &str, at: u64) -> HeldPermission {
-        HeldPermission {
-            request_id: id.to_string(),
-            session_id: "sess-1".to_string(),
-            asked_at_millis: at,
-            options: vec!["allow".to_string(), "reject".to_string()],
-        }
-    }
 
     #[test]
     fn a_parked_effect_tells_the_client_how_to_resolve_it() {
@@ -221,66 +90,5 @@ mod test {
                 .unwrap()
                 .contains("/approvals/")
         );
-    }
-
-    #[test]
-    fn a_held_request_is_answered_with_an_offered_option() {
-        let pending = PendingPermissions::new();
-        pending.hold(held("req-1", 0));
-
-        let answer = pending
-            .resolve("req-1", "allow")
-            .expect("an offered option");
-        assert_eq!(answer["outcome"]["outcome"], "selected");
-        assert_eq!(answer["outcome"]["optionId"], "allow");
-        // Answered once: a second resolve has nothing to answer, so a duplicate
-        // click cannot send two replies to one JSON-RPC id.
-        assert!(pending.resolve("req-1", "allow").is_none());
-        assert!(pending.is_empty());
-    }
-
-    #[test]
-    fn an_option_the_agent_never_offered_is_refused() {
-        // Echoing back an arbitrary id answers a question the agent did not
-        // ask; a harness that cannot match it may do anything.
-        let pending = PendingPermissions::new();
-        pending.hold(held("req-1", 0));
-
-        assert!(pending.resolve("req-1", "delete-everything").is_none());
-        assert!(!pending.is_empty(), "the request is still open");
-    }
-
-    #[test]
-    fn an_unanswered_request_is_cancelled_rather_than_held_forever() {
-        // The request is a live JSON-RPC call holding a socket, and the harness
-        // on the other end is blocked on it. Without a bound, a laptop closed
-        // at the wrong moment pins a runner and its worktree indefinitely.
-        let pending = PendingPermissions::new();
-        pending.hold(held("req-1", 0));
-
-        assert!(
-            pending.expire(PERMISSION_TTL_MILLIS - 1).is_empty(),
-            "not yet"
-        );
-
-        let expired = pending.expire(PERMISSION_TTL_MILLIS);
-        assert_eq!(expired.len(), 1);
-        assert_eq!(expired[0].0, "req-1");
-        // ACP's own cancellation, not a synthetic rejection: "rejected" would
-        // report a decision to the model that nobody made.
-        assert_eq!(expired[0].1["outcome"]["outcome"], "cancelled");
-        assert!(pending.is_empty());
-    }
-
-    #[test]
-    fn expiry_only_takes_the_requests_that_are_actually_stale() {
-        let pending = PendingPermissions::new();
-        pending.hold(held("old", 0));
-        pending.hold(held("fresh", PERMISSION_TTL_MILLIS));
-
-        let expired = pending.expire(PERMISSION_TTL_MILLIS);
-        assert_eq!(expired.len(), 1);
-        assert_eq!(expired[0].0, "old");
-        assert!(pending.get("fresh").is_some());
     }
 }

--- a/src/server/acp/mod.rs
+++ b/src/server/acp/mod.rs
@@ -26,7 +26,7 @@ pub mod map;
 pub mod session;
 mod transport;
 
-pub use approvals::{HeldPermission, PendingPermissions};
+pub use approvals::parked_notification;
 pub use session::{AcpSession, SessionRegistry, SessionSweeper};
 
 /// The authenticated HTTP transport for ACP JSON-RPC requests.

--- a/src/server/acp/mod.rs
+++ b/src/server/acp/mod.rs
@@ -27,7 +27,7 @@ pub mod session;
 mod transport;
 
 pub use approvals::{HeldPermission, PendingPermissions};
-pub use session::{AcpSession, SessionRegistry};
+pub use session::{AcpSession, SessionRegistry, SessionSweeper};
 
 /// The authenticated HTTP transport for ACP JSON-RPC requests.
 pub fn router() -> axum::Router<crate::AppState> {

--- a/src/server/acp/session.rs
+++ b/src/server/acp/session.rs
@@ -247,7 +247,10 @@ impl SessionRegistry {
     }
 
     /// Looks up a session for `owner`, refusing a connection id it does not
-    /// hold. Renews the session's idle TTL on a hit.
+    /// hold. Renews the session's idle TTL on a hit; evicts and refuses one
+    /// already past [`SESSION_TTL_MILLIS`] instead — otherwise a lookup that
+    /// lands in the gap between two [`SessionSweeper`] ticks would revive an
+    /// already-expired session merely by touching it.
     pub fn get(
         &self,
         connection: &str,
@@ -263,13 +266,27 @@ impl SessionRegistry {
         if conn.owner != owner {
             return None;
         }
+        if conn
+            .sessions
+            .get(id)
+            .is_some_and(|e| Self::expired(e, now_millis))
+        {
+            conn.sessions.remove(id);
+            if conn.sessions.is_empty() {
+                by_connection.remove(connection);
+            }
+            return None;
+        }
         let entry = conn.sessions.get_mut(id)?;
         entry.last_used_millis = now_millis;
         Some(Arc::clone(&entry.session))
     }
 
     /// Looks up a session for `owner` without renewing its idle TTL, refusing
-    /// a connection id it does not hold.
+    /// a connection id it does not hold. Evicts and refuses one already past
+    /// [`SESSION_TTL_MILLIS`], for the same reason [`Self::get`] does — a
+    /// caller cannot authorize itself to act on a session that has already
+    /// aged out, no matter which lookup finds it.
     ///
     /// For a caller that still has to run `authorize_address` on the
     /// session's company before it may act on it — the ACP transport's
@@ -278,16 +295,38 @@ impl SessionRegistry {
     /// access to one company under it was revoked keep a session's cap slot
     /// alive indefinitely, by repeatedly presenting it and losing the
     /// authorization check every time.
-    pub fn peek(&self, connection: &str, owner: &str, id: &str) -> Option<Arc<AcpSession>> {
-        let by_connection = self
+    pub fn peek(
+        &self,
+        connection: &str,
+        owner: &str,
+        id: &str,
+        now_millis: u64,
+    ) -> Option<Arc<AcpSession>> {
+        let mut by_connection = self
             .by_connection
             .lock()
             .expect("session registry poisoned");
-        let conn = by_connection.get(connection)?;
+        let conn = by_connection.get_mut(connection)?;
         if conn.owner != owner {
             return None;
         }
+        if conn
+            .sessions
+            .get(id)
+            .is_some_and(|e| Self::expired(e, now_millis))
+        {
+            conn.sessions.remove(id);
+            if conn.sessions.is_empty() {
+                by_connection.remove(connection);
+            }
+            return None;
+        }
         Some(Arc::clone(&conn.sessions.get(id)?.session))
+    }
+
+    /// Whether `entry` has sat idle longer than [`SESSION_TTL_MILLIS`].
+    fn expired(entry: &SessionEntry, now_millis: u64) -> bool {
+        now_millis.saturating_sub(entry.last_used_millis) > SESSION_TTL_MILLIS
     }
 
     /// Renews a session's idle TTL, once the caller's authorization to act on
@@ -356,23 +395,49 @@ impl SessionRegistry {
         removed
     }
 
-    /// Drops every session a connection `owner` holds, and reports their ids.
-    /// A connection `owner` does not hold is left untouched — reports none.
-    pub fn close_connection(&self, connection: &str, owner: &str) -> Vec<String> {
+    /// Drops every session a connection `owner` holds that `authorized`
+    /// approves, under one lock, and reports the ids actually removed. A
+    /// connection `owner` does not hold is left untouched — reports none.
+    ///
+    /// `authorized` is a per-session check, not a blanket one, because
+    /// `owner` names a tenant rather than an authorization scope: two
+    /// platform credentials for the same tenant can carry different company
+    /// allow-lists (`PlatformClaims::companies`), and a connection can hold
+    /// sessions opened under either. Removing every session on the
+    /// connection unconditionally would let a narrowly-scoped credential
+    /// close sessions for companies outside its own allow-list, just because
+    /// it shares an owner string with whichever credential opened them.
+    /// Checked under the same lock as the removal so a concurrent
+    /// `session/new` cannot land in a gap between the check and the removal.
+    pub fn close_connection(
+        &self,
+        connection: &str,
+        owner: &str,
+        mut authorized: impl FnMut(&CompanyId) -> bool,
+    ) -> Vec<String> {
         let mut by_connection = self
             .by_connection
             .lock()
             .expect("session registry poisoned");
-        let owned = by_connection
-            .get(connection)
-            .is_some_and(|conn| conn.owner == owner);
-        if !owned {
+        let Some(conn) = by_connection.get_mut(connection) else {
+            return Vec::new();
+        };
+        if conn.owner != owner {
             return Vec::new();
         }
-        by_connection
-            .remove(connection)
-            .map(|conn| conn.sessions.into_keys().collect())
-            .unwrap_or_default()
+        let mut removed = Vec::new();
+        conn.sessions.retain(|id, entry| {
+            if authorized(&entry.session.company) {
+                removed.push(id.clone());
+                false
+            } else {
+                true
+            }
+        });
+        if conn.sessions.is_empty() {
+            by_connection.remove(connection);
+        }
+        removed
     }
 
     /// Forgets every session idle past [`SESSION_TTL_MILLIS`], and every
@@ -531,7 +596,11 @@ mod test {
         assert!(registry.get("conn-a", "mallory", "s1", 0).is_none());
         assert!(registry.list("conn-a", "mallory").is_none());
         assert!(!registry.remove("conn-a", "mallory", "s1"));
-        assert!(registry.close_connection("conn-a", "mallory").is_empty());
+        assert!(
+            registry
+                .close_connection("conn-a", "mallory", |_| true)
+                .is_empty()
+        );
         // None of mallory's attempts touched alice's session.
         assert!(registry.get("conn-a", "alice", "s1", 0).is_some());
     }
@@ -626,7 +695,11 @@ mod test {
             .unwrap();
         // A `peek` at half the TTL — a pre-authorization check — must not
         // extend the clock the way `get` does.
-        assert!(registry.peek("conn-a", "alice", "s1").is_some());
+        assert!(
+            registry
+                .peek("conn-a", "alice", "s1", SESSION_TTL_MILLIS / 2)
+                .is_some()
+        );
         assert_eq!(
             registry.sweep_expired(SESSION_TTL_MILLIS + 1),
             1,
@@ -640,9 +713,9 @@ mod test {
         registry
             .open("conn-a", "alice", session("s1", "acme"), 0)
             .unwrap();
-        assert!(registry.peek("conn-b", "alice", "s1").is_none());
-        assert!(registry.peek("conn-a", "mallory", "s1").is_none());
-        assert!(registry.peek("conn-a", "alice", "s1").is_some());
+        assert!(registry.peek("conn-b", "alice", "s1", 0).is_none());
+        assert!(registry.peek("conn-a", "mallory", "s1", 0).is_none());
+        assert!(registry.peek("conn-a", "alice", "s1", 0).is_some());
     }
 
     #[test]
@@ -651,12 +724,45 @@ mod test {
         registry
             .open("conn-a", "alice", session("s1", "acme"), 0)
             .unwrap();
-        assert!(registry.peek("conn-a", "alice", "s1").is_some());
+        assert!(registry.peek("conn-a", "alice", "s1", 0).is_some());
         registry.touch("conn-a", "alice", "s1", SESSION_TTL_MILLIS / 2);
         assert_eq!(
             registry.sweep_expired(SESSION_TTL_MILLIS),
             0,
             "touch renewed at TTL/2, so a full TTL later it is not yet idle that long"
+        );
+    }
+
+    #[test]
+    fn peek_cannot_revive_a_session_already_past_its_ttl() {
+        // Landing in the gap between two sweeper ticks must not let a lookup
+        // (and the touch a caller runs after it authorizes) revive a session
+        // that is already stale — the sweep is a cleanup convenience, not the
+        // only place staleness is enforced (codex review).
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        assert!(
+            registry
+                .peek("conn-a", "alice", "s1", SESSION_TTL_MILLIS + 1)
+                .is_none(),
+            "a peek past the TTL must refuse, not hand back a session to authorize and touch"
+        );
+        // And it evicted the stale entry rather than merely refusing this call.
+        assert!(registry.list("conn-a", "alice").is_none());
+    }
+
+    #[test]
+    fn get_cannot_revive_a_session_already_past_its_ttl() {
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        assert!(
+            registry
+                .get("conn-a", "alice", "s1", SESSION_TTL_MILLIS + 1)
+                .is_none()
         );
     }
 
@@ -698,12 +804,43 @@ mod test {
             .open("conn-b", "bob", session("s2", "acme"), 0)
             .unwrap();
 
-        let closed = registry.close_connection("conn-a", "alice");
+        let closed = registry.close_connection("conn-a", "alice", |_| true);
         assert_eq!(closed, vec!["s1".to_string()]);
         assert!(registry.get("conn-a", "alice", "s1", 0).is_none());
         assert!(
             registry.get("conn-b", "bob", "s2", 0).is_some(),
             "other connections survive"
+        );
+    }
+
+    #[test]
+    fn close_connection_leaves_a_session_the_caller_is_not_authorized_for() {
+        // `owner` names a tenant, not an authorization scope: two platform
+        // credentials for the same tenant can carry different company
+        // allow-lists, so a connection can hold sessions the *presented*
+        // credential is not itself authorized to act on (coderabbit review).
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "platform:acme", session("s-allowed", "acme"), 0)
+            .unwrap();
+        registry
+            .open(
+                "conn-a",
+                "platform:acme",
+                session("s-restricted", "globex"),
+                0,
+            )
+            .unwrap();
+
+        let closed = registry.close_connection("conn-a", "platform:acme", |company| {
+            company.as_ref() == "acme"
+        });
+        assert_eq!(closed, vec!["s-allowed".to_string()]);
+        assert!(
+            registry
+                .get("conn-a", "platform:acme", "s-restricted", 0)
+                .is_some(),
+            "a session for a company outside the caller's own allow-list must survive its disconnect"
         );
     }
 
@@ -715,7 +852,7 @@ mod test {
                 .open("conn-a", "alice", session(&format!("s{i}"), "acme"), 0)
                 .unwrap();
         }
-        let closed = registry.close_connection("conn-a", "alice");
+        let closed = registry.close_connection("conn-a", "alice", |_| true);
         assert_eq!(closed.len(), 5);
         for i in 0..5 {
             assert!(

--- a/src/server/acp/session.rs
+++ b/src/server/acp/session.rs
@@ -744,7 +744,7 @@ mod test {
         // Landing in the gap between two sweeper ticks must not let a lookup
         // (and the touch a caller runs after it authorizes) revive a session
         // that is already stale — the sweep is a cleanup convenience, not the
-        // only place staleness is enforced (codex review).
+        // only place staleness is enforced.
         let registry = SessionRegistry::new();
         registry
             .open("conn-a", "alice", session("s1", "acme"), 0)
@@ -778,7 +778,7 @@ mod test {
         // `peek` and `get` already refuse it as expired, landing in the same
         // gap between two hourly sweeper ticks — otherwise a client is told a
         // session is resumable and then has `session/prompt` immediately
-        // report it unknown (codex review).
+        // report it unknown.
         let registry = SessionRegistry::new();
         registry
             .open("conn-a", "alice", session("s1", "acme"), 0)
@@ -845,7 +845,7 @@ mod test {
         // `owner` names a tenant, not an authorization scope: two platform
         // credentials for the same tenant can carry different company
         // allow-lists, so a connection can hold sessions the *presented*
-        // credential is not itself authorized to act on (coderabbit review).
+        // credential is not itself authorized to act on.
         let registry = SessionRegistry::new();
         registry
             .open("conn-a", "platform:acme", session("s-allowed", "acme"), 0)

--- a/src/server/acp/session.rs
+++ b/src/server/acp/session.rs
@@ -159,12 +159,14 @@ impl OpenSessionRefusal {
     }
 }
 
+#[derive(Debug)]
 struct SessionEntry {
     session: Arc<AcpSession>,
     last_used_millis: u64,
 }
 
 /// One connection's sessions, plus who is allowed to address it.
+#[derive(Debug)]
 struct Connection {
     owner: String,
     sessions: HashMap<String, SessionEntry>,

--- a/src/server/acp/session.rs
+++ b/src/server/acp/session.rs
@@ -14,6 +14,10 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
 
 use crate::ports::types::CompanyId;
 use crate::runtime::assignee::DM_PREFIX;
@@ -114,11 +118,68 @@ pub fn cwd_meta(server_workspace: &str) -> serde_json::Value {
     })
 }
 
+/// The most ACP sessions one connection id may hold open at once.
+///
+/// A `connectionId` is caller-supplied and otherwise unbounded, so a caller
+/// minting one session after another on the same id would grow that
+/// connection's entry forever.
+pub const MAX_SESSIONS_PER_CONNECTION: usize = 32;
+
+/// The most ACP sessions this host holds open at once, across every
+/// connection. A circuit breaker on total memory, not a business limit.
+pub const MAX_SESSIONS_TOTAL: usize = 8_192;
+
+/// How long an ACP session may sit unused before [`SessionRegistry::sweep_expired`]
+/// reclaims it. This surface has no heartbeat, so the bound has to be
+/// generous enough to outlast a normal gap between prompts — one working day.
+pub const SESSION_TTL_MILLIS: u64 = 24 * 60 * 60 * 1000;
+
+/// Why [`SessionRegistry::open`] refused a `session/new`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpenSessionRefusal {
+    /// The connection id is already bound to a different caller, or this
+    /// caller never opened it.
+    NotOwned,
+    /// The connection already holds [`MAX_SESSIONS_PER_CONNECTION`] sessions.
+    PerConnectionCap,
+    /// The host already holds [`MAX_SESSIONS_TOTAL`] sessions.
+    TotalCap,
+}
+
+impl OpenSessionRefusal {
+    pub fn message(&self) -> &'static str {
+        match self {
+            // Deliberately the same wording as an unrecognized connection id:
+            // telling the two apart would let a caller learn that a foreign
+            // connection id exists by probing it.
+            Self::NotOwned => "unknown ACP connection",
+            Self::PerConnectionCap => "too many open ACP sessions on this connection",
+            Self::TotalCap => "too many open ACP sessions on this host",
+        }
+    }
+}
+
+struct SessionEntry {
+    session: Arc<AcpSession>,
+    last_used_millis: u64,
+}
+
+/// One connection's sessions, plus who is allowed to address it.
+struct Connection {
+    owner: String,
+    sessions: HashMap<String, SessionEntry>,
+}
+
 /// The live sessions on this host, keyed by connection so a disconnect can
 /// sweep them.
+///
+/// A connection id is bound to whichever caller first opens a session on it
+/// (see [`SessionRegistry::open`]); every other method refuses an id it does
+/// not recognize as that same caller's, rather than acting on whatever the
+/// request claims.
 #[derive(Debug, Default)]
 pub struct SessionRegistry {
-    by_connection: Mutex<HashMap<String, HashMap<String, Arc<AcpSession>>>>,
+    by_connection: Mutex<HashMap<String, Connection>>,
 }
 
 impl SessionRegistry {
@@ -126,71 +187,184 @@ impl SessionRegistry {
         Self::default()
     }
 
-    pub fn insert(&self, connection: &str, session: AcpSession) -> Arc<AcpSession> {
+    /// Opens a session on `connection`, binding it to `owner` if this is the
+    /// first session opened on that id. Refuses an id already bound to a
+    /// different owner, and refuses once either cap is hit.
+    pub fn open(
+        &self,
+        connection: &str,
+        owner: &str,
+        session: AcpSession,
+        now_millis: u64,
+    ) -> Result<Arc<AcpSession>, OpenSessionRefusal> {
+        let mut by_connection = self
+            .by_connection
+            .lock()
+            .expect("session registry poisoned");
+        if let Some(existing) = by_connection.get(connection) {
+            if existing.owner != owner {
+                return Err(OpenSessionRefusal::NotOwned);
+            }
+            if existing.sessions.len() >= MAX_SESSIONS_PER_CONNECTION {
+                return Err(OpenSessionRefusal::PerConnectionCap);
+            }
+        }
+        let total: usize = by_connection.values().map(|c| c.sessions.len()).sum();
+        if total >= MAX_SESSIONS_TOTAL {
+            return Err(OpenSessionRefusal::TotalCap);
+        }
         let session = Arc::new(session);
-        self.by_connection
-            .lock()
-            .expect("session registry poisoned")
+        let conn = by_connection
             .entry(connection.to_string())
-            .or_default()
-            .insert(session.id.clone(), Arc::clone(&session));
-        session
+            .or_insert_with(|| Connection {
+                owner: owner.to_string(),
+                sessions: HashMap::new(),
+            });
+        conn.sessions.insert(
+            session.id.clone(),
+            SessionEntry {
+                session: Arc::clone(&session),
+                last_used_millis: now_millis,
+            },
+        );
+        Ok(session)
     }
 
-    pub fn get(&self, connection: &str, id: &str) -> Option<Arc<AcpSession>> {
-        self.by_connection
+    /// Looks up a session for `owner`, refusing a connection id it does not
+    /// hold. Renews the session's idle TTL on a hit.
+    pub fn get(
+        &self,
+        connection: &str,
+        owner: &str,
+        id: &str,
+        now_millis: u64,
+    ) -> Option<Arc<AcpSession>> {
+        let mut by_connection = self
+            .by_connection
             .lock()
-            .expect("session registry poisoned")
-            .get(connection)
-            .and_then(|sessions| sessions.get(id).cloned())
+            .expect("session registry poisoned");
+        let conn = by_connection.get_mut(connection)?;
+        if conn.owner != owner {
+            return None;
+        }
+        let entry = conn.sessions.get_mut(id)?;
+        entry.last_used_millis = now_millis;
+        Some(Arc::clone(&entry.session))
     }
 
-    /// Every session on a connection, for `session/list`.
-    pub fn list(&self, connection: &str) -> Vec<Arc<AcpSession>> {
-        self.by_connection
+    /// Every session on a connection `owner` holds, for `session/list`.
+    /// `None` when the connection is unknown or belongs to someone else.
+    pub fn list(&self, connection: &str, owner: &str) -> Option<Vec<Arc<AcpSession>>> {
+        let by_connection = self
+            .by_connection
             .lock()
-            .expect("session registry poisoned")
-            .get(connection)
-            .map(|sessions| sessions.values().cloned().collect())
-            .unwrap_or_default()
+            .expect("session registry poisoned");
+        let conn = by_connection.get(connection)?;
+        if conn.owner != owner {
+            return None;
+        }
+        Some(
+            conn.sessions
+                .values()
+                .map(|entry| Arc::clone(&entry.session))
+                .collect(),
+        )
     }
 
     /// Drops one session, for ACP's `session/delete`.
     ///
     /// Returns whether the session existed. Deleting a session that was never
-    /// there is a silent no-op, exactly as ACP specifies — an opaque id says
-    /// nothing useful by its absence.
-    pub fn remove(&self, connection: &str, id: &str) -> bool {
+    /// there — or addressing a connection `owner` does not hold — is a silent
+    /// no-op, exactly as ACP specifies for an opaque id: absence says nothing
+    /// useful.
+    pub fn remove(&self, connection: &str, owner: &str, id: &str) -> bool {
         let mut by_connection = self
             .by_connection
             .lock()
             .expect("session registry poisoned");
-        let removed = by_connection
-            .get_mut(connection)
-            .map(|sessions| sessions.remove(id).is_some())
-            .unwrap_or(false);
-        // A connection's last session going also takes the connection key with
-        // it. Without this, `session/new` + `session/delete` (or `disconnect`)
-        // over fresh caller-controlled connection ids grows the host-wide map
-        // by one empty entry per connection, forever.
-        if by_connection
-            .get(connection)
-            .is_some_and(|sessions| sessions.is_empty())
-        {
+        let Some(conn) = by_connection.get_mut(connection) else {
+            return false;
+        };
+        if conn.owner != owner {
+            return false;
+        }
+        let removed = conn.sessions.remove(id).is_some();
+        // A connection's last session going also takes the connection key
+        // (and its owner binding) with it — otherwise `session/new` +
+        // `session/delete` over fresh caller-controlled connection ids grows
+        // the host-wide map by one empty entry per connection, forever.
+        if conn.sessions.is_empty() {
             by_connection.remove(connection);
         }
         removed
     }
 
-    /// Drops every session a connection held.
-    ///
-    /// Keyed by connection precisely so this is possible: without it, a client
-    /// that reconnects repeatedly accumulates sessions nothing will ever close.
-    pub fn close_connection(&self, connection: &str) {
-        self.by_connection
+    /// Drops every session a connection `owner` holds, and reports their ids.
+    /// A connection `owner` does not hold is left untouched — reports none.
+    pub fn close_connection(&self, connection: &str, owner: &str) -> Vec<String> {
+        let mut by_connection = self
+            .by_connection
             .lock()
-            .expect("session registry poisoned")
-            .remove(connection);
+            .expect("session registry poisoned");
+        match by_connection.get(connection) {
+            Some(conn) if conn.owner == owner => by_connection
+                .remove(connection)
+                .expect("checked present above")
+                .sessions
+                .into_keys()
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// Forgets every session idle past [`SESSION_TTL_MILLIS`], and every
+    /// connection that leaves empty. Returns how many sessions were reclaimed.
+    pub fn sweep_expired(&self, now_millis: u64) -> usize {
+        let mut by_connection = self
+            .by_connection
+            .lock()
+            .expect("session registry poisoned");
+        let mut removed = 0;
+        by_connection.retain(|_, conn| {
+            let before = conn.sessions.len();
+            conn.sessions.retain(|_, entry| {
+                now_millis.saturating_sub(entry.last_used_millis) <= SESSION_TTL_MILLIS
+            });
+            removed += before - conn.sessions.len();
+            !conn.sessions.is_empty()
+        });
+        removed
+    }
+}
+
+/// Periodically reclaims ACP sessions idle past [`SESSION_TTL_MILLIS`].
+///
+/// Mirrors [`crate::server::presence::PresenceSweeper`]: this registry is
+/// host-global, not scoped to a registered company, so it gets its own
+/// always-on task rather than riding the per-company maintenance ticker.
+pub struct SessionSweeper {
+    registry: Arc<SessionRegistry>,
+}
+
+impl SessionSweeper {
+    pub fn new(registry: Arc<SessionRegistry>) -> Self {
+        Self { registry }
+    }
+
+    /// Runs until `shutdown` is notified, sweeping once per [`SESSION_TTL_MILLIS`].
+    pub fn spawn(self, shutdown: Arc<Notify>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let notified = shutdown.notified();
+            tokio::pin!(notified);
+            loop {
+                tokio::select! {
+                    _ = &mut notified => break,
+                    _ = tokio::time::sleep(Duration::from_millis(SESSION_TTL_MILLIS)) => {
+                        self.registry.sweep_expired(crate::ports::now_millis());
+                    }
+                }
+            }
+        })
     }
 }
 
@@ -248,15 +422,147 @@ mod test {
         // Two clients must not see each other's sessions — and a reconnecting
         // one must not resume into another's.
         let registry = SessionRegistry::new();
-        registry.insert("conn-a", session("s1", "acme"));
-        registry.insert("conn-b", session("s2", "globex"));
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        registry
+            .open("conn-b", "bob", session("s2", "globex"), 0)
+            .unwrap();
 
-        assert!(registry.get("conn-a", "s1").is_some());
+        assert!(registry.get("conn-a", "alice", "s1", 0).is_some());
         assert!(
-            registry.get("conn-b", "s1").is_none(),
+            registry.get("conn-b", "alice", "s1", 0).is_none(),
             "no cross-connection reads"
         );
-        assert_eq!(registry.list("conn-a").len(), 1);
+        assert_eq!(registry.list("conn-a", "alice").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn a_caller_cannot_open_a_session_on_a_connection_it_does_not_own() {
+        // The defect this registry exists to close: a caller-supplied
+        // `connectionId` is otherwise just a guessable string, and whoever
+        // guesses it could open sessions into somebody else's connection.
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+
+        let refusal = registry
+            .open("conn-a", "mallory", session("s2", "acme"), 0)
+            .unwrap_err();
+        assert_eq!(refusal, OpenSessionRefusal::NotOwned);
+        assert_eq!(
+            registry.list("conn-a", "alice").unwrap().len(),
+            1,
+            "the attempted takeover left alice's session set untouched"
+        );
+        assert!(
+            registry.list("conn-a", "mallory").is_none(),
+            "mallory never owned the connection, so it stays invisible to her too"
+        );
+    }
+
+    #[test]
+    fn a_caller_cannot_read_or_act_on_a_connection_it_does_not_own() {
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+
+        assert!(registry.get("conn-a", "mallory", "s1", 0).is_none());
+        assert!(registry.list("conn-a", "mallory").is_none());
+        assert!(!registry.remove("conn-a", "mallory", "s1"));
+        assert!(registry.close_connection("conn-a", "mallory").is_empty());
+        // None of mallory's attempts touched alice's session.
+        assert!(registry.get("conn-a", "alice", "s1", 0).is_some());
+    }
+
+    #[test]
+    fn a_session_over_the_per_connection_cap_is_refused() {
+        let registry = SessionRegistry::new();
+        for i in 0..MAX_SESSIONS_PER_CONNECTION {
+            registry
+                .open("conn-a", "alice", session(&format!("s{i}"), "acme"), 0)
+                .unwrap();
+        }
+        let refusal = registry
+            .open("conn-a", "alice", session("s-over", "acme"), 0)
+            .unwrap_err();
+        assert_eq!(refusal, OpenSessionRefusal::PerConnectionCap);
+        assert_eq!(
+            registry.list("conn-a", "alice").unwrap().len(),
+            MAX_SESSIONS_PER_CONNECTION
+        );
+    }
+
+    #[test]
+    fn a_session_over_the_host_wide_cap_is_refused_even_on_a_fresh_connection() {
+        let registry = SessionRegistry::new();
+        // Fan the total cap out across many connections rather than one, so
+        // this proves the cap is host-wide and not just per-connection.
+        let mut opened = 0;
+        for i in 0..MAX_SESSIONS_TOTAL {
+            let conn = format!("conn-{i}");
+            registry
+                .open(&conn, "alice", session("s0", "acme"), 0)
+                .unwrap();
+            opened += 1;
+        }
+        assert_eq!(opened, MAX_SESSIONS_TOTAL);
+        let refusal = registry
+            .open("conn-fresh", "alice", session("s0", "acme"), 0)
+            .unwrap_err();
+        assert_eq!(refusal, OpenSessionRefusal::TotalCap);
+    }
+
+    #[test]
+    fn an_idle_session_past_its_ttl_is_swept() {
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+
+        assert_eq!(
+            registry.sweep_expired(SESSION_TTL_MILLIS),
+            0,
+            "exactly at the boundary is not yet expired"
+        );
+        assert_eq!(registry.sweep_expired(SESSION_TTL_MILLIS + 1), 1);
+        assert!(registry.get("conn-a", "alice", "s1", SESSION_TTL_MILLIS + 1).is_none());
+    }
+
+    #[test]
+    fn using_a_session_renews_its_idle_ttl() {
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        // A `get` at half the TTL — a live prompt — renews the clock.
+        assert!(
+            registry
+                .get("conn-a", "alice", "s1", SESSION_TTL_MILLIS / 2)
+                .is_some()
+        );
+        assert_eq!(
+            registry.sweep_expired(SESSION_TTL_MILLIS),
+            0,
+            "renewed at TTL/2, so a full TTL later it is not yet idle that long"
+        );
+        assert!(registry.get("conn-a", "alice", "s1", SESSION_TTL_MILLIS).is_some());
+    }
+
+    #[test]
+    fn sweeping_prunes_the_connection_once_every_session_on_it_expires() {
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        registry.sweep_expired(SESSION_TTL_MILLIS + 1);
+        let by_connection = registry
+            .by_connection
+            .lock()
+            .expect("session registry poisoned");
+        assert!(!by_connection.contains_key("conn-a"));
     }
 
     #[test]
@@ -264,15 +570,41 @@ mod test {
         // Without this a client that reconnects repeatedly accumulates sessions
         // nothing will ever close.
         let registry = SessionRegistry::new();
-        registry.insert("conn-a", session("s1", "acme"));
-        registry.insert("conn-b", session("s2", "acme"));
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        registry
+            .open("conn-b", "bob", session("s2", "acme"), 0)
+            .unwrap();
 
-        registry.close_connection("conn-a");
-        assert!(registry.get("conn-a", "s1").is_none());
+        let closed = registry.close_connection("conn-a", "alice");
+        assert_eq!(closed, vec!["s1".to_string()]);
+        assert!(registry.get("conn-a", "alice", "s1", 0).is_none());
         assert!(
-            registry.get("conn-b", "s2").is_some(),
+            registry.get("conn-b", "bob", "s2", 0).is_some(),
             "other connections survive"
         );
+    }
+
+    #[test]
+    fn disconnect_sweeps_every_session_it_opened_with_none_stranded() {
+        let registry = SessionRegistry::new();
+        for i in 0..5 {
+            registry
+                .open("conn-a", "alice", session(&format!("s{i}"), "acme"), 0)
+                .unwrap();
+        }
+        let closed = registry.close_connection("conn-a", "alice");
+        assert_eq!(closed.len(), 5);
+        for i in 0..5 {
+            assert!(
+                registry
+                    .get("conn-a", "alice", &format!("s{i}"), 0)
+                    .is_none(),
+                "session s{i} was stranded"
+            );
+        }
+        assert!(registry.list("conn-a", "alice").is_none());
     }
 
     #[test]
@@ -280,13 +612,17 @@ mod test {
         // ACP's `session/delete`: one session goes, the connection and its
         // other sessions survive.
         let registry = SessionRegistry::new();
-        registry.insert("conn-a", session("s1", "acme"));
-        registry.insert("conn-a", session("s2", "acme"));
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        registry
+            .open("conn-a", "alice", session("s2", "acme"), 0)
+            .unwrap();
 
-        assert!(registry.remove("conn-a", "s1"));
-        assert!(registry.get("conn-a", "s1").is_none());
-        assert!(registry.get("conn-a", "s2").is_some());
-        assert_eq!(registry.list("conn-a").len(), 1);
+        assert!(registry.remove("conn-a", "alice", "s1"));
+        assert!(registry.get("conn-a", "alice", "s1", 0).is_none());
+        assert!(registry.get("conn-a", "alice", "s2", 0).is_some());
+        assert_eq!(registry.list("conn-a", "alice").unwrap().len(), 1);
     }
 
     #[test]
@@ -295,10 +631,14 @@ mod test {
         // connection ids must not grow the host-wide registry by one empty map
         // per connection, forever.
         let registry = SessionRegistry::new();
-        registry.insert("conn-a", session("s1", "acme"));
-        registry.insert("conn-b", session("s2", "acme"));
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        registry
+            .open("conn-b", "bob", session("s2", "acme"), 0)
+            .unwrap();
 
-        assert!(registry.remove("conn-a", "s1"));
+        assert!(registry.remove("conn-a", "alice", "s1"));
         let by_connection = registry
             .by_connection
             .lock()
@@ -319,10 +659,12 @@ mod test {
         // succeed silently — an opaque id leaking "I never had that" by an
         // error would tell a caller more than it needs to know.
         let registry = SessionRegistry::new();
-        registry.insert("conn-a", session("s1", "acme"));
-        assert!(!registry.remove("conn-a", "ghost"));
-        assert!(!registry.remove("conn-b", "s1"));
-        assert_eq!(registry.list("conn-a").len(), 1);
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        assert!(!registry.remove("conn-a", "alice", "ghost"));
+        assert!(!registry.remove("conn-b", "alice", "s1"));
+        assert_eq!(registry.list("conn-a", "alice").unwrap().len(), 1);
     }
 
     #[test]

--- a/src/server/acp/session.rs
+++ b/src/server/acp/session.rs
@@ -306,15 +306,16 @@ impl SessionRegistry {
             .by_connection
             .lock()
             .expect("session registry poisoned");
-        match by_connection.get(connection) {
-            Some(conn) if conn.owner == owner => by_connection
-                .remove(connection)
-                .expect("checked present above")
-                .sessions
-                .into_keys()
-                .collect(),
-            _ => Vec::new(),
+        let owned = by_connection
+            .get(connection)
+            .is_some_and(|conn| conn.owner == owner);
+        if !owned {
+            return Vec::new();
         }
+        by_connection
+            .remove(connection)
+            .map(|conn| conn.sessions.into_keys().collect())
+            .unwrap_or_default()
     }
 
     /// Forgets every session idle past [`SESSION_TTL_MILLIS`], and every
@@ -528,7 +529,11 @@ mod test {
             "exactly at the boundary is not yet expired"
         );
         assert_eq!(registry.sweep_expired(SESSION_TTL_MILLIS + 1), 1);
-        assert!(registry.get("conn-a", "alice", "s1", SESSION_TTL_MILLIS + 1).is_none());
+        assert!(
+            registry
+                .get("conn-a", "alice", "s1", SESSION_TTL_MILLIS + 1)
+                .is_none()
+        );
     }
 
     #[test]
@@ -548,7 +553,11 @@ mod test {
             0,
             "renewed at TTL/2, so a full TTL later it is not yet idle that long"
         );
-        assert!(registry.get("conn-a", "alice", "s1", SESSION_TTL_MILLIS).is_some());
+        assert!(
+            registry
+                .get("conn-a", "alice", "s1", SESSION_TTL_MILLIS)
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/server/acp/session.rs
+++ b/src/server/acp/session.rs
@@ -350,7 +350,12 @@ impl SessionRegistry {
 
     /// Every session on a connection `owner` holds, for `session/list`.
     /// `None` when the connection is unknown or belongs to someone else.
-    pub fn list(&self, connection: &str, owner: &str) -> Option<Vec<Arc<AcpSession>>> {
+    pub fn list(
+        &self,
+        connection: &str,
+        owner: &str,
+        now_millis: u64,
+    ) -> Option<Vec<Arc<AcpSession>>> {
         let by_connection = self
             .by_connection
             .lock()
@@ -362,6 +367,7 @@ impl SessionRegistry {
         Some(
             conn.sessions
                 .values()
+                .filter(|entry| !Self::expired(entry, now_millis))
                 .map(|entry| Arc::clone(&entry.session))
                 .collect(),
         )
@@ -558,7 +564,7 @@ mod test {
             registry.get("conn-b", "alice", "s1", 0).is_none(),
             "no cross-connection reads"
         );
-        assert_eq!(registry.list("conn-a", "alice").unwrap().len(), 1);
+        assert_eq!(registry.list("conn-a", "alice", 0).unwrap().len(), 1);
     }
 
     #[test]
@@ -576,12 +582,12 @@ mod test {
             .unwrap_err();
         assert_eq!(refusal, OpenSessionRefusal::NotOwned);
         assert_eq!(
-            registry.list("conn-a", "alice").unwrap().len(),
+            registry.list("conn-a", "alice", 0).unwrap().len(),
             1,
             "the attempted takeover left alice's session set untouched"
         );
         assert!(
-            registry.list("conn-a", "mallory").is_none(),
+            registry.list("conn-a", "mallory", 0).is_none(),
             "mallory never owned the connection, so it stays invisible to her too"
         );
     }
@@ -594,7 +600,7 @@ mod test {
             .unwrap();
 
         assert!(registry.get("conn-a", "mallory", "s1", 0).is_none());
-        assert!(registry.list("conn-a", "mallory").is_none());
+        assert!(registry.list("conn-a", "mallory", 0).is_none());
         assert!(!registry.remove("conn-a", "mallory", "s1"));
         assert!(
             registry
@@ -618,7 +624,7 @@ mod test {
             .unwrap_err();
         assert_eq!(refusal, OpenSessionRefusal::PerConnectionCap);
         assert_eq!(
-            registry.list("conn-a", "alice").unwrap().len(),
+            registry.list("conn-a", "alice", 0).unwrap().len(),
             MAX_SESSIONS_PER_CONNECTION
         );
     }
@@ -750,7 +756,7 @@ mod test {
             "a peek past the TTL must refuse, not hand back a session to authorize and touch"
         );
         // And it evicted the stale entry rather than merely refusing this call.
-        assert!(registry.list("conn-a", "alice").is_none());
+        assert!(registry.list("conn-a", "alice", 0).is_none());
     }
 
     #[test]
@@ -764,6 +770,27 @@ mod test {
                 .get("conn-a", "alice", "s1", SESSION_TTL_MILLIS + 1)
                 .is_none()
         );
+    }
+
+    #[test]
+    fn list_does_not_advertise_a_session_already_past_its_ttl() {
+        // `session/list` must not tell a caller a session is there when
+        // `peek` and `get` already refuse it as expired, landing in the same
+        // gap between two hourly sweeper ticks — otherwise a client is told a
+        // session is resumable and then has `session/prompt` immediately
+        // report it unknown (codex review).
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        registry
+            .open("conn-a", "alice", session("s2", "acme"), SESSION_TTL_MILLIS)
+            .unwrap();
+        let listed = registry
+            .list("conn-a", "alice", SESSION_TTL_MILLIS + 1)
+            .expect("the connection itself is not expired, only one session on it");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, "s2");
     }
 
     #[test]
@@ -862,7 +889,7 @@ mod test {
                 "session s{i} was stranded"
             );
         }
-        assert!(registry.list("conn-a", "alice").is_none());
+        assert!(registry.list("conn-a", "alice", 0).is_none());
     }
 
     #[test]
@@ -880,7 +907,7 @@ mod test {
         assert!(registry.remove("conn-a", "alice", "s1"));
         assert!(registry.get("conn-a", "alice", "s1", 0).is_none());
         assert!(registry.get("conn-a", "alice", "s2", 0).is_some());
-        assert_eq!(registry.list("conn-a", "alice").unwrap().len(), 1);
+        assert_eq!(registry.list("conn-a", "alice", 0).unwrap().len(), 1);
     }
 
     #[test]
@@ -922,7 +949,7 @@ mod test {
             .unwrap();
         assert!(!registry.remove("conn-a", "alice", "ghost"));
         assert!(!registry.remove("conn-b", "alice", "s1"));
-        assert_eq!(registry.list("conn-a", "alice").unwrap().len(), 1);
+        assert_eq!(registry.list("conn-a", "alice", 0).unwrap().len(), 1);
     }
 
     #[test]

--- a/src/server/acp/session.rs
+++ b/src/server/acp/session.rs
@@ -134,6 +134,20 @@ pub const MAX_SESSIONS_TOTAL: usize = 8_192;
 /// generous enough to outlast a normal gap between prompts — one working day.
 pub const SESSION_TTL_MILLIS: u64 = 24 * 60 * 60 * 1000;
 
+/// How often [`SessionSweeper`] checks for expired sessions.
+///
+/// Deliberately much shorter than [`SESSION_TTL_MILLIS`]: a session that goes
+/// idle right after one sweep tick is not stale enough for the *next* tick
+/// (a full [`SESSION_TTL_MILLIS`] later) to reclaim either, so sweeping once
+/// per TTL lets a session squat its cap slot for up to twice its own TTL. An
+/// hourly cadence bounds that overshoot to about an hour instead.
+pub const SESSION_SWEEP_INTERVAL_MILLIS: u64 = 60 * 60 * 1000;
+
+const _: () = assert!(
+    SESSION_SWEEP_INTERVAL_MILLIS < SESSION_TTL_MILLIS,
+    "sweeping no more often than the TTL reintroduces the up-to-2x-TTL overshoot this constant exists to bound",
+);
+
 /// Why [`SessionRegistry::open`] refused a `session/new`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OpenSessionRefusal {
@@ -254,6 +268,47 @@ impl SessionRegistry {
         Some(Arc::clone(&entry.session))
     }
 
+    /// Looks up a session for `owner` without renewing its idle TTL, refusing
+    /// a connection id it does not hold.
+    ///
+    /// For a caller that still has to run `authorize_address` on the
+    /// session's company before it may act on it — the ACP transport's
+    /// `session/delete` and `session/prompt`. Renewing the TTL via [`Self::get`]
+    /// before that check can still refuse the caller would let a tenant whose
+    /// access to one company under it was revoked keep a session's cap slot
+    /// alive indefinitely, by repeatedly presenting it and losing the
+    /// authorization check every time.
+    pub fn peek(&self, connection: &str, owner: &str, id: &str) -> Option<Arc<AcpSession>> {
+        let by_connection = self
+            .by_connection
+            .lock()
+            .expect("session registry poisoned");
+        let conn = by_connection.get(connection)?;
+        if conn.owner != owner {
+            return None;
+        }
+        Some(Arc::clone(&conn.sessions.get(id)?.session))
+    }
+
+    /// Renews a session's idle TTL, once the caller's authorization to act on
+    /// it is already confirmed (typically via a prior [`Self::peek`]).
+    ///
+    /// A silent no-op for a connection or session `owner` does not hold, or
+    /// that vanished between the authorization check and this call — nothing
+    /// here needs a second refusal for a session that already will not run.
+    pub fn touch(&self, connection: &str, owner: &str, id: &str, now_millis: u64) {
+        let mut by_connection = self
+            .by_connection
+            .lock()
+            .expect("session registry poisoned");
+        if let Some(conn) = by_connection.get_mut(connection)
+            && conn.owner == owner
+            && let Some(entry) = conn.sessions.get_mut(id)
+        {
+            entry.last_used_millis = now_millis;
+        }
+    }
+
     /// Every session on a connection `owner` holds, for `session/list`.
     /// `None` when the connection is unknown or belongs to someone else.
     pub fn list(&self, connection: &str, owner: &str) -> Option<Vec<Arc<AcpSession>>> {
@@ -354,7 +409,8 @@ impl SessionSweeper {
         Self { registry }
     }
 
-    /// Runs until `shutdown` is notified, sweeping once per [`SESSION_TTL_MILLIS`].
+    /// Runs until `shutdown` is notified, sweeping every
+    /// [`SESSION_SWEEP_INTERVAL_MILLIS`].
     pub fn spawn(self, shutdown: Arc<Notify>) -> JoinHandle<()> {
         tokio::spawn(async move {
             let notified = shutdown.notified();
@@ -362,7 +418,7 @@ impl SessionSweeper {
             loop {
                 tokio::select! {
                     _ = &mut notified => break,
-                    _ = tokio::time::sleep(Duration::from_millis(SESSION_TTL_MILLIS)) => {
+                    _ = tokio::time::sleep(Duration::from_millis(SESSION_SWEEP_INTERVAL_MILLIS)) => {
                         self.registry.sweep_expired(crate::ports::now_millis());
                     }
                 }
@@ -560,6 +616,60 @@ mod test {
                 .get("conn-a", "alice", "s1", SESSION_TTL_MILLIS)
                 .is_some()
         );
+    }
+
+    #[test]
+    fn peek_does_not_renew_the_idle_ttl() {
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        // A `peek` at half the TTL — a pre-authorization check — must not
+        // extend the clock the way `get` does.
+        assert!(registry.peek("conn-a", "alice", "s1").is_some());
+        assert_eq!(
+            registry.sweep_expired(SESSION_TTL_MILLIS + 1),
+            1,
+            "peek must not have renewed the session past its original TTL"
+        );
+    }
+
+    #[test]
+    fn peek_refuses_a_connection_or_owner_it_does_not_hold() {
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        assert!(registry.peek("conn-b", "alice", "s1").is_none());
+        assert!(registry.peek("conn-a", "mallory", "s1").is_none());
+        assert!(registry.peek("conn-a", "alice", "s1").is_some());
+    }
+
+    #[test]
+    fn touch_renews_the_idle_ttl_that_peek_left_alone() {
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        assert!(registry.peek("conn-a", "alice", "s1").is_some());
+        registry.touch("conn-a", "alice", "s1", SESSION_TTL_MILLIS / 2);
+        assert_eq!(
+            registry.sweep_expired(SESSION_TTL_MILLIS),
+            0,
+            "touch renewed at TTL/2, so a full TTL later it is not yet idle that long"
+        );
+    }
+
+    #[test]
+    fn touch_is_a_silent_no_op_for_a_connection_or_owner_it_does_not_hold() {
+        let registry = SessionRegistry::new();
+        registry
+            .open("conn-a", "alice", session("s1", "acme"), 0)
+            .unwrap();
+        // Neither call may panic, and neither may renew alice's session.
+        registry.touch("conn-b", "alice", "s1", SESSION_TTL_MILLIS / 2);
+        registry.touch("conn-a", "mallory", "s1", SESSION_TTL_MILLIS / 2);
+        assert_eq!(registry.sweep_expired(SESSION_TTL_MILLIS + 1), 1);
     }
 
     #[test]

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -254,26 +254,22 @@ fn delete_session(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Va
     Ok(json!({}))
 }
 
-/// Closes the caller's connection: every session it opened whose company the
-/// caller may still address.
+/// Closes the caller's connection: every session it opened, in one stroke.
 ///
 /// The HTTP edge has no socket whose closure sweeps a connection, so the
-/// client ends its connection explicitly. `SessionRegistry::list` already
-/// refuses a connection this caller did not open; the per-session
-/// `authorize_address` re-check on top of that is defense in depth for
-/// authorization revoked between the session's open and now.
+/// client ends its connection explicitly. `SessionRegistry::close_connection`
+/// checks ownership and removes every session under the same lock, so there
+/// is no snapshot for a concurrent `session/new` to land in after the check
+/// and survive the disconnect, and no session left counted against either cap
+/// pending a sweep because its company's authorization happened to lapse
+/// first. Closing bookkeeping for a session is not reading or writing that
+/// company's content, so unlike `session/list`, `session/delete` and
+/// `session/prompt`, there is no per-session `authorize_address` re-check
+/// here to skip a session over.
 fn disconnect(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Value, String> {
     let conn = connection(params)?;
     let owner = owner(auth);
-    let registry = state.acp_sessions();
-    let Some(sessions) = registry.list(conn, &owner) else {
-        return Ok(json!({}));
-    };
-    for session in sessions {
-        if authorize_address(state, auth, &session.company).is_none() {
-            registry.remove(conn, &owner, &session.id);
-        }
-    }
+    state.acp_sessions().close_connection(conn, &owner);
     Ok(json!({}))
 }
 
@@ -951,6 +947,42 @@ mode = "full"
         }
         let refusal = open_session(&state, &auth, &params).await;
         assert!(refusal.is_err(), "the cap must refuse the next open");
+    }
+
+    #[tokio::test]
+    async fn disconnect_closes_every_session_on_the_connection_at_once() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-disconnect-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state(home.path()).await;
+        let company = CompanyId::new("acme");
+        let admin = seed_user(&state, &company, "u-admin", "Admin Person").await;
+        let auth = admin_auth(&company, admin, "hash");
+        let params = json!({
+            "_meta": {
+                "opencompany": { "company": "acme" },
+                "opencompany/connectionId": "conn-close",
+            }
+        });
+
+        open_session(&state, &auth, &params)
+            .await
+            .expect("first session");
+        open_session(&state, &auth, &params)
+            .await
+            .expect("second session");
+
+        let closed = disconnect(&state, &auth, &params);
+        assert!(closed.is_ok());
+
+        // The whole connection is gone, not merely emptied of sessions:
+        // `list_sessions` on an unknown connection is the same refusal as one
+        // this caller never owned.
+        assert!(
+            list_sessions(&state, &auth, &params).is_err(),
+            "the connection must not survive its own disconnect"
+        );
     }
 
     #[test]

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -374,7 +374,7 @@ async fn prompt(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Valu
         .run_journaled_cycle(vec![(message_seq, event)], None)
         .await
         .map_err(|e| e.to_string())?;
-    Ok(prompt_result(&session.id, report))
+    Ok(prompt_result(report))
 }
 
 /// Builds a `session/prompt` result from a finished cycle.
@@ -383,7 +383,7 @@ async fn prompt(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Valu
 /// module docs) — the cycle still completes and answers `end_turn`. The
 /// client learns of the park through a notification per parked approval
 /// instead.
-fn prompt_result(session_id: &str, report: crate::runtime::CycleReport) -> Value {
+fn prompt_result(report: crate::runtime::CycleReport) -> Value {
     let mut updates = report
         .responses
         .into_iter()
@@ -934,7 +934,7 @@ mode = "full"
             persisted_seq: None,
             input_seqs: Vec::new(),
         };
-        let result = prompt_result("sess-1", report);
+        let result = prompt_result(report);
         assert_eq!(result["stopReason"], "end_turn");
         let updates = result["updates"].as_array().expect("updates array");
         assert_eq!(updates.len(), 1);
@@ -951,7 +951,7 @@ mode = "full"
             persisted_seq: None,
             input_seqs: Vec::new(),
         };
-        let result = prompt_result("sess-1", report);
+        let result = prompt_result(report);
         assert_eq!(result["stopReason"], "end_turn");
         assert!(
             result["updates"]

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -96,6 +96,17 @@ fn connection(params: &Value) -> Result<&str, String> {
         .ok_or_else(|| "`_meta.opencompany/connectionId` is required".to_string())
 }
 
+/// A stable identity for whoever presented `auth`, used to bind a
+/// caller-supplied `connectionId` to the caller that first used it. Two
+/// different users (or platform tenants) must never resolve to the same
+/// owner string.
+fn owner(auth: &GqlAuth) -> String {
+    match auth {
+        GqlAuth::User(user) => format!("user:{}", user.user_id),
+        GqlAuth::Platform(claims) => format!("platform:{}", claims.tenant),
+    }
+}
+
 fn target(params: &Value) -> Result<(&str, String, Option<String>), String> {
     let meta = params
         .get("_meta")
@@ -163,22 +174,27 @@ async fn open_session(state: &AppState, auth: &GqlAuth, params: &Value) -> Resul
         }
     }
     let id = uuid::Uuid::new_v4().to_string();
-    state.acp_sessions().insert(
-        connection(params)?,
-        super::AcpSession {
-            id: id.clone(),
-            company,
-            // A pinned session answers as its member; see `AcpSession::thread_key`.
-            chat: super::AcpSession::thread_key(&requested_chat, agent_id.as_deref()),
-            agent_id,
-        },
-    );
+    let session = state
+        .acp_sessions()
+        .open(
+            connection(params)?,
+            &owner(auth),
+            super::AcpSession {
+                id,
+                company,
+                // A pinned session answers as its member; see `AcpSession::thread_key`.
+                chat: super::AcpSession::thread_key(&requested_chat, agent_id.as_deref()),
+                agent_id,
+            },
+            crate::ports::now_millis(),
+        )
+        .map_err(|refusal| refusal.message().to_string())?;
     // ACP's result requires a `cwd`. On this host the workspace is server-side
     // and the client's own path is never used — the same truth `cwd_meta`
     // reports in `_meta` is stated as `cwd` so a strict client deserializes.
     let workspace = "server-side company workspace";
     Ok(json!({
-        "sessionId": id,
+        "sessionId": session.id,
         "cwd": workspace,
         "_meta": super::session::cwd_meta(workspace),
     }))
@@ -189,10 +205,12 @@ fn list_sessions(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Val
     // authenticated tenant who learns another tenant's connection id must not
     // be able to enumerate its company, thread, agent and session ids. Each
     // entry is therefore filtered through the same `authorize_address` every
-    // other company-scoped read gets.
+    // other company-scoped read gets — and the connection itself must be one
+    // this caller opened, checked by `SessionRegistry::list`.
     let sessions = state
         .acp_sessions()
-        .list(connection(params)?)
+        .list(connection(params)?, &owner(auth))
+        .ok_or_else(|| "unknown ACP connection".to_string())?
         .into_iter()
         .filter(|s| authorize_address(state, auth, &s.company).is_none())
         .map(|s| {
@@ -217,38 +235,40 @@ fn delete_session(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Va
         .and_then(Value::as_str)
         .ok_or_else(|| "`sessionId` is required".to_string())?;
     let conn = connection(params)?;
+    let owner = owner(auth);
     let registry = state.acp_sessions();
-    // Authorize against the session when it exists. A never-existing session
-    // deletes silently — ACP says so, and an id is opaque enough that saying
-    // "I never had that" leaks nothing useful.
-    if let Some(session) = registry.get(conn, session_id)
+    // Authorize against the session when it exists. A never-existing session,
+    // and a connection this caller does not own, both delete silently — ACP
+    // says so for the former, and an id is opaque enough that saying "I never
+    // had that" leaks nothing useful either way.
+    if let Some(session) = registry.get(conn, &owner, session_id, crate::ports::now_millis())
         && authorize_address(state, auth, &session.company).is_some()
     {
         return Err("not authorized for this company".to_string());
     }
-    registry.remove(conn, session_id);
+    registry.remove(conn, &owner, session_id);
     Ok(json!({}))
 }
 
-/// Closes the caller's connection: every session it holds whose company the
-/// caller may address.
+/// Closes the caller's connection: every session it opened whose company the
+/// caller may still address.
 ///
 /// The HTTP edge has no socket whose closure sweeps a connection, so the
-/// client ends its connection explicitly. Each session is authorized
-/// individually, matching `session/list` — a caller may only close sessions it
-/// could have listed, so one tenant cannot sweep another's by guessing its
-/// connection id.
+/// client ends its connection explicitly. `SessionRegistry::list` already
+/// refuses a connection this caller did not open; the per-session
+/// `authorize_address` re-check on top of that is defense in depth for
+/// authorization revoked between the session's open and now.
 fn disconnect(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Value, String> {
     let conn = connection(params)?;
+    let owner = owner(auth);
     let registry = state.acp_sessions();
-    let ours: Vec<String> = registry
-        .list(conn)
-        .into_iter()
-        .filter(|s| authorize_address(state, auth, &s.company).is_none())
-        .map(|s| s.id.clone())
-        .collect();
-    for id in ours {
-        registry.remove(conn, &id);
+    let Some(sessions) = registry.list(conn, &owner) else {
+        return Ok(json!({}));
+    };
+    for session in sessions {
+        if authorize_address(state, auth, &session.company).is_none() {
+            registry.remove(conn, &owner, &session.id);
+        }
     }
     Ok(json!({}))
 }
@@ -260,7 +280,12 @@ async fn prompt(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Valu
         .ok_or_else(|| "`sessionId` is required".to_string())?;
     let session = state
         .acp_sessions()
-        .get(connection(params)?, session_id)
+        .get(
+            connection(params)?,
+            &owner(auth),
+            session_id,
+            crate::ports::now_millis(),
+        )
         .ok_or_else(|| "unknown ACP session".to_string())?;
     if authorize_address(state, auth, &session.company).is_some() {
         return Err("not authorized for this company".to_string());
@@ -349,7 +374,17 @@ async fn prompt(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Valu
         .run_journaled_cycle(vec![(message_seq, event)], None)
         .await
         .map_err(|e| e.to_string())?;
-    let updates = report
+    Ok(prompt_result(&session.id, report))
+}
+
+/// Builds a `session/prompt` result from a finished cycle.
+///
+/// A park does not suspend this host's ACP turn (see `acp::approvals`'s
+/// module docs) — the cycle still completes and answers `end_turn`. The
+/// client learns of the park through a notification per parked approval
+/// instead.
+fn prompt_result(session_id: &str, report: crate::runtime::CycleReport) -> Value {
+    let mut updates = report
         .responses
         .into_iter()
         .map(|reply| {
@@ -359,7 +394,14 @@ async fn prompt(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Valu
             })
         })
         .collect::<Vec<_>>();
-    Ok(json!({ "stopReason": "end_turn", "updates": updates }))
+    for approval_id in &report.parked {
+        updates.push(super::approvals::parked_notification(
+            session_id,
+            approval_id.as_ref(),
+            "OpenCompany parked an effect from this turn, awaiting your approval",
+        ));
+    }
+    json!({ "stopReason": "end_turn", "updates": updates })
 }
 
 /// The text of an ACP `session/prompt`, from its content-block array.
@@ -410,7 +452,7 @@ mod test {
 
     use crate::company::CompanyManifest;
     use crate::ports::EventSeq;
-    use crate::ports::types::{CompressedTrace, CycleRequest, CycleResult, TokenUsage};
+    use crate::ports::types::{ApprovalId, CompressedTrace, CycleRequest, CycleResult, TokenUsage};
     use crate::ports::users::{UserRecord, UserRole, UserStatus};
     use crate::ports::{Brain, CompanyStore, CycleHost};
     use crate::server::graphql::auth::UserPrincipal;
@@ -618,15 +660,20 @@ mode = "full"
             credential: crate::ports::SessionKind::Browser,
         });
 
-        state.acp_sessions().insert(
-            "conn-1",
-            crate::server::acp::AcpSession {
-                id: "s-1".to_string(),
-                company: company.clone(),
-                chat: "engineering".to_string(),
-                agent_id: None,
-            },
-        );
+        state
+            .acp_sessions()
+            .open(
+                "conn-1",
+                &owner(&auth),
+                crate::server::acp::AcpSession {
+                    id: "s-1".to_string(),
+                    company: company.clone(),
+                    chat: "engineering".to_string(),
+                    agent_id: None,
+                },
+                crate::ports::now_millis(),
+            )
+            .expect("open session");
 
         let result = prompt(
             &state,
@@ -685,15 +732,20 @@ mode = "full"
             credential: crate::ports::SessionKind::Browser,
         });
 
-        state.acp_sessions().insert(
-            "conn-1",
-            crate::server::acp::AcpSession {
-                id: "s-1".to_string(),
-                company: company.clone(),
-                chat: "engineering".to_string(),
-                agent_id: None,
-            },
-        );
+        state
+            .acp_sessions()
+            .open(
+                "conn-1",
+                &owner(&auth),
+                crate::server::acp::AcpSession {
+                    id: "s-1".to_string(),
+                    company: company.clone(),
+                    chat: "engineering".to_string(),
+                    agent_id: None,
+                },
+                crate::ports::now_millis(),
+            )
+            .expect("open session");
 
         runtime.quiesce().await;
 
@@ -756,15 +808,20 @@ mode = "full"
         // client requested `_meta.opencompany.chat = "operator"`
         // (`AcpSession::thread_key` passes an unpinned request through
         // verbatim).
-        state.acp_sessions().insert(
-            "conn-1",
-            crate::server::acp::AcpSession {
-                id: "s-1".to_string(),
-                company: company.clone(),
-                chat: "operator".to_string(),
-                agent_id: None,
-            },
-        );
+        state
+            .acp_sessions()
+            .open(
+                "conn-1",
+                &owner(&auth),
+                crate::server::acp::AcpSession {
+                    id: "s-1".to_string(),
+                    company: company.clone(),
+                    chat: "operator".to_string(),
+                    agent_id: None,
+                },
+                crate::ports::now_millis(),
+            )
+            .expect("open session");
 
         let result = prompt(
             &state,
@@ -796,5 +853,110 @@ mode = "full"
                 .all(|stored| !matches!(&stored.event, CompanyEvent::OperatorMessage { .. })),
             "a refused prompt must not leave a message in the journal: {events:?}"
         );
+    }
+
+    fn admin_auth(company: &CompanyId, user_id: String, session_token_hash: &str) -> GqlAuth {
+        GqlAuth::User(UserPrincipal {
+            company: company.clone(),
+            user_id,
+            email: "admin@example.test".to_string(),
+            role: UserRole::Admin,
+            must_change_password: false,
+            session_token_hash: session_token_hash.to_string(),
+            credential: crate::ports::SessionKind::Browser,
+        })
+    }
+
+    #[tokio::test]
+    async fn a_caller_cannot_open_a_session_on_a_connection_it_does_not_own() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-conn-owner-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state(home.path()).await;
+        let company = CompanyId::new("acme");
+        let alice = seed_user(&state, &company, "u-alice", "Alice").await;
+        let bob = seed_user(&state, &company, "u-bob", "Bob").await;
+        let auth_alice = admin_auth(&company, alice, "hash-alice");
+        let auth_bob = admin_auth(&company, bob, "hash-bob");
+        let params = json!({
+            "_meta": {
+                "opencompany": { "company": "acme" },
+                "opencompany/connectionId": "conn-shared",
+            }
+        });
+
+        let first = open_session(&state, &auth_alice, &params).await;
+        assert!(first.is_ok(), "alice opens the connection first: {first:?}");
+
+        let second = open_session(&state, &auth_bob, &params).await;
+        assert!(
+            second.is_err(),
+            "bob must not be able to open a session on alice's connection"
+        );
+
+        // And bob gets no view into what alice has, by any surface.
+        let listed = list_sessions(&state, &auth_bob, &params);
+        assert!(listed.is_err(), "bob cannot list alice's connection either");
+    }
+
+    #[tokio::test]
+    async fn open_session_refuses_once_the_per_connection_cap_is_hit() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-conn-cap-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state(home.path()).await;
+        let company = CompanyId::new("acme");
+        let admin = seed_user(&state, &company, "u-admin", "Admin Person").await;
+        let auth = admin_auth(&company, admin, "hash");
+        let params = json!({
+            "_meta": {
+                "opencompany": { "company": "acme" },
+                "opencompany/connectionId": "conn-cap",
+            }
+        });
+
+        for _ in 0..crate::server::acp::session::MAX_SESSIONS_PER_CONNECTION {
+            let result = open_session(&state, &auth, &params).await;
+            assert!(result.is_ok(), "{result:?}");
+        }
+        let refusal = open_session(&state, &auth, &params).await;
+        assert!(refusal.is_err(), "the cap must refuse the next open");
+    }
+
+    #[test]
+    fn a_parked_turn_carries_an_approval_notification_but_still_ends_the_turn() {
+        let report = crate::runtime::CycleReport {
+            cycle_id: "c1".to_string(),
+            responses: Vec::new(),
+            executed_effects: Vec::new(),
+            parked: vec![ApprovalId::from("appr-1".to_string())],
+            persisted_seq: None,
+            input_seqs: Vec::new(),
+        };
+        let result = prompt_result("sess-1", report);
+        assert_eq!(result["stopReason"], "end_turn");
+        let updates = result["updates"].as_array().expect("updates array");
+        assert_eq!(updates.len(), 1);
+        assert_eq!(
+            updates[0]["_meta"]["opencompany/approval"]["id"],
+            "appr-1"
+        );
+    }
+
+    #[test]
+    fn a_clean_turn_carries_no_approval_notification() {
+        let report = crate::runtime::CycleReport {
+            cycle_id: "c1".to_string(),
+            responses: Vec::new(),
+            executed_effects: Vec::new(),
+            parked: Vec::new(),
+            persisted_seq: None,
+            input_seqs: Vec::new(),
+        };
+        let result = prompt_result("sess-1", report);
+        assert_eq!(result["stopReason"], "end_turn");
+        assert!(result["updates"].as_array().expect("updates array").is_empty());
     }
 }

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -276,7 +276,7 @@ fn delete_session(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Va
 /// under the same lock — so there is no snapshot for a concurrent
 /// `session/new` to land in after the check and survive the disconnect,
 /// unlike the list-then-remove loop this replaced. The per-session check
-/// stays (coderabbit review): `owner` names a tenant, not an authorization
+/// stays: `owner` names a tenant, not an authorization
 /// scope, and two platform credentials for the same tenant can carry
 /// different company allow-lists — closing every session unconditionally
 /// would let a narrowly-scoped credential remove sessions for companies

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -106,7 +106,16 @@ fn owner(auth: &GqlAuth) -> String {
         // companies can legitimately mint the same id — so both are part of
         // the key, or a collision would let a second company's user share a
         // connection binding with the first's.
-        GqlAuth::User(user) => format!("user:{}:{}", user.company, user.user_id),
+        GqlAuth::User(user) => {
+            // Length-prefixed, because a plain join is not injective: neither
+            // `CompanyId::new` nor a stored `UserRecord::id` forbids a `:`, so
+            // (company `a:b`, user `c`) and (company `a`, user `b:c`) would
+            // produce the same owner and let one address the other's
+            // connection — defeating the check this key exists to make.
+            let company = user.company.as_ref();
+            let id = user.user_id.as_str();
+            format!("user:{}:{}:{}:{}", company.len(), company, id.len(), id)
+        }
         // Canonicalized for the same reason `authorize_address` compares
         // tenants in this form: `tenant:acme` and `acme` name the same
         // tenant, and a raw-string key would treat a token whose issuer
@@ -938,6 +947,23 @@ mode = "full"
             session_token_hash: session_token_hash.to_string(),
             credential: crate::ports::SessionKind::Browser,
         })
+    }
+
+    /// A colon is legal in both halves of the owner key, so the join has to be
+    /// injective on its own rather than by assuming the components are clean.
+    #[test]
+    fn two_different_principals_never_share_an_owner_key() {
+        let left = owner(&admin_auth(&CompanyId::new("a:b"), "c".to_string(), "h"));
+        let right = owner(&admin_auth(&CompanyId::new("a"), "b:c".to_string(), "h"));
+        assert_ne!(
+            left, right,
+            "a company and a user id that split differently must not collide"
+        );
+
+        // The same principal still resolves to one stable key, or an operator
+        // would lose their own connection between calls.
+        let again = owner(&admin_auth(&CompanyId::new("a:b"), "c".to_string(), "h"));
+        assert_eq!(left, again);
     }
 
     #[tokio::test]

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -939,10 +939,7 @@ mode = "full"
         assert_eq!(result["stopReason"], "end_turn");
         let updates = result["updates"].as_array().expect("updates array");
         assert_eq!(updates.len(), 1);
-        assert_eq!(
-            updates[0]["_meta"]["opencompany/approval"]["id"],
-            "appr-1"
-        );
+        assert_eq!(updates[0]["_meta"]["opencompany/approval"]["id"], "appr-1");
     }
 
     #[test]
@@ -957,6 +954,11 @@ mode = "full"
         };
         let result = prompt_result("sess-1", report);
         assert_eq!(result["stopReason"], "end_turn");
-        assert!(result["updates"].as_array().expect("updates array").is_empty());
+        assert!(
+            result["updates"]
+                .as_array()
+                .expect("updates array")
+                .is_empty()
+        );
     }
 }

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -251,8 +251,10 @@ fn delete_session(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Va
     // Authorize against the session when it exists. A never-existing session,
     // and a connection this caller does not own, both delete silently — ACP
     // says so for the former, and an id is opaque enough that saying "I never
-    // had that" leaks nothing useful either way.
-    if let Some(session) = registry.get(conn, &owner, session_id, crate::ports::now_millis())
+    // had that" leaks nothing useful either way. `peek`, not `get`: deleting
+    // renews nothing, so there is no reason to touch the idle TTL of a
+    // session this call may yet refuse to act on.
+    if let Some(session) = registry.peek(conn, &owner, session_id)
         && authorize_address(state, auth, &session.company).is_some()
     {
         return Err("not authorized for this company".to_string());
@@ -285,18 +287,20 @@ async fn prompt(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Valu
         .get("sessionId")
         .and_then(Value::as_str)
         .ok_or_else(|| "`sessionId` is required".to_string())?;
-    let session = state
-        .acp_sessions()
-        .get(
-            connection(params)?,
-            &owner(auth),
-            session_id,
-            crate::ports::now_millis(),
-        )
+    let conn = connection(params)?;
+    let owner = owner(auth);
+    let registry = state.acp_sessions();
+    // `peek`, not `get`: authorization can still refuse this call below, and
+    // renewing the idle TTL ahead of that would let a caller whose access to
+    // this session's company was revoked keep the session's cap slot alive
+    // indefinitely by repeatedly presenting it and losing the check.
+    let session = registry
+        .peek(conn, &owner, session_id)
         .ok_or_else(|| "unknown ACP session".to_string())?;
     if authorize_address(state, auth, &session.company).is_some() {
         return Err("not authorized for this company".to_string());
     }
+    registry.touch(conn, &owner, session_id, crate::ports::now_millis());
     let text = prompt_text(params)?;
     let runtime = state
         .registry()

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -220,7 +220,11 @@ fn list_sessions(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Val
     // this caller opened, checked by `SessionRegistry::list`.
     let sessions = state
         .acp_sessions()
-        .list(connection(params)?, &owner(auth))
+        .list(
+            connection(params)?,
+            &owner(auth),
+            crate::ports::now_millis(),
+        )
         .ok_or_else(|| "unknown ACP connection".to_string())?
         .into_iter()
         .filter(|s| authorize_address(state, auth, &s.company).is_none())

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -107,7 +107,14 @@ fn owner(auth: &GqlAuth) -> String {
         // the key, or a collision would let a second company's user share a
         // connection binding with the first's.
         GqlAuth::User(user) => format!("user:{}:{}", user.company, user.user_id),
-        GqlAuth::Platform(claims) => format!("platform:{}", claims.tenant),
+        // Canonicalized for the same reason `authorize_address` compares
+        // tenants in this form: `tenant:acme` and `acme` name the same
+        // tenant, and a raw-string key would treat a token whose issuer
+        // format changed (or was rotated to the other form) as a stranger to
+        // its own still-open connection.
+        GqlAuth::Platform(claims) => {
+            format!("platform:{}", crate::app::canonical_tenant(&claims.tenant))
+        }
     }
 }
 
@@ -455,6 +462,7 @@ mod test {
     use crate::ports::users::{UserRecord, UserRole, UserStatus};
     use crate::ports::{Brain, CompanyStore, CycleHost};
     use crate::server::graphql::auth::UserPrincipal;
+    use crate::server::platform_auth::PlatformClaims;
     use crate::store::FsCompanyStore;
     use crate::{AppConfig, ports::types::CompanyRecord};
 
@@ -547,6 +555,24 @@ mod test {
             credential: crate::ports::SessionKind::Browser,
         });
         assert_ne!(owner(&same_id_in_acme), owner(&same_id_in_globex));
+    }
+
+    #[test]
+    fn owner_canonicalizes_the_platform_tenant() {
+        // `authorize_address` compares tenants in canonical_tenant form, so a
+        // raw-string owner key would treat `tenant:acme` and `acme` as two
+        // different owners even though they name the same tenant.
+        let prefixed = GqlAuth::Platform(PlatformClaims {
+            tenant: "tenant:acme".to_string(),
+            scopes: Default::default(),
+            companies: None,
+        });
+        let bare = GqlAuth::Platform(PlatformClaims {
+            tenant: "acme".to_string(),
+            scopes: Default::default(),
+            companies: None,
+        });
+        assert_eq!(owner(&prefixed), owner(&bare));
     }
 
     /// A brain that answers a cycle with nothing, so the ACP `prompt` turn

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -395,8 +395,7 @@ fn prompt_result(session_id: &str, report: crate::runtime::CycleReport) -> Value
         })
         .collect::<Vec<_>>();
     for approval_id in &report.parked {
-        updates.push(super::approvals::parked_notification(
-            session_id,
+        updates.push(super::approvals::parked_update(
             approval_id.as_ref(),
             "OpenCompany parked an effect from this turn, awaiting your approval",
         ));

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -254,7 +254,7 @@ fn delete_session(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Va
     // had that" leaks nothing useful either way. `peek`, not `get`: deleting
     // renews nothing, so there is no reason to touch the idle TTL of a
     // session this call may yet refuse to act on.
-    if let Some(session) = registry.peek(conn, &owner, session_id)
+    if let Some(session) = registry.peek(conn, &owner, session_id, crate::ports::now_millis())
         && authorize_address(state, auth, &session.company).is_some()
     {
         return Err("not authorized for this company".to_string());
@@ -263,22 +263,36 @@ fn delete_session(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Va
     Ok(json!({}))
 }
 
-/// Closes the caller's connection: every session it opened, in one stroke.
+/// Closes the caller's connection: every session it opened whose company the
+/// caller may still address, in one stroke.
 ///
 /// The HTTP edge has no socket whose closure sweeps a connection, so the
 /// client ends its connection explicitly. `SessionRegistry::close_connection`
-/// checks ownership and removes every session under the same lock, so there
-/// is no snapshot for a concurrent `session/new` to land in after the check
-/// and survive the disconnect, and no session left counted against either cap
-/// pending a sweep because its company's authorization happened to lapse
-/// first. Closing bookkeeping for a session is not reading or writing that
-/// company's content, so unlike `session/list`, `session/delete` and
-/// `session/prompt`, there is no per-session `authorize_address` re-check
-/// here to skip a session over.
+/// checks ownership, runs `authorized` per session, and removes what passes
+/// under the same lock — so there is no snapshot for a concurrent
+/// `session/new` to land in after the check and survive the disconnect,
+/// unlike the list-then-remove loop this replaced. The per-session check
+/// stays (coderabbit review): `owner` names a tenant, not an authorization
+/// scope, and two platform credentials for the same tenant can carry
+/// different company allow-lists — closing every session unconditionally
+/// would let a narrowly-scoped credential remove sessions for companies
+/// outside its own allow-list merely by sharing an owner string with
+/// whichever credential opened them. A session whose authorization has since
+/// lapsed is left for the periodic sweep instead — an hourly cadence
+/// ([`SESSION_SWEEP_INTERVAL_MILLIS`](super::session::SESSION_SWEEP_INTERVAL_MILLIS)),
+/// not the day-long gap a blanket removal would have closed.
 fn disconnect(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Value, String> {
     let conn = connection(params)?;
     let owner = owner(auth);
-    state.acp_sessions().close_connection(conn, &owner);
+    // Per-session, not blanket: `owner` names a tenant, and two platform
+    // credentials for the same tenant can carry different company
+    // allow-lists, so a connection's sessions may span companies the
+    // presented credential is not itself authorized for.
+    state
+        .acp_sessions()
+        .close_connection(conn, &owner, |company| {
+            authorize_address(state, auth, company).is_none()
+        });
     Ok(json!({}))
 }
 
@@ -294,13 +308,14 @@ async fn prompt(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Valu
     // renewing the idle TTL ahead of that would let a caller whose access to
     // this session's company was revoked keep the session's cap slot alive
     // indefinitely by repeatedly presenting it and losing the check.
+    let now_millis = crate::ports::now_millis();
     let session = registry
-        .peek(conn, &owner, session_id)
+        .peek(conn, &owner, session_id, now_millis)
         .ok_or_else(|| "unknown ACP session".to_string())?;
     if authorize_address(state, auth, &session.company).is_some() {
         return Err("not authorized for this company".to_string());
     }
-    registry.touch(conn, &owner, session_id, crate::ports::now_millis());
+    registry.touch(conn, &owner, session_id, now_millis);
     let text = prompt_text(params)?;
     let runtime = state
         .registry()

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -102,7 +102,11 @@ fn connection(params: &Value) -> Result<&str, String> {
 /// owner string.
 fn owner(auth: &GqlAuth) -> String {
     match auth {
-        GqlAuth::User(user) => format!("user:{}", user.user_id),
+        // `user_id` is only guaranteed stable within `user.company` — two
+        // companies can legitimately mint the same id — so both are part of
+        // the key, or a collision would let a second company's user share a
+        // connection binding with the first's.
+        GqlAuth::User(user) => format!("user:{}:{}", user.company, user.user_id),
         GqlAuth::Platform(claims) => format!("platform:{}", claims.tenant),
     }
 }
@@ -522,6 +526,31 @@ mod test {
     #[test]
     fn an_empty_prompt_is_refused() {
         assert!(prompt_text(&json!({ "prompt": [] })).is_err());
+    }
+
+    #[test]
+    fn owner_keys_a_user_by_company_as_well_as_id() {
+        // `user_id` is only guaranteed unique within a company, so two
+        // companies minting the same id must not collide into one owner.
+        let same_id_in_acme = GqlAuth::User(UserPrincipal {
+            company: CompanyId::new("acme"),
+            user_id: "u1".to_string(),
+            email: "a@example.test".to_string(),
+            role: UserRole::Admin,
+            must_change_password: false,
+            session_token_hash: "hash".to_string(),
+            credential: crate::ports::SessionKind::Browser,
+        });
+        let same_id_in_globex = GqlAuth::User(UserPrincipal {
+            company: CompanyId::new("globex"),
+            user_id: "u1".to_string(),
+            email: "b@example.test".to_string(),
+            role: UserRole::Admin,
+            must_change_password: false,
+            session_token_hash: "hash".to_string(),
+            credential: crate::ports::SessionKind::Browser,
+        });
+        assert_ne!(owner(&same_id_in_acme), owner(&same_id_in_globex));
     }
 
     /// A brain that answers a cycle with nothing, so the ACP `prompt` turn


### PR DESCRIPTION
## Summary

`connection()` read the caller-supplied `_meta.opencompany/connectionId` and required only that it
be non-empty. `open_session` then wrote into whatever id it was handed. There was no check that
the connection belonged to the caller, no cap, no TTL and no sweeper — and `disconnect` filtered
foreign-injected sessions out, so they were never reclaimed either.

Hosted tenants are not exposed: `acp` is absent from `TENANT_FEATURES`. **The macOS desktop app
ships `acp`**, so this is live in a shipped product.

- Sessions are bound to the connection that opened them; a caller cannot open on, read from, or
  act on a connection it does not own.
- A per-connection cap, an idle TTL that renews on use, and a sweeper spawned at boot.
- `disconnect` now sweeps every session it opened, with none stranded.

**Deleted the inbound permission queue** (`PendingPermissions`, `HeldPermission`,
`PermissionOutcome`, `PERMISSION_TTL_MILLIS`, `expire()`) rather than wiring it. Nothing in this
repo ever called `.hold()`: the one shipped ACP client is the desktop shell, whose production
`ClientHandler` answers `session/request_permission` **synchronously**. A TTL bounds how long a
request waits in a queue; with nothing ever entering the queue there was no window to bound, and
the type read as a live capability the host does not have. `acp/map.rs` was left alone — unlike
`approvals.rs` it has no shipped alternative occupying its slot; it is seam code for a streaming
transport that does not exist yet.

**Correction to an earlier version of this description.** This PR previously called the
`prompt_result` shape a *second defect found on main*. That was wrong, and the claim is withdrawn.
On base `0056ddf0e` `prompt_result` does not exist and `parked_notification` has zero callers, so
parked approvals were never emitted at all — they were not mis-shaped. `prompt_result` is new code
in this branch, and the shape problem was a bug in that new code, caught and fixed before it
shipped. Ordinary development, not a discovery, and the "failed 12 of 12 runs" figure was measured
against this branch's own intermediate state, not against main.

What the branch does add: a `session/prompt` result now carries parked approvals as bare
`SessionUpdate` objects, consistent with every other element of that array, so a client switching
on `sessionUpdate` reads them. `parked_update` returns what a result carries and
`parked_notification` wraps it for a transport that pushes frames — mirroring how `map` already
splits the two. Note `parked_notification` remains uncalled in production; it exists for the
streaming transport that does not yet exist, the same status as `map.rs`.

## API Or Behavior Changes

- `session/prompt` results now carry a parked approval as a bare update object, consistent with
  every other element of the same array. A client reading `updates[i].params.update` for that one
  element would have to change — but nothing could have been reading it that way and also reading
  its siblings, which is the bug.
- An ACP caller must now own a connection to address it, and sessions expire. Both are new
  refusals where the host previously accepted.
- `PendingPermissions` and friends are gone from the public surface.
- `spawn_acp_session_sweeper` is wired from `bin/opencompany.rs`, following the existing pattern
  used by `PresenceSweeper`, `WorkflowScheduler`, `MaintenanceTicker` and `LifecycleScheduler` —
  none of which self-spawn, because a real runtime and a process-lifetime shutdown handle only
  exist at that point.

## Tests

43 tests pass under `--features acp`, covering ownership refusal, the per-connection cap, TTL
sweep, renewal on use, `disconnect` sweeping with none stranded, and connection pruning.

**Honest note on red proofs.** These assertions could not be observed failing against the
pre-fix code, because the old `SessionRegistry` had no `owner` parameter, no cap constant and no
`sweep_expired` — the new tests do not compile against it. That is proof by construction that the
property was absent, not the same claim as watching a test fail, and it is stated here rather
than implied away.

The one assertion that *was* observed failing is the `prompt_result` shape test, which failed
deterministically 12 times out of 12 before the fix above and passes after. That test was written
correctly and never run; running it is what found the second defect.

- [x] `cargo fmt --check` — 0
- [x] `cargo clippy --locked --no-deps --features acp --all-targets -- -D warnings` — 0
- [x] `cargo test --features acp --lib server::acp` — 0 · 43 passed, 0 failed

## Documentation

Module docs updated in place: `approvals.rs` explains why the inbound queue is gone rather than
dormant, and `parked_update` documents the result-versus-notification split.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ACP sessions are restricted to their authenticated owner.
  - Added limits on sessions per connection and across the service.
  - Idle sessions automatically expire and are periodically cleaned up.

- **Improvements**
  - Session activity renews its idle lifetime.
  - Expired sessions no longer appear in session listings.
  - Disconnect cleanup removes only sessions still authorized for that connection.
  - Permission requests are handled synchronously, while parked approval updates continue to appear in session results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->