### PR TITLE
test: pin route-principal authority matrix

### DIFF
--- a/scripts/ci/assert-auth-matrix.sh
+++ b/scripts/ci/assert-auth-matrix.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+# Naming the target explicitly makes a missing/disabled integration target an
+# error instead of Cargo's successful "zero tests selected" failure mode.
+cargo test --locked --features openhuman --test auth_matrix

--- a/src/server/test_support.rs
+++ b/src/server/test_support.rs
@@ -5,9 +5,19 @@
 //! the one place that mints it, so the shape of "an authenticated request" is
 //! stated once rather than in every test module.
 
+// Integration targets include this source directly, so the library-test crate
+// cannot see every helper consumer when it performs dead-code analysis.
+#![allow(dead_code)]
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
 use crate::AppState;
 use crate::ports::types::CompanyId;
 use crate::ports::{SessionRecord, UserRecord, UserRole, UserStatus, generate_id, now_millis};
+use crate::server::platform_auth::{
+    PlatformAuthConfig, PlatformClaims, PlatformVerifier, StaticPlatformVerifier,
+};
 use crate::server::users::cookie::session_cookie_name;
 use crate::server::users::token::{OsTokens, mint_session_token, sha256_hex};
 
@@ -139,6 +149,62 @@ pub(crate) async fn seed_fixed_admin(state: &AppState, company: &str) {
 /// Same safety property as [`FIXED_TEST_TOKEN`]: only its hash is stored.
 pub(crate) const FIXED_MEMBER_TEST_TOKEN: &str = "fixed-test-member-session-token-not-a-secret";
 
+/// A fixed session token for a test principal that must replace its password.
+///
+/// Only the hash is stored, with the same safety boundary as
+/// [`FIXED_TEST_TOKEN`]: it authenticates solely against the disposable store
+/// a test has just seeded.
+pub(crate) const FIXED_TEMP_PASSWORD_TEST_TOKEN: &str =
+    "fixed-test-temp-password-session-token-not-a-secret";
+
+/// Fixed bearer literals for tests that need both tenant ownership outcomes and
+/// the platform-wide machine principal.
+pub(crate) const FIXED_TENANT_OWNER_TEST_TOKEN: &str = "fixed-test-tenant-owner-token-not-a-secret";
+pub(crate) const FIXED_TENANT_NON_OWNER_TEST_TOKEN: &str =
+    "fixed-test-tenant-non-owner-token-not-a-secret";
+pub(crate) const FIXED_PLATFORM_TEST_TOKEN: &str = "fixed-test-platform-token-not-a-secret";
+
+/// A verifier for the three fixed machine principals above.
+///
+/// Tenant literals stand in only for claims that a production verifier has
+/// already authenticated. The platform literal still passes through the real
+/// exact-secret verifier. This object belongs only in an AppState whose
+/// companies and ownership rows were created inside a disposable test root.
+struct FixedPrincipalVerifier {
+    platform: StaticPlatformVerifier,
+}
+
+impl FixedPrincipalVerifier {
+    fn new() -> Self {
+        Self {
+            platform: StaticPlatformVerifier::new(FIXED_PLATFORM_TEST_TOKEN),
+        }
+    }
+
+    fn tenant_claims(tenant: &str) -> PlatformClaims {
+        PlatformClaims {
+            tenant: tenant.to_string(),
+            scopes: HashSet::from(["operator".to_string()]),
+            companies: None,
+        }
+    }
+}
+
+impl PlatformVerifier for FixedPrincipalVerifier {
+    fn verify(&self, bearer: &str) -> std::result::Result<PlatformClaims, crate::OpenCompanyError> {
+        match bearer {
+            FIXED_TENANT_OWNER_TEST_TOKEN => Ok(Self::tenant_claims("tenant:matrix-owner")),
+            FIXED_TENANT_NON_OWNER_TEST_TOKEN => Ok(Self::tenant_claims("tenant:matrix-outsider")),
+            _ => self.platform.verify(bearer),
+        }
+    }
+}
+
+/// Platform-auth configuration carrying the fixed machine principals.
+pub(crate) fn fixed_principal_platform_auth() -> PlatformAuthConfig {
+    PlatformAuthConfig::new(Arc::new(FixedPrincipalVerifier::new()))
+}
+
 /// Seeds a non-admin user whose session uses [`FIXED_MEMBER_TEST_TOKEN`].
 ///
 /// Exists because the harness signs every request in as an admin
@@ -191,6 +257,67 @@ pub(crate) async fn seed_fixed_member(state: &AppState, company: &str) {
         )
         .await
         .expect("seed_fixed_member: create session");
+}
+
+/// Seeds an admin whose otherwise-live session is behind the temporary-password
+/// boundary.
+///
+/// This mirrors the record shape produced by the admin password-reset route,
+/// while avoiding a password hashing round trip in route-authority tests. The
+/// caller must provide an [`AppState`] backed by disposable test storage.
+pub(crate) async fn seed_fixed_temp_password_admin(state: &AppState, company: &str) {
+    let id = CompanyId::new(company);
+    let runtime = state
+        .registry()
+        .get(&id)
+        .expect("seed_fixed_temp_password_admin: company is not registered");
+    let now = now_millis();
+    let user_id = generate_id();
+    runtime
+        .users()
+        .upsert_user(
+            &id,
+            &UserRecord {
+                id: user_id.clone(),
+                email: "harness-temp-password-admin@example.test".to_string(),
+                display_name: None,
+                avatar: None,
+                role: UserRole::Admin,
+                status: UserStatus::Active,
+                password_hash: None,
+                must_change_password: true,
+                created_at_millis: now,
+                last_seen_at_millis: None,
+                updated_at_millis: now,
+            },
+        )
+        .await
+        .expect("seed_fixed_temp_password_admin: upsert user");
+    runtime
+        .sessions()
+        .create(
+            &id,
+            &SessionRecord {
+                id: generate_id(),
+                token_hash: sha256_hex(FIXED_TEMP_PASSWORD_TEST_TOKEN),
+                user_id,
+                created_at_millis: now,
+                expires_at_millis: now + 60 * 60 * 1000,
+                user_agent: None,
+                kind: crate::ports::SessionKind::Browser,
+                label: None,
+            },
+        )
+        .await
+        .expect("seed_fixed_temp_password_admin: create session");
+}
+
+/// The `Cookie` header for [`seed_fixed_temp_password_admin`]'s session.
+pub(crate) fn temp_password_cookie(company: &str) -> String {
+    format!(
+        "{}={FIXED_TEMP_PASSWORD_TEST_TOKEN}",
+        session_cookie_name(&CompanyId::new(company)).expect("cookie-safe company id")
+    )
 }
 
 /// The `Cookie` header for [`seed_fixed_member`]'s session in `company`.

--- a/tests/auth_matrix.rs
+++ b/tests/auth_matrix.rs
@@ -649,28 +649,10 @@ const OPS_SCOPED_ROUTES: &[Route] = &[
     r!(Put, "/search", Admin, Credential, ""),
     r!(Delete, "/search/key", Admin, Credential, ""),
     r!(Post, "/setup/roster", Scoped, Ordinary, ""),
-    r!(
-        Post,
-        "/skills/{slug}/install",
-        Scoped,
-        Authority,
-        "Members may install a skill into every agent's prompt."
-    ),
-    r!(
-        Post,
-        "/skills/{slug}/uninstall",
-        Scoped,
-        Destructive,
-        "Members may remove an installed skill."
-    ),
+    r!(Post, "/skills/{slug}/install", Admin, Authority, ""),
+    r!(Post, "/skills/{slug}/uninstall", Admin, Destructive, ""),
     r!(Get, "/skills/registry", Scoped, Ordinary, ""),
-    r!(
-        Put,
-        "/skills/{slug}",
-        Scoped,
-        Authority,
-        "Members may enable or disable a skill for the company."
-    ),
+    r!(Put, "/skills/{slug}", Admin, Authority, ""),
     red!(Post, "/skills", Authority, SkillsBranch),
     r!(Get, "/skills", Scoped, Ordinary, ""),
     r!(Get, "/smtp", Scoped, Ordinary, ""),
@@ -1315,8 +1297,8 @@ fn table_counts_and_intentional_widenings_are_explicit() {
             .iter()
             .filter(|route| route.access == Access::Admin)
             .count(),
-        55,
-        "40 signature-admin, seven body-admin, and eight aspirational authority rows",
+        58,
+        "43 signature-admin, seven body-admin, and eight aspirational authority rows",
     );
     assert_eq!(
         OPS_SCOPED_ROUTES

--- a/tests/auth_matrix.rs
+++ b/tests/auth_matrix.rs
@@ -355,8 +355,8 @@ macro_rules! body_admin {
     }};
 }
 
-// Source-derived at upstream/main 0056ddf0e: 184 canonical scoped route-method
-// pairs across 142 suffixes. Forty method pairs use `AdminScopedCompany`; the
+// Source-derived at upstream/main 54de00102: 185 canonical scoped route-method
+// pairs across 143 suffixes. Forty method pairs use `AdminScopedCompany`; the
 // earlier count of 28 conflated an older source revision with unique paths.
 const OPS_SCOPED_ROUTES: &[Route] = &[
     r!(Get, "/activation", Scoped, Ordinary, ""),
@@ -736,6 +736,7 @@ const OPS_SCOPED_ROUTES: &[Route] = &[
     ),
     red!(Delete, "/team/{agent_id}", Destructive, TeamFix),
     r!(Post, "/team/draft", Scoped, Ordinary, ""),
+    r!(Post, "/team/design", Scoped, Ordinary, ""),
     r!(Post, "/team/{agent_id}/draft", Scoped, Ordinary, ""),
     r!(
         Put,
@@ -1258,24 +1259,24 @@ async fn company_status_temp_password_boundary_waits_for_an_assigned_branch() {
 
 #[test]
 fn table_counts_and_intentional_widenings_are_explicit() {
-    assert_eq!(OPS_SCOPED_ROUTES.len(), 184);
+    assert_eq!(OPS_SCOPED_ROUTES.len(), 185);
     assert_eq!(
         OPS_SCOPED_ROUTES
             .iter()
             .map(|route| route.path)
             .collect::<BTreeSet<_>>()
             .len(),
-        142,
+        143,
     );
     assert_eq!(OPS_EXACT_ROUTES.len(), 3);
     assert_eq!(
         OPS_SCOPED_ROUTES.len() * 2,
-        368,
+        370,
         "dual-address ops route-method rows",
     );
     assert_eq!(
         OPS_SCOPED_ROUTES.len() * 2 + OPS_EXACT_ROUTES.len(),
-        371,
+        373,
         "complete ops route-method rows",
     );
     assert_eq!(EXTERNAL_AUTHORITY_ROUTES.len(), 8);
@@ -1284,7 +1285,7 @@ fn table_counts_and_intentional_widenings_are_explicit() {
         all_routes()
             .map(|route| route_patterns(route).len())
             .sum::<usize>(),
-        380,
+        382,
         "concrete route-method rows",
     );
     assert_eq!(
@@ -1292,10 +1293,10 @@ fn table_counts_and_intentional_widenings_are_explicit() {
             .flat_map(route_patterns)
             .collect::<BTreeSet<_>>()
             .len(),
-        295,
+        297,
         "concrete paths",
     );
-    assert_eq!(render_snapshot().lines().count(), 2_660);
+    assert_eq!(render_snapshot().lines().count(), 2_674);
     assert_eq!(
         all_routes()
             .map(|route| {

--- a/tests/auth_matrix.rs
+++ b/tests/auth_matrix.rs
@@ -1,0 +1,2134 @@
+//! Route-authority matrix for the production ops router.
+//!
+//! This target asserts authorization verdicts, not handler success. A request
+//! admitted past the guard may reach a deliberately absent resource, invalid
+//! sentinel, or unwired optional service. `Permitted` therefore means neither
+//! the status nor the JSON error code is an authorization refusal.
+//!
+//! The source gate covers the ops inventory: every production `scoped(...)`
+//! call plus the three literal, non-dual ops routes. Lifecycle and approval
+//! decisions live outside that inventory and are declared separately because
+//! they are known authority defects. Runtime `TRACE` probes pin every method
+//! set, and the anonymous column pins route existence.
+//!
+//! Red-proof log (all temporary edits were restored from `/tmp` copies before
+//! continuing, and `git diff` was byte-identical to the pre-proof tree):
+//! - Removed `clear_policy`'s `require_admin`: the member `DELETE /policy`
+//!   cells changed from expected 403 to observed 200 on both address forms.
+//! - Added `scoped("/matrix-canary", ...)`: the source gate failed with the
+//!   unexpected canonical suffix `/matrix-canary`.
+//! - Added `.delete(get_activation)` to `/activation`: the method gate failed
+//!   on both forms with runtime `{DELETE, GET}` versus declared `{GET}`.
+
+#![cfg(feature = "openhuman")]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::{Method, Request, StatusCode, header};
+use opencompany::company::CompanyManifest;
+use opencompany::ports::types::CompanyId;
+use opencompany::runtime::RuntimeBuilder;
+use serde_json::Value;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+// `server::test_support` is crate-private and `cfg(test)`. Including this owned
+// helper source keeps the integration target on the same fixture seam without
+// exposing fixed test credentials in production.
+pub use opencompany::{AppState, OpenCompanyError, ports, server};
+#[path = "../src/server/test_support.rs"]
+mod test_support;
+
+const COMPANY: &str = "matrix-acme";
+const ABSENT_ID: &str = "__matrix_absent__";
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum Principal {
+    Anonymous,
+    Member,
+    Admin,
+    MustChangePasswordAdmin,
+    TenantOwner,
+    TenantNonOwner,
+    Platform,
+}
+
+impl Principal {
+    const ALL: [Self; 7] = [
+        Self::Anonymous,
+        Self::Member,
+        Self::Admin,
+        Self::MustChangePasswordAdmin,
+        Self::TenantOwner,
+        Self::TenantNonOwner,
+        Self::Platform,
+    ];
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Anonymous => "anonymous",
+            Self::Member => "member",
+            Self::Admin => "admin",
+            Self::MustChangePasswordAdmin => "must-change-password-admin",
+            Self::TenantOwner => "tenant-owner",
+            Self::TenantNonOwner => "tenant-non-owner",
+            Self::Platform => "platform",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Verdict {
+    Refused(StatusCode, &'static str),
+    Permitted,
+    Exact(StatusCode, Option<&'static str>),
+}
+
+impl Verdict {
+    fn snapshot(self) -> String {
+        match self {
+            Self::Refused(status, code) => format!("refused:{}:{code}", status.as_u16()),
+            Self::Permitted => "permitted".to_string(),
+            Self::Exact(status, Some(code)) => format!("exact:{}:{code}", status.as_u16()),
+            Self::Exact(status, None) => format!("exact:{}", status.as_u16()),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Access {
+    Scoped,
+    Admin,
+    Addressed,
+    Person,
+    Capability,
+    Hmac,
+    PublicGone,
+}
+
+impl Access {
+    const fn expected(self, principal: Principal) -> Verdict {
+        use Principal::{
+            Admin, Anonymous, Member, MustChangePasswordAdmin, Platform, TenantNonOwner,
+            TenantOwner,
+        };
+        match self {
+            Self::Scoped => match principal {
+                Anonymous => Verdict::Refused(StatusCode::UNAUTHORIZED, "unauthorized"),
+                Member | Admin | TenantOwner | Platform => Verdict::Permitted,
+                MustChangePasswordAdmin => {
+                    Verdict::Refused(StatusCode::FORBIDDEN, "password_change_required")
+                }
+                TenantNonOwner => Verdict::Refused(StatusCode::FORBIDDEN, "forbidden"),
+            },
+            Self::Admin => match principal {
+                Anonymous => Verdict::Refused(StatusCode::UNAUTHORIZED, "unauthorized"),
+                Member | TenantNonOwner => Verdict::Refused(StatusCode::FORBIDDEN, "forbidden"),
+                Admin | TenantOwner | Platform => Verdict::Permitted,
+                MustChangePasswordAdmin => {
+                    Verdict::Refused(StatusCode::FORBIDDEN, "password_change_required")
+                }
+            },
+            // `company_status` uses CompanyAuth + authorize_address directly.
+            Self::Addressed => match principal {
+                Anonymous => Verdict::Refused(StatusCode::UNAUTHORIZED, "unauthorized"),
+                Member | Admin | TenantOwner | Platform => Verdict::Permitted,
+                MustChangePasswordAdmin => {
+                    Verdict::Refused(StatusCode::FORBIDDEN, "password_change_required")
+                }
+                TenantNonOwner => Verdict::Refused(StatusCode::FORBIDDEN, "forbidden"),
+            },
+            Self::Person => match principal {
+                Anonymous | TenantOwner | Platform => {
+                    Verdict::Refused(StatusCode::UNAUTHORIZED, "unauthorized")
+                }
+                Member | Admin => Verdict::Permitted,
+                MustChangePasswordAdmin => {
+                    Verdict::Refused(StatusCode::FORBIDDEN, "password_change_required")
+                }
+                TenantNonOwner => Verdict::Refused(StatusCode::FORBIDDEN, "forbidden"),
+            },
+            Self::Capability => Verdict::Exact(StatusCode::NOT_FOUND, Some("not_found")),
+            Self::Hmac => Verdict::Refused(StatusCode::UNAUTHORIZED, "unauthorized"),
+            Self::PublicGone => Verdict::Exact(StatusCode::GONE, None),
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Scoped => "scoped",
+            Self::Admin => "admin",
+            Self::Addressed => "addressed",
+            Self::Person => "person",
+            Self::Capability => "capability",
+            Self::Hmac => "hmac",
+            Self::PublicGone => "public-gone",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Blast {
+    Ordinary,
+    Authority,
+    Destructive,
+    Credential,
+}
+
+impl Blast {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Ordinary => "ordinary",
+            Self::Authority => "authority",
+            Self::Destructive => "destructive",
+            Self::Credential => "credential",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Verb {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+}
+
+impl Verb {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Patch => "PATCH",
+            Self::Delete => "DELETE",
+        }
+    }
+
+    fn method(self) -> Method {
+        Method::from_bytes(self.label().as_bytes()).expect("static matrix method")
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Address {
+    Dual,
+    Exact,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Source {
+    Ops,
+    ExternalAuthority,
+}
+
+impl Source {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Ops => "ops",
+            Self::ExternalAuthority => "external",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Probe {
+    Empty,
+    Json(&'static str),
+    Capability,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Wait {
+    None,
+    AuthRoleBranch,
+    SkillsBranch,
+    BodyAdminFix,
+    LedgerFix,
+    TeamFix,
+    WorkflowFix,
+    TempPasswordBoundaryFix,
+}
+
+impl Wait {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::None => "-",
+            Self::AuthRoleBranch => "fix/auth-role-dimension-on-authorize-address",
+            Self::SkillsBranch => "fix/skills-admin-and-bounded-write",
+            Self::BodyAdminFix => "none-assigned:body-admin-signature",
+            Self::LedgerFix => "none-assigned:ledger-authority",
+            Self::TeamFix => "none-assigned:team-delete-authority",
+            Self::WorkflowFix => "none-assigned:workflow-authority",
+            Self::TempPasswordBoundaryFix => "none-assigned:temp-password-boundary",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RedCells {
+    None,
+    Member,
+    MemberAndTempPassword,
+    TenantOwnerAndPlatform,
+    TempPassword,
+}
+
+impl RedCells {
+    const fn contains(self, principal: Principal) -> bool {
+        match self {
+            Self::None => false,
+            Self::Member => matches!(principal, Principal::Member),
+            Self::MemberAndTempPassword => matches!(
+                principal,
+                Principal::Member | Principal::MustChangePasswordAdmin
+            ),
+            Self::TenantOwnerAndPlatform => {
+                matches!(principal, Principal::TenantOwner | Principal::Platform)
+            }
+            Self::TempPassword => matches!(principal, Principal::MustChangePasswordAdmin),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Route {
+    method: Verb,
+    path: &'static str,
+    address: Address,
+    source: Source,
+    access: Access,
+    features: &'static [&'static str],
+    blast: Blast,
+    probe: Probe,
+    note: &'static str,
+    wait: Wait,
+    red_cells: RedCells,
+}
+
+macro_rules! r {
+    ($method:ident, $path:literal, $access:ident, $blast:ident, $note:literal) => {
+        Route {
+            method: Verb::$method,
+            path: $path,
+            address: Address::Dual,
+            source: Source::Ops,
+            access: Access::$access,
+            features: &["openhuman"],
+            blast: Blast::$blast,
+            probe: Probe::Empty,
+            note: $note,
+            wait: Wait::None,
+            red_cells: RedCells::None,
+        }
+    };
+}
+
+macro_rules! rj {
+    ($method:ident, $path:literal, $access:ident, $blast:ident, $body:literal, $note:literal) => {{
+        let mut route = r!($method, $path, $access, $blast, $note);
+        route.probe = Probe::Json($body);
+        route
+    }};
+}
+
+macro_rules! red {
+    ($method:ident, $path:literal, $blast:ident, $wait:ident) => {{
+        let mut route = r!($method, $path, Admin, $blast, "");
+        route.wait = Wait::$wait;
+        route.red_cells = RedCells::Member;
+        route
+    }};
+}
+
+macro_rules! body_admin {
+    ($route:expr) => {{
+        let mut route = $route;
+        route.wait = Wait::BodyAdminFix;
+        route.red_cells = RedCells::TenantOwnerAndPlatform;
+        route
+    }};
+}
+
+// Source-derived at upstream/main 0056ddf0e: 184 canonical scoped route-method
+// pairs across 142 suffixes. Forty method pairs use `AdminScopedCompany`; the
+// earlier count of 28 conflated an older source revision with unique paths.
+const OPS_SCOPED_ROUTES: &[Route] = &[
+    r!(Get, "/activation", Scoped, Ordinary, ""),
+    r!(Get, "/tasks/{task_id}/artifacts", Scoped, Ordinary, ""),
+    r!(Post, "/artifacts", Scoped, Ordinary, ""),
+    r!(Get, "/artifacts/{artifact_id}", Scoped, Ordinary, ""),
+    r!(
+        Delete,
+        "/artifacts/{artifact_id}",
+        Scoped,
+        Destructive,
+        "Members may remove task artifacts."
+    ),
+    r!(
+        Post,
+        "/artifacts/{artifact_id}/versions",
+        Scoped,
+        Ordinary,
+        ""
+    ),
+    r!(Get, "/artifacts/{artifact_id}/diff", Scoped, Ordinary, ""),
+    r!(Post, "/avatars", Scoped, Ordinary, ""),
+    r!(Get, "/billing/chargebee", Scoped, Ordinary, ""),
+    r!(Put, "/billing/chargebee", Admin, Credential, ""),
+    r!(Delete, "/billing/chargebee/key", Admin, Credential, ""),
+    r!(Get, "/billing/paypal", Scoped, Ordinary, ""),
+    r!(Put, "/billing/paypal", Admin, Credential, ""),
+    r!(Delete, "/billing/paypal/key", Admin, Credential, ""),
+    r!(Get, "/agents/{agent_id}/budget-pause", Scoped, Ordinary, ""),
+    r!(
+        Post,
+        "/agents/{agent_id}/budget-pause/redeem",
+        Scoped,
+        Authority,
+        "Members may resume an agent after the budget interruption is cleared."
+    ),
+    r!(Get, "/capabilities", Scoped, Ordinary, ""),
+    r!(Get, "/credential", Scoped, Ordinary, ""),
+    r!(Put, "/credential", Admin, Credential, ""),
+    r!(Put, "/logo", Admin, Authority, ""),
+    body_admin!(rj!(Patch, "", Admin, Authority, "{}", "")),
+    r!(Get, "/composio", Scoped, Ordinary, ""),
+    r!(Put, "/composio/token", Admin, Credential, ""),
+    r!(Put, "/composio/api-key", Admin, Credential, ""),
+    r!(Post, "/composio/authorize", Admin, Credential, ""),
+    r!(Get, "/composio/connections", Scoped, Ordinary, ""),
+    r!(
+        Delete,
+        "/composio/connections/{connection_id}",
+        Admin,
+        Credential,
+        ""
+    ),
+    r!(
+        Put,
+        "/composio/connections/{connection_id}/default",
+        Admin,
+        Credential,
+        ""
+    ),
+    r!(
+        Delete,
+        "/composio/connections/{connection_id}/default",
+        Admin,
+        Credential,
+        ""
+    ),
+    r!(Post, "/connections/{provider}/start", Admin, Credential, ""),
+    r!(
+        Post,
+        "/connections/{provider}/disconnect",
+        Admin,
+        Credential,
+        ""
+    ),
+    r!(Get, "/connections", Scoped, Ordinary, ""),
+    r!(Delete, "/deep-trace", Admin, Destructive, ""),
+    r!(Delete, "/deep-trace/{run_id}", Admin, Destructive, ""),
+    r!(Get, "/domain", Scoped, Ordinary, ""),
+    r!(Put, "/domain", Admin, Authority, ""),
+    r!(Post, "/domain/verify", Scoped, Ordinary, ""),
+    r!(
+        Get,
+        "/finance/chargebee/invoices",
+        Scoped,
+        Authority,
+        "Members may read Chargebee invoice data."
+    ),
+    r!(Post, "/finance/chargebee/invoices", Admin, Authority, ""),
+    r!(
+        Get,
+        "/finance/chargebee/invoices/{invoice_id}",
+        Scoped,
+        Authority,
+        "Members may read Chargebee invoice data."
+    ),
+    r!(
+        Get,
+        "/finance/chargebee/customers",
+        Scoped,
+        Authority,
+        "Members may read Chargebee customer data."
+    ),
+    r!(
+        Post,
+        "/finance/chargebee/test",
+        Scoped,
+        Credential,
+        "Members may probe Chargebee with the stored credential."
+    ),
+    r!(
+        Get,
+        "/finance/paypal/balance",
+        Scoped,
+        Authority,
+        "Members may read the PayPal balance."
+    ),
+    r!(
+        Get,
+        "/finance/paypal/transactions",
+        Scoped,
+        Authority,
+        "Members may read PayPal transactions."
+    ),
+    r!(
+        Post,
+        "/finance/paypal/test",
+        Scoped,
+        Credential,
+        "Members may probe PayPal with the stored credential."
+    ),
+    r!(Get, "/finances", Scoped, Ordinary, ""),
+    r!(Get, "/harnesses", Scoped, Ordinary, ""),
+    r!(Get, "/hosting", Scoped, Ordinary, ""),
+    r!(Put, "/hosting", Admin, Credential, ""),
+    r!(Delete, "/hosting/key", Admin, Credential, ""),
+    r!(Get, "/inference", Scoped, Ordinary, ""),
+    r!(Put, "/inference", Admin, Credential, ""),
+    r!(Delete, "/inference", Admin, Credential, ""),
+    r!(Get, "/inference/models", Scoped, Ordinary, ""),
+    r!(
+        Post,
+        "/inference/test",
+        Scoped,
+        Credential,
+        "Members may probe inference with the stored credential."
+    ),
+    r!(Post, "/inference/restart", Admin, Authority, ""),
+    r!(Get, "/ledgers", Scoped, Ordinary, ""),
+    red!(Post, "/ledgers", Authority, LedgerFix),
+    r!(Get, "/ledgers/{slug}", Scoped, Ordinary, ""),
+    red!(Delete, "/ledgers/{slug}", Destructive, LedgerFix),
+    r!(Get, "/ledgers/{slug}/rendered", Scoped, Ordinary, ""),
+    r!(Post, "/ledgers/{slug}/entries", Scoped, Ordinary, ""),
+    r!(Get, "/ledgers/{slug}/entries", Scoped, Ordinary, ""),
+    r!(
+        Delete,
+        "/ledgers/{slug}/entries/{entry_id}",
+        Scoped,
+        Destructive,
+        "Members may delete ledger entries."
+    ),
+    r!(Get, "/inboxes", Scoped, Ordinary, ""),
+    r!(Get, "/inboxes/{key}/messages", Scoped, Ordinary, ""),
+    r!(Post, "/inboxes/{key}/read", Scoped, Ordinary, ""),
+    r!(Post, "/mcp/servers", Admin, Credential, ""),
+    r!(Get, "/mcp/servers", Scoped, Ordinary, ""),
+    r!(Put, "/mcp/servers/{name}", Admin, Credential, ""),
+    r!(Delete, "/mcp/servers/{name}", Admin, Credential, ""),
+    r!(
+        Get,
+        "/mcp/servers/{name}/tools",
+        Scoped,
+        Credential,
+        "Members may discover tools using the stored server credential."
+    ),
+    r!(
+        Post,
+        "/mcp/servers/{name}/test",
+        Scoped,
+        Credential,
+        "Members may connect using the stored server credential."
+    ),
+    r!(
+        Post,
+        "/mcp/servers/{name}/oauth/start",
+        Admin,
+        Credential,
+        ""
+    ),
+    r!(Get, "/mcp/config", Scoped, Ordinary, ""),
+    r!(Put, "/mcp/config", Admin, Credential, ""),
+    r!(Get, "/mcp/registry/search", Scoped, Ordinary, ""),
+    r!(Get, "/mcp/registry/entry", Scoped, Ordinary, ""),
+    r!(Post, "/mcp/registry/install", Admin, Credential, ""),
+    r!(
+        Post,
+        "/mcp/registry/{server_id}/connect",
+        Admin,
+        Credential,
+        ""
+    ),
+    r!(
+        Post,
+        "/mcp/registry/{server_id}/disconnect",
+        Admin,
+        Credential,
+        ""
+    ),
+    r!(Put, "/mcp/registry/{server_id}/env", Admin, Credential, ""),
+    r!(Delete, "/mcp/registry/{server_id}", Admin, Credential, ""),
+    r!(Post, "/memory", Scoped, Ordinary, ""),
+    r!(Get, "/memory", Scoped, Ordinary, ""),
+    r!(Get, "/memory/traces", Scoped, Ordinary, ""),
+    r!(Get, "/memory/stats", Scoped, Ordinary, ""),
+    r!(Get, "/memory/archives", Scoped, Ordinary, ""),
+    r!(
+        Delete,
+        "/memory/{fact_id}",
+        Scoped,
+        Destructive,
+        "Members may delete company memory facts."
+    ),
+    r!(Get, "/memory/engine", Admin, Authority, ""),
+    r!(Put, "/memory/engine", Admin, Credential, ""),
+    r!(Post, "/memory/engine/test", Admin, Credential, ""),
+    r!(Post, "/memory/ingest", Scoped, Ordinary, ""),
+    r!(
+        Post,
+        "/memory/ingest/links",
+        Scoped,
+        Authority,
+        "Members may submit URLs for server-side ingestion."
+    ),
+    r!(
+        Delete,
+        "/memory/document/{source}",
+        Scoped,
+        Destructive,
+        "Members may forget an ingested document."
+    ),
+    r!(Get, "/chat/mentionables", Person, Ordinary, ""),
+    r!(Get, "/notifications", Person, Ordinary, ""),
+    r!(Put, "/notifications", Person, Ordinary, ""),
+    r!(Get, "/pages", Scoped, Ordinary, ""),
+    r!(Get, "/pages/{slug}", Scoped, Ordinary, ""),
+    Route {
+        probe: Probe::Capability,
+        access: Access::Capability,
+        ..r!(Get, "/pages/{slug}/bootstrap.mjs", Scoped, Ordinary, "")
+    },
+    Route {
+        probe: Probe::Capability,
+        access: Access::Capability,
+        ..r!(Get, "/pages/{slug}/bundle.mjs", Scoped, Ordinary, "")
+    },
+    r!(Get, "/policy", Scoped, Ordinary, ""),
+    body_admin!(rj!(Put, "/policy", Admin, Authority, "{}", "")),
+    body_admin!(r!(Delete, "/policy", Admin, Authority, "")),
+    r!(Get, "/presence", Person, Ordinary, ""),
+    rj!(
+        Put,
+        "/presence",
+        Person,
+        Ordinary,
+        r#"{"status":"online"}"#,
+        ""
+    ),
+    r!(Delete, "/presence", Person, Ordinary, ""),
+    rj!(
+        Post,
+        "/chat/typing",
+        Person,
+        Ordinary,
+        r#"{"chatId":"__matrix_absent__"}"#,
+        ""
+    ),
+    r!(Get, "/chat/read-state", Person, Ordinary, ""),
+    rj!(
+        Put,
+        "/chat/read-state",
+        Person,
+        Ordinary,
+        r#"{"channelId":"__matrix_absent__","lastReadAt":0}"#,
+        ""
+    ),
+    r!(Get, "/runs", Scoped, Ordinary, ""),
+    r!(Get, "/runs/{run_id}", Scoped, Ordinary, ""),
+    r!(Get, "/search", Scoped, Ordinary, ""),
+    r!(Put, "/search", Admin, Credential, ""),
+    r!(Delete, "/search/key", Admin, Credential, ""),
+    r!(Post, "/setup/roster", Scoped, Ordinary, ""),
+    r!(
+        Post,
+        "/skills/{slug}/install",
+        Scoped,
+        Authority,
+        "Members may install a skill into every agent's prompt."
+    ),
+    r!(
+        Post,
+        "/skills/{slug}/uninstall",
+        Scoped,
+        Destructive,
+        "Members may remove an installed skill."
+    ),
+    r!(Get, "/skills/registry", Scoped, Ordinary, ""),
+    r!(
+        Put,
+        "/skills/{slug}",
+        Scoped,
+        Authority,
+        "Members may enable or disable a skill for the company."
+    ),
+    red!(Post, "/skills", Authority, SkillsBranch),
+    r!(Get, "/skills", Scoped, Ordinary, ""),
+    r!(Get, "/smtp", Scoped, Ordinary, ""),
+    r!(Put, "/smtp", Admin, Credential, ""),
+    r!(Post, "/smtp/test", Admin, Credential, ""),
+    r!(Get, "/tasks/{task_id}/export", Scoped, Ordinary, ""),
+    r!(Post, "/tasks", Scoped, Ordinary, ""),
+    r!(Get, "/tasks", Scoped, Ordinary, ""),
+    r!(Get, "/tasks/inflight", Scoped, Ordinary, ""),
+    r!(Get, "/tasks/{task_id}", Scoped, Ordinary, ""),
+    r!(Patch, "/tasks/{task_id}", Scoped, Ordinary, ""),
+    r!(
+        Delete,
+        "/tasks/{task_id}",
+        Scoped,
+        Destructive,
+        "Members may delete task cards."
+    ),
+    r!(
+        Post,
+        "/tasks/{task_id}/steer",
+        Scoped,
+        Authority,
+        "Members may steer or cancel active task work."
+    ),
+    r!(
+        Post,
+        "/tasks/{task_id}/workflow-proposal/apply",
+        Scoped,
+        Authority,
+        "Members may accept a task-authored workflow proposal."
+    ),
+    r!(
+        Post,
+        "/tasks/{task_id}/workflow-proposal/reject",
+        Scoped,
+        Authority,
+        "Members may reject a task-authored workflow proposal."
+    ),
+    r!(Post, "/tasks/{task_id}/discussion", Scoped, Ordinary, ""),
+    r!(
+        Delete,
+        "/tasks/{task_id}/discussion/{seq}",
+        Scoped,
+        Destructive,
+        "Members may redact task discussion messages."
+    ),
+    r!(Get, "/team", Scoped, Ordinary, ""),
+    r!(
+        Post,
+        "/team",
+        Scoped,
+        Authority,
+        "Members may add teammates unless privileged budget or tool fields are requested."
+    ),
+    r!(Get, "/team/{agent_id}", Scoped, Ordinary, ""),
+    r!(
+        Patch,
+        "/team/{agent_id}",
+        Scoped,
+        Authority,
+        "Members may edit non-sensitive teammate fields; tools, model, and harness require admin."
+    ),
+    red!(Delete, "/team/{agent_id}", Destructive, TeamFix),
+    r!(Post, "/team/draft", Scoped, Ordinary, ""),
+    r!(Post, "/team/{agent_id}/draft", Scoped, Ordinary, ""),
+    r!(
+        Put,
+        "/team/{agent_id}/inbox",
+        Scoped,
+        Authority,
+        "Members may enable or disable a teammate inbox."
+    ),
+    body_admin!(rj!(
+        Put,
+        "/team/{agent_id}/budget",
+        Admin,
+        Authority,
+        r#"{"budgetUsdDaily":null}"#,
+        ""
+    )),
+    body_admin!(r!(Delete, "/team/{agent_id}/budget", Admin, Authority, "")),
+    r!(Get, "/tools/catalog", Scoped, Ordinary, ""),
+    r!(Get, "/tools/grants", Scoped, Ordinary, ""),
+    body_admin!(rj!(
+        Put,
+        "/tools/grants",
+        Admin,
+        Authority,
+        r#"{"namespace":"__matrix_absent__"}"#,
+        ""
+    )),
+    body_admin!(r!(Delete, "/tools/grants", Admin, Authority, "")),
+    r!(Get, "/usage", Scoped, Ordinary, ""),
+    red!(Post, "/workflows", Authority, WorkflowFix),
+    r!(Get, "/workflows", Scoped, Ordinary, ""),
+    r!(Get, "/workflows/runs", Scoped, Ordinary, ""),
+    r!(Post, "/workflows/cron/preview", Scoped, Ordinary, ""),
+    r!(Post, "/workflows/validate", Scoped, Ordinary, ""),
+    r!(
+        Post,
+        "/workflows/draft-from-description",
+        Scoped,
+        Ordinary,
+        ""
+    ),
+    r!(Get, "/workflows/tool-slugs", Scoped, Ordinary, ""),
+    r!(Get, "/workflows/wired-channels", Scoped, Ordinary, ""),
+    r!(
+        Post,
+        "/workflows/runs/{rid}/cancel",
+        Scoped,
+        Destructive,
+        "Members may cancel an active workflow run."
+    ),
+    r!(Get, "/workflows/runs/{rid}/output", Scoped, Ordinary, ""),
+    r!(Get, "/workflows/runs/{rid}/artifacts", Scoped, Ordinary, ""),
+    r!(Get, "/workflows/{wid}", Scoped, Ordinary, ""),
+    red!(Put, "/workflows/{wid}", Authority, WorkflowFix),
+    red!(Delete, "/workflows/{wid}", Destructive, WorkflowFix),
+    red!(Post, "/workflows/{wid}/run", Authority, WorkflowFix),
+    r!(Post, "/workflows/{wid}/fix-from-run", Scoped, Ordinary, ""),
+    r!(
+        Put,
+        "/workflows/{wid}/enabled",
+        Scoped,
+        Authority,
+        "Members may enable or disable workflow scheduling."
+    ),
+    r!(Get, "/workflows/{wid}/revisions", Scoped, Ordinary, ""),
+    r!(
+        Post,
+        "/workflows/{wid}/revisions/{rev}/restore",
+        Scoped,
+        Authority,
+        "Members may restore workflow revisions."
+    ),
+    r!(Post, "/workspace", Scoped, Ordinary, ""),
+    r!(Get, "/workspace", Scoped, Ordinary, ""),
+    r!(Put, "/workspace/file/{node_id}", Scoped, Ordinary, ""),
+    r!(Get, "/workspace/file/{node_id}", Scoped, Ordinary, ""),
+    r!(Get, "/workspace/search", Scoped, Ordinary, ""),
+    r!(
+        Post,
+        "/workspace/sweep-empty-agent-folders",
+        Scoped,
+        Destructive,
+        "Members may remove empty agent folders."
+    ),
+    r!(
+        Post,
+        "/workspace/merge-duplicate-folders",
+        Scoped,
+        Destructive,
+        "Members may merge and remove duplicate folders."
+    ),
+    r!(Get, "/workspace/blob/{node_id}", Scoped, Ordinary, ""),
+    r!(Post, "/workspace/upload", Scoped, Ordinary, ""),
+    r!(Patch, "/workspace/{node_id}", Scoped, Ordinary, ""),
+    r!(
+        Delete,
+        "/workspace/{node_id}",
+        Scoped,
+        Destructive,
+        "Members may delete workspace nodes."
+    ),
+    r!(Post, "/chat/upload", Scoped, Ordinary, ""),
+];
+
+const OPS_EXACT_ROUTES: &[Route] = &[
+    Route {
+        method: Verb::Get,
+        path: "/api/v1/oauth/callback",
+        address: Address::Exact,
+        source: Source::Ops,
+        access: Access::PublicGone,
+        features: &["openhuman"],
+        blast: Blast::Ordinary,
+        probe: Probe::Empty,
+        note: "",
+        wait: Wait::None,
+        red_cells: RedCells::None,
+    },
+    Route {
+        method: Verb::Post,
+        path: "/api/v1/companies/{id}/inboxes/ingest",
+        address: Address::Exact,
+        source: Source::Ops,
+        access: Access::Hmac,
+        features: &["openhuman"],
+        blast: Blast::Ordinary,
+        probe: Probe::Empty,
+        note: "",
+        wait: Wait::None,
+        red_cells: RedCells::None,
+    },
+    Route {
+        method: Verb::Post,
+        path: "/api/v1/company/inboxes/ingest",
+        address: Address::Exact,
+        source: Source::Ops,
+        access: Access::Hmac,
+        features: &["openhuman"],
+        blast: Blast::Ordinary,
+        probe: Probe::Empty,
+        note: "",
+        wait: Wait::None,
+        red_cells: RedCells::None,
+    },
+];
+
+const EXTERNAL_AUTHORITY_ROUTES: &[Route] = &[
+    external_admin(
+        Verb::Post,
+        "/api/v1/companies/{id}/pause",
+        Probe::Empty,
+        RedCells::Member,
+    ),
+    external_admin(
+        Verb::Post,
+        "/api/v1/companies/{id}/resume",
+        Probe::Empty,
+        RedCells::Member,
+    ),
+    external_admin(
+        Verb::Post,
+        "/api/v1/companies/{id}/emergency-pause",
+        Probe::Empty,
+        RedCells::Member,
+    ),
+    external_admin(
+        Verb::Post,
+        "/api/v1/companies/{id}/emergency-resume",
+        Probe::Empty,
+        RedCells::Member,
+    ),
+    external_admin(
+        Verb::Post,
+        "/api/v1/companies/{id}/approvals/{aid}",
+        Probe::Json(r#"{"verdict":"deny","amended_payload":{}}"#),
+        RedCells::MemberAndTempPassword,
+    ),
+    external_admin(
+        Verb::Post,
+        "/api/v1/company/approvals/{aid}",
+        Probe::Json(r#"{"verdict":"deny","amended_payload":{}}"#),
+        RedCells::Member,
+    ),
+    external_admin(
+        Verb::Post,
+        "/api/v1/companies/{id}/approvals/{aid}/extend",
+        Probe::Empty,
+        RedCells::MemberAndTempPassword,
+    ),
+    external_admin(
+        Verb::Post,
+        "/api/v1/company/approvals/{aid}/extend",
+        Probe::Empty,
+        RedCells::Member,
+    ),
+];
+
+// The empty scoped suffix shares this concrete path with the operator status
+// route. It is represented so the runtime method-set gate remains exact.
+const OVERLAPPING_EXTERNAL_ROUTES: &[Route] = &[Route {
+    method: Verb::Get,
+    path: "/api/v1/companies/{id}",
+    address: Address::Exact,
+    source: Source::ExternalAuthority,
+    access: Access::Addressed,
+    features: &["openhuman"],
+    blast: Blast::Ordinary,
+    probe: Probe::Empty,
+    note: "",
+    wait: Wait::TempPasswordBoundaryFix,
+    red_cells: RedCells::TempPassword,
+}];
+
+const fn external_admin(
+    method: Verb,
+    path: &'static str,
+    probe: Probe,
+    red_cells: RedCells,
+) -> Route {
+    Route {
+        method,
+        path,
+        address: Address::Exact,
+        source: Source::ExternalAuthority,
+        access: Access::Admin,
+        features: &["openhuman"],
+        blast: Blast::Authority,
+        probe,
+        note: "",
+        wait: Wait::AuthRoleBranch,
+        red_cells,
+    }
+}
+
+fn all_routes() -> impl Iterator<Item = &'static Route> {
+    OPS_SCOPED_ROUTES
+        .iter()
+        .chain(OPS_EXACT_ROUTES)
+        .chain(EXTERNAL_AUTHORITY_ROUTES)
+        .chain(OVERLAPPING_EXTERNAL_ROUTES)
+}
+
+fn routes() -> impl Iterator<Item = &'static Route> {
+    all_routes().filter(|route| {
+        route
+            .features
+            .iter()
+            .all(|feature| feature_enabled(feature))
+    })
+}
+
+fn feature_enabled(feature: &str) -> bool {
+    match feature {
+        "openhuman" => cfg!(feature = "openhuman"),
+        "mcp" => cfg!(feature = "mcp"),
+        "composio" => cfg!(feature = "composio"),
+        "acp" => cfg!(feature = "acp"),
+        "documents" => cfg!(feature = "documents"),
+        "webhooks" => cfg!(feature = "webhooks"),
+        "tinyplace" => cfg!(feature = "tinyplace"),
+        unknown => panic!("matrix row names unknown Cargo feature {unknown:?}"),
+    }
+}
+
+struct Harness {
+    _home: TempDir,
+    app: Router,
+}
+
+impl Harness {
+    async fn build() -> Self {
+        let home = tempfile::Builder::new()
+            .prefix("opencompany-auth-matrix-")
+            .tempdir()
+            .expect("matrix tempdir");
+        let manifest: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Matrix Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n[policy]\nmode = \"full\"\n",
+        )
+        .expect("minimal matrix manifest");
+        let id = CompanyId::new(COMPANY);
+        let runtime = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .expect("matrix runtime");
+        let state = AppState::new(opencompany::AppConfig::default())
+            .with_home(home.path().to_path_buf())
+            .with_platform_auth(test_support::fixed_principal_platform_auth());
+        state.registry().insert(id.clone(), Arc::new(runtime));
+        state.set_owner(id, "tenant:matrix-owner");
+        test_support::seed_fixed_member(&state, COMPANY).await;
+        test_support::seed_fixed_admin(&state, COMPANY).await;
+        test_support::seed_fixed_temp_password_admin(&state, COMPANY).await;
+        let app = server::router(state);
+        Self { _home: home, app }
+    }
+
+    async fn request(
+        &self,
+        method: Method,
+        uri: &str,
+        principal: Principal,
+        probe: Probe,
+    ) -> Observed {
+        let mut request = Request::builder().method(method).uri(uri);
+        request = match principal {
+            Principal::Anonymous => request,
+            Principal::Member => request.header("cookie", test_support::member_cookie(COMPANY)),
+            Principal::Admin => request.header("cookie", test_support::fixed_cookie(COMPANY)),
+            Principal::MustChangePasswordAdmin => {
+                request.header("cookie", test_support::temp_password_cookie(COMPANY))
+            }
+            Principal::TenantOwner => request.header(
+                "authorization",
+                format!("Bearer {}", test_support::FIXED_TENANT_OWNER_TEST_TOKEN),
+            ),
+            Principal::TenantNonOwner => request.header(
+                "authorization",
+                format!("Bearer {}", test_support::FIXED_TENANT_NON_OWNER_TEST_TOKEN),
+            ),
+            Principal::Platform => request.header(
+                "authorization",
+                format!("Bearer {}", test_support::FIXED_PLATFORM_TEST_TOKEN),
+            ),
+        };
+        let body = match probe {
+            Probe::Empty | Probe::Capability => Body::empty(),
+            Probe::Json(json) => {
+                request = request.header(header::CONTENT_TYPE, "application/json");
+                Body::from(json)
+            }
+        };
+        let response = self
+            .app
+            .clone()
+            .oneshot(request.body(body).expect("matrix request"))
+            .await
+            .expect("infallible router response");
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .expect("bounded matrix body");
+        let json = serde_json::from_slice::<Value>(&body).ok();
+        Observed {
+            status,
+            headers,
+            json,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Observed {
+    status: StatusCode,
+    headers: axum::http::HeaderMap,
+    json: Option<Value>,
+}
+
+impl Observed {
+    fn code(&self) -> Option<&str> {
+        self.json.as_ref()?.get("code")?.as_str()
+    }
+}
+
+fn route_patterns(route: &Route) -> Vec<String> {
+    match route.address {
+        Address::Dual => vec![
+            format!("/api/v1/companies/{{id}}{}", route.path),
+            format!("/api/v1/company{}", route.path),
+        ],
+        Address::Exact => vec![route.path.to_string()],
+    }
+}
+
+fn request_uri(route: &Route, pattern: &str) -> String {
+    let mut uri = materialize_path(pattern);
+    if route.probe == Probe::Capability {
+        uri.push_str("?oc_cap=__matrix_absent__");
+    }
+    uri
+}
+
+fn materialize_path(pattern: &str) -> String {
+    let mut result = pattern.replace("{id}", COMPANY);
+    while let Some(open) = result.find('{') {
+        let close = result[open..]
+            .find('}')
+            .map(|offset| open + offset)
+            .expect("balanced path parameter");
+        result.replace_range(open..=close, ABSENT_ID);
+    }
+    result
+}
+
+fn check_verdict(
+    route: &Route,
+    pattern: &str,
+    principal: Principal,
+    observed: &Observed,
+) -> Result<(), String> {
+    let expected = route.access.expected(principal);
+    let context = format!(
+        "{} {} for {} expected {} but observed {observed:?}",
+        route.method.label(),
+        pattern,
+        principal.label(),
+        expected.snapshot(),
+    );
+    match expected {
+        Verdict::Refused(status, code) => {
+            if observed.status == status && observed.code() == Some(code) {
+                Ok(())
+            } else {
+                Err(context)
+            }
+        }
+        Verdict::Permitted => {
+            let refused_status = matches!(
+                observed.status,
+                StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+            );
+            let refused_code = matches!(
+                observed.code(),
+                Some("unauthorized" | "forbidden" | "password_change_required")
+            );
+            if refused_status || refused_code {
+                Err(context)
+            } else {
+                Ok(())
+            }
+        }
+        Verdict::Exact(status, code) => {
+            if observed.status == status && code.is_none_or(|value| observed.code() == Some(value))
+            {
+                Ok(())
+            } else {
+                Err(context)
+            }
+        }
+    }
+}
+
+async fn check_cells(wait: Option<Wait>) {
+    let harness = Harness::build().await;
+    let mut failures = Vec::new();
+    for route in routes() {
+        for pattern in route_patterns(route) {
+            for principal in Principal::ALL {
+                let selected = match wait {
+                    None => !route.red_cells.contains(principal),
+                    Some(group) => route.wait == group && route.red_cells.contains(principal),
+                };
+                if !selected {
+                    continue;
+                }
+                let observed = harness
+                    .request(
+                        route.method.method(),
+                        &request_uri(route, &pattern),
+                        principal,
+                        route.probe,
+                    )
+                    .await;
+                if let Err(failure) = check_verdict(route, &pattern, principal, &observed) {
+                    failures.push(failure);
+                }
+            }
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[tokio::test]
+async fn declared_non_defect_cells_hold_the_seven_principal_boundary() {
+    check_cells(None).await;
+}
+
+#[tokio::test]
+#[ignore = "waits on fix/auth-role-dimension-on-authorize-address"]
+async fn lifecycle_and_approval_authority_waits_on_auth_role_branch() {
+    check_cells(Some(Wait::AuthRoleBranch)).await;
+}
+
+#[tokio::test]
+#[ignore = "waits on fix/skills-admin-and-bounded-write"]
+async fn custom_skill_authority_waits_on_skills_branch() {
+    check_cells(Some(Wait::SkillsBranch)).await;
+}
+
+#[tokio::test]
+#[ignore = "waits on a body-admin signature branch; none assigned in handoff section 7"]
+async fn body_admin_machine_principals_wait_for_an_assigned_branch() {
+    check_cells(Some(Wait::BodyAdminFix)).await;
+}
+
+#[tokio::test]
+#[ignore = "waits on a ledger-authority branch; none assigned in handoff section 7"]
+async fn ledger_authority_waits_for_an_assigned_branch() {
+    check_cells(Some(Wait::LedgerFix)).await;
+}
+
+#[tokio::test]
+#[ignore = "waits on a team-delete-authority branch; none assigned in handoff section 7"]
+async fn team_delete_authority_waits_for_an_assigned_branch() {
+    check_cells(Some(Wait::TeamFix)).await;
+}
+
+#[tokio::test]
+#[ignore = "waits on a workflow-authority branch; none assigned in handoff section 7"]
+async fn workflow_authority_waits_for_an_assigned_branch() {
+    check_cells(Some(Wait::WorkflowFix)).await;
+}
+
+#[tokio::test]
+#[ignore = "waits on a temp-password-boundary branch; none assigned in handoff section 7"]
+async fn company_status_temp_password_boundary_waits_for_an_assigned_branch() {
+    check_cells(Some(Wait::TempPasswordBoundaryFix)).await;
+}
+
+#[test]
+fn table_counts_and_intentional_widenings_are_explicit() {
+    assert_eq!(OPS_SCOPED_ROUTES.len(), 184);
+    assert_eq!(
+        OPS_SCOPED_ROUTES
+            .iter()
+            .map(|route| route.path)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        142,
+    );
+    assert_eq!(OPS_EXACT_ROUTES.len(), 3);
+    assert_eq!(
+        OPS_SCOPED_ROUTES.len() * 2,
+        368,
+        "dual-address ops route-method rows",
+    );
+    assert_eq!(
+        OPS_SCOPED_ROUTES.len() * 2 + OPS_EXACT_ROUTES.len(),
+        371,
+        "complete ops route-method rows",
+    );
+    assert_eq!(EXTERNAL_AUTHORITY_ROUTES.len(), 8);
+    assert_eq!(OVERLAPPING_EXTERNAL_ROUTES.len(), 1);
+    assert_eq!(
+        all_routes()
+            .map(|route| route_patterns(route).len())
+            .sum::<usize>(),
+        380,
+        "concrete route-method rows",
+    );
+    assert_eq!(
+        all_routes()
+            .flat_map(route_patterns)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        295,
+        "concrete paths",
+    );
+    assert_eq!(render_snapshot().lines().count(), 2_660);
+    assert_eq!(
+        all_routes()
+            .map(|route| {
+                route_patterns(route).len()
+                    * Principal::ALL
+                        .into_iter()
+                        .filter(|principal| route.red_cells.contains(*principal))
+                        .count()
+            })
+            .sum::<usize>(),
+        55,
+        "ignored red principal cells",
+    );
+    assert_eq!(
+        OPS_SCOPED_ROUTES
+            .iter()
+            .filter(|route| route.access == Access::Admin)
+            .count(),
+        55,
+        "40 signature-admin, seven body-admin, and eight aspirational authority rows",
+    );
+    assert_eq!(
+        OPS_SCOPED_ROUTES
+            .iter()
+            .filter(|route| route.red_cells == RedCells::TenantOwnerAndPlatform)
+            .count(),
+        7,
+        "seven source routes still put require_admin in the handler body",
+    );
+
+    let mut failures = Vec::new();
+    for route in all_routes() {
+        assert!(
+            !route.features.is_empty(),
+            "{} {} has no owning feature lane",
+            route.method.label(),
+            route.path,
+        );
+        for feature in route.features {
+            let _ = feature_enabled(feature);
+        }
+        if route.access.expected(Principal::Member) == Verdict::Permitted
+            && route.blast != Blast::Ordinary
+            && route.note.trim().is_empty()
+        {
+            failures.push(format!(
+                "{} {} permits members at {} blast radius without a note",
+                route.method.label(),
+                route.path,
+                route.blast.label(),
+            ));
+        }
+        if route.wait == Wait::None && route.red_cells != RedCells::None {
+            failures.push(format!(
+                "{} {} has red cells without a named wait",
+                route.method.label(),
+                route.path,
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn committed_snapshot_pins_every_expected_cell() {
+    let actual = render_snapshot();
+    let snapshot = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/snapshots/auth-matrix.txt");
+    if std::env::var_os("BLESS_AUTH_MATRIX").is_some() {
+        std::fs::write(&snapshot, &actual).expect("write auth matrix snapshot");
+        return;
+    }
+    assert_eq!(actual, include_str!("snapshots/auth-matrix.txt"));
+}
+
+fn render_snapshot() -> String {
+    let mut lines = Vec::new();
+    for route in all_routes() {
+        for path in route_patterns(route) {
+            for principal in Principal::ALL {
+                let wait = if route.red_cells.contains(principal) {
+                    route.wait.label()
+                } else {
+                    "-"
+                };
+                lines.push(format!(
+                    "{} {} {} {} source={} access={} features={} blast={} note={:?} wait={}",
+                    route.method.label(),
+                    path,
+                    principal.label(),
+                    route.access.expected(principal).snapshot(),
+                    route.source.label(),
+                    route.access.label(),
+                    route.features.join("+"),
+                    route.blast.label(),
+                    route.note,
+                    wait,
+                ));
+            }
+        }
+    }
+    lines.sort();
+    let mut out = lines.join("\n");
+    out.push('\n');
+    out
+}
+
+#[test]
+fn source_path_set_equals_the_ops_matrix_path_set() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/server/ops");
+    let scanned = scan_ops_routes(&root).unwrap_or_else(|error| panic!("{error}"));
+
+    let expected_suffixes: BTreeSet<_> = OPS_SCOPED_ROUTES
+        .iter()
+        .map(|route| route.path.to_string())
+        .collect();
+    assert_set_eq("scoped suffix", &expected_suffixes, &scanned.scoped);
+
+    let expected_direct: BTreeSet<_> = OPS_EXACT_ROUTES
+        .iter()
+        .map(|route| route.path.to_string())
+        .collect();
+    assert_set_eq("direct ops path", &expected_direct, &scanned.direct);
+    assert_eq!(
+        scanned.allowed_nonliteral,
+        BTreeMap::from([
+            ("connections_read.rs:self.route(stored)", 1),
+            ("scope.rs:company-id-format", 1),
+            ("scope.rs:single-company-format", 1),
+        ]),
+        "non-Axum/dynamic route allowlist drifted"
+    );
+}
+
+#[test]
+fn external_authority_router_files_have_no_unclassified_paths() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/server");
+    let provision = scan_file_route_literals(&root.join("provision.rs"))
+        .unwrap_or_else(|error| panic!("{error}"));
+    assert_set_eq(
+        "provision direct path",
+        &string_set(&[
+            "/api/v1/companies",
+            "/api/v1/companies/provisioning",
+            "/api/v1/companies/{id}/pause",
+            "/api/v1/companies/{id}/resume",
+            "/api/v1/companies/{id}/emergency-pause",
+            "/api/v1/companies/{id}/emergency-resume",
+            "/api/v1/companies/{id}/suspend",
+            "/api/v1/companies/{id}/archive",
+        ]),
+        &provision.direct,
+    );
+    assert!(provision.scoped.is_empty());
+
+    let operator = scan_file_route_literals(&root.join("operator.rs"))
+        .unwrap_or_else(|error| panic!("{error}"));
+    assert_set_eq(
+        "operator direct path",
+        &string_set(&[
+            "/api/v1/companies",
+            "/api/v1/companies/{id}",
+            "/api/v1/companies/{id}/chat",
+            "/api/v1/companies/{id}/chat/history",
+            "/api/v1/companies/{id}/chat/attribution-audit",
+            "/api/v1/companies/{id}/chat/messages/{seq}/reactions",
+            "/api/v1/companies/{id}/approvals",
+            "/api/v1/companies/{id}/approvals/{aid}",
+            "/api/v1/companies/{id}/approvals/{aid}/extend",
+            "/api/v1/company/chat",
+            "/api/v1/company/chat/history",
+            "/api/v1/company/chat/attribution-audit",
+            "/api/v1/company/chat/messages/{seq}/reactions",
+            "/api/v1/company/approvals",
+            "/api/v1/company/approvals/{aid}",
+            "/api/v1/company/approvals/{aid}/extend",
+        ]),
+        &operator.direct,
+    );
+    assert_set_eq(
+        "operator scoped suffix",
+        &string_set(&[
+            "/desks",
+            "/desks/{desk_id}",
+            "/desks/{desk_id}/members",
+            "/desks/{desk_id}/members/{agent_id}",
+            "/desks/{desk_id}/order",
+            "/operator-channel",
+            "/events",
+            "/grants",
+            "/grants/{gid}",
+            "/chat/review",
+        ]),
+        &operator.scoped,
+    );
+}
+
+fn string_set(values: &[&str]) -> BTreeSet<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}
+
+fn assert_set_eq(label: &str, expected: &BTreeSet<String>, actual: &BTreeSet<String>) {
+    let missing: Vec<_> = expected.difference(actual).collect();
+    let unexpected: Vec<_> = actual.difference(expected).collect();
+    assert!(
+        missing.is_empty() && unexpected.is_empty(),
+        "{label} set drifted; missing={missing:?}; unexpected={unexpected:?}",
+    );
+}
+
+#[tokio::test]
+async fn runtime_allow_headers_equal_the_declared_method_sets() {
+    let harness = Harness::build().await;
+    let expected = declared_method_sets();
+    let mut failures = Vec::new();
+    for (pattern, methods) in expected {
+        let uri = materialize_path(&pattern);
+        let observed = harness
+            .request(Method::TRACE, &uri, Principal::Anonymous, Probe::Empty)
+            .await;
+        if observed.status != StatusCode::METHOD_NOT_ALLOWED {
+            failures.push(format!(
+                "TRACE {pattern}: expected 405, observed {:?}",
+                observed.status
+            ));
+            continue;
+        }
+        let Some(allow) = observed
+            .headers
+            .get(header::ALLOW)
+            .and_then(|value| value.to_str().ok())
+        else {
+            failures.push(format!("TRACE {pattern}: 405 response had no Allow header"));
+            continue;
+        };
+        let mut actual: BTreeSet<String> = allow
+            .split(',')
+            .map(str::trim)
+            .filter(|method| !method.is_empty())
+            .map(str::to_string)
+            .collect();
+        // Axum adds HEAD implicitly to every GET router. On a non-GET path,
+        // HEAD remains significant so an explicit addition cannot hide here.
+        if methods.contains("GET") {
+            actual.remove("HEAD");
+        }
+        if actual != methods {
+            failures.push(format!(
+                "{pattern}: declared methods {methods:?}, runtime Allow methods {actual:?}"
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+fn declared_method_sets() -> BTreeMap<String, BTreeSet<String>> {
+    let mut sets = BTreeMap::<String, BTreeSet<String>>::new();
+    for route in routes() {
+        for pattern in route_patterns(route) {
+            sets.entry(pattern)
+                .or_default()
+                .insert(route.method.label().to_string());
+        }
+    }
+    sets
+}
+
+#[derive(Debug)]
+struct Scan {
+    scoped: BTreeSet<String>,
+    direct: BTreeSet<String>,
+    allowed_nonliteral: BTreeMap<&'static str, usize>,
+}
+
+fn scan_file_route_literals(file: &Path) -> Result<Scan, String> {
+    let source = std::fs::read_to_string(file).map_err(|error| error.to_string())?;
+    let tokens = lex(&source).map_err(|error| format!("{}: {error}", file.display()))?;
+    let skipped = test_only_token_indexes(&tokens);
+    let mut scoped = BTreeSet::new();
+    let mut direct = BTreeSet::new();
+    for index in 0..tokens.len() {
+        if skipped.contains(&index) {
+            continue;
+        }
+        if ident_at(&tokens, index) == Some("scoped") && punct_at(&tokens, index + 1) == Some('(') {
+            match tokens.get(index + 2).map(|token| &token.kind) {
+                Some(TokenKind::String(path)) => {
+                    scoped.insert(path.clone());
+                }
+                _ => {
+                    return Err(format!(
+                        "{}:{}: external scoped(...) argument is not a parseable literal",
+                        file.display(),
+                        tokens[index].line,
+                    ));
+                }
+            }
+        }
+        if punct_at(&tokens, index) == Some('.')
+            && ident_at(&tokens, index + 1) == Some("route")
+            && punct_at(&tokens, index + 2) == Some('(')
+        {
+            match tokens.get(index + 3).map(|token| &token.kind) {
+                Some(TokenKind::String(path)) => {
+                    direct.insert(path.clone());
+                }
+                _ => {
+                    return Err(format!(
+                        "{}:{}: external .route(...) argument is not a parseable literal",
+                        file.display(),
+                        tokens[index].line,
+                    ));
+                }
+            }
+        }
+    }
+    Ok(Scan {
+        scoped,
+        direct,
+        allowed_nonliteral: BTreeMap::new(),
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TokenKind {
+    Ident(String),
+    String(String),
+    Punct(char),
+}
+
+#[derive(Clone, Debug)]
+struct Token {
+    kind: TokenKind,
+    line: usize,
+}
+
+fn scan_ops_routes(root: &Path) -> Result<Scan, String> {
+    let mut files = Vec::new();
+    collect_rust_files(root, &mut files).map_err(|error| error.to_string())?;
+    files.sort();
+    let mut scoped = BTreeSet::new();
+    let mut direct = BTreeSet::new();
+    let mut allowed_nonliteral = BTreeMap::new();
+    for file in files {
+        let relative = file.strip_prefix(root).expect("collected under root");
+        if is_external_test_file(relative) {
+            continue;
+        }
+        let source = std::fs::read_to_string(&file).map_err(|error| error.to_string())?;
+        let tokens = lex(&source).map_err(|error| format!("{}: {error}", file.display()))?;
+        let skipped = test_only_token_indexes(&tokens);
+        for index in 0..tokens.len() {
+            if skipped.contains(&index) {
+                continue;
+            }
+            if ident_at(&tokens, index) == Some("scoped")
+                && punct_at(&tokens, index + 1) == Some('(')
+                && ident_at(&tokens, index.wrapping_sub(1)) != Some("fn")
+            {
+                match tokens.get(index + 2).map(|token| &token.kind) {
+                    Some(TokenKind::String(path)) => {
+                        scoped.insert(path.clone());
+                    }
+                    _ => {
+                        return Err(format!(
+                            "{}:{}: production scoped(...) argument is not a parseable literal",
+                            relative.display(),
+                            tokens[index].line,
+                        ));
+                    }
+                }
+            }
+            if punct_at(&tokens, index) == Some('.')
+                && ident_at(&tokens, index + 1) == Some("route")
+                && punct_at(&tokens, index + 2) == Some('(')
+            {
+                match tokens.get(index + 3).map(|token| &token.kind) {
+                    Some(TokenKind::String(path)) => {
+                        direct.insert(path.clone());
+                    }
+                    _ => {
+                        let Some(fingerprint) =
+                            allowed_nonliteral_route(relative, &tokens, index + 3)
+                        else {
+                            return Err(format!(
+                                "{}:{}: production .route(...) argument is not a parseable literal",
+                                relative.display(),
+                                tokens[index].line,
+                            ));
+                        };
+                        *allowed_nonliteral.entry(fingerprint).or_insert(0) += 1;
+                    }
+                }
+            }
+        }
+    }
+    Ok(Scan {
+        scoped,
+        direct,
+        allowed_nonliteral,
+    })
+}
+
+fn collect_rust_files(root: &Path, files: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(root)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_rust_files(&path, files)?;
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn is_external_test_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    name == "test.rs"
+        || name == "tests.rs"
+        || name.ends_with("_test.rs")
+        || name.ends_with("_tests.rs")
+}
+
+fn allowed_nonliteral_route(
+    relative: &Path,
+    tokens: &[Token],
+    argument: usize,
+) -> Option<&'static str> {
+    let file = relative.to_string_lossy();
+    if file == "connections_read.rs"
+        && ident_at(tokens, argument.wrapping_sub(4)) == Some("self")
+        && ident_at(tokens, argument) == Some("stored")
+        && punct_at(tokens, argument + 1) == Some(')')
+    {
+        return Some("connections_read.rs:self.route(stored)");
+    }
+    if file != "scope.rs"
+        || punct_at(tokens, argument) != Some('&')
+        || ident_at(tokens, argument + 1) != Some("format")
+        || punct_at(tokens, argument + 2) != Some('!')
+        || punct_at(tokens, argument + 3) != Some('(')
+    {
+        return None;
+    }
+    match tokens.get(argument + 4).map(|token| &token.kind) {
+        Some(TokenKind::String(value)) if value == "/api/v1/companies/{{id}}{suffix}" => {
+            Some("scope.rs:company-id-format")
+        }
+        Some(TokenKind::String(value)) if value == "/api/v1/company{suffix}" => {
+            Some("scope.rs:single-company-format")
+        }
+        _ => None,
+    }
+}
+
+fn ident_at(tokens: &[Token], index: usize) -> Option<&str> {
+    match tokens.get(index)?.kind {
+        TokenKind::Ident(ref value) => Some(value),
+        _ => None,
+    }
+}
+
+fn punct_at(tokens: &[Token], index: usize) -> Option<char> {
+    match tokens.get(index)?.kind {
+        TokenKind::Punct(value) => Some(value),
+        _ => None,
+    }
+}
+
+fn test_only_token_indexes(tokens: &[Token]) -> BTreeSet<usize> {
+    let mut skipped = BTreeSet::new();
+    let mut index = 0;
+    while index + 5 < tokens.len() {
+        if punct_at(tokens, index) != Some('#') || punct_at(tokens, index + 1) != Some('[') {
+            index += 1;
+            continue;
+        }
+        let Some(close) = matching_delimiter(tokens, index + 1, '[', ']') else {
+            index += 1;
+            continue;
+        };
+        let cfg_cannot_run_in_production = ident_at(tokens, index + 2) == Some("cfg")
+            && punct_at(tokens, index + 3) == Some('(')
+            && cfg_can_be_true_without_test(tokens, index + 4, close - 1) == Some(false);
+        if !cfg_cannot_run_in_production {
+            index = close + 1;
+            continue;
+        }
+        let item_start = close + 1;
+        let Some(item_end) = attributed_item_end(tokens, item_start) else {
+            index = close + 1;
+            continue;
+        };
+        skipped.extend(index..=item_end);
+        index = item_end + 1;
+    }
+    skipped
+}
+
+// Evaluates whether a cfg expression can be true when `test=false`. Every
+// other predicate is treated as independently selectable, which retains
+// `cfg(any(test, feature = "..."))` production items.
+fn cfg_can_be_true_without_test(tokens: &[Token], start: usize, end: usize) -> Option<bool> {
+    if start >= end {
+        return None;
+    }
+    if ident_at(tokens, start) == Some("test") {
+        return Some(false);
+    }
+    let function = ident_at(tokens, start)?;
+    if punct_at(tokens, start + 1) != Some('(') {
+        return Some(true);
+    }
+    let close = matching_delimiter(tokens, start + 1, '(', ')')?;
+    if close > end {
+        return None;
+    }
+    let mut values = Vec::new();
+    let mut cursor = start + 2;
+    while cursor < close {
+        let next = cfg_expression_end(tokens, cursor, close);
+        values.push(cfg_can_be_true_without_test(tokens, cursor, next)?);
+        cursor = next;
+        if punct_at(tokens, cursor) == Some(',') {
+            cursor += 1;
+        }
+    }
+    match function {
+        "all" => Some(values.into_iter().all(|value| value)),
+        "any" => Some(values.into_iter().any(|value| value)),
+        // A non-test predicate may be either true or false, so a negation can
+        // still be true. The only exact false case needed here is not(any())
+        // over constants; retaining an item is the safe direction.
+        "not" => Some(true),
+        _ => Some(true),
+    }
+}
+
+fn cfg_expression_end(tokens: &[Token], start: usize, limit: usize) -> usize {
+    let mut cursor = start;
+    let mut depth = 0usize;
+    while cursor < limit {
+        match punct_at(tokens, cursor) {
+            Some('(' | '[' | '{') => depth += 1,
+            Some(')' | ']' | '}') if depth > 0 => depth -= 1,
+            Some(',') if depth == 0 => break,
+            _ => {}
+        }
+        cursor += 1;
+    }
+    cursor
+}
+
+fn attributed_item_end(tokens: &[Token], start: usize) -> Option<usize> {
+    let mut cursor = start;
+    while cursor < tokens.len() {
+        match punct_at(tokens, cursor) {
+            Some('{') => return matching_delimiter(tokens, cursor, '{', '}'),
+            Some(';') => return Some(cursor),
+            _ => cursor += 1,
+        }
+    }
+    None
+}
+
+fn matching_delimiter(tokens: &[Token], open: usize, left: char, right: char) -> Option<usize> {
+    let mut depth = 0usize;
+    for (index, token) in tokens.iter().enumerate().skip(open) {
+        match token.kind {
+            TokenKind::Punct(value) if value == left => depth += 1,
+            TokenKind::Punct(value) if value == right => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn lex(source: &str) -> Result<Vec<Token>, String> {
+    let bytes = source.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    let mut line = 1;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\n' => {
+                line += 1;
+                index += 1;
+            }
+            byte if byte.is_ascii_whitespace() => index += 1,
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index += 2;
+                while index < bytes.len() && bytes[index] != b'\n' {
+                    index += 1;
+                }
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index = skip_block_comment(bytes, index, &mut line)?;
+            }
+            b'"' => {
+                let string_line = line;
+                let (value, next) = normal_string(bytes, index, &mut line)?;
+                tokens.push(Token {
+                    kind: TokenKind::String(value),
+                    line: string_line,
+                });
+                index = next;
+            }
+            b'r' if raw_string_start(bytes, index).is_some() => {
+                let string_line = line;
+                let (value, next) = raw_string(bytes, index, &mut line)?;
+                tokens.push(Token {
+                    kind: TokenKind::String(value),
+                    line: string_line,
+                });
+                index = next;
+            }
+            byte if byte.is_ascii_alphabetic() || byte == b'_' => {
+                let start = index;
+                index += 1;
+                while index < bytes.len()
+                    && (bytes[index].is_ascii_alphanumeric() || bytes[index] == b'_')
+                {
+                    index += 1;
+                }
+                tokens.push(Token {
+                    kind: TokenKind::Ident(source[start..index].to_string()),
+                    line,
+                });
+            }
+            b'\'' => {
+                index = skip_char_or_lifetime(bytes, index, &mut line)?;
+            }
+            byte => {
+                tokens.push(Token {
+                    kind: TokenKind::Punct(char::from(byte)),
+                    line,
+                });
+                index += 1;
+            }
+        }
+    }
+    Ok(tokens)
+}
+
+fn skip_block_comment(bytes: &[u8], mut index: usize, line: &mut usize) -> Result<usize, String> {
+    let mut depth = 0usize;
+    while index + 1 < bytes.len() {
+        match (bytes[index], bytes[index + 1]) {
+            (b'/', b'*') => {
+                depth += 1;
+                index += 2;
+            }
+            (b'*', b'/') => {
+                depth -= 1;
+                index += 2;
+                if depth == 0 {
+                    return Ok(index);
+                }
+            }
+            (b'\n', _) => {
+                *line += 1;
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+    Err("unterminated block comment".to_string())
+}
+
+fn normal_string(
+    bytes: &[u8],
+    mut index: usize,
+    line: &mut usize,
+) -> Result<(String, usize), String> {
+    index += 1;
+    let mut value = String::new();
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' => return Ok((value, index + 1)),
+            b'\\' => {
+                let escaped = *bytes.get(index + 1).ok_or("unterminated string escape")?;
+                if escaped == b'\n' {
+                    *line += 1;
+                    index += 2;
+                    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+                        if bytes[index] == b'\n' {
+                            *line += 1;
+                        }
+                        index += 1;
+                    }
+                    continue;
+                }
+                let decoded = match escaped {
+                    b'"' => '"',
+                    b'\\' => '\\',
+                    b'n' => '\n',
+                    b'r' => '\r',
+                    b't' => '\t',
+                    b'0' => '\0',
+                    // Route literals are plain ASCII. Other strings only need
+                    // to remain one token, so retaining the escaped byte is
+                    // sufficient for scanner correctness.
+                    _ => char::from(escaped),
+                };
+                value.push(decoded);
+                index += 2;
+            }
+            b'\n' => {
+                *line += 1;
+                value.push('\n');
+                index += 1;
+            }
+            byte => {
+                value.push(char::from(byte));
+                index += 1;
+            }
+        }
+    }
+    Err("unterminated string".to_string())
+}
+
+fn raw_string_start(bytes: &[u8], index: usize) -> Option<usize> {
+    let mut cursor = index + 1;
+    while bytes.get(cursor) == Some(&b'#') {
+        cursor += 1;
+    }
+    (bytes.get(cursor) == Some(&b'"')).then_some(cursor - index - 1)
+}
+
+fn raw_string(bytes: &[u8], index: usize, line: &mut usize) -> Result<(String, usize), String> {
+    let hashes = raw_string_start(bytes, index).expect("checked raw string");
+    let content_start = index + hashes + 2;
+    let mut cursor = content_start;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\n' {
+            *line += 1;
+        }
+        if bytes[cursor] == b'"'
+            && bytes.get(cursor + 1..cursor + 1 + hashes) == Some(&vec![b'#'; hashes][..])
+        {
+            let value = String::from_utf8(bytes[content_start..cursor].to_vec())
+                .map_err(|error| error.to_string())?;
+            return Ok((value, cursor + 1 + hashes));
+        }
+        cursor += 1;
+    }
+    Err("unterminated raw string".to_string())
+}
+
+fn skip_char_or_lifetime(bytes: &[u8], index: usize, line: &mut usize) -> Result<usize, String> {
+    let Some(next) = bytes.get(index + 1).copied() else {
+        return Err("dangling apostrophe".to_string());
+    };
+    if next.is_ascii_alphabetic() || next == b'_' {
+        let mut cursor = index + 2;
+        while cursor < bytes.len()
+            && (bytes[cursor].is_ascii_alphanumeric() || bytes[cursor] == b'_')
+        {
+            cursor += 1;
+        }
+        if bytes.get(cursor) != Some(&b'\'') {
+            return Ok(cursor);
+        }
+    }
+    let mut cursor = index + 1;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'\\' => cursor += 2,
+            b'\'' => return Ok(cursor + 1),
+            b'\n' => {
+                *line += 1;
+                cursor += 1;
+            }
+            _ => cursor += 1,
+        }
+    }
+    Err("unterminated character literal".to_string())
+}
+
+#[cfg(test)]
+mod scanner_tests {
+    use super::*;
+
+    #[test]
+    fn lexer_ignores_calls_in_comments_and_strings() {
+        let source = r#"
+            // scoped("/comment", get(handler))
+            let _ = "scoped(\"/string\", get(handler))";
+            scoped("/live", get(handler));
+        "#;
+        let tokens = lex(source).expect("lex fixture");
+        let calls = tokens
+            .windows(3)
+            .filter_map(
+                |window| match (&window[0].kind, &window[1].kind, &window[2].kind) {
+                    (TokenKind::Ident(name), TokenKind::Punct('('), TokenKind::String(path))
+                        if name == "scoped" =>
+                    {
+                        Some(path.clone())
+                    }
+                    _ => None,
+                },
+            )
+            .collect::<Vec<_>>();
+        assert_eq!(calls, ["/live"]);
+    }
+
+    #[test]
+    fn cfg_test_items_are_skipped_without_truncating_the_file() {
+        let tokens = lex(r#"
+                #[cfg(test)]
+                fn only_test() { scoped("/test", get(handler)); }
+                fn production() { scoped("/production", get(handler)); }
+            "#)
+        .expect("lex fixture");
+        let skipped = test_only_token_indexes(&tokens);
+        let visible = tokens
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| !skipped.contains(index))
+            .any(|(_, token)| token.kind == TokenKind::String("/production".to_string()));
+        let hidden = tokens
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| !skipped.contains(index))
+            .any(|(_, token)| token.kind == TokenKind::String("/test".to_string()));
+        assert!(visible);
+        assert!(!hidden);
+    }
+}

--- a/tests/snapshots/auth-matrix.txt
+++ b/tests/snapshots/auth-matrix.txt
@@ -1790,6 +1790,13 @@ POST /api/v1/companies/{id}/team must-change-password-admin refused:403:password
 POST /api/v1/companies/{id}/team platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
 POST /api/v1/companies/{id}/team tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
 POST /api/v1/companies/{id}/team tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/companies/{id}/team/design admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/design anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/design member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/design must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/design platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/design tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/design tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 POST /api/v1/companies/{id}/team/draft admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 POST /api/v1/companies/{id}/team/draft anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 POST /api/v1/companies/{id}/team/draft member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
@@ -2182,6 +2189,13 @@ POST /api/v1/company/team must-change-password-admin refused:403:password_change
 POST /api/v1/company/team platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
 POST /api/v1/company/team tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
 POST /api/v1/company/team tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/company/team/design admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/design anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/design member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/design must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/design platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/design tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/design tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 POST /api/v1/company/team/draft admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 POST /api/v1/company/team/draft anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 POST /api/v1/company/team/draft member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-

--- a/tests/snapshots/auth-matrix.txt
+++ b/tests/snapshots/auth-matrix.txt
@@ -1727,20 +1727,20 @@ POST /api/v1/companies/{id}/skills must-change-password-admin refused:403:passwo
 POST /api/v1/companies/{id}/skills platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/companies/{id}/skills tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/companies/{id}/skills tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
-POST /api/v1/companies/{id}/skills/{slug}/install admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/install anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/install member permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/install must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/install platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/install tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/install tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/uninstall admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/uninstall anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/uninstall member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/uninstall must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/uninstall platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/uninstall tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/companies/{id}/skills/{slug}/uninstall tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
 POST /api/v1/companies/{id}/smtp/test admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
 POST /api/v1/companies/{id}/smtp/test anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
 POST /api/v1/companies/{id}/smtp/test member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
@@ -2126,20 +2126,20 @@ POST /api/v1/company/skills must-change-password-admin refused:403:password_chan
 POST /api/v1/company/skills platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/skills tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/skills tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
-POST /api/v1/company/skills/{slug}/install admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/company/skills/{slug}/install anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/company/skills/{slug}/install member permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/company/skills/{slug}/install must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/company/skills/{slug}/install platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/company/skills/{slug}/install tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/company/skills/{slug}/install tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
-POST /api/v1/company/skills/{slug}/uninstall admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/company/skills/{slug}/uninstall anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/company/skills/{slug}/uninstall member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/company/skills/{slug}/uninstall must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/company/skills/{slug}/uninstall platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/company/skills/{slug}/uninstall tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
-POST /api/v1/company/skills/{slug}/uninstall tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/company/skills/{slug}/install admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills/{slug}/install anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills/{slug}/install member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills/{slug}/install must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills/{slug}/install platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills/{slug}/install tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills/{slug}/install tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills/{slug}/uninstall admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/company/skills/{slug}/uninstall anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/company/skills/{slug}/uninstall member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/company/skills/{slug}/uninstall must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/company/skills/{slug}/uninstall platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/company/skills/{slug}/uninstall tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+POST /api/v1/company/skills/{slug}/uninstall tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
 POST /api/v1/company/smtp/test admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
 POST /api/v1/company/smtp/test anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
 POST /api/v1/company/smtp/test member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
@@ -2427,13 +2427,13 @@ PUT /api/v1/companies/{id}/search must-change-password-admin refused:403:passwor
 PUT /api/v1/companies/{id}/search platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
 PUT /api/v1/companies/{id}/search tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
 PUT /api/v1/companies/{id}/search tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
-PUT /api/v1/companies/{id}/skills/{slug} admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/companies/{id}/skills/{slug} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/companies/{id}/skills/{slug} member permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/companies/{id}/skills/{slug} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/companies/{id}/skills/{slug} platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/companies/{id}/skills/{slug} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/companies/{id}/skills/{slug} tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/companies/{id}/skills/{slug} admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/skills/{slug} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/skills/{slug} member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/skills/{slug} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/skills/{slug} platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/skills/{slug} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/skills/{slug} tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
 PUT /api/v1/companies/{id}/smtp admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
 PUT /api/v1/companies/{id}/smtp anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
 PUT /api/v1/companies/{id}/smtp member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
@@ -2616,13 +2616,13 @@ PUT /api/v1/company/search must-change-password-admin refused:403:password_chang
 PUT /api/v1/company/search platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
 PUT /api/v1/company/search tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
 PUT /api/v1/company/search tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
-PUT /api/v1/company/skills/{slug} admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/company/skills/{slug} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/company/skills/{slug} member permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/company/skills/{slug} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/company/skills/{slug} platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/company/skills/{slug} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
-PUT /api/v1/company/skills/{slug} tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/company/skills/{slug} admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/skills/{slug} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/skills/{slug} member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/skills/{slug} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/skills/{slug} platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/skills/{slug} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/skills/{slug} tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
 PUT /api/v1/company/smtp admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
 PUT /api/v1/company/smtp anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
 PUT /api/v1/company/smtp member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-

--- a/tests/snapshots/auth-matrix.txt
+++ b/tests/snapshots/auth-matrix.txt
@@ -1,0 +1,2660 @@
+DELETE /api/v1/companies/{id}/artifacts/{artifact_id} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/companies/{id}/artifacts/{artifact_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/companies/{id}/artifacts/{artifact_id} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/companies/{id}/artifacts/{artifact_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/companies/{id}/artifacts/{artifact_id} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/companies/{id}/artifacts/{artifact_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/companies/{id}/artifacts/{artifact_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/companies/{id}/billing/chargebee/key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/chargebee/key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/chargebee/key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/chargebee/key must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/chargebee/key platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/chargebee/key tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/chargebee/key tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/paypal/key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/paypal/key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/paypal/key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/paypal/key must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/paypal/key platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/paypal/key tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/billing/paypal/key tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id} admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id} member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id} platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id} tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id}/default admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id}/default anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id}/default member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id}/default must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id}/default platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id}/default tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/composio/connections/{connection_id}/default tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace/{run_id} admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace/{run_id} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace/{run_id} member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace/{run_id} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace/{run_id} platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace/{run_id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/deep-trace/{run_id} tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/hosting/key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/hosting/key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/hosting/key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/hosting/key must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/hosting/key platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/hosting/key tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/hosting/key tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/inference admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/inference anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/inference member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/inference must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/inference platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/inference tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/inference tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug} admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug} member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=none-assigned:ledger-authority
+DELETE /api/v1/companies/{id}/ledgers/{slug} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug} platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug} tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug}/entries/{entry_id} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug}/entries/{entry_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug}/entries/{entry_id} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug}/entries/{entry_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug}/entries/{entry_id} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug}/entries/{entry_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/companies/{id}/ledgers/{slug}/entries/{entry_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/companies/{id}/mcp/registry/{server_id} admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/registry/{server_id} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/registry/{server_id} member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/registry/{server_id} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/registry/{server_id} platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/registry/{server_id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/registry/{server_id} tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/servers/{name} admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/servers/{name} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/servers/{name} member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/servers/{name} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/servers/{name} platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/servers/{name} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/mcp/servers/{name} tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/memory/document/{source} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/companies/{id}/memory/document/{source} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/companies/{id}/memory/document/{source} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/companies/{id}/memory/document/{source} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/companies/{id}/memory/document/{source} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/companies/{id}/memory/document/{source} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/companies/{id}/memory/document/{source} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/companies/{id}/memory/{fact_id} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/companies/{id}/memory/{fact_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/companies/{id}/memory/{fact_id} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/companies/{id}/memory/{fact_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/companies/{id}/memory/{fact_id} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/companies/{id}/memory/{fact_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/companies/{id}/memory/{fact_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/companies/{id}/policy admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/policy anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/policy member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/policy must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/policy platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/companies/{id}/policy tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/policy tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/companies/{id}/presence admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/companies/{id}/presence anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/companies/{id}/presence member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/companies/{id}/presence must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/companies/{id}/presence platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/companies/{id}/presence tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/companies/{id}/presence tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/companies/{id}/search/key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/search/key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/search/key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/search/key must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/search/key platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/search/key tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/search/key tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id}/discussion/{seq} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id}/discussion/{seq} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id}/discussion/{seq} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id}/discussion/{seq} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id}/discussion/{seq} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id}/discussion/{seq} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/companies/{id}/tasks/{task_id}/discussion/{seq} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id} admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id} member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=none-assigned:team-delete-authority
+DELETE /api/v1/companies/{id}/team/{agent_id} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id} platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id} tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id}/budget admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id}/budget anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id}/budget member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id}/budget must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id}/budget platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/companies/{id}/team/{agent_id}/budget tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/team/{agent_id}/budget tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/companies/{id}/tools/grants admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/tools/grants anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/tools/grants member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/tools/grants must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/tools/grants platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/companies/{id}/tools/grants tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/companies/{id}/tools/grants tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/companies/{id}/workflows/{wid} admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/workflows/{wid} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/workflows/{wid} member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=none-assigned:workflow-authority
+DELETE /api/v1/companies/{id}/workflows/{wid} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/workflows/{wid} platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/workflows/{wid} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/workflows/{wid} tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/workspace/{node_id} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/companies/{id}/workspace/{node_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/companies/{id}/workspace/{node_id} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/companies/{id}/workspace/{node_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/companies/{id}/workspace/{node_id} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/companies/{id}/workspace/{node_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/companies/{id}/workspace/{node_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/company/artifacts/{artifact_id} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/company/artifacts/{artifact_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/company/artifacts/{artifact_id} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/company/artifacts/{artifact_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/company/artifacts/{artifact_id} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/company/artifacts/{artifact_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/company/artifacts/{artifact_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove task artifacts." wait=-
+DELETE /api/v1/company/billing/chargebee/key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/chargebee/key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/chargebee/key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/chargebee/key must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/chargebee/key platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/chargebee/key tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/chargebee/key tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/paypal/key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/paypal/key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/paypal/key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/paypal/key must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/paypal/key platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/paypal/key tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/billing/paypal/key tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id} admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id} member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id} platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id} tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id}/default admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id}/default anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id}/default member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id}/default must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id}/default platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id}/default tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/composio/connections/{connection_id}/default tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/deep-trace admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace/{run_id} admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace/{run_id} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace/{run_id} member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace/{run_id} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace/{run_id} platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace/{run_id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/deep-trace/{run_id} tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/hosting/key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/hosting/key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/hosting/key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/hosting/key must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/hosting/key platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/hosting/key tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/hosting/key tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/inference admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/inference anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/inference member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/inference must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/inference platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/inference tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/inference tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/ledgers/{slug} admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/ledgers/{slug} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/ledgers/{slug} member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=none-assigned:ledger-authority
+DELETE /api/v1/company/ledgers/{slug} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/ledgers/{slug} platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/ledgers/{slug} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/ledgers/{slug} tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/ledgers/{slug}/entries/{entry_id} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/company/ledgers/{slug}/entries/{entry_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/company/ledgers/{slug}/entries/{entry_id} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/company/ledgers/{slug}/entries/{entry_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/company/ledgers/{slug}/entries/{entry_id} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/company/ledgers/{slug}/entries/{entry_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/company/ledgers/{slug}/entries/{entry_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete ledger entries." wait=-
+DELETE /api/v1/company/mcp/registry/{server_id} admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/registry/{server_id} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/registry/{server_id} member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/registry/{server_id} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/registry/{server_id} platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/registry/{server_id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/registry/{server_id} tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/servers/{name} admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/servers/{name} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/servers/{name} member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/servers/{name} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/servers/{name} platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/servers/{name} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/mcp/servers/{name} tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/memory/document/{source} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/company/memory/document/{source} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/company/memory/document/{source} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/company/memory/document/{source} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/company/memory/document/{source} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/company/memory/document/{source} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/company/memory/document/{source} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may forget an ingested document." wait=-
+DELETE /api/v1/company/memory/{fact_id} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/company/memory/{fact_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/company/memory/{fact_id} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/company/memory/{fact_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/company/memory/{fact_id} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/company/memory/{fact_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/company/memory/{fact_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete company memory facts." wait=-
+DELETE /api/v1/company/policy admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/policy anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/policy member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/policy must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/policy platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/company/policy tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/policy tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/company/presence admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/company/presence anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/company/presence member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/company/presence must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/company/presence platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/company/presence tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/company/presence tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+DELETE /api/v1/company/search/key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/search/key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/search/key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/search/key must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/search/key platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/search/key tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/search/key tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+DELETE /api/v1/company/tasks/{task_id} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/company/tasks/{task_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/company/tasks/{task_id} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/company/tasks/{task_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/company/tasks/{task_id} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/company/tasks/{task_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/company/tasks/{task_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete task cards." wait=-
+DELETE /api/v1/company/tasks/{task_id}/discussion/{seq} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/company/tasks/{task_id}/discussion/{seq} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/company/tasks/{task_id}/discussion/{seq} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/company/tasks/{task_id}/discussion/{seq} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/company/tasks/{task_id}/discussion/{seq} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/company/tasks/{task_id}/discussion/{seq} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/company/tasks/{task_id}/discussion/{seq} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may redact task discussion messages." wait=-
+DELETE /api/v1/company/team/{agent_id} admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/team/{agent_id} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/team/{agent_id} member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=none-assigned:team-delete-authority
+DELETE /api/v1/company/team/{agent_id} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/team/{agent_id} platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/team/{agent_id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/team/{agent_id} tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/team/{agent_id}/budget admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/team/{agent_id}/budget anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/team/{agent_id}/budget member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/team/{agent_id}/budget must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/team/{agent_id}/budget platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/company/team/{agent_id}/budget tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/team/{agent_id}/budget tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/company/tools/grants admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/tools/grants anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/tools/grants member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/tools/grants must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/tools/grants platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/company/tools/grants tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+DELETE /api/v1/company/tools/grants tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+DELETE /api/v1/company/workflows/{wid} admin permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/workflows/{wid} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/workflows/{wid} member refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=none-assigned:workflow-authority
+DELETE /api/v1/company/workflows/{wid} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/workflows/{wid} platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/workflows/{wid} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/workflows/{wid} tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/workspace/{node_id} admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/company/workspace/{node_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/company/workspace/{node_id} member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/company/workspace/{node_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/company/workspace/{node_id} platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/company/workspace/{node_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+DELETE /api/v1/company/workspace/{node_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may delete workspace nodes." wait=-
+GET /api/v1/companies/{id} admin permitted source=external access=addressed features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id} anonymous refused:401:unauthorized source=external access=addressed features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id} member permitted source=external access=addressed features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id} must-change-password-admin refused:403:password_change_required source=external access=addressed features=openhuman blast=ordinary note="" wait=none-assigned:temp-password-boundary
+GET /api/v1/companies/{id} platform permitted source=external access=addressed features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id} tenant-non-owner refused:403:forbidden source=external access=addressed features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id} tenant-owner permitted source=external access=addressed features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/activation admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/activation anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/activation member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/activation must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/activation platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/activation tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/activation tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/agents/{agent_id}/budget-pause admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/agents/{agent_id}/budget-pause anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/agents/{agent_id}/budget-pause member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/agents/{agent_id}/budget-pause must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/agents/{agent_id}/budget-pause platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/agents/{agent_id}/budget-pause tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/agents/{agent_id}/budget-pause tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id}/diff admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id}/diff anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id}/diff member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id}/diff must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id}/diff platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id}/diff tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/artifacts/{artifact_id}/diff tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/chargebee admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/chargebee anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/chargebee member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/chargebee must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/chargebee platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/chargebee tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/chargebee tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/paypal admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/paypal anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/paypal member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/paypal must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/paypal platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/paypal tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/billing/paypal tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/capabilities admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/capabilities anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/capabilities member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/capabilities must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/capabilities platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/capabilities tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/capabilities tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/mentionables admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/mentionables anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/mentionables member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/mentionables must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/mentionables platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/mentionables tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/mentionables tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/read-state admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/read-state anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/read-state member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/read-state must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/read-state platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/read-state tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/chat/read-state tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio/connections admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio/connections anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio/connections member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio/connections must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio/connections platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio/connections tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/composio/connections tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/connections admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/connections anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/connections member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/connections must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/connections platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/connections tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/connections tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/credential admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/credential anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/credential member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/credential must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/credential platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/credential tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/credential tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/domain admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/domain anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/domain member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/domain must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/domain platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/domain tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/domain tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/finance/chargebee/customers admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/customers anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/customers member permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/customers must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/customers platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/customers tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/customers tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices member permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices/{invoice_id} admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices/{invoice_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices/{invoice_id} member permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices/{invoice_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices/{invoice_id} platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices/{invoice_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/chargebee/invoices/{invoice_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/companies/{id}/finance/paypal/balance admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/companies/{id}/finance/paypal/balance anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/companies/{id}/finance/paypal/balance member permitted source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/companies/{id}/finance/paypal/balance must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/companies/{id}/finance/paypal/balance platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/companies/{id}/finance/paypal/balance tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/companies/{id}/finance/paypal/balance tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/companies/{id}/finance/paypal/transactions admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/companies/{id}/finance/paypal/transactions anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/companies/{id}/finance/paypal/transactions member permitted source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/companies/{id}/finance/paypal/transactions must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/companies/{id}/finance/paypal/transactions platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/companies/{id}/finance/paypal/transactions tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/companies/{id}/finance/paypal/transactions tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/companies/{id}/finances admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/finances anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/finances member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/finances must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/finances platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/finances tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/finances tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/harnesses admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/harnesses anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/harnesses member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/harnesses must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/harnesses platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/harnesses tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/harnesses tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/hosting admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/hosting anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/hosting member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/hosting must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/hosting platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/hosting tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/hosting tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes/{key}/messages admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes/{key}/messages anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes/{key}/messages member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes/{key}/messages must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes/{key}/messages platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes/{key}/messages tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inboxes/{key}/messages tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference/models admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference/models anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference/models member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference/models must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference/models platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference/models tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/inference/models tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/entries admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/entries anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/entries member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/entries must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/entries platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/entries tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/entries tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/rendered admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/rendered anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/rendered member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/rendered must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/rendered platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/rendered tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/ledgers/{slug}/rendered tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/config admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/config anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/config member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/config must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/config platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/config tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/config tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/entry admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/entry anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/entry member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/entry must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/entry platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/entry tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/entry tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/search admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/search anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/search member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/search must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/search platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/search tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/registry/search tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/servers admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/servers anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/servers member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/servers must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/servers platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/servers tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/servers tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/mcp/servers/{name}/tools admin permitted source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/companies/{id}/mcp/servers/{name}/tools anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/companies/{id}/mcp/servers/{name}/tools member permitted source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/companies/{id}/mcp/servers/{name}/tools must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/companies/{id}/mcp/servers/{name}/tools platform permitted source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/companies/{id}/mcp/servers/{name}/tools tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/companies/{id}/mcp/servers/{name}/tools tenant-owner permitted source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/companies/{id}/memory admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/archives admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/archives anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/archives member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/archives must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/archives platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/archives tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/archives tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/engine admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/companies/{id}/memory/engine anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/companies/{id}/memory/engine member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/companies/{id}/memory/engine must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/companies/{id}/memory/engine platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/companies/{id}/memory/engine tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/companies/{id}/memory/engine tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/companies/{id}/memory/stats admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/stats anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/stats member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/stats must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/stats platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/stats tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/stats tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/traces admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/traces anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/traces member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/traces must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/traces platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/traces tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/memory/traces tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/notifications admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/notifications anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/notifications member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/notifications must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/notifications platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/notifications tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/notifications tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bootstrap.mjs admin exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bootstrap.mjs anonymous exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bootstrap.mjs member exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bootstrap.mjs must-change-password-admin exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bootstrap.mjs platform exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bootstrap.mjs tenant-non-owner exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bootstrap.mjs tenant-owner exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bundle.mjs admin exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bundle.mjs anonymous exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bundle.mjs member exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bundle.mjs must-change-password-admin exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bundle.mjs platform exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bundle.mjs tenant-non-owner exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/pages/{slug}/bundle.mjs tenant-owner exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/policy admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/policy anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/policy member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/policy must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/policy platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/policy tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/policy tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/presence admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/presence anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/presence member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/presence must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/presence platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/presence tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/presence tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs/{run_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs/{run_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs/{run_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs/{run_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs/{run_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs/{run_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/runs/{run_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/search admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/search anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/search member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/search must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/search platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/search tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/search tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills/registry admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills/registry anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills/registry member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills/registry must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills/registry platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills/registry tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/skills/registry tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/smtp admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/smtp anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/smtp member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/smtp must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/smtp platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/smtp tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/smtp tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/inflight admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/inflight anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/inflight member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/inflight must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/inflight platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/inflight tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/inflight tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/artifacts admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/artifacts anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/artifacts member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/artifacts must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/artifacts platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/artifacts tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/artifacts tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/export admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/export anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/export member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/export must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/export platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/export tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tasks/{task_id}/export tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team/{agent_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team/{agent_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team/{agent_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team/{agent_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team/{agent_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team/{agent_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/team/{agent_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/catalog admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/catalog anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/catalog member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/catalog must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/catalog platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/catalog tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/catalog tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/grants admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/grants anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/grants member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/grants must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/grants platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/grants tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/tools/grants tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/usage admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/usage anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/usage member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/usage must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/usage platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/usage tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/usage tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/artifacts admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/artifacts anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/artifacts member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/artifacts must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/artifacts platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/artifacts tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/artifacts tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/output admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/output anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/output member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/output must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/output platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/output tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/runs/{rid}/output tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/tool-slugs admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/tool-slugs anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/tool-slugs member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/tool-slugs must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/tool-slugs platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/tool-slugs tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/tool-slugs tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/wired-channels admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/wired-channels anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/wired-channels member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/wired-channels must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/wired-channels platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/wired-channels tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/wired-channels tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid}/revisions admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid}/revisions anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid}/revisions member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid}/revisions must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid}/revisions platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid}/revisions tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workflows/{wid}/revisions tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/blob/{node_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/blob/{node_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/blob/{node_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/blob/{node_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/blob/{node_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/blob/{node_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/blob/{node_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/file/{node_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/file/{node_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/file/{node_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/file/{node_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/file/{node_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/file/{node_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/file/{node_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/search admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/search anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/search member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/search must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/search platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/search tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/workspace/search tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/activation admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/activation anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/activation member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/activation must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/activation platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/activation tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/activation tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/agents/{agent_id}/budget-pause admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/agents/{agent_id}/budget-pause anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/agents/{agent_id}/budget-pause member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/agents/{agent_id}/budget-pause must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/agents/{agent_id}/budget-pause platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/agents/{agent_id}/budget-pause tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/agents/{agent_id}/budget-pause tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id}/diff admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id}/diff anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id}/diff member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id}/diff must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id}/diff platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id}/diff tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/artifacts/{artifact_id}/diff tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/chargebee admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/chargebee anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/chargebee member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/chargebee must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/chargebee platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/chargebee tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/chargebee tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/paypal admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/paypal anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/paypal member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/paypal must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/paypal platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/paypal tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/billing/paypal tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/capabilities admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/capabilities anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/capabilities member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/capabilities must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/capabilities platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/capabilities tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/capabilities tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/mentionables admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/mentionables anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/mentionables member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/mentionables must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/mentionables platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/mentionables tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/mentionables tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/read-state admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/read-state anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/read-state member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/read-state must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/read-state platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/read-state tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/chat/read-state tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio/connections admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio/connections anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio/connections member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio/connections must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio/connections platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio/connections tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/composio/connections tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/connections admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/connections anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/connections member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/connections must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/connections platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/connections tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/connections tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/credential admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/credential anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/credential member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/credential must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/credential platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/credential tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/credential tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/domain admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/domain anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/domain member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/domain must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/domain platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/domain tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/domain tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/finance/chargebee/customers admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/company/finance/chargebee/customers anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/company/finance/chargebee/customers member permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/company/finance/chargebee/customers must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/company/finance/chargebee/customers platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/company/finance/chargebee/customers tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/company/finance/chargebee/customers tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee customer data." wait=-
+GET /api/v1/company/finance/chargebee/invoices admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices member permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices/{invoice_id} admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices/{invoice_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices/{invoice_id} member permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices/{invoice_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices/{invoice_id} platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices/{invoice_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/chargebee/invoices/{invoice_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may read Chargebee invoice data." wait=-
+GET /api/v1/company/finance/paypal/balance admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/company/finance/paypal/balance anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/company/finance/paypal/balance member permitted source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/company/finance/paypal/balance must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/company/finance/paypal/balance platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/company/finance/paypal/balance tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/company/finance/paypal/balance tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may read the PayPal balance." wait=-
+GET /api/v1/company/finance/paypal/transactions admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/company/finance/paypal/transactions anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/company/finance/paypal/transactions member permitted source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/company/finance/paypal/transactions must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/company/finance/paypal/transactions platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/company/finance/paypal/transactions tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/company/finance/paypal/transactions tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may read PayPal transactions." wait=-
+GET /api/v1/company/finances admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/finances anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/finances member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/finances must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/finances platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/finances tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/finances tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/harnesses admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/harnesses anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/harnesses member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/harnesses must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/harnesses platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/harnesses tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/harnesses tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/hosting admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/hosting anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/hosting member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/hosting must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/hosting platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/hosting tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/hosting tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes/{key}/messages admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes/{key}/messages anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes/{key}/messages member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes/{key}/messages must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes/{key}/messages platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes/{key}/messages tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inboxes/{key}/messages tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference/models admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference/models anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference/models member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference/models must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference/models platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference/models tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/inference/models tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/entries admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/entries anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/entries member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/entries must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/entries platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/entries tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/entries tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/rendered admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/rendered anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/rendered member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/rendered must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/rendered platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/rendered tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/ledgers/{slug}/rendered tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/config admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/config anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/config member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/config must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/config platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/config tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/config tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/entry admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/entry anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/entry member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/entry must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/entry platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/entry tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/entry tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/search admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/search anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/search member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/search must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/search platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/search tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/registry/search tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/servers admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/servers anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/servers member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/servers must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/servers platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/servers tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/servers tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/mcp/servers/{name}/tools admin permitted source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/company/mcp/servers/{name}/tools anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/company/mcp/servers/{name}/tools member permitted source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/company/mcp/servers/{name}/tools must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/company/mcp/servers/{name}/tools platform permitted source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/company/mcp/servers/{name}/tools tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/company/mcp/servers/{name}/tools tenant-owner permitted source=ops access=scoped features=openhuman blast=credential note="Members may discover tools using the stored server credential." wait=-
+GET /api/v1/company/memory admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/archives admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/archives anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/archives member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/archives must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/archives platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/archives tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/archives tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/engine admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/company/memory/engine anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/company/memory/engine member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/company/memory/engine must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/company/memory/engine platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/company/memory/engine tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/company/memory/engine tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+GET /api/v1/company/memory/stats admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/stats anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/stats member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/stats must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/stats platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/stats tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/stats tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/traces admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/traces anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/traces member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/traces must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/traces platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/traces tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/memory/traces tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/notifications admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/notifications anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/notifications member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/notifications must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/notifications platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/notifications tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/notifications tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bootstrap.mjs admin exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bootstrap.mjs anonymous exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bootstrap.mjs member exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bootstrap.mjs must-change-password-admin exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bootstrap.mjs platform exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bootstrap.mjs tenant-non-owner exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bootstrap.mjs tenant-owner exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bundle.mjs admin exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bundle.mjs anonymous exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bundle.mjs member exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bundle.mjs must-change-password-admin exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bundle.mjs platform exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bundle.mjs tenant-non-owner exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/pages/{slug}/bundle.mjs tenant-owner exact:404:not_found source=ops access=capability features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/policy admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/policy anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/policy member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/policy must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/policy platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/policy tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/policy tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/presence admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/presence anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/presence member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/presence must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/presence platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/presence tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/presence tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs/{run_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs/{run_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs/{run_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs/{run_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs/{run_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs/{run_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/runs/{run_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/search admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/search anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/search member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/search must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/search platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/search tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/search tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills/registry admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills/registry anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills/registry member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills/registry must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills/registry platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills/registry tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/skills/registry tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/smtp admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/smtp anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/smtp member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/smtp must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/smtp platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/smtp tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/smtp tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/inflight admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/inflight anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/inflight member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/inflight must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/inflight platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/inflight tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/inflight tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/artifacts admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/artifacts anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/artifacts member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/artifacts must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/artifacts platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/artifacts tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/artifacts tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/export admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/export anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/export member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/export must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/export platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/export tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tasks/{task_id}/export tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team/{agent_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team/{agent_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team/{agent_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team/{agent_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team/{agent_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team/{agent_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/team/{agent_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/catalog admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/catalog anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/catalog member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/catalog must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/catalog platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/catalog tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/catalog tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/grants admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/grants anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/grants member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/grants must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/grants platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/grants tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/tools/grants tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/usage admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/usage anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/usage member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/usage must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/usage platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/usage tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/usage tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/artifacts admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/artifacts anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/artifacts member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/artifacts must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/artifacts platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/artifacts tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/artifacts tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/output admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/output anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/output member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/output must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/output platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/output tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/runs/{rid}/output tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/tool-slugs admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/tool-slugs anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/tool-slugs member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/tool-slugs must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/tool-slugs platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/tool-slugs tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/tool-slugs tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/wired-channels admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/wired-channels anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/wired-channels member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/wired-channels must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/wired-channels platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/wired-channels tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/wired-channels tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid}/revisions admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid}/revisions anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid}/revisions member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid}/revisions must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid}/revisions platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid}/revisions tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workflows/{wid}/revisions tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/blob/{node_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/blob/{node_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/blob/{node_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/blob/{node_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/blob/{node_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/blob/{node_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/blob/{node_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/file/{node_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/file/{node_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/file/{node_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/file/{node_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/file/{node_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/file/{node_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/file/{node_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/search admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/search anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/search member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/search must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/search platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/search tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/workspace/search tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/oauth/callback admin exact:410 source=ops access=public-gone features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/oauth/callback anonymous exact:410 source=ops access=public-gone features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/oauth/callback member exact:410 source=ops access=public-gone features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/oauth/callback must-change-password-admin exact:410 source=ops access=public-gone features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/oauth/callback platform exact:410 source=ops access=public-gone features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/oauth/callback tenant-non-owner exact:410 source=ops access=public-gone features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/oauth/callback tenant-owner exact:410 source=ops access=public-gone features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id} admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PATCH /api/v1/companies/{id} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PATCH /api/v1/companies/{id} member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PATCH /api/v1/companies/{id} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PATCH /api/v1/companies/{id} platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PATCH /api/v1/companies/{id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PATCH /api/v1/companies/{id} tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PATCH /api/v1/companies/{id}/tasks/{task_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/tasks/{task_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/tasks/{task_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/tasks/{task_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/tasks/{task_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/tasks/{task_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/tasks/{task_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/team/{agent_id} admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/companies/{id}/team/{agent_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/companies/{id}/team/{agent_id} member permitted source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/companies/{id}/team/{agent_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/companies/{id}/team/{agent_id} platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/companies/{id}/team/{agent_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/companies/{id}/team/{agent_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/companies/{id}/workspace/{node_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/workspace/{node_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/workspace/{node_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/workspace/{node_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/workspace/{node_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/workspace/{node_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/companies/{id}/workspace/{node_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PATCH /api/v1/company anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PATCH /api/v1/company member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PATCH /api/v1/company must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PATCH /api/v1/company platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PATCH /api/v1/company tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PATCH /api/v1/company tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PATCH /api/v1/company/tasks/{task_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/tasks/{task_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/tasks/{task_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/tasks/{task_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/tasks/{task_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/tasks/{task_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/tasks/{task_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/team/{agent_id} admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/company/team/{agent_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/company/team/{agent_id} member permitted source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/company/team/{agent_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/company/team/{agent_id} platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/company/team/{agent_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/company/team/{agent_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may edit non-sensitive teammate fields; tools, model, and harness require admin." wait=-
+PATCH /api/v1/company/workspace/{node_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/workspace/{node_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/workspace/{node_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/workspace/{node_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/workspace/{node_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/workspace/{node_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PATCH /api/v1/company/workspace/{node_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/agents/{agent_id}/budget-pause/redeem admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/companies/{id}/agents/{agent_id}/budget-pause/redeem anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/companies/{id}/agents/{agent_id}/budget-pause/redeem member permitted source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/companies/{id}/agents/{agent_id}/budget-pause/redeem must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/companies/{id}/agents/{agent_id}/budget-pause/redeem platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/companies/{id}/agents/{agent_id}/budget-pause/redeem tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/companies/{id}/agents/{agent_id}/budget-pause/redeem tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/companies/{id}/approvals/{aid} admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/approvals/{aid} anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/approvals/{aid} member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/companies/{id}/approvals/{aid} must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/companies/{id}/approvals/{aid} platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/approvals/{aid} tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/approvals/{aid} tenant-owner permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/approvals/{aid}/extend admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/approvals/{aid}/extend anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/approvals/{aid}/extend member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/companies/{id}/approvals/{aid}/extend must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/companies/{id}/approvals/{aid}/extend platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/approvals/{aid}/extend tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/approvals/{aid}/extend tenant-owner permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/artifacts admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts/{artifact_id}/versions admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts/{artifact_id}/versions anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts/{artifact_id}/versions member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts/{artifact_id}/versions must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts/{artifact_id}/versions platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts/{artifact_id}/versions tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/artifacts/{artifact_id}/versions tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/avatars admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/avatars anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/avatars member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/avatars must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/avatars platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/avatars tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/avatars tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/typing admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/typing anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/typing member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/typing must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/typing platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/typing tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/typing tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/upload admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/upload anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/upload member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/upload must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/upload platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/upload tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/chat/upload tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/composio/authorize admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/composio/authorize anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/composio/authorize member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/composio/authorize must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/composio/authorize platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/composio/authorize tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/composio/authorize tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/disconnect admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/disconnect anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/disconnect member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/disconnect must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/disconnect platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/disconnect tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/disconnect tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/start admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/start anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/start member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/start must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/start platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/start tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/connections/{provider}/start tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/domain/verify admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/domain/verify anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/domain/verify member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/domain/verify must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/domain/verify platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/domain/verify tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/domain/verify tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/emergency-pause admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-pause anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-pause member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/companies/{id}/emergency-pause must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-pause platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-pause tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-pause tenant-owner permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-resume admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-resume anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-resume member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/companies/{id}/emergency-resume must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-resume platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-resume tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/emergency-resume tenant-owner permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/finance/chargebee/invoices admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/finance/chargebee/invoices anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/finance/chargebee/invoices member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/finance/chargebee/invoices must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/finance/chargebee/invoices platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/finance/chargebee/invoices tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/finance/chargebee/invoices tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/finance/chargebee/test admin permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/chargebee/test anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/chargebee/test member permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/chargebee/test must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/chargebee/test platform permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/chargebee/test tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/chargebee/test tenant-owner permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/paypal/test admin permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/paypal/test anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/paypal/test member permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/paypal/test must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/paypal/test platform permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/paypal/test tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/companies/{id}/finance/paypal/test tenant-owner permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/companies/{id}/inboxes/ingest admin refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/ingest anonymous refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/ingest member refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/ingest must-change-password-admin refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/ingest platform refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/ingest tenant-non-owner refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/ingest tenant-owner refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/{key}/read admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/{key}/read anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/{key}/read member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/{key}/read must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/{key}/read platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/{key}/read tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inboxes/{key}/read tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/inference/restart admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/inference/restart anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/inference/restart member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/inference/restart must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/inference/restart platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/inference/restart tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/inference/restart tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/inference/test admin permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/companies/{id}/inference/test anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/companies/{id}/inference/test member permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/companies/{id}/inference/test must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/companies/{id}/inference/test platform permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/companies/{id}/inference/test tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/companies/{id}/inference/test tenant-owner permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/companies/{id}/ledgers admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/ledgers anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/ledgers member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:ledger-authority
+POST /api/v1/companies/{id}/ledgers must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/ledgers platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/ledgers tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/ledgers tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/ledgers/{slug}/entries admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/ledgers/{slug}/entries anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/ledgers/{slug}/entries member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/ledgers/{slug}/entries must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/ledgers/{slug}/entries platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/ledgers/{slug}/entries tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/ledgers/{slug}/entries tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/install admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/install anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/install member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/install must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/install platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/install tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/install tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/connect admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/connect anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/connect member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/connect must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/connect platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/connect tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/connect tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/disconnect admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/disconnect anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/disconnect member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/disconnect must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/disconnect platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/disconnect tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/registry/{server_id}/disconnect tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/oauth/start admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/oauth/start anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/oauth/start member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/oauth/start must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/oauth/start platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/oauth/start tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/oauth/start tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/test admin permitted source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/test anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/test member permitted source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/test must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/test platform permitted source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/test tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/companies/{id}/mcp/servers/{name}/test tenant-owner permitted source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/companies/{id}/memory admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory/engine/test admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/memory/engine/test anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/memory/engine/test member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/memory/engine/test must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/memory/engine/test platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/memory/engine/test tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/memory/engine/test tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/memory/ingest admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory/ingest anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory/ingest member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory/ingest must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory/ingest platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory/ingest tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory/ingest tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/memory/ingest/links admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/companies/{id}/memory/ingest/links anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/companies/{id}/memory/ingest/links member permitted source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/companies/{id}/memory/ingest/links must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/companies/{id}/memory/ingest/links platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/companies/{id}/memory/ingest/links tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/companies/{id}/memory/ingest/links tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/companies/{id}/pause admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/pause anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/pause member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/companies/{id}/pause must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/pause platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/pause tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/pause tenant-owner permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/resume admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/resume anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/resume member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/companies/{id}/resume must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/resume platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/resume tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/resume tenant-owner permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/setup/roster admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/setup/roster anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/setup/roster member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/setup/roster must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/setup/roster platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/setup/roster tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/setup/roster tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/skills admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=fix/skills-admin-and-bounded-write
+POST /api/v1/companies/{id}/skills must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install member permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/install tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/companies/{id}/skills/{slug}/uninstall tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/companies/{id}/smtp/test admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/smtp/test anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/smtp/test member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/smtp/test must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/smtp/test platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/smtp/test tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/smtp/test tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/companies/{id}/tasks admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/discussion admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/discussion anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/discussion member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/discussion must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/discussion platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/discussion tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/discussion tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/steer admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/steer anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/steer member permitted source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/steer must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/steer platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/steer tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/steer tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/apply admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/apply anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/apply member permitted source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/apply must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/apply platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/apply tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/apply tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/reject admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/reject anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/reject member permitted source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/reject must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/reject platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/reject tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/tasks/{task_id}/workflow-proposal/reject tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/companies/{id}/team admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/companies/{id}/team anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/companies/{id}/team member permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/companies/{id}/team must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/companies/{id}/team platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/companies/{id}/team tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/companies/{id}/team tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/companies/{id}/team/draft admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/draft anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/draft member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/draft must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/draft platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/draft tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/draft tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/{agent_id}/draft admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/{agent_id}/draft anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/{agent_id}/draft member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/{agent_id}/draft must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/{agent_id}/draft platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/{agent_id}/draft tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/team/{agent_id}/draft tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:workflow-authority
+POST /api/v1/companies/{id}/workflows must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows/cron/preview admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/cron/preview anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/cron/preview member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/cron/preview must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/cron/preview platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/cron/preview tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/cron/preview tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/draft-from-description admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/draft-from-description anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/draft-from-description member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/draft-from-description must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/draft-from-description platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/draft-from-description tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/draft-from-description tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/runs/{rid}/cancel admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/companies/{id}/workflows/runs/{rid}/cancel anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/companies/{id}/workflows/runs/{rid}/cancel member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/companies/{id}/workflows/runs/{rid}/cancel must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/companies/{id}/workflows/runs/{rid}/cancel platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/companies/{id}/workflows/runs/{rid}/cancel tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/companies/{id}/workflows/runs/{rid}/cancel tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/companies/{id}/workflows/validate admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/validate anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/validate member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/validate must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/validate platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/validate tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/validate tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/fix-from-run admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/fix-from-run anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/fix-from-run member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/fix-from-run must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/fix-from-run platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/fix-from-run tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/fix-from-run tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/revisions/{rev}/restore admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/revisions/{rev}/restore anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/revisions/{rev}/restore member permitted source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/revisions/{rev}/restore must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/revisions/{rev}/restore platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/revisions/{rev}/restore tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/revisions/{rev}/restore tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/run admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/run anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/run member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:workflow-authority
+POST /api/v1/companies/{id}/workflows/{wid}/run must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/run platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/run tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workflows/{wid}/run tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/companies/{id}/workspace admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace/merge-duplicate-folders admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/companies/{id}/workspace/merge-duplicate-folders anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/companies/{id}/workspace/merge-duplicate-folders member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/companies/{id}/workspace/merge-duplicate-folders must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/companies/{id}/workspace/merge-duplicate-folders platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/companies/{id}/workspace/merge-duplicate-folders tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/companies/{id}/workspace/merge-duplicate-folders tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/companies/{id}/workspace/sweep-empty-agent-folders admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/companies/{id}/workspace/sweep-empty-agent-folders anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/companies/{id}/workspace/sweep-empty-agent-folders member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/companies/{id}/workspace/sweep-empty-agent-folders must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/companies/{id}/workspace/sweep-empty-agent-folders platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/companies/{id}/workspace/sweep-empty-agent-folders tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/companies/{id}/workspace/sweep-empty-agent-folders tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/companies/{id}/workspace/upload admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace/upload anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace/upload member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace/upload must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace/upload platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace/upload tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/companies/{id}/workspace/upload tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/agents/{agent_id}/budget-pause/redeem admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/company/agents/{agent_id}/budget-pause/redeem anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/company/agents/{agent_id}/budget-pause/redeem member permitted source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/company/agents/{agent_id}/budget-pause/redeem must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/company/agents/{agent_id}/budget-pause/redeem platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/company/agents/{agent_id}/budget-pause/redeem tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/company/agents/{agent_id}/budget-pause/redeem tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
+POST /api/v1/company/approvals/{aid} admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid} anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid} member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/company/approvals/{aid} must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid} platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid} tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid} tenant-owner permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid}/extend admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid}/extend anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid}/extend member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/company/approvals/{aid}/extend must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid}/extend platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid}/extend tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/approvals/{aid}/extend tenant-owner permitted source=external access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/artifacts admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts/{artifact_id}/versions admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts/{artifact_id}/versions anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts/{artifact_id}/versions member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts/{artifact_id}/versions must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts/{artifact_id}/versions platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts/{artifact_id}/versions tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/artifacts/{artifact_id}/versions tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/avatars admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/avatars anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/avatars member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/avatars must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/avatars platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/avatars tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/avatars tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/typing admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/typing anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/typing member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/typing must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/typing platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/typing tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/typing tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/upload admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/upload anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/upload member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/upload must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/upload platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/upload tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/chat/upload tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/composio/authorize admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/composio/authorize anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/composio/authorize member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/composio/authorize must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/composio/authorize platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/composio/authorize tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/composio/authorize tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/disconnect admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/disconnect anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/disconnect member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/disconnect must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/disconnect platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/disconnect tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/disconnect tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/start admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/start anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/start member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/start must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/start platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/start tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/connections/{provider}/start tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/domain/verify admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/domain/verify anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/domain/verify member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/domain/verify must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/domain/verify platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/domain/verify tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/domain/verify tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/finance/chargebee/invoices admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/finance/chargebee/invoices anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/finance/chargebee/invoices member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/finance/chargebee/invoices must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/finance/chargebee/invoices platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/finance/chargebee/invoices tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/finance/chargebee/invoices tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/finance/chargebee/test admin permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/company/finance/chargebee/test anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/company/finance/chargebee/test member permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/company/finance/chargebee/test must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/company/finance/chargebee/test platform permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/company/finance/chargebee/test tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/company/finance/chargebee/test tenant-owner permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe Chargebee with the stored credential." wait=-
+POST /api/v1/company/finance/paypal/test admin permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/company/finance/paypal/test anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/company/finance/paypal/test member permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/company/finance/paypal/test must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/company/finance/paypal/test platform permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/company/finance/paypal/test tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/company/finance/paypal/test tenant-owner permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe PayPal with the stored credential." wait=-
+POST /api/v1/company/inboxes/ingest admin refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/ingest anonymous refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/ingest member refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/ingest must-change-password-admin refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/ingest platform refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/ingest tenant-non-owner refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/ingest tenant-owner refused:401:unauthorized source=ops access=hmac features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/{key}/read admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/{key}/read anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/{key}/read member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/{key}/read must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/{key}/read platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/{key}/read tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inboxes/{key}/read tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/inference/restart admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/inference/restart anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/inference/restart member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/inference/restart must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/inference/restart platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/inference/restart tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/inference/restart tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/inference/test admin permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/company/inference/test anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/company/inference/test member permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/company/inference/test must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/company/inference/test platform permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/company/inference/test tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/company/inference/test tenant-owner permitted source=ops access=scoped features=openhuman blast=credential note="Members may probe inference with the stored credential." wait=-
+POST /api/v1/company/ledgers admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/ledgers anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/ledgers member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:ledger-authority
+POST /api/v1/company/ledgers must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/ledgers platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/ledgers tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/ledgers tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/ledgers/{slug}/entries admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/ledgers/{slug}/entries anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/ledgers/{slug}/entries member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/ledgers/{slug}/entries must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/ledgers/{slug}/entries platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/ledgers/{slug}/entries tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/ledgers/{slug}/entries tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/mcp/registry/install admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/install anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/install member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/install must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/install platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/install tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/install tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/connect admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/connect anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/connect member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/connect must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/connect platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/connect tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/connect tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/disconnect admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/disconnect anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/disconnect member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/disconnect must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/disconnect platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/disconnect tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/registry/{server_id}/disconnect tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers/{name}/oauth/start admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers/{name}/oauth/start anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers/{name}/oauth/start member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers/{name}/oauth/start must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers/{name}/oauth/start platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers/{name}/oauth/start tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers/{name}/oauth/start tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/mcp/servers/{name}/test admin permitted source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/company/mcp/servers/{name}/test anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/company/mcp/servers/{name}/test member permitted source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/company/mcp/servers/{name}/test must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/company/mcp/servers/{name}/test platform permitted source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/company/mcp/servers/{name}/test tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/company/mcp/servers/{name}/test tenant-owner permitted source=ops access=scoped features=openhuman blast=credential note="Members may connect using the stored server credential." wait=-
+POST /api/v1/company/memory admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory/engine/test admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/memory/engine/test anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/memory/engine/test member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/memory/engine/test must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/memory/engine/test platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/memory/engine/test tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/memory/engine/test tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/memory/ingest admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory/ingest anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory/ingest member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory/ingest must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory/ingest platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory/ingest tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory/ingest tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/memory/ingest/links admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/company/memory/ingest/links anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/company/memory/ingest/links member permitted source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/company/memory/ingest/links must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/company/memory/ingest/links platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/company/memory/ingest/links tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/company/memory/ingest/links tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may submit URLs for server-side ingestion." wait=-
+POST /api/v1/company/setup/roster admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/setup/roster anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/setup/roster member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/setup/roster must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/setup/roster platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/setup/roster tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/setup/roster tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/skills admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=fix/skills-admin-and-bounded-write
+POST /api/v1/company/skills must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/skills/{slug}/install admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/company/skills/{slug}/install anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/company/skills/{slug}/install member permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/company/skills/{slug}/install must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/company/skills/{slug}/install platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/company/skills/{slug}/install tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/company/skills/{slug}/install tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may install a skill into every agent's prompt." wait=-
+POST /api/v1/company/skills/{slug}/uninstall admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/company/skills/{slug}/uninstall anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/company/skills/{slug}/uninstall member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/company/skills/{slug}/uninstall must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/company/skills/{slug}/uninstall platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/company/skills/{slug}/uninstall tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/company/skills/{slug}/uninstall tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove an installed skill." wait=-
+POST /api/v1/company/smtp/test admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/smtp/test anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/smtp/test member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/smtp/test must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/smtp/test platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/smtp/test tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/smtp/test tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+POST /api/v1/company/tasks admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks/{task_id}/discussion admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks/{task_id}/discussion anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks/{task_id}/discussion member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks/{task_id}/discussion must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks/{task_id}/discussion platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks/{task_id}/discussion tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks/{task_id}/discussion tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/tasks/{task_id}/steer admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/company/tasks/{task_id}/steer anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/company/tasks/{task_id}/steer member permitted source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/company/tasks/{task_id}/steer must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/company/tasks/{task_id}/steer platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/company/tasks/{task_id}/steer tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/company/tasks/{task_id}/steer tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may steer or cancel active task work." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/apply admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/apply anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/apply member permitted source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/apply must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/apply platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/apply tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/apply tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may accept a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/reject admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/reject anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/reject member permitted source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/reject must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/reject platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/reject tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/company/tasks/{task_id}/workflow-proposal/reject tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may reject a task-authored workflow proposal." wait=-
+POST /api/v1/company/team admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/company/team anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/company/team member permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/company/team must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/company/team platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/company/team tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/company/team tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may add teammates unless privileged budget or tool fields are requested." wait=-
+POST /api/v1/company/team/draft admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/draft anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/draft member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/draft must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/draft platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/draft tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/draft tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/{agent_id}/draft admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/{agent_id}/draft anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/{agent_id}/draft member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/{agent_id}/draft must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/{agent_id}/draft platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/{agent_id}/draft tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/team/{agent_id}/draft tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:workflow-authority
+POST /api/v1/company/workflows must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows/cron/preview admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/cron/preview anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/cron/preview member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/cron/preview must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/cron/preview platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/cron/preview tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/cron/preview tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/draft-from-description admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/draft-from-description anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/draft-from-description member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/draft-from-description must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/draft-from-description platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/draft-from-description tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/draft-from-description tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/runs/{rid}/cancel admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/company/workflows/runs/{rid}/cancel anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/company/workflows/runs/{rid}/cancel member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/company/workflows/runs/{rid}/cancel must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/company/workflows/runs/{rid}/cancel platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/company/workflows/runs/{rid}/cancel tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/company/workflows/runs/{rid}/cancel tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may cancel an active workflow run." wait=-
+POST /api/v1/company/workflows/validate admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/validate anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/validate member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/validate must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/validate platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/validate tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/validate tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/{wid}/fix-from-run admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/{wid}/fix-from-run anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/{wid}/fix-from-run member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/{wid}/fix-from-run must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/{wid}/fix-from-run platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/{wid}/fix-from-run tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/{wid}/fix-from-run tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workflows/{wid}/revisions/{rev}/restore admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/company/workflows/{wid}/revisions/{rev}/restore anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/company/workflows/{wid}/revisions/{rev}/restore member permitted source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/company/workflows/{wid}/revisions/{rev}/restore must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/company/workflows/{wid}/revisions/{rev}/restore platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/company/workflows/{wid}/revisions/{rev}/restore tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/company/workflows/{wid}/revisions/{rev}/restore tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may restore workflow revisions." wait=-
+POST /api/v1/company/workflows/{wid}/run admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows/{wid}/run anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows/{wid}/run member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:workflow-authority
+POST /api/v1/company/workflows/{wid}/run must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows/{wid}/run platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows/{wid}/run tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workflows/{wid}/run tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+POST /api/v1/company/workspace admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace/merge-duplicate-folders admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/company/workspace/merge-duplicate-folders anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/company/workspace/merge-duplicate-folders member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/company/workspace/merge-duplicate-folders must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/company/workspace/merge-duplicate-folders platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/company/workspace/merge-duplicate-folders tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/company/workspace/merge-duplicate-folders tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may merge and remove duplicate folders." wait=-
+POST /api/v1/company/workspace/sweep-empty-agent-folders admin permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/company/workspace/sweep-empty-agent-folders anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/company/workspace/sweep-empty-agent-folders member permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/company/workspace/sweep-empty-agent-folders must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/company/workspace/sweep-empty-agent-folders platform permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/company/workspace/sweep-empty-agent-folders tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/company/workspace/sweep-empty-agent-folders tenant-owner permitted source=ops access=scoped features=openhuman blast=destructive note="Members may remove empty agent folders." wait=-
+POST /api/v1/company/workspace/upload admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace/upload anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace/upload member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace/upload must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace/upload platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace/upload tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+POST /api/v1/company/workspace/upload tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/billing/chargebee admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/chargebee anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/chargebee member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/chargebee must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/chargebee platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/chargebee tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/chargebee tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/paypal admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/paypal anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/paypal member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/paypal must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/paypal platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/paypal tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/billing/paypal tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/chat/read-state admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/chat/read-state anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/chat/read-state member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/chat/read-state must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/chat/read-state platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/chat/read-state tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/chat/read-state tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/composio/api-key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/api-key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/api-key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/api-key must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/api-key platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/api-key tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/api-key tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/connections/{connection_id}/default admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/connections/{connection_id}/default anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/connections/{connection_id}/default member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/connections/{connection_id}/default must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/connections/{connection_id}/default platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/connections/{connection_id}/default tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/connections/{connection_id}/default tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/token admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/token anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/token member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/token must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/token platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/token tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/composio/token tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/credential admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/credential anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/credential member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/credential must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/credential platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/credential tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/credential tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/domain admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/domain anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/domain member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/domain must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/domain platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/domain tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/domain tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/hosting admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/hosting anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/hosting member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/hosting must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/hosting platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/hosting tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/hosting tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/inference admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/inference anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/inference member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/inference must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/inference platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/inference tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/inference tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/logo admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/logo anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/logo member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/logo must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/logo platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/logo tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/logo tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/mcp/config admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/config anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/config member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/config must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/config platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/config tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/config tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/registry/{server_id}/env admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/registry/{server_id}/env anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/registry/{server_id}/env member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/registry/{server_id}/env must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/registry/{server_id}/env platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/registry/{server_id}/env tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/registry/{server_id}/env tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/servers/{name} admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/servers/{name} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/servers/{name} member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/servers/{name} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/servers/{name} platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/servers/{name} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/mcp/servers/{name} tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/memory/engine admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/memory/engine anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/memory/engine member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/memory/engine must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/memory/engine platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/memory/engine tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/memory/engine tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/notifications admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/notifications anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/notifications member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/notifications must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/notifications platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/notifications tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/notifications tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/policy admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/policy anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/policy member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/policy must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/policy platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/companies/{id}/policy tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/policy tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/companies/{id}/presence admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/presence anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/presence member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/presence must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/presence platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/presence tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/presence tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/search admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/search anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/search member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/search must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/search platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/search tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/search tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/skills/{slug} admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/companies/{id}/skills/{slug} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/companies/{id}/skills/{slug} member permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/companies/{id}/skills/{slug} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/companies/{id}/skills/{slug} platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/companies/{id}/skills/{slug} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/companies/{id}/skills/{slug} tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/companies/{id}/smtp admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/smtp anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/smtp member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/smtp must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/smtp platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/smtp tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/smtp tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/budget admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/budget anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/budget member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/budget must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/budget platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/companies/{id}/team/{agent_id}/budget tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/budget tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/companies/{id}/team/{agent_id}/inbox admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/inbox anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/inbox member permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/inbox must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/inbox platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/inbox tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/companies/{id}/team/{agent_id}/inbox tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/companies/{id}/tools/grants admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/tools/grants anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/tools/grants member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/tools/grants must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/tools/grants platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/companies/{id}/tools/grants tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/tools/grants tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/companies/{id}/workflows/{wid} admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/workflows/{wid} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/workflows/{wid} member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:workflow-authority
+PUT /api/v1/companies/{id}/workflows/{wid} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/workflows/{wid} platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/workflows/{wid} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/workflows/{wid} tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/companies/{id}/workflows/{wid}/enabled admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/companies/{id}/workflows/{wid}/enabled anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/companies/{id}/workflows/{wid}/enabled member permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/companies/{id}/workflows/{wid}/enabled must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/companies/{id}/workflows/{wid}/enabled platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/companies/{id}/workflows/{wid}/enabled tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/companies/{id}/workflows/{wid}/enabled tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/companies/{id}/workspace/file/{node_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/workspace/file/{node_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/workspace/file/{node_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/workspace/file/{node_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/workspace/file/{node_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/workspace/file/{node_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/companies/{id}/workspace/file/{node_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/billing/chargebee admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/chargebee anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/chargebee member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/chargebee must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/chargebee platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/chargebee tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/chargebee tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/paypal admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/paypal anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/paypal member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/paypal must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/paypal platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/paypal tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/billing/paypal tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/chat/read-state admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/chat/read-state anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/chat/read-state member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/chat/read-state must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/chat/read-state platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/chat/read-state tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/chat/read-state tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/composio/api-key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/api-key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/api-key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/api-key must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/api-key platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/api-key tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/api-key tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/connections/{connection_id}/default admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/connections/{connection_id}/default anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/connections/{connection_id}/default member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/connections/{connection_id}/default must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/connections/{connection_id}/default platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/connections/{connection_id}/default tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/connections/{connection_id}/default tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/token admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/token anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/token member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/token must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/token platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/token tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/composio/token tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/credential admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/credential anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/credential member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/credential must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/credential platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/credential tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/credential tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/domain admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/domain anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/domain member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/domain must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/domain platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/domain tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/domain tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/hosting admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/hosting anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/hosting member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/hosting must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/hosting platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/hosting tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/hosting tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/inference admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/inference anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/inference member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/inference must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/inference platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/inference tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/inference tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/logo admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/logo anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/logo member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/logo must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/logo platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/logo tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/logo tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/mcp/config admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/config anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/config member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/config must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/config platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/config tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/config tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/registry/{server_id}/env admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/registry/{server_id}/env anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/registry/{server_id}/env member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/registry/{server_id}/env must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/registry/{server_id}/env platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/registry/{server_id}/env tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/registry/{server_id}/env tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/servers/{name} admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/servers/{name} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/servers/{name} member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/servers/{name} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/servers/{name} platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/servers/{name} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/mcp/servers/{name} tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/memory/engine admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/memory/engine anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/memory/engine member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/memory/engine must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/memory/engine platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/memory/engine tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/memory/engine tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/notifications admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/notifications anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/notifications member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/notifications must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/notifications platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/notifications tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/notifications tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/policy admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/policy anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/policy member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/policy must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/policy platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/company/policy tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/policy tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/company/presence admin permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/presence anonymous refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/presence member permitted source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/presence must-change-password-admin refused:403:password_change_required source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/presence platform refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/presence tenant-non-owner refused:403:forbidden source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/presence tenant-owner refused:401:unauthorized source=ops access=person features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/search admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/search anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/search member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/search must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/search platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/search tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/search tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/skills/{slug} admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/company/skills/{slug} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/company/skills/{slug} member permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/company/skills/{slug} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/company/skills/{slug} platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/company/skills/{slug} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/company/skills/{slug} tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a skill for the company." wait=-
+PUT /api/v1/company/smtp admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/smtp anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/smtp member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/smtp must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/smtp platform permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/smtp tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/smtp tenant-owner permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
+PUT /api/v1/company/team/{agent_id}/budget admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/team/{agent_id}/budget anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/team/{agent_id}/budget member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/team/{agent_id}/budget must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/team/{agent_id}/budget platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/company/team/{agent_id}/budget tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/team/{agent_id}/budget tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/company/team/{agent_id}/inbox admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/company/team/{agent_id}/inbox anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/company/team/{agent_id}/inbox member permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/company/team/{agent_id}/inbox must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/company/team/{agent_id}/inbox platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/company/team/{agent_id}/inbox tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/company/team/{agent_id}/inbox tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable a teammate inbox." wait=-
+PUT /api/v1/company/tools/grants admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/tools/grants anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/tools/grants member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/tools/grants must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/tools/grants platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/company/tools/grants tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/tools/grants tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:body-admin-signature
+PUT /api/v1/company/workflows/{wid} admin permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/workflows/{wid} anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/workflows/{wid} member refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=none-assigned:workflow-authority
+PUT /api/v1/company/workflows/{wid} must-change-password-admin refused:403:password_change_required source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/workflows/{wid} platform permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/workflows/{wid} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/workflows/{wid} tenant-owner permitted source=ops access=admin features=openhuman blast=authority note="" wait=-
+PUT /api/v1/company/workflows/{wid}/enabled admin permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/company/workflows/{wid}/enabled anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/company/workflows/{wid}/enabled member permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/company/workflows/{wid}/enabled must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/company/workflows/{wid}/enabled platform permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/company/workflows/{wid}/enabled tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/company/workflows/{wid}/enabled tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may enable or disable workflow scheduling." wait=-
+PUT /api/v1/company/workspace/file/{node_id} admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/workspace/file/{node_id} anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/workspace/file/{node_id} member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/workspace/file/{node_id} must-change-password-admin refused:403:password_change_required source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/workspace/file/{node_id} platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/workspace/file/{node_id} tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+PUT /api/v1/company/workspace/file/{node_id} tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-


### PR DESCRIPTION
## Outcome

Adds the Workstream A route × principal matrix as a Rust integration target, backed by fixed disposable-state principals and a CI assertion that names the target explicitly.

There is no production behavior change in this PR. The matrix preserves the intended authorization contract even where `main` is currently weaker; those known-red cells are isolated in ignored tests rather than normalized to the defect.

## Coverage and counting

- Source audit at `0056ddf0e`: 184 canonical ops route-method pairs across 142 unique scoped suffixes.
- Both scope forms produce 368 concrete route-method rows; two HMAC routes plus the OAuth callback bring the ops inventory to 371.
- Eight lifecycle/approval authority rows and the overlapping company-status GET bring the complete table to **380 concrete route-method rows across 295 concrete paths**.
- Seven principals per row produce **2,660 committed expectation cells**: 2,605 active and 55 intentionally ignored/red on `main`.
- The real `AdminScopedCompany` slice is **40 route-method pairs across 36 unique suffix paths**, or 80 concrete rows after expanding both address forms. The handoff's 28 was stale; this count comes from parsing the current router method chains, so routes, unique paths, and route-method pairs are kept distinct.
- Warm full-target runtime: **1.56 s wall clock** (`0.99 s` inside the test binary), well below the 45-second budget.

The anti-rot mechanism combines exact source path-set equality, exact runtime method sets from 405 `Allow` headers, anonymous existence checks, explicit feature-lane metadata, widening notes, and the committed 2,660-line snapshot. The source lexer rejects unparseable production registrations and uses exact counted fingerprints for the three intentional nonliteral registrations.

## Red on `main`

The ignored groups preserve **39 concrete route-method rows / 55 principal cells** that fail the intended contract today:

| Group | Rows / cells | Current behavior and intended boundary | Wait |
|---|---:|---|---|
| lifecycle + approval decisions | 8 / 10 | Members reach pause/resume/emergency and approval handlers (`200`, confirmation `400`, or absent-resource `404`) instead of 403; must-change-password admins reach the two `{id}` approval handlers instead of the password-change 403 | `fix/auth-role-dimension-on-authorize-address` |
| custom skill authoring | 2 / 2 | A member reaches body decoding (`415`) instead of admin 403 on both scope forms | `fix/skills-admin-and-bounded-write` |
| seven body-admin methods | 14 / 28 | Tenant-owner and platform principals receive 401 because authorization lives in body-only `require_admin`; the `AdminScopedCompany` contract permits those machine-admin principals | no branch assigned in handoff §7 |
| ledger define + retire | 4 / 4 | A member reaches handler validation/resource lookup (`415`/`404`) instead of admin 403 | no branch assigned in handoff §7 |
| teammate delete | 2 / 2 | A member reaches the absent teammate lookup (`404`) instead of admin 403 | no branch assigned in handoff §7 |
| workflow create/update/delete/run | 8 / 8 | A member reaches handler decoding/validation/resource lookup (`415`/`400`/`404`) instead of admin 403 | no branch assigned in handoff §7 |
| company status temp-password boundary | 1 / 1 | A must-change-password admin receives 200 instead of `403 password_change_required` | no branch assigned in handoff §7 |

Each ignored test and snapshot cell names its real waiting branch where §7 provides one. The remaining five groups explicitly say `none-assigned` rather than inventing branch names; owners/tracking branches are needed before those labels can be made more specific.

## Observed red proofs

All proof edits were copied to `/tmp`, never committed or stashed, restored before continuing, and verified byte-identical afterward (`cmp=0`, source `git diff=0`). The target docblock records the same observations.

1. Removed `clear_policy`'s `require_admin`: member `DELETE /policy` flipped from expected 403 to observed 200 on both address forms; matrix exit 101.
2. Added `scoped("/matrix-canary", ...)`: the source path-set gate named `/matrix-canary` as unexpected; exit 101.
3. Added `.delete(get_activation)` to the existing `/activation` method router: both forms reported runtime `{DELETE, GET}` versus declared `{GET}`; exit 101.

The AdminScoped skeleton was exercised first against the source-derived 40-pair set before the full table was expanded.

## Gates

Run individually and unpiped:

- `cargo fmt --check` — exit 0
- `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings` — exit 0
- `cargo test --features openhuman` — exit 0 (`7,112` library tests passed; all selected integration targets passed)

## Not expressible as one route-level cell

- `POST {scope}/team`: privileged budget/billing/tool fields are conditional on payload content.
- `PATCH {scope}/team/{agent_id}`: tool, model, and harness edits are conditional on payload content and require a real teammate; ordinary profile fields remain member-editable.

Those two rows carry explicit widening notes, but their field-sensitive boundaries remain owned by handler-level tests. Per the requested lane discipline, this PR ran only the `openhuman` feature lane and did not run a union build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive authorization coverage for operations routes across anonymous, member, admin, tenant, platform, and password-change-required access levels.
  * Added checks to verify route declarations, allowed HTTP methods, and expected authorization responses.
  * Added fixed test authentication scenarios for tenant and platform principals.
  * Added automated CI execution for the authorization test suite, ensuring missing or disabled test targets fail clearly.
  * Documented selected known authorization cases as pending follow-up fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->