### PR TITLE
fix(skills): require admin for skill writes and bound the document size

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -13,6 +13,7 @@
 // still the right trade where the alternative is no console at all.
 
 import type { OpenCompanyClient } from "./client";
+import { ApiError } from "./types";
 
 /** What a company may call a user. */
 export type UserRole = "admin" | "member";
@@ -240,6 +241,23 @@ export async function loginWithPassword(
 /** Who the current session belongs to; throws 401 when signed out. */
 export async function me(client: OpenCompanyClient, company: string | null): Promise<Me> {
   return client.get<Me>(`${client.scopeFor(company)}/auth/me`);
+}
+
+/**
+ * Whether {@link me} failed because there is confirmedly no session, rather
+ * than for some other reason.
+ *
+ * A caller falling back to a platform bearer's own authority on *any* {@link
+ * me} failure (codex review) would also fall back on a network error, a
+ * timeout, or a `5xx` — none of which mean "no session"; a member's session
+ * could still be live and would still take precedence on the host. The
+ * host's own `no_session()` answers `401` with `code: "unauthorized"` from
+ * its own `{error, code}` envelope, which {@link ApiError.fromHost}
+ * distinguishes from a `401` (or any other status) synthesised between the
+ * browser and the host giving up before reaching it at all.
+ */
+export function hasNoSession(err: unknown): boolean {
+  return err instanceof ApiError && err.fromHost && err.status === 401 && err.code === "unauthorized";
 }
 
 /** Sets or replaces the signed-in user's own password. */

--- a/frontend/src/views/SettingsSection.tsx
+++ b/frontend/src/views/SettingsSection.tsx
@@ -168,7 +168,10 @@ export function SettingsSection({ client, company, feed, sub, onFlag, onResetCom
         {page === "search" && (
           <SearchView key={company ?? "self"} client={client} company={company} />
         )}
-        {page === "skills" && <SkillsView client={client} company={company} />}
+        {/* Same remount rule, same reason: canManage (and the Add dialog's
+            draft) must not carry an admin's authority from one company into
+            another's still-resolving read (codeRabbit review). */}
+        {page === "skills" && <SkillsView key={company ?? "self"} client={client} company={company} />}
         {/* Observatory has a row on this rail but renders nothing here: the row
             is a doorway, and `#/settings/observatory` is rewritten onto
             `#/observatory` before it ever reaches this dispatch.

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
-import { me as fetchMe } from "@/api/auth";
+import { hasNoSession, me as fetchMe } from "@/api/auth";
 import {
   createSkill,
   installSkill,
@@ -106,18 +106,18 @@ export function SkillsView({ client, company }: Props) {
       let admin = false;
       try {
         admin = (await fetchMe(client, company)).role === "admin";
-      } catch {
+      } catch (err) {
         // `resolve_principal` on the host tries a human session first and
         // only falls back to the platform/tenant bearer when none is
         // present — a hub console can carry both, and the write routes
         // below are AdminScopedCompany, which admits that machine principal
-        // unconditionally once it has addressed this company. So `/auth/me`
-        // failing outright (no session at all) means the bearer is what the
-        // host will actually authorize on; `/auth/me` *succeeding* with a
-        // member role — even with a bearer also present — means the host
-        // resolved that member and will 403 the same as it would with no
-        // bearer at all, which the `try` above already handles correctly.
-        admin = client.carriesPlatformBearer;
+        // unconditionally once it has addressed this company. So a
+        // *confirmed* absence of any session means the bearer is what the
+        // host will actually authorize on. A network error, a timeout, or a
+        // `5xx` is not that confirmation — a member's session could still be
+        // live and still take precedence on the host — so those stay
+        // non-admin rather than assuming the bearer wins (codeRabbit review).
+        admin = client.carriesPlatformBearer && hasNoSession(err);
       }
       if (live) setCanManage(admin);
     })();

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -101,23 +101,23 @@ export function SkillsView({ client, company }: Props) {
   const gen = useRef(0);
 
   useEffect(() => {
-    // A platform or tenant bearer has no human session for `/auth/me` to
-    // return, but the write routes below are AdminScopedCompany on the host,
-    // which admits that machine principal unconditionally once it has
-    // addressed this company. Asking `/auth/me` anyway would read the missing
-    // session as "not an admin" and hide controls whose write would in fact
-    // succeed.
-    if (client.carriesPlatformBearer) {
-      setCanManage(true);
-      return;
-    }
     let live = true;
     void (async () => {
       let admin = false;
       try {
         admin = (await fetchMe(client, company)).role === "admin";
       } catch {
-        // No user plane on this host, or not signed in — treat as non-admin.
+        // `resolve_principal` on the host tries a human session first and
+        // only falls back to the platform/tenant bearer when none is
+        // present — a hub console can carry both, and the write routes
+        // below are AdminScopedCompany, which admits that machine principal
+        // unconditionally once it has addressed this company. So `/auth/me`
+        // failing outright (no session at all) means the bearer is what the
+        // host will actually authorize on; `/auth/me` *succeeding* with a
+        // member role — even with a bearer also present — means the host
+        // resolved that member and will 403 the same as it would with no
+        // bearer at all, which the `try` above already handles correctly.
+        admin = client.carriesPlatformBearer;
       }
       if (live) setCanManage(admin);
     })();

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -1,7 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { BookOpen, Check, Download, Loader2, Plus, Search, Sparkles, Trash2 } from "lucide-react";
+import {
+  BookOpen,
+  Check,
+  Download,
+  Info,
+  Loader2,
+  Plus,
+  Search,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
 import { toast } from "sonner";
 
+import { me as fetchMe } from "@/api/auth";
 import {
   createSkill,
   installSkill,
@@ -14,7 +25,7 @@ import {
 } from "@/api/skills";
 import type { OpenCompanyClient } from "@/api/client";
 import { PageHeader } from "@/components/page-header";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -70,6 +81,11 @@ function categoryStyle(category: string): string {
  * optimistically, reverting on error.
  */
 export function SkillsView({ client, company }: Props) {
+  // Install, uninstall, toggle and custom-authoring are all AdminScopedCompany
+  // on the host — a skill's content lands in every agent's effective prompt,
+  // company-wide, so a member's write here would only ever earn a 403.
+  // Resolved the way `HostingView` and `SearchView` resolve the same question.
+  const [canManage, setCanManage] = useState(false);
   const [skills, setSkills] = useState<Skill[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -83,6 +99,32 @@ export function SkillsView({ client, company }: Props) {
   // A generation token so a response from a previous company scope (or after
   // unmount) can't overwrite the current one.
   const gen = useRef(0);
+
+  useEffect(() => {
+    // A platform or tenant bearer has no human session for `/auth/me` to
+    // return, but the write routes below are AdminScopedCompany on the host,
+    // which admits that machine principal unconditionally once it has
+    // addressed this company. Asking `/auth/me` anyway would read the missing
+    // session as "not an admin" and hide controls whose write would in fact
+    // succeed.
+    if (client.carriesPlatformBearer) {
+      setCanManage(true);
+      return;
+    }
+    let live = true;
+    void (async () => {
+      let admin = false;
+      try {
+        admin = (await fetchMe(client, company)).role === "admin";
+      } catch {
+        // No user plane on this host, or not signed in — treat as non-admin.
+      }
+      if (live) setCanManage(admin);
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
 
   const refresh = useCallback(async () => {
     const mine = ++gen.current;
@@ -187,11 +229,11 @@ export function SkillsView({ client, company }: Props) {
           </>
         }
         actions={
-          <>
-          <Button onClick={() => setAddOpen(true)}>
-            <Plus className="size-4" /> Add skill
-          </Button>
-          </>
+          canManage ? (
+            <Button onClick={() => setAddOpen(true)}>
+              <Plus className="size-4" /> Add skill
+            </Button>
+          ) : undefined
         }
       />
       <div className="mx-auto min-h-0 w-full max-w-5xl flex-1 space-y-5 overflow-y-auto px-4 py-6">
@@ -205,6 +247,17 @@ export function SkillsView({ client, company }: Props) {
           <BookOpen className="size-4" />
           <AlertDescription>{SKILLS_READ_ONLY_NOTE}</AlertDescription>
         </Alert>
+
+        {!canManage && (
+          <Alert data-testid="skills-admin-only">
+            <Info className="size-4" />
+            <AlertTitle>Only an admin can change this company&apos;s skills</AlertTitle>
+            <AlertDescription>
+              A skill's content reaches every teammate, so an admin installs, removes, enables and
+              adds them. You can see what is installed and enabled.
+            </AlertDescription>
+          </Alert>
+        )}
 
         {error && (
           <Alert variant="destructive">
@@ -234,6 +287,7 @@ export function SkillsView({ client, company }: Props) {
                     <InstalledCard
                       key={s.id}
                       skill={s}
+                      canManage={canManage}
                       onToggle={() => void toggle(s)}
                       onUninstall={() => void uninstall(s)}
                     />
@@ -271,6 +325,7 @@ export function SkillsView({ client, company }: Props) {
                     key={s.id}
                     skill={s}
                     installed={installedIds.has(s.id)}
+                    canManage={canManage}
                     onInstall={() => void install(s)}
                   />
                 ))}
@@ -300,10 +355,12 @@ export function SkillsView({ client, company }: Props) {
 
 function InstalledCard({
   skill,
+  canManage,
   onToggle,
   onUninstall,
 }: {
   skill: Skill;
+  canManage: boolean;
   onToggle: () => void;
   onUninstall: () => void;
 }) {
@@ -315,7 +372,12 @@ function InstalledCard({
             <Sparkles className="size-4 text-muted-foreground" />
             <p className="font-medium">{skill.name}</p>
           </div>
-          <Switch checked={skill.enabled} onCheckedChange={onToggle} aria-label="Enable skill" />
+          <Switch
+            checked={skill.enabled}
+            onCheckedChange={onToggle}
+            disabled={!canManage}
+            aria-label="Enable skill"
+          />
         </div>
         <p className="text-sm text-muted-foreground">{skill.description}</p>
         <div className="flex items-center justify-between pt-1">
@@ -330,7 +392,7 @@ function InstalledCard({
               · {skillReachLabel(skill.enabled)}
             </span>
           </div>
-          {skill.source !== "company" && (
+          {canManage && skill.source !== "company" && (
             <Button
               variant="ghost"
               size="icon"
@@ -350,10 +412,12 @@ function InstalledCard({
 function RegistryCard({
   skill,
   installed,
+  canManage,
   onInstall,
 }: {
   skill: RegistrySkill;
   installed: boolean;
+  canManage: boolean;
   onInstall: () => void;
 }) {
   return (
@@ -379,9 +443,11 @@ function RegistryCard({
               <Check className="size-3.5" /> Installed
             </span>
           ) : (
-            <Button variant="outline" size="sm" onClick={onInstall}>
-              <Download className="size-4" /> Install
-            </Button>
+            canManage && (
+              <Button variant="outline" size="sm" onClick={onInstall}>
+                <Download className="size-4" /> Install
+              </Button>
+            )
           )}
         </div>
       </CardContent>

--- a/frontend/test/unit/skills-view-authority.test.ts
+++ b/frontend/test/unit/skills-view-authority.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { SkillsView } from "@/views/SkillsView";
+
+/**
+ * Install, uninstall, toggle and custom-authoring are all `AdminScopedCompany`
+ * on the host — a skill's content lands in every agent's effective prompt,
+ * company-wide, so these are decisions for the company rather than for the
+ * caller alone (codex review). Before this, the console had no role check at
+ * all: a member saw every write control enabled and learned only from a 403
+ * toast that pasting one in was never going to work.
+ */
+
+const INSTALLED: Array<{
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  source: string;
+  enabled: boolean;
+}> = [
+  {
+    id: "seo-audit",
+    name: "SEO audit",
+    description: "Checks a site's on-page SEO.",
+    category: "Marketing",
+    source: "registry",
+    enabled: true,
+  },
+];
+
+const REGISTRY: Array<{
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  publisher: string;
+}> = [
+  {
+    id: "cold-outreach",
+    name: "Cold outreach",
+    description: "Drafts a cold email sequence.",
+    category: "Marketing",
+    publisher: "OpenCompany",
+  },
+];
+
+/**
+ * A client answering the two reads with fixed data, and `/auth/me` as an
+ * admin by default — matching `HostingView`'s own fixture convention.
+ * `carriesPlatformBearer` defaults to `false`, matching a browser session
+ * authenticating by cookie.
+ */
+function clientWith(role: "admin" | "member" = "admin", carriesPlatformBearer = false): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    carriesPlatformBearer,
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme", hasPassword: true });
+      }
+      if (path.endsWith("/skills/registry")) {
+        return Promise.resolve(REGISTRY);
+      }
+      return Promise.resolve(INSTALLED);
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(SkillsView, { client, company: "acme" }));
+  });
+  // `refresh` resolves both reads as one `Promise.allSettled`, and canManage
+  // resolves through its own `/auth/me` round trip — each lands a tick after
+  // the initial render, so give React those ticks rather than assuming one
+  // flush covers every source.
+  await act(async () => {});
+  await act(async () => {});
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+/** Switches to the Registry tab, whose panel is not mounted until active. */
+async function openRegistryTab() {
+  const tab = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]')).find((t) =>
+    t.textContent?.includes("Registry"),
+  );
+  await act(async () => {
+    tab?.click();
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("SkillsView authority", () => {
+  it("offers a member no way to add, install, enable, or uninstall a skill", async () => {
+    await show(clientWith("member"));
+
+    expect(at("skills-admin-only")?.textContent).toContain("Only an admin");
+    // The page-level "Add skill" action is gone, not merely disabled.
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) => b.textContent?.includes("Add skill")),
+    ).toBe(false);
+
+    const toggle = at("installed-card")?.querySelector('[aria-label="Enable skill"]');
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute("aria-disabled")).toBe("true");
+
+    expect(at("installed-card")?.querySelector('[aria-label="Uninstall"]')).toBeNull();
+
+    // Not a blank page: the installed skill's name and reach are still shown.
+    // Checked before switching tabs — the Installed panel unmounts once the
+    // Registry tab takes its place.
+    expect(container.textContent).toContain("SEO audit");
+    expect(container.textContent).toContain("Teammates can read this");
+
+    await openRegistryTab();
+    expect(
+      Array.from(at("registry-card")?.querySelectorAll("button") ?? []).some((b) =>
+        b.textContent?.includes("Install"),
+      ),
+    ).toBe(false);
+  });
+
+  it("offers an admin every control, with no read-only notice", async () => {
+    await show(clientWith("admin"));
+
+    expect(at("skills-admin-only")).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) => b.textContent?.includes("Add skill")),
+    ).toBe(true);
+
+    const toggle = at("installed-card")?.querySelector('[aria-label="Enable skill"]');
+    expect(toggle?.getAttribute("aria-disabled")).not.toBe("true");
+
+    await openRegistryTab();
+    expect(
+      Array.from(at("registry-card")?.querySelectorAll("button") ?? []).some((b) =>
+        b.textContent?.includes("Install"),
+      ),
+    ).toBe(true);
+  });
+
+  it("offers a platform bearer every control without calling /auth/me", async () => {
+    const client = clientWith("member", true);
+    const getSpy = vi.spyOn(client, "get");
+    await show(client);
+
+    expect(at("skills-admin-only")).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) => b.textContent?.includes("Add skill")),
+    ).toBe(true);
+    expect(getSpy.mock.calls.some(([path]) => String(path).endsWith("/auth/me"))).toBe(false);
+  });
+});

--- a/frontend/test/unit/skills-view-authority.test.ts
+++ b/frontend/test/unit/skills-view-authority.test.ts
@@ -51,18 +51,27 @@ const REGISTRY: Array<{
 ];
 
 /**
- * A client answering the two reads with fixed data, and `/auth/me` as an
- * admin by default — matching `HostingView`'s own fixture convention.
- * `carriesPlatformBearer` defaults to `false`, matching a browser session
- * authenticating by cookie.
+ * A client answering the two reads with fixed data.
+ *
+ * `session` and `carriesPlatformBearer` are independent, matching
+ * `resolve_principal` on the host: a hub console can carry both a platform
+ * bearer and a signed-in member (`authHeaders`'s own doc comment), and the
+ * host tries the session first, falling back to the bearer only when there is
+ * none at all. `session: "none"` makes `/auth/me` reject the way it does for
+ * an unauthenticated or bearer-only caller.
  */
-function clientWith(role: "admin" | "member" = "admin", carriesPlatformBearer = false): OpenCompanyClient {
+function clientWith(
+  session: "admin" | "member" | "none" = "admin",
+  carriesPlatformBearer = false,
+): OpenCompanyClient {
   return {
     scopeFor: () => "/api/v1/companies/acme",
     carriesPlatformBearer,
     get: (path: string) => {
       if (path.endsWith("/auth/me")) {
-        return Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme", hasPassword: true });
+        return session === "none"
+          ? Promise.reject(new Error("no session"))
+          : Promise.resolve({ id: "u1", email: "a@b.c", role: session, company: "acme", hasPassword: true });
       }
       if (path.endsWith("/skills/registry")) {
         return Promise.resolve(REGISTRY);
@@ -163,15 +172,33 @@ describe("SkillsView authority", () => {
     ).toBe(true);
   });
 
-  it("offers a platform bearer every control without calling /auth/me", async () => {
-    const client = clientWith("member", true);
-    const getSpy = vi.spyOn(client, "get");
-    await show(client);
+  it("offers a bearer-only caller every control once /auth/me finds no session", async () => {
+    await show(clientWith("none", true));
 
     expect(at("skills-admin-only")).toBeNull();
     expect(
       Array.from(container.querySelectorAll("button")).some((b) => b.textContent?.includes("Add skill")),
     ).toBe(true);
-    expect(getSpy.mock.calls.some(([path]) => String(path).endsWith("/auth/me"))).toBe(false);
+  });
+
+  it("defers to a member session even when a platform bearer is also present", async () => {
+    // A hub console can carry both credentials at once (`authHeaders`), and
+    // resolve_principal tries the session first — so a bearer must never
+    // paper over a member's own 403 (codex review).
+    await show(clientWith("member", true));
+
+    expect(at("skills-admin-only")?.textContent).toContain("Only an admin");
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) => b.textContent?.includes("Add skill")),
+    ).toBe(false);
+  });
+
+  it("defers to an admin session when a platform bearer is also present", async () => {
+    await show(clientWith("admin", true));
+
+    expect(at("skills-admin-only")).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) => b.textContent?.includes("Add skill")),
+    ).toBe(true);
   });
 });

--- a/frontend/test/unit/skills-view-authority.test.ts
+++ b/frontend/test/unit/skills-view-authority.test.ts
@@ -4,6 +4,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import { SkillsView } from "@/views/SkillsView";
 
@@ -57,11 +58,15 @@ const REGISTRY: Array<{
  * `resolve_principal` on the host: a hub console can carry both a platform
  * bearer and a signed-in member (`authHeaders`'s own doc comment), and the
  * host tries the session first, falling back to the bearer only when there is
- * none at all. `session: "none"` makes `/auth/me` reject the way it does for
- * an unauthenticated or bearer-only caller.
+ * none at all. `session: "none"` makes `/auth/me` reject the way the host's
+ * own `no_session()` does — a real `ApiError` from its `{error, code}`
+ * envelope — for an unauthenticated or bearer-only caller. `session: "error"`
+ * rejects with a plain network-style error, the ambiguous case coderabbit
+ * flagged: not a confirmed absence of a session, so it must not be read as
+ * one.
  */
 function clientWith(
-  session: "admin" | "member" | "none" = "admin",
+  session: "admin" | "member" | "none" | "error" = "admin",
   carriesPlatformBearer = false,
 ): OpenCompanyClient {
   return {
@@ -69,9 +74,13 @@ function clientWith(
     carriesPlatformBearer,
     get: (path: string) => {
       if (path.endsWith("/auth/me")) {
-        return session === "none"
-          ? Promise.reject(new Error("no session"))
-          : Promise.resolve({ id: "u1", email: "a@b.c", role: session, company: "acme", hasPassword: true });
+        if (session === "none") {
+          return Promise.reject(new ApiError(401, "unauthorized", "not signed in", true));
+        }
+        if (session === "error") {
+          return Promise.reject(new Error("network down"));
+        }
+        return Promise.resolve({ id: "u1", email: "a@b.c", role: session, company: "acme", hasPassword: true });
       }
       if (path.endsWith("/skills/registry")) {
         return Promise.resolve(REGISTRY);
@@ -179,6 +188,19 @@ describe("SkillsView authority", () => {
     expect(
       Array.from(container.querySelectorAll("button")).some((b) => b.textContent?.includes("Add skill")),
     ).toBe(true);
+  });
+
+  it("stays read-only on an ambiguous /auth/me failure, even with a bearer present", async () => {
+    // A network error, a timeout, or a 5xx is not a confirmed absence of a
+    // session — a member's session could still be live and would still take
+    // precedence on the host (coderabbit review). Only the host's own
+    // no_session() answer may be read as "the bearer is what's left".
+    await show(clientWith("error", true));
+
+    expect(at("skills-admin-only")?.textContent).toContain("Only an admin");
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) => b.textContent?.includes("Add skill")),
+    ).toBe(false);
   });
 
   it("defers to a member session even when a platform bearer is also present", async () => {

--- a/frontend/test/unit/skills-view-company-switch.test.ts
+++ b/frontend/test/unit/skills-view-company-switch.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { SkillsView } from "@/views/SkillsView";
+
+/**
+ * `canManage` must not survive a company switch.
+ *
+ * `SettingsSection` mounts `SkillsView` with `key={company ?? "self"}`, the
+ * same remount rule `HostingView`/`SearchView` already carry (codeRabbit
+ * review — the key was missing here). Without it, an admin's `canManage` from
+ * the company they just left stays `true` in state until the new company's
+ * `/auth/me` settles, and during that window Add/Install/enable/Uninstall
+ * render enabled for whatever role the operator actually holds in the company
+ * now addressed. Driven at the view level, keyed the way the section keys it
+ * — matching `finance-company-switch.test.ts`'s own reasoning for testing
+ * composition rather than `SettingsSection` itself.
+ */
+
+function clientFor(company: string, role: "admin" | "member"): OpenCompanyClient {
+  return {
+    scopeFor: () => `/api/v1/companies/${company}`,
+    carriesPlatformBearer: false,
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return Promise.resolve({ id: "u1", email: "a@b.c", role, company, hasPassword: true });
+      }
+      return Promise.resolve([]);
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+/** Renders the page exactly as `SettingsSection` does: keyed by company. */
+async function showSkills(company: string, role: "admin" | "member") {
+  await act(async () => {
+    root.render(
+      createElement(SkillsView, {
+        key: company,
+        client: clientFor(company, role),
+        company,
+      }),
+    );
+  });
+  // canManage resolves through its own /auth/me round trip, a tick after render.
+  await act(async () => {});
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("SkillsView company switch", () => {
+  it("does not carry an admin's authority into a company where the operator is a member", async () => {
+    await showSkills("acme", "admin");
+    expect(at("skills-admin-only")).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) => b.textContent?.includes("Add skill")),
+    ).toBe(true);
+
+    await showSkills("globex", "member");
+    expect(at("skills-admin-only")?.textContent).toContain("Only an admin");
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) => b.textContent?.includes("Add skill")),
+    ).toBe(false);
+  });
+});

--- a/src/server/ops/skills.rs
+++ b/src/server/ops/skills.rs
@@ -11,9 +11,18 @@
 //! The console holds no skill catalog of its own; it browses the shared library
 //! over `GET …/skills/registry` and installs by slug, with the host resolving
 //! the content.
+//!
+//! Every write here is gated
+//! [`AdminScopedCompany`](crate::server::ops::AdminScopedCompany): a skill's
+//! content becomes part of every agent's effective prompt, company-wide, so
+//! installing, uninstalling, toggling, or authoring one decides something for
+//! the company rather than for the caller alone. The two reads —
+//! `GET …/skills` and `GET …/skills/registry` — stay open to any member; only
+//! the writes decide anything.
 
 use std::collections::HashMap;
 use std::path::Path as FsPath;
+use std::sync::Arc;
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -25,14 +34,26 @@ use crate::AppState;
 use crate::company::{SkillDoc, parse_skill_md, render_skill_md};
 use crate::error::OpenCompanyError;
 use crate::ports::skills_state::{SkillSource, SkillState};
+use crate::ports::types::CompanyId;
 use crate::server::error::ApiError;
 use crate::server::ops::language;
-use crate::server::ops::{ScopedCompany, scoped};
+use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 
 /// The default category stamped on a skill whose doc carries none.
 const DEFAULT_CATEGORY: &str = "Ops";
 /// The publisher stamped on shared-library skills (mirrors the GraphQL type).
 const REGISTRY_PUBLISHER: &str = "OpenCompany";
+
+/// The largest a skill's persisted `SKILL.md` (frontmatter and body together)
+/// may be.
+///
+/// A skill's content lands in every agent's effective prompt, company-wide, so
+/// this is a prompt budget rather than a storage limit. A quarter mebibyte
+/// matches the codebase's existing ceiling for inline prose,
+/// `MAX_ARTIFACT_BODY_BYTES` — generous for hand-authored instructions, and
+/// still small enough that no single skill can quietly dominate what every
+/// agent reads on every turn.
+const MAX_SKILL_DOC_BYTES: usize = 256 * 1024;
 
 /// Whether `slug` is a safe skill id: `^[a-z0-9][a-z0-9-]*$`. A slug is also a
 /// directory name in the agent's scratch tree (`skills/<slug>/`), so a
@@ -45,6 +66,49 @@ fn valid_slug(slug: &str) -> bool {
         _ => return false,
     }
     chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// Refuses a skill document over [`MAX_SKILL_DOC_BYTES`].
+///
+/// Checked on the assembled `SKILL.md` rather than the raw request fields, so
+/// it bounds what actually lands in the agent's prompt regardless of which
+/// field (name, description, or body) grew.
+fn check_skill_doc_size(doc: &str) -> Result<(), ApiError> {
+    if doc.len() > MAX_SKILL_DOC_BYTES {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
+            "that skill is {:.1} KB — a skill's content has to be under {} KB.",
+            doc.len() as f64 / 1024.0,
+            MAX_SKILL_DOC_BYTES / 1024
+        ))));
+    }
+    Ok(())
+}
+
+/// Per-company serialization for the skill write routes.
+///
+/// `install` and `create_custom` write a fresh [`SkillState`] straight through
+/// [`SkillStateStore::set`](crate::ports::SkillStateStore::set) and are
+/// raceless on their own — the store upserts by slug, so two of them landing
+/// concurrently is an ordinary last-write-wins. `set_enabled` is the one
+/// genuine read-modify-write: it lists the existing delta so it can preserve
+/// the slug's `source` and `custom_doc`, then writes a new one back. An
+/// install or an authoring landing in the middle of that window would be
+/// silently reverted — its fresh doc and source overwritten by whatever
+/// `set_enabled` read before it ran. Taking this lock unconditionally in every
+/// write handler, exactly as `smtp.rs`'s `write_lock` does for its own
+/// read-modify-write, keeps that ordering rule in one place rather than in
+/// each handler.
+fn write_lock(company: &CompanyId) -> Arc<tokio::sync::Mutex<()>> {
+    static LOCKS: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<CompanyId, Arc<tokio::sync::Mutex<()>>>>,
+    > = std::sync::OnceLock::new();
+    let locks = LOCKS.get_or_init(Default::default);
+    let mut locks = locks.lock().expect("skill write locks poisoned");
+    Arc::clone(
+        locks
+            .entry(company.clone())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
+    )
 }
 
 /// Builds the skills route fragment.
@@ -305,7 +369,7 @@ fn company_bundles(source_dir: Option<&FsPath>) -> Vec<InstalledSkill> {
 /// be server-authoritative.
 async fn install(
     State(state): State<AppState>,
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Path(SlugPath { slug }): Path<SlugPath>,
     body: Option<Json<InstallSkill>>,
 ) -> Result<Json<InstalledSkill>, ApiError> {
@@ -315,6 +379,8 @@ async fn install(
              is `[a-z0-9][a-z0-9-]*`."
         ))));
     }
+    let lock = write_lock(company.id());
+    let _guard = lock.lock().await;
     let registry = state.shared_skill_registry()?;
     let doc = match registry.iter().find(|doc| doc.slug == slug) {
         Some(doc) => render_skill_md(doc),
@@ -337,6 +403,7 @@ async fn install(
             skill_md(&name, &description, meta.category.as_deref(), &description)
         }
     };
+    check_skill_doc_size(&doc)?;
     let delta = SkillState {
         slug,
         enabled: true,
@@ -371,9 +438,11 @@ async fn list_registry(
 }
 
 async fn uninstall(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Path(SlugPath { slug }): Path<SlugPath>,
 ) -> Result<StatusCode, ApiError> {
+    let lock = write_lock(company.id());
+    let _guard = lock.lock().await;
     let existing = company
         .runtime
         .skills()
@@ -396,7 +465,7 @@ async fn uninstall(
 }
 
 async fn set_enabled(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Path(SlugPath { slug }): Path<SlugPath>,
     Json(body): Json<SetEnabled>,
 ) -> Result<Json<InstalledSkill>, ApiError> {
@@ -406,6 +475,8 @@ async fn set_enabled(
              is `[a-z0-9][a-z0-9-]*`."
         ))));
     }
+    let lock = write_lock(company.id());
+    let _guard = lock.lock().await;
     // Preserve an existing delta's source and custom doc; a first toggle of a
     // built-in company skill records a Company-sourced override.
     let existing = company
@@ -429,7 +500,7 @@ async fn set_enabled(
 }
 
 async fn create_custom(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Json(body): Json<CreateSkill>,
 ) -> Result<Json<InstalledSkill>, ApiError> {
     if body.name.trim().is_empty() || body.description.trim().is_empty() {
@@ -437,6 +508,8 @@ async fn create_custom(
             language::SKILL_FIELDS_REQUIRED.to_string(),
         )));
     }
+    let lock = write_lock(company.id());
+    let _guard = lock.lock().await;
     let slug = slugify(&body.name);
     let doc = skill_md(
         &body.name,
@@ -444,6 +517,7 @@ async fn create_custom(
         body.category.as_deref(),
         body.body.as_deref().unwrap_or(""),
     );
+    check_skill_doc_size(&doc)?;
     let state = SkillState {
         slug,
         enabled: true,
@@ -647,6 +721,58 @@ mod tests {
         assert!(valid_slug("seo-audit"), "typical slug");
     }
 
+    #[test]
+    fn check_skill_doc_size_rejects_only_over_cap() {
+        assert!(check_skill_doc_size(&"x".repeat(MAX_SKILL_DOC_BYTES)).is_ok());
+        let err = check_skill_doc_size(&"x".repeat(MAX_SKILL_DOC_BYTES + 1))
+            .expect_err("over-cap doc must be refused");
+        assert!(matches!(err.0, OpenCompanyError::InvalidRequest(_)));
+    }
+
+    /// The mutual-exclusion property [`write_lock`] exists for: two holders of
+    /// the same company's lock run strictly one after the other, never
+    /// interleaved, which is what keeps `set_enabled`'s
+    /// list-then-preserve-then-write window from landing between another
+    /// handler's write and its own read.
+    #[tokio::test]
+    async fn write_lock_serializes_same_company_writes() {
+        let id = CompanyId::new("acme");
+        let lock_a = write_lock(&id);
+        let lock_b = write_lock(&id);
+        assert!(
+            Arc::ptr_eq(&lock_a, &lock_b),
+            "the same company id must resolve to the same lock"
+        );
+        // A different company gets its own lock, so one tenant's writes never
+        // block another's.
+        let other = write_lock(&CompanyId::new("other"));
+        assert!(!Arc::ptr_eq(&lock_a, &other));
+
+        let order: Arc<tokio::sync::Mutex<Vec<&'static str>>> =
+            Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let guard = lock_a.lock().await;
+
+        let order_clone = Arc::clone(&order);
+        let waiter = tokio::spawn(async move {
+            // Blocks here until the holder below drops its guard.
+            let _guard = lock_b.lock().await;
+            order_clone.lock().await.push("second");
+        });
+
+        // Give the spawned task a chance to actually reach the blocked
+        // `.lock().await` before the holder records its own turn.
+        tokio::task::yield_now().await;
+        order.lock().await.push("first");
+        drop(guard);
+        waiter.await.expect("waiter task did not panic");
+
+        assert_eq!(
+            *order.lock().await,
+            vec!["first", "second"],
+            "the second acquirer must not have run until the first released"
+        );
+    }
+
     /// HTTP-level coverage of the two path-slug handlers. A slug that fails
     /// `valid_slug` must be rejected with `400` **before** any write, so the
     /// effective skill set is untouched; a valid slug succeeds and lands.
@@ -667,7 +793,9 @@ mod tests {
         use crate::ports::types::{CompanyId, CompanyRecord};
         use crate::runtime::RuntimeBuilder;
         use crate::server::router;
-        use crate::server::test_support::{fixed_cookie, seed_fixed_admin};
+        use crate::server::test_support::{
+            fixed_cookie, member_cookie, seed_fixed_admin, seed_fixed_member,
+        };
         use crate::{AppConfig, AppState};
 
         async fn state_with_company(home: &std::path::Path) -> AppState {
@@ -711,16 +839,31 @@ mod tests {
             state
         }
 
+        /// Sends as the fixed admin session — the common case, since every write
+        /// route here is admin-gated.
         async fn send(
             state: &AppState,
             method: &str,
             uri: &str,
             body: Option<&str>,
         ) -> (StatusCode, Value, String) {
-            let request = Request::builder()
-                .method(method)
-                .uri(uri)
-                .header("cookie", fixed_cookie("acme"));
+            send_as(state, method, uri, body, Some(&fixed_cookie("acme"))).await
+        }
+
+        /// [`send`], with the caller's cookie explicit — `None` for no session at
+        /// all, so the privilege boundary can be driven with an admin session, a
+        /// member session, or nothing.
+        async fn send_as(
+            state: &AppState,
+            method: &str,
+            uri: &str,
+            body: Option<&str>,
+            cookie: Option<&str>,
+        ) -> (StatusCode, Value, String) {
+            let mut request = Request::builder().method(method).uri(uri);
+            if let Some(cookie) = cookie {
+                request = request.header("cookie", cookie);
+            }
             let request = match body {
                 Some(body) => request
                     .header("content-type", "application/json")
@@ -804,6 +947,141 @@ mod tests {
             assert!(
                 slugs(&state).await.iter().any(|s| s == "a-1"),
                 "the valid slug lands in the effective set"
+            );
+        }
+
+        /// Every write route here decides something for the whole company (see
+        /// the module doc): a Member is refused exactly like an unauthenticated
+        /// caller, on all four of them, and neither refusal lands a delta.
+        #[tokio::test]
+        async fn every_write_route_refuses_a_member_and_an_unauthenticated_caller() {
+            let home = tempfile::tempdir().unwrap();
+            let state = state_with_company(home.path()).await;
+            seed_fixed_member(&state, "acme").await;
+            let member = member_cookie("acme");
+
+            let attempts: [(&str, &str, Option<&str>); 4] = [
+                ("POST", "/api/v1/company/skills/seo-audit/install", None),
+                (
+                    "PUT",
+                    "/api/v1/company/skills/seo-audit",
+                    Some(r#"{"enabled":true}"#),
+                ),
+                (
+                    "POST",
+                    "/api/v1/company/skills",
+                    Some(r#"{"name":"Member Skill","description":"a member tried this"}"#),
+                ),
+                ("POST", "/api/v1/company/skills/seo-audit/uninstall", None),
+            ];
+
+            for (method, uri, body) in attempts {
+                let (status, resp, raw) = send_as(&state, method, uri, body, Some(&member)).await;
+                assert_eq!(
+                    status,
+                    StatusCode::FORBIDDEN,
+                    "{method} {uri} as a member: {raw}"
+                );
+                assert_eq!(resp["code"], "forbidden", "{method} {uri}: {raw}");
+
+                let (status, resp, raw) = send_as(&state, method, uri, body, None).await;
+                assert_eq!(
+                    status,
+                    StatusCode::UNAUTHORIZED,
+                    "{method} {uri} with no session: {raw}"
+                );
+                assert_eq!(resp["code"], "unauthorized", "{method} {uri}: {raw}");
+            }
+
+            assert!(
+                slugs(&state).await.is_empty(),
+                "no member or unauthenticated attempt landed a delta"
+            );
+        }
+
+        /// The other half of the boundary: an admin is not caught by the same
+        /// gate, and every write route still does its job end to end —
+        /// install, toggle, author, then uninstall the one route that allows
+        /// it.
+        #[tokio::test]
+        async fn an_admin_can_use_every_write_route() {
+            let home = tempfile::tempdir().unwrap();
+            let state = state_with_company(home.path()).await;
+
+            let (status, _, raw) = send(
+                &state,
+                "POST",
+                "/api/v1/company/skills/seo-audit/install",
+                None,
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "admin install: {raw}");
+
+            let (status, _, raw) = send(
+                &state,
+                "PUT",
+                "/api/v1/company/skills/seo-audit",
+                Some(r#"{"enabled":false}"#),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "admin set_enabled: {raw}");
+
+            let (status, resp, raw) = send(
+                &state,
+                "POST",
+                "/api/v1/company/skills",
+                Some(r#"{"name":"Admin Skill","description":"authored by an admin"}"#),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "admin create_custom: {raw}");
+            assert_eq!(resp["id"], "admin-skill");
+
+            let (status, _, raw) = send(
+                &state,
+                "POST",
+                "/api/v1/company/skills/seo-audit/uninstall",
+                None,
+            )
+            .await;
+            assert_eq!(status, StatusCode::NO_CONTENT, "admin uninstall: {raw}");
+
+            let after = slugs(&state).await;
+            assert!(
+                !after.iter().any(|s| s == "seo-audit"),
+                "the uninstall landed: {after:?}"
+            );
+            assert!(
+                after.iter().any(|s| s == "admin-skill"),
+                "the authored skill landed: {after:?}"
+            );
+        }
+
+        /// A skill's document becomes part of every agent's effective prompt,
+        /// so [`MAX_SKILL_DOC_BYTES`] is enforced on the assembled `SKILL.md`,
+        /// not just accepted and truncated later — and the refusal is the same
+        /// `400 invalid_request` shape every other bad-input write already
+        /// uses, not a bespoke code.
+        #[tokio::test]
+        async fn an_over_cap_custom_skill_body_is_refused() {
+            let home = tempfile::tempdir().unwrap();
+            let state = state_with_company(home.path()).await;
+
+            let oversized = "x".repeat(MAX_SKILL_DOC_BYTES);
+            let body = serde_json::json!({
+                "name": "Huge Skill",
+                "description": "short",
+                "body": oversized,
+            })
+            .to_string();
+
+            let (status, resp, raw) =
+                send(&state, "POST", "/api/v1/company/skills", Some(&body)).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{raw}");
+            assert_eq!(resp["code"], "invalid_request", "{raw}");
+
+            assert!(
+                slugs(&state).await.is_empty(),
+                "an over-cap body must not land a delta"
             );
         }
     }

--- a/src/server/ops/skills.rs
+++ b/src/server/ops/skills.rs
@@ -792,6 +792,7 @@ mod tests {
         use crate::ports::CompanyStore;
         use crate::ports::types::{CompanyId, CompanyRecord};
         use crate::runtime::RuntimeBuilder;
+        use crate::server::ops::skills::MAX_SKILL_DOC_BYTES;
         use crate::server::router;
         use crate::server::test_support::{
             fixed_cookie, member_cookie, seed_fixed_admin, seed_fixed_member,


### PR DESCRIPTION
## Summary

`POST {scope}/skills` took `ScopedCompany`, so **any company member — not an admin — could write
an unbounded, unvalidated `SKILL.md` body that lands in every agent's effective prompt,
company-wide.** No size cap, no authority check, and no tests on the file at all.

Four writes move to `AdminScopedCompany`, because each changes what every agent in the company is
told to do:

- `POST …/skills/{slug}/install` and `…/uninstall` — symmetric; each changes the effective skill set
- `PUT …/skills/{slug}` — same blast radius, reversible; flips whether a skill's instructions are live
- `POST …/skills` (create custom) — the original defect: arbitrary prose becomes agent instructions

Two reads stay member-level, deliberately. `GET …/skills` changes nothing, and
`GET …/skills/registry` is metadata-only — `RegistrySkill` carries no `body` by construction. Neither
crosses the line `scope.rs`'s own doc draws between addressing a company and deciding for it.

**Size cap**: `MAX_SKILL_DOC_BYTES = 256 KiB`, checked against the *assembled* `SKILL.md` rather
than raw request fields, so it bounds whichever field actually grew. The number matches
`MAX_ARTIFACT_BODY_BYTES` in `publish.rs` — the codebase's existing ceiling for prose stored inline
— not avatars' 4 MiB, which guards against decompression bombs on binary and is a different
problem. The largest real `SKILL.md` in this repo is ~2 KB, so this is roughly 128× headroom.
Refusal is `400` / `invalid_request`, the envelope every other bad-input write in the file uses.

**A concurrency hazard, not where expected.** Two racing installs are ordinary last-write-wins.
The real one is `set_enabled`, a genuine read-modify-write: it lists to find the existing delta so
it can preserve that slug's `source` and `custom_doc`, then writes back. An install landing between
its read and write is silently clobbered — `set_enabled` restores the stale pre-install values it
read. Now serialised by a per-company lock held across all four writes, following `smtp.rs`'s
`write_lock` pattern with its own dedicated static.

## API Or Behavior Changes

Four routes that accepted any member now refuse with `403` / `forbidden`. A skill document over
256 KiB is refused with `400` / `invalid_request`. Reads are unchanged.

**This needs a console sibling.** `frontend/src/views/SkillsView.tsx` wires all four write controls
— the enable/disable switch, Uninstall, Install and the create-custom dialog — with **no admin gate
anywhere**; grepping it for `isAdmin` or a role check finds nothing, while `TeamView`,
`McpServersView`, `PeopleView`, `HostingView` and `InferenceView` all already use the established
pattern. After this merges a member's click gets a 403 with no handling beyond a generic toast.
That is the same enabled-control-that-will-refuse defect fixed for Search, Hosting, Domain and SMTP
in #2123, and it should land with or shortly after this. No frontend file is touched here.

## Tests

The file had **zero** tests. It now has ten, covering the member/admin/unauthenticated matrix on
every write route, the cap on both paths that assemble a document, and the lock's mutual exclusion.

**Red proof, observed.** Reverting the four extractors to `ScopedCompany` and disabling both cap
checks makes exactly the two tests that should fail, fail:

```
test ...::every_write_route_refuses_a_member_and_an_unauthenticated_caller ... FAILED
test ...::an_over_cap_custom_skill_body_is_refused ... FAILED
test result: FAILED. 8 passed; 2 failed
```

The file was restored from an out-of-tree copy and the tree confirmed clean afterwards.

The lock test proves mutual exclusion directly — two spawned holders in strict acquire order, plus
independent locks for different companies — rather than trying to force two real handlers to
interleave at a specific await point, which is not reliably deterministic without internal
instrumentation. Flagging that as a judgement call.

- [x] `cargo fmt --check` — 0
- [x] `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings` — 0
- [x] `cargo test --features openhuman --lib server::ops::skills` — 0 · 10 passed
- [ ] N/A: `cargo build --all-targets` — covered by the clippy run above

## Documentation

Module doc updated to state which routes require authority and why the reads do not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill management actions are restricted to company administrators.
  * Members can view available and installed skills but cannot modify them.
  * Non-admins see an access notice, with management controls hidden or disabled.
  * Skill installations and custom skills are limited to 256 KiB.

* **Bug Fixes**
  * Improved consistency when multiple skill updates occur simultaneously.
  * Improved handling of unauthenticated and member access.
  * Prevented management permissions from carrying over when switching companies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->