### PR TITLE
fix(a2a): spend the x402 nonce and refuse a skill the card never advertised

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -358,10 +358,12 @@ work reaches cognition:
 2. Verify the SIWX `Authorization` header (skew window + single-use replay
    protection via a host-global nonce cache). A bad/missing header is `401`.
 3. Classify the requested skill against the card's advertised prices: an id
-   the company never advertised is refused with `404`, whether or not the
-   company prices anything else — it is a different answer from "free", not
-   the same one. An id priced at `0.00`, or at a price this build cannot
-   parse, is served for free with no payment step at all.
+   the company never advertised is refused with `404` on a company that
+   prices at least one skill above `0.00` — it is a different answer from
+   "free", not the same one. A card that prices nothing above `0.00` charges
+   for nothing, so every id on it is free, including one it does not list.
+   An id priced at `0.00`, or at a price this build cannot parse, is served
+   for free with no payment step at all.
 4. For a skill priced above `0.00`, require a valid x402 authorization bound
    to this company's own address and to at least its advertised price;
    without one, or with one addressed to another company or underpaying, the

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -357,10 +357,22 @@ work reaches cognition:
    matching `[company].handle`); a miss is `404`.
 2. Verify the SIWX `Authorization` header (skew window + single-use replay
    protection via a host-global nonce cache). A bad/missing header is `401`.
-3. For a skill priced above `0.00`, require a valid x402 authorization; without
-   one the response is a `402` challenge naming the amount and the company's
-   own tiny.place address.
-4. Sanitize the counterparty payload (a minimal promptguard pass — control
+3. Classify the requested skill against the card's advertised prices: an id
+   the company never advertised is refused with `404`, whether or not the
+   company prices anything else — it is a different answer from "free", not
+   the same one. An id priced at `0.00`, or at a price this build cannot
+   parse, is served for free with no payment step at all.
+4. For a skill priced above `0.00`, require a valid x402 authorization bound
+   to this company's own address and to at least its advertised price;
+   without one, or with one addressed to another company or underpaying, the
+   response is a `402` challenge naming the amount and the company's own
+   tiny.place address. A **valid** authorization's nonce is spent atomically
+   with acceptance — signature and freshness (±10 minutes) are checked before
+   the nonce is consumed, and consumption itself happens only once the
+   payment is confirmed bound to this company and sufficient, so the same
+   authorization can never buy two tasks and a mismatch does not burn a nonce
+   the payer could still use correctly elsewhere.
+5. Sanitize the counterparty payload (a minimal promptguard pass — control
    characters are stripped) before it becomes an `A2aTaskReceived` event and
    drives exactly one cycle. Paying customers run under the same approval gates
    as any other stimulus.

--- a/docs/spec/integrations/tinyplace.md
+++ b/docs/spec/integrations/tinyplace.md
@@ -58,7 +58,12 @@ lifecycle from tiny.place's reference bots:
 
 - Serve inbound `/a2a/{handle}` with SIWX verification and x402 challenge/
   verify for priced skills; sanitize counterparty text (promptguard) before
-  it reaches the brain.
+  it reaches the brain. A skill id the Agent Card does not advertise is a
+  `404` on a company that prices its work, not free work — the card's
+  payment requirements enumerate every skill the company offers. An x402
+  authorization is single-use: its nonce is spent on first presentation and
+  the authorization is refused once older than ten minutes, so one signature
+  buys one task.
 - Outbound hiring: directory search → checkpoint for new counterparties →
   `send_a2a_task` with x402 payment under `BudgetScope`
   ([commerce](../company-as-agent/commerce.md)).

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -484,6 +484,16 @@ pub struct AppState {
     /// request. Gated behind `tinyplace` so the default build links no crypto.
     #[cfg(feature = "tinyplace")]
     nonce: std::sync::Arc<crate::economy::NonceCache>,
+    /// Host-global spent-nonce set for inbound x402 payment authorizations.
+    ///
+    /// Separate from `nonce` because the two guard different values over
+    /// different windows: a SIWX signature is good for the clock-skew window,
+    /// an authorization nonce for
+    /// [`x402::MAX_AGE_SECS`](crate::economy::x402::MAX_AGE_SECS). Sharing one
+    /// set would let either keyspace prune the other's record, and a forgotten
+    /// payment nonce is a free task.
+    #[cfg(feature = "tinyplace")]
+    x402_nonce: std::sync::Arc<crate::economy::NonceCache>,
     /// In-flight console MCP OAuth flows, keyed by the opaque `state` the browser
     /// round-trips (issue #90). The `/mcp/servers/{name}/oauth/start` route parks
     /// a [`PendingOAuth`](crate::company::mcp_oauth::PendingOAuth) here; the
@@ -579,6 +589,10 @@ impl AppState {
             cors: crate::server::cors::CorsConfig::default(),
             #[cfg(feature = "tinyplace")]
             nonce: std::sync::Arc::new(crate::economy::NonceCache::new()),
+            #[cfg(feature = "tinyplace")]
+            x402_nonce: std::sync::Arc::new(crate::economy::NonceCache::with_ttl(
+                crate::economy::x402::MAX_AGE_SECS,
+            )),
             #[cfg(feature = "mcp")]
             oauth_pending: Arc::new(std::sync::Mutex::new(HashMap::new())),
             analytics: crate::analytics::null_tracker(),
@@ -1073,6 +1087,12 @@ impl AppState {
     #[cfg(feature = "tinyplace")]
     pub fn nonce(&self) -> &std::sync::Arc<crate::economy::NonceCache> {
         &self.nonce
+    }
+
+    /// The host-global spent-nonce set for inbound x402 authorizations.
+    #[cfg(feature = "tinyplace")]
+    pub fn x402_nonce(&self) -> &std::sync::Arc<crate::economy::NonceCache> {
+        &self.x402_nonce
     }
 
     /// How long a parked OAuth flow stays reclaimable before it's swept. Longer

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -990,6 +990,23 @@ impl CompanyManifest {
             }
         }
 
+        // A duplicate skill id is not two skills — it is one id with two
+        // conflicting answers to "what does this cost", and a lookup by id
+        // alone (Agent Card generation, x402 charging) can only ever return
+        // one of them. Rejecting the manifest outright, rather than picking a
+        // resolution order, is what keeps that lookup free to change without
+        // reopening a way to advertise a skill above zero and serve it for
+        // free.
+        let mut seen_skill_ids = std::collections::HashSet::new();
+        for skill in &self.place.skills {
+            if !seen_skill_ids.insert(skill.id.as_str()) {
+                problems.push(format!(
+                    "skill `{}` is declared more than once in `[place].skills` — each id must be unique.",
+                    skill.id
+                ));
+            }
+        }
+
         if let Some(monthly) = self.budget.monthly_usd
             && monthly < 0.0
         {
@@ -2463,6 +2480,30 @@ mod tests {
         let problems = manifest.validate();
         assert!(problems.iter().any(|p| p.contains("price_usd")));
         assert!(problems.iter().any(|p| p.contains("5 fields")));
+    }
+
+    #[test]
+    fn rejects_a_duplicate_skill_id() {
+        let manifest = parse(
+            r#"
+            [company]
+            name = "X"
+            handle = "x"
+            [place]
+            discoverable = true
+            skills = [
+                { id = "seo.audit", price_usd = "0.00" },
+                { id = "seo.audit", price_usd = "25.00" },
+            ]
+            "#,
+        );
+        let problems = manifest.validate();
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("seo.audit") && p.contains("more than once")),
+            "{problems:?}"
+        );
     }
 
     #[test]

--- a/src/economy/siwx.rs
+++ b/src/economy/siwx.rs
@@ -29,6 +29,7 @@
 //! requests); this module does not hash bodies itself.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::Mutex;
 
 use crate::Result;
@@ -160,7 +161,7 @@ pub fn verify(
         &parsed.signature_b58,
     )?;
 
-    if !seen.check_and_insert(&parsed.signature_b58, now) {
+    if !seen.check_and_insert(&parsed.signature_b58, now)? {
         return Err(OpenCompanyError::InvalidRequest(
             "authorization signature has already been used (replay)".into(),
         ));
@@ -169,34 +170,76 @@ pub fn verify(
     Ok(parsed.agent_id)
 }
 
-/// A process-local record of accepted signatures for replay protection.
+/// A process-local record of spent single-use values, for replay protection.
 ///
-/// Entries older than [`SKEW_SECS`] are pruned on insert, bounding memory to the
-/// skew window. In-memory only; cross-restart persistence is a documented
-/// follow-up.
-#[derive(Debug, Default)]
+/// Entries older than the cache's TTL are pruned on insert, bounding memory to
+/// the window in which a value can still be accepted. In-memory only;
+/// cross-restart persistence is a documented follow-up.
+///
+/// Two callers keep separate instances with separate windows: SIWX signatures
+/// live for [`SKEW_SECS`], x402 authorization nonces for
+/// [`x402::MAX_AGE_SECS`](crate::economy::x402::MAX_AGE_SECS). Sharing one set
+/// across both would let either keyspace evict the other's record.
+#[derive(Debug)]
 pub struct NonceCache {
     seen: Mutex<HashMap<String, i64>>,
+    ttl_secs: i64,
+}
+
+impl Default for NonceCache {
+    fn default() -> Self {
+        Self::with_ttl(SKEW_SECS)
+    }
 }
 
 impl NonceCache {
-    /// Creates an empty cache.
+    /// Creates an empty cache remembering a value for [`SKEW_SECS`].
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Records `signature` as used at `now`, pruning stale entries first.
+    /// Creates an empty cache remembering a value for `ttl_secs`.
     ///
-    /// Returns `true` if the signature was previously unseen (accept), `false`
-    /// if it is a replay (reject).
-    pub fn check_and_insert(&self, signature: &str, now: i64) -> bool {
-        let mut guard = self.seen.lock().expect("nonce cache poisoned");
-        guard.retain(|_, ts| (now - *ts).abs() <= SKEW_SECS);
-        if guard.contains_key(signature) {
-            return false;
+    /// The TTL must be at least as long as the window in which the caller will
+    /// still accept the value it guards, or a replay outlives the memory of it.
+    pub fn with_ttl(ttl_secs: i64) -> Self {
+        Self {
+            seen: Mutex::new(HashMap::new()),
+            ttl_secs,
         }
-        guard.insert(signature.to_string(), now);
-        true
+    }
+
+    /// Records `key` as spent at `now`, pruning stale entries first.
+    ///
+    /// `Ok(true)` if it was previously unseen (accept), `Ok(false)` on a replay
+    /// (reject), `Err` if the cache cannot answer (reject). The guarded section
+    /// touches only a `HashMap` and an `i64`, so a poisoned lock means a panic
+    /// unwound through it and the record of what has been spent can no longer
+    /// be trusted — the caller must refuse rather than recover, because a cache
+    /// that cannot answer admits every replay.
+    pub fn check_and_insert(&self, key: &str, now: i64) -> Result<bool> {
+        let mut guard = self
+            .seen
+            .lock()
+            .map_err(|_| OpenCompanyError::Store("replay-protection cache is unusable".into()))?;
+        guard.retain(|_, ts| (now - *ts).abs() <= self.ttl_secs);
+        match guard.entry(key.to_string()) {
+            Entry::Occupied(_) => Ok(false),
+            Entry::Vacant(slot) => {
+                slot.insert(now);
+                Ok(true)
+            }
+        }
+    }
+
+    /// Poisons the lock so a caller's fail-closed path can be exercised. The
+    /// panic it raises is caught here and is expected in test output.
+    #[cfg(test)]
+    pub(crate) fn poison_for_tests(&self) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = self.seen.lock().expect("cache is not already poisoned");
+            panic!("deliberately poisoning the replay-protection cache");
+        }));
     }
 }
 
@@ -283,8 +326,48 @@ mod test {
     #[test]
     fn nonce_cache_prunes_stale_entries() {
         let cache = NonceCache::new();
-        assert!(cache.check_and_insert("sig-a", 1_000));
+        assert!(cache.check_and_insert("sig-a", 1_000).unwrap());
         // Far in the future: the stale entry is pruned, so re-inserting is fine.
-        assert!(cache.check_and_insert("sig-a", 1_000 + SKEW_SECS * 4));
+        assert!(
+            cache
+                .check_and_insert("sig-a", 1_000 + SKEW_SECS * 4)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn nonce_cache_honours_a_custom_ttl() {
+        let cache = NonceCache::with_ttl(SKEW_SECS * 4);
+        assert!(cache.check_and_insert("sig-a", 1_000).unwrap());
+        // Still inside the wider window, so still remembered as spent.
+        assert!(
+            !cache
+                .check_and_insert("sig-a", 1_000 + SKEW_SECS * 3)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn an_unusable_cache_refuses_rather_than_admits() {
+        let cache = NonceCache::new();
+        cache.poison_for_tests();
+        assert!(
+            cache.check_and_insert("sig-a", 1_000).is_err(),
+            "a cache that cannot answer must not report a value as fresh"
+        );
+    }
+
+    #[test]
+    fn an_unusable_cache_refuses_the_siwx_signature() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let header = header_value(&build_header(&signer, &payload(now)));
+        let cache = NonceCache::new();
+        cache.poison_for_tests();
+
+        assert!(
+            verify(&header, "POST", "/a2a/acme", "abc123", now, &cache).is_err(),
+            "a correctly signed header must not pass when replay protection is down"
+        );
     }
 }

--- a/src/economy/siwx.rs
+++ b/src/economy/siwx.rs
@@ -161,7 +161,7 @@ pub fn verify(
         &parsed.signature_b58,
     )?;
 
-    if !seen.check_and_insert(&parsed.signature_b58, now)? {
+    if !seen.check_and_insert(&parsed.signature_b58, now, parsed.timestamp)? {
         return Err(OpenCompanyError::InvalidRequest(
             "authorization signature has already been used (replay)".into(),
         ));
@@ -209,7 +209,20 @@ impl NonceCache {
         }
     }
 
-    /// Records `key` as spent at `now`, pruning stale entries first.
+    /// Records `key` as spent, pruning stale entries first.
+    ///
+    /// `now` is the verifier's current clock, used only to decide which
+    /// existing entries have aged out. `record_ts` is the timestamp the entry
+    /// is remembered under — the claimed timestamp of the thing being spent
+    /// (an authorization's `timestamp`, a SIWX header's signing time), not
+    /// `now`. Storing `record_ts` rather than `now` matters because a caller's
+    /// own freshness check already tolerates skew between the two: if the
+    /// entry were stamped with `now`, a replay landing just past the caller's
+    /// freshness window could still land inside the prune window, since the
+    /// two windows would be measured from different origins. Stamping with
+    /// `record_ts` instead ties both checks to the same origin, so the entry
+    /// is forgotten at the same moment the freshness check would refuse it
+    /// again — never before, never after.
     ///
     /// `Ok(true)` if it was previously unseen (accept), `Ok(false)` on a replay
     /// (reject), `Err` if the cache cannot answer (reject). The guarded section
@@ -217,7 +230,7 @@ impl NonceCache {
     /// unwound through it and the record of what has been spent can no longer
     /// be trusted — the caller must refuse rather than recover, because a cache
     /// that cannot answer admits every replay.
-    pub fn check_and_insert(&self, key: &str, now: i64) -> Result<bool> {
+    pub fn check_and_insert(&self, key: &str, now: i64, record_ts: i64) -> Result<bool> {
         let mut guard = self
             .seen
             .lock()
@@ -226,7 +239,7 @@ impl NonceCache {
         match guard.entry(key.to_string()) {
             Entry::Occupied(_) => Ok(false),
             Entry::Vacant(slot) => {
-                slot.insert(now);
+                slot.insert(record_ts);
                 Ok(true)
             }
         }
@@ -326,11 +339,11 @@ mod test {
     #[test]
     fn nonce_cache_prunes_stale_entries() {
         let cache = NonceCache::new();
-        assert!(cache.check_and_insert("sig-a", 1_000).unwrap());
+        assert!(cache.check_and_insert("sig-a", 1_000, 1_000).unwrap());
         // Far in the future: the stale entry is pruned, so re-inserting is fine.
         assert!(
             cache
-                .check_and_insert("sig-a", 1_000 + SKEW_SECS * 4)
+                .check_and_insert("sig-a", 1_000 + SKEW_SECS * 4, 1_000 + SKEW_SECS * 4)
                 .unwrap()
         );
     }
@@ -338,12 +351,37 @@ mod test {
     #[test]
     fn nonce_cache_honours_a_custom_ttl() {
         let cache = NonceCache::with_ttl(SKEW_SECS * 4);
-        assert!(cache.check_and_insert("sig-a", 1_000).unwrap());
+        assert!(cache.check_and_insert("sig-a", 1_000, 1_000).unwrap());
         // Still inside the wider window, so still remembered as spent.
         assert!(
             !cache
-                .check_and_insert("sig-a", 1_000 + SKEW_SECS * 3)
+                .check_and_insert("sig-a", 1_000 + SKEW_SECS * 3, 1_000 + SKEW_SECS * 3)
                 .unwrap()
+        );
+    }
+
+    #[test]
+    fn nonce_cache_prunes_by_record_timestamp_not_insertion_time() {
+        // A signature stamped at the far edge of tolerated skew (future-dated,
+        // but still within the freshness window when first checked) must stay
+        // remembered for as long as *its own claimed timestamp* would still
+        // pass a freshness check — not merely for `ttl_secs` past the moment
+        // it happened to be verified. Keying the stored entry off the
+        // verifier's clock instead of the claimed timestamp would prune it
+        // early, reopening the slot for a replay of the same signature while
+        // the claimed timestamp is still "fresh" by the caller's own check.
+        let cache = NonceCache::with_ttl(SKEW_SECS);
+        let claimed_ts = 1_000 + SKEW_SECS; // maximally future-dated, still fresh at now=1_000
+        assert!(cache.check_and_insert("sig-a", 1_000, claimed_ts).unwrap());
+        // Past the point at which keying off insertion time (1_000) would have
+        // pruned the entry, but still within `ttl_secs` of `claimed_ts`.
+        let replay_now = 1_000 + SKEW_SECS + 1;
+        assert!(
+            !cache
+                .check_and_insert("sig-a", replay_now, claimed_ts)
+                .unwrap(),
+            "entry must still be remembered because its claimed timestamp is \
+             still within the freshness window, even though insertion time is not"
         );
     }
 
@@ -352,7 +390,7 @@ mod test {
         let cache = NonceCache::new();
         cache.poison_for_tests();
         assert!(
-            cache.check_and_insert("sig-a", 1_000).is_err(),
+            cache.check_and_insert("sig-a", 1_000, 1_000).is_err(),
             "a cache that cannot answer must not report a value as fresh"
         );
     }

--- a/src/economy/siwx.rs
+++ b/src/economy/siwx.rs
@@ -143,7 +143,7 @@ pub fn verify(
 ) -> Result<String> {
     let parsed = parse_header(header)?;
 
-    if (now - parsed.timestamp).abs() > SKEW_SECS {
+    if now.abs_diff(parsed.timestamp) > SKEW_SECS as u64 {
         return Err(OpenCompanyError::InvalidRequest(format!(
             "authorization timestamp is outside the ±{SKEW_SECS}s window"
         )));
@@ -235,7 +235,7 @@ impl NonceCache {
             .seen
             .lock()
             .map_err(|_| OpenCompanyError::Store("replay-protection cache is unusable".into()))?;
-        guard.retain(|_, ts| (now - *ts).abs() <= self.ttl_secs);
+        guard.retain(|_, ts| now.abs_diff(*ts) <= self.ttl_secs as u64);
         match guard.entry(key.to_string()) {
             Entry::Occupied(_) => Ok(false),
             Entry::Vacant(slot) => {
@@ -304,6 +304,30 @@ mod test {
         let now = signed_at + SKEW_SECS + 100;
         let err = verify(&header, "POST", "/a2a/acme", "abc123", now, &cache);
         assert!(err.is_err(), "stale timestamp must be rejected");
+    }
+
+    #[test]
+    fn an_extreme_timestamp_is_rejected_rather_than_wrapping() {
+        let signer = LocalSigner::generate();
+        let header = header_value(&build_header(&signer, &payload(i64::MIN)));
+        let cache = NonceCache::new();
+
+        let err = verify(&header, "POST", "/a2a/acme", "abc123", 0, &cache);
+        assert!(
+            err.is_err(),
+            "a timestamp whose distance from now cannot be held in an i64 must be refused"
+        );
+    }
+
+    #[test]
+    fn the_cache_prunes_an_entry_whose_distance_from_now_overflows() {
+        let cache = NonceCache::with_ttl(SKEW_SECS);
+        assert!(cache.check_and_insert("sig-a", 0, i64::MIN).unwrap());
+
+        assert!(
+            cache.check_and_insert("sig-a", 0, 0).unwrap(),
+            "an entry that far outside the window must expire rather than live forever"
+        );
     }
 
     #[test]

--- a/src/economy/x402.rs
+++ b/src/economy/x402.rs
@@ -221,7 +221,8 @@ fn authorize_amount(
     }
 }
 
-/// Verifies an authorization and spends its nonce, at most once ever.
+/// Verifies an authorization and spends its nonce, so one signature buys one
+/// task.
 ///
 /// Enforces, in order: the signature against the declared `agentId`, freshness
 /// within [`MAX_AGE_SECS`], and single use of the nonce against `spent`.

--- a/src/economy/x402.rs
+++ b/src/economy/x402.rs
@@ -248,7 +248,7 @@ pub fn verify(auth: &X402Authorization, spent: &NonceCache, now: i64) -> Result<
     );
     verify_b58(&auth.agent_id, &msg, &auth.signature_b58)?;
 
-    if (now - auth.timestamp).abs() > MAX_AGE_SECS {
+    if now.abs_diff(auth.timestamp) > MAX_AGE_SECS as u64 {
         return Err(OpenCompanyError::InvalidRequest(format!(
             "x402 authorization timestamp is outside the ±{MAX_AGE_SECS}s window"
         )));
@@ -479,6 +479,18 @@ mod test {
         assert!(
             verify(&auth, &spent, signed_at + MAX_AGE_SECS + 1).is_err(),
             "an authorization older than the spent set's memory must not verify"
+        );
+    }
+
+    #[test]
+    fn an_extreme_timestamp_is_refused_rather_than_wrapping() {
+        let signer = LocalSigner::generate();
+        let auth = authorize(&signer, &sample_challenge(), i64::MIN);
+        let spent = NonceCache::with_ttl(MAX_AGE_SECS);
+
+        assert!(
+            verify(&auth, &spent, 0).is_err(),
+            "a timestamp whose distance from now cannot be held in an i64 must be refused"
         );
     }
 

--- a/src/economy/x402.rs
+++ b/src/economy/x402.rs
@@ -254,7 +254,7 @@ pub fn verify(auth: &X402Authorization, spent: &NonceCache, now: i64) -> Result<
         )));
     }
 
-    if !spent.check_and_insert(&auth.nonce, now)? {
+    if !spent.check_and_insert(&auth.nonce, now, auth.timestamp)? {
         return Err(OpenCompanyError::InvalidRequest(
             "x402 authorization nonce has already been spent (replay)".into(),
         ));
@@ -496,6 +496,33 @@ mod test {
         // Late enough for the prune to drop the nonce — and late enough for the
         // age check to refuse the authorization anyway.
         assert!(verify(&auth, &spent, signed_at + MAX_AGE_SECS * 2).is_err());
+    }
+
+    #[test]
+    fn a_future_dated_authorization_cannot_outlive_its_own_nonce() {
+        // A future-dated authorization is accepted (the age check is
+        // symmetric), but its nonce must be remembered for as long as the
+        // authorization itself would still be considered fresh — not merely
+        // for MAX_AGE_SECS past the moment it happened to be verified. A
+        // nonce recorded under the verification time rather than the
+        // authorization's own timestamp would be forgotten while a replay of
+        // the same future-dated authorization still passes the age check.
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        // Maximally future-dated: still exactly inside the ±MAX_AGE_SECS window.
+        let auth = authorize(&signer, &sample_challenge(), now + MAX_AGE_SECS);
+        let spent = NonceCache::with_ttl(MAX_AGE_SECS);
+
+        verify(&auth, &spent, now).expect("future-dated but within tolerance");
+        // Past the point at which keying the nonce off verification time
+        // (`now`) would have pruned it, but the authorization's own claimed
+        // timestamp is still within MAX_AGE_SECS of this later clock.
+        let replay_at = now + MAX_AGE_SECS + 1;
+        assert!(
+            verify(&auth, &spent, replay_at).is_err(),
+            "a future-dated authorization's nonce must not be forgotten while \
+             the authorization is still within its own age window"
+        );
     }
 
     #[test]

--- a/src/economy/x402.rs
+++ b/src/economy/x402.rs
@@ -23,12 +23,27 @@
 //! Isolated in [`canonical_bytes`] so it is a one-function change to reconcile
 //! with the real tiny.place server when reachable.
 //!
+//! ## Single use is enforced, not merely documented
+//!
+//! The signature covers the whole payload including the nonce, so a payer
+//! cannot re-point one authorization at different work — but nothing about a
+//! signature stops the *same* authorization being presented again. [`verify`]
+//! therefore takes the spent-nonce set and the current time, and refuses both a
+//! nonce it has already seen and an authorization older than
+//! [`MAX_AGE_SECS`]. Neither is optional, because a verified-but-unspent
+//! authorization is a bearer token: one signature buying unlimited work.
+//!
+//! Bounding acceptance by age is what makes forgetting a nonce safe. The spent
+//! set prunes on the same constant, so a nonce is dropped only once the
+//! authorization carrying it would be refused on age anyway, and there is no
+//! window in which a replay outlives the memory of it.
+//!
 //! ## The nonce comes from the OS CSPRNG
 //!
-//! `nonce` is documented as single-use and is signed into the payload above,
-//! so a counterparty's replay check is only as good as the value's
-//! unpredictability and uniqueness. It is therefore minted by [`mint_nonce`]
-//! from 256 bits of OS randomness through the same
+//! The nonce is signed into the payload above, so a counterparty's replay check
+//! is only as good as the value's unpredictability and uniqueness. It is
+//! therefore minted by [`mint_nonce`] from 256 bits of OS randomness through
+//! the same
 //! [`TokenSource`](crate::server::users::token::TokenSource) seam the user-auth
 //! secrets use — **not** from
 //! [`generate_id`](crate::ports::generate_id), whose epoch-millis-plus-counter
@@ -39,12 +54,26 @@ use serde::{Deserialize, Serialize};
 
 use crate::Result;
 use crate::economy::signer::{LocalSigner, verify_b58};
+use crate::economy::siwx::{NonceCache, SKEW_SECS};
 use crate::error::OpenCompanyError;
 use crate::server::platform_auth::b64url_encode;
 use crate::server::users::token::{OsTokens, TokenSource};
 
 /// The domain-separation tag pinning the x402 canonical layout version.
 pub const X402_DOMAIN: &str = "tiny.place-x402-v1";
+
+/// How long an authorization stays acceptable, and therefore how long its nonce
+/// is remembered as spent. Ten minutes.
+///
+/// Twice the SIWX clock-skew tolerance. An authorization only ever arrives
+/// inside a SIWX-signed request, and that request is already refused unless its
+/// own timestamp is within [`SKEW_SECS`] of the verifier's clock, so this
+/// covers a payer at the far edge of tolerated clock offset plus a full
+/// challenge → authorize → resend round trip — a round trip that in practice
+/// takes under a second. Anything older is a request the transport layer would
+/// have turned away, so accepting it buys the payer nothing and costs the spent
+/// set unbounded memory.
+pub const MAX_AGE_SECS: i64 = 2 * SKEW_SECS;
 
 /// A payment challenge parsed from a counterparty's `402` response body.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -103,9 +132,10 @@ pub struct X402Authorization {
     pub network: String,
     /// A single-use nonce: 256 bits of OS randomness, base64url, 43 chars.
     ///
-    /// Opaque to every reader — nothing parses, stores, or matches its shape —
-    /// so the counterparty only needs it to be unpredictable and unique. See
-    /// [`mint_nonce`].
+    /// Opaque to every reader — nothing parses or matches its shape — so the
+    /// counterparty only needs it to be unpredictable and unique. [`verify`]
+    /// spends it against a [`NonceCache`], which is what makes "single-use"
+    /// true. See [`mint_nonce`].
     pub nonce: String,
     /// The authorization timestamp, epoch seconds.
     pub timestamp: i64,
@@ -191,8 +221,21 @@ fn authorize_amount(
     }
 }
 
-/// Verifies an authorization's signature against its own declared `agentId`.
-pub fn verify(auth: &X402Authorization) -> Result<()> {
+/// Verifies an authorization and spends its nonce, at most once ever.
+///
+/// Enforces, in order: the signature against the declared `agentId`, freshness
+/// within [`MAX_AGE_SECS`], and single use of the nonce against `spent`.
+///
+/// `spent` and `now` are parameters rather than something a caller may choose
+/// to consult. A signature proves who authorized the payment, not that the
+/// payment has not already been collected; a caller that could verify without
+/// spending would be treating the authorization as a bearer token, which is
+/// precisely the bug this signature shape exists to prevent.
+///
+/// The signature is checked before the nonce is spent, so an unverifiable
+/// authorization cannot burn a nonce — otherwise anyone who observed a payer's
+/// nonce could spend it on their behalf with a forged signature.
+pub fn verify(auth: &X402Authorization, spent: &NonceCache, now: i64) -> Result<()> {
     let msg = canonical_bytes(
         &auth.agent_id,
         &auth.amount,
@@ -202,7 +245,21 @@ pub fn verify(auth: &X402Authorization) -> Result<()> {
         &auth.nonce,
         auth.timestamp,
     );
-    verify_b58(&auth.agent_id, &msg, &auth.signature_b58)
+    verify_b58(&auth.agent_id, &msg, &auth.signature_b58)?;
+
+    if (now - auth.timestamp).abs() > MAX_AGE_SECS {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "x402 authorization timestamp is outside the ±{MAX_AGE_SECS}s window"
+        )));
+    }
+
+    if !spent.check_and_insert(&auth.nonce, now)? {
+        return Err(OpenCompanyError::InvalidRequest(
+            "x402 authorization nonce has already been spent (replay)".into(),
+        ));
+    }
+
+    Ok(())
 }
 
 fn string_field(obj: &serde_json::Value, keys: &[&str]) -> Option<String> {
@@ -267,7 +324,8 @@ mod test {
         assert_eq!(auth.agent_id, signer.agent_id());
         assert_eq!(auth.amount, "25.00");
         assert_eq!(auth.recipient, "RecipientAddr");
-        verify(&auth).expect("authorization verifies against its own key");
+        verify(&auth, &NonceCache::new(), 1_700_000_000)
+            .expect("authorization verifies against its own key");
     }
 
     #[test]
@@ -276,7 +334,7 @@ mod test {
         let ch = sample_challenge();
         let auth = authorize_upto(&signer, &ch, "100.00", 1_700_000_000);
         assert_eq!(auth.amount, "100.00");
-        verify(&auth).expect("upto authorization verifies");
+        verify(&auth, &NonceCache::new(), 1_700_000_000).expect("upto authorization verifies");
     }
 
     #[test]
@@ -286,7 +344,7 @@ mod test {
         let mut auth = authorize(&signer, &ch, 1_700_000_000);
         auth.amount = "0.01".into();
         assert!(
-            verify(&auth).is_err(),
+            verify(&auth, &NonceCache::new(), 1_700_000_000).is_err(),
             "changed amount must break the signature"
         );
     }
@@ -379,9 +437,92 @@ mod test {
         let mut auth = authorize(&signer, &sample_challenge(), 1_700_000_000);
         auth.nonce = mint_nonce(&OsTokens);
         assert!(
-            verify(&auth).is_err(),
+            verify(&auth, &NonceCache::new(), 1_700_000_000).is_err(),
             "changed nonce must break the signature"
         );
+    }
+
+    #[test]
+    fn a_replayed_authorization_is_refused() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let auth = authorize(&signer, &sample_challenge(), now);
+        let spent = NonceCache::with_ttl(MAX_AGE_SECS);
+
+        verify(&auth, &spent, now).expect("first presentation is the payment");
+        assert!(
+            verify(&auth, &spent, now).is_err(),
+            "one signed authorization must not buy a second task"
+        );
+    }
+
+    #[test]
+    fn a_second_authorization_is_still_admitted() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let spent = NonceCache::with_ttl(MAX_AGE_SECS);
+
+        for _ in 0..3 {
+            let auth = authorize(&signer, &sample_challenge(), now);
+            verify(&auth, &spent, now).expect("each fresh nonce pays its own way");
+        }
+    }
+
+    #[test]
+    fn a_stale_authorization_is_refused() {
+        let signer = LocalSigner::generate();
+        let signed_at = 1_700_000_000;
+        let auth = authorize(&signer, &sample_challenge(), signed_at);
+        let spent = NonceCache::with_ttl(MAX_AGE_SECS);
+
+        assert!(
+            verify(&auth, &spent, signed_at + MAX_AGE_SECS + 1).is_err(),
+            "an authorization older than the spent set's memory must not verify"
+        );
+    }
+
+    #[test]
+    fn a_stale_authorization_is_refused_before_its_nonce_is_forgotten() {
+        // The two windows are the same constant, so at the moment the spent set
+        // would prune a nonce the authorization carrying it is already too old.
+        // This is the property that makes a bounded store sufficient.
+        let signer = LocalSigner::generate();
+        let signed_at = 1_700_000_000;
+        let auth = authorize(&signer, &sample_challenge(), signed_at);
+        let spent = NonceCache::with_ttl(MAX_AGE_SECS);
+
+        verify(&auth, &spent, signed_at).expect("fresh");
+        // Late enough for the prune to drop the nonce — and late enough for the
+        // age check to refuse the authorization anyway.
+        assert!(verify(&auth, &spent, signed_at + MAX_AGE_SECS * 2).is_err());
+    }
+
+    #[test]
+    fn an_unusable_spent_set_refuses_the_payment() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let auth = authorize(&signer, &sample_challenge(), now);
+        let spent = NonceCache::with_ttl(MAX_AGE_SECS);
+        spent.poison_for_tests();
+
+        assert!(
+            verify(&auth, &spent, now).is_err(),
+            "a spent set that cannot answer must refuse, not admit"
+        );
+    }
+
+    #[test]
+    fn an_unverifiable_authorization_cannot_burn_a_nonce() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let auth = authorize(&signer, &sample_challenge(), now);
+        let spent = NonceCache::with_ttl(MAX_AGE_SECS);
+
+        let mut forged = auth.clone();
+        forged.amount = "0.01".into();
+        assert!(verify(&forged, &spent, now).is_err(), "forgery is refused");
+
+        verify(&auth, &spent, now).expect("the payer's own nonce is still unspent");
     }
 
     #[test]

--- a/src/economy/x402.rs
+++ b/src/economy/x402.rs
@@ -132,10 +132,10 @@ pub struct X402Authorization {
     pub network: String,
     /// A single-use nonce: 256 bits of OS randomness, base64url, 43 chars.
     ///
-    /// Opaque to every reader — nothing parses or matches its shape — so the
-    /// counterparty only needs it to be unpredictable and unique. [`verify`]
-    /// spends it against a [`NonceCache`], which is what makes "single-use"
-    /// true. See [`mint_nonce`].
+    /// [`verify`] rejects any value that is not exactly [`NONCE_LEN`]
+    /// base64url characters before it ever reaches the shared
+    /// [`NonceCache`], so a counterparty cannot grow the cache's memory
+    /// footprint by signing an oversized nonce. See [`mint_nonce`].
     pub nonce: String,
     /// The authorization timestamp, epoch seconds.
     pub timestamp: i64,
@@ -148,6 +148,10 @@ pub struct X402Authorization {
 /// matching the user-auth secrets, so two mints colliding is not a scenario.
 const NONCE_BYTES: usize = 32;
 
+/// The exact length of a [`mint_nonce`] output: unpadded base64url of
+/// [`NONCE_BYTES`] bytes.
+const NONCE_LEN: usize = (NONCE_BYTES * 4).div_ceil(3);
+
 /// Mints an authorization nonce: 256 bits from `src`, base64url, 43 chars.
 ///
 /// A pure function of the source bytes — no clock, no counter, no process
@@ -157,6 +161,18 @@ pub fn mint_nonce(src: &dyn TokenSource) -> String {
     let mut bytes = [0u8; NONCE_BYTES];
     src.fill(&mut bytes);
     b64url_encode(&bytes)
+}
+
+/// Whether `nonce` has the exact shape [`mint_nonce`] produces: [`NONCE_LEN`]
+/// unpadded base64url characters. [`verify`] enforces this before the nonce
+/// ever reaches the shared [`NonceCache`], so a counterparty cannot grow that
+/// cache's memory footprint by signing an authorization around an oversized
+/// nonce.
+fn has_nonce_shape(nonce: &str) -> bool {
+    nonce.len() == NONCE_LEN
+        && nonce
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
 }
 
 /// Builds the canonical bytes an x402 authorization signs. See module docs.
@@ -224,8 +240,9 @@ fn authorize_amount(
 /// Verifies an authorization and spends its nonce, so one signature buys one
 /// task.
 ///
-/// Enforces, in order: the signature against the declared `agentId`, freshness
-/// within [`MAX_AGE_SECS`], and single use of the nonce against `spent`.
+/// Enforces, in order: the nonce's shape, the signature against the declared
+/// `agentId`, freshness within [`MAX_AGE_SECS`], and single use of the nonce
+/// against `spent`.
 ///
 /// `spent` and `now` are parameters rather than something a caller may choose
 /// to consult. A signature proves who authorized the payment, not that the
@@ -237,6 +254,12 @@ fn authorize_amount(
 /// authorization cannot burn a nonce — otherwise anyone who observed a payer's
 /// nonce could spend it on their behalf with a forged signature.
 pub fn verify(auth: &X402Authorization, spent: &NonceCache, now: i64) -> Result<()> {
+    if !has_nonce_shape(&auth.nonce) {
+        return Err(OpenCompanyError::InvalidRequest(
+            "x402 authorization nonce is not a valid mint_nonce value".into(),
+        ));
+    }
+
     let msg = canonical_bytes(
         &auth.agent_id,
         &auth.amount,
@@ -491,6 +514,67 @@ mod test {
         assert!(
             verify(&auth, &spent, 0).is_err(),
             "a timestamp whose distance from now cannot be held in an i64 must be refused"
+        );
+    }
+
+    /// Builds a validly-signed authorization around an arbitrary nonce, so a
+    /// test can prove `verify` rejects a malformed nonce on its own merits
+    /// rather than piggybacking on a broken signature.
+    fn authorization_with_nonce(
+        signer: &LocalSigner,
+        ch: &X402Challenge,
+        now: i64,
+        nonce: &str,
+    ) -> X402Authorization {
+        let agent_id = signer.agent_id();
+        let msg = canonical_bytes(
+            &agent_id,
+            &ch.amount,
+            &ch.recipient,
+            &ch.asset,
+            &ch.network,
+            nonce,
+            now,
+        );
+        X402Authorization {
+            agent_id,
+            amount: ch.amount.clone(),
+            recipient: ch.recipient.clone(),
+            asset: ch.asset.clone(),
+            network: ch.network.clone(),
+            nonce: nonce.to_string(),
+            timestamp: now,
+            signature_b58: signer.sign_b58(&msg),
+        }
+    }
+
+    #[test]
+    fn an_oversized_nonce_is_refused_before_touching_the_cache() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let oversized = "A".repeat(NONCE_LEN + 1);
+        let auth = authorization_with_nonce(&signer, &sample_challenge(), now, &oversized);
+        let spent = NonceCache::with_ttl(MAX_AGE_SECS);
+
+        assert!(
+            verify(&auth, &spent, now).is_err(),
+            "a validly-signed authorization around an oversized nonce must still be refused, \
+             so a counterparty cannot grow the shared cache with unbounded nonce strings"
+        );
+    }
+
+    #[test]
+    fn a_nonce_outside_the_base64url_alphabet_is_refused() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let mut malformed = mint_nonce(&OsTokens);
+        malformed.replace_range(0..1, "/");
+        let auth = authorization_with_nonce(&signer, &sample_challenge(), now, &malformed);
+        let spent = NonceCache::with_ttl(MAX_AGE_SECS);
+
+        assert!(
+            verify(&auth, &spent, now).is_err(),
+            "a nonce containing a character mint_nonce never produces must be refused"
         );
     }
 

--- a/src/server/a2a.rs
+++ b/src/server/a2a.rs
@@ -18,9 +18,9 @@
 //! (skew + single-use replay protection via the host-global
 //! [`NonceCache`](crate::economy::NonceCache)) before anything reaches cognition,
 //! answer a `402` challenge for a priced skill lacking a valid, unspent
-//! [`X402Authorization`](crate::economy::X402Authorization) — refusing outright
-//! a skill id the Agent Card never advertised, which is a different thing from
-//! one it advertises for nothing — sanitize the
+//! [`X402Authorization`](crate::economy::X402Authorization), refuse outright a
+//! skill id the Agent Card never advertised (a different thing from one it
+//! advertises for nothing), sanitize the
 //! counterparty payload (a minimal promptguard pass), and only then append an
 //! [`A2aTaskReceived`](crate::ports::types::CompanyEvent::A2aTaskReceived) event
 //! and run one cycle. A paying customer runs under the same approval gates as any

--- a/src/server/a2a.rs
+++ b/src/server/a2a.rs
@@ -264,11 +264,8 @@ async fn a2a_task(
         match extract_payment(&rpc.params) {
             None => return payment_required(&state, &runtime, pay).await,
             Some(auth) => {
-                if x402::verify(&auth).is_err() {
-                    return ApiError(OpenCompanyError::InvalidRequest(
-                        "x402 payment authorization did not verify".into(),
-                    ))
-                    .into_response();
+                if let Err(err) = x402::verify(&auth, state.x402_nonce(), now_secs()) {
+                    return ApiError(err).into_response();
                 }
                 // Bind the payment to THIS company: the payer must have signed a
                 // `recipient` equal to our own agent id. Without this a
@@ -798,6 +795,50 @@ mod test {
         // The identical signature is rejected on replay.
         let second = app.oneshot(build()).await.unwrap();
         assert_eq!(second.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// The spent-nonce set is the only thing that makes an authorization
+    /// single-use, so a set that cannot answer must stop the sale.
+    #[tokio::test]
+    async fn an_unusable_spent_nonce_set_refuses_a_paid_task() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let runtime = state.registry().sole().unwrap();
+        let our_id = signer_for(dir.path(), &CompanyId::new("acme"))
+            .await
+            .unwrap()
+            .agent_id();
+        state.x402_nonce().poison_for_tests();
+        let app = router().with_state(state);
+
+        let challenge = X402Challenge {
+            amount: "25.00".into(),
+            recipient: our_id,
+            asset: "USDC".into(),
+            network: "solana".into(),
+        };
+        let auth = x402::authorize(&client, &challenge, now_secs());
+        let response = app
+            .oneshot(paid_request(&client, &auth, "x.com"))
+            .await
+            .unwrap();
+
+        assert_ne!(
+            response.status(),
+            StatusCode::OK,
+            "an unreadable spent-nonce set must refuse the payment"
+        );
+        let stored = runtime
+            .events
+            .read_from(runtime.id(), EventSeq::new(0), 10)
+            .await
+            .unwrap();
+        assert!(
+            !stored
+                .iter()
+                .any(|e| matches!(&e.event, CompanyEvent::A2aTaskReceived { .. })),
+            "no task may reach cognition when the payment was refused"
+        );
     }
 
     #[tokio::test]

--- a/src/server/a2a.rs
+++ b/src/server/a2a.rs
@@ -364,14 +364,23 @@ enum SkillCharge<'a> {
 /// A card advertising nothing above zero charges for nothing, so every id on it
 /// is free — including one it does not list. Refusing there would take A2A away
 /// from companies that never opted into pricing.
+///
+/// Manifest validation rejects a duplicate skill id outright, so
+/// `payment_requirements` should never carry two entries for the same
+/// `skill`. If one somehow reaches this card anyway (an older store predating
+/// that check), a priced entry always outranks a free or unparsable one for
+/// the same id — the reverse would let a duplicate free entry waive a price
+/// the company does charge for that skill.
 fn classify_skill<'a>(card: &'a AgentCard, skill: &str) -> SkillCharge<'a> {
-    match card
-        .payment_requirements
-        .iter()
-        .find(|pay| pay.skill_id == skill)
-    {
-        Some(pay) if priced_above_zero(pay) => SkillCharge::Priced(pay),
-        Some(_) => SkillCharge::Free,
+    let matching = || {
+        card.payment_requirements
+            .iter()
+            .filter(|pay| pay.skill_id == skill)
+    };
+
+    match matching().find(|pay| priced_above_zero(pay)) {
+        Some(pay) => SkillCharge::Priced(pay),
+        None if matching().next().is_some() => SkillCharge::Free,
         None if card.payment_requirements.iter().any(priced_above_zero) => SkillCharge::Unknown,
         None => SkillCharge::Free,
     }
@@ -912,6 +921,26 @@ mod test {
         assert!(matches!(
             classify_skill(&AgentCard::default(), "seo.ghost"),
             SkillCharge::Free
+        ));
+    }
+
+    #[test]
+    fn a_duplicate_id_with_a_priced_entry_is_still_charged() {
+        // Manifest validation now rejects this shape outright, but the lookup
+        // itself must stay safe by construction: given both a free and a
+        // priced entry under the same id, in either order, the priced one
+        // must win. Letting the free entry win would waive a price the
+        // company does charge for that skill.
+        let free_first = card_pricing(&[("seo.audit", "0.00"), ("seo.audit", "25.00")]);
+        assert!(matches!(
+            classify_skill(&free_first, "seo.audit"),
+            SkillCharge::Priced(_)
+        ));
+
+        let priced_first = card_pricing(&[("seo.audit", "25.00"), ("seo.audit", "0.00")]);
+        assert!(matches!(
+            classify_skill(&priced_first, "seo.audit"),
+            SkillCharge::Priced(_)
         ));
     }
 

--- a/src/server/a2a.rs
+++ b/src/server/a2a.rs
@@ -845,7 +845,7 @@ mod test {
         // host, submitting a valid authorization against the wrong company's
         // handle would otherwise burn it here and reject the payer's retry
         // against the right company as a replay, even though it was never
-        // accepted anywhere (codex review).
+        // accepted anywhere.
         assert!(
             state
                 .x402_nonce()

--- a/src/server/a2a.rs
+++ b/src/server/a2a.rs
@@ -463,6 +463,24 @@ mod test {
         siwx::header_value(&header)
     }
 
+    /// Builds a SIWX-signed `seo.audit` request carrying `auth` as its payment.
+    /// `site` varies the body so each request has its own SIWX signature.
+    fn paid_request(client: &LocalSigner, auth: &X402Authorization, site: &str) -> Request<Body> {
+        let rpc = JsonRpcRequest::new(
+            "tasks/send",
+            json!({ "skill": "seo.audit", "input": { "site": site }, "payment": auth }),
+        );
+        let body = serde_json::to_vec(&rpc).unwrap();
+        let header = siwx_header(client, "acme", &body, now_secs());
+        Request::builder()
+            .method("POST")
+            .uri("/a2a/acme")
+            .header(AUTHORIZATION, header)
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap()
+    }
+
     fn task_body(skill: &str) -> Vec<u8> {
         serde_json::to_vec(&JsonRpcRequest::new(
             "tasks/send",
@@ -621,6 +639,100 @@ mod test {
             .find(|e| e.kind == "x402.in")
             .expect("x402.in row");
         assert_eq!(inflow.amount_usd, 25.0);
+    }
+
+    /// The same signed authorization, presented on two different tasks. Each
+    /// request carries its own SIWX signature, so the transport replay cache
+    /// admits both; only the payment layer can refuse the second.
+    #[tokio::test]
+    async fn replayed_x402_authorization_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let our_id = signer_for(dir.path(), &CompanyId::new("acme"))
+            .await
+            .unwrap()
+            .agent_id();
+        let app = router().with_state(state);
+
+        let challenge = X402Challenge {
+            amount: "25.00".into(),
+            recipient: our_id,
+            asset: "USDC".into(),
+            network: "solana".into(),
+        };
+        let auth = x402::authorize(&client, &challenge, now_secs());
+
+        let first = paid_request(&client, &auth, "first.example");
+        let response = app.clone().oneshot(first).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "first purchase is served"
+        );
+
+        let second = paid_request(&client, &auth, "second.example");
+        let response = app.oneshot(second).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "the same authorization must not buy a second task"
+        );
+    }
+
+    /// Spending one nonce must not blind the company to the next payment.
+    #[tokio::test]
+    async fn a_freshly_minted_authorization_is_admitted() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let our_id = signer_for(dir.path(), &CompanyId::new("acme"))
+            .await
+            .unwrap()
+            .agent_id();
+        let app = router().with_state(state);
+
+        let challenge = X402Challenge {
+            amount: "25.00".into(),
+            recipient: our_id,
+            asset: "USDC".into(),
+            network: "solana".into(),
+        };
+
+        for site in ["first.example", "second.example"] {
+            let auth = x402::authorize(&client, &challenge, now_secs());
+            let request = paid_request(&client, &auth, site);
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{site} pays its own way");
+        }
+    }
+
+    /// A skill id the card never advertises must not slip past the pricing gate
+    /// on a company that prices its work.
+    #[tokio::test]
+    async fn unknown_skill_id_is_refused_on_a_pricing_card() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let app = router().with_state(state);
+
+        let body = task_body("seo.ghost");
+        let header = siwx_header(&client, "acme", &body, now_secs());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "an unpriced, unadvertised skill must not run for free"
+        );
     }
 
     #[tokio::test]

--- a/src/server/a2a.rs
+++ b/src/server/a2a.rs
@@ -289,12 +289,19 @@ async fn a2a_task(
                 if auth.recipient != our_id {
                     return payment_required(&state, &runtime, pay).await;
                 }
-                let paid = auth.amount.trim().parse::<f64>().unwrap_or(0.0);
-                let price = pay.price.trim().parse::<f64>().unwrap_or(f64::INFINITY);
-                if paid < price {
-                    // Underpaid: re-challenge for the correct amount.
+                let paid = auth.amount.trim().parse::<f64>().ok();
+                let price = pay.price.trim().parse::<f64>().ok();
+                let sufficient = matches!(
+                    (paid, price),
+                    (Some(paid), Some(price))
+                        if paid.is_finite() && price.is_finite() && paid >= price
+                );
+                if auth.asset != pay.asset || auth.network != pay.network || !sufficient {
+                    // Underpaid, unparsable/non-finite, or paid in the wrong
+                    // asset/network: re-challenge for the correct terms.
                     return payment_required(&state, &runtime, pay).await;
                 }
+                let paid = paid.expect("sufficient implies paid is Some and finite");
                 if let Err(err) = x402::verify(&auth, state.x402_nonce(), now_secs()) {
                     return ApiError(err).into_response();
                 }
@@ -900,6 +907,113 @@ mod test {
             "an underpaid authorization must not burn its nonce — the payer \
              cannot fix the amount without re-signing, but nothing here \
              should have consumed it either"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_correctly_priced_authorization_in_the_wrong_asset_is_rechallenged() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let app = router().with_state(state.clone());
+
+        let our_id = signer_for(state.home(), &CompanyId::new("acme"))
+            .await
+            .unwrap()
+            .agent_id();
+        // The payer signs a fully-priced authorization, but in an asset the
+        // card never priced this skill in.
+        let challenge = X402Challenge {
+            amount: "25.00".into(),
+            recipient: our_id,
+            asset: "NOTUSDC".into(),
+            network: "solana".into(),
+        };
+        let auth = x402::authorize(&client, &challenge, now_secs());
+        let rpc = JsonRpcRequest::new(
+            "tasks/send",
+            json!({ "skill": "seo.audit", "input": {}, "payment": auth }),
+        );
+        let body = serde_json::to_vec(&rpc).unwrap();
+        let header = siwx_header(&client, "acme", &body, now_secs());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::PAYMENT_REQUIRED,
+            "a signed payment in the wrong asset must not buy work priced in a different one"
+        );
+        assert!(
+            state
+                .x402_nonce()
+                .check_and_insert(&auth.nonce, now_secs(), auth.timestamp)
+                .expect("nonce cache must still answer"),
+            "the rejected authorization must not have spent its nonce"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_non_finite_amount_is_rechallenged_not_treated_as_paid() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let app = router().with_state(state.clone());
+
+        let our_id = signer_for(state.home(), &CompanyId::new("acme"))
+            .await
+            .unwrap()
+            .agent_id();
+        // `"NaN".parse::<f64>()` succeeds and every comparison against NaN is
+        // false, so a naive `paid < price` underpayment check treats this as
+        // sufficient. It must not be.
+        let challenge = X402Challenge {
+            amount: "NaN".into(),
+            recipient: our_id,
+            asset: "USDC".into(),
+            network: "solana".into(),
+        };
+        let auth = x402::authorize(&client, &challenge, now_secs());
+        let rpc = JsonRpcRequest::new(
+            "tasks/send",
+            json!({ "skill": "seo.audit", "input": {}, "payment": auth }),
+        );
+        let body = serde_json::to_vec(&rpc).unwrap();
+        let header = siwx_header(&client, "acme", &body, now_secs());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::PAYMENT_REQUIRED,
+            "a non-finite claimed amount must never be treated as sufficient payment"
+        );
+        assert!(
+            state
+                .x402_nonce()
+                .check_and_insert(&auth.nonce, now_secs(), auth.timestamp)
+                .expect("nonce cache must still answer"),
+            "the rejected authorization must not have spent its nonce"
         );
     }
 

--- a/src/server/a2a.rs
+++ b/src/server/a2a.rs
@@ -17,8 +17,10 @@
 //! order: resolve a **discoverable** company, verify the SIWX `Authorization`
 //! (skew + single-use replay protection via the host-global
 //! [`NonceCache`](crate::economy::NonceCache)) before anything reaches cognition,
-//! answer a `402` challenge for a priced skill lacking a valid
-//! [`X402Authorization`](crate::economy::X402Authorization), sanitize the
+//! answer a `402` challenge for a priced skill lacking a valid, unspent
+//! [`X402Authorization`](crate::economy::X402Authorization) — refusing outright
+//! a skill id the Agent Card never advertised, which is a different thing from
+//! one it advertises for nothing — sanitize the
 //! counterparty payload (a minimal promptguard pass), and only then append an
 //! [`A2aTaskReceived`](crate::ports::types::CompanyEvent::A2aTaskReceived) event
 //! and run one cycle. A paying customer runs under the same approval gates as any
@@ -251,17 +253,18 @@ async fn a2a_task(
         Err(err) => return err.into_response(),
     };
 
-    // 4. If the requested skill is priced above zero, require a valid x402
-    // authorization. A `0.00` (or unparsable) price is served for free.
-    if let Some(pay) = card.payment_requirements.iter().find(|p| {
-        p.skill_id == skill
-            && p.price
-                .trim()
-                .parse::<f64>()
-                .map(|v| v > 0.0)
-                .unwrap_or(false)
-    }) {
-        match extract_payment(&rpc.params) {
+    // 4. Charge for the requested skill. See `classify_skill` for why an
+    // unadvertised id is not the same answer as a free one.
+    match classify_skill(&card, &skill) {
+        SkillCharge::Unknown => {
+            return ApiError(OpenCompanyError::NotFound(format!(
+                "@{handle} does not offer skill `{}`",
+                sanitize_text(&skill)
+            )))
+            .into_response();
+        }
+        SkillCharge::Free => {}
+        SkillCharge::Priced(pay) => match extract_payment(&rpc.params) {
             None => return payment_required(&state, &runtime, pay).await,
             Some(auth) => {
                 if let Err(err) = x402::verify(&auth, state.x402_nonce(), now_secs()) {
@@ -295,7 +298,7 @@ async fn a2a_task(
                     return ApiError(err).into_response();
                 }
             }
-        }
+        },
     }
 
     // 5. Promptguard: sanitize the counterparty payload before it becomes an
@@ -333,6 +336,54 @@ fn unauthorized(err: &OpenCompanyError) -> Response {
         Json(json!({ "error": err.to_string(), "code": err.code() })),
     )
         .into_response()
+}
+
+/// What a company's Agent Card says about a requested skill id.
+enum SkillCharge<'a> {
+    /// Advertised above zero: the task needs a valid, unspent authorization.
+    Priced(&'a CardPayment),
+    /// Advertised at `0.00`, or at a price this build cannot parse. Served.
+    Free,
+    /// Not advertised at all, by a company that charges for its work. Refused.
+    Unknown,
+}
+
+/// Classifies `skill` against the card's advertised prices.
+///
+/// The three answers are genuinely different and collapsing any two of them
+/// gives work away. `payment_requirements` is a one-to-one projection of the
+/// manifest's `[place].skills`, so an id missing from it is an id the company
+/// never offered — not an id it offers for nothing. Reading "no price found" as
+/// "free" let any unadvertised string buy the whole `tasks/send` path on a
+/// company that prices every skill it does advertise.
+///
+/// An unparsable price stays free deliberately: a company that has misdeclared
+/// its own price has not thereby declared a task unavailable, and the manifest
+/// validator already names the mistake.
+///
+/// A card advertising nothing above zero charges for nothing, so every id on it
+/// is free — including one it does not list. Refusing there would take A2A away
+/// from companies that never opted into pricing.
+fn classify_skill<'a>(card: &'a AgentCard, skill: &str) -> SkillCharge<'a> {
+    match card
+        .payment_requirements
+        .iter()
+        .find(|pay| pay.skill_id == skill)
+    {
+        Some(pay) if priced_above_zero(pay) => SkillCharge::Priced(pay),
+        Some(_) => SkillCharge::Free,
+        None if card.payment_requirements.iter().any(priced_above_zero) => SkillCharge::Unknown,
+        None => SkillCharge::Free,
+    }
+}
+
+/// Whether this requirement names a price the company actually charges.
+fn priced_above_zero(pay: &CardPayment) -> bool {
+    pay.price
+        .trim()
+        .parse::<f64>()
+        .map(|price| price > 0.0)
+        .unwrap_or(false)
 }
 
 /// Builds the `402` challenge naming the price and the company's own address.
@@ -795,6 +846,73 @@ mod test {
         // The identical signature is rejected on replay.
         let second = app.oneshot(build()).await.unwrap();
         assert_eq!(second.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    fn card_pricing(skills: &[(&str, &str)]) -> AgentCard {
+        AgentCard {
+            payment_requirements: skills
+                .iter()
+                .map(|(id, price)| CardPayment {
+                    skill_id: (*id).to_string(),
+                    price: (*price).to_string(),
+                    asset: "USDC".into(),
+                    network: "solana".into(),
+                })
+                .collect(),
+            ..AgentCard::default()
+        }
+    }
+
+    #[test]
+    fn a_priced_skill_is_charged_for() {
+        let card = card_pricing(&[("seo.audit", "25.00")]);
+        assert!(matches!(
+            classify_skill(&card, "seo.audit"),
+            SkillCharge::Priced(_)
+        ));
+    }
+
+    #[test]
+    fn a_zero_price_is_deliberately_free() {
+        let card = card_pricing(&[("seo.audit", "25.00"), ("seo.free", "0.00")]);
+        assert!(matches!(
+            classify_skill(&card, "seo.free"),
+            SkillCharge::Free
+        ));
+    }
+
+    #[test]
+    fn an_unparsable_price_is_still_free() {
+        let card = card_pricing(&[("seo.audit", "25.00"), ("seo.odd", "gratis")]);
+        assert!(matches!(
+            classify_skill(&card, "seo.odd"),
+            SkillCharge::Free
+        ));
+    }
+
+    #[test]
+    fn an_unadvertised_skill_is_unknown_not_free() {
+        let card = card_pricing(&[("seo.audit", "25.00"), ("seo.free", "0.00")]);
+        assert!(matches!(
+            classify_skill(&card, "seo.ghost"),
+            SkillCharge::Unknown
+        ));
+    }
+
+    #[test]
+    fn a_card_that_prices_nothing_charges_for_nothing() {
+        // A company that never opted into pricing keeps serving every id,
+        // including one it does not list — refusing here would take A2A away
+        // from it.
+        let card = card_pricing(&[("seo.free", "0.00")]);
+        assert!(matches!(
+            classify_skill(&card, "seo.ghost"),
+            SkillCharge::Free
+        ));
+        assert!(matches!(
+            classify_skill(&AgentCard::default(), "seo.ghost"),
+            SkillCharge::Free
+        ));
     }
 
     /// The spent-nonce set is the only thing that makes an authorization

--- a/src/server/a2a.rs
+++ b/src/server/a2a.rs
@@ -267,9 +267,17 @@ async fn a2a_task(
         SkillCharge::Priced(pay) => match extract_payment(&rpc.params) {
             None => return payment_required(&state, &runtime, pay).await,
             Some(auth) => {
-                if let Err(err) = x402::verify(&auth, state.x402_nonce(), now_secs()) {
-                    return ApiError(err).into_response();
-                }
+                // Checked against the claimed (not yet verified) fields,
+                // before `x402::verify` spends the nonce below: on a
+                // multi-company host, a correctly-signed authorization
+                // submitted against the wrong company's handle — or one
+                // that underpays — would otherwise burn its nonce on this
+                // re-challenge and could never be resubmitted, even against
+                // the right company or with the right amount. A forged
+                // recipient or amount is still caught by `verify`'s
+                // signature check right after, since those fields are part
+                // of what it signs.
+                //
                 // Bind the payment to THIS company: the payer must have signed a
                 // `recipient` equal to our own agent id. Without this a
                 // counterparty could self-sign an authorization paying anyone
@@ -286,6 +294,9 @@ async fn a2a_task(
                 if paid < price {
                     // Underpaid: re-challenge for the correct amount.
                     return payment_required(&state, &runtime, pay).await;
+                }
+                if let Err(err) = x402::verify(&auth, state.x402_nonce(), now_secs()) {
+                    return ApiError(err).into_response();
                 }
                 // Journal the inbound receipt before doing the work.
                 let entry = LedgerEntry {
@@ -796,7 +807,7 @@ mod test {
     async fn paid_skill_with_wrong_recipient_is_rechallenged() {
         let dir = tempfile::tempdir().unwrap();
         let (state, client) = seeded_state(dir.path()).await;
-        let app = router().with_state(state);
+        let app = router().with_state(state.clone());
 
         // A well-formed, correctly-signed authorization that pays SOMEONE ELSE
         // (a self-dealing payer) must not buy priced work from this company.
@@ -829,6 +840,67 @@ mod test {
 
         // Re-challenged with a 402, not served for free.
         assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+        // And the rejection must not have spent the nonce: on a multi-company
+        // host, submitting a valid authorization against the wrong company's
+        // handle would otherwise burn it here and reject the payer's retry
+        // against the right company as a replay, even though it was never
+        // accepted anywhere (codex review).
+        assert!(
+            state
+                .x402_nonce()
+                .check_and_insert(&auth.nonce, now_secs(), auth.timestamp)
+                .expect("nonce cache must still answer")
+        );
+    }
+
+    #[tokio::test]
+    async fn an_underpaid_authorization_does_not_spend_its_nonce() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let app = router().with_state(state.clone());
+
+        let our_id = signer_for(state.home(), &CompanyId::new("acme"))
+            .await
+            .unwrap()
+            .agent_id();
+        let challenge = X402Challenge {
+            amount: "1.00".into(), // below seo.audit's price
+            recipient: our_id,
+            asset: "USDC".into(),
+            network: "solana".into(),
+        };
+        let auth = x402::authorize(&client, &challenge, now_secs());
+        let rpc = JsonRpcRequest::new(
+            "tasks/send",
+            json!({ "skill": "seo.audit", "input": {}, "payment": auth }),
+        );
+        let body = serde_json::to_vec(&rpc).unwrap();
+        let header = siwx_header(&client, "acme", &body, now_secs());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(
+            state
+                .x402_nonce()
+                .check_and_insert(&auth.nonce, now_secs(), auth.timestamp)
+                .expect("nonce cache must still answer"),
+            "an underpaid authorization must not burn its nonce — the payer \
+             cannot fix the amount without re-signing, but nothing here \
+             should have consumed it either"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Two defects on the inbound A2A paid-task path, both letting a caller take work for free.

**The x402 nonce was never spent.** `verify` checked only the signature over the canonical bytes.
The nonce was signed into the payload and then recorded nowhere — the word appeared in this crate
only in doc comments, one describing it as "single-use". Nothing enforced that. One signed
authorization bought unlimited tasks.

**An unadvertised skill id was served free.** The payment requirement sat inside
`if let Some(pay) = …find(|p| p.skill_id == skill && price > 0.0)`, so a `None` skipped the whole
block. A skill id absent from `payment_requirements` therefore ran free even on a card pricing
every skill it offers. That `None` conflated two different things — *deliberately free* and
*never offered* — so the fix splits them: `classify_skill` returns `Priced` / `Free` / `Unknown`,
and an unknown id on a pricing card is refused. A card that prices nothing still charges for
nothing, and an unparsable price is still free, both deliberately preserved.

**A bounded nonce store alone would have been a band-aid on a timer.** Nothing bounded how old an
authorization could be, so waiting out the store's TTL replayed it. `verify` now also refuses
authorizations older than `MAX_AGE_SECS`, and the store prunes on the same constant — a nonce is
forgotten only once the authorization carrying it is already too old to verify. 600s is twice the
SIWX skew tolerance: a payer at the far edge of tolerated clock offset, plus a
challenge→authorize→resend round trip that in practice takes under a second.

The seam is `verify(auth, spent, now)` — the store and clock are required parameters, so a caller
*cannot* verify without spending. A caller that could is treating the authorization as a bearer
token, which is the bug; making that unconstructible beats documenting it. Mirrors
`siwx::verify(header, …, now, seen)`, the sibling primitive. Signature is checked **before** the
nonce is spent, so observing a payer's nonce and forging a signature cannot burn it.

## API Or Behavior Changes

- A replayed x402 authorization is refused (`400`). Previously it succeeded.
- An x402 authorization older than 10 minutes is refused. Nothing bounded its age before.
- A skill id the Agent Card never advertised returns `404` on a card that prices anything.
  Previously it ran the cycle free.
- A poisoned nonce cache maps to `Store` → `500` and is **permanent for the process lifetime**.
  Fail-closed by design, but it is a standing refusal rather than a transient one — flagged for a
  reviewer. The guarded section touches only a `HashMap` and an `i64`, so poisoning means the
  spent record is untrustworthy and recovering it would mean trusting it.
- Also fixes the SIWX replay path, which previously panicked on a poisoned lock.

## Tests

**Red proof, observed.** The assertions were committed first and run against the pre-fix code, so
the history carries the proof:

- `replayed_x402_authorization_is_refused` — **FAILED, `left: 200, right: 400`.** Same
  authorization, two different tasks; each request carries its own SIWX signature, so the
  transport replay cache admitted both and the second purchase succeeded.
- `unknown_skill_id_is_refused_on_a_pricing_card` — **FAILED, `left: 200, right: 404`.**
  `seo.ghost` ran free on a card pricing `seo.audit` at 25.00.

For assertions that could not exist pre-fix, mutation testing rather than trusting a green:
dropping the "card prices nothing" guard, routing unparsable→Unknown, and disabling the age check
each made the specific test that guards it fail. Two tests are named as proving nothing about the
defect — they are over-blocking guards, not defect proofs.

**Gate correction worth recording**: this code is `#[cfg(feature = "tinyplace")]` at the module
declaration, so `--features openhuman` compiles none of it. A run under that lane reports
`0 passed; 0 failed; 7115 filtered out` and **exits 0** — a vacuous green. `feature-lanes.txt:53`
names `tinyplace` as the lane that runs the whole `--lib` because it gates code across the tree.

- [x] `cargo fmt --check` — 0
- [x] `cargo clippy --locked --no-deps --features tinyplace --all-targets -- -D warnings` — 0
- [x] `cargo test --locked --features tinyplace --lib` — 0 · **4825 passed, 0 failed**
- [x] `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings` — 0

## Documentation

`docs/spec/integrations/tinyplace.md` now states the inbound A2A charging contract: which of the
three skill classes charge, what a replay does, and the age window.

## Related

Commits 1–3 are individually red by design — the assertions land first and later commits turn
them green. The branch tip is fully green. Squash them if red intermediate commits are unwanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment authorizations are now single-use and expire after ten minutes.
  * Fresh payment requests are accepted, while replayed or expired authorizations are refused.
  * Requests for skills not advertised by a priced service now return a 404 response.

* **Bug Fixes**
  * Invalid, misdirected, underpaid, non-finite, or mismatched payment authorizations no longer consume authorizations.
  * Duplicate skill IDs in service manifests are now rejected.
  * Malformed payment nonces and verification failures are handled safely.

* **Documentation**
  * Updated guidance covers skill availability, authorization expiry, and single-use payments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->