### PR TITLE
fix(harness): gate the MCP registry tools on an explicit grant

### DIFF
--- a/docs/modules/mcp.md
+++ b/docs/modules/mcp.md
@@ -282,13 +282,26 @@ An unreadable store or a directory that will not answer resolves to "no
 installs", and `GET …/mcp/servers` still returns the declared list. The declared
 half is what governs what the agents reach, so it is the half that must survive.
 
-### Per-agent scoping does not apply to installs
+### Per-agent scoping applies to installs, gated by an explicit grant
 
-`harness::built_in::build` pushes the registry bridge tools onto **every**
-agent's belt with no grant check, so every teammate can call every installed
-server. Issue #1270 leaves that in place deliberately and makes it visible: a
-registry row's `reachableBy` lists the whole roster (and nobody when the install
-is disabled) rather than claiming a scope the harness does not apply.
+`harness::built_in::build` wires the registry bridge tools
+(`mcp_registry_list_tools` / `mcp_registry_tool_call`) onto an agent's belt only
+when its effective grants explicitly include `mcp_registry` (or a
+`mcp_registry.<sub>` grant) — see
+[`grants_mcp_registry_explicit`](../../src/company/types.rs). A catch-all `*`
+does **not** confer it, the same rule as `composio`/`media`/`search`: the
+registry pair reaches any server the company has installed and connected,
+addressed at call time by a bare `server_id`, with none of the declared
+bridge's per-server scoping. Granted but no registry home configured wires
+nothing (fail-closed) rather than erroring.
+
+A registry row's `reachableBy` has not caught up to this gate yet: it still
+lists the whole roster (and nobody when the install is disabled), the shape it
+had when the tools were wired unconditionally. An agent without the
+`mcp_registry` grant can therefore appear as a reacher on the Connections
+screen even though the harness will not wire it the tools — narrowing
+`reachableBy` to agents holding the grant is a tracked follow-up, not done
+here.
 
 ## Which builds can honour a server (issue #567)
 

--- a/frontend/src/lib/agent.ts
+++ b/frontend/src/lib/agent.ts
@@ -384,6 +384,11 @@ export function companyCovers(allow: string[], glob: string): boolean {
   if (literal === "media" || literal.startsWith("media.")) {
     return grantsExplicit(allow, "media") && grantsExplicit([glob], "media");
   }
+  if (literal === "mcp_registry" || literal.startsWith("mcp_registry.")) {
+    return (
+      grantsExplicit(allow, "mcp_registry") && grantsExplicit([glob], "mcp_registry")
+    );
+  }
   if (literal === "composio" || literal.startsWith("composio.")) {
     return grantsExplicit(allow, "composio") && grantsExplicit([glob], "composio");
   }

--- a/frontend/test/unit/agent-tool-grants.test.ts
+++ b/frontend/test/unit/agent-tool-grants.test.ts
@@ -102,9 +102,25 @@ describe("companyCovers", () => {
     expect(companyCovers(["*"], "hosting.deploy")).toBe(false);
     expect(companyCovers(["*"], "paypal")).toBe(false);
     expect(companyCovers(["*"], "paypal.wallet")).toBe(false);
+    expect(companyCovers(["*"], "mcp_registry")).toBe(false);
+    expect(companyCovers(["*"], "mcp_registry.notion")).toBe(false);
     expect(companyCovers(["*"], "mcp:*")).toBe(false);
     expect(companyCovers(["*"], "mcp:notion")).toBe(false);
     expect(companyCovers(["*"], "mcp*")).toBe(false);
+  });
+
+it("covers the MCP registry only on an explicit grant", () => {
+    // The host gates `mcp_registry_list_tools` / `mcp_registry_tool_call` on
+    // `grants_mcp_registry_explicit`, so a catch-all must not preview them as
+    // covered — the card would render the saved grant effective while the
+    // tools stay unwired.
+    expect(companyCovers(["mcp_registry"], "mcp_registry")).toBe(true);
+    expect(companyCovers(["mcp_registry"], "mcp_registry.notion")).toBe(true);
+    expect(companyCovers(["mcp_registry.notion"], "mcp_registry.notion")).toBe(true);
+    // A glued star is not a spelling the wiring predicate accepts.
+    expect(companyCovers(["mcp_registry"], "mcp_registry*")).toBe(false);
+    // The per-server `mcp:` bridge is a different namespace and confers nothing here.
+    expect(companyCovers(["mcp:*"], "mcp_registry")).toBe(false);
   });
 
   it("treats the bare workspace grant as explicit-only, not a catch-all read", () => {

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -193,8 +193,9 @@ pub use types::{
     PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan, Policy, Schedule, Skill, TIERS,
     TOOL_PROVIDERS, Tools, creation_default_grants, grants_chargebee_explicit,
     grants_composio_explicit, grants_confer_native, grants_files_or_docs, grants_hosting_explicit,
-    grants_media_explicit, grants_paypal_explicit, grants_search_explicit,
-    grants_workspace_write_explicit, native_capability_namespaces, orchestrator_id,
+    grants_mcp_registry_explicit, grants_media_explicit, grants_paypal_explicit,
+    grants_search_explicit, grants_workspace_write_explicit, native_capability_namespaces,
+    orchestrator_id,
 };
 pub use workflow_file::{
     STAGELESS_SCHEDULE_REFUSAL, STAGELESS_WORKFLOW_NOTICE, UNDELIVERABLE_SCHEDULE_REFUSAL,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -196,6 +196,38 @@ pub fn grants_composio_explicit(grants: &[String]) -> bool {
         .any(|grant| grant == "composio" || grant.starts_with("composio."))
 }
 
+/// Whether a tool-grant list **explicitly** grants the `mcp_registry`
+/// namespace — the operator-installed MCP registry surface
+/// (`mcp_registry_list_tools` / `mcp_registry_tool_call`).
+///
+/// This is distinct from the per-server `mcp:<name>` bridge
+/// ([`crate::runtime::tools::grants_cover_server`]): the bridge reaches only
+/// the servers a company declared in its manifest/`mcp.json` and an agent was
+/// scoped to by name, while the registry pair reaches **any** server the
+/// company has installed and connected through the console, addressed at call
+/// time by a bare `server_id` argument the tool itself accepts.
+///
+/// Like [`grants_composio_explicit`], the catch-all `*` does **not** grant it:
+/// `mcp_registry_tool_call` invokes an arbitrary tool on any connected server
+/// with no per-server scoping — the same "reaches a third party, moves a real
+/// side effect" shape as Composio, just against whichever servers happen to be
+/// installed rather than a fixed toolkit list. `mcp_registry_list_tools` (a
+/// read-only schema listing over the same registry) rides the SAME grant as
+/// the mutating tool rather than a split one of its own: every existing
+/// third-party-reaching family already bundles its read-only discovery tools
+/// under the single grant that covers the mutating ones (`composio_list_tools`
+/// sits behind the same `composio` grant as `composio_execute`), and splitting
+/// here would only recreate that shape with no sibling precedent for it.
+/// Matches the bare `mcp_registry` grant or any `mcp_registry.*` sub-grant.
+/// Lives here (always compiled) so both the feature-gated harness wiring
+/// (`build::build_agent`) and the manifest-narrowing gate
+/// (`runtime::builder::allow_covers`) key off one source of truth.
+pub fn grants_mcp_registry_explicit(grants: &[String]) -> bool {
+    grants
+        .iter()
+        .any(|grant| grant == "mcp_registry" || grant.starts_with("mcp_registry."))
+}
+
 /// Whether a tool-grant list **explicitly** grants the `chargebee` billing
 /// namespace (issue #788).
 ///
@@ -1906,6 +1938,34 @@ mod test {
         assert!(!grants_composio_explicit(&[]));
         // A substring match must not count as the composio namespace.
         assert!(!grants_composio_explicit(&["composiotools".into()]));
+    }
+
+    /// The operator-installed `mcp_registry` surface is granted ONLY by an
+    /// explicit `mcp_registry` / `mcp_registry.*` grant — never by the
+    /// catch-all `*`. `mcp_registry_tool_call` invokes an arbitrary tool on any
+    /// server the company has installed and connected, with no per-server
+    /// scoping, so a broadly-permissioned company must still opt into it by
+    /// name.
+    #[test]
+    fn mcp_registry_grant_requires_explicit_namespace_not_wildcard() {
+        assert!(grants_mcp_registry_explicit(&["mcp_registry".into()]));
+        assert!(grants_mcp_registry_explicit(
+            &["mcp_registry.notion".into()]
+        ));
+        assert!(grants_mcp_registry_explicit(&[
+            "web.*".into(),
+            "mcp_registry".into()
+        ]));
+        // The catch-all `*` must NOT grant the registry surface.
+        assert!(!grants_mcp_registry_explicit(&["*".into()]));
+        assert!(!grants_mcp_registry_explicit(&["web.*".into()]));
+        assert!(!grants_mcp_registry_explicit(&[]));
+        // The per-server bridge namespace (`mcp:<name>`) is a different grant
+        // and must not be mistaken for it.
+        assert!(!grants_mcp_registry_explicit(&["mcp:notion".into()]));
+        assert!(!grants_mcp_registry_explicit(&["mcp:*".into()]));
+        // A substring match must not count as the registry namespace.
+        assert!(!grants_mcp_registry_explicit(&["mcp_registryextra".into()]));
     }
 
     /// The `[tools.composio]` sub-section parses its toolkit allowlist and an

--- a/src/harness/built_in/build.rs
+++ b/src/harness/built_in/build.rs
@@ -345,20 +345,49 @@ pub fn build_agent(
             deps.store.clone(),
         )));
     }
+    // Installed-MCP-registry surface (`mcp_registry_list_tools` /
+    // `mcp_registry_tool_call`) — distinct from the per-server `mcp:<name>`
+    // bridge below, and reaching further: `mcp_registry_tool_call` invokes an
+    // arbitrary tool on ANY server the company has installed and connected,
+    // addressed at call time by a bare `server_id` argument, with none of the
+    // bridge's per-server grant scoping. Two hard gates before either tool is
+    // wired, following the `composio`/`media`/`search` precedent above:
+    //
+    //  1. an **EXPLICIT** `mcp_registry` grant
+    //     (`grants_mcp_registry_explicit`) — the catch-all `*` does NOT confer
+    //     it, for the same reason it does not confer `composio`: this reaches
+    //     third-party servers and can mutate them, so a broadly-permissioned
+    //     company must still opt in by name.
+    //  2. a configured registry store (`deps.mcp_home`) — the store an install
+    //     writes through. Granted-but-unconfigured wires nothing and warns
+    //     (fail-closed), matching every other explicit namespace in this file.
+    //
+    // `mcp_registry_list_tools` (read-only schema discovery over the same
+    // registry) rides the SAME grant as the mutating call tool rather than a
+    // narrower one of its own — see `grants_mcp_registry_explicit`'s doc
+    // comment for why: every other third-party-reaching family already bundles
+    // its read-only discovery tools under the one grant that covers the
+    // mutating ones, and OpenHuman's own tool description frames the two as a
+    // single discover-then-call workflow.
     #[cfg(feature = "mcp")]
-    {
-        // These read the installed-server registry, so installs and lifecycle
-        // changes are visible without rebuilding agents. They take the config
-        // that selects the store now rather than reading a process global —
-        // hand them this company's own, the one REST writes through.
-        if let Some(mcp_home) = deps.mcp_home.clone() {
-            let config = std::sync::Arc::new(crate::harness::mcp::McpRuntime::config_for(mcp_home));
-            tools.push(Box::new(
-                oh::mcp::registry::tools::McpRegistryListToolsTool::new(config.clone()),
-            ));
-            tools.push(Box::new(
-                oh::mcp::registry::tools::McpRegistryToolCallTool::new(config),
-            ));
+    if crate::company::grants_mcp_registry_explicit(grants) {
+        match deps.mcp_home.clone() {
+            Some(mcp_home) => {
+                let config =
+                    std::sync::Arc::new(crate::harness::mcp::McpRuntime::config_for(mcp_home));
+                tools.push(Box::new(
+                    oh::mcp::registry::tools::McpRegistryListToolsTool::new(config.clone()),
+                ));
+                tools.push(Box::new(
+                    oh::mcp::registry::tools::McpRegistryToolCallTool::new(config),
+                ));
+            }
+            None => tracing::warn!(
+                company = %company,
+                agent = %manifest_agent.id,
+                "[build] agent explicitly grants `mcp_registry` but no MCP registry home is \
+                 configured; mcp_registry tools NOT wired (fail-closed)"
+            ),
         }
     }
 
@@ -2724,24 +2753,14 @@ mod tests {
     /// curated exec subset (shell / code / web) plus the intrinsic memory + file
     /// tools; it contains NO delegation tool and NO deferred family, and — the
     /// #238 addition — no `web_search`, because a bare `*` does not confer the
-    /// `search` grant.
-    ///
-    /// **Feature-aware (issue #297).** The belt genuinely differs by feature
-    /// set: `#[cfg(feature = "mcp")]` pushes two `mcp_registry_*` tools
-    /// unconditionally in `build_agent`, so a flat literal was *wrong* under
-    /// `--features openhuman,mcp` — the combination a full local build
-    /// and the shipped tenant image both use, and which no CI lane ran. The pin
-    /// was therefore failing unseen on `main`. Extending the array
-    /// unconditionally would only move the failure onto plain
-    /// `--features openhuman`, which CI *does* run, so the fix has to branch.
-    /// Composing the expectation from the same `cfg` the wiring uses keeps the
-    /// two from drifting again.
+    /// `search` grant. Nor does it contain `mcp_registry_list_tools` /
+    /// `mcp_registry_tool_call`, for the identical reason: those two ride the
+    /// explicit `mcp_registry` grant, never the wildcard — see the
+    /// `mcp_registry_tools_are_wired_only_by_explicit_grant` test below for the
+    /// belt a company that names that grant actually receives.
     #[test]
     fn dispatched_desk_agent_tool_belt_is_pinned() {
         let names = built_tool_names(&["*"], false);
-        // `mut` is only used by the `mcp` arm below; without the feature the
-        // literal is already the whole expectation.
-        #[cfg_attr(not(feature = "mcp"), allow(unused_mut))]
         let mut expected = vec![
             "apply_patch",
             "csv_export",
@@ -2776,18 +2795,125 @@ mod tests {
         // belt now — including a company with no skills source of its own.
         expected.extend(["describe_skill", "list_skills", "read_skill_resource"]);
         expected.sort();
-        // Mirrors the `#[cfg(feature = "mcp")]` push in `build_agent`. These two
-        // are intrinsic (unmapped by `namespace_of`), so no grant gates them:
-        // the feature plus a configured `HarnessDeps::mcp_home` is the whole
-        // condition. The home is what selects the company's own registry store,
-        // and a tool built without it would read a different one.
-        #[cfg(feature = "mcp")]
-        {
-            expected.push("mcp_registry_list_tools");
-            expected.push("mcp_registry_tool_call");
-            expected.sort();
-        }
         assert_eq!(names, expected, "dispatched desk belt drifted: {names:?}");
+    }
+
+    /// The three gate states of the `mcp_registry` surface, mirroring
+    /// [`web_search_is_wired_only_by_explicit_grant_and_credential`].
+    ///
+    /// The load-bearing row is the first: a broad `*` grant does **not** wire
+    /// either `mcp_registry_list_tools` or `mcp_registry_tool_call`, even with
+    /// a configured registry home (`pin_deps` always sets one). Before this
+    /// gate existed, both tools were pushed unconditionally whenever
+    /// `deps.mcp_home` was set — this row is the regression check for that.
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn mcp_registry_tools_are_wired_only_by_explicit_grant() {
+        const REGISTRY_TOOLS: [&str; 2] = ["mcp_registry_list_tools", "mcp_registry_tool_call"];
+
+        // No grant at all → absent.
+        let ungranted = built_tool_names(&[], false);
+        for tool in REGISTRY_TOOLS {
+            assert!(
+                !ungranted.contains(&tool.to_string()),
+                "no grant must mean no `{tool}`: {ungranted:?}"
+            );
+        }
+
+        // `*` (with a configured home) → still absent. The wildcard never
+        // confers a third-party-reaching, mutating surface.
+        let wildcard = built_tool_names(&["*"], false);
+        for tool in REGISTRY_TOOLS {
+            assert!(
+                !wildcard.contains(&tool.to_string()),
+                "a bare `*` must NOT confer `{tool}`: {wildcard:?}"
+            );
+        }
+
+        // An unrelated grant → absent.
+        let unrelated = built_tool_names(&["web.*"], false);
+        for tool in REGISTRY_TOOLS {
+            assert!(
+                !unrelated.contains(&tool.to_string()),
+                "an unrelated grant must not confer `{tool}`: {unrelated:?}"
+            );
+        }
+
+        // Explicit `mcp_registry` grant, with a configured home → BOTH tools,
+        // together — list is never conferred without call, or vice versa.
+        let granted = built_tool_names(&["mcp_registry"], false);
+        for tool in REGISTRY_TOOLS {
+            assert!(
+                granted.contains(&tool.to_string()),
+                "an explicit `mcp_registry` grant must wire `{tool}`: {granted:?}"
+            );
+        }
+
+        // The sub-grant form works the same way `search.web` / `composio.gmail`
+        // do.
+        let sub_granted = built_tool_names(&["mcp_registry.notion"], false);
+        for tool in REGISTRY_TOOLS {
+            assert!(
+                sub_granted.contains(&tool.to_string()),
+                "`mcp_registry.notion` must wire `{tool}`: {sub_granted:?}"
+            );
+        }
+    }
+
+    /// Explicit `mcp_registry` grant, NO configured registry home → absent,
+    /// fail-closed — matching every other explicit namespace's
+    /// granted-but-uncredentialed shape (`media`, `composio`, `chargebee`,
+    /// `paypal`, `hosting`, `search`).
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn mcp_registry_tools_fail_closed_with_no_registry_home() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut deps = pin_deps(dir.path().to_path_buf());
+        deps.mcp_home = None;
+        let manifest_agent = ManifestAgent {
+            global: false,
+            id: "desk".to_string(),
+            role: "Desk Lead".to_string(),
+            name: None,
+            description: None,
+            tier: None,
+            harness: None,
+            tools: None,
+            delegates_to: Vec::new(),
+            context: None,
+            budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
+            model: None,
+        };
+        let policy = ApprovalPolicy::new(&Policy::default(), None);
+        let grants: Vec<String> = vec!["mcp_registry".to_string()];
+        let agent = build_agent(
+            &CompanyId::new("acme"),
+            "Acme",
+            &manifest_agent,
+            policy,
+            &deps,
+            &grants,
+            &[],
+            &[],
+            None,
+            false,
+        )
+        .expect("agent builds");
+        let names: Vec<String> = agent.tools().iter().map(|t| t.name().to_string()).collect();
+        assert!(
+            !names.contains(&"mcp_registry_list_tools".to_string()),
+            "granted-but-unconfigured must not wire `mcp_registry_list_tools`: {names:?}"
+        );
+        assert!(
+            !names.contains(&"mcp_registry_tool_call".to_string()),
+            "granted-but-unconfigured must not wire `mcp_registry_tool_call`: {names:?}"
+        );
     }
 
     #[test]

--- a/src/harness/built_in/confine.rs
+++ b/src/harness/built_in/confine.rs
@@ -253,11 +253,11 @@ pub fn confined_persona(company_name: &str, confinement: &Confinement) -> String
 /// Builds the ephemeral agent a confined turn runs on.
 ///
 /// Deliberately **not** [`build_agent`](crate::harness::build::build_agent) with
-/// empty grants: that path wires the intrinsic memory tools and (under the `mcp`
-/// feature) the MCP registry tools onto every agent regardless of grants, which
-/// is exactly the company reach this turn must not have. Nothing is cached — the
-/// agent is built per turn and dropped with it, so a confined turn cannot
-/// accumulate state that a later one reads.
+/// empty grants: that path wires the intrinsic memory tools onto every agent
+/// regardless of grants, and even an empty-grants call still gets the approval,
+/// thread-read, and escalate-to-human tools — reach this turn must not have.
+/// Nothing is cached — the agent is built per turn and dropped with it, so a
+/// confined turn cannot accumulate state that a later one reads.
 pub fn build_confined_agent(
     company: &CompanyId,
     company_name: &str,

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -3801,9 +3801,22 @@ pub(crate) fn effective_policy(manifest: &Policy, override_: Option<&PolicyOverr
 /// on `[tools]` exists to prevent. `media` is absent for the same reason: it
 /// spends real money and has no connect page to be dead-ended on.
 ///
+/// `mcp_registry` joins the list for the same reason `composio` is in it: the
+/// registry's own install form (`McpRegistryBrowser`) is the credential step —
+/// some servers ask for one, some do not, but installing is always the
+/// deliberate act the grant is the second half of — and without an entry here
+/// a hosted tenant, whose manifest is a read-only boot snapshot, could install
+/// a registry server no agent could ever be granted access to.
+///
 /// Sorted, so the console's own ordering is not a second source of truth.
-pub const CONSOLE_GRANTABLE_NAMESPACES: [&str; 5] =
-    ["chargebee", "composio", "hosting", "paypal", "search"];
+pub const CONSOLE_GRANTABLE_NAMESPACES: [&str; 6] = [
+    "chargebee",
+    "composio",
+    "hosting",
+    "mcp_registry",
+    "paypal",
+    "search",
+];
 
 /// Whether `namespace` is one the console is allowed to grant.
 pub fn console_grantable(namespace: &str) -> bool {

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -296,6 +296,10 @@ pub(crate) fn allow_covers(allow: &[String], tool: &str) -> bool {
         return crate::company::grants_search_explicit(allow)
             && crate::company::grants_search_explicit(&[tool.to_string()]);
     }
+    if literal == "mcp_registry" || literal.starts_with("mcp_registry.") {
+        return crate::company::grants_mcp_registry_explicit(allow)
+            && crate::company::grants_mcp_registry_explicit(&[tool.to_string()]);
+    }
 
     // MCP grants use a colon namespace, so `mcp:*` is the explicit opt-in for
     // an agent asking for all company servers. A bare `*` must not confer it.
@@ -5430,6 +5434,9 @@ mod test {
                 "search.web",
                 "mcp:*",
                 "mcp*",
+                "mcp_registry",
+                "mcp_registry.*",
+                "mcp_registry.notion",
             ] {
                 assert!(
                     !allow_covers(&allow, grant),
@@ -5459,6 +5466,7 @@ mod test {
                 "paypal",
                 "search",
                 "mcp:*",
+                "mcp_registry",
                 "workspace",
             ]);
             for grant in [
@@ -5481,6 +5489,9 @@ mod test {
                 "search.*",
                 "search.web",
                 "mcp:*",
+                "mcp_registry",
+                "mcp_registry.*",
+                "mcp_registry.notion",
                 "workspace",
                 "workspace.write",
             ] {
@@ -5522,6 +5533,10 @@ mod test {
             assert!(allow_covers(&strings(&["search"]), "search.web"));
             assert!(allow_covers(&strings(&["media"]), "media.image"));
             assert!(allow_covers(&strings(&["chargebee"]), "chargebee.read"));
+            assert!(allow_covers(
+                &strings(&["mcp_registry"]),
+                "mcp_registry.notion"
+            ));
             assert!(
                 !allow_covers(&strings(&["docs"]), "docs.read"),
                 "ordinary namespaces keep the unstarred-grant exact-match rule"
@@ -5547,6 +5562,7 @@ mod test {
                 "hosting",
                 "paypal",
                 "mcp:*",
+                "mcp_registry",
             ]);
             for grant in [
                 "search*",
@@ -5558,6 +5574,7 @@ mod test {
                 "hosting*",
                 "paypal*",
                 "mcp*",
+                "mcp_registry*",
             ] {
                 assert!(
                     !allow_covers(&allow, grant),
@@ -5573,13 +5590,14 @@ mod test {
         /// exact write token, and `mcp:notion*` is a colon-scoped prefix.
         #[test]
         fn a_separator_broken_opt_in_request_stays_covered() {
-            let allow = strings(&["search", "workspace", "media", "mcp:*"]);
+            let allow = strings(&["search", "workspace", "media", "mcp:*", "mcp_registry"]);
             assert!(allow_covers(&allow, "search.*"));
             assert!(allow_covers(&allow, "search.web*"));
             assert!(allow_covers(&allow, "workspace.write"));
             assert!(allow_covers(&allow, "media.*"));
             assert!(allow_covers(&allow, "media.image*"));
             assert!(allow_covers(&allow, "mcp:notion*"));
+            assert!(allow_covers(&allow, "mcp_registry.notion*"));
         }
 
         /// Runs the three-level narrowing over `&str` slices, so each case below

--- a/src/server/ops/tool_grants.rs
+++ b/src/server/ops/tool_grants.rs
@@ -551,7 +551,14 @@ mod tests {
         assert_eq!(body["added"], json!([]));
         assert_eq!(
             body["grantable"],
-            json!(["chargebee", "composio", "hosting", "paypal", "search"])
+            json!([
+                "chargebee",
+                "composio",
+                "hosting",
+                "mcp_registry",
+                "paypal",
+                "search"
+            ])
         );
         assert!(body["setBy"].is_null());
     }
@@ -597,6 +604,42 @@ mod tests {
         );
         assert!(
             crate::company::grants_chargebee_explicit(&record.effective_tool_allow()),
+            "and so must the effective list"
+        );
+    }
+
+    /// `mcp_registry` is grantable here too (a hosted tenant, whose manifest
+    /// is a read-only boot snapshot, has no other way to confer it once the
+    /// harness starts requiring the explicit grant), and the grant reaches the
+    /// same reader the harness gate uses.
+    #[tokio::test]
+    async fn granting_mcp_registry_is_visible_to_the_harness_grant_check() {
+        let dir = home();
+        let state = state(dir.path()).await;
+        let (status, body) = call(
+            &state,
+            "PUT",
+            URI,
+            Some(json!({"namespace": "mcp_registry"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["allow"], json!(["*", "search", "mcp_registry"]));
+        assert_eq!(body["added"], json!(["mcp_registry"]));
+
+        let store = FsCompanyStore::new(dir.path().to_path_buf());
+        let record = store
+            .load(&CompanyId::new("acme"))
+            .await
+            .unwrap()
+            .expect("the company is stored");
+        assert!(
+            crate::company::grants_mcp_registry_explicit(&record.manifest.tools.allow),
+            "the stored manifest must grant it: {:?}",
+            record.manifest.tools.allow
+        );
+        assert!(
+            crate::company::grants_mcp_registry_explicit(&record.effective_tool_allow()),
             "and so must the effective list"
         );
     }


### PR DESCRIPTION
## Summary

`build_agent` pushed `mcp_registry_list_tools` and `mcp_registry_tool_call` onto **every** agent
whenever an MCP home was configured, with no grant check and no gateable namespace.
`mcp_registry_tool_call` invokes an arbitrary tool on any MCP server the company has connected, so
every agent held that reach unconditionally.

This was doubly wrong because the sibling families are already explicit-grant-only — a bare `*`
does not confer `media`, `composio`, `chargebee`, `paypal`, `hosting`, `search` or
`workspace.write`. The registry pair was simply never brought under that discipline.

**The repository's own test asserted the bug was correct behaviour.** On `main`,
`dispatched_desk_agent_tool_belt_is_pinned` contained:

```rust
expected.push("mcp_registry_list_tools");
expected.push("mcp_registry_tool_call");
```

— pinning, under a bare `*` grant, that both tools belong in a dispatched desk agent's belt. That
is the defect written down as a passing assertion and protected against regression. It needed no
manufactured red proof; the checked-in test *was* the proof, and this PR inverts it.

**A second leak, one layer up.** `allow_covers` in `runtime/builder.rs` narrows an agent's own
`tools` request against the company `[tools].allow` list. Without a branch there, a company with
`allow = ["*"]` and an agent requesting `tools = ["mcp_registry"]` fell through to the generic glob
matcher, which treats `*` as universal — so the request survived narrowing and reached
`build_agent`'s grants even though the allow-list never named the namespace. Gating only at
`build.rs` would have left the wildcard defeating the opt-in a layer above. One four-line branch
mirroring the `search`/`chargebee` branches immediately above it.

**Read and call are gated as one pair, deliberately.** No sibling family in this codebase splits
discovery from invocation — `composio_list_tools` sits behind the same grant as `composio_execute`
— and the vendored tool's own description frames them as one workflow: *"Use this to discover what
a connected server can do before calling `mcp_registry_tool_call`."* Splitting would invent a shape
with no precedent. The reasoning is recorded on `grants_mcp_registry_explicit`'s doc comment.

**Fail-closed by withholding, not refusing at call.** The gate is at construction: an ungranted
agent's tool vector never contains either name, matching how every other explicit namespace
behaves. There is no call-time denial because there is nothing to call.

## API Or Behavior Changes

An agent that previously received both MCP registry tools under a bare `*` grant no longer does.
A company must name `mcp_registry` explicitly in `[tools].allow`, and the agent must request it.
Any roster relying on the wildcard to reach a connected MCP server needs that entry added.

A stale doc comment claiming the pair is wired unconditionally is removed.

## Tests

53 pass under `--features openhuman,mcp`. Coverage: the three gate states (no grant, bare `*`,
explicit grant), the fail-closed case where an explicit grant exists but no registry home is
configured, and five `allow_covers` table rows for the narrowing layer.

**Red proof**: the pre-existing pinned belt test, described above — the bug encoded as a passing
assertion, verifiable in this PR's diff against `main`.

- [x] `cargo fmt --check` — 0
- [x] `cargo clippy --locked --no-deps --features openhuman,mcp --all-targets -- -D warnings` — 0
- [x] `cargo test --locked --features openhuman,mcp --lib` — 0 · 53 passed, 0 failed

## Documentation

Doc comments on `grants_mcp_registry_explicit` and in `build.rs` state why the pair is explicit
and why read and call share one grant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * MCP Registry access now requires an explicit `mcp_registry` or `mcp_registry.*` grant.
  * Broad wildcard permissions no longer automatically include MCP Registry access.
  * Per-server MCP permissions do not grant MCP Registry access.

* **Bug Fixes**
  * MCP Registry tools are unavailable when no registry is configured or authorization is incomplete, preventing unintended access.
  * Registry tools are now exposed only when both explicit access and a configured registry are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->