### PR TITLE
Settings: drop nav hints, go full width, gate custom domain and SMTP as coming soon

### DIFF
--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -87,17 +87,180 @@ function isUnwired(err: unknown): boolean {
  * Write-only three ways, exactly as in `HostingView`: the host has no field to
  * return it, nothing persists it to browser storage, and a successful save
  * clears the input. See `src/api/smtp.ts` and `src/lib/domain.ts`.
+ *
+ * # Both cards are gated as coming soon (#2131)
+ *
+ * Neither feature is ready, so `DomainSettings` renders `ComingSoon` previews
+ * and mounts neither card. `DomainCard` and `SmtpCard` below are exported and
+ * otherwise unchanged: their host-backed guarantees are still covered by
+ * `test/unit/domain-settings-host-backed.test.ts`, which renders them
+ * directly, so switching the feature on is putting them back into the two
+ * slots below rather than rebuilding them out of the git history.
  */
-export function DomainSettings({ client, company }: Props) {
+export function DomainSettings(_props: Props) {
   return (
     <>
-      <DomainCard client={client} company={company} />
-      <SmtpCard client={client} company={company} />
+      <ComingSoon
+        testid="domain-card"
+        icon={Globe}
+        title="Custom domain"
+        description="Sending and receiving on your own domain is on the way. It is not switched on yet, so there is nothing to configure here."
+      >
+        <DomainPreview />
+      </ComingSoon>
+      <ComingSoon
+        testid="smtp-card"
+        icon={Mail}
+        title="Email (SMTP)"
+        description="Pointing this company at your own outbound mail server is on the way. It is not switched on yet, so there is nothing to configure here."
+      >
+        <SmtpPreview />
+      </ComingSoon>
     </>
   );
 }
 
-function DomainCard({ client, company }: Props) {
+/**
+ * A card that shows the shape of a surface without letting anyone use it.
+ *
+ * # Why the controls are absent rather than disabled
+ *
+ * The brief for #2131 is that these two are *genuinely* inert — not reachable
+ * by mouse, not in the tab order, and with nothing that can be submitted.
+ * `disabled` and `inert` deliver the first two and neither delivers the third:
+ * an inert `<button>` still runs its handler when something calls `.click()` on
+ * it, and a disabled `<input>` is still an input whose value a script or an
+ * autofill can set. The SMTP card's fields include a password and a Save that
+ * puts it in the host's secret store, which is exactly the pair that must not
+ * be one `querySelector` away from firing.
+ *
+ * So the gate is that `children` is a static picture: `div`s carrying the real
+ * field labels, with no `input`, `button`, `select` or handler anywhere in it.
+ * There is no control to enable, no state to fill and no request to send —
+ * these cards do not even read the host any more. The blur is decoration over
+ * a surface that was already empty rather than the thing standing between an
+ * operator and a save. `settings-coming-soon.test.ts` pins that property.
+ *
+ * `inert` is set anyway, imperatively — React 18's types predate the boolean
+ * prop, which is why `Overview.tsx` sets it the same way — so the guarantee
+ * survives someone later dropping a real control into a preview. `aria-hidden`
+ * goes with it: the header and the description carry the whole meaning for a
+ * screen reader, which is why they say "not switched on yet" in words instead
+ * of leaving it to a blur nobody can hear.
+ */
+function ComingSoon({
+  testid,
+  icon: Icon,
+  title,
+  description,
+  children,
+}: {
+  testid: string;
+  icon: typeof Globe;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card data-testid={testid}>
+      <CardHeader>
+        <CardTitle className="flex flex-wrap items-center gap-2 text-base">
+          <Icon className="size-4" /> {title}
+          <Badge variant="secondary" className="font-normal" data-testid={`${testid}-coming-soon`}>
+            Coming soon
+          </Badge>
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div
+          data-testid={`${testid}-preview`}
+          aria-hidden="true"
+          ref={(el) => el?.setAttribute("inert", "")}
+          className="pointer-events-none max-w-4xl select-none opacity-60 blur-xs"
+        >
+          {children}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** One labelled bar standing in for a field. Not a control — see `ComingSoon`. */
+function PreviewField({ label, className }: { label: string; className?: string }) {
+  return (
+    <div className={cn("grid gap-2", className)}>
+      <span className="text-sm font-medium">{label}</span>
+      <div className="h-9 rounded-md border bg-muted/40" />
+    </div>
+  );
+}
+
+/** Stands in for a button, so the blurred card keeps the rhythm of the real one. */
+function PreviewButton({ label, className }: { label: string; className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex h-9 items-center justify-center rounded-md border bg-muted px-4 text-sm font-medium",
+        className,
+      )}
+    >
+      {label}
+    </div>
+  );
+}
+
+function DomainPreview() {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <div className="h-9 flex-1 rounded-md border bg-muted/40" />
+        <PreviewButton label="Add domain" className="shrink-0" />
+      </div>
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Add these DNS records</p>
+        <div className="rounded-lg border">
+          <div className="flex gap-6 border-b bg-muted/50 px-3 py-2 text-xs font-medium">
+            <span className="w-16">Type</span>
+            <span className="w-40">Name</span>
+            <span className="w-40">Value</span>
+          </div>
+          {["TXT", "CNAME"].map((type) => (
+            <div key={type} className="flex items-center gap-6 px-3 py-2 text-xs">
+              <span className="w-16 font-mono">{type}</span>
+              <div className="h-3 w-40 rounded bg-muted" />
+              <div className="h-3 w-40 rounded bg-muted" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SmtpPreview() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <PreviewField label="SMTP host" />
+        <div className="grid grid-cols-2 gap-3">
+          <PreviewField label="Port" />
+          <PreviewField label="Security" />
+        </div>
+        <PreviewField label="Username" />
+        <PreviewField label="Password" />
+        <PreviewField label="From name" />
+        <PreviewField label="From email" />
+      </div>
+      <div className="flex gap-2">
+        <PreviewButton label="Save" />
+        <PreviewButton label="Test connection" />
+      </div>
+    </div>
+  );
+}
+
+export function DomainCard({ client, company }: Props) {
   const [status, setStatus] = useState<DomainStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -391,7 +554,7 @@ function CopyCell({ value }: { value: string }) {
   );
 }
 
-function SmtpCard({ client, company }: Props) {
+export function SmtpCard({ client, company }: Props) {
   const [status, setStatus] = useState<SmtpStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);

--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -210,6 +210,20 @@ function PreviewButton({ label, className }: { label: string; className?: string
   );
 }
 
+/**
+ * The shape of {@link DomainCard} with nothing in it that works.
+ *
+ * It mirrors the real card's three parts — the domain entry row, the "Add
+ * these DNS records" heading, and the TXT/CNAME table — because a preview that
+ * does not resemble what is coming tells the operator nothing about what
+ * switching it on would get them. The record values are bare bars rather than
+ * plausible-looking hostnames: an invented `_oc-verify.example.com` sitting
+ * under a blur is the kind of thing someone squints at and copies into their
+ * DNS.
+ *
+ * Every node here is a `div` or a `span`. See {@link ComingSoon} for why that
+ * is the gate rather than `disabled`.
+ */
 function DomainPreview() {
   return (
     <div className="space-y-4">
@@ -238,6 +252,16 @@ function DomainPreview() {
   );
 }
 
+/**
+ * The shape of {@link SmtpCard} with nothing in it that works.
+ *
+ * The six field labels are the real ones in the real order, so an operator can
+ * tell at a glance whether they will have what the form is going to ask for.
+ * The "Password" row is a {@link PreviewField} like the other five — a
+ * labelled bar, not an `<input type="password">` — which is the whole point of
+ * {@link ComingSoon}: there is no field here for a password manager to fill,
+ * and no Save to put what it filled into the host's secret store.
+ */
 function SmtpPreview() {
   return (
     <div className="space-y-4">
@@ -260,6 +284,17 @@ function SmtpPreview() {
   );
 }
 
+/**
+ * The real custom-domain card: add a domain, read back the DNS records the
+ * host wants, and ask it to verify them.
+ *
+ * Not mounted anywhere while #2131's gate stands — {@link DomainSettings}
+ * renders {@link DomainPreview} in its place. It is exported rather than
+ * deleted so that switching the feature on is putting one element back, and so
+ * that `test/unit/domain-settings-host-backed.test.ts` can go on rendering it
+ * directly and pinning the guarantee that matters here: every field is read
+ * from and written to the host, and none of it is cached in the browser.
+ */
 export function DomainCard({ client, company }: Props) {
   const [status, setStatus] = useState<DomainStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -554,6 +589,16 @@ function CopyCell({ value }: { value: string }) {
   );
 }
 
+/**
+ * The real outbound-mail card: point the company at an SMTP server, save the
+ * credentials into the host's secret store, and send a test message.
+ *
+ * Not mounted anywhere while #2131's gate stands — {@link DomainSettings}
+ * renders {@link SmtpPreview} in its place. Exported for the same two reasons
+ * as {@link DomainCard}, and one more that is specific to it: the password is
+ * write-only three ways, and `test/unit/domain-settings-host-backed.test.ts`
+ * is what holds that property while nothing renders the card.
+ */
 export function SmtpCard({ client, company }: Props) {
   const [status, setStatus] = useState<SmtpStatus | null>(null);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -39,6 +39,7 @@ import { Label } from "@/components/ui/label";
 import { applyAutonomy } from "@/hooks/use-autonomy";
 import { usd } from "@/lib/money";
 import { cn } from "@/lib/utils";
+import { SETTINGS_FIELD_COLUMN } from "@/views/settings-pages";
 
 /**
  * Tools worth naming as an *example* of something to always ask about, most
@@ -1094,6 +1095,10 @@ export function PolicySettings({ client, company }: Props) {
               </p>
               <Input
                 id="always-approve"
+                // The settings pane is full width (#2131), and a bare comma
+                // list stretched to 1400px puts the label and the caret a
+                // head-turn apart. Capped where every other settings field is.
+                className={SETTINGS_FIELD_COLUMN}
                 value={draftAlways}
                 disabled
                 list={wiredTools.length > 0 ? "always-approve-tools" : undefined}

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -11,6 +11,8 @@ import {
 import { me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { PageHeader } from "@/components/page-header";
+import { cn } from "@/lib/utils";
+import { SETTINGS_FIELD_COLUMN } from "@/views/settings-pages";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { GrantNamespace } from "@/components/grant-namespace";
 import { Badge } from "@/components/ui/badge";
@@ -176,7 +178,7 @@ export function HostingView({ client, company }: Props) {
   const header = (
     <PageHeader
       title="Hosting"
-      width="5xl"
+      width="full"
       description={
         <>
           Connect a hosting provider so your teammates can put a site from this
@@ -191,7 +193,7 @@ export function HostingView({ client, company }: Props) {
     return (
       <div className="flex min-h-0 flex-1 flex-col">
         {header}
-        <div className="mx-auto w-full max-w-5xl px-4 py-6">
+        <div className="w-full px-4 py-6">
           <Alert variant="destructive" data-testid="hosting-load-error">
             <TriangleAlert className="size-4" />
             <AlertDescription>Could not load hosting settings: {loadError}</AlertDescription>
@@ -217,7 +219,7 @@ export function HostingView({ client, company }: Props) {
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="hosting-view">
       {header}
-      <div className="mx-auto min-h-0 w-full max-w-5xl flex-1 space-y-6 overflow-y-auto px-4 py-6">
+      <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto px-4 py-6">
 
         {/* The two problems this form cannot fix, said before the form so an
           operator does not fill it in and wonder why nothing happened. */}
@@ -264,7 +266,7 @@ export function HostingView({ client, company }: Props) {
               ) : null}
             </div>
 
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className={cn("grid gap-4 sm:grid-cols-2", SETTINGS_FIELD_COLUMN)}>
               <div className="space-y-2">
                 <Label htmlFor="hosting-key">API token</Label>
                 <Input

--- a/frontend/src/views/InferenceView.tsx
+++ b/frontend/src/views/InferenceView.tsx
@@ -50,14 +50,14 @@ export function InferenceView({ client, company }: Props) {
     <div className="flex min-h-0 flex-1 flex-col">
       <PageHeader
         title="Inference"
-        width="5xl"
+        width="full"
         description={
           <>
             The model your teammates think with, and the key their turns are billed to.
           </>
         }
       />
-      <div className="mx-auto min-h-0 w-full max-w-5xl flex-1 space-y-6 overflow-y-auto px-4 py-6">
+      <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto px-4 py-6">
         {!canManage && (
           <Alert data-testid="inference-read-only">
             <Info className="size-4" />

--- a/frontend/src/views/PeopleView.tsx
+++ b/frontend/src/views/PeopleView.tsx
@@ -186,15 +186,16 @@ export function PeopleView({ client, company }: Props) {
     it is never offered before the role is known, which is the part that
     matters.
 
-    The width is the one thing `loading` does decide. It stays `4xl` while the
-    skeletons show so the common path — an admin who came here to manage
-    access — has no reflow when the rows arrive; a non-admin sees the column
-    narrow once, at the same moment the content replaces the skeletons.
+    The width used to be the one thing `loading` decided — `4xl` while the
+    skeletons showed and for an admin, `3xl` for everyone else — so that the
+    common path had no reflow when the rows arrived. Issue #2131 takes every
+    settings page full width, which removes that reflow outright rather than
+    timing it: there is no longer a narrower state to arrive at.
   */
   const header = (
     <PageHeader
       title="People"
-      width={loading || isAdmin ? "4xl" : "3xl"}
+      width="full"
       description={
         isAdmin
           ? "The humans who can sign in. Access is invite-only."
@@ -215,7 +216,7 @@ export function PeopleView({ client, company }: Props) {
     return (
       <div className="flex min-h-0 flex-1 flex-col">
         {header}
-        <div className="mx-auto w-full max-w-4xl space-y-3 px-4 py-6">
+        <div className="w-full space-y-3 px-4 py-6">
           <Skeleton className="h-8 w-48" />
           <Skeleton className="h-24 w-full" />
           <Skeleton className="h-24 w-full" />
@@ -228,7 +229,7 @@ export function PeopleView({ client, company }: Props) {
     return (
       <div className="flex min-h-0 flex-1 flex-col">
         {header}
-        <div className="mx-auto min-h-0 w-full max-w-3xl flex-1 overflow-y-auto px-4 py-6">
+        <div className="min-h-0 w-full flex-1 overflow-y-auto px-4 py-6">
         <Alert>
           <ShieldCheck className="size-4" />
           <AlertDescription>
@@ -244,7 +245,7 @@ export function PeopleView({ client, company }: Props) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {header}
-      <div className="mx-auto min-h-0 w-full max-w-4xl flex-1 space-y-6 overflow-y-auto px-4 py-6">
+      <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto px-4 py-6">
 
       {error ? (
         <Alert variant="destructive">

--- a/frontend/src/views/SearchView.tsx
+++ b/frontend/src/views/SearchView.tsx
@@ -6,6 +6,8 @@ import { clearSearch, getSearch, saveSearch, type SearchStatus } from "@/api/sea
 import { me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { PageHeader } from "@/components/page-header";
+import { cn } from "@/lib/utils";
+import { SETTINGS_FIELD_COLUMN } from "@/views/settings-pages";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { GrantNamespace } from "@/components/grant-namespace";
 import { Badge } from "@/components/ui/badge";
@@ -203,7 +205,7 @@ export function SearchView({ client, company }: Props) {
   const header = (
     <PageHeader
       title="Search"
-      width="5xl"
+      width="full"
       description={
         <>
           Where your teammates look things up. Every teammate that can search
@@ -218,7 +220,7 @@ export function SearchView({ client, company }: Props) {
     return (
       <div className="flex min-h-0 flex-1 flex-col">
         {header}
-        <div className="mx-auto w-full max-w-5xl px-4 py-6">
+        <div className="w-full px-4 py-6">
           <Alert variant="destructive" data-testid="search-load-error">
             <TriangleAlert className="size-4" />
             <AlertDescription>Could not load search settings: {loadError}</AlertDescription>
@@ -248,7 +250,7 @@ export function SearchView({ client, company }: Props) {
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="search-view">
       {header}
-      <div className="mx-auto min-h-0 w-full max-w-5xl flex-1 space-y-6 overflow-y-auto px-4 py-6">
+      <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto px-4 py-6">
 
         {!status.inBuild ? (
           <Alert data-testid="search-not-in-build">
@@ -295,7 +297,7 @@ export function SearchView({ client, company }: Props) {
               ) : null}
             </div>
 
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className={cn("grid gap-4 sm:grid-cols-2", SETTINGS_FIELD_COLUMN)}>
               <div className="space-y-2">
                 <Label htmlFor="search-provider">Provider</Label>
                 <Select

--- a/frontend/src/views/SettingsSection.tsx
+++ b/frontend/src/views/SettingsSection.tsx
@@ -79,20 +79,27 @@ export function SettingsSection({ client, company, feed, sub, onFlag, onResetCom
               {group.label}
             </div>
             {SETTINGS_PAGES.filter((item) => item.group === group.id).map((item) => (
+              // One line per row, and the row's own `title` carries what the
+              // second line used to say (issue #2131). The hint was rendered
+              // under every label here, and at `w-60` most of them wrapped:
+              // "Approvals, connection, lifecycle, domain, mail" is three
+              // lines, "What your teammates actually did" is two, and ten rows
+              // of that is a wall rather than a list you can scan. The labels
+              // are the navigation; the hint is a gloss, and a gloss that
+              // triples the height of the thing it explains has stopped
+              // helping.
               <a
                 key={item.id}
                 href={`#/settings/${item.id}`}
+                title={item.hint}
                 aria-current={page === item.id ? "page" : undefined}
                 className={cn(
-                  "flex items-start gap-2.5 rounded-lg px-2 py-2 text-left transition-colors",
+                  "flex items-center gap-2.5 rounded-lg px-2 py-2 text-left transition-colors",
                   page === item.id ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
                 )}
               >
-                <item.icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                <span className="min-w-0">
-                  <span className="block text-sm font-medium">{item.label}</span>
-                  <span className="block text-xs text-muted-foreground">{item.hint}</span>
-                </span>
+                <item.icon className="size-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 truncate text-sm font-medium">{item.label}</span>
               </a>
             ))}
           </section>
@@ -117,6 +124,12 @@ export function SettingsSection({ client, company, feed, sub, onFlag, onResetCom
             z-30` gives it its own stacking context above the drag band without
             touching `WindowDragBar` itself, whose absolute-overlay contract
             other pages (the graph, the workflow editor) still rely on. */}
+        {/* Both `hint` readers below survive #2131, which was about the
+            desktop rail. This row is a different surface with a different
+            problem: the chips carry the label alone, so the `title` is the only
+            gloss a chip has, and the line under them describes the *active*
+            page rather than repeating itself under all ten. Neither is a
+            second line per row, which is the thing that was removed. */}
         <div className="relative z-30 border-b lg:hidden">
           <div className="flex gap-1 overflow-x-auto p-2">
             {SETTINGS_PAGES.map((item) => (

--- a/frontend/src/views/SettingsSection.tsx
+++ b/frontend/src/views/SettingsSection.tsx
@@ -83,8 +83,10 @@ export function SettingsSection({ client, company, feed, sub, onFlag, onResetCom
               // second line used to say (issue #2131). The hint was rendered
               // under every label here, and at `w-60` most of them wrapped:
               // "Approvals, connection, lifecycle, domain, mail" is three
-              // lines, "What your teammates actually did" is two, and ten rows
-              // of that is a wall rather than a list you can scan. The labels
+              // lines, "What your teammates actually did" is two, and eight
+              // rows of that is a wall rather than a list you can scan. The
+              // count is `SETTINGS_PAGES.length`, so read it there rather than
+              // trusting this sentence after the next page lands. The labels
               // are the navigation; the hint is a gloss, and a gloss that
               // triples the height of the thing it explains has stopped
               // helping.
@@ -128,8 +130,8 @@ export function SettingsSection({ client, company, feed, sub, onFlag, onResetCom
             desktop rail. This row is a different surface with a different
             problem: the chips carry the label alone, so the `title` is the only
             gloss a chip has, and the line under them describes the *active*
-            page rather than repeating itself under all ten. Neither is a
-            second line per row, which is the thing that was removed. */}
+            page rather than repeating itself under every one of them. Neither
+            is a second line per row, which is the thing that was removed. */}
         <div className="relative z-30 border-b lg:hidden">
           <div className="flex gap-1 overflow-x-auto p-2">
             {SETTINGS_PAGES.map((item) => (

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -97,8 +97,8 @@ export function SettingsView({ client, company, feed, onFlag, onResetCompany }: 
         rule — and the rail says "Settings", which is the section, while this
         says "General settings", which is the page.
       */}
-      <PageHeader title="General settings" width="3xl" />
-      <div className="mx-auto min-h-0 w-full max-w-3xl flex-1 space-y-6 overflow-y-auto px-4 py-6">
+      <PageHeader title="General settings" width="full" />
+      <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto px-4 py-6">
         {/* Device pairing was here. Sessions are the frontend client's own
             business now — the desktop app holds its session the same way the
             browser does — so there is no machine for this page to pair. */}

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -180,7 +180,7 @@ export function SkillsView({ client, company }: Props) {
     <div className="flex min-h-0 flex-1 flex-col">
       <PageHeader
         title="Skills"
-        width="5xl"
+        width="full"
         description={
           <>
             Playbooks your teammates read. Enable, install from the registry, or add your own.
@@ -194,7 +194,7 @@ export function SkillsView({ client, company }: Props) {
           </>
         }
       />
-      <div className="mx-auto min-h-0 w-full max-w-5xl flex-1 space-y-5 overflow-y-auto px-4 py-6">
+      <div className="min-h-0 w-full flex-1 space-y-5 overflow-y-auto px-4 py-6">
         {/* Issue #569: what install / enable actually buy. A desk agent can list,
             describe and read a skill and can never run one — deliberate, and
             pinned by `dispatched_belt_excludes_every_deferred_family` — but this

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -145,7 +145,7 @@ export function UsageView({ client, company }: Props) {
     <div className="flex min-h-0 flex-1 flex-col">
       <PageHeader
         title="Usage"
-        width="6xl"
+        width="full"
         description={
           <>
             What your company is burning — tokens and OAuth calls.
@@ -168,7 +168,7 @@ export function UsageView({ client, company }: Props) {
           </>
         }
       />
-      <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 space-y-6 overflow-y-auto px-4 py-6">
+      <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto px-4 py-6">
         {usageFailed ? (
           <Alert data-testid="usage-load-error">
             <TriangleAlert className="size-4" />

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -42,7 +42,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 import { INFERENCE_MANAGED_HIDDEN } from "@/product-scope";
+import { SETTINGS_FIELD_COLUMN } from "@/views/settings-pages";
 
 /** The abstract cognition tiers the tenant model table maps. */
 const TIERS = ["chat-v1", "reasoning-v1", "agentic-v1", "vision-v1"] as const;
@@ -1057,7 +1059,7 @@ export function InferenceSection({
                 agent's prompts travel to and the key they are billed against
                 (issue #403). */}
             {canManage && (
-              <div className="space-y-3 border-t border-border pt-3">
+              <div className={cn("space-y-3 border-t border-border pt-3", SETTINGS_FIELD_COLUMN)}>
                 <div className="grid gap-2 sm:grid-cols-2 sm:items-end">
                   <div className="space-y-1">
                     <Label htmlFor="inference-provider" className="text-xs">

--- a/frontend/src/views/settings-pages.ts
+++ b/frontend/src/views/settings-pages.ts
@@ -105,6 +105,36 @@ export const SETTINGS_PAGE_GROUPS = [
 
 export const DEFAULT_SETTINGS_PAGE: SettingsPage = "general";
 
+/**
+ * The readable measure a **form** keeps inside a full-width settings page.
+ *
+ * Every sub-page under this rail used to centre its body on a `max-w-*` column
+ * — `3xl` on General and People, `5xl` on Inference, Hosting, Search and
+ * Skills, `6xl` on Usage. Issue #2131 removes that: on a 1920px window the
+ * settings pane is about 1400px wide, so General's 768px column left roughly
+ * 600px of empty margin either side of cards that had nothing to do with
+ * prose, and the rail beside them made the whole page read as a narrow strip.
+ *
+ * What the column was actually protecting is *fields*, not cards. A card is a
+ * container — its header, its alerts, its DNS and member tables and its
+ * provider grids all get better with width. A text input does not: a single
+ * one stretched across a 27" monitor is a worse control than the constraint
+ * being removed, because the label at the left and the caret at the right are
+ * a head-turn apart.
+ *
+ * So the page is full width and this is the cap on the field grids inside it.
+ * `4xl` (896px) rather than a wider one because these grids are two-column at
+ * `sm` and up, which puts each control at roughly 430px — the width they
+ * already had inside the old `5xl` body, so no field the operator uses today
+ * changes size.
+ *
+ * A class string rather than a component: the grids that need it already exist
+ * and differ (`sm:grid-cols-2`, `sm:items-end`, a nested pair), and wrapping
+ * each in a layout component to pass one number would be a bigger change than
+ * the number.
+ */
+export const SETTINGS_FIELD_COLUMN = "max-w-4xl";
+
 /** Whether a hash segment names a real sub-page. */
 export function isSettingsPage(sub: string | null): sub is SettingsPage {
   return SETTINGS_PAGES.some((page) => page.id === sub);

--- a/frontend/test/unit/domain-settings-host-backed.test.ts
+++ b/frontend/test/unit/domain-settings-host-backed.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, createElement } from "react";
+import { act, createElement, Fragment } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -49,7 +49,12 @@ vi.mock("sonner", () => {
   return { toast };
 });
 
-const { DomainSettings } = await import("@/components/domain-settings");
+// The two cards directly, not `DomainSettings`. Both are gated as coming soon
+// (issue #2131) and the section renders static previews instead — but the
+// guarantees below are about the cards themselves and have to keep holding for
+// the release that switches them back on, so they are exercised at the level
+// they belong to. `settings-coming-soon.test.ts` covers the gate.
+const { DomainCard, SmtpCard } = await import("@/components/domain-settings");
 
 /** Distinctive enough that a substring search over the store is meaningful. */
 const SECRET = "pw-77c1e2-do-not-persist";
@@ -117,7 +122,12 @@ let root: Root;
 
 async function show(client: OpenCompanyClient) {
   await act(async () => {
-    root.render(createElement(DomainSettings, { client, company: "acme" }));
+    root.render(
+      createElement(Fragment, null, [
+        createElement(DomainCard, { key: "domain", client, company: "acme" }),
+        createElement(SmtpCard, { key: "smtp", client, company: "acme" }),
+      ]),
+    );
   });
 }
 

--- a/frontend/test/unit/settings-coming-soon.test.ts
+++ b/frontend/test/unit/settings-coming-soon.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+
+/**
+ * Custom domain and Email (SMTP) are gated as coming soon (issue #2131).
+ *
+ * The brief is that they are *genuinely* inert: nothing reachable by mouse,
+ * nothing in the tab order, nothing that can be submitted. So the assertions
+ * here are about what is in the DOM rather than about how it looks — a blur and
+ * an `opacity` are the affordance, not the gate, and a screenshot cannot tell
+ * a disabled password field from an absent one.
+ *
+ * Why absent rather than `disabled`: an inert `<button>` still runs its handler
+ * when something calls `.click()` on it, and a disabled `<input>` is still an
+ * input whose value a script or a password manager can set. The SMTP card takes
+ * a password and saves it into the host's secret store, so "you cannot Tab to
+ * it" is not a strong enough promise for it.
+ *
+ * `domain-settings-host-backed.test.ts` covers the other half: the two cards
+ * still behave, rendered directly, for the release that switches them on.
+ */
+
+vi.mock("sonner", () => {
+  const fn = () => {};
+  const toast = Object.assign(fn, {
+    success: fn,
+    error: fn,
+    warning: fn,
+    info: fn,
+    message: fn,
+  });
+  return { toast };
+});
+
+const { DomainSettings } = await import("@/components/domain-settings");
+
+/**
+ * A client that records every call rather than answering one.
+ *
+ * A gated card must not read the host either — a request fired by a surface
+ * nobody can use is a request nobody can explain, and on a company with a
+ * domain configured it would paint real values behind the blur.
+ */
+function forbiddenClient(): { client: OpenCompanyClient; touched: string[] } {
+  const touched: string[] = [];
+  const record = (verb: string) => (path: string) => {
+    touched.push(`${verb} ${path}`);
+    return Promise.resolve({});
+  };
+  const client = {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: record("GET"),
+    put: record("PUT"),
+    post: record("POST"),
+    del: record("DELETE"),
+  } as unknown as OpenCompanyClient;
+  return { client, touched };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(DomainSettings, { client, company: "acme" }));
+  });
+}
+
+function card(testid: string): HTMLElement {
+  const el = container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+  expect(el, `${testid} should be on the page`).not.toBeNull();
+  return el!;
+}
+
+describe("Custom domain and Email (SMTP) are gated as coming soon (#2131)", () => {
+  it("still shows both cards, and says why each is not usable", async () => {
+    // Gated, not deleted. An operator who came looking for "where do I put my
+    // domain" has to find the answer where they expect it, and the answer has
+    // to be a sentence rather than a control that does nothing.
+    const { client } = forbiddenClient();
+    await show(client);
+
+    expect(card("domain-card").textContent).toContain("Custom domain");
+    expect(card("domain-card").textContent).toContain("not switched on yet");
+    expect(card("smtp-card").textContent).toContain("Email (SMTP)");
+    expect(card("smtp-card").textContent).toContain("not switched on yet");
+
+    // Said in the header too, where the eye lands before the paragraph.
+    expect(card("domain-card-coming-soon").textContent).toBe("Coming soon");
+    expect(card("smtp-card-coming-soon").textContent).toBe("Coming soon");
+  });
+
+  it("renders no control anyone or anything could operate", async () => {
+    // The assertion the issue is actually about. Not "the controls are
+    // disabled" — there are none. Nothing to Tab to, nothing to click, nothing
+    // for `document.querySelector(…).click()` to reach, and in particular no
+    // password field for an autofill to put a credential into.
+    const { client } = forbiddenClient();
+    await show(client);
+
+    for (const testid of ["domain-card", "smtp-card"]) {
+      const scope = card(testid);
+      expect(scope.querySelectorAll("input"), `${testid} inputs`).toHaveLength(0);
+      expect(scope.querySelectorAll("button"), `${testid} buttons`).toHaveLength(0);
+      expect(scope.querySelectorAll("select"), `${testid} selects`).toHaveLength(0);
+      expect(scope.querySelectorAll("textarea"), `${testid} textareas`).toHaveLength(0);
+      expect(scope.querySelectorAll("a[href]"), `${testid} links`).toHaveLength(0);
+      // Anything that made itself focusable another way — a `tabindex`, a
+      // `contenteditable`, a role that implies interaction.
+      expect(scope.querySelectorAll("[tabindex]"), `${testid} tabindex`).toHaveLength(0);
+      expect(scope.querySelectorAll("[contenteditable]"), `${testid} editable`).toHaveLength(0);
+    }
+  });
+
+  it("marks the preview inert and hides it from a screen reader", async () => {
+    // Belt and braces over the assertion above: if someone later drops a real
+    // control into a preview, `inert` keeps it out of the tab order and out of
+    // the accessibility tree while the review catches up. Which is also why the
+    // card's meaning lives in the header and description, not in the blur —
+    // `aria-hidden` means nothing under it is announced at all.
+    const { client } = forbiddenClient();
+    await show(client);
+
+    for (const testid of ["domain-card", "smtp-card"]) {
+      const preview = card(`${testid}-preview`);
+      expect(preview.getAttribute("aria-hidden"), `${testid} aria-hidden`).toBe("true");
+      expect(preview.hasAttribute("inert"), `${testid} inert`).toBe(true);
+      expect(preview.className, `${testid} pointer events`).toContain("pointer-events-none");
+    }
+  });
+
+  it("asks the host for nothing at all", async () => {
+    // A gated card that still reads `/domain` and `/smtp` would fire two
+    // requests for a surface nobody can use — and on a company that already has
+    // a domain it would paint real values behind the blur.
+    const { client, touched } = forbiddenClient();
+    await show(client);
+
+    expect(touched).toEqual([]);
+  });
+});

--- a/frontend/test/unit/settings-navigation.test.ts
+++ b/frontend/test/unit/settings-navigation.test.ts
@@ -106,7 +106,39 @@ describe("Settings navigation (issue #1468)", () => {
     // #1763 makes it visible at every width, because every one of its siblings
     // above sits beside that same rail and shows one.
     expect(read("views/SettingsView.tsx")).toContain(
-      '<PageHeader title="General settings" width="3xl" />',
+      '<PageHeader title="General settings" width="full" />',
     );
+  });
+
+  it("gives every settings page the whole pane, not a centred column", () => {
+    // Issue #2131. Each page used to centre its body on a fixed column — `3xl`
+    // on General and People, `5xl` on Inference, Hosting, Search and Skills,
+    // `6xl` on Usage — which on a 1920px window left General's cards in a
+    // 768px strip with ~600px of empty margin either side, beside a rail that
+    // already narrows the pane.
+    //
+    // Swept rather than restated per page, and derived from `SETTINGS_NAMED_BY`
+    // for the same reason the header check above is: a page added to the rail
+    // with a centred body would otherwise pass by not being on anyone's list.
+    //
+    // Observatory is excluded and is the one honest exception: its row here is
+    // a doorway, `#/settings/observatory` is rewritten onto `#/observatory`
+    // before this section ever dispatches, and the view is routed by the shell
+    // rather than rendered inside this pane. It is already full width.
+    const paneRendered = SETTINGS_PAGES.filter(({ id }) => id !== "observatory");
+    expect(paneRendered.length).toBe(SETTINGS_PAGES.length - 1);
+
+    for (const { id } of paneRendered) {
+      const source = read(`views/${SETTINGS_NAMED_BY[id]}`);
+      // Said explicitly even though `full` is `PageHeader`'s default: the
+      // header's row has to track the body's column, and a page that states
+      // its width is a page whose next editor knows the two are paired.
+      expect(source, `${id} header width`).toContain('width="full"');
+      // The body. `mx-auto` is what a centred column needs and what none of
+      // these pages has any other use for, so its absence is the property —
+      // narrower than banning `max-w-*`, which these pages still legitimately
+      // use on a search box, a dialog, and the field measure inside a form.
+      expect(source, `${id} body column`).not.toContain("mx-auto");
+    }
   });
 });


### PR DESCRIPTION
Closes #2131.

Three changes to Settings, from the operator screenshots on 2026-09-07. One
commit each, plus a fourth for a field the second one stretched.

## 1. The settings rail drops its hint line

`SettingsSection.tsx` rendered each page's `hint` under its label. At `w-60`
most of them wrapped — "Approvals, connection, lifecycle, domain, mail" is
three lines, "What your teammates actually did" is two — so ten rows read as a
wall rather than a list you can scan. The row is one line now, `items-start`
became `items-center` and the icon lost its `mt-0.5` offset so the icon and the
label sit on the same baseline.

**The two other `hint` consumers, decided on their merits — both kept:**

- `SettingsSection.tsx:126`, the `title=` on the collapsed chip rail. **Kept.**
  Below `lg` the rail is a scrolling row of chips carrying the label and
  nothing else, so the tooltip is the only gloss a chip has. Removing it would
  take something away rather than give the width back.
- `SettingsSection.tsx:137`, the `<p>` under the chip row. **Kept.** It
  describes the *active* page, once, rather than repeating under all ten rows —
  which is the opposite of the thing that was removed, and on the surface that
  has no room for a description anywhere else.

The rail row now carries `title={item.hint}` itself, so the gloss is still a
hover away on the desktop rail too. `hint` therefore stays in
`settings-pages.ts`, and the `as const satisfies` type is untouched.

## 2. Every settings page uses the pane

Each sub-page centred its body on a fixed column — `3xl` on General and People,
`5xl` on Inference, Hosting, Search and Skills, `6xl` on Usage. On a 1920px
window the settings pane is about 1400px, so General's 768px column left
roughly 600px of empty margin either side, beside a rail that already narrows
the pane. All seven now pass `width="full"` and drop `mx-auto max-w-*`.

**On readability.** The column was protecting *fields*, not cards. Card
headers, alerts, the DNS and member tables, the provider grids and the usage
charts all read better with width — Usage goes from a cramped 1152px to five
stat tiles across, and Skills from one column of playbooks to two. A single
text input does not: stretched across a 27" monitor its label and its caret are
a head-turn apart. So the cap moved down a level, to
`SETTINGS_FIELD_COLUMN` (`max-w-4xl`) in `settings-pages.ts`, applied to the
four credential field grids — Hosting, Search, Inference's switch form, and the
always-ask list on General (commit 4; it was the one input on that page with no
width of its own). `4xl` puts each control in a two-column grid at roughly
430px, which is the width it already had inside the old `5xl` body, so no field
an operator uses today changes size.

The one thing I did **not** narrow is body prose — Inference's intro paragraph
and Hosting's footnote now run the full pane, about 100 characters a line at
1920px. Wider than ideal for reading, but capping them would re-introduce
exactly the strip the issue is about, and they are two sentences rather than a
document. Worth an operator's opinion.

Observatory is untouched and is the honest exception: its row on the rail is a
doorway, `#/settings/observatory` is rewritten onto `#/observatory` before
`SettingsSection` dispatches, the shell routes the view, and it is already full
width.

`settings-navigation.test.ts` gains a sweep over `SETTINGS_NAMED_BY` asserting
`width="full"` and no `mx-auto` on every pane-rendered page, so a page added to
the rail with a centred body fails rather than passing by not being on a list.

## 3. Custom domain and Email (SMTP) are gated as coming soon

**Gated by not rendering the controls, not by disabling them.** `inert` and
`disabled` stop a mouse and the tab order and neither stops
`document.querySelector('[data-testid="smtp-save"]').click()` — an inert button
still runs its handler, and a disabled input is still an input a script or a
password manager can fill. The SMTP card takes a **password** and saves it into
the host's secret store, so "you cannot Tab to it" is not a strong enough
promise for it.

So each card renders a static picture of its own shape: `div`s carrying the
real field labels, with no `input`, `button`, `select`, `a[href]`, `tabindex`,
`contenteditable` or handler anywhere in it — under a **Coming soon** badge and
a sentence saying it is not switched on yet. The preview is `aria-hidden`,
`pointer-events-none` and blurred; the blur is decoration over a surface that
was already empty rather than the gate. `inert` is set anyway (imperatively,
the way `Overview.tsx` does it — React 18's types predate the boolean prop) so
the guarantee survives someone later dropping a real control into a preview.

They also no longer read the host: two requests for a surface nobody can use,
and on a company with a domain configured they would paint real values behind
the blur.

`DomainCard` and `SmtpCard` are exported and otherwise unchanged, so switching
the feature on is putting them back into the two slots rather than rebuilding
them out of the git history. Their host-backed guarantees keep their coverage:
`domain-settings-host-backed.test.ts` renders the two cards directly now
instead of the section.

### Proof they are inert

In Chromium at 1920x1200, against a real host:

- `querySelectorAll("input, button, select, textarea, a[href], [tabindex],
  [contenteditable]")` inside each card → **0**.
- preview `inert` → `true`, `aria-hidden` → `"true"`, computed
  `pointer-events` → `none`, computed `filter` → `blur(4px)`.
- **Real Tab sweep.** A `focusin` recorder, focus placed on the Lifecycle
  card's Pause button (the control immediately above the two cards), then six
  real `Tab` presses. The trail: Pause → Change theme → Replay tour → Set up
  company → Flag something → Skip to content (wrap). Focus entered neither
  gated card: `enteredGated: 0`. Note the second stop, "Change theme", is the
  Appearance card which sits **after** both gated cards in the DOM — the tab
  order steps straight over them.
- New `frontend/test/unit/settings-coming-soon.test.ts` (4 tests) pins all of
  the above except the live Tab sweep.

## Commands run

From `frontend/`, all green:

- `npm run typecheck` · `npm run typecheck:unit` · `npm run typecheck:e2e`
- `npx vitest run` — **497 files, 4593 tests, 0 failed** (up from 4588: one
  new sweep in `settings-navigation.test.ts` and four in
  `settings-coming-soon.test.ts`)
- `./scripts/ci/assert-design-tokens.sh` — "no arbitrary sizes, no palette
  colours, no stray hex"

**E2E.** No spec selects on the hint text or on a settings pane width. The one
grep hit, `connections-authority.spec.ts:111`, is a *comment* explaining why it
passes `exact: true`; the assertion itself is `toHaveCount(0)` on a button role
and is unaffected (the rail rows are links, and a link with text content takes
its accessible name from the text, not from `title`). I could not run
`npm run e2e` here — it needs `target/debug/opencompany`, which this worktree
has not built — so the two Console E2E lanes on this PR are the real check.

**Heads up on visual snapshots:** `test/e2e/visual.spec.ts-snapshots/
settings-{light,dark}-linux.png` are now stale. That lane is `PW_VISUAL`-gated
and no CI workflow runs it, and the baselines are `-linux` so they cannot be
regenerated on macOS — flagging rather than fixing.

## Browser verification

Chromium at 1920x1200 against the operator's saved company on a copied data
directory, **light and dark**. Screenshots on the machine at
`frontend/target/mcp/wt13-*.png`:

| | what it shows |
|---|---|
| `wt13-02-general-light` | rail with hints gone — eight single-line rows, no wrapping — and General at full pane width |
| `wt13-03-gated-light` | both gated cards: Coming soon badges, honest copy, blurred inert previews |
| `wt13-04-inference-light` | Inference full width, credential form capped at `4xl` |
| `wt13-05-people-light` | People full width, member rows using the width |
| `wt13-07-general-dark` | General dark, top of page, always-ask field capped |
| `wt13-06-gated-dark` | both gated cards in dark |
| `wt13-09-hosting-dark` | Hosting dark, API token / Team capped, alerts full width |
| `wt13-10-usage-dark` | Usage dark — five stat tiles across |
| `wt13-11-skills-dark` | Skills dark — two columns of playbooks |

The rail is shown at its real cap: all eight rows (`SETTINGS_PAGES.length`), every group, nothing elided.



## Review cycle (2026-09-07)

Both known gaps in the original description are now closed, and both review findings are answered.

### The E2E gap is closed — the suite was run locally

The description said E2E had never been run against this branch. It has now been, in Playwright's managed-host mode against a `cargo build --bin opencompany` host on the pinned `vendor/openhuman`:

```
$ npm run typecheck && npm run typecheck:unit && npm run typecheck:e2e   # all clean
$ npm test                                                              # 497 files, 4593 tests passed
$ ./scripts/ci/assert-design-tokens.sh                                  # clean
$ npx playwright test <the 15 specs that navigate to #/settings>
  45 passed, 0 failed, 2 skipped (51.6s)
```

The 15 specs are every file under `test/e2e/` that navigates to `#/settings` — including `shell-two-layer` (which measures the content card the full-width change sits inside), `connections-authority`, `theme-toggle-visible`, `shell-scrollbars` and `sidebar-toggle-reachable`. Nothing selects on hint text or on a pane's `max-w-*`, and nothing broke.

### The stale visual baselines are not this PR's to fix — filed as #2135

@chatgpt-codex-connector asked this PR to regenerate `settings-{light,dark}-linux.png`. It is right that `npm run e2e:visual` fails on Settings, and wrong that this PR caused it or can fix it:

- **All sixteen baselines were last recorded on 2026-08-23**, and **2263 commits have touched `frontend/src`** since. 153 of them touched the settings surface specifically, including `f8d8a3725`, `80b8d599c` and `f452782c1` — all before this branch existed.
- **They cannot be regenerated off Linux.** `playwright.config.ts` sets no `snapshotPathTemplate`, so `--update-snapshots` on macOS writes `settings-light-darwin.png`, a new file never compared against the committed `-linux` one.
- **No CI lane runs the check.** `PW_VISUAL` appears only in `frontend/package.json`; `visual.spec.ts` is in `testIgnore` for every other lane. `frontend/README.md` says why that is deliberate.

Full evidence and three options are in **#2135**. Answered in-thread [here](https://github.com/tinyhumansai/opencompany/pull/2133#discussion_r3951329419).

### Two commits added during review

- `7acbb9bb1` — docstrings for the four functions the gate added or newly exported, which was CodeRabbit's one failing pre-merge check (Docstring Coverage 66.67%). `DomainCard` and `SmtpCard` went from private to exported here, and an exported component whose only caller is a test needs to say why it still exists.
- `e7ee9a0da` — the rail has **eight** rows, not ten. Two comments said ten; `SETTINGS_PAGES` holds eight and a browser renders eight. Corrected, and pointed at `SETTINGS_PAGES.length` rather than restating a number that drifts.

### Re-verified in a browser after the last change

1920x1080, light and dark, against a local host, driven from an isolated Chromium (a sibling process on this machine kept stealing the shared browser's tab, so every step asserts `location.port` before it measures anything):

| what | light | dark |
|---|---|---|
| rail rows rendering hint text | 0 | 0 |
| rail rows carrying `title` | all | all |
| settings pane width | 1680px | 1680px |
| Hosting card / capped credential grid | 1406px / 896px | 1406px / 896px |
| always-ask field width | 896px (`max-w-4xl`) | 896px (`max-w-4xl`) |
| `inert` + `aria-hidden` on both previews | yes | yes |
| focusable elements inside either gated card | **0** | **0** |
| elements reached by **250 `Tab` presses** inside either gated card | **0** | **0** |

The last row is the one that matters for the coming-soon gate: neither card can be reached by keyboard, and there is no `input`, `button`, `select`, `textarea`, `form`, `a` or `[tabindex]` inside either preview to reach. Independently confirmed in source too — across the whole gated subtree (`DomainSettings` through `SmtpPreview`) the only matches for `useState|useEffect|fetch|client\.|onClick|onChange|onSubmit|<input|<button|<select|<form` are inside prose docstrings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom domain and Email (SMTP) settings now display inactive “Coming soon” previews.
  * Settings pages use full-width layouts with consistent field sizing.

* **Improvements**
  * Desktop settings navigation is more compact, with hints available on hover.
  * Hosting, Inference, People, Search, Skills, Usage, and general Settings pages now make better use of available screen space.

* **Bug Fixes**
  * Standardized settings form field widths for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
