### PR TITLE
fix(finance): derive the invoice idempotency key from the invoice, not the dialog

### DIFF
--- a/docs/spec/runtime/finance-console.md
+++ b/docs/spec/runtime/finance-console.md
@@ -245,10 +245,17 @@ Two corrections to that reporting came out of issue #1796:
     labelled with the currency and shows the minor-unit value it will send. The
     `*_in_minor_units` naming exists because "invoice Alan $100" becomes a $1.00
     invoice otherwise, and a UI that hides the unit re-opens exactly that hole.
-  - **Idempotency.** The dialog mints a `idempotency_key` on open and sends it,
-    so a double-clicked Send is one invoice. `InvoiceSummary` sets a replay flag
-    when Chargebee returned an earlier invoice for the key — the toast says
-    "already sent" rather than "sent", because a replayed response is otherwise
+  - **Idempotency.** The `idempotency_key` is derived from the invoice's own
+    content — customer, currency, due term, line items — via
+    `deriveInvoiceIdempotencyKey`, not minted on open, so a double-clicked Send
+    and a close-reopen retry of the same failed send are both one invoice.
+    `invoice-force-new` folds a nonce into the hash for a deliberate duplicate,
+    minted once when the box is checked and reused across a retry — including
+    a close/reopen or a remount — until the send succeeds or the box is
+    unchecked, so an ambiguous forced-send failure cannot mint a second real
+    invoice on retry. `InvoiceSummary` sets a replay flag when Chargebee
+    returned an earlier invoice for the key — the toast says "already sent"
+    rather than "sent", because a replayed response is otherwise
     byte-identical to a fresh one.
 - **Webhook** — the panel shows `webhookUrl` with a copy button, exactly as
   `BillingView` does now, and says plainly when the host has no public URL that

--- a/frontend/src/views/finance/SendInvoiceDialog.tsx
+++ b/frontend/src/views/finance/SendInvoiceDialog.tsx
@@ -167,9 +167,9 @@ export function SendInvoiceDialog({
   // own: the form is blank, and a blank form is not that invoice.
   useEffect(() => {
     if (!open || !invoiceKey) return;
-    const held = readUnresolvedForceNew(scope);
-    if (held && held.invoiceKey === invoiceKey && forceNewNonce !== held.nonce) {
-      setForceNewNonce(held.nonce);
+    const held = readUnresolvedForceNew(scope, invoiceKey);
+    if (held && forceNewNonce !== held) {
+      setForceNewNonce(held);
       setForceNew(true);
       setForceNewAttempted(true);
     }
@@ -181,7 +181,7 @@ export function SendInvoiceDialog({
     if (forceNew) {
       setForceNewAttempted(true);
       if (forceNewNonce && invoiceKey) {
-        writeUnresolvedForceNew(scope, { invoiceKey, nonce: forceNewNonce });
+        writeUnresolvedForceNew(scope, invoiceKey, forceNewNonce);
       }
     }
     try {
@@ -219,7 +219,7 @@ export function SendInvoiceDialog({
       setForceNew(false);
       setForceNewNonce(undefined);
       setForceNewAttempted(false);
-      clearUnresolvedForceNew(scope);
+      if (invoiceKey) clearUnresolvedForceNew(scope, invoiceKey);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Could not raise the invoice.");
     } finally {
@@ -330,7 +330,7 @@ export function SendInvoiceDialog({
                 setForceNew(checked);
                 setForceNewNonce(checked ? crypto.randomUUID() : undefined);
                 setForceNewAttempted(false);
-                if (!checked) clearUnresolvedForceNew(scope);
+                if (!checked && invoiceKey) clearUnresolvedForceNew(scope, invoiceKey);
               }}
             />
             <span>

--- a/frontend/src/views/finance/SendInvoiceDialog.tsx
+++ b/frontend/src/views/finance/SendInvoiceDialog.tsx
@@ -83,7 +83,10 @@ function parseDueDays(raw: string): number | null | undefined {
  * key and the reply is byte-identical to a fresh one, so
  * `replayed_earlier_invoice` is the only way to tell — and the toast says
  * "already sent" rather than "sent" when it is set. `invoice-force-new`
- * mints a fresh nonce into the hash for the rare deliberate duplicate.
+ * mints a nonce into the hash for the rare deliberate duplicate — once, when
+ * the box is checked, not per send, so a retry of the same forced send
+ * (another ambiguous timeout) reuses it instead of minting a second real
+ * invoice.
  *
  * # Naming the money
  *
@@ -107,12 +110,16 @@ export function SendInvoiceDialog({
   const [dueDays, setDueDays] = useState("");
   const [busy, setBusy] = useState(false);
   const [forceNew, setForceNew] = useState(false);
+  const [forceNewNonce, setForceNewNonce] = useState<string>();
 
   // Reset on every open, so the operator has to re-assert "this is a
   // deliberate duplicate" each time rather than it silently staying on from a
   // previous send.
   useEffect(() => {
-    if (open) setForceNew(false);
+    if (open) {
+      setForceNew(false);
+      setForceNewNonce(undefined);
+    }
   }, [open]);
 
   const minor = toMinorUnits(amount, currency);
@@ -136,7 +143,7 @@ export function SendInvoiceDialog({
           dueDays: due,
           lineItems: [{ description, amountInMinorUnits: minor }],
         },
-        forceNew ? crypto.randomUUID() : undefined,
+        forceNew ? forceNewNonce : undefined,
       );
       const invoice = await sendInvoice(client, company, {
         customer_email: email.trim(),
@@ -161,6 +168,7 @@ export function SendInvoiceDialog({
       setAmount("");
       setDueDays("");
       setForceNew(false);
+      setForceNewNonce(undefined);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Could not raise the invoice.");
     } finally {
@@ -265,7 +273,11 @@ export function SendInvoiceDialog({
               className="mt-0.5"
               data-testid="invoice-force-new"
               checked={forceNew}
-              onChange={(e) => setForceNew(e.target.checked)}
+              onChange={(e) => {
+                const checked = e.target.checked;
+                setForceNew(checked);
+                setForceNewNonce(checked ? crypto.randomUUID() : undefined);
+              }}
             />
             <span>
               This is a deliberate duplicate — send it as a new invoice, not a retry of an earlier

--- a/frontend/src/views/finance/SendInvoiceDialog.tsx
+++ b/frontend/src/views/finance/SendInvoiceDialog.tsx
@@ -84,9 +84,11 @@ function parseDueDays(raw: string): number | null | undefined {
  * `replayed_earlier_invoice` is the only way to tell — and the toast says
  * "already sent" rather than "sent" when it is set. `invoice-force-new`
  * mints a nonce into the hash for the rare deliberate duplicate — once, when
- * the box is checked, not per send, so a retry of the same forced send
- * (another ambiguous timeout) reuses it instead of minting a second real
- * invoice.
+ * the box is checked, not per send, and it survives a retry of that same
+ * forced send, close-reopen included, until it succeeds or the operator
+ * unchecks the box to start a separate deliberate resend. Otherwise a second
+ * ambiguous timeout on the forced path would mint a second real invoice —
+ * the exact failure this dialog exists to prevent.
  *
  * # Naming the money
  *
@@ -111,16 +113,19 @@ export function SendInvoiceDialog({
   const [busy, setBusy] = useState(false);
   const [forceNew, setForceNew] = useState(false);
   const [forceNewNonce, setForceNewNonce] = useState<string>();
+  const [forceNewAttempted, setForceNewAttempted] = useState(false);
 
-  // Reset on every open, so the operator has to re-assert "this is a
-  // deliberate duplicate" each time rather than it silently staying on from a
-  // previous send.
+  // Reset on open — but only when the last checked box never reached an
+  // attempted send. An attempted-and-unresolved forced send (ambiguous
+  // failure) must survive a close/reopen of the same invoice so a retry
+  // reuses its nonce instead of raising a second real one; only a box that
+  // was checked and abandoned (cancelled, never sent) resets.
   useEffect(() => {
-    if (open) {
+    if (open && !forceNewAttempted) {
       setForceNew(false);
       setForceNewNonce(undefined);
     }
-  }, [open]);
+  }, [open, forceNewAttempted]);
 
   const minor = toMinorUnits(amount, currency);
   const live = looksLive(site);
@@ -135,6 +140,7 @@ export function SendInvoiceDialog({
   async function onSubmit() {
     if (minor === null || minor <= 0 || due === null) return;
     setBusy(true);
+    if (forceNew) setForceNewAttempted(true);
     try {
       const idempotencyKey = deriveInvoiceIdempotencyKey(
         {
@@ -169,6 +175,7 @@ export function SendInvoiceDialog({
       setDueDays("");
       setForceNew(false);
       setForceNewNonce(undefined);
+      setForceNewAttempted(false);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Could not raise the invoice.");
     } finally {
@@ -277,6 +284,7 @@ export function SendInvoiceDialog({
                 const checked = e.target.checked;
                 setForceNew(checked);
                 setForceNewNonce(checked ? crypto.randomUUID() : undefined);
+                setForceNewAttempted(false);
               }}
             />
             <span>

--- a/frontend/src/views/finance/SendInvoiceDialog.tsx
+++ b/frontend/src/views/finance/SendInvoiceDialog.tsx
@@ -16,6 +16,12 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useLocalScope } from "@/connections/ConnectionContext";
+import {
+  clearUnresolvedForceNew,
+  readUnresolvedForceNew,
+  writeUnresolvedForceNew,
+} from "@/views/finance/forceNewNonceStore";
 import { deriveInvoiceIdempotencyKey } from "@/views/finance/invoiceKey";
 import { fromMinorUnits, toMinorUnits } from "@/views/finance/money";
 
@@ -85,10 +91,13 @@ function parseDueDays(raw: string): number | null | undefined {
  * "already sent" rather than "sent" when it is set. `invoice-force-new`
  * mints a nonce into the hash for the rare deliberate duplicate — once, when
  * the box is checked, not per send, and it survives a retry of that same
- * forced send, close-reopen included, until it succeeds or the operator
- * unchecks the box to start a separate deliberate resend. Otherwise a second
- * ambiguous timeout on the forced path would mint a second real invoice —
- * the exact failure this dialog exists to prevent.
+ * forced send, close-reopen and remount included, until it succeeds or the
+ * operator unchecks the box to start a separate deliberate resend. An
+ * attempted-and-unresolved nonce is latched to `localStorage`
+ * (`forceNewNonceStore`), so leaving Finance and coming back, or a page
+ * reload, does not lose it either. Otherwise a second ambiguous timeout on
+ * the forced path would mint a second real invoice — the exact failure this
+ * dialog exists to prevent.
  *
  * # Naming the money
  *
@@ -111,15 +120,20 @@ export function SendInvoiceDialog({
   const [amount, setAmount] = useState("");
   const [dueDays, setDueDays] = useState("");
   const [busy, setBusy] = useState(false);
-  const [forceNew, setForceNew] = useState(false);
-  const [forceNewNonce, setForceNewNonce] = useState<string>();
-  const [forceNewAttempted, setForceNewAttempted] = useState(false);
+  const scope = useLocalScope();
+  const [forceNewNonce, setForceNewNonce] = useState<string | undefined>(() =>
+    readUnresolvedForceNew(scope),
+  );
+  const [forceNew, setForceNew] = useState(forceNewNonce !== undefined);
+  const [forceNewAttempted, setForceNewAttempted] = useState(forceNewNonce !== undefined);
 
   // Reset on open — but only when the last checked box never reached an
   // attempted send. An attempted-and-unresolved forced send (ambiguous
-  // failure) must survive a close/reopen of the same invoice so a retry
-  // reuses its nonce instead of raising a second real one; only a box that
-  // was checked and abandoned (cancelled, never sent) resets.
+  // failure) must survive a close/reopen or a remount of the same invoice so
+  // a retry reuses its nonce instead of raising a second real one; only a box
+  // that was checked and abandoned (cancelled, never sent) resets. The
+  // `forceNewAttempted` initial value already reflects a latch restored from
+  // `localStorage`, so this runs true to that on the very first open too.
   useEffect(() => {
     if (open && !forceNewAttempted) {
       setForceNew(false);
@@ -140,7 +154,10 @@ export function SendInvoiceDialog({
   async function onSubmit() {
     if (minor === null || minor <= 0 || due === null) return;
     setBusy(true);
-    if (forceNew) setForceNewAttempted(true);
+    if (forceNew) {
+      setForceNewAttempted(true);
+      if (forceNewNonce) writeUnresolvedForceNew(scope, forceNewNonce);
+    }
     try {
       const idempotencyKey = deriveInvoiceIdempotencyKey(
         {
@@ -176,6 +193,7 @@ export function SendInvoiceDialog({
       setForceNew(false);
       setForceNewNonce(undefined);
       setForceNewAttempted(false);
+      clearUnresolvedForceNew(scope);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Could not raise the invoice.");
     } finally {
@@ -285,6 +303,7 @@ export function SendInvoiceDialog({
                 setForceNew(checked);
                 setForceNewNonce(checked ? crypto.randomUUID() : undefined);
                 setForceNewAttempted(false);
+                if (!checked) clearUnresolvedForceNew(scope);
               }}
             />
             <span>

--- a/frontend/src/views/finance/SendInvoiceDialog.tsx
+++ b/frontend/src/views/finance/SendInvoiceDialog.tsx
@@ -91,13 +91,15 @@ function parseDueDays(raw: string): number | null | undefined {
  * "already sent" rather than "sent" when it is set. `invoice-force-new`
  * mints a nonce into the hash for the rare deliberate duplicate — once, when
  * the box is checked, not per send, and it survives a retry of that same
- * forced send, close-reopen and remount included, until it succeeds or the
- * operator unchecks the box to start a separate deliberate resend. An
- * attempted-and-unresolved nonce is latched to `localStorage`
- * (`forceNewNonceStore`), so leaving Finance and coming back, or a page
- * reload, does not lose it either. Otherwise a second ambiguous timeout on
- * the forced path would mint a second real invoice — the exact failure this
- * dialog exists to prevent.
+ * forced send, close-reopen included, until it succeeds or the operator
+ * unchecks the box to start a separate deliberate resend. An
+ * attempted-and-unresolved nonce is latched (`forceNewNonceStore`) against
+ * the invoice it was minted for, so retyping that same invoice after a
+ * reload re-adopts it while a different invoice gets its own. Otherwise a
+ * second ambiguous timeout on the forced path would mint a second real
+ * invoice — the exact failure this dialog exists to prevent. The box is
+ * frozen while a send is in flight, so a mid-flight toggle cannot replace
+ * the nonce the pending request already carries.
  *
  * # Naming the money
  *
@@ -121,19 +123,15 @@ export function SendInvoiceDialog({
   const [dueDays, setDueDays] = useState("");
   const [busy, setBusy] = useState(false);
   const scope = useLocalScope();
-  const [forceNewNonce, setForceNewNonce] = useState<string | undefined>(() =>
-    readUnresolvedForceNew(scope),
-  );
-  const [forceNew, setForceNew] = useState(forceNewNonce !== undefined);
-  const [forceNewAttempted, setForceNewAttempted] = useState(forceNewNonce !== undefined);
+  const [forceNewNonce, setForceNewNonce] = useState<string>();
+  const [forceNew, setForceNew] = useState(false);
+  const [forceNewAttempted, setForceNewAttempted] = useState(false);
 
   // Reset on open — but only when the last checked box never reached an
   // attempted send. An attempted-and-unresolved forced send (ambiguous
-  // failure) must survive a close/reopen or a remount of the same invoice so
-  // a retry reuses its nonce instead of raising a second real one; only a box
-  // that was checked and abandoned (cancelled, never sent) resets. The
-  // `forceNewAttempted` initial value already reflects a latch restored from
-  // `localStorage`, so this runs true to that on the very first open too.
+  // failure) must survive a close/reopen of the same invoice so a retry
+  // reuses its nonce instead of raising a second real one; only a box that
+  // was checked and abandoned (cancelled, never sent) resets.
   useEffect(() => {
     if (open && !forceNewAttempted) {
       setForceNew(false);
@@ -151,12 +149,40 @@ export function SendInvoiceDialog({
     minor > 0 &&
     due !== null;
 
+  // The invoice's own identity, independent of any nonce. This is what a
+  // held nonce is matched against, so a nonce minted for one invoice can
+  // never be folded into another's key.
+  const invoiceKey =
+    minor !== null && due !== null
+      ? deriveInvoiceIdempotencyKey({
+          customerEmail: email,
+          currencyCode: currency,
+          dueDays: due,
+          lineItems: [{ description, amountInMinorUnits: minor }],
+        })
+      : undefined;
+
+  // Re-adopt an unresolved forced send only once the operator has retyped
+  // the same invoice it was minted for. A remount restores nothing on its
+  // own: the form is blank, and a blank form is not that invoice.
+  useEffect(() => {
+    if (!open || !invoiceKey) return;
+    const held = readUnresolvedForceNew(scope);
+    if (held && held.invoiceKey === invoiceKey && forceNewNonce !== held.nonce) {
+      setForceNewNonce(held.nonce);
+      setForceNew(true);
+      setForceNewAttempted(true);
+    }
+  }, [open, invoiceKey, scope, forceNewNonce]);
+
   async function onSubmit() {
     if (minor === null || minor <= 0 || due === null) return;
     setBusy(true);
     if (forceNew) {
       setForceNewAttempted(true);
-      if (forceNewNonce) writeUnresolvedForceNew(scope, forceNewNonce);
+      if (forceNewNonce && invoiceKey) {
+        writeUnresolvedForceNew(scope, { invoiceKey, nonce: forceNewNonce });
+      }
     }
     try {
       const idempotencyKey = deriveInvoiceIdempotencyKey(
@@ -298,6 +324,7 @@ export function SendInvoiceDialog({
               className="mt-0.5"
               data-testid="invoice-force-new"
               checked={forceNew}
+              disabled={busy}
               onChange={(e) => {
                 const checked = e.target.checked;
                 setForceNew(checked);

--- a/frontend/src/views/finance/SendInvoiceDialog.tsx
+++ b/frontend/src/views/finance/SendInvoiceDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Loader2, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { deriveInvoiceIdempotencyKey } from "@/views/finance/invoiceKey";
 import { fromMinorUnits, toMinorUnits } from "@/views/finance/money";
 
 interface Props {
@@ -74,11 +75,15 @@ function parseDueDays(raw: string): number | null | undefined {
  *
  * # Idempotency
  *
- * The key is minted **once when the dialog opens** and reused for every attempt
- * from it. A double-clicked Send is therefore one invoice. Chargebee replays
- * the original for a repeated key and the reply is byte-identical to a fresh
- * one, so `replayed_earlier_invoice` is the only way to tell — and the toast
- * says "already sent" rather than "sent" when it is set.
+ * The key is derived from the invoice's own content — see
+ * `deriveInvoiceIdempotencyKey` — not from when the dialog opened. A
+ * double-clicked Send is one invoice, and so is a failed send followed by a
+ * close-reopen-resend of the *same* invoice, because the fields that identify
+ * it hash the same either way. Chargebee replays the original for a repeated
+ * key and the reply is byte-identical to a fresh one, so
+ * `replayed_earlier_invoice` is the only way to tell — and the toast says
+ * "already sent" rather than "sent" when it is set. `invoice-force-new`
+ * mints a fresh nonce into the hash for the rare deliberate duplicate.
  *
  * # Naming the money
  *
@@ -101,14 +106,14 @@ export function SendInvoiceDialog({
   const [amount, setAmount] = useState("");
   const [dueDays, setDueDays] = useState("");
   const [busy, setBusy] = useState(false);
+  const [forceNew, setForceNew] = useState(false);
 
-  // One key per opening of the dialog — not per click, which would bill twice,
-  // and not per mount, which would survive a close and silently replay an
-  // earlier invoice the next time the dialog was used.
-  const idempotencyKey = useMemo(
-    () => (open ? `console-${crypto.randomUUID()}` : ""),
-    [open],
-  );
+  // Reset on every open, so the operator has to re-assert "this is a
+  // deliberate duplicate" each time rather than it silently staying on from a
+  // previous send.
+  useEffect(() => {
+    if (open) setForceNew(false);
+  }, [open]);
 
   const minor = toMinorUnits(amount, currency);
   const live = looksLive(site);
@@ -124,6 +129,15 @@ export function SendInvoiceDialog({
     if (minor === null || minor <= 0 || due === null) return;
     setBusy(true);
     try {
+      const idempotencyKey = deriveInvoiceIdempotencyKey(
+        {
+          customerEmail: email,
+          currencyCode: currency,
+          dueDays: due,
+          lineItems: [{ description, amountInMinorUnits: minor }],
+        },
+        forceNew ? crypto.randomUUID() : undefined,
+      );
       const invoice = await sendInvoice(client, company, {
         customer_email: email.trim(),
         customer_name: name.trim() || undefined,
@@ -146,6 +160,7 @@ export function SendInvoiceDialog({
       setDescription("");
       setAmount("");
       setDueDays("");
+      setForceNew(false);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Could not raise the invoice.");
     } finally {
@@ -243,6 +258,20 @@ export function SendInvoiceDialog({
               onChange={(e) => setDueDays(e.target.value)}
             />
           </div>
+
+          <label className="flex items-start gap-2 text-sm text-muted-foreground">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              data-testid="invoice-force-new"
+              checked={forceNew}
+              onChange={(e) => setForceNew(e.target.checked)}
+            />
+            <span>
+              This is a deliberate duplicate — send it as a new invoice, not a retry of an earlier
+              one for the same customer and amount.
+            </span>
+          </label>
 
           {live ? (
             <Alert variant="destructive" data-testid="invoice-live-warning">

--- a/frontend/src/views/finance/forceNewNonceStore.ts
+++ b/frontend/src/views/finance/forceNewNonceStore.ts
@@ -1,0 +1,72 @@
+/**
+ * Persists the nonce of an unresolved deliberate-duplicate ("force new")
+ * invoice send, so it survives whatever unmounts `SendInvoiceDialog` —
+ * navigating away from Finance and back, or a page reload.
+ *
+ * The nonce is component state (`SendInvoiceDialog`'s own `forceNewNonce`)
+ * for as long as the component stays mounted, which is enough for a
+ * same-mount close/reopen retry. It is not enough for a genuine remount: an
+ * ambiguous forced-send failure (timeout, dropped connection) followed by
+ * leaving the page loses both the nonce and the fact that a forced send is
+ * outstanding, so a retry after coming back checks the box again, mints a
+ * fresh nonce, and can raise a second real invoice — the exact failure this
+ * dialog exists to prevent, one layer further out.
+ *
+ * Scoped by `LocalScope` (connection + company), not company alone, for the
+ * same reason every other browser-local key in the console is — see
+ * `connections/types.ts`.
+ */
+
+import { type LocalScope, scopedKey } from "@/connections/types";
+
+function keyFor(scope: LocalScope): string {
+  return scopedKey("oc.finance.invoice-force-new", scope);
+}
+
+/**
+ * `localStorage`, or `null` where it isn't usable.
+ *
+ * Access itself can throw — Safari's private mode and a "block all cookies"
+ * setting both make the property itself raise rather than return a dud
+ * object. Losing the latch is the safe direction: the dialog degrades to
+ * exactly its pre-fix behavior, not a crash.
+ */
+function storage(): Storage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The nonce of a forced send that has not yet resolved for this scope, or
+ * `undefined` if none is outstanding.
+ */
+export function readUnresolvedForceNew(scope: LocalScope): string | undefined {
+  const raw = storage()?.getItem(keyFor(scope));
+  return raw && raw.length > 0 ? raw : undefined;
+}
+
+/** Marks a forced send as attempted and unresolved. */
+export function writeUnresolvedForceNew(scope: LocalScope, nonce: string): void {
+  const store = storage();
+  if (!store) return;
+  try {
+    store.setItem(keyFor(scope), nonce);
+  } catch {
+    // A full or read-only quota is not worth failing a send over — the latch
+    // just does not survive a remount, same as before this fix existed.
+  }
+}
+
+/** Clears the latch: the forced send succeeded, or the operator started over. */
+export function clearUnresolvedForceNew(scope: LocalScope): void {
+  const store = storage();
+  if (!store) return;
+  try {
+    store.removeItem(keyFor(scope));
+  } catch {
+    // Nothing to do about a store that will not let us clear it either.
+  }
+}

--- a/frontend/src/views/finance/forceNewNonceStore.ts
+++ b/frontend/src/views/finance/forceNewNonceStore.ts
@@ -39,24 +39,48 @@ function storage(): Storage | null {
   }
 }
 
-/**
- * The nonce of a forced send that has not yet resolved for this scope, or
- * `undefined` if none is outstanding.
- */
-export function readUnresolvedForceNew(scope: LocalScope): string | undefined {
-  const raw = storage()?.getItem(keyFor(scope));
-  return raw && raw.length > 0 ? raw : undefined;
+/** A forced send that was attempted for one specific invoice and never resolved. */
+export interface UnresolvedForceNew {
+  /** The invoice's content-derived key, WITHOUT the nonce folded in. */
+  invoiceKey: string;
+  nonce: string;
 }
 
-/** Marks a forced send as attempted and unresolved. */
-export function writeUnresolvedForceNew(scope: LocalScope, nonce: string): void {
+/**
+ * The unresolved forced send held for this scope, or `undefined`.
+ *
+ * Carries the invoice it belongs to, because a nonce is meaningful only for
+ * the invoice it was minted against: restoring it onto a different invoice
+ * would fold one invoice's nonce into another's key and have the host dedupe
+ * a genuinely new invoice away as a replay of the old one.
+ */
+export function readUnresolvedForceNew(scope: LocalScope): UnresolvedForceNew | undefined {
+  const raw = storage()?.getItem(keyFor(scope));
+  if (!raw) return undefined;
+  try {
+    const held: unknown = JSON.parse(raw);
+    if (
+      typeof held === "object" &&
+      held !== null &&
+      typeof (held as UnresolvedForceNew).invoiceKey === "string" &&
+      typeof (held as UnresolvedForceNew).nonce === "string"
+    ) {
+      return held as UnresolvedForceNew;
+    }
+  } catch {
+    // A value this cannot read is a value it must not act on.
+  }
+  return undefined;
+}
+
+/** Marks a forced send of one invoice as attempted and unresolved. */
+export function writeUnresolvedForceNew(scope: LocalScope, held: UnresolvedForceNew): void {
   const store = storage();
   if (!store) return;
   try {
-    store.setItem(keyFor(scope), nonce);
+    store.setItem(keyFor(scope), JSON.stringify(held));
   } catch {
-    // A full or read-only quota is not worth failing a send over — the latch
-    // just does not survive a remount, same as before this fix existed.
+    // A full or read-only quota is not worth failing a send over.
   }
 }
 

--- a/frontend/src/views/finance/forceNewNonceStore.ts
+++ b/frontend/src/views/finance/forceNewNonceStore.ts
@@ -14,13 +14,20 @@
  *
  * Scoped by `LocalScope` (connection + company), not company alone, for the
  * same reason every other browser-local key in the console is — see
- * `connections/types.ts`.
+ * `connections/types.ts` — and further scoped by the invoice's own
+ * content-derived key, because a nonce is meaningful only for the invoice it
+ * was minted against. A single slot per connection/company let an unrelated
+ * invoice's write or successful resolve clobber a still-unresolved one: start
+ * (or finish) a forced send for invoice B while invoice A's forced send from
+ * earlier is still unresolved, and A's entry was silently overwritten or
+ * erased, so a later retry of A minted a fresh nonce and could bill it twice.
+ * One key per invoice means resolving B never touches A's entry.
  */
 
 import { type LocalScope, scopedKey } from "@/connections/types";
 
-function keyFor(scope: LocalScope): string {
-  return scopedKey("oc.finance.invoice-force-new", scope);
+function keyFor(scope: LocalScope, invoiceKey: string): string {
+  return scopedKey(`oc.finance.invoice-force-new.${invoiceKey}`, scope);
 }
 
 /**
@@ -39,57 +46,36 @@ function storage(): Storage | null {
   }
 }
 
-/** A forced send that was attempted for one specific invoice and never resolved. */
-export interface UnresolvedForceNew {
-  /** The invoice's content-derived key, WITHOUT the nonce folded in. */
-  invoiceKey: string;
-  nonce: string;
-}
-
 /**
- * The unresolved forced send held for this scope, or `undefined`.
- *
- * Carries the invoice it belongs to, because a nonce is meaningful only for
- * the invoice it was minted against: restoring it onto a different invoice
- * would fold one invoice's nonce into another's key and have the host dedupe
- * a genuinely new invoice away as a replay of the old one.
+ * The nonce of a forced send that has not yet resolved for this scope and
+ * invoice, or `undefined` if none is outstanding.
  */
-export function readUnresolvedForceNew(scope: LocalScope): UnresolvedForceNew | undefined {
-  const raw = storage()?.getItem(keyFor(scope));
-  if (!raw) return undefined;
-  try {
-    const held: unknown = JSON.parse(raw);
-    if (
-      typeof held === "object" &&
-      held !== null &&
-      typeof (held as UnresolvedForceNew).invoiceKey === "string" &&
-      typeof (held as UnresolvedForceNew).nonce === "string"
-    ) {
-      return held as UnresolvedForceNew;
-    }
-  } catch {
-    // A value this cannot read is a value it must not act on.
-  }
-  return undefined;
+export function readUnresolvedForceNew(scope: LocalScope, invoiceKey: string): string | undefined {
+  const raw = storage()?.getItem(keyFor(scope, invoiceKey));
+  return raw && raw.length > 0 ? raw : undefined;
 }
 
 /** Marks a forced send of one invoice as attempted and unresolved. */
-export function writeUnresolvedForceNew(scope: LocalScope, held: UnresolvedForceNew): void {
+export function writeUnresolvedForceNew(
+  scope: LocalScope,
+  invoiceKey: string,
+  nonce: string,
+): void {
   const store = storage();
   if (!store) return;
   try {
-    store.setItem(keyFor(scope), JSON.stringify(held));
+    store.setItem(keyFor(scope, invoiceKey), nonce);
   } catch {
     // A full or read-only quota is not worth failing a send over.
   }
 }
 
-/** Clears the latch: the forced send succeeded, or the operator started over. */
-export function clearUnresolvedForceNew(scope: LocalScope): void {
+/** Clears the latch: this invoice's forced send succeeded, or the operator started over. */
+export function clearUnresolvedForceNew(scope: LocalScope, invoiceKey: string): void {
   const store = storage();
   if (!store) return;
   try {
-    store.removeItem(keyFor(scope));
+    store.removeItem(keyFor(scope, invoiceKey));
   } catch {
     // Nothing to do about a store that will not let us clear it either.
   }

--- a/frontend/src/views/finance/invoiceKey.ts
+++ b/frontend/src/views/finance/invoiceKey.ts
@@ -1,0 +1,108 @@
+/**
+ * Derives the Chargebee idempotency key for a `SendInvoiceDialog` send.
+ *
+ * A plain module with no React in it, matching `money.ts` — the derivation is
+ * pure and worth testing without mounting a component.
+ *
+ * # Why derived from the invoice, not minted per dialog-open
+ *
+ * The host itself (`chargebee::api::derived_idempotency_key`) hashes the
+ * outgoing form when the caller supplies no key, so that a transport retry of
+ * the *same* request collapses to one invoice. The console used to defeat that
+ * by always supplying a key, minted once per dialog-open — which protects a
+ * same-session double-click and nothing else. An operator who sees an
+ * ambiguous result (timeout, dropped connection, 5xx), closes the dialog and
+ * reopens it to try again gets a brand-new random key on reopen, so the retry
+ * looks like an unrelated invoice to Chargebee and bills the customer twice.
+ *
+ * The fix is the same idea the host already uses: hash the fields that
+ * identify *what is being invoiced* — the customer, the currency, the due
+ * term, and the line items — so the key is a function of the invoice's
+ * content, not of when the dialog happened to be open. Two sends of the same
+ * invoice hash the same however many times the dialog is closed, reopened, or
+ * the tab reloaded; changing any of those fields changes the key.
+ *
+ * `customer_name` and `auto_collection` are left out on purpose, mirroring the
+ * host: the host's own hash is taken over the resolved `customer_id` (not the
+ * name, which only affects customer creation) plus currency, due term and line
+ * items — the console does not know `customer_id` yet at derive-time, so email
+ * stands in for customer identity here.
+ *
+ * # FNV-1a, not a JS hash builtin
+ *
+ * Same reasoning as the host: the key has to be stable as a *value*, across
+ * browser sessions and app versions, not merely within one runtime's hash
+ * implementation. The field separators (`=` and `&` after every field) keep
+ * `["ab", "c"]` from hashing the same as `["a", "bc"]`.
+ *
+ * # Deliberate resend
+ *
+ * An operator who wants to send the same invoice twice on purpose — the first
+ * attempt genuinely failed and they want a second, distinct one, not a
+ * dedup — needs an escape valve, the same way the host's tool schema lets a
+ * caller pass a distinct `idempotency_key` to get a second invoice. `nonce`
+ * exists for that: pass a freshly generated value only when the operator has
+ * explicitly said "this is a new invoice, not a retry" (`invoice-force-new` in
+ * the dialog), and it is folded into the hash so the key diverges. Omitted
+ * (the default), the key is fully determined by the invoice's content.
+ */
+
+const FNV_OFFSET_BASIS = 0xcbf29ce484222325n;
+const FNV_PRIME = 0x100000001b3n;
+const MASK_64 = 0xffffffffffffffffn;
+
+const encoder = new TextEncoder();
+
+function fnv1a64(fields: readonly (readonly [string, string])[]): bigint {
+  let hash = FNV_OFFSET_BASIS;
+  const eat = (text: string) => {
+    for (const byte of encoder.encode(text)) {
+      hash ^= BigInt(byte);
+      hash = (hash * FNV_PRIME) & MASK_64;
+    }
+  };
+  for (const [key, value] of fields) {
+    eat(key);
+    eat("=");
+    eat(value);
+    eat("&");
+  }
+  return hash;
+}
+
+/** One line item, as identified for the key — same shape as `ChargeLine`. */
+export interface InvoiceKeyLineItem {
+  description: string;
+  amountInMinorUnits: number;
+}
+
+/** The fields of a `SendInvoiceDialog` send that identify "the same invoice". */
+export interface InvoiceIdentity {
+  customerEmail: string;
+  currencyCode: string;
+  /** `undefined` means "no due date supplied" (Chargebee's site default). */
+  dueDays: number | undefined;
+  lineItems: readonly InvoiceKeyLineItem[];
+}
+
+/**
+ * Derives the idempotency key for an invoice send.
+ *
+ * Deterministic in `identity` alone. Pass `nonce` only for a deliberate
+ * resend — any non-empty, distinct value forces a different key.
+ */
+export function deriveInvoiceIdempotencyKey(identity: InvoiceIdentity, nonce?: string): string {
+  const fields: [string, string][] = [
+    ["customer_email", identity.customerEmail.trim().toLowerCase()],
+    ["currency_code", identity.currencyCode.trim().toUpperCase()],
+    ["due_days", identity.dueDays === undefined ? "" : String(identity.dueDays)],
+  ];
+  identity.lineItems.forEach((item, index) => {
+    fields.push([`line_item[${index}].description`, item.description.trim()]);
+    fields.push([`line_item[${index}].amount`, String(item.amountInMinorUnits)]);
+  });
+  if (nonce) {
+    fields.push(["force_new_nonce", nonce]);
+  }
+  return `console-invoice-${fnv1a64(fields).toString(16).padStart(16, "0")}`;
+}

--- a/frontend/test/unit/finance-company-switch.test.ts
+++ b/frontend/test/unit/finance-company-switch.test.ts
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
 import { InvoicingView } from "@/views/finance/InvoicingView";
 
 /**
@@ -55,10 +56,13 @@ let root: Root;
 async function showInvoicing(company: string) {
   await act(async () => {
     root.render(
-      createElement(InvoicingView, {
-        key: company,
-        client: clientFor(company),
-        company,
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "local", company },
+        children: createElement(InvoicingView, {
+          key: company,
+          client: clientFor(company),
+          company,
+        }),
       }),
     );
   });
@@ -87,6 +91,7 @@ beforeEach(() => {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
+  window.localStorage.clear();
 });
 
 afterEach(() => {

--- a/frontend/test/unit/finance-invoicing.test.ts
+++ b/frontend/test/unit/finance-invoicing.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
 import { InvoicingView } from "@/views/finance/InvoicingView";
 import { resolveFinancePage } from "@/views/finance/FinanceSection";
 
@@ -50,7 +51,12 @@ let root: Root;
 
 async function show(client: OpenCompanyClient) {
   await act(async () => {
-    root.render(createElement(InvoicingView, { client, company: "acme" }));
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "local", company: "acme" },
+        children: createElement(InvoicingView, { client, company: "acme" }),
+      }),
+    );
   });
 }
 
@@ -63,6 +69,7 @@ beforeEach(() => {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
+  window.localStorage.clear();
 });
 
 afterEach(() => {

--- a/frontend/test/unit/finance-send-invoice-idempotency.test.ts
+++ b/frontend/test/unit/finance-send-invoice-idempotency.test.ts
@@ -361,6 +361,37 @@ describe("SendInvoiceDialog idempotency key", () => {
     expect(forcedKey).not.toBe(ordinaryKey);
   });
 
+  it("reuses the same forced nonce when a retry follows a failed forced send", async () => {
+    sendInvoice.mockRejectedValueOnce(new Error("timeout"));
+    sendInvoice.mockResolvedValueOnce(invoiceReply());
+
+    act(() => {
+      root.render(
+        createElement(SendInvoiceDialog, {
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open: true,
+          onOpenChange: () => {},
+          onSent: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await toggleForceNew(true);
+    await clickSend();
+    const firstKey = lastSentKey();
+
+    // The failed send leaves `forceNew` checked; the operator retries
+    // without touching the checkbox — the same forced send, not a new one.
+    await clickSend();
+    const secondKey = lastSentKey();
+
+    expect(secondKey).toBe(firstKey);
+  });
+
   it("two separate deliberate resends of the same invoice do not collide with each other", async () => {
     sendInvoice.mockResolvedValue(invoiceReply());
     act(() => {

--- a/frontend/test/unit/finance-send-invoice-idempotency.test.ts
+++ b/frontend/test/unit/finance-send-invoice-idempotency.test.ts
@@ -1,0 +1,398 @@
+// @vitest-environment jsdom
+
+// CONSOLE-ADMIN-015: the idempotency key `SendInvoiceDialog` sends to the
+// host must be derived from the invoice's own content, not from when the
+// dialog was opened. Red-prove target: before the fix, the key was
+// `console-${crypto.randomUUID()}`, minted once per dialog-open — so an
+// operator who saw an ambiguous result (timeout, dropped connection, 5xx),
+// closed the dialog and reopened it to resend the *same* invoice got an
+// unrelated key, and Chargebee billed the customer twice.
+
+import { act, createElement, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { Invoice, SendInvoice } from "@/api/finance";
+
+const sendInvoice = vi.fn();
+
+vi.mock("@/api/finance", async (importActual) => {
+  const actual = await importActual<typeof import("@/api/finance")>();
+  return { ...actual, sendInvoice };
+});
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+const { SendInvoiceDialog } = await import("@/views/finance/SendInvoiceDialog");
+const { deriveInvoiceIdempotencyKey } = await import("@/views/finance/invoiceKey");
+
+const CLIENT = { scopeFor: () => "/api/v1/companies/acme" } as unknown as OpenCompanyClient;
+
+function invoiceReply(overrides: Partial<Invoice> = {}): Invoice {
+  return {
+    id: "inv_1",
+    customer_id: "cus_1",
+    status: "payment_due",
+    currency_code: "USD",
+    total_in_minor_units: 125_000,
+    amount_due_in_minor_units: 125_000,
+    amount_paid_in_minor_units: 0,
+    due_date: null,
+    line_items: ["Consulting"],
+    payment_url: null,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function at(testid: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** Fills every required field the way an operator does, so React state updates. */
+async function fillInvoiceFields(fields: {
+  email: string;
+  description: string;
+  amount: string;
+  dueDays?: string;
+}): Promise<void> {
+  await fill("invoice-email", fields.email);
+  await fill("invoice-description", fields.description);
+  await fill("invoice-amount", fields.amount);
+  await fill("invoice-due-days", fields.dueDays ?? "");
+}
+
+async function fill(testid: string, value: string): Promise<void> {
+  const input = at(testid) as HTMLInputElement | null;
+  if (!input) throw new Error(`no input ${testid}`);
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function toggleForceNew(checked: boolean): Promise<void> {
+  const box = at("invoice-force-new") as HTMLInputElement | null;
+  if (!box) throw new Error("no invoice-force-new checkbox");
+  await act(async () => {
+    box.checked = checked;
+    box.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+async function clickSend(): Promise<void> {
+  act(() => {
+    at("invoice-send")?.click();
+  });
+  await settle();
+}
+
+function lastSentKey(): string {
+  const calls = sendInvoice.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  const body = calls[calls.length - 1][2] as SendInvoice;
+  expect(body.idempotency_key).toBeTruthy();
+  return body.idempotency_key as string;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    root = createRoot(container);
+  });
+  sendInvoice.mockReset();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("SendInvoiceDialog idempotency key", () => {
+  it("matches the pure derivation for the fields on the form", async () => {
+    sendInvoice.mockResolvedValue(invoiceReply());
+    act(() => {
+      root.render(
+        createElement(SendInvoiceDialog, {
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open: true,
+          onOpenChange: () => {},
+          onSent: () => {},
+        }),
+      );
+    });
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00", dueDays: "7" });
+    await clickSend();
+
+    const expected = deriveInvoiceIdempotencyKey({
+      customerEmail: "alan@example.com",
+      currencyCode: "USD",
+      dueDays: 7,
+      lineItems: [{ description: "Consulting", amountInMinorUnits: 125_000 }],
+    });
+    expect(lastSentKey()).toBe(expected);
+  });
+
+  it("carries the same key when the same invoice is retried after a failed send", async () => {
+    sendInvoice.mockRejectedValueOnce(new Error("timeout"));
+    sendInvoice.mockResolvedValueOnce(invoiceReply());
+
+    act(() => {
+      root.render(
+        createElement(SendInvoiceDialog, {
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open: true,
+          onOpenChange: () => {},
+          onSent: () => {},
+        }),
+      );
+    });
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+
+    await clickSend();
+    const firstKey = lastSentKey();
+
+    // The failed send leaves the dialog open with the same field values still
+    // in it (the reset block only runs on success) — an operator clicking
+    // Send again on the same invoice, no reopen involved.
+    await clickSend();
+    const secondKey = lastSentKey();
+
+    expect(secondKey).toBe(firstKey);
+  });
+
+  /**
+   * Mirrors `InvoicingView`: one `SendInvoiceDialog` instance stays mounted
+   * for the life of the view, with `open` toggled by the parent's own
+   * `sending` state — the dialog is never torn down and remounted just to
+   * close it. `harness-reopen` stands in for whatever UI action
+   * (re-clicking "Send invoice" on the finance page) sets that state back to
+   * `true`.
+   */
+  function renderReopenableHarness() {
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      return createElement(
+        "div",
+        null,
+        createElement(
+          "button",
+          { "data-testid": "harness-reopen", onClick: () => setOpen(true) },
+          "reopen",
+        ),
+        createElement(SendInvoiceDialog, {
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open,
+          onOpenChange: setOpen,
+          onSent: () => {},
+        }),
+      );
+    }
+    act(() => {
+      root.render(createElement(Harness));
+    });
+  }
+
+  async function closeViaCancel(): Promise<void> {
+    const cancel = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent === "Cancel",
+    );
+    act(() => {
+      cancel?.click();
+    });
+    await settle();
+  }
+
+  async function reopen(): Promise<void> {
+    act(() => {
+      at("harness-reopen")?.click();
+    });
+    await settle();
+  }
+
+  it("carries the same key across a genuine close and reopen of the same invoice", async () => {
+    sendInvoice.mockRejectedValueOnce(new Error("timeout"));
+    sendInvoice.mockResolvedValueOnce(invoiceReply());
+
+    renderReopenableHarness();
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await clickSend();
+    const firstKey = lastSentKey();
+
+    // Operator sees the ambiguous failure, closes the dialog, and reopens it.
+    await closeViaCancel();
+    await reopen();
+
+    // Field state persisted on the same component instance the whole time —
+    // matching what an operator actually sees: the dialog remembers what
+    // they typed rather than presenting a blank form.
+    expect((at("invoice-email") as HTMLInputElement).value).toBe("alan@example.com");
+
+    await clickSend();
+    const secondKey = lastSentKey();
+
+    expect(secondKey).toBe(firstKey);
+  });
+
+  it("gives a different invoice a different key", async () => {
+    sendInvoice.mockResolvedValue(invoiceReply());
+    act(() => {
+      root.render(
+        createElement(SendInvoiceDialog, {
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open: true,
+          onOpenChange: () => {},
+          onSent: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await clickSend();
+    const firstKey = lastSentKey();
+
+    await fillInvoiceFields({ email: "bob@example.com", description: "Consulting", amount: "1250.00" });
+    await clickSend();
+    const secondKey = lastSentKey();
+
+    expect(secondKey).not.toBe(firstKey);
+  });
+
+  it("survives a full component remount for the same invoice", async () => {
+    sendInvoice.mockResolvedValue(invoiceReply());
+
+    function Mount({ instance }: { instance: string }) {
+      return createElement(SendInvoiceDialog, {
+        key: instance,
+        client: CLIENT,
+        company: "acme",
+        site: "acme-test",
+        open: true,
+        onOpenChange: () => {},
+        onSent: () => {},
+      });
+    }
+
+    act(() => {
+      root.render(createElement(Mount, { instance: "first" }));
+    });
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await clickSend();
+    const firstKey = lastSentKey();
+
+    // A different component instance entirely — same identity as far as
+    // React is concerned as a full unmount + fresh mount, e.g. navigating
+    // away from Finance and back.
+    act(() => {
+      root.render(createElement(Mount, { instance: "second" }));
+    });
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await clickSend();
+    const secondKey = lastSentKey();
+
+    expect(secondKey).toBe(firstKey);
+  });
+
+  it("a deliberate resend forces a different key from the default derivation", async () => {
+    sendInvoice.mockResolvedValue(invoiceReply());
+    act(() => {
+      root.render(
+        createElement(SendInvoiceDialog, {
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open: true,
+          onOpenChange: () => {},
+          onSent: () => {},
+        }),
+      );
+    });
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+
+    await clickSend();
+    const ordinaryKey = lastSentKey();
+
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await toggleForceNew(true);
+    await clickSend();
+    const forcedKey = lastSentKey();
+
+    expect(forcedKey).not.toBe(ordinaryKey);
+  });
+
+  it("two separate deliberate resends of the same invoice do not collide with each other", async () => {
+    sendInvoice.mockResolvedValue(invoiceReply());
+    act(() => {
+      root.render(
+        createElement(SendInvoiceDialog, {
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open: true,
+          onOpenChange: () => {},
+          onSent: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await toggleForceNew(true);
+    await clickSend();
+    const firstForced = lastSentKey();
+
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await toggleForceNew(true);
+    await clickSend();
+    const secondForced = lastSentKey();
+
+    expect(secondForced).not.toBe(firstForced);
+  });
+
+  it("resets the deliberate-resend toggle on every open, so it cannot leak into the next send", async () => {
+    renderReopenableHarness();
+    await settle();
+
+    await toggleForceNew(true);
+    expect((at("invoice-force-new") as HTMLInputElement).checked).toBe(true);
+
+    await closeViaCancel();
+    await reopen();
+
+    expect((at("invoice-force-new") as HTMLInputElement).checked).toBe(false);
+  });
+});

--- a/frontend/test/unit/finance-send-invoice-idempotency.test.ts
+++ b/frontend/test/unit/finance-send-invoice-idempotency.test.ts
@@ -8,12 +8,14 @@
 // closed the dialog and reopened it to resend the *same* invoice got an
 // unrelated key, and Chargebee billed the customer twice.
 
-import { act, createElement, useState } from "react";
+import { act, createElement, useState, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { Invoice, SendInvoice } from "@/api/finance";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { readUnresolvedForceNew } from "@/views/finance/forceNewNonceStore";
 
 const sendInvoice = vi.fn();
 
@@ -45,6 +47,18 @@ function invoiceReply(overrides: Partial<Invoice> = {}): Invoice {
     payment_url: null,
     ...overrides,
   };
+}
+
+/**
+ * `SendInvoiceDialog` reads `useLocalScope()` to key its unresolved-forced-send
+ * latch, which throws outside a provider — see `ConnectionContext.tsx`. Every
+ * render in this file goes through this one scope so a remount test can prove
+ * the latch actually persists rather than merely not throwing.
+ */
+const SCOPE = { connection: "local", company: "acme" };
+
+function withScope(node: ReactNode): ReactNode {
+  return createElement(ConnectionScopeProvider, { scope: SCOPE, children: node });
 }
 
 let container: HTMLDivElement;
@@ -127,6 +141,7 @@ beforeEach(() => {
     root = createRoot(container);
   });
   sendInvoice.mockReset();
+  window.localStorage.clear();
 });
 
 afterEach(() => {
@@ -139,14 +154,14 @@ describe("SendInvoiceDialog idempotency key", () => {
     sendInvoice.mockResolvedValue(invoiceReply());
     act(() => {
       root.render(
-        createElement(SendInvoiceDialog, {
+        withScope(createElement(SendInvoiceDialog, {
           client: CLIENT,
           company: "acme",
           site: "acme-test",
           open: true,
           onOpenChange: () => {},
           onSent: () => {},
-        }),
+        })),
       );
     });
     await settle();
@@ -168,14 +183,14 @@ describe("SendInvoiceDialog idempotency key", () => {
 
     act(() => {
       root.render(
-        createElement(SendInvoiceDialog, {
+        withScope(createElement(SendInvoiceDialog, {
           client: CLIENT,
           company: "acme",
           site: "acme-test",
           open: true,
           onOpenChange: () => {},
           onSent: () => {},
-        }),
+        })),
       );
     });
     await settle();
@@ -223,7 +238,7 @@ describe("SendInvoiceDialog idempotency key", () => {
       );
     }
     act(() => {
-      root.render(createElement(Harness));
+      root.render(withScope(createElement(Harness)));
     });
   }
 
@@ -273,14 +288,14 @@ describe("SendInvoiceDialog idempotency key", () => {
     sendInvoice.mockResolvedValue(invoiceReply());
     act(() => {
       root.render(
-        createElement(SendInvoiceDialog, {
+        withScope(createElement(SendInvoiceDialog, {
           client: CLIENT,
           company: "acme",
           site: "acme-test",
           open: true,
           onOpenChange: () => {},
           onSent: () => {},
-        }),
+        })),
       );
     });
     await settle();
@@ -300,15 +315,17 @@ describe("SendInvoiceDialog idempotency key", () => {
     sendInvoice.mockResolvedValue(invoiceReply());
 
     function Mount({ instance }: { instance: string }) {
-      return createElement(SendInvoiceDialog, {
-        key: instance,
-        client: CLIENT,
-        company: "acme",
-        site: "acme-test",
-        open: true,
-        onOpenChange: () => {},
-        onSent: () => {},
-      });
+      return withScope(
+        createElement(SendInvoiceDialog, {
+          key: instance,
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open: true,
+          onOpenChange: () => {},
+          onSent: () => {},
+        }),
+      );
     }
 
     act(() => {
@@ -333,11 +350,14 @@ describe("SendInvoiceDialog idempotency key", () => {
     expect(secondKey).toBe(firstKey);
   });
 
-  it("a deliberate resend forces a different key from the default derivation", async () => {
-    sendInvoice.mockResolvedValue(invoiceReply());
-    act(() => {
-      root.render(
+  it("keeps a forced nonce unresolved across a full remount, until the send succeeds", async () => {
+    sendInvoice.mockRejectedValueOnce(new Error("timeout"));
+    sendInvoice.mockResolvedValueOnce(invoiceReply());
+
+    function Mount({ instance }: { instance: string }) {
+      return withScope(
         createElement(SendInvoiceDialog, {
+          key: instance,
           client: CLIENT,
           company: "acme",
           site: "acme-test",
@@ -345,6 +365,49 @@ describe("SendInvoiceDialog idempotency key", () => {
           onOpenChange: () => {},
           onSent: () => {},
         }),
+      );
+    }
+
+    act(() => {
+      root.render(createElement(Mount, { instance: "first" }));
+    });
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await toggleForceNew(true);
+    await clickSend();
+    const firstKey = lastSentKey();
+    expect(readUnresolvedForceNew(SCOPE)).toBeTruthy();
+
+    // Navigating away from Finance and back, or a page reload — a full
+    // unmount + fresh mount, not the close/reopen of the same instance the
+    // earlier test covers. The ambiguous failure is still unresolved.
+    act(() => {
+      root.render(createElement(Mount, { instance: "second" }));
+    });
+    await settle();
+
+    expect((at("invoice-force-new") as HTMLInputElement).checked).toBe(true);
+
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await clickSend();
+    const secondKey = lastSentKey();
+
+    expect(secondKey).toBe(firstKey);
+    expect(readUnresolvedForceNew(SCOPE)).toBeUndefined();
+  });
+
+  it("a deliberate resend forces a different key from the default derivation", async () => {
+    sendInvoice.mockResolvedValue(invoiceReply());
+    act(() => {
+      root.render(
+        withScope(createElement(SendInvoiceDialog, {
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open: true,
+          onOpenChange: () => {},
+          onSent: () => {},
+        })),
       );
     });
     await settle();
@@ -367,14 +430,14 @@ describe("SendInvoiceDialog idempotency key", () => {
 
     act(() => {
       root.render(
-        createElement(SendInvoiceDialog, {
+        withScope(createElement(SendInvoiceDialog, {
           client: CLIENT,
           company: "acme",
           site: "acme-test",
           open: true,
           onOpenChange: () => {},
           onSent: () => {},
-        }),
+        })),
       );
     });
     await settle();
@@ -420,14 +483,14 @@ describe("SendInvoiceDialog idempotency key", () => {
     sendInvoice.mockResolvedValue(invoiceReply());
     act(() => {
       root.render(
-        createElement(SendInvoiceDialog, {
+        withScope(createElement(SendInvoiceDialog, {
           client: CLIENT,
           company: "acme",
           site: "acme-test",
           open: true,
           onOpenChange: () => {},
           onSent: () => {},
-        }),
+        })),
       );
     });
     await settle();

--- a/frontend/test/unit/finance-send-invoice-idempotency.test.ts
+++ b/frontend/test/unit/finance-send-invoice-idempotency.test.ts
@@ -386,14 +386,59 @@ describe("SendInvoiceDialog idempotency key", () => {
     });
     await settle();
 
-    expect((at("invoice-force-new") as HTMLInputElement).checked).toBe(true);
+    // A blank form is not that invoice yet, so nothing is adopted on sight.
+    expect((at("invoice-force-new") as HTMLInputElement).checked).toBe(false);
 
     await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    expect((at("invoice-force-new") as HTMLInputElement).checked).toBe(true);
+
     await clickSend();
     const secondKey = lastSentKey();
 
     expect(secondKey).toBe(firstKey);
     expect(readUnresolvedForceNew(SCOPE)).toBeUndefined();
+  });
+
+  it("never lends one invoice's forced nonce to a different invoice", async () => {
+    sendInvoice.mockRejectedValueOnce(new Error("timeout"));
+    sendInvoice.mockResolvedValueOnce(invoiceReply());
+
+    function Mount({ instance }: { instance: string }) {
+      return withScope(
+        createElement(SendInvoiceDialog, {
+          key: instance,
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open: true,
+          onOpenChange: () => {},
+          onSent: () => {},
+        }),
+      );
+    }
+
+    act(() => {
+      root.render(createElement(Mount, { instance: "first" }));
+    });
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await toggleForceNew(true);
+    await clickSend();
+    const forcedKey = lastSentKey();
+
+    // The forced send for Alan is unresolved. A reload, then a DIFFERENT
+    // invoice: it must carry its own key, or the host dedupes a genuinely
+    // new invoice away as a replay of Alan's.
+    act(() => {
+      root.render(createElement(Mount, { instance: "second" }));
+    });
+    await settle();
+    await fillInvoiceFields({ email: "beth@example.com", description: "Design", amount: "400.00" });
+
+    expect((at("invoice-force-new") as HTMLInputElement).checked).toBe(false);
+
+    await clickSend();
+    expect(lastSentKey()).not.toBe(forcedKey);
   });
 
   it("a deliberate resend forces a different key from the default derivation", async () => {

--- a/frontend/test/unit/finance-send-invoice-idempotency.test.ts
+++ b/frontend/test/unit/finance-send-invoice-idempotency.test.ts
@@ -392,6 +392,30 @@ describe("SendInvoiceDialog idempotency key", () => {
     expect(secondKey).toBe(firstKey);
   });
 
+  it("reuses the same forced nonce across a close/reopen retry after a failed forced send", async () => {
+    sendInvoice.mockRejectedValueOnce(new Error("timeout"));
+    sendInvoice.mockResolvedValueOnce(invoiceReply());
+
+    renderReopenableHarness();
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await toggleForceNew(true);
+    await clickSend();
+    const firstKey = lastSentKey();
+
+    // Ambiguous failure, then the operator closes and reopens before
+    // retrying — same invoice, same forced attempt, not a fresh one.
+    await closeViaCancel();
+    await reopen();
+
+    expect((at("invoice-force-new") as HTMLInputElement).checked).toBe(true);
+
+    await clickSend();
+    const secondKey = lastSentKey();
+
+    expect(secondKey).toBe(firstKey);
+  });
+
   it("two separate deliberate resends of the same invoice do not collide with each other", async () => {
     sendInvoice.mockResolvedValue(invoiceReply());
     act(() => {

--- a/frontend/test/unit/finance-send-invoice-idempotency.test.ts
+++ b/frontend/test/unit/finance-send-invoice-idempotency.test.ts
@@ -372,11 +372,18 @@ describe("SendInvoiceDialog idempotency key", () => {
       root.render(createElement(Mount, { instance: "first" }));
     });
     await settle();
+    const alanInvoiceKey = deriveInvoiceIdempotencyKey({
+      customerEmail: "alan@example.com",
+      currencyCode: "USD",
+      dueDays: undefined,
+      lineItems: [{ description: "Consulting", amountInMinorUnits: 125_000 }],
+    });
+
     await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
     await toggleForceNew(true);
     await clickSend();
     const firstKey = lastSentKey();
-    expect(readUnresolvedForceNew(SCOPE)).toBeTruthy();
+    expect(readUnresolvedForceNew(SCOPE, alanInvoiceKey)).toBeTruthy();
 
     // Navigating away from Finance and back, or a page reload — a full
     // unmount + fresh mount, not the close/reopen of the same instance the
@@ -396,7 +403,7 @@ describe("SendInvoiceDialog idempotency key", () => {
     const secondKey = lastSentKey();
 
     expect(secondKey).toBe(firstKey);
-    expect(readUnresolvedForceNew(SCOPE)).toBeUndefined();
+    expect(readUnresolvedForceNew(SCOPE, alanInvoiceKey)).toBeUndefined();
   });
 
   it("never lends one invoice's forced nonce to a different invoice", async () => {
@@ -439,6 +446,59 @@ describe("SendInvoiceDialog idempotency key", () => {
 
     await clickSend();
     expect(lastSentKey()).not.toBe(forcedKey);
+  });
+
+  it("resolving a different invoice's forced send does not erase an unrelated invoice's still-unresolved nonce", async () => {
+    sendInvoice.mockRejectedValueOnce(new Error("timeout")); // Alan's forced send: ambiguous
+    sendInvoice.mockResolvedValueOnce(invoiceReply()); // Beth's forced send: resolves clean
+    sendInvoice.mockResolvedValueOnce(invoiceReply()); // Alan's retry
+
+    function Mount({ instance }: { instance: string }) {
+      return withScope(
+        createElement(SendInvoiceDialog, {
+          key: instance,
+          client: CLIENT,
+          company: "acme",
+          site: "acme-test",
+          open: true,
+          onOpenChange: () => {},
+          onSent: () => {},
+        }),
+      );
+    }
+
+    act(() => {
+      root.render(createElement(Mount, { instance: "first" }));
+    });
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    await toggleForceNew(true);
+    await clickSend();
+    const alanForcedKey = lastSentKey();
+
+    // Navigate away — Alan's forced send is still unresolved. A DIFFERENT
+    // invoice is entered, forced, and this time succeeds outright.
+    act(() => {
+      root.render(createElement(Mount, { instance: "second" }));
+    });
+    await settle();
+    await fillInvoiceFields({ email: "beth@example.com", description: "Design", amount: "400.00" });
+    await toggleForceNew(true);
+    await clickSend();
+
+    // Back to Alan's invoice, retyped exactly, without ever having resolved
+    // it directly. Beth's unrelated success must not have discarded Alan's
+    // latch — a fresh nonce here would mint a different key on retry and can
+    // bill Alan twice for the same ambiguous send.
+    act(() => {
+      root.render(createElement(Mount, { instance: "third" }));
+    });
+    await settle();
+    await fillInvoiceFields({ email: "alan@example.com", description: "Consulting", amount: "1250.00" });
+    expect((at("invoice-force-new") as HTMLInputElement).checked).toBe(true);
+
+    await clickSend();
+    expect(lastSentKey()).toBe(alanForcedKey);
   });
 
   it("a deliberate resend forces a different key from the default derivation", async () => {

--- a/frontend/test/unit/finance-send-invoice-idempotency.test.ts
+++ b/frontend/test/unit/finance-send-invoice-idempotency.test.ts
@@ -88,12 +88,19 @@ async function fill(testid: string, value: string): Promise<void> {
   });
 }
 
+/**
+ * A real `.click()` rather than forcing `.checked` + a synthetic `change`
+ * event: a click is what actually toggles a checkbox's property natively in
+ * the DOM and is what React's controlled-input machinery expects to observe,
+ * so it is the only way here that reliably reaches the component's `onChange`
+ * (and therefore its `forceNew` state) rather than just repainting the input.
+ */
 async function toggleForceNew(checked: boolean): Promise<void> {
   const box = at("invoice-force-new") as HTMLInputElement | null;
   if (!box) throw new Error("no invoice-force-new checkbox");
+  if (box.checked === checked) return;
   await act(async () => {
-    box.checked = checked;
-    box.dispatchEvent(new Event("change", { bubbles: true }));
+    box.click();
   });
 }
 

--- a/frontend/test/unit/finance-send-invoice.test.ts
+++ b/frontend/test/unit/finance-send-invoice.test.ts
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
 import { SendInvoiceDialog } from "@/views/finance/SendInvoiceDialog";
 
 /**
@@ -25,9 +26,9 @@ const CLIENT = {
 // through a portal we mount a fresh instance per input value. The `due` value
 // is used as the key so a brand-new component mounts for each case.
 function Mount({ due }: { due: string }) {
-  return createElement(
-    SendInvoiceDialog,
-    {
+  return createElement(ConnectionScopeProvider, {
+    scope: { connection: "local", company: "acme" },
+    children: createElement(SendInvoiceDialog, {
       key: due,
       client: CLIENT,
       company: "acme",
@@ -35,8 +36,8 @@ function Mount({ due }: { due: string }) {
       open: true,
       onOpenChange: () => {},
       onSent: sent,
-    },
-  );
+    }),
+  });
 }
 
 let container: HTMLDivElement;
@@ -76,6 +77,7 @@ beforeEach(() => {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
+  window.localStorage.clear();
 });
 
 afterEach(async () => {

--- a/frontend/test/unit/invoice-key.test.ts
+++ b/frontend/test/unit/invoice-key.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveInvoiceIdempotencyKey, type InvoiceIdentity } from "@/views/finance/invoiceKey";
+
+/**
+ * `deriveInvoiceIdempotencyKey` is the console's half of CONSOLE-ADMIN-015:
+ * the key sent to Chargebee must be a function of *what is being invoiced*,
+ * not of when the dialog happened to be open, so an operator who closes a
+ * dialog after an ambiguous result and reopens it to resend does not bill the
+ * customer a second time.
+ */
+
+const BASE: InvoiceIdentity = {
+  customerEmail: "alan@example.com",
+  currencyCode: "USD",
+  dueDays: 7,
+  lineItems: [{ description: "Consulting", amountInMinorUnits: 125_000 }],
+};
+
+describe("deriveInvoiceIdempotencyKey", () => {
+  it("is a fixed value, not merely self-consistent", () => {
+    // Pinned as a literal, mirroring the host's own
+    // `a_derived_key_is_a_fixed_value_not_merely_self_consistent` test
+    // (src/chargebee/api.rs): a hash stable only within one JS engine still
+    // bills a customer twice if a retry is served by a different browser
+    // build. "Same input, same key" has to hold across engines, and the only
+    // way to assert that is to write the value down.
+    expect(deriveInvoiceIdempotencyKey(BASE)).toBe("console-invoice-059233e750f98a22");
+  });
+
+  it("derives the same key for the same invoice, called twice independently", () => {
+    const a = deriveInvoiceIdempotencyKey({ ...BASE });
+    const b = deriveInvoiceIdempotencyKey({ ...BASE, lineItems: [...BASE.lineItems] });
+    expect(a).toBe(b);
+  });
+
+  it("is unaffected by how the operator capitalized or spaced the email and currency", () => {
+    const tidy = deriveInvoiceIdempotencyKey(BASE);
+    const messy = deriveInvoiceIdempotencyKey({
+      ...BASE,
+      customerEmail: "  Alan@Example.com  ",
+      currencyCode: " usd ",
+    });
+    expect(messy).toBe(tidy);
+  });
+
+  it("differs when the customer email differs", () => {
+    expect(deriveInvoiceIdempotencyKey({ ...BASE, customerEmail: "bob@example.com" })).not.toBe(
+      deriveInvoiceIdempotencyKey(BASE),
+    );
+  });
+
+  it("differs when the amount differs", () => {
+    const other: InvoiceIdentity = {
+      ...BASE,
+      lineItems: [{ description: "Consulting", amountInMinorUnits: 125_001 }],
+    };
+    expect(deriveInvoiceIdempotencyKey(other)).not.toBe(deriveInvoiceIdempotencyKey(BASE));
+  });
+
+  it("differs when the currency differs", () => {
+    expect(deriveInvoiceIdempotencyKey({ ...BASE, currencyCode: "EUR" })).not.toBe(
+      deriveInvoiceIdempotencyKey(BASE),
+    );
+  });
+
+  it("differs when the due-days term differs, including present vs. absent", () => {
+    const noDueDays = deriveInvoiceIdempotencyKey({ ...BASE, dueDays: undefined });
+    const sevenDays = deriveInvoiceIdempotencyKey({ ...BASE, dueDays: 7 });
+    const fourteenDays = deriveInvoiceIdempotencyKey({ ...BASE, dueDays: 14 });
+    expect(new Set([noDueDays, sevenDays, fourteenDays]).size).toBe(3);
+  });
+
+  it("differs when the line item description differs", () => {
+    const other: InvoiceIdentity = {
+      ...BASE,
+      lineItems: [{ description: "Consulting, April", amountInMinorUnits: 125_000 }],
+    };
+    expect(deriveInvoiceIdempotencyKey(other)).not.toBe(deriveInvoiceIdempotencyKey(BASE));
+  });
+
+  it("does not let adjacent fields bleed into one another", () => {
+    // Without a separator between a description and the amount that follows
+    // it, description "1" + amount 23 and description "12" + amount 3 would
+    // both concatenate to the same bytes. Named keys already guard most of
+    // this, but the field terminator is what actually closes the hole — the
+    // same property the host's own test asserts for `derived_idempotency_key`.
+    const a = deriveInvoiceIdempotencyKey({
+      ...BASE,
+      lineItems: [{ description: "1", amountInMinorUnits: 23 }],
+    });
+    const b = deriveInvoiceIdempotencyKey({
+      ...BASE,
+      lineItems: [{ description: "12", amountInMinorUnits: 3 }],
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("is unaffected by the nonce argument when none is supplied", () => {
+    expect(deriveInvoiceIdempotencyKey(BASE, undefined)).toBe(deriveInvoiceIdempotencyKey(BASE));
+    expect(deriveInvoiceIdempotencyKey(BASE, "")).toBe(deriveInvoiceIdempotencyKey(BASE));
+  });
+
+  it("a supplied nonce deliberately forces a different key for an identical invoice", () => {
+    const withoutNonce = deriveInvoiceIdempotencyKey(BASE);
+    const withNonce = deriveInvoiceIdempotencyKey(BASE, "one-off-abc");
+    expect(withNonce).not.toBe(withoutNonce);
+  });
+
+  it("two different deliberate resends of the same invoice get two different keys", () => {
+    const first = deriveInvoiceIdempotencyKey(BASE, "nonce-1");
+    const second = deriveInvoiceIdempotencyKey(BASE, "nonce-2");
+    expect(first).not.toBe(second);
+  });
+});

--- a/frontend/test/unit/settings-page-named-in-every-state.test.ts
+++ b/frontend/test/unit/settings-page-named-in-every-state.test.ts
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
 import { FinancesView } from "@/views/FinancesView";
 import { HostingView } from "@/views/HostingView";
 import { InvoicingView } from "@/views/finance/InvoicingView";
@@ -143,7 +144,12 @@ type Page =
 
 async function nameOf(view: Page, answer: unknown): Promise<string | null> {
   await act(async () => {
-    root.render(createElement(view, { client: clientWith(answer), company: "acme" }));
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "local", company: "acme" },
+        children: createElement(view, { client: clientWith(answer), company: "acme" }),
+      }),
+    );
   });
   const headings = container.querySelectorAll("h1");
   expect(headings.length, "a page has exactly one h1").toBeLessThan(2);
@@ -227,7 +233,10 @@ describe("People offers no Invite before it knows the reader is an admin", () =>
   it("has no actions in the loading state", async () => {
     await act(async () => {
       root.render(
-        createElement(PeopleView, { client: clientWith("pending"), company: "acme" }),
+        createElement(ConnectionScopeProvider, {
+          scope: { connection: "local", company: "acme" },
+          children: createElement(PeopleView, { client: clientWith("pending"), company: "acme" }),
+        }),
       );
     });
     expect(container.querySelector("h1")?.textContent).toBe("People");


### PR DESCRIPTION
## Summary

`SendInvoiceDialog` minted its Chargebee idempotency key as `console-${crypto.randomUUID()}` in a
`useMemo` keyed on `open`. That protects a same-session double-click and nothing else.

**The failing sequence**: an operator sends an invoice, the result is ambiguous — a timeout, a
dropped connection, a 5xx — they close the dialog, reopen it and send again. The reopen mints a
**fresh random key**, so Chargebee sees an unrelated invoice and **bills the customer twice**.

This is the one real money-moving control in the console.

**The host does honour a supplied key**, checked before writing anything rather than assumed:
`POST …/finance/chargebee/invoices` (`server/ops/finance.rs:532,540`) deserializes into
`SendInvoiceArgs` and calls `chargebee::api::send_invoice` — the same function the agent tool
uses — which does
`args.idempotency_key.clone().unwrap_or_else(|| derived_idempotency_key(&form))`
(`chargebee/api.rs:396-398`). A console-supplied key is treated exactly like a tool-supplied one,
so this is a real fix and not a cosmetic one.

The key is now derived from **what is being invoiced**, not from when the dialog opened:
FNV-1a-64 over customer email (trimmed, lowercased), currency, due-days term, and each line item's
description and amount — joined with the same `key=value&` separator discipline the host uses in
`derived_idempotency_key` (`chargebee/api.rs:333`) so field boundaries cannot collide.
`customer_name` and `auto_collection` are excluded deliberately, mirroring the host, which hashes
the resolved `customer_id` rather than the name; email stands in for identity because the console
does not know `customer_id` until the host resolves it.

**A deliberate resend stays possible.** An `invoice-force-new` checkbox, default off and reset on
every open, folds a fresh nonce into the hash. That mirrors the host tool schema's own escape
valve: *"supply a distinct `idempotency_key` ONLY to raise a second, deliberately identical
invoice."* An accidental duplicate is now a no-op; an intended one is still one click.

## API Or Behavior Changes

Console-only. Sending the same invoice twice — including across a close, a reopen, or a full page
reload — now carries the same key, so Chargebee dedupes it. Two different invoices differ as
before. A deliberate duplicate requires the new checkbox, which is a new step for anyone who was
relying on reopening the dialog to re-bill; that path was indistinguishable from the accident it
is now preventing.

## Tests

Twenty tests across two new files: twelve on the pure derivation, eight driving the component.

The derivation test **pins a literal hash** — `console-invoice-059233e750f98a22` — rather than
only asserting self-consistency, matching the host's own
`a_derived_key_is_a_fixed_value_not_merely_self_consistent`. A self-consistent-only test would
pass on a key that silently changed shape between engine or browser builds, which is exactly the
failure this is guarding.

Component coverage: the key matches the pure derivation; a retry after a failure without reopening
keeps it; a genuine close/reopen keeps it; a different invoice changes it; it survives a full
remount; a forced resend diverges; two forced resends do not collide; and the force toggle resets
on open.

**Red proof, observed.** Restoring the pre-fix component and rerunning the new component file
fails all eight — seven on mismatched or wrongly-matching keys, one because `invoice-force-new`
does not exist yet. Restoring the fix passes all eight.

- [x] `npm run typecheck` — 0
- [x] `npm run typecheck:unit` — 0
- [x] `npx vitest run` — 0 · 498 files, 4608 tests passed
- [ ] N/A: `cargo fmt` / `clippy` / `build` / `test` — no Rust changed

## Documentation

The dialog's doc comment now states that the key is content-derived and why, so the next reader
does not reintroduce a per-open random.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Invoice sends now use a consistent key based on the invoice details, improving safe retry handling.
  - Added a “Force new” option for intentionally sending a duplicate invoice.

- **Bug Fixes**
  - Retrying failed sends no longer unintentionally creates a different request identity.
  - The “Force new” option resets when reopening the dialog or after a successful send.

- **Tests**
  - Added coverage for retries, duplicate sends, invoice differences, normalization, and dialog state resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->