### PR TITLE
Console: pin the Room rail in the sidebar and move section sub-nav to a two-column content layout

### DIFF
--- a/docs/spec/runtime/console-sections.md
+++ b/docs/spec/runtime/console-sections.md
@@ -1,7 +1,7 @@
 # The console's four sections
 
 The sidebar is four rows — **Room**, **Company**, **Connections**, **Flows** —
-with the contents of the one you are in listed beneath them. This file is the
+with the Room rail pinned beneath them on every one of them. This file is the
 record of that decision. It is Rule 8 of
 [`ledgers-console-ia.md`](ledgers-console-ia.md) written out, because that file
 is at its 500-line ceiling and this is the largest IA change it has seen.
@@ -30,54 +30,84 @@ question an operator is answering:
 Everything else is chrome (Settings, Feedback, Discord in the footer; Overview
 and Approvals in the window's title row) or is filed under one of the four.
 
-## The sub-navigation is in the SIDEBAR
+## The sub-navigation is in the CONTENT AREA — and this reverses a decision
 
-Finance, Settings and — until this change — Connections each drew a `w-60` rail
-inside the content area. That is the wrong place once more than one section has
-sub-pages, for two reasons that are not about layout fashion:
+This file first recorded the opposite, and the reversal is issue #2130. Both
+arguments are kept, because a decision reversed without its reasons on the page
+gets reversed back.
 
-- It puts the same kind of list in two different places depending on which
-  section you are in — the sidebar for the sections without sub-pages, a rail
-  for the ones with — so there is no rule to learn.
-- It charges the content pane 240px on every page under it, on a screen that
-  already has a sidebar to its left.
+**What it said.** Finance, Settings and Connections each drew a `w-60` rail
+inside the content area, and that was the wrong place once more than one section
+had sub-pages, for two reasons that are not about layout fashion: it puts the
+same kind of list in two different places depending on which section you are in
+— the sidebar for the sections without sub-pages, a rail for the ones with — so
+there is no rule to learn; and it charges the content pane 240px on every page
+under it, on a screen that already has a sidebar to its left. PR #1977 built a
+Connections content rail and removed it on exactly that argument.
 
-`components/sidebar-navigation.tsx` owns the pattern, and all four sections use
-it. `views/connections/ConnectionsSection.tsx` kept its dispatch and lost its
-rail in the same change that introduced the pattern, so the console never had
-two answers at once.
+**What outweighs it.** Putting a section's pages in the sidebar's middle region
+meant spending that region on them — and what it was spending was the **channel
+list**, which only appeared while you were in Room. The channel list is the one
+list an operator returns to continuously, from wherever they are. Losing it on
+every trip to Company, Connections or Flows is not a width, it is a round trip:
+go to Room, find the channel, come back. That costs more than 240px does.
 
-### Not an accordion
+So the trade is inverted. The sidebar's middle region is the Room rail,
+permanently, on every section. Company's five pages and Connections' two are the
+first column of their content area, drawn by `components/section-rail.tsx` from
+the same `NAV_SECTIONS` table the four rows come from.
+
+**The "two places" half of the old argument is answered, not ignored.** There is
+exactly one rule now — a section's sub-navigation is the first column of its
+content — and exactly one rail on screen at a time:
+
+- **Finance folds in.** Its three pages are nested rows on Company's rail,
+  visible while Finance is the open row. A rail of its own would be the second
+  240px column beside Company's, which is the 768–1023px band of issue #1383
+  reproduced at *every* width. `views/finance/FinanceSection.tsx` is
+  dispatch-only as a result — the shape `ConnectionsSection` already had.
+- **Settings keeps its own** because it is not one of the four at all. It is a
+  footer utility, and its rail *is* this pattern; the shared component copies
+  its geometry (`w-60` from `lg`, chips below) rather than the other way round.
+- **Room and Flows draw none.** Room's sub-navigation is the pinned channel
+  list. Flows has none to move: the canvas's Workflows/Runs toggle is a control
+  on the page's title row whose state is client-side rather than an address, so
+  promoting it would be inventing sub-pages rather than relocating any.
+
+### Not an accordion, and no longer a swap either
 
 The four rows are always visible, always contiguous, always in the same place.
-Selecting a section swaps the block **below** them; it does not expand a row in
-place and does not displace a row's siblings. Exactly one section's contents are
-on screen at a time.
+Selecting a section does not expand a row in place and does not displace a row's
+siblings — and since #2130 it does not swap the block below them either. That
+block is the channel list on every route, which makes the whole column fixed
+furniture: the same four rows and the same list, wherever you are.
 
 ```text
-┌─────────────────┐
-│ ■ Room          │  the four, fixed — they do not
-│   Company       │  move when you switch section
-│   Connections   │
-│   Flows         │
-│                 │  space, not a rule
-│ CHANNELS      + │  the active section's contents,
-│  # engineering  │  and only its contents. This is
-│  # general      │  the block that scrolls.
-│ DIRECT MSGS   ✎ │
-│  Neil · Alex    │
-├─────────────────┤
-│ ⚙ Settings      │  pinned, unchanged
-│ ⚑ Feedback      │
-│ ✦ Discord       │
-└─────────────────┘
+┌─────────────────┐┌────────────┬──────────────────┐
+│ ■ Room          ││ COMPANY    │                  │
+│   Company       ││  Agents    │  the page        │
+│   Connections   ││  Work      │                  │
+│   Flows         ││  Workspace │                  │
+│                 ││  Brain     │                  │
+│ CHANNELS      + ││  Finance   │                  │
+│  # engineering  ││   Overview │  the section's   │
+│  # general      ││   Invoicing│  rail — nested   │
+│ DIRECT MSGS   ✎ ││   Wallet   │  rows only while │
+│  Neil · Alex    ││            │  Finance is open │
+├─────────────────┤│            │                  │
+│ ⚙ Settings      ││            │                  │
+│ ⚑ Feedback      ││            │                  │
+│ ✦ Discord       ││            │                  │
+└─────────────────┘└────────────┴──────────────────┘
+  fixed on every      one rail, never two
+  route now
 ```
 
 The accordion — each row expanding under itself — was the first shape this took
 and was rejected twice over. The rows move, so "Flows is the fourth thing" only
-holds while nothing above it is open. And the one section whose contents are
-unbounded, Room, pushes every row after it off the bottom at an ordinary twenty
-channels: the wall, recreated inside one row.
+holds while nothing above it is open. And the one region whose contents are
+unbounded, the channel list, pushes every row after it off the bottom at an
+ordinary twenty channels: the wall, recreated inside one row.
 
 A fixed block also has no per-row open/closed state to keep. Which section is
 showing is which section you are in, and the route already carries that.
@@ -89,12 +119,12 @@ whatever a removed element's margins happened to be.
 
 ### On the collapsed rail
 
-The four icons stay. A section whose contents are a fixed list hides them —
-those rows are 3rem of nothing without their labels, and the parent icon still
-leads to them. **Room is the exception**: `ChannelRail` has a compact variant
-built for exactly that width, and dropping it would make collapsing the sidebar
-silently lose the channel list — the regression issue #1018 filed about the
-approvals badge, in a new place.
+The four icons stay, and so does the channel list: `ChannelRail` has a compact
+variant built for exactly that width, and dropping it would make collapsing the
+sidebar silently lose the channel list — the regression issue #1018 filed about
+the approvals badge, in a new place. Nothing else is in this region to hide any
+more. The fixed lists of child rows that *were* hidden here at 3rem are
+content-rail rows now, where they keep their labels at every width.
 
 ## Room is the chat column, moved whole
 
@@ -111,7 +141,34 @@ node, not the component tree. Lifting the model would have meant an effect
 writing it up to the shell and a re-render of the whole console every time an
 unread count changed.
 
-Two consequences worth stating:
+### Pinning the rail keeps `ChatView` mounted, and that is the price
+
+The rail is painted on every section now, so the view that renders it has to
+outlive the route that used to own it. The shell mounts `ChatView` on every
+route and hands it `routeOpen`; off Room it renders the rail, its two dialogs,
+and nothing else.
+
+The same two options were reweighed and the answer did not change. Lifting the
+model into the shell would now be *worse* than it was: the console would
+re-render on every unread tick from every section rather than only from Room.
+
+What the portal costs, stated plainly: ~2,400 lines of chat model stay mounted
+while an operator is on Company or Flows. The **data** was already resident —
+the shell owns the transcripts, the mention feed and the unread map precisely
+*because* `ChatView` used to unmount — so what is newly kept is the view's own
+state and its desks/roster reads, not the traffic. `ChatView` takes one roster
+read at shell mount that it did not take before, which
+`onboarding-gate-setup-controller-mount.test.ts` accounts for by name. In
+exchange the channel list is never a round trip away and a return to Room
+refetches nothing.
+
+One correctness consequence has to be said with it: **a mounted transcript is no
+longer evidence of a visible one.** `chatPaneVisible` is `routeOpen && !covering`
+— a mention must not be marked read because the operator happens to be on
+Company, for the same reason it must not be marked read behind the phone's
+covering sheet.
+
+Two further consequences worth stating:
 
 - **The 768–1023px two-rail band is gone by construction.** The rail was a
   second column competing with the app sidebar for the viewport, which is what
@@ -200,6 +257,9 @@ that one.
 - Rule 2's reasoning about a row per declared list is the argument this file
   generalises. Nothing in it is superseded.
 - Rule 6 is unchanged and is now exercised by eight views rather than five.
-- Rule 7's Connections section survives; only its rail moved into the sidebar.
-- `finance-console.md` still describes Finance's sub-pages correctly. Its
-  content rail is the last one left and is the obvious next thing to convert.
+- Rule 7's Connections section survives. Its rail moved into the sidebar and
+  came back to the content area as the shared one — through both moves the
+  section itself stayed dispatch-only, which is the property that mattered.
+- `finance-console.md` still describes Finance's sub-pages correctly. They are
+  nested rows on Company's rail rather than a rail of their own; the pages,
+  their addresses and their order are unchanged.

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -29,6 +29,7 @@ import { RouteLoading } from "@/components/route-loading";
 import { WINDOW_TITLE_BAR_HEIGHT } from "@/components/window-chrome";
 import { WindowTitleBar } from "@/components/window-title-bar";
 import { SidebarCollapseButton, SidebarUtilityBar } from "@/components/sidebar-controls";
+import { SectionContentRail } from "@/components/section-rail";
 import { SidebarNavigation } from "@/components/sidebar-navigation";
 import { RoomRailSlotProvider } from "@/components/room-rail";
 import { SetupController } from "@/setup/SetupController";
@@ -3432,7 +3433,7 @@ export function AppShell({
 
         <nav aria-label="Main navigation" className="flex min-h-0 flex-1 flex-col">
           <SidebarContent data-tour="sidebar">
-          <SidebarNavigation view={view} sub={sub} onNavigate={setView} />
+          <SidebarNavigation view={view} onNavigate={setView} />
         </SidebarContent>
         {/* The console's own utilities sit at the FOOT of the column, under the
             destinations rather than over them. They act on the console, not on
@@ -3507,6 +3508,13 @@ export function AppShell({
             it. */}
         <AgentProfileProvider client={client} company={company}>
         <ContentSurface>
+          {/* A section's sub-navigation is the first column of its content
+              (issue #2130) — Company's five pages, Connections' two — driven by
+              the same `NAV_SECTIONS` table the sidebar's four rows come from.
+              Sections with no children (Room, Flows) and addresses filed under
+              none (Settings, Overview, Approvals) render bare, exactly as they
+              did. See `components/section-rail.tsx`. */}
+          <SectionContentRail view={view} sub={sub} onNavigate={setView}>
           {/* `#/overview` is the company graph again — the page #1321 swapped
               out for the operator landing view. The graph keeps the
               `#/company/graph` alias that issue gave it, so every link minted
@@ -3552,11 +3560,33 @@ export function AppShell({
               onRunSetup={() => setSetupForced(true)}
             />
           )}
-          {view === "chat" && (
-            <ChatView
+          {/* Mounted on EVERY route, not only on `#/chat` (issue #2130).
+
+              The sidebar's channel rail is portalled out of this view
+              (`components/room-rail.tsx`), and it is pinned in the sidebar on
+              every section now — so the view that feeds it has to outlive the
+              route that used to own it. `routeOpen` is how it knows the
+              difference: false, and it renders the rail and nothing else.
+
+              What that costs, said plainly: ~2,400 lines of chat model stay
+              mounted while the operator is on Company or Flows. The data was
+              always resident — this shell owns `transcripts`, the mention feed
+              and the unread map precisely *because* `ChatView` used to unmount
+              — so what is newly kept is the view's own state and its
+              desks/roster reads, not the polling. The return is a channel list
+              that is never a round trip away, and a trip back to Room that
+              refetches nothing.
+
+              The alternative, lifting the rail model up into this shell, was
+              rejected when the rail shipped and is worse now: it would put an
+              effect in `ChatView` writing state up here and re-render the whole
+              console on every unread tick from every section, rather than only
+              from Room. */}
+          <ChatView
               client={client}
               company={company}
               sub={sub}
+              routeOpen={view === "chat"}
               presence={presence.peers}
               companyPeople={companyPeople}
               resolveTypingNames={resolveTypingNames}
@@ -3597,7 +3627,6 @@ export function AppShell({
               budgetProximity={budgetProximity}
               onDismissBudgetProximity={() => setBudgetProximity(null)}
             />
-          )}
           {view === "inbox" && <InboxView client={client} company={company} />}
           {/* All that is left of the Tasks page: the card detail. `sub` is a
               real id by the time this renders — `REWRITE_RETIRED` sent every
@@ -3890,12 +3919,10 @@ export function AppShell({
                 />
               }
             >
-              <FinanceSection
-                client={client}
-                company={company}
-                sub={sub}
-                onNavigate={(page) => navigate("finances", page)}
-              />
+              {/* Dispatch only: its three pages are nested rows on Company's
+                  section rail now, not a second `w-60` rail inside this pane
+                  (issue #2130, and #1383 for what two rails cost). */}
+              <FinanceSection client={client} company={company} sub={sub} />
             </Suspense>
           )}
           {view === "connections" && (
@@ -3913,6 +3940,7 @@ export function AppShell({
           )}
           {view === "feedback" && <FeedbackView client={client} company={company} />}
           {view === "not-found" && <UnknownRouteView address={sub} />}
+          </SectionContentRail>
         </ContentSurface>
         </AgentProfileProvider>
 

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -134,6 +134,7 @@ import { fetchWithOneRetry } from "@/lib/fetch-with-retry";
 import { Overview } from "@/views/Overview";
 import { CompanyView } from "@/views/company/CompanyView";
 import { ManageListsView } from "@/views/company/ManageListsView";
+import { readLastChannel } from "@/lib/last-channel";
 import { ChatView } from "@/views/ChatView";
 import { shouldClearReceipt, type ChatReceipt } from "@/views/chat/ChatLiveReceipt";
 import {
@@ -661,8 +662,16 @@ export function AppShell({
    * belongs to another section: the rail keeps naming the channel Room will
    * return to. State rather than a ref, because the rail has to re-render when
    * it changes.
+   *
+   * Seeded from `readLastChannel`, not from nothing (Codex P2 review on #2130).
+   * A console loaded straight onto `#/company` has never had `view === "chat"`,
+   * so with a bare `null` the rail highlighted the first desk — while clicking
+   * **Room** ran chat's own bare-route restoration and landed on the remembered
+   * channel instead. A highlight has to name the destination it is offering,
+   * and this is the same value chat restores from, read the same scoped way, so
+   * the two cannot disagree.
    */
-  const [chatSub, setChatSub] = useState<string | null>(null);
+  const [chatSub, setChatSub] = useState<string | null>(() => readLastChannel(scope));
   // Which thread panel is open in that channel, or `null` for none (#1890 B).
   //
   // A third condition on "is this completion's marker actually on screen",

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -646,6 +646,23 @@ export function AppShell({
   // after a walk to Approvals — that must keep using the last channel even
   // while the rail is what's on screen (#1768 codex review).
   const chatPaneVisibleRef = useRef(true);
+  /**
+   * The chat segment, remembered across a trip to another section (#2130).
+   *
+   * `ChatView` is mounted on every route now, and `sub` is whatever the CURRENT
+   * view's second segment is — `mcp` on `#/connections/mcp`, `goals` on
+   * `#/ledgers/goals`. Handing that straight to chat would have it resolve
+   * `mcp` as a channel id and raise the unknown-channel notice for a segment
+   * that was never addressed to it. Handing it nothing instead would drop the
+   * pinned rail's highlight back to the first desk the moment an operator
+   * stepped into Company.
+   *
+   * So the shell keeps the last chat segment and replays it while the address
+   * belongs to another section: the rail keeps naming the channel Room will
+   * return to. State rather than a ref, because the rail has to re-render when
+   * it changes.
+   */
+  const [chatSub, setChatSub] = useState<string | null>(null);
   // Which thread panel is open in that channel, or `null` for none (#1890 B).
   //
   // A third condition on "is this completion's marker actually on screen",
@@ -657,6 +674,9 @@ export function AppShell({
   // nowhere: the exact "suppressed a toast for a marker the operator cannot
   // see" defect #1768's review established the rule against.
   const openThreadRootRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (view === "chat") setChatSub(sub);
+  }, [view, sub]);
   const onChatPaneVisibilityChange = useCallback((visible: boolean) => {
     chatPaneVisibleRef.current = visible;
   }, []);
@@ -3585,7 +3605,8 @@ export function AppShell({
           <ChatView
               client={client}
               company={company}
-              sub={sub}
+              // The chat segment, not the current view's — see `chatSub`.
+              sub={view === "chat" ? sub : chatSub}
               routeOpen={view === "chat"}
               presence={presence.peers}
               companyPeople={companyPeople}

--- a/frontend/src/components/room-rail.tsx
+++ b/frontend/src/components/room-rail.tsx
@@ -24,10 +24,38 @@ import { useSidebar } from "@/components/ui/sidebar";
  * model up to the shell and a second render of the whole console every time an
  * unread count changed.
  *
- * The slot is `null` whenever the Room section is not expanded — a different
- * section is active, or the mobile sheet is closed and has unmounted its
- * contents. `ChatView` renders no rail at all then, which is the intended
- * behaviour rather than a fallback.
+ * ## The rail is permanent, so `ChatView` is mounted permanently (issue #2130)
+ *
+ * The slot used to be `null` whenever Room was not the open section, and
+ * `ChatView` rendered no rail at all then — the intended behaviour, while the
+ * sidebar's middle region belonged to whichever section you were in. It belongs
+ * to the channel list now, on every section, so that gap had to close, and there
+ * were the same two ways out as before.
+ *
+ * It closed the same way, for the same reason: the shell keeps `ChatView`
+ * mounted on every route and hands it `routeOpen`, which is false off Room. The
+ * rail portals as it always did; the transcript, the header and the members pane
+ * render only when `routeOpen`. Lifting the model into the shell was rejected
+ * twice now on the same grounds, and the second time it would have been worse —
+ * the console would re-render on every unread tick from *every* section rather
+ * than only from Room.
+ *
+ * What it costs is honest and worth stating: ~2,400 lines of chat model stay
+ * mounted while an operator is on Company or Flows, with its polls and its SSE
+ * subscriptions live. That was always true *of the data* — the shell owns the
+ * transcripts, the mention feed and the unread map precisely because `ChatView`
+ * used to unmount — so what is newly resident is the view's own state and its
+ * desks/roster reads, not the traffic. In exchange the channel list is never a
+ * round trip away, and returning to Room no longer refetches what it just had.
+ *
+ * `routeOpen` also gates `chatPaneVisible`, which is what stops a mention being
+ * marked read while the operator is somewhere else entirely — a mounted-but-off
+ * -screen transcript must not clear anything, exactly as the phone's covering
+ * sheet must not.
+ *
+ * The slot is still `null` in one case: the mobile sheet is closed and has
+ * unmounted its contents. `ChatView` renders no rail then, which remains the
+ * intended behaviour rather than a fallback.
  *
  * The sidebar's own density travels the same way. `ChatView` used to keep a
  * `collapsed` flag of its own in `localStorage` (`lib/chat-rail.ts`), because the
@@ -37,7 +65,10 @@ import { useSidebar } from "@/components/ui/sidebar";
  * disagree.
  */
 interface RoomRailSlot {
-  /** The sidebar's mount point, or `null` while Room is not expanded. */
+  /**
+   * The sidebar's mount point — present on every section since #2130, and
+   * `null` only while the mobile sheet is closed and has unmounted its contents.
+   */
   element: HTMLElement | null;
   /** Called by the sidebar with its slot node, as a ref callback. */
   setElement: (element: HTMLElement | null) => void;

--- a/frontend/src/components/section-rail.tsx
+++ b/frontend/src/components/section-rail.tsx
@@ -40,6 +40,12 @@ export interface SectionRailRow {
    * This row's own sub-pages, rendered indented beneath it while it is the open
    * row. Finance is the only one today — see `SectionContentRail` for why they
    * nest here rather than getting a second rail of their own.
+   *
+   * **One level, deliberately.** A nested row draws no children of its own: the
+   * indent is the only thing expressing depth, and a second indent inside a
+   * 240px column stops reading as hierarchy and starts reading as ragged. A
+   * third level of navigation is a sign the section wants splitting, not a
+   * deeper rail.
    */
   children?: SectionRailRow[];
 }
@@ -78,9 +84,15 @@ export function SectionRail({
   rows: SectionRailRow[];
   children: ReactNode;
 }) {
-  // Flattened for the chip row: below `lg` there is no indentation to express
-  // depth with, and a nested page that only appeared after its parent had been
-  // chosen would be a page an operator cannot reach in one move.
+  // The chip row is the rail flattened, and it follows the rail exactly: a
+  // row's sub-pages join it while that row is the open one, and not before.
+  //
+  // Showing every nested page unconditionally was the alternative and is worse
+  // here specifically. A chip row has no indentation to express depth with, so
+  // Overview, Invoicing and Wallet would sit beside Brain as peers of it —
+  // eight equal chips in a horizontal scroller, three of which are only
+  // meaningful under a fourth. Following the rail costs one extra tap and keeps
+  // the two surfaces saying the same thing.
   const chips = rows.flatMap((row) => [row, ...(row.active ? (row.children ?? []) : [])]);
   const open = chips.find((row) => row.active);
 

--- a/frontend/src/components/section-rail.tsx
+++ b/frontend/src/components/section-rail.tsx
@@ -94,7 +94,13 @@ export function SectionRail({
   // meaningful under a fourth. Following the rail costs one extra tap and keeps
   // the two surfaces saying the same thing.
   const chips = rows.flatMap((row) => [row, ...(row.active ? (row.children ?? []) : [])]);
-  const open = chips.find((row) => row.active);
+  // The DEEPEST active row, not the first. On `#/finances/wallet` both Finance
+  // and Wallet are active and Finance comes first, so a `find` here named the
+  // parent — "What it earns and spends" — on the one surface where the label
+  // alone does not say which page you are on (Codex P2 review). The leaf is
+  // also the row that carries `aria-current`, for the same reason: there is one
+  // current page, and an ancestor of it is not a second one.
+  const current = chips.filter((row) => row.active).at(-1);
 
   return (
     <div className="flex min-h-0 flex-1">
@@ -111,11 +117,14 @@ export function SectionRail({
         <div className="px-2 pb-2 pt-1 text-xs font-medium text-muted-foreground">{label}</div>
         {rows.map((row) => (
           <Fragment key={row.key}>
-            <RailRow row={row} />
+            <RailRow row={row} current={row === current} />
             {/* A row's own sub-pages, only while it is the row you are on.
                 Always-visible would put every leaf of every branch on one rail,
                 which is the wall `ledgers-console-ia.md` Rule 2 rejected. */}
-            {row.active && row.children?.map((child) => <RailRow key={child.key} row={child} nested />)}
+            {row.active &&
+              row.children?.map((child) => (
+                <RailRow key={child.key} row={child} current={child === current} nested />
+              ))}
           </Fragment>
         ))}
       </nav>
@@ -138,7 +147,7 @@ export function SectionRail({
                 type="button"
                 title={row.hint}
                 onClick={row.onSelect}
-                aria-current={row.active ? "page" : undefined}
+                aria-current={row === current ? "page" : undefined}
                 className={cn(
                   "shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors",
                   row.active ? "bg-accent text-accent-foreground" : "text-muted-foreground",
@@ -153,7 +162,7 @@ export function SectionRail({
               so this line is the only gloss it has — and it describes the
               *active* page rather than repeating itself under all of them.
               That is not a second line per row, which is what was removed. */}
-          {open && <p className="px-3 pb-2 text-xs text-muted-foreground">{open.hint}</p>}
+          {current && <p className="px-3 pb-2 text-xs text-muted-foreground">{current.hint}</p>}
         </div>
 
         {children}
@@ -177,20 +186,34 @@ export function SectionRail({
  * the sidebar's rows have, so every selector written as
  * `[data-tour="nav-x"] >> role=button` works against both.
  */
-function RailRow({ row, nested = false }: { row: SectionRailRow; nested?: boolean }) {
+function RailRow({
+  row,
+  current,
+  nested = false,
+}: {
+  row: SectionRailRow;
+  /** The deepest active row — the one page you are actually on. */
+  current: boolean;
+  nested?: boolean;
+}) {
   return (
     <div data-tour={row.anchor}>
       <button
         type="button"
         title={row.hint}
         onClick={row.onSelect}
-        aria-current={row.active ? "page" : undefined}
+        // Exactly one row per rail says `page`, and it is the leaf. Finance is
+        // *active* while you are on `#/finances/wallet` — it is the branch you
+        // are in — but it is not a second current page, and two nodes answering
+        // `aria-current="page"` is a page a screen reader cannot locate you on.
+        // What says "you are in this branch" is that its children are showing.
+        aria-current={current ? "page" : undefined}
         className={cn(
           "flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left transition-colors",
           // Depth is what the indent says. Every row is one line now, so this is
           // the only thing distinguishing a sub-page from its parent.
           nested && "pl-8",
-          row.active ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
+          current ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
         )}
       >
         <row.icon className="size-4 shrink-0 text-muted-foreground" />

--- a/frontend/src/components/section-rail.tsx
+++ b/frontend/src/components/section-rail.tsx
@@ -150,7 +150,13 @@ export function SectionRail({
                 aria-current={row === current ? "page" : undefined}
                 className={cn(
                   "shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors",
-                  row.active ? "bg-accent text-accent-foreground" : "text-muted-foreground",
+                  // The leaf, not every active row. Finance is active on
+                  // `#/finances/wallet` and so is Wallet, and this row has no
+                  // indent to say which of the two you are on — two filled
+                  // chips read as two current destinations (Codex P2 review).
+                  // What says "you are in this branch" here is the same thing
+                  // that says it on the rail: its children are in the row at all.
+                  row === current ? "bg-accent text-accent-foreground" : "text-muted-foreground",
                 )}
               >
                 {row.label}

--- a/frontend/src/components/section-rail.tsx
+++ b/frontend/src/components/section-rail.tsx
@@ -25,7 +25,11 @@ import { cn } from "@/lib/utils";
 export interface SectionRailRow {
   key: string;
   label: string;
-  /** What the row prints under its label — what the page is for, in a phrase. */
+  /**
+   * What the page is for, in a phrase. The row's `title` and, below `lg`, the
+   * line under the chip row — not a second line under the label. See `RailRow`
+   * for why (issue #2131).
+   */
   hint: string;
   icon: LucideIcon;
   active: boolean;
@@ -132,6 +136,11 @@ export function SectionRail({
               </button>
             ))}
           </div>
+          {/* The hint survives here, and #2131 did not touch the equivalent row
+              in Settings for the same reason: a chip carries the label alone,
+              so this line is the only gloss it has — and it describes the
+              *active* page rather than repeating itself under all of them.
+              That is not a second line per row, which is what was removed. */}
           {open && <p className="px-3 pb-2 text-xs text-muted-foreground">{open.hint}</p>}
         </div>
 
@@ -142,7 +151,15 @@ export function SectionRail({
 }
 
 /**
- * One rail row.
+ * One rail row: one line, with the gloss on `title`.
+ *
+ * The hint was a second line under every label, and at `w-60` most of them
+ * wrapped — so a five-row rail was fifteen lines of prose and had stopped being
+ * a list you can scan. The labels are the navigation; the hint is a gloss, and a
+ * gloss that triples the height of the thing it explains has stopped helping.
+ * PR #2133 made exactly this change to the Settings rail (issue #2131) and this
+ * copies it deliberately: the two layouts sit side by side and must not
+ * diverge — same `items-center`, same iconless `mt-0.5` removal, same `title`.
  *
  * The `data-tour` anchor sits on the wrapper, not the button — the same shape
  * the sidebar's rows have, so every selector written as
@@ -153,22 +170,19 @@ function RailRow({ row, nested = false }: { row: SectionRailRow; nested?: boolea
     <div data-tour={row.anchor}>
       <button
         type="button"
+        title={row.hint}
         onClick={row.onSelect}
         aria-current={row.active ? "page" : undefined}
         className={cn(
-          "flex w-full items-start gap-2.5 rounded-lg px-2 py-2 text-left transition-colors",
-          // Indented and label-only. Depth is what the indent says; a second
-          // line of hint under a nested row makes the rail taller than the list
-          // it is navigating.
+          "flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left transition-colors",
+          // Depth is what the indent says. Every row is one line now, so this is
+          // the only thing distinguishing a sub-page from its parent.
           nested && "pl-8",
           row.active ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
         )}
       >
-        <row.icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-        <span className="min-w-0">
-          <span className="block text-sm font-medium">{row.label}</span>
-          {!nested && <span className="block text-xs text-muted-foreground">{row.hint}</span>}
-        </span>
+        <row.icon className="size-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 truncate text-sm font-medium">{row.label}</span>
       </button>
     </div>
   );

--- a/frontend/src/components/section-rail.tsx
+++ b/frontend/src/components/section-rail.tsx
@@ -1,0 +1,252 @@
+import { Fragment, type ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+
+import {
+  childActive,
+  childAnchor,
+  grandchildActive,
+  sectionOwning,
+  type NavChild,
+  type NavSection,
+} from "@/components/sidebar-navigation";
+import type { View } from "@/lib/console-routes";
+import { cn } from "@/lib/utils";
+
+/**
+ * One row on a section's rail.
+ *
+ * `onSelect` rather than an `href`: these rows address views the shell already
+ * navigates by `(view, sub)` pair, and routing them through the shell's own
+ * `navigate` keeps one place that decides what an address means.
+ * `SettingsSection` uses links because its rows are all one view's sub-pages
+ * and a hash is the whole address; that difference is real and neither is a
+ * copy of the other's mistake.
+ */
+export interface SectionRailRow {
+  key: string;
+  label: string;
+  /** What the row prints under its label — what the page is for, in a phrase. */
+  hint: string;
+  icon: LucideIcon;
+  active: boolean;
+  /** The `data-tour` anchor, or `undefined` where it would collide. */
+  anchor?: string;
+  onSelect: () => void;
+  /**
+   * This row's own sub-pages, rendered indented beneath it while it is the open
+   * row. Finance is the only one today — see `SectionContentRail` for why they
+   * nest here rather than getting a second rail of their own.
+   */
+  children?: SectionRailRow[];
+}
+
+/**
+ * A section's sub-navigation, as the first column of its content area.
+ *
+ * ## Why the content area and not the sidebar
+ *
+ * The sidebar's middle region is the Room rail, permanently, on every section
+ * (issue #2130) — the channel list is the thing an operator returns to most,
+ * and losing it whenever they step into Company or Connections costs more than
+ * the 240px this column charges. The full argument, including the one this
+ * reverses, is on `NAV_SECTIONS` in `components/sidebar-navigation.tsx`.
+ *
+ * ## Modelled on the Settings rail, deliberately
+ *
+ * Same widths, same breakpoint, same two shapes: a `w-60` rail from `lg`, and a
+ * scrolling row of chips below it. `SettingsSection` keeps drawing its own
+ * because its rows are `<a href>` links over one view's sub-pages rather than
+ * `(view, sub)` navigations, but the geometry is copied from it on purpose so
+ * that an operator meets one pattern rather than two that nearly agree.
+ *
+ * The breakpoint is `lg`, not `sm`, and that is the whole of issue #1383: from
+ * 768–1023px the app sidebar is already on, and a second `w-60` rail there
+ * squeezes the working pane to ~290px. Below `lg` this collapses to chips so
+ * the pane gets the full width.
+ */
+export function SectionRail({
+  label,
+  rows,
+  children,
+}: {
+  /** The section's own name, as the rail's caption and its accessible name. */
+  label: string;
+  rows: SectionRailRow[];
+  children: ReactNode;
+}) {
+  // Flattened for the chip row: below `lg` there is no indentation to express
+  // depth with, and a nested page that only appeared after its parent had been
+  // chosen would be a page an operator cannot reach in one move.
+  const chips = rows.flatMap((row) => [row, ...(row.active ? (row.children ?? []) : [])]);
+  const open = chips.find((row) => row.active);
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <nav
+        aria-label={label}
+        className="hidden w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-3 lg:flex"
+      >
+        {/* A visual caption for the rail, not a heading. The `nav` is already
+            named by its `aria-label`, so an `h2` here would add nothing for a
+            screen reader and would break the document outline: the rail renders
+            before the sub-page, so heading navigation meets a section-level
+            heading ahead of the page's own `h1` (issue #1392, and
+            `nav-rail-headings.test.ts` holds it). */}
+        <div className="px-2 pb-2 pt-1 text-xs font-medium text-muted-foreground">{label}</div>
+        {rows.map((row) => (
+          <Fragment key={row.key}>
+            <RailRow row={row} />
+            {/* A row's own sub-pages, only while it is the row you are on.
+                Always-visible would put every leaf of every branch on one rail,
+                which is the wall `ledgers-console-ia.md` Rule 2 rejected. */}
+            {row.active && row.children?.map((child) => <RailRow key={child.key} row={child} nested />)}
+          </Fragment>
+        ))}
+      </nav>
+
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {/* Below `lg` the rail collapses to a scrolling row of chips, so the
+            sub-pages stay reachable without a second drawer.
+
+            `relative z-30`: on the macOS desktop `WindowDragBar` overlays the
+            top 28px of the content area with a pointer-events-enabled drag band
+            at `z-20`, and this row is the one page top that sits in that band
+            below `lg`. Without its own stacking context its links are
+            unreachable at 880–1023px window widths — the same fix, for the same
+            reason, that `SettingsSection`'s chip row carries. */}
+        <div className="relative z-30 border-b lg:hidden">
+          <div className="flex gap-1 overflow-x-auto p-2">
+            {chips.map((row) => (
+              <button
+                key={row.key}
+                type="button"
+                title={row.hint}
+                onClick={row.onSelect}
+                aria-current={row.active ? "page" : undefined}
+                className={cn(
+                  "shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                  row.active ? "bg-accent text-accent-foreground" : "text-muted-foreground",
+                )}
+              >
+                {row.label}
+              </button>
+            ))}
+          </div>
+          {open && <p className="px-3 pb-2 text-xs text-muted-foreground">{open.hint}</p>}
+        </div>
+
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One rail row.
+ *
+ * The `data-tour` anchor sits on the wrapper, not the button — the same shape
+ * the sidebar's rows have, so every selector written as
+ * `[data-tour="nav-x"] >> role=button` works against both.
+ */
+function RailRow({ row, nested = false }: { row: SectionRailRow; nested?: boolean }) {
+  return (
+    <div data-tour={row.anchor}>
+      <button
+        type="button"
+        onClick={row.onSelect}
+        aria-current={row.active ? "page" : undefined}
+        className={cn(
+          "flex w-full items-start gap-2.5 rounded-lg px-2 py-2 text-left transition-colors",
+          // Indented and label-only. Depth is what the indent says; a second
+          // line of hint under a nested row makes the rail taller than the list
+          // it is navigating.
+          nested && "pl-8",
+          row.active ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
+        )}
+      >
+        <row.icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0">
+          <span className="block text-sm font-medium">{row.label}</span>
+          {!nested && <span className="block text-xs text-muted-foreground">{row.hint}</span>}
+        </span>
+      </button>
+    </div>
+  );
+}
+
+/**
+ * The section rail for whichever section the current address belongs to, or the
+ * page bare where that section has no sub-pages.
+ *
+ * Driven by `NAV_SECTIONS` — the same table the sidebar's four rows come from,
+ * `sectionOwning` resolves against and `childActive` lights a row from. One
+ * table, read from both ends, so a row added to a section appears here without
+ * anyone remembering to add it twice.
+ *
+ * Room and Flows have no children, so they render their page with no rail at
+ * all: Room's sub-navigation is the channel list, which is pinned in the
+ * sidebar, and Flows has none to move. Settings is not in this table (it is a
+ * footer utility, not one of the four) and keeps drawing its own rail.
+ *
+ * ## The Finance question
+ *
+ * Company's rows include Finance, and Finance has three sub-pages of its own —
+ * as does Settings, and both used to draw a `w-60` rail inside the page. Under
+ * this layout Company already draws one, so Finance's would be the *second*
+ * rail in the viewport: sidebar plus 240 plus 240 plus content, which is the
+ * 768–1023px band issue #1383 was filed about, now reproduced at every width.
+ *
+ * So they nest rather than stacking: Finance's pages are indented rows on
+ * Company's rail, visible while Finance is the open row. One rail per section,
+ * always, and never two. `FinanceSection` is dispatch-only as a result — the
+ * shape `ConnectionsSection` has had since PR #1977.
+ */
+export function SectionContentRail({
+  view,
+  sub,
+  onNavigate,
+  children,
+}: {
+  view: View;
+  /** The hash's second segment, so a row can light for its own sub-page. */
+  sub: string | null;
+  onNavigate: (view: View, sub?: string) => void;
+  children: ReactNode;
+}) {
+  const section = sectionOwning(view);
+  if (!section?.children) return <>{children}</>;
+
+  return (
+    <SectionRail label={section.label} rows={sectionRows(section, view, sub, onNavigate)}>
+      {children}
+    </SectionRail>
+  );
+}
+
+/** One section's children as rail rows, with their own children folded in. */
+function sectionRows(
+  section: NavSection,
+  view: View,
+  sub: string | null,
+  onNavigate: (view: View, sub?: string) => void,
+): SectionRailRow[] {
+  const row = (child: NavChild, active: boolean, anchor?: string): SectionRailRow => ({
+    key: `${child.view}/${child.sub ?? ""}`,
+    label: child.label,
+    hint: child.hint,
+    icon: child.icon,
+    active,
+    anchor,
+    onSelect: () => onNavigate(child.view, child.sub),
+  });
+
+  return (section.children ?? []).map((child) => ({
+    ...row(child, childActive(section, child, view, sub), childAnchor(section, child)),
+    children: child.children?.map((grandchild) =>
+      // No `data-tour` on a nested row: the anchors follow the address, and a
+      // grandchild's address is its parent's view with a second segment — which
+      // `childAnchor` would name after the view, colliding with the parent.
+      row(grandchild, grandchildActive(child, grandchild, view, sub)),
+    ),
+  }));
+}

--- a/frontend/src/components/sidebar-navigation.tsx
+++ b/frontend/src/components/sidebar-navigation.tsx
@@ -41,10 +41,13 @@ export interface NavChild {
   label: string;
   icon: LucideIcon;
   /**
-   * What the rail prints under the label: what the page is for, in a phrase.
-   * Every other rail in the console carries one — `SETTINGS_PAGES`,
-   * `CONNECTION_PAGES` and `FINANCE_PAGES` each require it — and a row without
-   * one is a word an operator has to click to understand.
+   * What the page is for, in a phrase.
+   *
+   * Not a second line under the label — that was removed from every rail in the
+   * console by issue #2131, because at `w-60` most of them wrapped and a rail
+   * of them was a wall rather than a list. It is the row's `title`, and below
+   * `lg` it is the line under the chip row naming the active page. Kept as data
+   * for exactly that reason, the way `SETTINGS_PAGES` keeps its own.
    */
   hint: string;
   /**

--- a/frontend/src/components/sidebar-navigation.tsx
+++ b/frontend/src/components/sidebar-navigation.tsx
@@ -298,7 +298,22 @@ export function grandchildActive(
   return rowActive(child.children ?? [], grandchild, view, sub);
 }
 
-/** Which of a list of sibling rows an address lights, if any. */
+/**
+ * Which of a list of sibling rows an address lights, if any.
+ *
+ * A row that names no `sub` owns its whole view. A row that names one owns
+ * exactly that segment — **and the first of the set additionally owns every
+ * segment none of them names**, not only the bare address.
+ *
+ * That second half is the part worth stating, because it is not a nicety: it is
+ * what keeps this table agreeing with the page. `resolveFinancePage`,
+ * `resolveConnectionPage` and `resolveSettingsPage` all fall back to their first
+ * page for an unknown segment, so `#/finances/old-page` — a stale bookmark, a
+ * typo, a renamed page — *renders Overview*. Matching on the segment alone left
+ * the rail marking only the Finance ancestor and the chip row naming the parent
+ * while Overview was on screen (Codex P2 review on #2130). The resolver decides
+ * what renders; this decides what is marked; they have to be the same rule.
+ */
 function rowActive(
   siblings: readonly NavChild[],
   row: NavChild,
@@ -307,7 +322,8 @@ function rowActive(
 ): boolean {
   if (!isNavigationActive(row.view, view)) return false;
   if (row.sub === undefined) return true;
-  if (sub === null) return siblings[0] === row;
+  const named = siblings.some((sibling) => sibling.sub === sub);
+  if (sub === null || !named) return siblings[0] === row;
   return row.sub === sub;
 }
 

--- a/frontend/src/components/sidebar-navigation.tsx
+++ b/frontend/src/components/sidebar-navigation.tsx
@@ -22,11 +22,15 @@ import { RESTING_ROW } from "@/components/sidebar-controls";
 import { useRoomRailSlot } from "@/components/room-rail";
 import { isNavigationActive, type View } from "@/lib/console-routes";
 import { CONNECTION_PAGES } from "@/views/connection-pages";
+// The leaf table, not the section — importing `FinanceSection` here would pull
+// `InvoicingView`, `WalletView` and the lazy `FinancesView` into the module the
+// sidebar renders on every route. Same reason `connection-pages.ts` exists.
+import { FINANCE_PAGES } from "@/views/finance/finance-pages";
 import { cn } from "@/lib/utils";
 
 /**
- * One destination inside a section: a row rendered under its parent while that
- * section is the one you are in.
+ * One destination inside a section: a row on that section's content rail
+ * (`components/section-rail.tsx`) while it is the section you are in.
  *
  * `sub` is the hash's second segment, for a child that is a sub-page of its
  * parent's view (`#/connections/apps`) rather than a view of its own.
@@ -36,6 +40,20 @@ export interface NavChild {
   sub?: string;
   label: string;
   icon: LucideIcon;
+  /**
+   * What the rail prints under the label: what the page is for, in a phrase.
+   * Every other rail in the console carries one — `SETTINGS_PAGES`,
+   * `CONNECTION_PAGES` and `FINANCE_PAGES` each require it — and a row without
+   * one is a word an operator has to click to understand.
+   */
+  hint: string;
+  /**
+   * This child's own sub-pages, rendered indented under it while it is the open
+   * row. Finance is the only one, and it nests rather than drawing a rail of its
+   * own because two `w-60` rails in one viewport is issue #1383 — the argument
+   * is on `SectionContentRail`.
+   */
+  children?: NavChild[];
 }
 
 /**
@@ -53,12 +71,6 @@ export interface NavSection {
   label: string;
   icon: LucideIcon;
   children?: NavChild[];
-  /**
-   * Renders in place of `children`, for a section whose contents are live data
-   * rather than a fixed list. Room is the only one: its contents are the
-   * channel list, which `ChatView` portals in (`room-rail.tsx`).
-   */
-  slot?: "room";
 }
 
 /**
@@ -82,13 +94,45 @@ export interface NavSection {
  * anchors follow the view id for the same reason: they are how the guided tour
  * and the e2e specs find a row, and they should not move when a word does.
  *
- * ## Sub-navigation lives HERE, not in a rail inside the content area
+ * ## Sub-navigation lives in the CONTENT area, not here
  *
- * Finance and Settings each draw their own `w-60` rail inside the page. That is
- * the wrong place for it once more than one section has sub-pages: it puts the
- * same kind of list in two different places depending on which section you are
- * in, and it costs the content pane 240px on every one of them. A section's
- * contents belong under its row, where the sidebar already is.
+ * This table feeds two surfaces now, and only one of them is the sidebar. The
+ * four rows above are the sidebar's; every `children` list below is read by
+ * `components/section-rail.tsx` and drawn as the first column of the content
+ * area, the way Settings has always drawn its own.
+ *
+ * ### This reverses what shipped, on purpose (issue #2130)
+ *
+ * The argument that put these rows in the sidebar was good, and it is written
+ * out here rather than deleted, because a decision reversed without its reasons
+ * on the page gets reversed back. It said: a rail inside the page puts the same
+ * kind of list in two different places depending on which section you are in —
+ * the sidebar for the sections without sub-pages, a rail for the ones with — so
+ * there is no rule to learn; and it charges the content pane 240px on every page
+ * under it, on a screen that already has a sidebar. PR #1977 shipped a
+ * Connections content rail and then removed it on exactly that reasoning.
+ *
+ * What outweighs it is what the sidebar's middle region was being spent on. It
+ * held whichever section you were in, which meant it held the **channel list**
+ * only while you were in Room — and the channel list is the one list an operator
+ * comes back to continuously, from wherever they are. Losing it on every trip to
+ * Company, Connections or Flows costs more than 240px of content width does,
+ * because it is not a width, it is a round trip: go to Room, find the channel,
+ * come back.
+ *
+ * So the trade is inverted. The sidebar's middle region is the Room rail,
+ * permanently, on every section (`SidebarNavigation` below, and `room-rail.tsx`
+ * for the portal that fills it). The sections that had sub-navigation there draw
+ * it as a content rail instead.
+ *
+ * The "two places" half of the old argument survives the reversal, and is
+ * answered rather than ignored: there is exactly **one** rule now, which is that
+ * a section's sub-navigation is the first column of its content, and exactly one
+ * rail on screen at a time. Finance and Settings each drew a `w-60` rail of
+ * their own; Finance's is gone, folded into Company's as nested rows, precisely
+ * so that the rule has no exception (see `SectionContentRail`). Settings keeps
+ * drawing its own because it is not one of the four sections at all — it is a
+ * footer utility — and its rail *is* this pattern.
  */
 export const NAV_SECTIONS: NavSection[] = [
   // The chat column, whole, and the console's default landing view
@@ -96,9 +140,11 @@ export const NAV_SECTIONS: NavSection[] = [
   // says what they want and where their company answers — the thing they came
   // to do — so it is what opens, and it is first.
   //
-  // Its contents are not a table here: they are the channel list `ChatView`
-  // already renders, portalled into the slot below. See `room-rail.tsx`.
-  { view: "chat", label: "Room", icon: MessagesSquare, slot: "room" },
+  // It has no `children`, and it needs none: its contents are the channel list
+  // `ChatView` renders, portalled into the sidebar's own middle region — which
+  // is now pinned there on every section rather than being Room's turn at it.
+  // See `room-rail.tsx`.
+  { view: "chat", label: "Room", icon: MessagesSquare },
   // The company itself: who is in it, what they are working on, what it keeps,
   // what it remembers, and what it spends. Five surfaces that were five
   // top-level rows and are one subject.
@@ -110,24 +156,43 @@ export const NAV_SECTIONS: NavSection[] = [
       // Today's Company page, renamed. "Company > Company" said the word twice
       // and told you nothing; what the page actually is, is the roster and the
       // org chart — the agents.
-      { view: "company", label: "Agents", icon: Network },
+      { view: "company", label: "Agents", icon: Network, hint: "Who is in this company" },
       // Tasks by default; every other list the company declared is one click
       // away through the switcher on `LedgersView`'s own title. See
       // `docs/spec/runtime/ledgers-console-ia.md` Rule 2 for why this is one
       // row and not one per list.
-      { view: "ledgers", label: "Work", icon: BookText },
-      { view: "workspace", label: "Workspace", icon: FolderClosed },
-      { view: "brain", label: "Brain", icon: Brain },
-      { view: "finances", label: "Finance", icon: Wallet },
+      { view: "ledgers", label: "Work", icon: BookText, hint: "Tasks, and every list it declared" },
+      { view: "workspace", label: "Workspace", icon: FolderClosed, hint: "The files it keeps" },
+      { view: "brain", label: "Brain", icon: Brain, hint: "What it remembers" },
+      // The one row with sub-pages of its own. They are nested here rather than
+      // left as a second rail inside the Finance page: Company already draws a
+      // `w-60` rail, and a second one beside it is issue #1383 at every width
+      // rather than only at 768–1023px. `FinanceSection` is dispatch-only as a
+      // result, which is the shape `ConnectionsSection` already had.
+      {
+        view: "finances",
+        label: "Finance",
+        icon: Wallet,
+        hint: "What it earns and spends",
+        children: FINANCE_PAGES.map((page) => ({
+          view: "finances" as const,
+          sub: page.id,
+          label: page.label,
+          icon: page.icon,
+          hint: page.hint,
+        })),
+      },
     ],
   },
   // What the company can act through: the apps its teammates sign in to, and
   // the MCP tool servers they can call. Its children come straight off
   // `CONNECTION_PAGES` rather than being restated here — that table is already
   // what the route resolver, the rewrites and `CONNECTIONS_NAMED_BY` read, and
-  // a fourth copy of two labels is a fourth thing to forget. This section grew
-  // its own content rail when it shipped (PR #1977); the rail is gone and these
-  // rows are what replaced it.
+  // a fourth copy of two labels is a fourth thing to forget. This section
+  // shipped with a content rail of its own (PR #1977), gave it up for rows in
+  // the sidebar, and has it back — as the shared one every section with
+  // sub-pages now draws, rather than one built here. See the reversal argument
+  // on this table above; `ConnectionsSection` is still dispatch-only either way.
   {
     view: "connections",
     label: "Connections",
@@ -137,9 +202,16 @@ export const NAV_SECTIONS: NavSection[] = [
       sub: page.id,
       label: page.label,
       icon: page.icon,
+      hint: page.hint,
     })),
   },
   // Was "Workflows". One word, and the word an operator uses out loud.
+  //
+  // No `children`, and so no content rail — it has no sub-navigation to move.
+  // The canvas's own Workflows/Runs toggle is a control on the page's title row
+  // whose state is persisted client-side rather than carried by the address
+  // (`WorkflowsView`'s `indexTab`), so it is not a pair of routes and promoting
+  // it to a rail would be inventing sub-pages rather than relocating any.
   { view: "workflows", label: "Flows", icon: Workflow },
   // Overview and Approvals are NOT here, and neither is Observatory. All three
   // are Rule-6 calls, made explicitly in
@@ -203,10 +275,37 @@ export function childActive(
   view: View,
   sub: string | null,
 ): boolean {
-  if (!isNavigationActive(child.view, view)) return false;
-  if (child.sub === undefined) return true;
-  if (sub === null) return section.children?.[0] === child;
-  return child.sub === sub;
+  return rowActive(section.children ?? [], child, view, sub);
+}
+
+/**
+ * Whether a child's own sub-page is the one open.
+ *
+ * The same rule one level down, against its siblings rather than the section's:
+ * `#/finances` with no segment is Overview because Overview is first, exactly as
+ * `#/connections` is Apps. Shared with `childActive` rather than restated, so
+ * the two levels cannot come to disagree about what a bare address means.
+ */
+export function grandchildActive(
+  child: NavChild,
+  grandchild: NavChild,
+  view: View,
+  sub: string | null,
+): boolean {
+  return rowActive(child.children ?? [], grandchild, view, sub);
+}
+
+/** Which of a list of sibling rows an address lights, if any. */
+function rowActive(
+  siblings: readonly NavChild[],
+  row: NavChild,
+  view: View,
+  sub: string | null,
+): boolean {
+  if (!isNavigationActive(row.view, view)) return false;
+  if (row.sub === undefined) return true;
+  if (sub === null) return siblings[0] === row;
+  return row.sub === sub;
 }
 
 /**
@@ -224,14 +323,24 @@ export function childAnchor(section: NavSection, child: NavChild): string | unde
 }
 
 /**
- * The sidebar: four fixed rows, then whatever is filed under the one you are in.
+ * The sidebar: four fixed rows, and the Room rail under them — always.
  *
- * ## Not an accordion
+ * ## Not an accordion, and no longer a swap either
  *
  * The four rows are always visible, always contiguous, and always in the same
  * place. Selecting a section does not displace its siblings and does not expand
- * a row in place — it swaps the block BELOW the four, under a divider. Exactly
- * one section's contents are on screen at a time.
+ * a row in place.
+ *
+ * What is below the four used to swap with the section you were in. It does not
+ * any more (issue #2130): it is the channel list, on every section, and every
+ * other section's sub-navigation is the first column of its content area
+ * instead (`components/section-rail.tsx`). The reversal and what it is worth are
+ * argued on `NAV_SECTIONS` above.
+ *
+ * That makes the column entirely fixed furniture — four rows and one list, in
+ * the same place on every route — which is the property the four-row restructure
+ * was reaching for and could not have while the middle region was a variable.
+ * There is still no open/closed state to keep anywhere.
  *
  * The two blocks are separated by space rather than by a rule: the column is
  * already quiet, and the console draws no rule above its footer either, so one
@@ -240,34 +349,28 @@ export function childAnchor(section: NavSection, child: NavChild): string | unde
  * The alternative — each row expanding under itself, pushing the rows after it
  * down — was the first thing this looked like and is worse in two specific
  * ways. The rows move, so the muscle memory of "Flows is the fourth thing" only
- * holds while nothing above it is open. And the one section whose contents are
- * unbounded, Room, pushes every row after it off the bottom at an ordinary
- * twenty channels — which recreates, inside one row, exactly the wall this
- * restructure exists to remove (`ledgers-console-ia.md` Rule 2, Draft 1).
+ * holds while nothing above it is open. And the one region whose contents are
+ * unbounded, the channel list, pushes every row after it off the bottom at an
+ * ordinary twenty channels — which recreates, inside one row, exactly the wall
+ * this restructure exists to remove (`ledgers-console-ia.md` Rule 2, Draft 1).
  *
- * With a fixed block the four rows never scroll away and the contents block is
- * the only thing that scrolls. There is also no per-row open/closed state to
- * keep: which section is showing is which section you are in, and the route
- * already carries that.
+ * With a fixed block the four rows never scroll away and the rail is the only
+ * thing that scrolls.
  *
  * ## On the collapsed rail
  *
- * The four icons stay; the contents block is hidden for a section with a fixed
- * list of children — those rows are 3rem of nothing without their labels, and
- * their parent icon still leads to them. Room is the exception, and
- * deliberately so: `ChannelRail` has a compact variant built for exactly this
- * width (avatars and `#` glyphs with unread dots), and dropping it would make
- * collapsing the sidebar silently lose the channel list — the same regression
- * issue #1018 filed about the approvals badge.
+ * The four icons stay, and so does the channel list: `ChannelRail` has a compact
+ * variant built for exactly this width (avatars and `#` glyphs with unread
+ * dots), and dropping it would make collapsing the sidebar silently lose the
+ * channel list — the same regression issue #1018 filed about the approvals
+ * badge. Nothing else is in this region to hide any more; the fixed lists of
+ * child rows that used to be hidden here at 3rem are content-rail rows now.
  */
 export function SidebarNavigation({
   view,
-  sub,
   onNavigate,
 }: {
   view: View;
-  /** The hash's second segment, so a child row can light for its own sub-page. */
-  sub: string | null;
   onNavigate: (view: View, sub?: string) => void;
 }) {
   const { isMobile, setOpenMobile } = useSidebar();
@@ -282,11 +385,6 @@ export function SidebarNavigation({
   );
 
   const active = sectionOwning(view);
-  // Room's contents are not a table here, they are whatever `ChatView` portals
-  // in — so they exist only on the view `ChatView` renders on. A Room-owned
-  // view that does not mount `ChatView` would draw the slot with nothing in it.
-  const roomContents = active?.slot === "room" && view === "chat";
-  const hasContents = Boolean(active && (active.children || roomContents));
 
   return (
     <>
@@ -310,106 +408,58 @@ export function SidebarNavigation({
         </SidebarMenu>
       </SidebarGroup>
 
-      {active && hasContents && (
-        <>
-          {/* Space, not a rule.
-              
-              A horizontal line here was the reflex and it is the wrong mark:
-              this column is already quiet, and one more seam across 13.5rem
-              reads as hardware bolted on. The gap does the same work — above
-              it, the four places you can go; below it, what is inside the one
-              you are in — and it does it without adding anything to look at.
-              The console draws no rule above its footer either, so a rule here
-              would also have been the only one in the column.
+      {/* Space, not a rule.
 
-              `pt-5` rather than the group's own `py-1`: deliberate, and large
-              enough that the break is legible at a glance rather than a row gap
-              that reads as an accident. Together with the fixed block's `pb-1`
-              that is 24px of air against an 8px rhythm.
+          A horizontal line here was the reflex and it is the wrong mark: this
+          column is already quiet, and one more seam across 13.5rem reads as
+          hardware bolted on. The gap does the same work — above it, the four
+          places you can go; below it, the room you talk in — and it does it
+          without adding anything to look at. The console draws no rule above its
+          footer either, so a rule here would also have been the only one in the
+          column.
 
-              `min-h-0 flex-1`, so a long contents block scrolls INSIDE itself
-              rather than pushing the four rows or the footer off the column. A
-              flex item's default `min-height: auto` floors it at its content,
-              which is why the zero has to be said here as well as on the child
-              that actually scrolls. */}
-          <SidebarGroup
-            className={cn(
-              "min-h-0 flex-1 pt-5",
-              !roomContents && "group-data-[collapsible=icon]:hidden",
-              // On the 3rem rail this group's own `px-2` is the difference
-              // between fitting and not. The rail is 48px; the gutter leaves a
-              // 32px content box, and `ChannelRail`'s compact rows are `size-9`
-              // (36px) with their unread dots hung off the right edge — so the
-              // rows overhung the slot by 2px a side and the dots landed in
-              // horizontal overflow (codex P2 review). Measured before this:
-              // slot `clientWidth` 32 against `scrollWidth` 34.
-              //
-              // The gutter goes rather than the rows shrinking: 36px is the
-              // compact rail's own avatar size, shared with the roster and the
-              // `#` glyphs, and re-sizing it for one container is how the two
-              // densities drift apart. Only in icon mode — the expanded column
-              // keeps the gutter every other group has.
-              roomContents && "group-data-[collapsible=icon]:px-0",
-            )}
-          >
-            {active.children && (
-              // Named, not headed. `nav-rail-headings.test.ts` (issue #1392)
-              // forbids an `h1`–`h6` inside a `<nav>`: the sidebar renders
-              // before the page, so a heading here would meet a screen reader's
-              // heading navigation ahead of the page's own `h1`. `aria-label`
-              // names the list without entering the document outline.
-              <SidebarMenu aria-label={`${active.label} pages`}>
-                {active.children.map((child) => {
-                  const open = childActive(active, child, view, sub);
-                  return (
-                    // The `data-tour` anchor sits on the ITEM, not the button —
-                    // the same shape a section row has, so every selector
-                    // written as `[data-tour="nav-x"] >> role=button` works for
-                    // both. Putting it on the button made a child row the one
-                    // exception, and `list-switcher.spec.ts` found it.
-                    //
-                    // `childAnchor` is `undefined` for the child that shares its
-                    // section's address — Agents *is* `#/company`, so an anchor
-                    // here would put two `nav-company` nodes on screen whenever
-                    // the section is open, and every selector written against it
-                    // becomes a strict-mode violation rather than a click. The
-                    // section row keeps the name; nothing targets the child.
-                    <SidebarMenuItem
-                      key={`${child.view}/${child.sub ?? ""}`}
-                      data-tour={childAnchor(active, child)}
-                    >
-                      <SidebarMenuButton
-                        isActive={open}
-                        aria-current={open ? "page" : undefined}
-                        tooltip={child.label}
-                        onClick={() => navigate(child.view, child.sub)}
-                        className={RESTING_ROW}
-                      >
-                        <child.icon />
-                        <span>{child.label}</span>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  );
-                })}
-              </SidebarMenu>
-            )}
+          `pt-5` rather than the group's own `py-1`: deliberate, and large enough
+          that the break is legible at a glance rather than a row gap that reads
+          as an accident. Together with the fixed block's `pb-1` that is 24px of
+          air against an 8px rhythm.
 
-            {/* Room's contents. The node is the portal target; what lands in it
-                is `ChatView`'s own `ChannelRail`, unchanged — see
-                `room-rail.tsx`. It scrolls rather than truncating behind a
-                "show all": a channel list is scanned for a name you already
-                know, and hiding its tail behind a control makes the one thing
-                you came for the one thing you cannot see. */}
-            {roomContents && (
-              <div
-                ref={setElement}
-                data-testid="room-rail-slot"
-                className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto"
-              />
-            )}
-          </SidebarGroup>
-        </>
-      )}
+          `min-h-0 flex-1`, so a long channel list scrolls INSIDE itself rather
+          than pushing the four rows or the footer off the column. A flex item's
+          default `min-height: auto` floors it at its content, which is why the
+          zero has to be said here as well as on the child that actually
+          scrolls. */}
+      <SidebarGroup
+        className={cn(
+          "min-h-0 flex-1 pt-5",
+          // On the 3rem rail this group's own `px-2` is the difference between
+          // fitting and not. The rail is 48px; the gutter leaves a 32px content
+          // box, and `ChannelRail`'s compact rows are `size-9` (36px) with their
+          // unread dots hung off the right edge — so the rows overhung the slot
+          // by 2px a side and the dots landed in horizontal overflow (codex P2
+          // review). Measured before this: slot `clientWidth` 32 against
+          // `scrollWidth` 34.
+          //
+          // The gutter goes rather than the rows shrinking: 36px is the compact
+          // rail's own avatar size, shared with the roster and the `#` glyphs,
+          // and re-sizing it for one container is how the two densities drift
+          // apart. Only in icon mode — the expanded column keeps the gutter
+          // every other group has.
+          "group-data-[collapsible=icon]:px-0",
+        )}
+      >
+        {/* The Room rail's mount point, on every section. What lands in it is
+            `ChatView`'s own `ChannelRail`, unchanged — see `room-rail.tsx`, and
+            `app-shell.tsx` for why `ChatView` stays mounted off Room to keep
+            feeding it. It scrolls rather than truncating behind a "show all": a
+            channel list is scanned for a name you already know, and hiding its
+            tail behind a control makes the one thing you came for the one thing
+            you cannot see. */}
+        <div
+          ref={setElement}
+          data-testid="room-rail-slot"
+          className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto"
+        />
+      </SidebarGroup>
     </>
   );
 }

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -1349,8 +1349,23 @@ export function ChatView({
   // `?thread=<id>` on the hash opens straight into that thread instead, and
   // is consumed (stripped via `replaceState`) so it does not reopen on a
   // later switch back to this channel.
+  //
+  // `routeOpen` is both a guard and a dependency, and it has to be both since
+  // #2130 (Codex P2 review on that PR).
+  //
+  // As a **dependency**, because arriving on Room no longer remounts this view.
+  // A task card's "Opened from chat" link goes `#/tasks/<id>` →
+  // `#/chat/<channel>?thread=<id>`, and this view can already be sitting on that
+  // very channel — the shell replays the last chat segment while the address
+  // belongs to another section. Only `routeOpen` and the query then change, so
+  // keyed on `channel?.id` alone this never fired: the thread did not open and
+  // the query was never consumed, so it lay in wait for a later switch.
+  //
+  // As a **guard**, because a view mounted off its own route must not rewrite
+  // another section's address. This calls `replaceState` on whatever hash it
+  // finds, and the hash it finds off Room belongs to Company or Flows.
   useEffect(() => {
-    if (!channel?.id) return;
+    if (!routeOpen || !channel?.id) return;
     const [path, query = ""] = window.location.hash.replace(/^#/, "").split("?");
     const params = new URLSearchParams(query);
     const threadId = params.get("thread");
@@ -1360,7 +1375,7 @@ export function ChatView({
       const qs = params.toString();
       window.history.replaceState(null, "", `#${path}${qs ? `?${qs}` : ""}`);
     }
-  }, [channel?.id]);
+  }, [routeOpen, channel?.id]);
 
   // Whoever owns the unread counts needs to know what is actually being looked
   // at. Re-runs as the open channel's transcript grows, not only on a switch:

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -1395,6 +1395,26 @@ export function ChatView({
    */
   const threadResolvedFor = useRef<string | null>(null);
 
+  /**
+   * The nonce of the `?thread=` already acted on, so one link opens one thread
+   * once (Codex P2 review on #2130).
+   *
+   * Consuming is a `replaceState`, which fires no `hashchange` — so the query
+   * state keeps naming the thread it just opened until the address next moves.
+   * `useHashView.navigate` writes `window.location.hash` and calls `setRoute`
+   * **synchronously**, and `hashchange` arrives a task later: so picking another
+   * channel re-runs this effect for the new `channel.id` while the query still
+   * says `h41`. Without this ref that reopened h41 on the channel the operator
+   * had just switched to, and the correcting pass could not undo it — by then
+   * `threadResolvedFor` held the new channel, so `arrived` was false and the
+   * stale panel stayed, suppressing that channel's live steps and receipt.
+   *
+   * A ref rather than clearing the state: clearing is a second render for a
+   * fact that is not rendered. And a nonce rather than a boolean, because the
+   * same thread id can legitimately arrive twice.
+   */
+  const consumedThreadNonce = useRef<number | null>(null);
+
   // An open thread only makes sense while its parent is on screen; arriving at
   // a channel closes whatever was open rather than leaving a panel pointing at
   // nothing. `?thread=<id>` on the hash opens straight into that thread
@@ -1426,7 +1446,8 @@ export function ChatView({
     if (!routeOpen || !channel?.id) return;
     const arrived = threadResolvedFor.current !== channel.id;
     threadResolvedFor.current = channel.id;
-    if (threadQuery.value !== null) {
+    if (threadQuery.value !== null && consumedThreadNonce.current !== threadQuery.nonce) {
+      consumedThreadNonce.current = threadQuery.nonce;
       setOpenThreadId(threadQuery.value);
       const [path, query = ""] = window.location.hash.replace(/^#/, "").split("?");
       const params = new URLSearchParams(query);

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -467,6 +467,30 @@ export function ChatView({
 }: Props) {
   // Which (connection, company) this subtree's browser-local state belongs to.
   const scope = useLocalScope();
+  /**
+   * How many times Room has been entered — the mount this view no longer has
+   * (Codex P2 review on #2130).
+   *
+   * Every read below was keyed on `[client, company]` alone, and that was
+   * sufficient while navigating away unmounted the view: coming back was a
+   * mount, and a mount re-read everything. It is not sufficient now. Add a
+   * teammate on Company, delete a desk on the org chart, and the pinned rail
+   * would go on showing the roster and channels it loaded once — until a reload
+   * or a company switch, and in plain sight, because the rail is on screen the
+   * whole time.
+   *
+   * A counter incremented on ENTRY, rather than `routeOpen` in each dependency
+   * list, for two reasons. `routeOpen` moves in both directions, so leaving Room
+   * would spend a second round of reads on a section the operator has just left.
+   * And gating the reads on `routeOpen` instead would leave the rail empty on a
+   * console loaded straight onto `#/company`, which is the one thing this whole
+   * change exists to prevent — the reads still run on mount, wherever that is.
+   */
+  const [roomVisits, setRoomVisits] = useState(0);
+  useEffect(() => {
+    if (routeOpen) setRoomVisits((n) => n + 1);
+  }, [routeOpen]);
+
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [loadingTeam, setLoadingTeam] = useState(true);
   /**
@@ -703,7 +727,7 @@ export function ChatView({
     } finally {
       setLoadingTeam(false);
     }
-  }, [client, company]);
+  }, [client, company, roomVisits]);
 
   /**
    * Hiding the budget controls from a non-admin is **courtesy, not
@@ -749,7 +773,7 @@ export function ChatView({
       // Attribution falls back to "an admin"; not worth a toast.
       setPeople([]);
     }
-  }, [client, company]);
+  }, [client, company, roomVisits]);
 
   useEffect(() => {
     setLoadingTeam(true);
@@ -870,7 +894,7 @@ export function ChatView({
         error instanceof Error ? error.message : "Couldn't load this company's channels.",
       );
     }
-  }, [client, company]);
+  }, [client, company, roomVisits]);
 
   useEffect(() => {
     void loadDesks();
@@ -914,7 +938,7 @@ export function ChatView({
         console.debug("[ChatView] getOperatorChannel returned an unexpected shape", dto);
       }
     });
-  }, [client, company]);
+  }, [client, company, roomVisits]);
 
   /**
    * Re-entering Chat with no channel in the hash returns the operator to the
@@ -1137,7 +1161,7 @@ export function ChatView({
     return () => {
       directoryEpoch.current += 1;
     };
-  }, [client, company]);
+  }, [client, company, roomVisits]);
 
   /**
    * The directory with this channel's teammates marked, so they rank first.

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -133,6 +133,28 @@ interface Props {
   company: string | null;
   /** The hash's second segment — the channel id, e.g. `main` in `#/chat/main`. */
   sub: string | null;
+  /**
+   * Whether `#/chat` is the address on screen.
+   *
+   * The shell keeps this view mounted on **every** route since issue #2130,
+   * because the sidebar's channel rail is portalled out of here and is pinned
+   * there on every section — see `components/room-rail.tsx` for the two ways
+   * that could have been done and why this is the one taken.
+   *
+   * So the rail renders unconditionally and everything that belongs to the Room
+   * *route* — the transcript, the header, the members pane — renders only when
+   * this is true. It also gates `chatPaneVisible`: a transcript that is mounted
+   * but not routed must not mark a mention read, for the same reason the phone's
+   * covering sheet must not.
+   *
+   * Optional, defaulting to **true**: a caller that renders this view as a page
+   * — every unit test, a future embed — means the transcript, and should not
+   * have to say so. It is the shell keeping it mounted off-route that is the
+   * unusual case, and the shell is the one that says it. Same rule
+   * `useRoomRailSlot` follows when there is no provider: the standalone shape
+   * is the one that works with nothing configured.
+   */
+  routeOpen?: boolean;
   onNavigate: (channelId: string) => void;
   /** Called after a reply lands, so the shell can refresh approvals/status. */
   onReply?: () => void;
@@ -404,6 +426,7 @@ export function ChatView({
   client,
   company,
   sub,
+  routeOpen = true,
   onNavigate,
   onReply,
   transcripts,
@@ -526,11 +549,16 @@ export function ChatView({
   // where it is, how dense it is, and whether it is covering the transcript.
   // See `components/room-rail.tsx`.
   const roomRail = useRoomRailSlot();
-  // Whether the transcript is actually on screen. The rail sits beside it at
-  // every width the sidebar is a column; only the phone's sheet covers it.
+  // Whether the transcript is actually on screen. Two ways for it not to be,
+  // and both have to be said here. The operator may be on another section
+  // entirely — this view stays mounted to keep feeding the sidebar's rail
+  // (#2130), so being mounted is no longer evidence of being visible. Or the
+  // sidebar may be a sheet covering the whole screen, which is the phone.
+  //
   // Mention clearing is gated on this so a mention cannot be marked read while
-  // the operator is looking at the channel list (codex P1 review).
-  const chatPaneVisible = !roomRail.covering;
+  // the operator is looking at the channel list (codex P1 review) — or at
+  // Company, which would be the same defect one route further away.
+  const chatPaneVisible = routeOpen && !roomRail.covering;
   const channelsCollapsed = roomRail.collapsed;
   // Section disclosure is shared by the desktop and sub-`lg` rail instances
   // (codex P2 review): each instance would otherwise keep its own fold state,
@@ -1432,6 +1460,13 @@ export function ChatView({
   */
   const header = <PageHeader hidden title="Chat" />;
 
+  // Off Room this view exists only to keep the channel rail alive in the
+  // sidebar, and in all three states below there is no rail to render — no
+  // desks, or none that loaded. Whatever section the operator actually is in
+  // owns the content area, so contribute nothing to it rather than painting a
+  // chat empty-state over Company.
+  if (!routeOpen && (desksError || !desks || !channel)) return null;
+
   // Three ways to have no channel on screen, which used to be one blank pane.
   // Which one it is, is the whole point: "still loading" and "this company has
   // nothing" are different facts and only one of them is worth acting on.
@@ -2245,7 +2280,7 @@ export function ChatView({
   const additionalThreadReviewAnchors = threadReviewAnchors.slice(1);
 
   return (
-    <div className="flex min-h-0 flex-1">
+    <>
       {/* ONE rail, painted in the app sidebar under the Room row.
           `createPortal` moves the node, not the component: every prop below is
           still this view's state, and the dialogs the rail opens still mount
@@ -2281,410 +2316,423 @@ export function ChatView({
           roomRail.element,
         )}
 
-      <div className="flex min-w-0 flex-1 flex-col">
-        <ChatHeader
-          channel={channel}
-          memberCount={headerCount}
-          membersOpen={membersOpen}
-          onToggleMembers={() => setMembersOpen((o) => !o)}
-          onOpenRail={roomRail.reveal}
-        />
+      {/* Everything that belongs to the Room *route*: the transcript, its
+          header and the members pane.
 
+          Gated, because this view is mounted on every section now to keep
+          the rail above fed (#2130) — and a transcript that is mounted
+          without being routed must not paint over the section the operator
+          is actually in. The dialogs below are deliberately OUTSIDE this
+          gate: their triggers are painted in the sidebar, so they have to
+          open from Company and Flows as readily as from Room. */}
+      {routeOpen && (
         <div className="flex min-h-0 flex-1">
           <div className="flex min-w-0 flex-1 flex-col">
-            {unknownChannel && (
-              <p
-                role="status"
-                className="flex shrink-0 items-center gap-1.5 border-b bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground"
-              >
-                <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
-                <span className="min-w-0 truncate">
-                  <span className="font-medium text-foreground">#{unknownChannel}</span> isn&apos;t a
-                  channel here — showing {channelTitle(active)} instead.
-                </span>
-              </p>
-            )}
-            <MessageTimeline
+            <ChatHeader
               channel={channel}
-              items={items}
-              cognition={cognition}
-              historyPending={historyPending}
-              openThreadId={openThreadId}
-              // An open turn keeps the row up after the POST has resolved, and
-              // puts it back on a console that reloaded mid-turn (#983).
-              // `!openThreadId` used to be here, blanking the channel's row for
-              // every turn whenever any thread was open. `openTurn` now
-              // excludes the open thread's own turn, so the row can stay for
-              // the work that is genuinely the channel's.
-              typing={sending || !!openTurn}
-              queued={!!openTurn?.queued}
-              liveSteps={openThreadId ? undefined : liveSteps}
-              // NOT excluded when a thread is open: these rows render inside
-              // their own message rather than as one strip for the channel, so
-              // there is no ambiguity about which turn they describe — which is
-              // the whole reason `liveSteps` above is withheld.
-              liveStepsByMessage={liveStepsByMessage}
-              // Thread-panel receipts are out of v1 (issue #1934): excluded here
-              // the same way `liveSteps` is when a thread is open.
-              receipt={openThreadId ? undefined : receipt}
-              agentNames={agentNames}
-              onOpenThread={setOpenThreadId}
-              onReact={react}
-              onDismissCard={(taskId) => void dismissCard(taskId)}
-              dismissingCardId={dismissingCardId}
-              onReviewCard={(taskId, decision) => void reviewCard(taskId, decision)}
-              reviewingCardIds={reviewingCardIds}
-              resolveAttachmentUrl={resolveAttachmentUrl}
-              taskStatusByTaskId={taskStatusByTaskId}
-              onStartBrief={() =>
-                setComposerPrefill((current) => ({
-                  text: FIRST_TEAM_BRIEF,
-                  revision: (current?.revision ?? 0) + 1,
-                }))
-              }
-              onAddPeople={() => setMembersOpen(true)}
-              now={now}
-              askerNames={askerNames}
-              decidingApprovals={decidingApprovals}
-              failedApprovals={failedApprovals}
-              onDecideApproval={onDecideApproval}
-              onRedeemBudgetPause={(agentId, noticeMessageId) =>
-                void redeemBudgetPause(agentId, noticeMessageId)
-              }
-              redeemingBudgetPauseAgent={redeemingBudgetPauseAgent}
-              latestBudgetPauseMessageIdByAgent={budgetPauseMessageIdByAgent}
+              memberCount={headerCount}
+              membersOpen={membersOpen}
+              onToggleMembers={() => setMembersOpen((o) => !o)}
+              onOpenRail={roomRail.reveal}
             />
-            {budgetProximity && (
-              <p
-                role="status"
-                className="flex shrink-0 items-center gap-1.5 border-t border-status-blocked/30 bg-status-blocked-soft px-3 py-1.5 text-xs text-status-blocked-text"
-              >
-                <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
-                <span className="min-w-0 flex-1">{budgetProximity.message}</span>
-                {onDismissBudgetProximity && (
-                  <button
-                    type="button"
-                    onClick={onDismissBudgetProximity}
-                    className="shrink-0 rounded px-1.5 py-0.5 font-medium hover:bg-status-blocked-soft"
+
+            <div className="flex min-h-0 flex-1">
+              <div className="flex min-w-0 flex-1 flex-col">
+                {unknownChannel && (
+                  <p
+                    role="status"
+                    className="flex shrink-0 items-center gap-1.5 border-b bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground"
                   >
-                    Dismiss
-                  </button>
+                    <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
+                    <span className="min-w-0 truncate">
+                      <span className="font-medium text-foreground">#{unknownChannel}</span> isn&apos;t a
+                      channel here — showing {channelTitle(active)} instead.
+                    </span>
+                  </p>
                 )}
-              </p>
-            )}
-            {consoleOnlyMember && (
-              <p
-                role="status"
-                className="flex shrink-0 items-center gap-1.5 border-t bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground"
-              >
-                <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
-                <span className="min-w-0">
-                  <span className="font-medium text-foreground">{consoleOnlyMember}</span> only
-                  exists in this console — the company has no such teammate, so nobody answers
-                  here. The transcript is still saved and survives a reload.
-                </span>
-              </p>
-            )}
-            {readOnly && (
-              <p
-                role="status"
-                className="flex shrink-0 items-center gap-1.5 border-t bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground"
-              >
-                <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
-                <span className="min-w-0">
-                  The <span className="font-medium text-foreground">Operator</span> channel is a
-                  read-only feed of workflow reports and notifications — a scannable “what
-                  happened” view. There is nothing to reply to here.
-                </span>
-              </p>
-            )}
-            <TypingLine names={resolveTypingNames?.(active.id) ?? []} />
-            {/* Issues #1734 / #1735, repositioned. Directly above the composer,
-                not above the transcript: what the notice warns about — a reply
-                that comes from the echo brain rather than the teammate it appears
-                under — is the consequence of pressing Send, and a caveat at the
-                other end of the page from the control it qualifies is one the
-                operator reads before it means anything and has forgotten by the
-                time it does. It stays OUTSIDE the scroller (a sibling strip,
-                `shrink-0`) like the read-only and budget strips above it, because
-                it is a standing fact about the company rather than a row in the
-                transcript.
-
-                It sits BELOW `TypingLine`, not above it. Proximity to the
-                composer is the whole reason this strip moved, and a typing line
-                between the two put a row back in the gap in exactly the case
-                where it matters most — mid-conversation, with someone at a
-                keyboard (CodeRabbit review on #1984). `chat-cognition-banner`'s
-                sibling-order test pins this WITH a typing line present, because
-                the order read correct with nobody typing and wrong with someone
-                typing.
-
-                Suppressed on a read-only channel: nothing can be sent there, so a
-                caveat about what sending produces has nothing left to qualify —
-                and the composer it would sit above is not rendered at all.
-
-                All four states below say "the replies in this conversation", not
-                "the replies below". They said "below" while this strip sat above
-                the transcript, and moving it made that word point at the composer
-                and the keyboard hint instead of at any reply — the copy asserted
-                a position rather than a fact. Direction-free is what keeps the
-                sentence true wherever this strip is put next; do not reintroduce
-                a directional word here.
-
-                `role="status"` (not `alert`) for the reason
-                `components/ui/alert.tsx` gives — a notice present on mount should
-                not interrupt a screen reader. */}
-            {echoing && !readOnly && (
-              <p
-                role="status"
-                data-testid="chat-cognition-banner"
-                className="flex shrink-0 items-center gap-1.5 border-t bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground"
-              >
-                <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
-                <span className="min-w-0">
-                  {cognition === "unconfigured" && (
-                    <>
-                      <span className="font-medium text-foreground">
-                        Teammates can&apos;t think yet.
-                      </span>{" "}
-                      This company has no model configured, so the replies in this
-                      conversation come from the offline echo brain rather than the teammate
-                      they appear under. Choose a provider in{" "}
-                      <a
-                        className="font-medium text-foreground underline-offset-4 hover:underline"
-                        href={settingsHref("inference")}
+                <MessageTimeline
+                  channel={channel}
+                  items={items}
+                  cognition={cognition}
+                  historyPending={historyPending}
+                  openThreadId={openThreadId}
+                  // An open turn keeps the row up after the POST has resolved, and
+                  // puts it back on a console that reloaded mid-turn (#983).
+                  // `!openThreadId` used to be here, blanking the channel's row for
+                  // every turn whenever any thread was open. `openTurn` now
+                  // excludes the open thread's own turn, so the row can stay for
+                  // the work that is genuinely the channel's.
+                  typing={sending || !!openTurn}
+                  queued={!!openTurn?.queued}
+                  liveSteps={openThreadId ? undefined : liveSteps}
+                  // NOT excluded when a thread is open: these rows render inside
+                  // their own message rather than as one strip for the channel, so
+                  // there is no ambiguity about which turn they describe — which is
+                  // the whole reason `liveSteps` above is withheld.
+                  liveStepsByMessage={liveStepsByMessage}
+                  // Thread-panel receipts are out of v1 (issue #1934): excluded here
+                  // the same way `liveSteps` is when a thread is open.
+                  receipt={openThreadId ? undefined : receipt}
+                  agentNames={agentNames}
+                  onOpenThread={setOpenThreadId}
+                  onReact={react}
+                  onDismissCard={(taskId) => void dismissCard(taskId)}
+                  dismissingCardId={dismissingCardId}
+                  onReviewCard={(taskId, decision) => void reviewCard(taskId, decision)}
+                  reviewingCardIds={reviewingCardIds}
+                  resolveAttachmentUrl={resolveAttachmentUrl}
+                  taskStatusByTaskId={taskStatusByTaskId}
+                  onStartBrief={() =>
+                    setComposerPrefill((current) => ({
+                      text: FIRST_TEAM_BRIEF,
+                      revision: (current?.revision ?? 0) + 1,
+                    }))
+                  }
+                  onAddPeople={() => setMembersOpen(true)}
+                  now={now}
+                  askerNames={askerNames}
+                  decidingApprovals={decidingApprovals}
+                  failedApprovals={failedApprovals}
+                  onDecideApproval={onDecideApproval}
+                  onRedeemBudgetPause={(agentId, noticeMessageId) =>
+                    void redeemBudgetPause(agentId, noticeMessageId)
+                  }
+                  redeemingBudgetPauseAgent={redeemingBudgetPauseAgent}
+                  latestBudgetPauseMessageIdByAgent={budgetPauseMessageIdByAgent}
+                />
+                {budgetProximity && (
+                  <p
+                    role="status"
+                    className="flex shrink-0 items-center gap-1.5 border-t border-status-blocked/30 bg-status-blocked-soft px-3 py-1.5 text-xs text-status-blocked-text"
+                  >
+                    <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
+                    <span className="min-w-0 flex-1">{budgetProximity.message}</span>
+                    {onDismissBudgetProximity && (
+                      <button
+                        type="button"
+                        onClick={onDismissBudgetProximity}
+                        className="shrink-0 rounded px-1.5 py-0.5 font-medium hover:bg-status-blocked-soft"
                       >
-                        Settings → Inference
-                      </a>
-                      .
-                    </>
-                  )}
-                  {/* A provider is configured and resolves; the runtime just
-                      predates it. Saying "no model configured" here sends an
-                      operator who did exactly the right thing back to redo it,
-                      which is why this is its own state. The link goes to the
-                      card that owns the restart — and stops there, because
-                      whether a restart can be performed in place is that card's
-                      fact to report (#1736), not a promise to make from here. */}
-                  {cognition === "restart-required" && (
-                    <>
-                      <span className="font-medium text-foreground">
-                        Teammates can&apos;t think yet — the model isn&apos;t live.
-                      </span>{" "}
-                      A provider is configured, but this company&apos;s runtime was built before
-                      it was saved, so the replies in this conversation still come from the
-                      offline echo brain rather than the teammate they appear under. Finish
-                      the switch in{" "}
-                      <a
-                        className="font-medium text-foreground underline-offset-4 hover:underline"
-                        href={settingsHref("inference")}
-                      >
-                        Settings → Inference
-                      </a>
-                      .
-                    </>
-                  )}
-                  {cognition === "unavailable" && (
-                    <>
-                      <span className="font-medium text-foreground">
-                        This host cannot reach a model — no agent harness is available.
-                      </span>{" "}
-                      The replies in this conversation come from the offline echo brain
-                      rather than the teammate they appear under. No setting changes that:
-                      it takes a host built and started with the harness.
-                    </>
-                  )}
-                  {/* The host is on the echo brain and cannot say why: it could
-                      not read this company's inference configuration. Names no
-                      remedy on purpose — an unreadable config is no evidence
-                      that saving one would help, which is the same #266
-                      doctrine that stops the workflow-run route answering
-                      `inference_required` in this state. A settings link here
-                      would be the switch that does nothing, one more time. */}
-                  {cognition === "undetermined" && (
-                    <>
-                      <span className="font-medium text-foreground">
-                        Teammates can&apos;t think, and this host can&apos;t say why.
-                      </span>{" "}
-                      Its inference configuration could not be read, so the replies in this
-                      conversation come from the offline echo brain rather than the teammate
-                      they appear under. Until the host can read that configuration, saving a
-                      provider is not known to help.
-                    </>
-                  )}
-                </span>
-              </p>
-            )}
-            {/* No composer at all on a read-only channel, rather than a disabled
-                one. A disabled control is still a claim that the action exists:
-                the strip above says "there is nothing to reply to here", and a
-                greyed-out reply box with a Send button and an "Enter to send"
-                hint under it says the opposite in the same breath. The notice is
-                what should occupy this space.
+                        Dismiss
+                      </button>
+                    )}
+                  </p>
+                )}
+                {consoleOnlyMember && (
+                  <p
+                    role="status"
+                    className="flex shrink-0 items-center gap-1.5 border-t bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground"
+                  >
+                    <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
+                    <span className="min-w-0">
+                      <span className="font-medium text-foreground">{consoleOnlyMember}</span> only
+                      exists in this console — the company has no such teammate, so nobody answers
+                      here. The transcript is still saved and survives a reload.
+                    </span>
+                  </p>
+                )}
+                {readOnly && (
+                  <p
+                    role="status"
+                    className="flex shrink-0 items-center gap-1.5 border-t bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground"
+                  >
+                    <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
+                    <span className="min-w-0">
+                      The <span className="font-medium text-foreground">Operator</span> channel is a
+                      read-only feed of workflow reports and notifications — a scannable “what
+                      happened” view. There is nothing to reply to here.
+                    </span>
+                  </p>
+                )}
+                <TypingLine names={resolveTypingNames?.(active.id) ?? []} />
+                {/* Issues #1734 / #1735, repositioned. Directly above the composer,
+                    not above the transcript: what the notice warns about — a reply
+                    that comes from the echo brain rather than the teammate it appears
+                    under — is the consequence of pressing Send, and a caveat at the
+                    other end of the page from the control it qualifies is one the
+                    operator reads before it means anything and has forgotten by the
+                    time it does. It stays OUTSIDE the scroller (a sibling strip,
+                    `shrink-0`) like the read-only and budget strips above it, because
+                    it is a standing fact about the company rather than a row in the
+                    transcript.
 
-                `disabled` therefore no longer carries `readOnly` — nothing can be
-                read-only and rendered here at the same time. The server's
-                read-only guard and `ThreadPanel`'s no-op `onSend` (issue #1757)
-                are untouched: this removes the affordance, not the belt.
+                    It sits BELOW `TypingLine`, not above it. Proximity to the
+                    composer is the whole reason this strip moved, and a typing line
+                    between the two put a row back in the gap in exactly the case
+                    where it matters most — mid-conversation, with someone at a
+                    keyboard (CodeRabbit review on #1984). `chat-cognition-banner`'s
+                    sibling-order test pins this WITH a typing line present, because
+                    the order read correct with nobody typing and wrong with someone
+                    typing.
 
-                `suppressed`, not `{!readOnly && …}`. The element stays in the
-                tree so React keeps the instance — and with it the draft, the
-                staged attachment, the resolved mentions and the selected intent,
-                all of which are state inside `MessageComposer`. Gating the
-                element itself unmounted it, so an operator who opened `#Operator`
-                for a moment with an unsent message in `#general` came back to an
-                empty box (codex review on PR #1984): the disabled composer this
-                PR removed was accidentally holding the draft across channel
-                navigation. `suppressed` renders `null` after its hooks, so the
-                DOM gets nothing — no textarea, no Send, no `data-tour` anchor —
-                while the draft survives. See that prop's doc for why a
-                `display:none` wrapper is not the same thing. */}
-            {/* Above the composer, and outside the read-only branch: a channel
-                nobody may post in is still a place the company's runs are
-                visible, and stopping one is not posting. */}
-            {inflightRuns !== undefined && onInflightSteered !== undefined && (
-              <InflightRunBar
-                client={client}
-                company={company}
-                runs={inflightRuns}
-                onSteered={onInflightSteered}
-              />
-            )}
-            <MessageComposer
-              suppressed={readOnly}
-              placeholder={`Message ${channelTitle(channel)}`}
-              disabled={sending}
-              prefill={composerPrefill ?? undefined}
-              // Not voided (unlike the thread composer below): the composer
-              // awaits this to know whether an attachment it carried actually
-              // journaled, so it can clean up one that did not (codex review
-              // finding on #1682) — see `deleteAttachment` and `send`'s doc.
-              onSend={(text, intent, attachments, mentions) =>
-                send(text, intent, undefined, attachments, mentions)
-              }
-              // Issue #1682: only the channel/DM composer attaches — the paperclip
-              // is present exactly because this prop is.
-              uploadAttachment={uploadAttachment}
-              // Cleans up a staged upload that never got sent (codex review
-              // finding on #1682) — see `deleteAttachment`.
-              deleteAttachment={deleteAttachment}
-              // Every keystroke asks; the hook throttles to one ping per
-              // channel per few seconds and skips entirely while the event
-              // stream is down.
-              onTyping={() => onTyping?.(active.id)}
-              // Channel *and* DM composers offer "just chatting" / "do it once" /
-              // "build me the workflow" (issues #580, #845, #1152) — see
-              // `offersDeliverableChoice`, which owns the rule and is unchanged:
-              // the new position inherits the same channel+DM gating. Only the
-              // thread and copilot composers below go without.
-              deliverableChoice={offersDeliverableChoice(active.kind)}
-              mentionables={mentionables}
-              channelMemberIds={inChannel?.map((m) => m.id)}
-            />
+                    Suppressed on a read-only channel: nothing can be sent there, so a
+                    caveat about what sending produces has nothing left to qualify —
+                    and the composer it would sit above is not rendered at all.
+
+                    All four states below say "the replies in this conversation", not
+                    "the replies below". They said "below" while this strip sat above
+                    the transcript, and moving it made that word point at the composer
+                    and the keyboard hint instead of at any reply — the copy asserted
+                    a position rather than a fact. Direction-free is what keeps the
+                    sentence true wherever this strip is put next; do not reintroduce
+                    a directional word here.
+
+                    `role="status"` (not `alert`) for the reason
+                    `components/ui/alert.tsx` gives — a notice present on mount should
+                    not interrupt a screen reader. */}
+                {echoing && !readOnly && (
+                  <p
+                    role="status"
+                    data-testid="chat-cognition-banner"
+                    className="flex shrink-0 items-center gap-1.5 border-t bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground"
+                  >
+                    <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
+                    <span className="min-w-0">
+                      {cognition === "unconfigured" && (
+                        <>
+                          <span className="font-medium text-foreground">
+                            Teammates can&apos;t think yet.
+                          </span>{" "}
+                          This company has no model configured, so the replies in this
+                          conversation come from the offline echo brain rather than the teammate
+                          they appear under. Choose a provider in{" "}
+                          <a
+                            className="font-medium text-foreground underline-offset-4 hover:underline"
+                            href={settingsHref("inference")}
+                          >
+                            Settings → Inference
+                          </a>
+                          .
+                        </>
+                      )}
+                      {/* A provider is configured and resolves; the runtime just
+                          predates it. Saying "no model configured" here sends an
+                          operator who did exactly the right thing back to redo it,
+                          which is why this is its own state. The link goes to the
+                          card that owns the restart — and stops there, because
+                          whether a restart can be performed in place is that card's
+                          fact to report (#1736), not a promise to make from here. */}
+                      {cognition === "restart-required" && (
+                        <>
+                          <span className="font-medium text-foreground">
+                            Teammates can&apos;t think yet — the model isn&apos;t live.
+                          </span>{" "}
+                          A provider is configured, but this company&apos;s runtime was built before
+                          it was saved, so the replies in this conversation still come from the
+                          offline echo brain rather than the teammate they appear under. Finish
+                          the switch in{" "}
+                          <a
+                            className="font-medium text-foreground underline-offset-4 hover:underline"
+                            href={settingsHref("inference")}
+                          >
+                            Settings → Inference
+                          </a>
+                          .
+                        </>
+                      )}
+                      {cognition === "unavailable" && (
+                        <>
+                          <span className="font-medium text-foreground">
+                            This host cannot reach a model — no agent harness is available.
+                          </span>{" "}
+                          The replies in this conversation come from the offline echo brain
+                          rather than the teammate they appear under. No setting changes that:
+                          it takes a host built and started with the harness.
+                        </>
+                      )}
+                      {/* The host is on the echo brain and cannot say why: it could
+                          not read this company's inference configuration. Names no
+                          remedy on purpose — an unreadable config is no evidence
+                          that saving one would help, which is the same #266
+                          doctrine that stops the workflow-run route answering
+                          `inference_required` in this state. A settings link here
+                          would be the switch that does nothing, one more time. */}
+                      {cognition === "undetermined" && (
+                        <>
+                          <span className="font-medium text-foreground">
+                            Teammates can&apos;t think, and this host can&apos;t say why.
+                          </span>{" "}
+                          Its inference configuration could not be read, so the replies in this
+                          conversation come from the offline echo brain rather than the teammate
+                          they appear under. Until the host can read that configuration, saving a
+                          provider is not known to help.
+                        </>
+                      )}
+                    </span>
+                  </p>
+                )}
+                {/* No composer at all on a read-only channel, rather than a disabled
+                    one. A disabled control is still a claim that the action exists:
+                    the strip above says "there is nothing to reply to here", and a
+                    greyed-out reply box with a Send button and an "Enter to send"
+                    hint under it says the opposite in the same breath. The notice is
+                    what should occupy this space.
+
+                    `disabled` therefore no longer carries `readOnly` — nothing can be
+                    read-only and rendered here at the same time. The server's
+                    read-only guard and `ThreadPanel`'s no-op `onSend` (issue #1757)
+                    are untouched: this removes the affordance, not the belt.
+
+                    `suppressed`, not `{!readOnly && …}`. The element stays in the
+                    tree so React keeps the instance — and with it the draft, the
+                    staged attachment, the resolved mentions and the selected intent,
+                    all of which are state inside `MessageComposer`. Gating the
+                    element itself unmounted it, so an operator who opened `#Operator`
+                    for a moment with an unsent message in `#general` came back to an
+                    empty box (codex review on PR #1984): the disabled composer this
+                    PR removed was accidentally holding the draft across channel
+                    navigation. `suppressed` renders `null` after its hooks, so the
+                    DOM gets nothing — no textarea, no Send, no `data-tour` anchor —
+                    while the draft survives. See that prop's doc for why a
+                    `display:none` wrapper is not the same thing. */}
+                {/* Above the composer, and outside the read-only branch: a channel
+                    nobody may post in is still a place the company's runs are
+                    visible, and stopping one is not posting. */}
+                {inflightRuns !== undefined && onInflightSteered !== undefined && (
+                  <InflightRunBar
+                    client={client}
+                    company={company}
+                    runs={inflightRuns}
+                    onSteered={onInflightSteered}
+                  />
+                )}
+                <MessageComposer
+                  suppressed={readOnly}
+                  placeholder={`Message ${channelTitle(channel)}`}
+                  disabled={sending}
+                  prefill={composerPrefill ?? undefined}
+                  // Not voided (unlike the thread composer below): the composer
+                  // awaits this to know whether an attachment it carried actually
+                  // journaled, so it can clean up one that did not (codex review
+                  // finding on #1682) — see `deleteAttachment` and `send`'s doc.
+                  onSend={(text, intent, attachments, mentions) =>
+                    send(text, intent, undefined, attachments, mentions)
+                  }
+                  // Issue #1682: only the channel/DM composer attaches — the paperclip
+                  // is present exactly because this prop is.
+                  uploadAttachment={uploadAttachment}
+                  // Cleans up a staged upload that never got sent (codex review
+                  // finding on #1682) — see `deleteAttachment`.
+                  deleteAttachment={deleteAttachment}
+                  // Every keystroke asks; the hook throttles to one ping per
+                  // channel per few seconds and skips entirely while the event
+                  // stream is down.
+                  onTyping={() => onTyping?.(active.id)}
+                  // Channel *and* DM composers offer "just chatting" / "do it once" /
+                  // "build me the workflow" (issues #580, #845, #1152) — see
+                  // `offersDeliverableChoice`, which owns the rule and is unchanged:
+                  // the new position inherits the same channel+DM gating. Only the
+                  // thread and copilot composers below go without.
+                  deliverableChoice={offersDeliverableChoice(active.kind)}
+                  mentionables={mentionables}
+                  channelMemberIds={inChannel?.map((m) => m.id)}
+                />
+              </div>
+
+              {parent && (
+                <ThreadPanel
+                  channel={channel}
+                  members={members}
+                  parent={parent}
+                  replies={threadReplies}
+                  inlineReplyIds={threadInlineReplyIds}
+                  // A query typed into this panel renders only here — parented
+                  // messages never reach the channel timeline — so the panel needs
+                  // the per-query rows too, or its turns show nothing at all.
+                  liveStepsByMessage={liveStepsByMessage}
+                  sending={sending}
+                  mentionables={mentionables}
+                  channelMemberIds={inChannel?.map((m) => m.id)}
+                  readOnly={readOnly}
+                  reviewing={threadReviewing}
+                  reviewTaskId={threadReviewAnchor?.taskId}
+                  onReviewCard={(taskId, decision) => void reviewCard(taskId, decision)}
+                  reviewInFlight={
+                    threadReviewAnchor !== undefined &&
+                    reviewingCardIds.has(threadReviewAnchor.taskId)
+                  }
+                  additionalReviewAnchors={additionalThreadReviewAnchors}
+                  reviewingTaskId={reviewingCardIds}
+                  youAvatar={youAvatar}
+                  resolveAttachmentUrl={resolveAttachmentUrl}
+                  onSend={(text, _intent, _attachments, mentions) => {
+                    // Belt to `ThreadPanel`'s own `readOnly` brace: never mutate
+                    // state or call `client.chat` for a channel the server's
+                    // read-only guard will refuse anyway (issue #1757).
+                    if (readOnly) return;
+                    void send(text, undefined, threadReviewAnchor?.anchorId ?? parent.id, undefined, mentions);
+                  }}
+                  onClose={() => setOpenThreadId(null)}
+                  typingNames={resolveTypingNames?.(active.id, parent.id) ?? []}
+                  openTurn={threadTurn}
+                  onTyping={() => onTyping?.(active.id, parent.id)}
+                  // A thread is not a lesser transcript (issue #1734): an echoed
+                  // reply read here is the same false attribution as one read in
+                  // the channel, so the panel marks its rows from the same state.
+                  cognition={cognition}
+                  onRedeemBudgetPause={(agentId, noticeMessageId) =>
+                    void redeemBudgetPause(agentId, noticeMessageId)
+                  }
+                  redeemingBudgetPauseAgent={redeemingBudgetPauseAgent}
+                  latestBudgetPauseMessageIdByAgent={budgetPauseMessageIdByAgent}
+                />
+              )}
+
+              {membersOpen && !readOnly && (
+                <MembersPane
+                  channelMembers={inChannel}
+                  others={outsideChannel}
+                  people={companyPeople}
+                  presence={presence}
+                  leadId={
+                    // An `auto` channel has no lead (issue #1835): its memberIds
+                    // are the channel's membership in the host's order, not a
+                    // hierarchy, so badging [0] would state a rank nothing
+                    // confers — the host's own `desk_lead` is `None` for it.
+                    activeIsDesk && !active.leadless ? active.memberIds?.[0] : undefined
+                  }
+                  loading={loadingTeam}
+                  fromHost={fromHost}
+                  onToggleInbox={(m) => void toggleMemberInbox(m)}
+                  onRemove={(id) => {
+                    const member = members.find((m) => m.id === id);
+                    if (member) void removeMember(member);
+                  }}
+                  onAdd={() => setAddOpen(true)}
+                  onMessage={(m) => selectChannel(dmChannelId(m))}
+                  /**
+                   * The way from this channel to the desk it is (issue #485).
+                   *
+                   * Only for a host-backed desk channel. A DM is not a desk, and a
+                   * fallback desk (`lib/desks.ts`) carries no `memberIds` because
+                   * the host has no desks surface at all — the chart would have
+                   * nothing to open. Both simply get no link rather than one that
+                   * lands nowhere.
+                   *
+                   * A desk's channel id **is** its desk id (`deskFromDto`), so
+                   * there is no mapping to keep in step. Written to the hash rather
+                   * than routed through a callback, as `ArtifactsTab`'s "Open in
+                   * workspace" does: this is a cross-view address, and the shell
+                   * only hands chat a chat-scoped navigate.
+                   */
+                  onManageDesk={
+                    activeIsDesk && active.memberIds
+                      ? () => {
+                          window.location.hash = `/company/${active.id}`;
+                        }
+                      : undefined
+                  }
+                  canEditBudget={isAdmin && fromHost}
+                  onEditBudget={setBudgetFor}
+                  onRemoveCap={(m) => void applyBudget(m, null)}
+                  onResetBudget={(m) => void resetBudget(m)}
+                  setByLabel={(m) => (m.budgetSetBy ? whoSet(m.budgetSetBy) : undefined)}
+                />
+              )}
+            </div>
           </div>
-
-          {parent && (
-            <ThreadPanel
-              channel={channel}
-              members={members}
-              parent={parent}
-              replies={threadReplies}
-              inlineReplyIds={threadInlineReplyIds}
-              // A query typed into this panel renders only here — parented
-              // messages never reach the channel timeline — so the panel needs
-              // the per-query rows too, or its turns show nothing at all.
-              liveStepsByMessage={liveStepsByMessage}
-              sending={sending}
-              mentionables={mentionables}
-              channelMemberIds={inChannel?.map((m) => m.id)}
-              readOnly={readOnly}
-              reviewing={threadReviewing}
-              reviewTaskId={threadReviewAnchor?.taskId}
-              onReviewCard={(taskId, decision) => void reviewCard(taskId, decision)}
-              reviewInFlight={
-                threadReviewAnchor !== undefined &&
-                reviewingCardIds.has(threadReviewAnchor.taskId)
-              }
-              additionalReviewAnchors={additionalThreadReviewAnchors}
-              reviewingTaskId={reviewingCardIds}
-              youAvatar={youAvatar}
-              resolveAttachmentUrl={resolveAttachmentUrl}
-              onSend={(text, _intent, _attachments, mentions) => {
-                // Belt to `ThreadPanel`'s own `readOnly` brace: never mutate
-                // state or call `client.chat` for a channel the server's
-                // read-only guard will refuse anyway (issue #1757).
-                if (readOnly) return;
-                void send(text, undefined, threadReviewAnchor?.anchorId ?? parent.id, undefined, mentions);
-              }}
-              onClose={() => setOpenThreadId(null)}
-              typingNames={resolveTypingNames?.(active.id, parent.id) ?? []}
-              openTurn={threadTurn}
-              onTyping={() => onTyping?.(active.id, parent.id)}
-              // A thread is not a lesser transcript (issue #1734): an echoed
-              // reply read here is the same false attribution as one read in
-              // the channel, so the panel marks its rows from the same state.
-              cognition={cognition}
-              onRedeemBudgetPause={(agentId, noticeMessageId) =>
-                void redeemBudgetPause(agentId, noticeMessageId)
-              }
-              redeemingBudgetPauseAgent={redeemingBudgetPauseAgent}
-              latestBudgetPauseMessageIdByAgent={budgetPauseMessageIdByAgent}
-            />
-          )}
-
-          {membersOpen && !readOnly && (
-            <MembersPane
-              channelMembers={inChannel}
-              others={outsideChannel}
-              people={companyPeople}
-              presence={presence}
-              leadId={
-                // An `auto` channel has no lead (issue #1835): its memberIds
-                // are the channel's membership in the host's order, not a
-                // hierarchy, so badging [0] would state a rank nothing
-                // confers — the host's own `desk_lead` is `None` for it.
-                activeIsDesk && !active.leadless ? active.memberIds?.[0] : undefined
-              }
-              loading={loadingTeam}
-              fromHost={fromHost}
-              onToggleInbox={(m) => void toggleMemberInbox(m)}
-              onRemove={(id) => {
-                const member = members.find((m) => m.id === id);
-                if (member) void removeMember(member);
-              }}
-              onAdd={() => setAddOpen(true)}
-              onMessage={(m) => selectChannel(dmChannelId(m))}
-              /**
-               * The way from this channel to the desk it is (issue #485).
-               *
-               * Only for a host-backed desk channel. A DM is not a desk, and a
-               * fallback desk (`lib/desks.ts`) carries no `memberIds` because
-               * the host has no desks surface at all — the chart would have
-               * nothing to open. Both simply get no link rather than one that
-               * lands nowhere.
-               *
-               * A desk's channel id **is** its desk id (`deskFromDto`), so
-               * there is no mapping to keep in step. Written to the hash rather
-               * than routed through a callback, as `ArtifactsTab`'s "Open in
-               * workspace" does: this is a cross-view address, and the shell
-               * only hands chat a chat-scoped navigate.
-               */
-              onManageDesk={
-                activeIsDesk && active.memberIds
-                  ? () => {
-                      window.location.hash = `/company/${active.id}`;
-                    }
-                  : undefined
-              }
-              canEditBudget={isAdmin && fromHost}
-              onEditBudget={setBudgetFor}
-              onRemoveCap={(m) => void applyBudget(m, null)}
-              onResetBudget={(m) => void resetBudget(m)}
-              setByLabel={(m) => (m.budgetSetBy ? whoSet(m.budgetSetBy) : undefined)}
-            />
-          )}
         </div>
-      </div>
+      )}
 
       <AddMemberDialog open={addOpen} onOpenChange={setAddOpen} onAdd={(fields) => void addMember(fields)} />
       <ChannelCreateDialog
@@ -2720,7 +2768,7 @@ export function ChatView({
           if (target) void applyBudget(target, cap);
         }}
       />
-    </div>
+    </>
   );
 }
 

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -1423,6 +1423,28 @@ export function ChatView({
     onChatPaneVisibilityChange?.(chatPaneVisible);
   }, [chatPaneVisible, onChatPaneVisibilityChange]);
 
+  /**
+   * Close the dialogs that belong to the Room *route* when the operator leaves
+   * it (Codex P2 review on #2130).
+   *
+   * Both of these open from the members pane, which is inside the `routeOpen`
+   * gate — but the dialogs themselves are deliberately outside it, because two
+   * of their siblings have triggers painted in the sidebar and must open from
+   * any section. That is right for those two and wrong for these: leaving Room
+   * on Back, Forward or a typed hash used to unmount this whole view, and now
+   * leaves an "Add teammate" sheet standing over Company. `BudgetDialog` is
+   * worse than untidy — it holds the member it was opened for, so it would come
+   * back later still pointing at them.
+   *
+   * Closed rather than unmounted, so returning to Room does not find them
+   * reopened by state nobody cleared.
+   */
+  useEffect(() => {
+    if (routeOpen) return;
+    setAddOpen(false);
+    setBudgetFor(null);
+  }, [routeOpen]);
+
   // Upload one attachment's bytes for the composer (issue #1682). Bound to the
   // active connection's client/company so the composer stays agnostic of both.
   // Must live above the early returns: a hook after them is skipped on the
@@ -2330,6 +2352,12 @@ export function ChatView({
             onAddChannel={onAddChannel}
             collapsed={channelsCollapsed}
             onExpand={toggleChannels}
+            // Off Room the marked channel is where Room will take you back to,
+            // not the page being read — so it stops claiming to be the current
+            // page. Without this, `#/finances/wallet` had two nodes answering
+            // `aria-current="page"`: this rail's open channel and the section
+            // rail's open sub-page.
+            currentPage={routeOpen}
             // In the sidebar the rail IS the column: it drops its own width,
             // its own border and its own fill, and lets the sidebar's scroll
             // container handle a long list.

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -1344,11 +1344,62 @@ export function ChatView({
     // re-runs with the new scope's notices.
   }, [budgetPauseMessageIdByAgent]);
 
-  // An open thread only makes sense while its parent is on screen; switching
-  // channels closes it rather than leaving a panel pointing at nothing.
-  // `?thread=<id>` on the hash opens straight into that thread instead, and
-  // is consumed (stripped via `replaceState`) so it does not reopen on a
-  // later switch back to this channel.
+  /**
+   * The `?thread=<id>` the address names right now, tracked reactively.
+   *
+   * `useHashView` deliberately parses only the path segments, so
+   * `#/chat/general` → `#/chat/general?thread=h41` changes neither `sub` nor
+   * `channel.id` and re-renders nothing an effect keyed on those would see. A
+   * subscription of its own is the answer, and it is the one `useHashFlag`
+   * already uses for `?new` — same event, same reason.
+   *
+   * `hashchange` is enough on its own. Every navigation in this console reaches
+   * the address through `window.location.hash = …` (`useHashView`'s `navigate`,
+   * `useHashFlag`'s setter) or through Back/Forward, and all of those fire it.
+   * The one write that does not is `replaceState`, which is exactly how the
+   * query below is *consumed* — so consuming leaves this value where it is and
+   * the effect cannot loop on its own write.
+   *
+   * Carried with a **nonce**, not as a bare string, and that is not decoration:
+   * consuming `?thread=h41` strips it from the address, so opening h41 a second
+   * time is a real hash change whose parsed value is the one already held.
+   * React would bail out of the re-render and the panel would not reopen —
+   * verified in a browser, where the third of three `?thread=` links was the
+   * one that did nothing. The nonce makes every hash change distinct; what
+   * stops the effect acting on the ones that are not about threads is
+   * `threadResolvedFor` below.
+   */
+  const [threadQuery, setThreadQuery] = useState<{ value: string | null; nonce: number }>({
+    value: null,
+    nonce: 0,
+  });
+  useEffect(() => {
+    const read = () => {
+      const [, query = ""] = window.location.hash.split("?");
+      return new URLSearchParams(query).get("thread");
+    };
+    const apply = () => setThreadQuery((prev) => ({ value: read(), nonce: prev.nonce + 1 }));
+    apply();
+    window.addEventListener("hashchange", apply);
+    return () => window.removeEventListener("hashchange", apply);
+  }, []);
+
+  /**
+   * Which channel the thread panel was last resolved for, so "you arrived here"
+   * can be told apart from "the address changed while you were already here".
+   *
+   * Only an arrival closes an open thread. A hash change that names no thread is
+   * some other surface's query moving — or this effect's own `replaceState`
+   * consuming the one it just opened — and neither is a reason to shut a panel
+   * the operator is reading.
+   */
+  const threadResolvedFor = useRef<string | null>(null);
+
+  // An open thread only makes sense while its parent is on screen; arriving at
+  // a channel closes whatever was open rather than leaving a panel pointing at
+  // nothing. `?thread=<id>` on the hash opens straight into that thread
+  // instead, and is consumed (stripped via `replaceState`) so it does not
+  // reopen on a later switch back to this channel.
   //
   // `routeOpen` is both a guard and a dependency, and it has to be both since
   // #2130 (Codex P2 review on that PR).
@@ -1364,18 +1415,28 @@ export function ChatView({
   // As a **guard**, because a view mounted off its own route must not rewrite
   // another section's address. This calls `replaceState` on whatever hash it
   // finds, and the hash it finds off Room belongs to Company or Flows.
+  //
+  // `threadQuery` is the third dependency, and it is what makes a same-channel
+  // link work: `#/chat/general` → `#/chat/general?thread=h41` moves nothing else
+  // (CodeRabbit review on #2130). That gap predates the rail work — the effect
+  // was keyed on `channel?.id` alone before it — and is closed here rather than
+  // carried, because pinning the rail made the same-channel case the *common*
+  // one: this view now sits on a channel far more often than it used to.
   useEffect(() => {
     if (!routeOpen || !channel?.id) return;
-    const [path, query = ""] = window.location.hash.replace(/^#/, "").split("?");
-    const params = new URLSearchParams(query);
-    const threadId = params.get("thread");
-    setOpenThreadId(threadId);
-    if (threadId !== null) {
+    const arrived = threadResolvedFor.current !== channel.id;
+    threadResolvedFor.current = channel.id;
+    if (threadQuery.value !== null) {
+      setOpenThreadId(threadQuery.value);
+      const [path, query = ""] = window.location.hash.replace(/^#/, "").split("?");
+      const params = new URLSearchParams(query);
       params.delete("thread");
       const qs = params.toString();
       window.history.replaceState(null, "", `#${path}${qs ? `?${qs}` : ""}`);
+      return;
     }
-  }, [routeOpen, channel?.id]);
+    if (arrived) setOpenThreadId(null);
+  }, [routeOpen, channel?.id, threadQuery]);
 
   // Whoever owns the unread counts needs to know what is actually being looked
   // at. Re-runs as the open channel's transcript grows, not only on a switch:
@@ -1443,6 +1504,12 @@ export function ChatView({
     if (routeOpen) return;
     setAddOpen(false);
     setBudgetFor(null);
+    // And the thread panel, which used to close because leaving Room unmounted
+    // the whole view. Clearing the marker with it makes the next arrival an
+    // arrival, so Room opens on the channel rather than on a panel the operator
+    // left behind two sections ago.
+    setOpenThreadId(null);
+    threadResolvedFor.current = null;
   }, [routeOpen]);
 
   // Upload one attachment's bytes for the composer (issue #1682). Bound to the

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -721,9 +721,26 @@ export function ChatView({
     }
   }
 
+  /**
+   * Which roster read this is, so only the newest may write — the same guard
+   * `loadDesks`, `viewerRun` and `directoryEpoch` each keep, and the one this
+   * read was missing (Codex P2 review on #2130).
+   *
+   * Two of these could not overlap while the read happened once per mount. They
+   * can now: a console that loads off Room and is taken *into* Room before the
+   * first `listTeam` settles starts a second one beside it. And the failure path
+   * is the dangerous half — it writes unconditionally, so a slow older rejection
+   * landing after a newer success replaces a real roster with `[]` and
+   * `fromHost: false`. Direct messages vanish and "New channel" goes with them,
+   * until some later entry to Room happens to fix it.
+   */
+  const rosterRead = useRef(0);
   const boot = useCallback(async () => {
+    const ticket = ++rosterRead.current;
+    const isCurrent = () => ticket === rosterRead.current;
     try {
       const roster = await client.listTeam(company);
+      if (!isCurrent()) return;
       if (roster.length) {
         setMembers(roster.map(fromDto));
         setFromHost(true);
@@ -737,11 +754,15 @@ export function ChatView({
       }
     } catch {
       // The roster read failed, so we do not know who works here. Still nobody:
-      // guessing a team is what this change exists to stop.
+      // guessing a team is what this change exists to stop. Guarded in both
+      // directions — a stale rejection overwriting a fresh success is the same
+      // bug with the sign flipped, which is the rule the cognition read already
+      // states.
+      if (!isCurrent()) return;
       setMembers([]);
       setFromHost(false);
     } finally {
-      setLoadingTeam(false);
+      if (isCurrent()) setLoadingTeam(false);
     }
   }, [client, company, roomVisits]);
 

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -485,10 +485,26 @@ export function ChatView({
    * And gating the reads on `routeOpen` instead would leave the rail empty on a
    * console loaded straight onto `#/company`, which is the one thing this whole
    * change exists to prevent — the reads still run on mount, wherever that is.
+   *
+   * The cognition read is in the set too, and it was not at first: it already
+   * refreshes on `visibilitychange`, which sounded like enough and is not. That
+   * event is about the *tab*, not the route — an admin who follows the Room
+   * warning to Settings → Inference, configures a provider and comes back has
+   * never hidden the tab, so the stale warning and its echo placeholders would
+   * have stayed (Codex P2 review).
    */
   const [roomVisits, setRoomVisits] = useState(0);
+  const wasRouteOpen = useRef(routeOpen);
   useEffect(() => {
-    if (routeOpen) setRoomVisits((n) => n + 1);
+    // A `false → true` transition, and only after the mount (Codex P2 review).
+    // Bumping on `routeOpen` being true at all counted the ordinary startup —
+    // the console opens on `#/chat` — so every read below ran twice in a row,
+    // and `loadDesks` clears the desk list on its way, dropping the pane back to
+    // its loading state a frame after it had arrived. The mount's own pass is
+    // the first visit; this counts the ones after it.
+    const entered = routeOpen && !wasRouteOpen.current;
+    wasRouteOpen.current = routeOpen;
+    if (entered) setRoomVisits((n) => n + 1);
   }, [routeOpen]);
 
   const [members, setMembers] = useState<TeamMember[]>([]);
@@ -665,7 +681,7 @@ export function ChatView({
       live = false;
       document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [client, company]);
+  }, [client, company, roomVisits]);
 
   /**
    * The host's answer *for the company on screen right now*, or `null` while

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -939,6 +939,13 @@ export function ChatView({
    */
   const restoredFor = useRef<string | null | undefined>(undefined);
   useEffect(() => {
+    // Never off Room. This view is mounted on every route since #2130, and a
+    // route that names no second segment — `#/workflows`, `#/connections` —
+    // reaches this effect with a bare `sub` and no channel in the hash. Writing
+    // the remembered channel into the hash there does not restore anything: it
+    // navigates the operator OUT of the section they just opened, which is what
+    // clicking Flows did before this guard (it landed on `#/chat/main`).
+    if (!routeOpen) return;
     if (sub) {
       // A channel is named, so the next bare `#/chat` is a fresh re-entry.
       restoredFor.current = undefined;
@@ -952,7 +959,7 @@ export function ChatView({
     restoredFor.current = scopeKey;
     const remembered = readLastChannel(scope);
     if (remembered) onNavigate(remembered);
-  }, [company, scope, sub, onNavigate]);
+  }, [company, routeOpen, scope, sub, onNavigate]);
 
   // No channels exist until the host has answered. Resolving against a
   // half-built list is exactly the first-paint swap issue #370 describes.

--- a/frontend/src/views/chat/ChannelRail.tsx
+++ b/frontend/src/views/chat/ChannelRail.tsx
@@ -52,6 +52,22 @@ interface Props {
   directMessages?: Channel[];
   onStartDirectMessage?: (id: string) => void;
   className?: string;
+  /**
+   * Whether the channel this rail marks is the page on screen.
+   *
+   * `true` — the default, and what a rail beside its own transcript means —
+   * makes the marked row `aria-current="page"`. `false` demotes it to
+   * `aria-current="true"`: still "the one of these you are on", but not a claim
+   * to be the current *page*.
+   *
+   * It exists because this rail is pinned in the app sidebar on every section
+   * since #2130. On `#/finances/wallet` the marked channel is where Room will
+   * take you back to, not the page being read — and two nodes claiming `page`
+   * is a page a screen reader cannot locate you on, which is the same defect
+   * the section rail was reviewed for on that PR. `ChatView` passes its own
+   * `routeOpen` straight through.
+   */
+  currentPage?: boolean;
 }
 
 /**
@@ -77,7 +93,11 @@ export function ChannelRail({
   directMessages = [],
   onStartDirectMessage,
   className,
+  currentPage = true,
 }: Props) {
+  // Resolved once and threaded down, so the three row shapes cannot come to
+  // disagree about what marking the open channel means.
+  const activeAria: "page" | "true" = currentPage ? "page" : "true";
   // Section disclosure lives here rather than inside `Section`, because the
   // collapsed branch below unmounts every `Section`. Held inside them, folding
   // a section and then collapsing the rail would reopen it on expand — the
@@ -119,6 +139,7 @@ export function ChannelRail({
               key={channel.id}
               channel={channel}
               active={channel.id === activeId}
+              activeAria={activeAria}
               unread={unread[channel.id] ?? 0}
               mentions={mentions?.[channel.id] ?? 0}
               onSelect={onSelect}
@@ -142,6 +163,7 @@ export function ChannelRail({
             key={section.id}
             channel={section.channels[0]}
             active={section.channels[0]?.id === activeId}
+            activeAria={activeAria}
             unread={section.channels[0] ? (unread[section.channels[0].id] ?? 0) : 0}
             onSelect={onSelect}
           />
@@ -172,6 +194,7 @@ export function ChannelRail({
               ) : undefined
             }
             activeId={activeId}
+            activeAria={activeAria}
             unread={unread}
             mentions={mentions}
             onSelect={onSelect}
@@ -202,11 +225,13 @@ export function ChannelRail({
 function PinnedOperatorRow({
   channel,
   active,
+  activeAria,
   unread,
   onSelect,
 }: {
   channel: Channel | undefined;
   active: boolean;
+  activeAria: "page" | "true";
   unread: number;
   onSelect: (id: string) => void;
 }) {
@@ -217,7 +242,7 @@ function PinnedOperatorRow({
       <button
         type="button"
         onClick={() => onSelect(channel.id)}
-        aria-current={active ? "page" : undefined}
+        aria-current={active ? activeAria : undefined}
         title={channelSubtitle(channel) ?? undefined}
         className={cn(
           "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
@@ -246,12 +271,14 @@ function PinnedOperatorRow({
 function CompactChannelRow({
   channel,
   active,
+  activeAria,
   unread,
   mentions,
   onSelect,
 }: {
   channel: Channel;
   active: boolean;
+  activeAria: "page" | "true";
   unread: number;
   mentions: number;
   onSelect: (id: string) => void;
@@ -263,7 +290,7 @@ function CompactChannelRow({
     <button
       type="button"
       onClick={() => onSelect(channel.id)}
-      aria-current={active ? "page" : undefined}
+      aria-current={active ? activeAria : undefined}
       // The compact row renders unread as a bare dot, so the count has to live
       // in the accessible name — the expanded row says it in text, and
       // collapsing the rail must not strip the same fact from the screen-reader
@@ -344,6 +371,7 @@ function SectionAction({
 function Section({
   section,
   activeId,
+  activeAria,
   unread,
   mentions,
   onSelect,
@@ -353,6 +381,7 @@ function Section({
 }: {
   section: ChannelSection;
   activeId: string | null;
+  activeAria: "page" | "true";
   unread: Record<string, number>;
   mentions?: Record<string, number>;
   onSelect: (id: string) => void;
@@ -423,6 +452,7 @@ function Section({
               <ChannelRow
                 channel={channel}
                 active={channel.id === activeId}
+                activeAria={activeAria}
                 unread={unread[channel.id] ?? 0}
                 mentions={mentions?.[channel.id] ?? 0}
                 onSelect={onSelect}
@@ -441,12 +471,14 @@ function Section({
 function ChannelRow({
   channel,
   active,
+  activeAria,
   unread,
   mentions,
   onSelect,
 }: {
   channel: Channel;
   active: boolean;
+  activeAria: "page" | "true";
   unread: number;
   mentions: number;
   onSelect: (id: string) => void;
@@ -458,7 +490,7 @@ function ChannelRow({
     <button
       type="button"
       onClick={() => onSelect(channel.id)}
-      aria-current={active ? "page" : undefined}
+      aria-current={active ? activeAria : undefined}
       // The row's own label is `channel.name`, so a tooltip that resolves to
       // the same string is the header's issue-#1180 duplicate in a slower
       // form: you hover for a second fact and get the one already under the

--- a/frontend/src/views/connections/ConnectionsSection.tsx
+++ b/frontend/src/views/connections/ConnectionsSection.tsx
@@ -34,24 +34,29 @@ interface Props {
  * three credential forms that argument also covers (Inference, Hosting, Search)
  * deliberately stayed in Settings, beside the things they unlock.
  *
- * # Where the rail went
+ * # Where the rail went, twice
  *
- * This section shipped with a 240px sub-rail inside the content area, modelled
- * on `finance/FinanceSection.tsx`. That rail is gone: sub-navigation lives in
- * the **sidebar** now, under the section's own row
- * (`components/sidebar-navigation.tsx`). Two reasons, and neither is layout
- * fashion. A rail inside the page puts the same kind of list in two different
- * places depending on which section an operator is in — the sidebar for the
- * sections without sub-pages, a rail for the ones with — so there is no rule to
- * learn. And it charges the content pane 240px on every page under it, on a
- * screen that already has a sidebar.
+ * This section shipped with a 240px sub-rail of its own inside the content
+ * area, modelled on `finance/FinanceSection.tsx` (PR #1977). It gave that up
+ * for rows in the sidebar under its own section row, on the argument that a
+ * per-section rail puts the same kind of list in two different places and
+ * charges the content pane 240px on a screen that already has a sidebar.
  *
- * What is left is the dispatch, which is all this component ever did besides
- * draw the rail. `OAuthView` and `McpServersView` are re-parented, not
- * rewritten. The one content change is `OAuthView`'s title: the page is called
- * **Apps** now, because "OAuth" names the protocol a connection happens to use
- * rather than the thing an operator came to find, and under a section already
- * named Connections it said the same word twice.
+ * Sub-navigation is a content rail again (issue #2130) — but the **shared** one,
+ * `components/section-rail.tsx`, built from the same `NAV_SECTIONS` table every
+ * section reads, because the sidebar's middle region is the Room channel list
+ * now and is pinned there on every section. The reversal and what it is worth
+ * are argued on `NAV_SECTIONS` in `components/sidebar-navigation.tsx`; the
+ * "two different places" half of the old argument is answered by there being
+ * exactly one rail implementation and never two rails on screen.
+ *
+ * This file is unchanged by either move, and that is the point worth keeping:
+ * what is left is the dispatch, which is all this component ever did besides
+ * draw a rail. `OAuthView` and `McpServersView` are re-parented, not rewritten.
+ * The one content change was `OAuthView`'s title: the page is called **Apps**
+ * now, because "OAuth" names the protocol a connection happens to use rather
+ * than the thing an operator came to find, and under a section already named
+ * Connections it said the same word twice.
  */
 export function ConnectionsSection({ client, company, sub }: Props) {
   const page = resolveConnectionPage(sub);

--- a/frontend/src/views/finance/FinanceSection.tsx
+++ b/frontend/src/views/finance/FinanceSection.tsx
@@ -1,9 +1,8 @@
 import { lazy, Suspense } from "react";
-import { CreditCard, LayoutDashboard, Wallet, type LucideIcon } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import { RouteLoading } from "@/components/route-loading";
-import { cn } from "@/lib/utils";
+import { resolveFinancePage } from "@/views/finance/finance-pages";
 import { InvoicingView } from "@/views/finance/InvoicingView";
 import { WalletView } from "@/views/finance/WalletView";
 
@@ -13,60 +12,31 @@ const FinancesView = lazy(() =>
   import("@/views/FinancesView").then((m) => ({ default: m.FinancesView })),
 );
 
-/**
- * The sub-pages under Finance. The id is the hash's second segment.
- *
- * Three, not two. Overview is the ledger projection (`GET …/finances`, folded by
- * `metering::finances_from` from the company's own ledger and its manifest
- * `[budget]`) — the company's internal accounting, which owes nothing to either
- * provider. It leads because it is the one page that has something to show on a
- * host where nothing is connected yet, so the section is never an empty shell.
- */
-export const FINANCE_PAGES = [
-  {
-    id: "overview",
-    label: "Overview",
-    icon: LayoutDashboard,
-    hint: "Balance, budget and spend from the ledger",
-  },
-  {
-    id: "invoicing",
-    label: "Invoicing",
-    icon: CreditCard,
-    hint: "What customers owe, through Chargebee",
-  },
-  {
-    id: "wallet",
-    label: "Wallet",
-    icon: Wallet,
-    hint: "The PayPal balance and what moved through it",
-  },
-] as const satisfies readonly { id: string; label: string; icon: LucideIcon; hint: string }[];
-
-export type FinancePage = (typeof FINANCE_PAGES)[number]["id"];
-
-const DEFAULT_PAGE: FinancePage = "overview";
-
-/** Whether a hash segment names a real sub-page. */
-export function resolveFinancePage(sub: string | null): FinancePage {
-  return FINANCE_PAGES.some((p) => p.id === sub) ? (sub as FinancePage) : DEFAULT_PAGE;
-}
+// The table itself lives in `finance-pages.ts` so that anything pointing at a
+// sub-page — the console's nav table, a route rewrite — can name one without
+// importing this section and the three views under it. Re-exported here so the
+// imports written while it lived in this file keep resolving.
+export {
+  DEFAULT_FINANCE_PAGE,
+  FINANCE_PAGES,
+  financeHref,
+  isFinancePage,
+  resolveFinancePage,
+  type FinancePage,
+} from "@/views/finance/finance-pages";
 
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
   /** The hash's second segment, e.g. `wallet` in `#/finances/wallet`. */
   sub: string | null;
-  onNavigate: (page: FinancePage) => void;
 }
 
 /**
  * Finance, as a section rather than a page.
  *
- * Modelled on `SettingsSection`, deliberately: a sub-sidebar on `sm:` and up, a
- * scrolling chip row below it, and each sub-page its own route
- * (`#/finances/wallet`) so it is linkable and survives a refresh exactly as a
- * top-level view does.
+ * Each sub-page is its own route (`#/finances/wallet`), so it is linkable and
+ * survives a refresh exactly as a top-level view does.
  *
  * # Why this replaced Settings → Billing
  *
@@ -78,6 +48,20 @@ interface Props {
  * charges me*, which is Settings → Usage. The credential forms now sit in a
  * collapsible panel at the top of the page whose data they unlock.
  *
+ * # Where the rail went
+ *
+ * This section drew a `w-60` rail of its own, and Settings copied it. Finance is
+ * a row *under Company* (`NAV_SECTIONS`), and Company draws a section rail of
+ * its own now (`components/section-rail.tsx`, issue #2130) — so a rail here
+ * would be the second one in the same viewport, which is exactly the 768–1023px
+ * two-rail band issue #1383 was filed about and `SettingsSection.tsx` still
+ * carries a comment about. One rail per section: Finance's three pages are
+ * nested rows on Company's rail, shown while Finance is the open row.
+ *
+ * What is left is the dispatch, which is all this component does besides draw
+ * the rail — the same shape `connections/ConnectionsSection.tsx` has, and for
+ * the same reason.
+ *
  * # The `key` on each provider page is load-bearing
  *
  * Both hold typed-but-unsaved credentials. `key={company}` remounts on a company
@@ -88,73 +72,22 @@ interface Props {
  * also makes `company` constant for the instance's lifetime, so a slow response
  * from a previous company cannot land on a later one's view.
  */
-export function FinanceSection({ client, company, sub, onNavigate }: Props) {
+export function FinanceSection({ client, company, sub }: Props) {
   const page = resolveFinancePage(sub);
 
   return (
-    <div className="flex min-h-0 flex-1">
-      <nav
-        aria-label="Finance"
-        className="hidden w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-3 sm:flex"
-      >
-        {/* A visual caption for the rail, not a heading. The `nav` is already
-            named by its `aria-label`, so an `h2` here added nothing for a screen
-            reader and broke the document outline: the rail renders before the
-            sub-page, so heading navigation met a section-level heading ahead of
-            the page's own `h1` (issue #1392). */}
-        <div className="px-2 pb-2 pt-1 text-xs font-medium text-muted-foreground">
-          Finance
-        </div>
-        {FINANCE_PAGES.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            onClick={() => onNavigate(item.id)}
-            aria-current={page === item.id ? "page" : undefined}
-            className={cn(
-              "flex items-start gap-2.5 rounded-lg px-2 py-2 text-left transition-colors",
-              page === item.id ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
-            )}
-          >
-            <item.icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-            <span className="min-w-0">
-              <span className="block text-sm font-medium">{item.label}</span>
-              <span className="block text-xs text-muted-foreground">{item.hint}</span>
-            </span>
-          </button>
-        ))}
-      </nav>
-
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <div className="flex gap-1 overflow-x-auto border-b p-2 sm:hidden">
-          {FINANCE_PAGES.map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              onClick={() => onNavigate(item.id)}
-              aria-current={page === item.id ? "page" : undefined}
-              className={cn(
-                "shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors",
-                page === item.id ? "bg-accent text-accent-foreground" : "text-muted-foreground",
-              )}
-            >
-              {item.label}
-            </button>
-          ))}
-        </div>
-
-        {page === "overview" && (
-          <Suspense fallback={<RouteLoading title="Finances" label="Loading finances…" />}>
-            <FinancesView client={client} company={company} />
-          </Suspense>
-        )}
-        {page === "invoicing" && (
-          <InvoicingView key={company ?? "self"} client={client} company={company} />
-        )}
-        {page === "wallet" && (
-          <WalletView key={company ?? "self"} client={client} company={company} />
-        )}
-      </div>
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+      {page === "overview" && (
+        <Suspense fallback={<RouteLoading title="Finances" label="Loading finances…" />}>
+          <FinancesView client={client} company={company} />
+        </Suspense>
+      )}
+      {page === "invoicing" && (
+        <InvoicingView key={company ?? "self"} client={client} company={company} />
+      )}
+      {page === "wallet" && (
+        <WalletView key={company ?? "self"} client={client} company={company} />
+      )}
     </div>
   );
 }

--- a/frontend/src/views/finance/finance-pages.ts
+++ b/frontend/src/views/finance/finance-pages.ts
@@ -1,0 +1,73 @@
+// The Finance section's sub-page table, and the helpers that read it.
+//
+// A leaf module, exactly as `views/connection-pages.ts` and
+// `views/settings-pages.ts` are, and for the same reason: anything *pointing
+// at* a sub-page has to name one without importing the section, which imports
+// every view under it.
+//
+// The case that forces it here is the console's sub-navigation. Finance's three
+// pages are rows on the Company section's content rail now
+// (`components/section-rail.tsx`, driven by `NAV_SECTIONS` in
+// `components/sidebar-navigation.tsx`), so the nav table reads this list — and
+// a static import of `FinanceSection` from the nav table would pull
+// `InvoicingView`, `WalletView` and the lazy `FinancesView` in behind it, into
+// a module the sidebar renders on every route.
+//
+// `FinanceSection.tsx` re-exports everything below, so the imports written
+// while the table lived there keep resolving.
+
+import { CreditCard, LayoutDashboard, Wallet, type LucideIcon } from "lucide-react";
+
+/**
+ * The sub-pages under Finance. The id is the hash's second segment.
+ *
+ * Three, not two. Overview is the ledger projection (`GET …/finances`, folded by
+ * `metering::finances_from` from the company's own ledger and its manifest
+ * `[budget]`) — the company's internal accounting, which owes nothing to either
+ * provider. It leads because it is the one page that has something to show on a
+ * host where nothing is connected yet, so the section is never an empty shell.
+ */
+export const FINANCE_PAGES = [
+  {
+    id: "overview",
+    label: "Overview",
+    icon: LayoutDashboard,
+    hint: "Balance, budget and spend from the ledger",
+  },
+  {
+    id: "invoicing",
+    label: "Invoicing",
+    icon: CreditCard,
+    hint: "What customers owe, through Chargebee",
+  },
+  {
+    id: "wallet",
+    label: "Wallet",
+    icon: Wallet,
+    hint: "The PayPal balance and what moved through it",
+  },
+] as const satisfies readonly { id: string; label: string; icon: LucideIcon; hint: string }[];
+
+export type FinancePage = (typeof FINANCE_PAGES)[number]["id"];
+
+export const DEFAULT_FINANCE_PAGE: FinancePage = "overview";
+
+/** Whether a hash segment names a real sub-page. */
+export function isFinancePage(sub: string | null): sub is FinancePage {
+  return FINANCE_PAGES.some((page) => page.id === sub);
+}
+
+/** The sub-page a hash segment resolves to, defaulting to Overview. */
+export function resolveFinancePage(sub: string | null): FinancePage {
+  return isFinancePage(sub) ? sub : DEFAULT_FINANCE_PAGE;
+}
+
+/**
+ * The console hash a link to one Finance sub-page needs.
+ *
+ * Typed for the same reason `settingsHref` and `connectionsHref` are: a link
+ * written against this cannot outlive the page it points at.
+ */
+export function financeHref(page: FinancePage): string {
+  return `#/finances/${page}`;
+}

--- a/frontend/test/e2e/board-drag.spec.ts
+++ b/frontend/test/e2e/board-drag.spec.ts
@@ -236,9 +236,23 @@ test("a card drags from Working to Done, and the board scrolls to get there", as
   request,
 }) => {
   const title = `e2e in-review to done ${Date.now()}`;
+  // Wide enough that `openBoard`'s `expandAll` finds NO rails and therefore
+  // pins nothing, which is the premise everything below rests on: a column that
+  // was pinned open while the window was wide will not collapse when it
+  // narrows, and the collapse is what this test then waits for.
+  //
+  // 1280 used to be wide enough for that. It is not since #2130: Work is a page
+  // under Company, and a section's sub-navigation is a 240px rail down the left
+  // of the content area now — so at 1280 the board has ~240px less than it did
+  // and folds a phase into a rail before this test has started. `expandAll`
+  // then pins all three open and nothing can collapse again.
+  //
+  // 1600 restores the old headroom rather than guessing at a new threshold:
+  // 1280 was comfortable before the rail, and 1600 is comfortable behind it.
+  await page.setViewportSize({ width: 1600, height: 720 });
   const { id, card } = await seedInReview(page, request, title);
 
-  // Three phases of ~260px no longer overflow the default 1280px window, so
+  // Three phases of ~260px do not overflow the window at the width above, so
   // the board cannot scroll and the park below lands on zero. Narrow the
   // window so the board genuinely overflows: the sidebar stays expanded above
   // `md` (768px), and the park needs ~260px of overflow to land mid-range.

--- a/frontend/test/e2e/list-switcher.spec.ts
+++ b/frontend/test/e2e/list-switcher.spec.ts
@@ -59,9 +59,12 @@ test("Work is one nav row, landing on Tasks by default with the title as the swi
   await page.goto("/#/company");
   await dismissTour(page);
 
-  // Work is a child row under Company now, so it is on screen because this
-  // spec opens on a Company-section address. One row, not one per declared
-  // list — which is the thing this assertion is actually about (Rule 2).
+  // Work is a row on Company's section rail — the first column of the content
+  // area since #2130, not the sidebar — so it is on screen because this spec
+  // opens on a Company-section address. Same `data-tour` anchor and same
+  // `role=button` shape it had in the sidebar: the anchors follow the view id
+  // and travelled with the row. One row, not one per declared list, which is
+  // the thing this assertion is actually about (Rule 2).
   await expect(page.locator('[data-tour="nav-ledgers"]')).toHaveCount(1);
   await expect(page.locator('[data-tour="nav-ledgers"]').getByRole("button")).toHaveText("Work");
 

--- a/frontend/test/e2e/shell-two-layer.spec.ts
+++ b/frontend/test/e2e/shell-two-layer.spec.ts
@@ -216,6 +216,12 @@ for (const theme of ["light", "dark"] as const) {
     const graph = await page.evaluate(() => {
       const card = document.querySelector('[data-testid="content-surface"]')!;
       const kg = document.querySelector(".oc-kg");
+      // The section rail, if this address is filed under one of the four
+      // sections — `#/company/graph` is, so since #2130 the card holds a 240px
+      // navigation column and then the page. Read from the DOM rather than
+      // assumed: at the widths below `lg` where the rail is a chip row instead,
+      // there is no column here and the page runs to the card's own edge.
+      const rail = card.querySelector("nav[aria-label]");
       const box = card.getBoundingClientRect();
       // The card's INNER box. Its 1px hairline is part of its border box, so the
       // content starts one pixel in on every side — `clientLeft`/`clientTop` are
@@ -231,16 +237,25 @@ for (const theme of ["light", "dark"] as const) {
         const r = el.getBoundingClientRect();
         return { left: r.left, top: r.top, right: r.right, bottom: r.bottom };
       };
-      return { inner, kg: rect(kg) };
+      return { inner, kg: rect(kg), rail: rect(rail) };
     });
 
-    // Every page is framed now, the graph included. What matters is that it
-    // takes the height the card actually has rather than the height of the
-    // window: it used to claim `h-svh`, which inside a card shorter than the
-    // viewport lays the graph out taller than the box that clips it and crops
-    // the bottom band — the legend with it.
+    // Every page is framed now, the graph included, and it fills every pixel the
+    // card gives it. What matters is that it takes the height the card actually
+    // has rather than the height of the window: it used to claim `h-svh`, which
+    // inside a card shorter than the viewport lays the graph out taller than the
+    // box that clips it and crops the bottom band — the legend with it.
+    //
+    // Three of the four edges are the card's. The leading edge is the card's too
+    // *unless* the address is filed under a section, in which case the card's
+    // first column is that section's navigation (#2130) and the graph starts
+    // where the rail ends. Asserted against the rail's measured right edge
+    // rather than against a width constant, so a change to the rail's width
+    // does not need this file changed with it — and a graph that ignored the
+    // rail and drew underneath it still fails, which is the spill this test is
+    // for.
     expect(graph.kg).not.toBeNull();
-    expect(graph.kg!.left).toBeCloseTo(graph.inner.left, 0);
+    expect(graph.kg!.left).toBeCloseTo(graph.rail?.right ?? graph.inner.left, 0);
     expect(graph.kg!.top).toBeCloseTo(graph.inner.top, 0);
     expect(graph.kg!.right).toBeCloseTo(graph.inner.right, 0);
     expect(graph.kg!.bottom).toBeCloseTo(graph.inner.bottom, 0);

--- a/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
+++ b/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
@@ -121,12 +121,16 @@ test.describe("sidebar toggle reachability", () => {
     await expect(sheet).toBeVisible();
     await expect(sheet).toHaveAttribute("aria-modal", "true");
 
-    // Work is a child row under Company, so it is on screen because the sheet
-    // opened on a Company-section address. That is the pattern under test as
-    // much as the sheet is: picking a destination inside an expanded section
-    // still closes the sheet behind it.
-    await sheet.getByRole("button", { name: "Work", exact: true }).click();
-    await expect(page).toHaveURL(/#\/ledgers\/tasks$/);
+    // A channel, not a section's child row. Since #2130 the sheet holds the four
+    // sections and the Room rail — a section's own pages are a content rail, so
+    // "Work" is not in here to pick any more. The channel list is the thing this
+    // sheet now has that nothing else does, and it is the harder case: it is
+    // portalled in from `ChatView` rather than rendered by the sidebar, so a
+    // dismiss that only fired for the sidebar's own rows would miss it (which is
+    // what `room-rail.tsx`'s `dismiss` exists for). Picking one still closes the
+    // sheet behind it, which is the pattern under test.
+    await sheet.getByRole("button", { name: "general", exact: true }).click();
+    await expect(page).toHaveURL(/#\/chat\//);
     await expect(sheet).toBeHidden();
   });
 

--- a/frontend/test/unit/connections-navigation.test.ts
+++ b/frontend/test/unit/connections-navigation.test.ts
@@ -68,8 +68,10 @@ describe("the Connections section", () => {
     for (const page of CONNECTION_PAGES) {
       expect(page.label, page.id).toBeTruthy();
       expect(page.hint, page.id).toBeTruthy();
-      // A hint is what the rail shows under the label; repeating the label
-      // there tells an operator nothing they cannot already see.
+      // The hint is the row's `title` and, below `lg`, the line naming the
+      // active chip — it stopped being a second line under the label with
+      // issue #2131. Repeating the label in it tells an operator nothing they
+      // cannot already see, wherever it is shown.
       expect(page.hint, page.id).not.toBe(page.label);
     }
   });

--- a/frontend/test/unit/connections-navigation.test.ts
+++ b/frontend/test/unit/connections-navigation.test.ts
@@ -83,18 +83,20 @@ describe("the Connections section", () => {
     expect(read("views/OAuthView.tsx")).not.toContain('title="OAuth"');
   });
 
-  it("draws its sub-navigation in the sidebar rather than a rail in the page", () => {
-    // This section shipped with a `w-60` rail inside the content area, modelled
-    // on Finance's. Sub-navigation lives in the sidebar now, under the
-    // section's own row, so all four sections use one pattern — and the
-    // content pane keeps the 240px the rail was charging it.
+  it("draws no rail of its own, whichever surface the sub-navigation is on", () => {
+    // This section shipped with a `w-60` rail of its own, modelled on Finance's,
+    // and gave it up for rows in the sidebar. Sub-navigation is a content rail
+    // again since #2130 — but the SHARED one, `components/section-rail.tsx`,
+    // built from the same `NAV_SECTIONS` table every section reads. This file
+    // stays dispatch-only through both moves, which is the property worth
+    // pinning: one rail implementation, not one per section.
     const section = read("views/connections/ConnectionsSection.tsx");
     expect(section).not.toMatch(/<nav[\s>]/);
     expect(section).not.toContain("w-60");
 
-    // Where it went, asserted from the rendered sidebar rather than from source
-    // text: the rows are what an operator clicks, and a `toContain` over a nav
-    // table is satisfied by a commented-out row that renders nothing (#1311).
+    // Where it went, asserted from the nav table rather than from source text: a
+    // `toContain` over a nav table is satisfied by a commented-out row that
+    // renders nothing (#1311).
     const connections = NAV_SECTIONS.find((s) => s.view === "connections")!;
     expect(connections.children?.map((child) => [child.label, child.sub])).toEqual([
       ["Apps", "apps"],

--- a/frontend/test/unit/nav-rail-headings.test.ts
+++ b/frontend/test/unit/nav-rail-headings.test.ts
@@ -73,9 +73,12 @@ describe("Navigation rails", () => {
   });
 
   it("still name themselves, so demoting those captions cost nothing", () => {
-    for (const name of ["SettingsSection", "finance/FinanceSection"]) {
-      const source = readFileSync(`${SRC}/views/${name}.tsx`, "utf8");
-      expect(source, `${name} must name its <nav>`).toMatch(/<nav\s+aria-label="/);
+    // Finance drew one of the two rails this rule was written for. It draws
+    // none now — its pages are nested rows on the section rail below (#2130) —
+    // so the shared rail is what has to keep naming itself in its place.
+    for (const path of ["views/SettingsSection.tsx", "components/section-rail.tsx"]) {
+      const source = readFileSync(`${SRC}/${path}`, "utf8");
+      expect(source, `${path} must name its <nav>`).toMatch(/<nav\s+aria-label=[{"]/);
     }
 
     // The Settings groups are named by reference rather than by a heading.

--- a/frontend/test/unit/onboarding-gate-setup-controller-mount.test.ts
+++ b/frontend/test/unit/onboarding-gate-setup-controller-mount.test.ts
@@ -278,6 +278,15 @@ describe("AppShell keeps SetupController mounted across its branch transitions",
     // for exactly rather than folded into a `>=` that would let a genuine
     // re-read through unnoticed.
     const GRAPH_ROSTER_READS = 1;
-    expect(listTeam.mock.calls.length).toBe(readsWhilePending + GRAPH_ROSTER_READS);
+    // `ChatView` is mounted on every route since #2130, not only on `#/chat`:
+    // the sidebar's channel rail is portalled out of it and is pinned there on
+    // every section, so the view that feeds it has to outlive the route that
+    // used to own it. It takes one roster read of its own on mount, for the
+    // rail's direct-message rows. Accounted for by name for the same reason the
+    // graph's is — a `>=` here would let a genuine re-read through unnoticed.
+    const CHAT_RAIL_ROSTER_READS = 1;
+    expect(listTeam.mock.calls.length).toBe(
+      readsWhilePending + GRAPH_ROSTER_READS + CHAT_RAIL_ROSTER_READS,
+    );
   });
 });

--- a/frontend/test/unit/responsive-two-rail-band.test.ts
+++ b/frontend/test/unit/responsive-two-rail-band.test.ts
@@ -64,10 +64,34 @@ describe("chat has no second rail left to band with (issues #1383, four-row side
   });
 });
 
-describe("settings sub-rail collapses to chips below lg (issue #1383)", () => {
+describe("every content rail collapses to chips below lg (issue #1383)", () => {
   const settings = read("views/SettingsSection.tsx");
+  // The shared rail every section with sub-pages draws since #2130. It is held
+  // to the same band as Settings' own, and that is the point of asserting both:
+  // #2130 put a second `w-60` rail on Company, Connections and Finance, and a
+  // rail that came on at `sm` there would rebuild the exact 768–1023px band this
+  // file exists to keep closed — three sections at a time instead of one.
+  const section = read("components/section-rail.tsx");
+
+  it("keeps Finance from being a SECOND rail beside the section rail", () => {
+    // Company's rail carries Finance's three pages as nested rows. Finance
+    // drawing its own would put two 240px rails and the app sidebar in one
+    // viewport at every width, not only in the band.
+    const finance = read("views/finance/FinanceSection.tsx");
+    expect(finance).not.toMatch(/<nav[\s>]/);
+    // Scoped to a `className`, not a bare substring: the file explains in prose
+    // why it no longer draws a `w-60` rail, and a guard that a comment can
+    // trip is a guard people delete the comment to satisfy.
+    expect(finance).not.toMatch(/className="[^"]*w-60/);
+  });
 
   it("shows the sub-rail only from lg", () => {
+    expect(section).toContain(
+      "hidden w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-3 lg:flex",
+    );
+    expect(section).not.toContain(
+      "hidden w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-3 sm:flex",
+    );
     expect(settings).toContain(
       "hidden w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-3 lg:flex",
     );
@@ -78,9 +102,14 @@ describe("settings sub-rail collapses to chips below lg (issue #1383)", () => {
   });
 
   it("shows the chip-row fallback below lg, so the pane gets full width", () => {
-    expect(settings).toContain("border-b lg:hidden");
-    expect(settings).toContain("flex gap-1 overflow-x-auto p-2");
-    expect(settings).not.toContain("border-b sm:hidden");
+    for (const [name, source] of [
+      ["SettingsSection", settings],
+      ["section-rail", section],
+    ] as const) {
+      expect(source, name).toContain("border-b lg:hidden");
+      expect(source, name).toContain("flex gap-1 overflow-x-auto p-2");
+      expect(source, name).not.toContain("border-b sm:hidden");
+    }
   });
 
   /**
@@ -98,10 +127,14 @@ describe("settings sub-rail collapses to chips below lg (issue #1383)", () => {
    * `relative z-30` stacking context, above the drag band's `z-20`.
    */
   it("keeps the chip row above the macOS drag band (z-30 over the band's z-20)", () => {
-    const idx = settings.indexOf('border-b lg:hidden');
-    expect(idx).toBeGreaterThan(-1);
-    const wrapper = settings.slice(Math.max(0, idx - 60), idx);
-    expect(wrapper).toContain("relative z-30");
+    for (const [name, source] of [
+      ["SettingsSection", settings],
+      ["section-rail", section],
+    ] as const) {
+      const idx = source.indexOf("border-b lg:hidden");
+      expect(idx, name).toBeGreaterThan(-1);
+      expect(source.slice(Math.max(0, idx - 60), idx), name).toContain("relative z-30");
+    }
   });
 });
 
@@ -138,7 +171,13 @@ describe("mention clearing is gated on the transcript being visible (codex P1)",
     // it, so the gate reads from the room-rail slot rather than from a
     // breakpoint this view guesses at.
     expect(chatView).toMatch(/if \(channel && chatPaneVisible\)/);
-    expect(chatView).toContain("const chatPaneVisible = !roomRail.covering;");
+    // Two ways for the transcript not to be on screen since #2130, and the gate
+    // has to name both. The sheet covering it is the phone. The other is the
+    // operator being on another section entirely — this view stays mounted
+    // there to keep the sidebar's rail fed, so being mounted stopped being
+    // evidence of being visible, and a mention marked read from Company is the
+    // same defect one route further away.
+    expect(chatView).toContain("const chatPaneVisible = routeOpen && !roomRail.covering;");
     // The visibility flag is a dependency, so closing the sheet re-runs the
     // report and clears whatever is newly visible.
     expect(chatView).toContain("chatPaneVisible,\n  ]);");

--- a/frontend/test/unit/room-rail-pinned.test.ts
+++ b/frontend/test/unit/room-rail-pinned.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * What pinning the Room rail costs `ChatView`, and the three things that pay it
+ * (issue #2130).
+ *
+ * The rail is painted in the sidebar on every section now, and it is portalled
+ * out of `ChatView` — so the shell keeps that view mounted on every route and
+ * hands it `routeOpen`. Three consequences follow, and each one was found the
+ * hard way or is one edit from being lost:
+ *
+ *   1. **A mounted view must not steer the route.** `ChatView` restores the
+ *      remembered channel into the hash whenever the hash names no channel.
+ *      Mounted everywhere, that fires on `#/workflows` and `#/connections` too
+ *      — which name no second segment — and navigates the operator straight
+ *      back out of the section they just opened. Found in a browser: clicking
+ *      **Flows** landed on `#/chat/main`.
+ *   2. **A mounted view must not paint over the page.** The transcript, its
+ *      header and the members pane render only when `routeOpen`.
+ *   3. **The dialogs must NOT be gated with them.** Their triggers are painted
+ *      in the sidebar — the rail's "+" and its "New message" pencil — so they
+ *      have to open from Company and Flows exactly as from Room. A portal moves
+ *      the DOM node, not the component tree, which is what makes that possible
+ *      at all, and putting them inside the `routeOpen` gate would quietly undo
+ *      it: the trigger would still be on screen and would open nothing.
+ *
+ * A source guard rather than a render test, in the idiom of
+ * `responsive-two-rail-band`: (1) needs a hash router and a mounted shell to
+ * reproduce, and (3) is invisible below the level of the whole shell — the
+ * dialogs are correct read on their own and wrong only once you know where
+ * their triggers are painted. `section-rail-layout.test.ts` covers what the
+ * rail and the content rail render.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
+
+describe("ChatView, mounted off its own route", () => {
+  const chatView = read("views/ChatView.tsx");
+
+  it("refuses to restore the remembered channel while another section is open", () => {
+    // The guard, and that it is the FIRST thing the effect does — after the
+    // `if (sub)` line it is already too late for a bare `#/workflows`.
+    const effect = chatView.slice(chatView.indexOf("const restoredFor = useRef"));
+    const guard = effect.indexOf("if (!routeOpen) return;");
+    const subCheck = effect.indexOf("if (sub) {");
+    expect(guard).toBeGreaterThan(-1);
+    expect(subCheck).toBeGreaterThan(-1);
+    expect(guard).toBeLessThan(subCheck);
+    // And it is a dependency, so arriving on Room re-runs the restore rather
+    // than skipping it for the life of the mount.
+    expect(effect.slice(0, effect.indexOf("}, [") + 200)).toContain(
+      "[company, routeOpen, scope, sub, onNavigate]",
+    );
+  });
+
+  it("renders the transcript only on its own route", () => {
+    expect(chatView).toContain("{routeOpen && (");
+  });
+
+  it("keeps both sidebar-triggered dialogs outside that gate", () => {
+    // Everything after the gate closes is what stays mounted off Room. Both
+    // dialogs have to be in it: their triggers are the rail's "+" and its "New
+    // message" pencil, which are painted in the sidebar on every section.
+    const gate = chatView.indexOf("{routeOpen && (");
+    const gateClose = chatView.indexOf("\n      )}\n", gate);
+    const dialog = chatView.search(/<ChannelCreateDialog[\s/>]/);
+    expect(gate).toBeGreaterThan(-1);
+    expect(gateClose).toBeGreaterThan(gate);
+    expect(dialog, "ChannelCreateDialog must mount after the routeOpen gate closes").toBeGreaterThan(
+      gateClose,
+    );
+    // `NewMessageDialog` mounts inside `ChannelRail`, which is the portalled
+    // node itself — so it rides along with the rail rather than needing a place
+    // in this tail. Asserted from the rail's side so the pairing is stated
+    // somewhere rather than assumed.
+    expect(read("views/chat/ChannelRail.tsx")).toMatch(/<NewMessageDialog[\s/>]/);
+  });
+
+  it("is mounted by the shell unconditionally, with routeOpen as the only gate", () => {
+    const shell = read("components/app-shell.tsx");
+    // The regression this replaces: `{view === "chat" && <ChatView …/>}`, which
+    // unmounted the rail's owner the moment the operator left Room.
+    expect(shell).not.toMatch(/\{view === "chat" && \(\s*<ChatView/);
+    expect(shell).toContain('routeOpen={view === "chat"}');
+    // And it is handed the CHAT segment, not the current view's. On
+    // `#/connections/mcp` the live `sub` is `mcp`, which chat would resolve as
+    // a channel id.
+    expect(shell).toContain('sub={view === "chat" ? sub : chatSub}');
+  });
+});

--- a/frontend/test/unit/room-rail-pinned.test.ts
+++ b/frontend/test/unit/room-rail-pinned.test.ts
@@ -164,6 +164,42 @@ describe("ChatView, mounted off its own route", () => {
     expect(rail).toContain("currentPage = true,");
   });
 
+  it("re-reads the roster, desks and directory on every entry to Room", () => {
+    // Codex P2 on this PR. Every one of these was keyed on `[client, company]`
+    // alone, which was sufficient while navigating away unmounted the view:
+    // coming back was a mount, and a mount re-read everything. Add a teammate on
+    // Company or delete a desk on the org chart now, and the pinned rail would
+    // go on showing what it loaded once — in plain sight, because the rail is on
+    // screen the whole time.
+    expect(chatView).toContain("const [roomVisits, setRoomVisits] = useState(0);");
+    expect(chatView).toContain("if (routeOpen) setRoomVisits((n) => n + 1);");
+    // The roster, the viewer's people, the desks, the Operator channel and the
+    // mention directory: everything the rail and the composer draw. Five, and
+    // deliberately not `reloadDirectory`'s own `useCallback` — that is a handle
+    // other code calls after it changes something, not a read on a schedule, and
+    // re-keying it would only churn its identity.
+    expect(chatView.match(/\}, \[client, company, roomVisits\]\);/g) ?? []).toHaveLength(5);
+    expect(chatView).toContain("const reloadDirectory = useCallback");
+
+    // On ENTRY, not on `routeOpen` itself: that moves in both directions, so
+    // leaving Room would spend a second round of reads on a section just left.
+    // And not as a *gate* on the reads either — that would leave the rail empty
+    // on a console loaded straight onto `#/company`, which is the one thing this
+    // change exists to prevent.
+    expect(chatView).not.toContain("}, [client, company, routeOpen]);");
+  });
+
+  it("seeds the pinned rail's highlight from the channel Room will actually open", () => {
+    // Codex P2 on this PR. A console loaded straight onto `#/company` has never
+    // had `view === "chat"`, so a bare `null` left the rail highlighting the
+    // first desk while clicking Room ran chat's own bare-route restoration and
+    // landed somewhere else. A highlight has to name the destination it offers.
+    const shell = read("components/app-shell.tsx");
+    expect(shell).toContain("useState<string | null>(() => readLastChannel(scope))");
+    // The same value chat restores from, read the same scoped way.
+    expect(chatView).toContain("readLastChannel(scope)");
+  });
+
   it("is mounted by the shell unconditionally, with routeOpen as the only gate", () => {
     const shell = read("components/app-shell.tsx");
     // The regression this replaces: `{view === "chat" && <ChatView …/>}`, which

--- a/frontend/test/unit/room-rail-pinned.test.ts
+++ b/frontend/test/unit/room-rail-pinned.test.ts
@@ -91,6 +91,18 @@ describe("ChatView, mounted off its own route", () => {
     // one already held and React would bail out of the re-render. Found in a
     // browser, where the third of three `?thread=` links did nothing.
     expect(chatView).toContain("nonce: prev.nonce + 1");
+    // And one link opens one thread ONCE. Consuming fires no `hashchange`, so
+    // the query keeps naming the thread it just opened — and
+    // `useHashView.navigate` sets the hash and calls `setRoute` synchronously
+    // while that event is still pending. So picking another channel re-ran this
+    // effect for the new channel with the old query and reopened the thread
+    // there, on a channel with no such parent, suppressing its live steps and
+    // receipt. The correcting pass could not undo it: `threadResolvedFor`
+    // already held the new channel, so `arrived` was false (Codex P2).
+    expect(chatView).toContain(
+      "threadQuery.value !== null && consumedThreadNonce.current !== threadQuery.nonce",
+    );
+    expect(chatView).toContain("consumedThreadNonce.current = threadQuery.nonce;");
     // Consuming is a `replaceState`, which fires no `hashchange` — so the value
     // stays put and the effect cannot loop on its own write. A hash change that
     // names no thread is somebody else's query moving, and only an ARRIVAL

--- a/frontend/test/unit/room-rail-pinned.test.ts
+++ b/frontend/test/unit/room-rail-pinned.test.ts
@@ -197,6 +197,21 @@ describe("ChatView, mounted off its own route", () => {
     // on a console loaded straight onto `#/company`, which is the one thing this
     // change exists to prevent.
     expect(chatView).not.toContain("}, [client, company, routeOpen]);");
+
+    // Re-keying makes two of these overlap for the first time, so the roster
+    // read needed the run token its neighbours already had (Codex P2). A console
+    // that loads off Room and is taken into Room before the first `listTeam`
+    // settles starts a second one beside it — and the failure path wrote
+    // unconditionally, so a slow older rejection landing after a newer success
+    // replaced a real roster with `[]`/`fromHost: false`: Direct messages gone
+    // and "New channel" with them, until some later entry happened to fix it.
+    expect(chatView).toContain("const ticket = ++rosterRead.current;");
+    // Guarded in both directions — a stale rejection overwriting a fresh success
+    // is the same bug with the sign flipped.
+    const boot = chatView.slice(chatView.indexOf("const boot = useCallback"));
+    const bootBody = boot.slice(0, boot.indexOf("}, [client, company, roomVisits]);"));
+    expect(bootBody.match(/if \(!isCurrent\(\)\) return;/g) ?? []).toHaveLength(2);
+    expect(bootBody).toContain("if (isCurrent()) setLoadingTeam(false);");
   });
 
   it("seeds the pinned rail's highlight from the channel Room will actually open", () => {

--- a/frontend/test/unit/room-rail-pinned.test.ts
+++ b/frontend/test/unit/room-rail-pinned.test.ts
@@ -172,13 +172,23 @@ describe("ChatView, mounted off its own route", () => {
     // go on showing what it loaded once — in plain sight, because the rail is on
     // screen the whole time.
     expect(chatView).toContain("const [roomVisits, setRoomVisits] = useState(0);");
-    expect(chatView).toContain("if (routeOpen) setRoomVisits((n) => n + 1);");
-    // The roster, the viewer's people, the desks, the Operator channel and the
-    // mention directory: everything the rail and the composer draw. Five, and
-    // deliberately not `reloadDirectory`'s own `useCallback` — that is a handle
+    // A `false → true` transition, and only after the mount. Counting
+    // `routeOpen` being true at all counted the ordinary startup — the console
+    // opens on `#/chat` — so every read ran twice in a row and `loadDesks`
+    // dropped the pane back to its loading state a frame after it arrived
+    // (Codex P2).
+    expect(chatView).toContain("const entered = routeOpen && !wasRouteOpen.current;");
+    expect(chatView).toContain("if (entered) setRoomVisits((n) => n + 1);");
+    // Cognition, the roster, the viewer's people, the desks, the Operator
+    // channel and the mention directory: everything the rail, the composer and
+    // the warning strip draw. Cognition is in the set even though it refreshes
+    // on `visibilitychange` — that event is about the tab, not the route, and an
+    // admin who fixes Inference and comes back has never hidden the tab.
+    //
+    // Deliberately NOT `reloadDirectory`'s own `useCallback`: that is a handle
     // other code calls after it changes something, not a read on a schedule, and
     // re-keying it would only churn its identity.
-    expect(chatView.match(/\}, \[client, company, roomVisits\]\);/g) ?? []).toHaveLength(5);
+    expect(chatView.match(/\}, \[client, company, roomVisits\]\);/g) ?? []).toHaveLength(6);
     expect(chatView).toContain("const reloadDirectory = useCallback");
 
     // On ENTRY, not on `routeOpen` itself: that moves in both directions, so

--- a/frontend/test/unit/room-rail-pinned.test.ts
+++ b/frontend/test/unit/room-rail-pinned.test.ts
@@ -73,9 +73,29 @@ describe("ChatView, mounted off its own route", () => {
     // It is a guard as well as a dependency, and the guard matters on its own:
     // the effect calls `replaceState` on whatever hash it finds, and off Room
     // that hash belongs to Company or Flows.
-    const effect = chatView.slice(chatView.indexOf('const threadId = params.get("thread")') - 900);
+    const effect = chatView.slice(chatView.indexOf("const arrived = threadResolvedFor.current") - 400);
     expect(effect).toContain("if (!routeOpen || !channel?.id) return;");
-    expect(effect.slice(0, effect.indexOf("}, [") + 40)).toContain("[routeOpen, channel?.id]");
+    expect(effect.slice(0, effect.indexOf("}, [") + 60)).toContain(
+      "[routeOpen, channel?.id, threadQuery]",
+    );
+
+    // And the query is reactive, which is what makes a SAME-channel link work:
+    // `#/chat/general` → `#/chat/general?thread=h41` moves neither `sub` nor
+    // `channel.id`, so an effect keyed on those alone never fires (CodeRabbit
+    // review on #2130). `useHashView` parses only the path segments; this keeps
+    // the subscription `useHashFlag` already uses for `?new`.
+    expect(chatView).toContain('new URLSearchParams(query).get("thread")');
+    expect(chatView).toContain('window.addEventListener("hashchange", apply)');
+    // Carried with a nonce, so opening the SAME thread twice still fires: the
+    // first open consumes the query, so the second link's parsed value is the
+    // one already held and React would bail out of the re-render. Found in a
+    // browser, where the third of three `?thread=` links did nothing.
+    expect(chatView).toContain("nonce: prev.nonce + 1");
+    // Consuming is a `replaceState`, which fires no `hashchange` — so the value
+    // stays put and the effect cannot loop on its own write. A hash change that
+    // names no thread is somebody else's query moving, and only an ARRIVAL
+    // closes an open panel.
+    expect(effect).toContain("if (arrived) setOpenThreadId(null);");
   });
 
   it("keeps both sidebar-triggered dialogs outside that gate", () => {

--- a/frontend/test/unit/room-rail-pinned.test.ts
+++ b/frontend/test/unit/room-rail-pinned.test.ts
@@ -97,6 +97,41 @@ describe("ChatView, mounted off its own route", () => {
     expect(read("views/chat/ChannelRail.tsx")).toMatch(/<NewMessageDialog[\s/>]/);
   });
 
+  it("closes the Room-only dialogs on the way out, and only those", () => {
+    // Codex P2 on this PR. `AddMemberDialog` and `BudgetDialog` open from the
+    // members pane, which is inside the `routeOpen` gate — but every dialog in
+    // this file sits OUTSIDE that gate, because two of them have triggers
+    // painted in the sidebar. Right for those two, wrong for these: leaving Room
+    // on Back used to unmount the view, and left an "Add teammate" sheet
+    // standing over Company once it stopped doing so. `BudgetDialog` also holds
+    // the member it was opened for, so it would come back still pointing at
+    // them.
+    const effect = chatView.slice(chatView.indexOf("if (routeOpen) return;"));
+    expect(chatView).toContain("if (routeOpen) return;");
+    expect(effect.slice(0, 200)).toContain("setAddOpen(false)");
+    expect(effect.slice(0, 200)).toContain("setBudgetFor(null)");
+    // And NOT the two the sidebar opens — closing those on the way out is the
+    // whole thing this PR had to keep working from another section.
+    expect(effect.slice(0, 200)).not.toContain("setChannelCreateOpen(false)");
+  });
+
+  it("stops the pinned rail claiming to be the current page off Room", () => {
+    // Two nodes answering `aria-current="page"` is a page a screen reader
+    // cannot locate you on. On `#/finances/wallet` there were exactly that: the
+    // channel rail's open channel and the section rail's open sub-page. Off
+    // Room the rail's mark is "where Room will take you back to", which is
+    // `aria-current="true"` — a current item within a set, not a current page.
+    expect(chatView).toContain("currentPage={routeOpen}");
+    const rail = read("views/chat/ChannelRail.tsx");
+    expect(rail).toContain('const activeAria: "page" | "true" = currentPage ? "page" : "true";');
+    // Every row shape reads the resolved value, so none of the three can drift.
+    expect(rail.match(/aria-current=\{active \? activeAria : undefined\}/g) ?? []).toHaveLength(3);
+    expect(rail).not.toContain('aria-current={active ? "page" : undefined}');
+    // And a standalone rail — the unit tests, a rail beside its own transcript —
+    // keeps saying `page` with nothing configured.
+    expect(rail).toContain("currentPage = true,");
+  });
+
   it("is mounted by the shell unconditionally, with routeOpen as the only gate", () => {
     const shell = read("components/app-shell.tsx");
     // The regression this replaces: `{view === "chat" && <ChatView …/>}`, which

--- a/frontend/test/unit/room-rail-pinned.test.ts
+++ b/frontend/test/unit/room-rail-pinned.test.ts
@@ -62,6 +62,22 @@ describe("ChatView, mounted off its own route", () => {
     expect(chatView).toContain("{routeOpen && (");
   });
 
+  it("re-reads `?thread=` when Room is entered, and rewrites no other section's hash", () => {
+    // Codex P2 on this PR. A task card's "Opened from chat" link goes
+    // `#/tasks/<id>` → `#/chat/<channel>?thread=<id>`, and this view can
+    // already be sitting on that very channel — the shell replays the last chat
+    // segment while the address belongs to another section. Only `routeOpen`
+    // and the query change, so an effect keyed on `channel?.id` alone never
+    // fired: the thread did not open and the query was never consumed.
+    //
+    // It is a guard as well as a dependency, and the guard matters on its own:
+    // the effect calls `replaceState` on whatever hash it finds, and off Room
+    // that hash belongs to Company or Flows.
+    const effect = chatView.slice(chatView.indexOf('const threadId = params.get("thread")') - 900);
+    expect(effect).toContain("if (!routeOpen || !channel?.id) return;");
+    expect(effect.slice(0, effect.indexOf("}, [") + 40)).toContain("[routeOpen, channel?.id]");
+  });
+
   it("keeps both sidebar-triggered dialogs outside that gate", () => {
     // Everything after the gate closes is what stays mounted off Room. Both
     // dialogs have to be in it: their triggers are the rail's "+" and its "New

--- a/frontend/test/unit/section-rail-layout.test.ts
+++ b/frontend/test/unit/section-rail-layout.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SectionContentRail } from "@/components/section-rail";
+import { grandchildActive, NAV_SECTIONS } from "@/components/sidebar-navigation";
+import type { View } from "@/lib/console-routes";
+
+/**
+ * A section's sub-navigation is the first column of its content area (#2130).
+ *
+ * The sidebar's middle region is the Room rail on every section now, so the rows
+ * that used to live under a section's sidebar entry are drawn here instead. What
+ * is worth pinning is what an operator can actually reach and what a spec can
+ * actually click:
+ *
+ *   - the rows are the section's `children`, whole and in order, so a row that
+ *     moved out of the sidebar did not go missing on the way;
+ *   - a section with no children draws no rail at all, so Room and Flows keep
+ *     their full pane;
+ *   - there is never more than ONE rail on screen, which is the whole of the
+ *     Finance decision and of issue #1383;
+ *   - the `data-tour` anchors travelled with the rows. They are how the guided
+ *     tour and `list-switcher.spec.ts` find a row, and they are deliberately
+ *     pinned to view ids rather than labels — a row that moved surface and
+ *     dropped its anchor is a silently skipped tour stop and a spec that clicks
+ *     nothing.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(view: View, sub: string | null = null, onNavigate = () => {}) {
+  act(() =>
+    root.render(
+      createElement(SectionContentRail, {
+        view,
+        sub,
+        onNavigate,
+        children: createElement("main", { "data-testid": "page" }, "the page"),
+      }),
+    ),
+  );
+}
+
+/** The rail's own rows, in document order — the `lg` column, not the chips. */
+function railRows(): string[] {
+  const nav = container.querySelector("nav");
+  if (!nav) return [];
+  return [...nav.querySelectorAll("button")].map((el) =>
+    (el.querySelector("span > span")?.textContent ?? "").trim(),
+  );
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("which sections get a rail", () => {
+  it("draws one for Company, with its five pages whole and in order", () => {
+    render("company");
+    expect(railRows()).toEqual(["Agents", "Work", "Workspace", "Brain", "Finance"]);
+    expect(container.querySelector("nav")?.getAttribute("aria-label")).toBe("Company");
+  });
+
+  it("draws one for Connections, with both of its pages", () => {
+    render("connections", "mcp");
+    expect(railRows()).toEqual(["Apps", "MCP Servers"]);
+  });
+
+  it("draws none for Room or Flows, so their pane keeps its full width", () => {
+    // Room's sub-navigation is the channel list, which is pinned in the sidebar;
+    // Flows has none to move. A rail here would be 240px charged for nothing.
+    for (const view of ["chat", "workflows"] as View[]) {
+      render(view);
+      expect(container.querySelector("nav"), view).toBeNull();
+      expect(container.querySelector("[data-testid='page']"), view).not.toBeNull();
+    }
+  });
+
+  it("draws none for an address filed under no section", () => {
+    // Settings and Feedback are footer utilities, Overview and Approvals are
+    // chrome in the title row. Settings draws a rail of its own; nothing here
+    // should draw a second one over it.
+    for (const view of ["settings", "overview", "approvals", "not-found"] as View[]) {
+      render(view);
+      expect(container.querySelector("nav"), view).toBeNull();
+    }
+  });
+
+  it("renders the page in every case, rail or no rail", () => {
+    for (const view of ["chat", "company", "connections", "workflows", "settings"] as View[]) {
+      render(view);
+      expect(container.querySelector("[data-testid='page']"), view).not.toBeNull();
+    }
+  });
+});
+
+describe("never two rails at once", () => {
+  it("keeps Finance's pages on Company's rail rather than giving them a second", () => {
+    // The Finance decision, asserted as the property it is for rather than as a
+    // layout preference: sidebar + 240 + 240 + content is the 768–1023px band
+    // of issue #1383 reproduced at every width. One rail per section, always.
+    render("finances", "wallet");
+    expect(container.querySelectorAll("nav")).toHaveLength(1);
+    expect(railRows()).toEqual([
+      "Agents",
+      "Work",
+      "Workspace",
+      "Brain",
+      "Finance",
+      "Overview",
+      "Invoicing",
+      "Wallet",
+    ]);
+  });
+
+  it("shows a nested page only while its parent is the open row", () => {
+    render("company");
+    expect(railRows()).not.toContain("Wallet");
+    render("brain");
+    expect(railRows()).not.toContain("Wallet");
+  });
+
+  it("marks exactly one row current, at whichever depth it is", () => {
+    render("finances", "invoicing");
+    const current = [...container.querySelectorAll('nav [aria-current="page"]')].map((el) =>
+      (el.querySelector("span > span")?.textContent ?? "").trim(),
+    );
+    // Finance is the section row you are in AND Invoicing is the page — both
+    // light, which is the same two-register marking the sidebar used to do with
+    // its section row and its child row.
+    expect(current).toEqual(["Finance", "Invoicing"]);
+  });
+});
+
+describe("the tour anchors travelled with the rows", () => {
+  it("keeps one node per anchor, and keeps the ones specs click", () => {
+    render("company");
+    const anchors = [...container.querySelectorAll("[data-tour]")].map((el) =>
+      el.getAttribute("data-tour"),
+    );
+    expect(new Set(anchors).size, anchors.join(", ")).toBe(anchors.length);
+    // `list-switcher.spec.ts` clicks this one from `#/company`.
+    expect(anchors).toContain("nav-ledgers");
+    // And it is a button inside the anchor, the shape every selector in the
+    // e2e suite is written as (`[data-tour="nav-x"] >> role=button`).
+    expect(
+      container.querySelector('[data-tour="nav-ledgers"] button')?.textContent,
+    ).toContain("Work");
+  });
+
+  it("gives the row that shares its section's address no anchor of its own", () => {
+    // Agents *is* `#/company`, so an anchor here would put two `nav-company`
+    // nodes on screen and every selector written against it becomes a
+    // strict-mode violation rather than a click. The sidebar row keeps the name.
+    render("company");
+    expect(container.querySelectorAll('[data-tour="nav-company"]')).toHaveLength(0);
+  });
+
+  it("gives a nested row no anchor, since it would collide with its parent's", () => {
+    render("finances");
+    const anchors = [...container.querySelectorAll("[data-tour]")].map((el) =>
+      el.getAttribute("data-tour"),
+    );
+    expect(anchors.filter((a) => a === "nav-finances")).toHaveLength(1);
+  });
+});
+
+describe("clicking a row", () => {
+  it("navigates by (view, sub), the same pair the sidebar rows used", () => {
+    const onNavigate = vi.fn();
+    render("company", null, onNavigate);
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-tour="nav-workspace"] button')!
+        .click();
+    });
+    expect(onNavigate).toHaveBeenCalledWith("workspace", undefined);
+  });
+
+  it("navigates a nested page to its own segment", () => {
+    const onNavigate = vi.fn();
+    render("finances", null, onNavigate);
+    const wallet = [...container.querySelectorAll<HTMLButtonElement>("nav button")].find((el) =>
+      el.textContent?.includes("Wallet"),
+    )!;
+    act(() => wallet.click());
+    expect(onNavigate).toHaveBeenCalledWith("finances", "wallet");
+  });
+});
+
+describe("grandchildActive", () => {
+  const finance = NAV_SECTIONS.find((s) => s.view === "company")!.children!.find(
+    (c) => c.view === "finances",
+  )!;
+  const page = (label: string) => finance.children!.find((c) => c.label === label)!;
+
+  it("lights the first page for the bare address, as the sections do", () => {
+    // `#/finances` is Overview for the same reason `#/connections` is Apps: the
+    // parent row lands on the bare address and the first page is what it shows.
+    expect(grandchildActive(finance, page("Overview"), "finances", null)).toBe(true);
+    expect(grandchildActive(finance, page("Wallet"), "finances", null)).toBe(false);
+  });
+
+  it("lights the page the segment names", () => {
+    expect(grandchildActive(finance, page("Wallet"), "finances", "wallet")).toBe(true);
+    expect(grandchildActive(finance, page("Overview"), "finances", "wallet")).toBe(false);
+  });
+
+  it("lights nothing outside its own view", () => {
+    expect(grandchildActive(finance, page("Overview"), "brain", null)).toBe(false);
+  });
+});

--- a/frontend/test/unit/section-rail-layout.test.ts
+++ b/frontend/test/unit/section-rail-layout.test.ts
@@ -130,15 +130,32 @@ describe("never two rails at once", () => {
     expect(railRows()).not.toContain("Wallet");
   });
 
-  it("marks exactly one row current, at whichever depth it is", () => {
+  it("marks exactly one row current, and it is the leaf", () => {
     render("finances", "invoicing");
     const current = [...container.querySelectorAll('nav [aria-current="page"]')].map((el) =>
       (el.textContent ?? "").trim(),
     );
-    // Finance is the section row you are in AND Invoicing is the page — both
-    // light, which is the same two-register marking the sidebar used to do with
-    // its section row and its child row.
-    expect(current).toEqual(["Finance", "Invoicing"]);
+    // Finance is the branch you are in, not a second page you are on. Two nodes
+    // answering `aria-current="page"` is a page a screen reader cannot locate
+    // you on; what says "you are in this branch" is that its children show.
+    expect(current).toEqual(["Invoicing"]);
+  });
+
+  it("names the page below lg, not the branch above it", () => {
+    // Codex P2 on this PR: the chip row's explanatory line took the FIRST
+    // active row, which on any `#/finances/…` address is Finance — so the one
+    // surface where the label alone does not say which page you are on named
+    // the parent instead. It takes the deepest active row.
+    for (const [sub, hint] of [
+      [null, "Balance, budget and spend from the ledger"],
+      ["invoicing", "What customers owe, through Chargebee"],
+      ["wallet", "The PayPal balance and what moved through it"],
+    ] as const) {
+      render("finances", sub);
+      const chips = container.querySelector(".lg\\:hidden")!;
+      expect(chips.textContent, String(sub)).toContain(hint);
+      expect(chips.textContent, String(sub)).not.toContain("What it earns and spends");
+    }
   });
 });
 

--- a/frontend/test/unit/section-rail-layout.test.ts
+++ b/frontend/test/unit/section-rail-layout.test.ts
@@ -49,9 +49,7 @@ function render(view: View, sub: string | null = null, onNavigate = () => {}) {
 function railRows(): string[] {
   const nav = container.querySelector("nav");
   if (!nav) return [];
-  return [...nav.querySelectorAll("button")].map((el) =>
-    (el.querySelector("span > span")?.textContent ?? "").trim(),
-  );
+  return [...nav.querySelectorAll("button")].map((el) => (el.textContent ?? "").trim());
 }
 
 beforeEach(() => {
@@ -135,12 +133,37 @@ describe("never two rails at once", () => {
   it("marks exactly one row current, at whichever depth it is", () => {
     render("finances", "invoicing");
     const current = [...container.querySelectorAll('nav [aria-current="page"]')].map((el) =>
-      (el.querySelector("span > span")?.textContent ?? "").trim(),
+      (el.textContent ?? "").trim(),
     );
     // Finance is the section row you are in AND Invoicing is the page — both
     // light, which is the same two-register marking the sidebar used to do with
     // its section row and its child row.
     expect(current).toEqual(["Finance", "Invoicing"]);
+  });
+});
+
+describe("one line per row, with the gloss on hover", () => {
+  it("prints the label alone and hangs the hint off `title` (issue #2131)", () => {
+    // The rail matches what PR #2133 did to Settings, because the two sit side
+    // by side: a second line under every label wrapped at `w-60` and turned a
+    // five-row rail into fifteen lines of prose. The hint is kept as data — it
+    // is the row's `title` here and the line under the active chip below `lg` —
+    // so this asserts where it is shown, not that it went away.
+    render("company");
+    const agents = container.querySelector<HTMLButtonElement>("nav button")!;
+    expect(agents.textContent?.trim()).toBe("Agents");
+    expect(agents.getAttribute("title")).toBe("Who is in this company");
+    expect(agents.className).toContain("items-center");
+    expect(agents.className).not.toContain("items-start");
+    expect(agents.querySelector("svg")?.getAttribute("class")).not.toContain("mt-0.5");
+  });
+
+  it("still names the active page once, below lg, where a chip has no room for it", () => {
+    render("connections", "mcp");
+    const chips = container.querySelector(".lg\\:hidden")!;
+    expect(chips.textContent).toContain("Tool servers and their tools");
+    // And exactly once — not under every chip.
+    expect(chips.textContent?.match(/Tool servers and their tools/g)).toHaveLength(1);
   });
 });
 
@@ -156,8 +179,8 @@ describe("the tour anchors travelled with the rows", () => {
     // And it is a button inside the anchor, the shape every selector in the
     // e2e suite is written as (`[data-tour="nav-x"] >> role=button`).
     expect(
-      container.querySelector('[data-tour="nav-ledgers"] button')?.textContent,
-    ).toContain("Work");
+      container.querySelector('[data-tour="nav-ledgers"] button')?.textContent?.trim(),
+    ).toBe("Work");
   });
 
   it("gives the row that shares its section's address no anchor of its own", () => {
@@ -192,8 +215,8 @@ describe("clicking a row", () => {
   it("navigates a nested page to its own segment", () => {
     const onNavigate = vi.fn();
     render("finances", null, onNavigate);
-    const wallet = [...container.querySelectorAll<HTMLButtonElement>("nav button")].find((el) =>
-      el.textContent?.includes("Wallet"),
+    const wallet = [...container.querySelectorAll<HTMLButtonElement>("nav button")].find(
+      (el) => el.textContent?.trim() === "Wallet",
     )!;
     act(() => wallet.click());
     expect(onNavigate).toHaveBeenCalledWith("finances", "wallet");

--- a/frontend/test/unit/section-rail-layout.test.ts
+++ b/frontend/test/unit/section-rail-layout.test.ts
@@ -182,6 +182,20 @@ describe("one line per row, with the gloss on hover", () => {
     // And exactly once — not under every chip.
     expect(chips.textContent?.match(/Tool servers and their tools/g)).toHaveLength(1);
   });
+
+  it("fills exactly one chip, so a flat row never shows two current destinations", () => {
+    // Codex P2 on this PR: the chip row had the accent on every *active* row,
+    // so on `#/finances/wallet` both Finance and Wallet were filled — and
+    // unlike the rail, a chip row has no indent to say which of the two you are
+    // on. What says "you are in this branch" here is the same thing that says
+    // it on the rail: its children are in the row at all.
+    render("finances", "wallet");
+    const chips = container.querySelector(".lg\\:hidden")!;
+    const filled = [...chips.querySelectorAll("button")]
+      .filter((b) => b.className.includes("bg-accent"))
+      .map((b) => b.textContent?.trim());
+    expect(filled).toEqual(["Wallet"]);
+  });
 });
 
 describe("the tour anchors travelled with the rows", () => {

--- a/frontend/test/unit/section-rail-layout.test.ts
+++ b/frontend/test/unit/section-rail-layout.test.ts
@@ -130,6 +130,27 @@ describe("never two rails at once", () => {
     expect(railRows()).not.toContain("Wallet");
   });
 
+  it("marks the resolved page for a segment that names none of them", () => {
+    // The rendered half of the `grandchildActive` case below: the rail and the
+    // chip row both have to say Overview, because Overview is what the page
+    // resolver put on screen.
+    render("finances", "old-page");
+    const current = [...container.querySelectorAll('nav [aria-current="page"]')].map((el) =>
+      (el.textContent ?? "").trim(),
+    );
+    expect(current).toEqual(["Overview"]);
+    const chips = container.querySelector(".lg\\:hidden")!;
+    expect(chips.textContent).toContain("Balance, budget and spend from the ledger");
+
+    // And the same one level up: `#/connections/not-a-page` renders Apps.
+    render("connections", "not-a-page");
+    expect(
+      [...container.querySelectorAll('nav [aria-current="page"]')].map((el) =>
+        (el.textContent ?? "").trim(),
+      ),
+    ).toEqual(["Apps"]);
+  });
+
   it("marks exactly one row current, and it is the leaf", () => {
     render("finances", "invoicing");
     const current = [...container.querySelectorAll('nav [aria-current="page"]')].map((el) =>
@@ -274,5 +295,16 @@ describe("grandchildActive", () => {
 
   it("lights nothing outside its own view", () => {
     expect(grandchildActive(finance, page("Overview"), "brain", null)).toBe(false);
+  });
+
+  it("lights the first page for a segment none of them names", () => {
+    // Codex P2 on this PR. `resolveFinancePage` falls back to Overview for an
+    // unknown segment, so `#/finances/old-page` — a stale bookmark, a typo, a
+    // renamed page — *renders Overview*. Matching on the segment alone left the
+    // rail marking only the Finance ancestor and the chip row naming the parent
+    // while Overview was on screen. The resolver decides what renders and this
+    // decides what is marked; they have to be one rule.
+    expect(grandchildActive(finance, page("Overview"), "finances", "old-page")).toBe(true);
+    expect(grandchildActive(finance, page("Wallet"), "finances", "old-page")).toBe(false);
   });
 });

--- a/frontend/test/unit/sidebar-sections.test.ts
+++ b/frontend/test/unit/sidebar-sections.test.ts
@@ -33,13 +33,13 @@ import type { View } from "@/lib/console-routes";
 let container: HTMLDivElement;
 let root: Root;
 
-function render(view: View, sub: string | null = null) {
+function render(view: View) {
   act(() =>
     root.render(
       createElement(
         SidebarProvider,
         null,
-        createElement(SidebarNavigation, { view, sub, onNavigate: () => {} }),
+        createElement(SidebarNavigation, { view, onNavigate: () => {} }),
       ),
     ),
   );
@@ -166,16 +166,6 @@ describe("the sidebar's section table", () => {
     expect(childAnchor(company, company.children![1])).toBe("nav-ledgers");
   });
 
-  it("renders one node per tour anchor, whichever section is open", () => {
-    for (const view of ["chat", "company", "connections", "workflows"] as View[]) {
-      render(view);
-      const seen = [...container.querySelectorAll("[data-tour]")].map((el) =>
-        el.getAttribute("data-tour"),
-      );
-      expect(new Set(seen).size, `${view}: ${seen.join(", ")}`).toBe(seen.length);
-    }
-  });
-
   it("gives every section a distinct view, so two rows can never light at once", () => {
     const views = NAV_SECTIONS.map((section) => section.view);
     expect(new Set(views).size).toBe(views.length);
@@ -242,42 +232,24 @@ describe("which child row is open", () => {
 });
 
 describe("the rendered sidebar", () => {
-  it("keeps the four rows fixed and swaps only the block beneath them", () => {
-    // Not an accordion. The four never move, never reorder and are never
-    // displaced by a sibling's contents — so the contents always come AFTER
-    // all four, whichever section is open.
-    render("company");
-    expect(fixedRows()).toEqual(["Room", "Company", "Connections", "Flows"]);
-    expect(renderedRows()).toEqual([
-      "Room",
-      "Company",
-      "Connections",
-      "Flows",
-      "Agents",
-      "Work",
-      "Workspace",
-      "Brain",
-      "Finance",
-    ]);
-
-    render("connections", "mcp");
-    expect(fixedRows()).toEqual(["Room", "Company", "Connections", "Flows"]);
-    expect(renderedRows()).toEqual([
-      "Room",
-      "Company",
-      "Connections",
-      "Flows",
-      "Apps",
-      "MCP Servers",
-    ]);
-
-    // Exactly one section's contents at a time: Flows has none, so the block
-    // is not there at all.
-    render("workflows");
-    expect(renderedRows()).toEqual(["Room", "Company", "Connections", "Flows"]);
+  it("is the four rows and the Room rail's slot, on every section", () => {
+    // The middle region stopped swapping with the section you are in (issue
+    // #2130). It is the channel list, always — so the four rows are the only
+    // rows this column paints, whichever address is open, and a section's own
+    // pages are rows on its content rail instead
+    // (`section-rail-layout.test.ts`).
+    for (const view of ["chat", "company", "connections", "workflows"] as View[]) {
+      render(view);
+      expect(fixedRows(), view).toEqual(["Room", "Company", "Connections", "Flows"]);
+      expect(renderedRows(), view).toEqual(["Room", "Company", "Connections", "Flows"]);
+      expect(
+        container.querySelectorAll("[data-testid='room-rail-slot']"),
+        view,
+      ).toHaveLength(1);
+    }
   });
 
-  it("separates the four from what is filed under them with space, not a rule", () => {
+  it("separates the four from the rail with space, not a rule", () => {
     // A horizontal line here reads as hardware bolted across a column that is
     // already quiet, and it would have been the only rule in it — the console
     // draws none above its footer either. The break is a deliberate gap.
@@ -289,26 +261,31 @@ describe("the rendered sidebar", () => {
     // Deliberate, not the row rhythm: `py-1` on the group either side of it is
     // 4px, and the break has to be legible at a glance.
     expect(groups[1].className).toContain("pt-5");
-
-    // And no contents block at all for a section that has none, so the gap
-    // never appears with nothing under it.
-    render("workflows");
-    expect(container.querySelectorAll("[data-sidebar='group']")).toHaveLength(1);
   });
 
-  it("marks the section in the fixed block and the page in the block below", () => {
+  it("keeps the rail on the 3rem icon rail rather than hiding it there", () => {
+    // `ChannelRail` has a compact variant built for exactly this width, and
+    // dropping it would make collapsing the sidebar silently lose the channel
+    // list — the regression issue #1018 filed about the approvals badge. The
+    // fixed child lists that USED to be hidden at this width are content-rail
+    // rows now, so nothing in this region is hidden any more.
+    render("company");
+    const rail = [...container.querySelectorAll("[data-sidebar='group']")][1];
+    expect(rail.className).not.toContain("group-data-[collapsible=icon]:hidden");
+    // And the gutter goes, so the compact rows' unread dots do not land in
+    // horizontal overflow (measured: slot clientWidth 32 against scrollWidth 34).
+    expect(rail.className).toContain("group-data-[collapsible=icon]:px-0");
+  });
+
+  it("marks the section an address is in, and only that", () => {
     render("workspace");
-    // The two say different things and are read in different registers: which
-    // of the four you are in, and which of its pages is open.
+    // Which of the four you are in. Which of its PAGES is open is said on the
+    // content rail now, so nothing in this column claims to say it twice.
     expect(fixedRows().filter((_, i) =>
       [...container.querySelectorAll("[data-sidebar='group']")[0]
         .querySelectorAll("[data-sidebar='menu-button']")][i].hasAttribute("data-active"),
     )).toEqual(["Company"]);
-
-    const current = [...container.querySelectorAll('[aria-current="page"]')].map(
-      (el) => el.textContent?.trim(),
-    );
-    expect(current).toEqual(["Workspace"]);
+    expect(container.querySelectorAll('[aria-current="page"]')).toHaveLength(0);
   });
 
   it("lights a section's own row when nothing under it is open", () => {
@@ -319,15 +296,14 @@ describe("the rendered sidebar", () => {
     expect(row.hasAttribute("data-active")).toBe(true);
   });
 
-  it("gives Room a slot for the channel list, and gives it to no one else", () => {
-    render("chat");
-    expect(container.querySelectorAll("[data-testid='room-rail-slot']")).toHaveLength(1);
-
-    // The slot is the portal target `ChatView` renders into. Absent while
-    // another section is open, which is what makes the list Room's contents
-    // rather than standing furniture.
-    render("company");
-    expect(container.querySelectorAll("[data-testid='room-rail-slot']")).toHaveLength(0);
+  it("renders one node per tour anchor, whichever section is open", () => {
+    for (const view of ["chat", "company", "connections", "workflows"] as View[]) {
+      render(view);
+      const seen = [...container.querySelectorAll("[data-tour]")].map((el) =>
+        el.getAttribute("data-tour"),
+      );
+      expect(new Set(seen).size, `${view}: ${seen.join(", ")}`).toBe(seen.length);
+    }
   });
 
   it("puts no heading in the sidebar, at runtime and not only in source", () => {

--- a/frontend/test/unit/task-origin-conversation.test.ts
+++ b/frontend/test/unit/task-origin-conversation.test.ts
@@ -91,7 +91,12 @@ describe("the origin thread rides the card → Room jump, not just the channel",
   });
 
   it("Room reads the thread the query names and opens it", () => {
-    expect(chatView).toContain('params.get("thread")');
-    expect(chatView).toContain("setOpenThreadId(threadId)");
+    // Read reactively since #2130: `useHashView` parses only the path segments,
+    // so a link that changes nothing but `?thread=` re-renders nothing an effect
+    // keyed on the channel would see. The read moved into its own `hashchange`
+    // subscription — the one `useHashFlag` uses — and the effect opens whatever
+    // it names.
+    expect(chatView).toContain('new URLSearchParams(query).get("thread")');
+    expect(chatView).toContain("setOpenThreadId(threadQuery.value)");
   });
 });


### PR DESCRIPTION
Closes #2130.

## What changed

The sidebar's middle region held whichever section you were in. It is the **Room rail — Channels, Direct messages, Operator — on every section now**, and the rows that used to live there are the first column of their section's content area.

- `components/section-rail.tsx` (new) draws that column, from the same `NAV_SECTIONS` table the sidebar's four rows come from. Company gets Agents / Work / Workspace / Brain / Finance; Connections gets Apps / MCP Servers.
- `components/sidebar-navigation.tsx` paints four rows and the rail's portal slot, and nothing else. `slot?: "room"` is gone — there is no alternative for it to be one of.
- `views/finance/FinanceSection.tsx` is dispatch-only, the shape `ConnectionsSection` has had since #1977. Its page table moved to `views/finance/finance-pages.ts` so the nav table can read it without pulling three views behind it.
- Room and Flows draw no rail: Room's sub-navigation *is* the pinned channel list, and Flows has none to move (see the open question below).

## The doc-comment reversal

`sidebar-navigation.tsx:85` argued the opposite under **"Sub-navigation lives HERE, not in a rail inside the content area"**, and PR #1977 shipped a Connections content rail and then removed it on exactly that reasoning. That comment, the matching one on `ConnectionsSection`, and the `## The sub-navigation is in the SIDEBAR` section of `docs/spec/runtime/console-sections.md` are all rewritten — **with the old argument kept beside the new one**, because a decision reversed without its reasons on the page gets reversed back.

The argument was: a per-section rail puts the same kind of list in two places depending on which section you are in, so there is no rule to learn; and it charges the content pane 240px on a screen that already has a sidebar. Neither half is wrong.

What outweighs it is what the sidebar's middle region was being *spent* on. Putting a section's pages there meant the channel list only existed while you were in Room — and the channel list is the one list an operator returns to continuously, from wherever they are. Losing it on every trip to Company, Connections or Flows is not a width, it is a round trip: go to Room, find the channel, come back.

The "two places" half is answered rather than ignored. There is exactly one rule now — a section's sub-navigation is the first column of its content — and exactly one rail on screen at a time.

## Which route the permanent rail took, and what it costs

**Route 1 from the issue: keep the portal, keep `ChatView` mounted.** The shell mounts it on every route and passes `routeOpen`; off Room it renders the rail and its dialogs and nothing else.

Lifting the model into the shell was reweighed and is *worse* than it was when it was first rejected: the console would re-render on every unread tick from **every** section rather than only from Room.

The cost, stated plainly: ~2,400 lines of chat model stay mounted while the operator is on Company or Flows. The **data** was already resident — the shell owns `transcripts`, the mention feed and the unread map precisely *because* `ChatView` used to unmount — so what is newly kept is the view's own state and its desks/roster reads, not the polling. It takes one extra roster read at shell mount, accounted for by name in `onboarding-gate-setup-controller-mount.test.ts`. In exchange the channel list is never a round trip away and a return to Room refetches nothing.

Two correctness consequences, both handled:

- **A mounted transcript is no longer evidence of a visible one.** `chatPaneVisible` is `routeOpen && !roomRail.covering`, so a mention cannot be marked read because the operator happens to be on Company — the same rule that already kept the phone's covering sheet from clearing one.
- **A mounted view must not steer the route.** Found in the browser: clicking **Flows** landed on `#/chat/main`. `ChatView` restores the remembered channel into the hash whenever the hash names no channel, and `#/workflows` names no second segment. Gated on `routeOpen`, with `test/unit/room-rail-pinned.test.ts` holding it. It was also being handed the *current view's* segment, so `#/connections/mcp` had chat resolving `mcp` as a channel id; the shell remembers the last chat segment and replays it instead, which also keeps the pinned rail naming the channel Room will return to.

`NewMessageDialog` and `ChannelCreateDialog` are deliberately **outside** the `routeOpen` gate — their triggers are painted in the sidebar, so they have to open from any section. A portal moves the DOM node, not the component tree, which is what makes that work; the same test pins it.

## The Finance / Settings nesting question

**Finance folds into Company's rail as nested rows. One rail per section, never two.**

Company now draws a `w-60` rail, and Finance drawing its own would put sidebar + 240 + 240 + content in one viewport — which is the 768–1023px band of issue #1383 reproduced at *every* width. `SettingsSection.tsx:105` makes exactly this argument about its own second rail; it applies here with more force. So Finance's three pages are indented rows on Company's rail, visible while Finance is the open row, and `FinanceSection` keeps only its dispatch.

**Settings keeps its own rail**, and that is consistent rather than an exception: it is not one of the four sections at all — it is a footer utility — and its rail *is* this pattern. The shared component copies its geometry (`w-60` from `lg`, chips below, `relative z-30` over the macOS drag band) rather than the other way round.

## Row density (added on request)

The rail's rows are one line, with the hint on `title`, matching what PR #2133 did to the Settings rail for issue #2131 — the two layouts sit side by side and must not diverge, so this copies its `items-center`, its removal of the icon's `mt-0.5`, and its move of the gloss onto `title`. The `hint` stays as data: it is the row's `title`, and below `lg` it is the line naming the active chip, which #2131 also kept.

## Open question for the operator

**Flows has no sub-navigation to move**, so it gets no rail. The canvas's Workflows/Runs toggle is a control on the page's own title row whose state is persisted client-side rather than carried by the address, so promoting it to a rail would be *inventing* sub-pages rather than relocating any. Say the word if you want that instead and I will do it as its own change.

## Commands run

Rust is untouched by this change, so the Rust gates were not run locally.

```
npm run typecheck            # tsc -b --noEmit                     clean
npm run typecheck:unit       # tsc -p tsconfig.unit.json           clean
npm run typecheck:e2e        # tsc -p tsconfig.e2e.json            clean
npx vitest run               # 498 files, 4611 tests, all passing
./scripts/ci/assert-design-tokens.sh
npm run build
```

Tests updated rather than deleted, and the `data-tour` anchors travelled with the rows so the specs that click them still do: `sidebar-sections`, `connections-navigation`, `nav-rail-headings`, `responsive-two-rail-band`, `onboarding-gate-setup-controller-mount`, and `e2e/list-switcher.spec.ts`'s comment. New: `section-rail-layout.test.ts` (18) and `room-rail-pinned.test.ts` (4).

## Browser verification

Real host on the operator's saved company (15 teammates, 5 channels, 8 DMs — the rail is 17 rows and scrolls inside itself at 523px against a 426px box, with the footer still on screen).

- Room → Company → Connections → Flows → Room: rail present on all four, `#/workflows` stays `#/workflows`.
- A channel clicked from Company → `#/chat/autumn_launch`; a DM clicked from Flows → `#/chat/dm:priya`.
- `ChannelCreateDialog` and `NewMessageDialog` both open from `#/connections`, fully populated, without changing the address.
- Collapsed 3rem sidebar on Company: the compact channel list is still there, with no horizontal overflow.
- 900px: the rail collapses to the chip row and the pane takes the full width.
- Light and dark, both.


---

## Review round 1 — what changed after the PR opened

Three findings from Codex, all valid, all fixed. Full reasoning is in the replies on each thread.

- **The rail named the branch, not the page.** `chips.find((row) => row.active)` matched Finance on every `#/finances/…` address, so below `lg` the explanatory line said "What it earns and spends" instead of Invoicing's or Wallet's own hint. Both that line and `aria-current` take the deepest active row now — which fixed a second thing with it: the rail had been putting `aria-current="page"` on **both** Finance and the open sub-page, and two nodes answering that is a page a screen reader cannot locate you on.
- **Two filled chips.** Same half-fix one level on: the chip's background still keyed on `active`, so on `#/finances/wallet` both Finance and Wallet were filled, and unlike the rail a chip row has no indent to say which of the two you are on. One filled chip now, and it is the leaf.
- **The thread deep link stopped opening.** A real regression from keeping `ChatView` mounted, and the one I am most glad was caught. A task card's "Opened from chat" goes `#/tasks/<id>` → `#/chat/<channel>?thread=<id>`, and this view can already be sitting on that channel; only `routeOpen` and the query change, and the effect was keyed on `channel?.id` alone. It never fired, so the thread stayed shut and the query was never consumed. `routeOpen` is a dependency **and** a guard now — the effect calls `replaceState` on whatever hash it finds, and off Room that hash belongs to another section.

A pre-existing gap is recorded on that thread rather than silently carried: `#/chat/foo` → `#/chat/foo?thread=h41` (same view, same segment) does not re-run the effect either, and did not before this PR. Fixing it means threading the hash query into the view, which is its own change.

## What the 240px actually costs, measured

Three surfaces move, and none of them is a guess — each was found by running the E2E lane against a real host locally rather than by reading:

- **The task board folds a phase at 1280.** `#/ledgers/tasks` is under Company, so the board has ~240px less and `Done` collapses to its rail — the board's own responsive behaviour, one click from expanding. Seen in a browser at 1280x800 on the operator's own company: Pending and Working full width, Done a labelled vertical rail reading "Done 0". `board-drag.spec.ts` depends on nothing being pinned open before it narrows the window, so it opens at 1600 now: that restores the headroom 1280 had before the rail rather than guessing a new threshold.
- **The knowledge graph starts where the rail ends.** `#/company/graph` is a Company address, so the card's first column is the section rail. `shell-two-layer.spec.ts` asserted the graph filled the card exactly; it asserts against the rail's *measured* right edge now, so a graph that drew underneath the rail still fails — which is the spill that test is for. The full-bleed graph is still available at `#/overview`, which is filed under no section.
- **The mobile sheet has no "Work" row to pick.** `sidebar-toggle-reachable.spec.ts` picked one to prove the sheet closes behind a destination. It picks a **channel** now, which is the harder case and the one this sheet uniquely has: the rail is portalled in from `ChatView` rather than rendered by the sidebar, so a dismiss wired only to the sidebar's own rows would miss it.

One thing to watch rather than a change: `WorkspaceView`'s `w-56` details aside comes on at `xl` (≥1280), so at exactly 1280 it now sits opposite the section rail. It is a details pane on the right rather than a second navigation column, so it is not the #1383 shape, but it is tighter than it was.

## E2E, run locally against a real host

`npx playwright test` — the same default lane CI runs — on a debug host built in this worktree, twice.

The first pass was 360 passed / 5 failed. Two of the five were mine, both listed above, both fixed. Two (`chat-live-events` "exactly one company bubble", `pages-render` sandboxed iframe — the latter an ORB/CORS refusal on `pages-sdk` assets from `origin 'null'`) passed on re-run and touch nothing this PR changes. The re-run of all four specs plus the two I fixed: **20 passed, 0 failed.**


## Screenshots

Taken in Chromium against a real host serving the operator's saved company (15 teammates, 5 channels, 8 direct messages), light and dark, at 1280x720 unless noted. They are on the machine this branch was built on rather than attached here; what each one shows:

| What | Reads |
| --- | --- |
| Room, light | Four section rows, the channel rail beneath them, transcript full width and no content rail. |
| Company, light and dark | The rail persists; Agents / Work / Workspace / Brain / Finance as a second column, one line each, one row filled. |
| Finance, dark | Overview / Invoicing / Wallet indented under Finance; **one** filled row and one `aria-current`, the leaf. |
| Connections, dark | Apps / MCP Servers; the section is dispatch-only and draws no rail of its own. |
| Flows, light | No rail at all — nothing to move — and the channel list still pinned. |
| New channel + New message, from `#/connections` | Both dialogs open, fully populated, address unchanged at `#/connections`. |
| Company, dark, sidebar collapsed | The 3rem icon rail keeps the compact channel list; no horizontal overflow. |
| Company, dark, 900px | The rail is a chip row and the pane takes the full width. |
| Work board, light, 1280x800 | Done folded into its own rail — the 240px, landing on the widest surface. |

Measured rather than eyeballed, at the roster's real cap: the pinned rail is 17 rows, scrolls inside itself (523px of content in a 426px box) with the sidebar footer still on screen, and overflows nothing horizontally. Navigation checked by driving it: Room → Company → Connections → Flows → Room with the rail present on all four and `#/workflows` staying `#/workflows`; a channel clicked from Company landing on `#/chat/autumn_launch`; a DM clicked from Flows landing on `#/chat/dm:priya`.

---

## Review rounds 2 and 3

**Codex, round 2** — two more, both valid, both fixed:

- **Room's own dialogs stayed open over another page.** `AddMemberDialog` and `BudgetDialog` open from the members pane, which is inside the `routeOpen` gate — but every dialog sits *outside* it, because two of them have triggers painted in the sidebar. Right for those two, wrong for these: leaving Room on Back used to unmount the view, and once it stopped doing so it left an "Add teammate" sheet standing over Company. `BudgetDialog` was worse than untidy — it held the member it was opened for. Both close on the way out; the sidebar-triggered pair deliberately does not.
- **The rail marked no page for an address the resolver could still render.** `resolveFinancePage` falls back to its first page, so `#/finances/old-page` — a stale bookmark, a typo, a renamed page — renders Overview while the rail lit only the Finance ancestor. `rowActive` now follows the resolver's rule: the first of a set owns the bare address *and* every segment none of them names. This also fixes the same shape at `#/connections/not-a-page`, which predates this PR.

Found in the same pass, unreported: the pinned rail was marking its open channel `aria-current="page"` on **every** section, so `#/finances/wallet` had two nodes claiming `page`. Off Room the rail's mark is "where Room will take you back to" — `aria-current="true"`.

**CodeRabbit, round 3** — one finding, valid, fixed, and its diagnosis corrected on the thread. `useHashView` parses only path segments, so `#/chat/general` → `#/chat/general?thread=h41` re-rendered nothing the thread effect could see. The gap predates this PR; it is closed rather than carried because pinning the rail made the same-channel case the common one. Three details that took a browser rather than a reading:

1. Consuming is a `replaceState`, which fires no `hashchange` — so the tracked value stays put and the effect cannot loop on its own write.
2. It carries a **nonce**. Consuming strips the query, so opening the *same* thread twice is a real hash change whose parsed value is the one already held; React bails out of the re-render. The third of three `?thread=` links did nothing until this — the shape CodeRabbit suggested has that hole.
3. Only an **arrival** closes an open panel, so `#/chat/main?view=list` does not shut a thread the operator is reading.

Verified against a real host on one channel, watching the query get consumed as proof the effect fired: `?thread=t-one` → consumed; `?thread=t-two` → consumed; `?thread=t-two` **again** → consumed; `?view=list` → left alone.

## Where the gates stand

- Three typecheck gates, `npx vitest run` (4618 passing), `assert-design-tokens.sh`.
- The full default Playwright lane run locally against a debug host built in this worktree: **365 passed, 33 skipped, 0 failed.**
- CI was green by head SHA on `73617944a` — zero failures, zero pending, the only non-success jobs being path-filtered `skipped` Rust matrix legs.

**Round 4, Codex again, and this one was mine:** the reactive query introduced a race. `useHashView.navigate` sets `window.location.hash` and calls `setRoute` **synchronously** while `hashchange` lands a task later — and consuming a query is a `replaceState` that fires no `hashchange`, so the tracked value still said `h41`. Picking another channel in that window re-ran the effect for the new `channel.id` and reopened `h41` there, on a channel with no such parent, suppressing its live steps and receipt. Worse, the correcting pass could not undo it: `threadResolvedFor` already held the new channel, so `arrived` was false and the stale panel stayed.

A `consumedThreadNonce` ref fixes it — one link opens one thread once. The racing pass falls past the open branch to `if (arrived) setOpenThreadId(null)`, so the switch *closes* the stale panel rather than reopening it: the failure becomes the correct behaviour rather than merely being avoided. Verified in a browser on the operator's company with a real thread opened from its reply row: open, closed on a channel switch, and no resurrection on return.


**Round 5, Codex, two more — the sharpest of the review.** Both are the same class: a mounted view no longer re-reads what a mount used to re-read.

- **The rail went stale in plain sight.** Six of `ChatView`'s reads — roster, viewer's people, desks, Operator channel, mention directory — were keyed on `[client, company]` alone, which was sufficient while navigating away unmounted the view. Add a teammate on Company now and the rail's Direct messages would not show them until a reload, *while the rail is on screen*. A `roomVisits` counter incremented on **entry** restores the old cadence. Not `routeOpen` in each dep list (it moves both ways, so leaving Room would spend a second round of reads on a section just left) and not a gate on `routeOpen` (that would leave the rail empty on a console loaded straight onto `#/company` — the one thing this change exists to prevent).
- **The highlight named a destination it was not offering.** `chatSub` started `null`, so a console loaded straight onto a non-Room route highlighted the first desk while clicking Room ran chat's own bare-route restoration and landed on the remembered channel. Seeded from `readLastChannel(scope)` — the same value chat restores from, read the same scoped way. Verified in a browser: with `site-rebuild` remembered, a fresh load on `#/company` highlights **site-rebuild** and Room lands on `#/chat/site_rebuild`.

Also declined, with evidence: tinysweeper flagged `companyPeople` as undefined. It is a `ChatView` prop declared at `ChatView.tsx:205`, destructured at `:437` and passed from `app-shell.tsx:3612` — untouched by this PR, and only in the diff because the pane moved inside the `routeOpen` gate and re-indented. An undefined identifier here is a compile error, not a `ReferenceError`, and all three typecheck gates are clean.


**Round 6, Codex, two follow-ups on round 5's own fix** — both mine, both fixed:

- **The counter counted the mount.** The console opens on `#/chat`, so `routeOpen` was true at mount and every re-keyed read ran twice in a row — and `loadDesks` clears the desk list on its way, so the pane dropped back to its loading state a frame after it had arrived. It counts a genuine `false → true` transition after the mount now, with the ref seeded from `routeOpen` so mounting *on* Room does not count while mounting off it still leaves the next entry counting.
- **Cognition was left out, wrongly.** I had reasoned its `visibilitychange` refresh was enough. That event is about the **tab**, not the route: an admin who follows the Room warning to Settings → Inference, configures a provider and comes back has never hidden the tab — so the stale warning that sent them there in the first place would have stayed. Six reads now, and the reasoning is written into the doc so nobody re-derives that `visibilitychange` looks sufficient.


**Round 7, Codex — the one the re-keying created.** Making those reads re-run on entry lets two of them overlap for the first time: a console that loads off Room and is taken *into* Room before the first `listTeam` settles starts a second one beside it. `boot` was the only one of the six without a run token — `loadDesks`, `viewerRun`, `directoryEpoch` and the cognition `ticket` all had one — and its catch writes unconditionally, so an older rejection landing after a newer success replaced a real roster with `[]` / `fromHost: false`. Direct messages gone from the pinned rail, and "New channel" with them (it is gated on `fromHost && members.length > 0`), until some later entry happened to correct it. It carries a ticket now, guarded on both exits and on the `finally`.

## Review summary

**Ten findings across seven rounds**, from Codex (8), CodeRabbit (1) and tinysweeper (1). Nine fixed, each answered on its own thread with what was verified and how; one declined with evidence — tinysweeper's `companyPeople`, a variable it could not see because it reads the diff alone, which its own next pass then cleared. Every reviewer that gives a verdict is now approving.

Seven of the nine were consequences of one decision — keeping `ChatView` mounted — and they are worth reading as a set, because each is the same shape: **something that used to be re-done by a remount, and now is not.** The route it steered, the dialogs it left open, the `aria-current` it kept claiming, the reads it stopped refreshing, the highlight it seeded from nothing, the query it consumed twice, the roster read that could now overlap itself. That is the real cost of the portal route, and it is larger than the "~2,400 lines stay mounted" line the issue anticipated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shared section navigation rail within the main content area for section-specific pages.
  - Finance pages now appear as nested navigation options within the section rail.
  - The Room channel list remains available in the sidebar across all sections.
  - Chat state and channel selections are preserved when moving between sections.
  - Thread links now respond correctly to URL changes and close stale thread panels when navigating away.

- **Accessibility**
  - Improved active-page indicators and navigation labels across section and channel rails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->