### PR TITLE
fix(console): gate the skills writes and approval decisions to admins

### DIFF
--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -568,7 +568,9 @@ export function ApprovalsView({
                       ? "1 thing needs your approval"
                       : `${rows.length} things need your approval`}
                   </h2>
-                  {bulkRows.length > 1 && (
+                  {/* Withheld on the same basis as a single card's footer: a
+                      bulk resolve is the same admin-scoped route, once per row. */}
+                  {bulkRows.length > 1 && bulkRows.every((a) => !a.contents_hidden) && (
                     <div className="flex shrink-0 items-center gap-2 self-center">
                       <Button
                         variant="outline"
@@ -987,7 +989,14 @@ export function ApprovalCard({
 
         <ApprovalPayload approval={a} />
 
-        {!blocker && (
+        {/* `contents_hidden` and the decide route's own admin check are the
+            same `may_administer` predicate on the host, so a card whose
+            contents this viewer cannot read is exactly a card this viewer
+            cannot resolve. Gating the scope controls and the footer below on
+            it, rather than on a separate role read, keeps a member's card at
+            one refusal — the one `ApprovalPayload` already stated — instead of
+            a second one repeating it in different words. */}
+        {!blocker && !a.contents_hidden && (
           <>
             <ApprovalScopeControl
               approval={a}
@@ -1032,7 +1041,13 @@ export function ApprovalCard({
         {/* The decide footer (#1406) — deliberately the LAST thing in the card,
             after the scope control it depends on. Disabled on THIS card's own
             state only; a decision in flight on another card leaves these live,
-            which is the whole of #373's first cause. */}
+            which is the whole of #373's first cause.
+
+            Omitted entirely, not disabled, when this viewer may not resolve
+            it: `ApprovalPayload` above already told them why, and a greyed-out
+            Approve/Decline/Extend row underneath would only invite the click
+            that ends in a 403 toast. */}
+        {!a.contents_hidden && (
         <div
           data-testid="approval-decide"
           className="flex flex-wrap justify-end gap-2 border-t border-border pt-3"
@@ -1123,6 +1138,7 @@ export function ApprovalCard({
             </>
           )}
         </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -98,16 +98,18 @@ export function SkillsView({ client, company }: Props) {
   // writes are admin-only on the host; an unresolved role must not render an
   // enabled control, so this defaults closed the way `HostingView` does.
   const [canManage, setCanManage] = useState(false);
-  const [authorityScope, setAuthorityScope] = useState(company);
+  const [authorityScope, setAuthorityScope] = useState({ client, company });
 
   // Closed *during* the render that first sees a new scope, not in the effect
   // that follows it. An effect runs after commit, so the frame carrying the new
-  // company would already have painted the previous scope's `canManage` — one
-  // real frame of live write controls aimed at a company this operator may not
-  // administer. Resetting here is React's documented adjust-state-during-render
-  // pattern: it re-renders before anything reaches the screen.
-  if (authorityScope !== company) {
-    setAuthorityScope(company);
+  // scope would already have painted the previous scope's `canManage` — one
+  // real frame of live write controls aimed at a scope this operator may not
+  // administer. Keyed by both `client` and `company`: a host reseat changes
+  // `client` identity while `company` can stay the same. Resetting here is
+  // React's documented adjust-state-during-render pattern: it re-renders
+  // before anything reaches the screen.
+  if (authorityScope.client !== client || authorityScope.company !== company) {
+    setAuthorityScope({ client, company });
     setCanManage(false);
     setAddOpen(false);
   }

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -101,6 +101,12 @@ export function SkillsView({ client, company }: Props) {
 
   useEffect(() => {
     let live = true;
+    // Closed the instant the scope changes, not just once the new role
+    // resolves: otherwise the previous scope's admin result — and any dialog
+    // it left open — would keep live write controls pointed at the new
+    // company until this request settles.
+    setCanManage(false);
+    setAddOpen(false);
     void (async () => {
       let admin = false;
       try {

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -98,15 +98,22 @@ export function SkillsView({ client, company }: Props) {
   // writes are admin-only on the host; an unresolved role must not render an
   // enabled control, so this defaults closed the way `HostingView` does.
   const [canManage, setCanManage] = useState(false);
+  const [authorityScope, setAuthorityScope] = useState(company);
+
+  // Closed *during* the render that first sees a new scope, not in the effect
+  // that follows it. An effect runs after commit, so the frame carrying the new
+  // company would already have painted the previous scope's `canManage` — one
+  // real frame of live write controls aimed at a company this operator may not
+  // administer. Resetting here is React's documented adjust-state-during-render
+  // pattern: it re-renders before anything reaches the screen.
+  if (authorityScope !== company) {
+    setAuthorityScope(company);
+    setCanManage(false);
+    setAddOpen(false);
+  }
 
   useEffect(() => {
     let live = true;
-    // Closed the instant the scope changes, not just once the new role
-    // resolves: otherwise the previous scope's admin result — and any dialog
-    // it left open — would keep live write controls pointed at the new
-    // company until this request settles.
-    setCanManage(false);
-    setAddOpen(false);
     void (async () => {
       let admin = false;
       try {

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -1,7 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { BookOpen, Check, Download, Loader2, Plus, Search, Sparkles, Trash2 } from "lucide-react";
+import {
+  BookOpen,
+  Check,
+  Download,
+  Info,
+  Loader2,
+  Plus,
+  Search,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
 import { toast } from "sonner";
 
+import { me as fetchMe } from "@/api/auth";
 import {
   createSkill,
   installSkill,
@@ -14,7 +25,7 @@ import {
 } from "@/api/skills";
 import type { OpenCompanyClient } from "@/api/client";
 import { PageHeader } from "@/components/page-header";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -83,6 +94,26 @@ export function SkillsView({ client, company }: Props) {
   // A generation token so a response from a previous company scope (or after
   // unmount) can't overwrite the current one.
   const gen = useRef(0);
+  // Whether this viewer may enable, install, uninstall or add a skill. The four
+  // writes are admin-only on the host; an unresolved role must not render an
+  // enabled control, so this defaults closed the way `HostingView` does.
+  const [canManage, setCanManage] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      let admin = false;
+      try {
+        admin = (await fetchMe(client, company)).role === "admin";
+      } catch {
+        // No user plane on this host, or not signed in — treat as non-admin.
+      }
+      if (live) setCanManage(admin);
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
 
   const refresh = useCallback(async () => {
     const mine = ++gen.current;
@@ -187,14 +218,27 @@ export function SkillsView({ client, company }: Props) {
           </>
         }
         actions={
-          <>
-          <Button onClick={() => setAddOpen(true)}>
-            <Plus className="size-4" /> Add skill
-          </Button>
-          </>
+          canManage ? (
+            <Button onClick={() => setAddOpen(true)}>
+              <Plus className="size-4" /> Add skill
+            </Button>
+          ) : undefined
         }
       />
       <div className="min-h-0 w-full flex-1 space-y-5 overflow-y-auto px-4 py-6">
+        {!canManage && (
+          <Alert data-testid="skills-admin-only">
+            <Info className="size-4" />
+            <AlertTitle>Only an admin can change this company&apos;s skills</AlertTitle>
+            <AlertDescription>
+              Enabling, installing, uninstalling and adding a skill change what every teammate is
+              told to do, so an admin makes those calls. You can see what is installed and browse
+              the registry.
+            </AlertDescription>
+          </Alert>
+        )}
+
+
         {/* Issue #569: what install / enable actually buy. A desk agent can list,
             describe and read a skill and can never run one — deliberate, and
             pinned by `dispatched_belt_excludes_every_deferred_family` — but this
@@ -234,6 +278,7 @@ export function SkillsView({ client, company }: Props) {
                     <InstalledCard
                       key={s.id}
                       skill={s}
+                      canManage={canManage}
                       onToggle={() => void toggle(s)}
                       onUninstall={() => void uninstall(s)}
                     />
@@ -271,6 +316,7 @@ export function SkillsView({ client, company }: Props) {
                     key={s.id}
                     skill={s}
                     installed={installedIds.has(s.id)}
+                    canManage={canManage}
                     onInstall={() => void install(s)}
                   />
                 ))}
@@ -300,10 +346,14 @@ export function SkillsView({ client, company }: Props) {
 
 function InstalledCard({
   skill,
+  canManage,
   onToggle,
   onUninstall,
 }: {
   skill: Skill;
+  /** Whether this viewer may flip the switch or uninstall. Read-only content —
+   *  the name, description, category and enabled state — renders either way. */
+  canManage: boolean;
   onToggle: () => void;
   onUninstall: () => void;
 }) {
@@ -315,7 +365,14 @@ function InstalledCard({
             <Sparkles className="size-4 text-muted-foreground" />
             <p className="font-medium">{skill.name}</p>
           </div>
-          <Switch checked={skill.enabled} onCheckedChange={onToggle} aria-label="Enable skill" />
+          {/* Disabled, not hidden: its position is itself the enabled/disabled
+              fact a member still needs to read. */}
+          <Switch
+            checked={skill.enabled}
+            disabled={!canManage}
+            onCheckedChange={canManage ? onToggle : undefined}
+            aria-label="Enable skill"
+          />
         </div>
         <p className="text-sm text-muted-foreground">{skill.description}</p>
         <div className="flex items-center justify-between pt-1">
@@ -330,7 +387,7 @@ function InstalledCard({
               · {skillReachLabel(skill.enabled)}
             </span>
           </div>
-          {skill.source !== "company" && (
+          {canManage && skill.source !== "company" && (
             <Button
               variant="ghost"
               size="icon"
@@ -350,10 +407,13 @@ function InstalledCard({
 function RegistryCard({
   skill,
   installed,
+  canManage,
   onInstall,
 }: {
   skill: RegistrySkill;
   installed: boolean;
+  /** Whether this viewer may install from the registry. */
+  canManage: boolean;
   onInstall: () => void;
 }) {
   return (
@@ -379,9 +439,11 @@ function RegistryCard({
               <Check className="size-3.5" /> Installed
             </span>
           ) : (
-            <Button variant="outline" size="sm" onClick={onInstall}>
-              <Download className="size-4" /> Install
-            </Button>
+            canManage && (
+              <Button variant="outline" size="sm" onClick={onInstall}>
+                <Download className="size-4" /> Install
+              </Button>
+            )
           )}
         </div>
       </CardContent>

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -271,6 +271,17 @@ export function ApprovalRow({
   const condensed = variant !== "full";
 
   const lead = approvals[0];
+  /**
+   * Whether this viewer may decide this card at all.
+   *
+   * Resolving and declining are the same admin-scoped route on the host, and
+   * `contents_hidden` is set by that same `may_administer` check on the
+   * summary read — so a card whose contents are hidden from this viewer is
+   * exactly a card this viewer cannot resolve. Reusing it here means a member
+   * gets ONE fact about the card ("your role withholds this") rather than two
+   * separately-worded refusals that happen to be about the same thing.
+   */
+  const canManage = !lead.contents_hidden;
   const pending = useMemo(() => approvals.filter((a) => !decided[a.id]), [approvals, decided]);
   const settledCount = approvals.length - pending.length;
   const failedCount = pending.filter((a) => failed[a.id]).length;
@@ -357,7 +368,7 @@ export function ApprovalRow({
   const declineVariant = compact ? "ghost" : "outline";
   const approveVariant = compact ? "ghost" : "default";
 
-  const actions = done ? undefined : soleBlocker ? (
+  const actions = done || !canManage ? undefined : soleBlocker ? (
     <BlockerDecide
       approval={soleBlocker}
       askerNames={askerNames}
@@ -555,7 +566,7 @@ export function ApprovalRow({
            * own grant, scoped to its own arguments (#739). One choice, one
            * grant per item — never one grant spanning them.
            */}
-          {!done && (
+          {!done && canManage && (
             <ApprovalScopeControl
               approval={pending[0]}
               askerNames={askerNames}
@@ -564,7 +575,14 @@ export function ApprovalRow({
               disabled={busy}
             />
           )}
-          {!done && <DeclineScopeControl approval={pending[0]} scope={declineScope} onChange={setDeclineScope} disabled={busy} />}
+          {!done && canManage && (
+            <DeclineScopeControl
+              approval={pending[0]}
+              scope={declineScope}
+              onChange={setDeclineScope}
+              disabled={busy}
+            />
+          )}
 
           <ApprovalMeta
             approval={lead}

--- a/frontend/test/unit/approval-admin-gate.test.ts
+++ b/frontend/test/unit/approval-admin-gate.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import { ApprovalCard } from "@/views/ApprovalsView";
+
+/**
+ * Resolve and extend are admin-scoped on the host. `contents_hidden` is set by
+ * the same role check the host applies to those routes, so a card a member
+ * cannot read is exactly a card they cannot decide — the assertions below
+ * exercise that as the single source of truth for whether the decide footer
+ * renders at all.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+const BASE: ApprovalSummary = {
+  id: "a1",
+  kind: "payment.send",
+  amount_usd: 1200,
+  at_millis: T0,
+  expires_at_millis: T0 + 3_600_000,
+  agent: "ops",
+  broadly_grantable: true,
+  broadly_deniable: true,
+  payload: { to: "vendor@example.test" },
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(approval: ApprovalSummary) {
+  await act(async () => {
+    root.render(
+      createElement(ApprovalCard, {
+        approval,
+        now: T0 + 60_000,
+        askerNames: new Map([["ops", "Ops"]]),
+        deciding: null,
+        batchIndex: 1,
+        batchTotal: 1,
+        onDecide: (_verdict: Verdict, _scope: GrantScope) => {},
+        onExtend: () => {},
+      }),
+    );
+  });
+}
+
+function query(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+function buttons(): string[] {
+  return [...container.querySelectorAll("button")].map((b) => b.textContent ?? "");
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("ApprovalCard's decide footer, gated on contents_hidden", () => {
+  it("offers Approve, Decline and Extend, and no notice, when contents are readable", async () => {
+    await render(BASE);
+
+    expect(query("approval-decide")).not.toBeNull();
+    expect(buttons().some((t) => t.includes("Approve"))).toBe(true);
+    expect(buttons().some((t) => t.includes("Decline"))).toBe(true);
+    expect(buttons().some((t) => t.includes("Extend"))).toBe(true);
+    expect(container.textContent).not.toContain("Details hidden by your role");
+  });
+
+  it("withholds Approve, Decline and Extend, and states why once, when contents are hidden", async () => {
+    // A real redaction nulls `amount_usd` alongside setting the flag — the host
+    // never leaves the money visible and only the flag flipped.
+    await render({ ...BASE, amount_usd: null, contents_hidden: true });
+
+    expect(query("approval-decide")).toBeNull();
+    expect(buttons().some((t) => t.includes("Approve"))).toBe(false);
+    expect(buttons().some((t) => t.includes("Decline"))).toBe(false);
+    expect(buttons().some((t) => t.includes("Extend"))).toBe(false);
+
+    // The read-only content survives — a hidden card is not a blank one.
+    expect(container.textContent).toContain("Details hidden by your role");
+    expect(container.textContent).toContain("Amount hidden");
+
+    // Exactly one explanation, not the payload's plus a second one repeating
+    // it beneath the (now absent) buttons.
+    expect(container.textContent?.match(/hidden by your role/g)?.length).toBe(1);
+  });
+
+  it("withholds the grant-scope controls alongside the buttons they configure", async () => {
+    await render({ ...BASE, amount_usd: null, contents_hidden: true });
+
+    expect(container.textContent).not.toContain("If you approve");
+    expect(container.textContent).not.toContain("If you decline");
+  });
+
+  it("still offers the scope controls to a reader who may see contents", async () => {
+    await render(BASE);
+
+    expect(container.textContent).toContain("If you approve");
+    expect(container.textContent).toContain("If you decline");
+  });
+});

--- a/frontend/test/unit/approval-bulk-contents-hidden.test.ts
+++ b/frontend/test/unit/approval-bulk-contents-hidden.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ApprovalSummary } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { CompanyFeed } from "@/hooks/use-company";
+import { ApprovalsView } from "@/views/ApprovalsView";
+
+/**
+ * Bulk resolve reuses the same admin-scoped route as a single card's footer,
+ * once per row — so it must be withheld on the same basis: any row this
+ * viewer cannot read must also not be swept into "Approve all" / "Decline
+ * all".
+ */
+
+const NOW = new Date("2026-08-23T10:00:00Z").getTime();
+
+function approval(id: string, contents_hidden?: boolean): ApprovalSummary {
+  return {
+    id,
+    kind: "web_fetch",
+    amount_usd: contents_hidden ? null : 0,
+    at_millis: NOW,
+    expires_at_millis: NOW + 60 * 60 * 1000,
+    agent: "seo",
+    thread: "desk-marketing",
+    ...(contents_hidden ? { contents_hidden: true } : {}),
+  };
+}
+
+const client = {
+  get: async <T>(path: string): Promise<T> => (path.endsWith("/users") ? [] : null) as T,
+  listGrants: async () => [],
+  listTeam: async () => [],
+  listDesks: async () => [],
+  revokeGrant: async () => undefined,
+  scopeFor: () => "/api/v1/company",
+} as unknown as OpenCompanyClient;
+
+function feedWith(approvals: ApprovalSummary[]): CompanyFeed {
+  return {
+    status: {} as CompanyFeed["status"],
+    approvals,
+    queue: "ready",
+    now: NOW,
+    refresh: async () => undefined,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(approvals: ApprovalSummary[]) {
+  await act(async () => {
+    root.render(
+      createElement(ApprovalsView, {
+        client,
+        company: null,
+        feed: feedWith(approvals),
+        onResolved: () => {},
+        onGoToConversation: () => {},
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function buttons(): string[] {
+  return [...container.querySelectorAll("button")].map((b) => b.textContent ?? "");
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the queue header's bulk resolve, gated on contents_hidden", () => {
+  it("offers Approve all / Decline all when every row in the batch is readable", async () => {
+    await show([approval("a1"), approval("a2")]);
+
+    expect(buttons().some((t) => t.includes("Approve all"))).toBe(true);
+    expect(buttons().some((t) => t.includes("Decline all"))).toBe(true);
+  });
+
+  it("withholds bulk resolve when any row in the batch has hidden contents", async () => {
+    await show([approval("a1"), approval("a2", true)]);
+
+    expect(buttons().some((t) => t.includes("Approve all"))).toBe(false);
+    expect(buttons().some((t) => t.includes("Decline all"))).toBe(false);
+  });
+
+  it("still offers each readable row's own decide footer even while bulk is withheld", async () => {
+    await show([approval("a1"), approval("a2", true)]);
+
+    const readableRow = container.querySelector('[data-approval-id="a1"]');
+    expect(readableRow?.textContent).toContain("Approve");
+  });
+});

--- a/frontend/test/unit/approval-bulk-contents-hidden.test.ts
+++ b/frontend/test/unit/approval-bulk-contents-hidden.test.ts
@@ -104,6 +104,10 @@ describe("the queue header's bulk resolve, gated on contents_hidden", () => {
     await show([approval("a1"), approval("a2", true)]);
 
     const readableRow = container.querySelector('[data-approval-id="a1"]');
-    expect(readableRow?.textContent).toContain("Approve");
+    const approve = [...(readableRow?.querySelectorAll<HTMLButtonElement>("button") ?? [])].find(
+      (button) => button.textContent?.includes("Approve"),
+    );
+    expect(approve).toBeDefined();
+    expect(approve?.disabled).toBe(false);
   });
 });

--- a/frontend/test/unit/approval-card-decide-order.test.ts
+++ b/frontend/test/unit/approval-card-decide-order.test.ts
@@ -145,23 +145,18 @@ describe("ApprovalCard decide ordering (#1406)", () => {
     );
   });
 
-  it("announces a hidden card's exact timestamp once", async () => {
-    // A redacted card's composition time is the only discriminator its buttons
-    // can carry (the payload is withheld), but it must be emitted exactly once:
-    // `decisionLabel` puts it in the "composed … (…)" phrase, and the caller
-    // omits its usual `request <timestamp>` suffix so the screen reader does not
-    // hear the opaque epoch twice on every hidden card.
+  it("offers no Approve or Decline at all on a hidden card", async () => {
+    // `contents_hidden` is the same admin check the resolve route itself
+    // applies, so a card whose contents this viewer cannot read is a card they
+    // cannot decide — see `approval-admin-gate.test.ts`. There is no longer an
+    // aria-label to get right or wrong here: the buttons do not render.
     await render({ ...APPROVAL, contents_hidden: true });
 
     const labelled = Array.from(container.querySelectorAll("button")).map((b) =>
       b.getAttribute("aria-label"),
     );
-    const approve = labelled.find((l) => l?.startsWith("Approve:"));
-    const decline = labelled.find((l) => l?.startsWith("Decline:"));
-    expect(approve).toContain(`composed 1m ago (${T0})`);
-    expect(approve).not.toContain(`request ${T0}`);
-    expect(decline).toContain(`composed 1m ago (${T0})`);
-    expect(decline).not.toContain(`request ${T0}`);
+    expect(labelled.find((l) => l?.startsWith("Approve:"))).toBeUndefined();
+    expect(labelled.find((l) => l?.startsWith("Decline:"))).toBeUndefined();
   });
 
   it("distinguishes two same-URL http_request cards by method (#1411)", async () => {

--- a/frontend/test/unit/approval-row-admin-gate.test.ts
+++ b/frontend/test/unit/approval-row-admin-gate.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import { ApprovalRow } from "@/views/chat/ApprovalRow";
+
+/**
+ * The chat and board rendering of a parked approval shares `contents_hidden`
+ * with the Approvals page's own gate (`approval-admin-gate.test.ts`): the same
+ * host role check backs both the redaction and the admin-scoped resolve route,
+ * so a card whose contents this viewer cannot read is a card they cannot
+ * decide from any surface that renders it.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+const CALL: ApprovalSummary = {
+  id: "a1",
+  kind: "web_fetch",
+  amount_usd: null,
+  at_millis: T0,
+  agent: "eng",
+  broadly_grantable: true,
+  payload: { url: "https://example.com" },
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(
+  approval: ApprovalSummary,
+  variant: "full" | "compact" | "card" = "full",
+) {
+  await act(async () => {
+    root.render(
+      createElement(ApprovalRow, {
+        approvals: [approval],
+        now: T0 + 60_000,
+        askerNames: new Map([["eng", "Engineer"]]),
+        variant,
+        deciding: new Map(),
+        decided: {},
+        failed: {},
+        onDecide: (_approval: ApprovalSummary, _verdict: Verdict, _scope: GrantScope) => {},
+      }),
+    );
+  });
+}
+
+function buttons(): string[] {
+  return [...container.querySelectorAll("button")].map((b) => b.textContent ?? "");
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("ApprovalRow's decide actions, gated on contents_hidden", () => {
+  it("offers Approve and Decline on the full transcript card when contents are readable", async () => {
+    await render(CALL, "full");
+
+    expect(buttons().some((t) => t.includes("Approve"))).toBe(true);
+    expect(buttons().some((t) => t.includes("Decline"))).toBe(true);
+  });
+
+  it("withholds Approve and Decline on the full card when contents are hidden", async () => {
+    await render({ ...CALL, contents_hidden: true }, "full");
+
+    expect(buttons().some((t) => t.includes("Approve"))).toBe(false);
+    expect(buttons().some((t) => t.includes("Decline"))).toBe(false);
+    // The card still says what it is and why it cannot be decided here.
+    expect(container.textContent).toContain("hidden by your role");
+  });
+
+  it("withholds the grant-scope control on the full card when contents are hidden", async () => {
+    await render({ ...CALL, contents_hidden: true }, "full");
+
+    expect(container.textContent).not.toContain("If you approve");
+  });
+
+  it("withholds the compact chat row's actions when contents are hidden", async () => {
+    await render({ ...CALL, contents_hidden: true }, "compact");
+
+    expect(buttons().some((t) => t.includes("Approve"))).toBe(false);
+    expect(buttons().some((t) => t.includes("Decline"))).toBe(false);
+  });
+
+  it("withholds the board card's actions when contents are hidden", async () => {
+    await render({ ...CALL, contents_hidden: true }, "card");
+
+    expect(buttons().some((t) => t.includes("Approve"))).toBe(false);
+    expect(buttons().some((t) => t.includes("Decline"))).toBe(false);
+  });
+});

--- a/frontend/test/unit/skills-view-admin-gate.test.ts
+++ b/frontend/test/unit/skills-view-admin-gate.test.ts
@@ -57,6 +57,21 @@ function clientAs(role: "admin" | "member"): OpenCompanyClient {
   } as unknown as OpenCompanyClient;
 }
 
+/** A client whose `/auth/me` never settles, so a test can prove a reset
+ *  happened before the new scope's role is known, rather than because it
+ *  happened to arrive quickly. */
+function clientWithHungAuth(): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/companies/beta",
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) return new Promise(() => {});
+      if (path.endsWith("/skills/registry")) return Promise.resolve([]);
+      if (path.endsWith("/skills")) return Promise.resolve([]);
+      return Promise.reject(new Error(`unexpected GET ${path}`));
+    },
+  } as unknown as OpenCompanyClient;
+}
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -143,5 +158,29 @@ describe("SkillsView authority", () => {
     });
 
     expect(buttons().some((t) => /\bInstall\b/.test(t))).toBe(true);
+  });
+
+  it("closes the write surface the instant the scope changes, before the new role is known", async () => {
+    await show(clientAs("admin"));
+
+    await act(async () => {
+      const addSkill = [...container.querySelectorAll("button")].find((b) =>
+        b.textContent?.includes("Add skill"),
+      ) as HTMLElement;
+      addSkill.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    // Radix portals dialog content onto `document.body`, not into `container`.
+    expect(document.body.textContent).toContain("Add a skill");
+
+    // The new scope's `/auth/me` never answers, so anything visible after this
+    // render can only be explained by the reset the scope-change effect runs
+    // up front — not by a fresh admin result arriving quickly.
+    await act(async () => {
+      root.render(createElement(SkillsView, { client: clientWithHungAuth(), company: "beta" }));
+    });
+
+    expect(document.body.textContent).not.toContain("Add a skill");
+    expect(at("skills-admin-only")?.textContent).toContain("Only an admin");
+    expect(buttons().some((t) => t.includes("Add skill"))).toBe(false);
   });
 });

--- a/frontend/test/unit/skills-view-admin-gate.test.ts
+++ b/frontend/test/unit/skills-view-admin-gate.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { SkillsView } from "@/views/SkillsView";
+
+/**
+ * Enabling, installing, uninstalling and adding a custom skill are admin-only
+ * on the host (`src/server/ops/skills.rs`); the two reads — the installed list
+ * and the registry browse — stay member-level. This pins the console's own
+ * half of that split: a member sees the same lists an admin does, with the
+ * four write controls withheld and a notice in their place, matching the
+ * established pattern (`HostingView`, `TeamView`).
+ */
+
+const INSTALLED = [
+  {
+    id: "press-outreach",
+    name: "Press Outreach",
+    description: "Pitch journalists a story.",
+    category: "Marketing",
+    source: "registry",
+    enabled: true,
+  },
+];
+
+const REGISTRY = [
+  {
+    id: "customer-followup",
+    name: "Customer Follow-up",
+    description: "Check back in after a sale.",
+    category: "Ops",
+    publisher: "OpenCompany",
+  },
+];
+
+function clientAs(role: "admin" | "member"): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return Promise.resolve({
+          id: "u1",
+          email: "a@b.c",
+          role,
+          company: "acme",
+          hasPassword: true,
+        });
+      }
+      if (path.endsWith("/skills/registry")) return Promise.resolve(REGISTRY);
+      if (path.endsWith("/skills")) return Promise.resolve(INSTALLED);
+      return Promise.reject(new Error(`unexpected GET ${path}`));
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(SkillsView, { client, company: "acme" }));
+  });
+  // Let the two independent list reads and the role read settle.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+function buttons(): string[] {
+  return [...container.querySelectorAll("button")].map((b) => b.textContent ?? "");
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("SkillsView authority", () => {
+  it("offers a member the installed list, with every write withheld", async () => {
+    await show(clientAs("member"));
+
+    expect(at("skills-admin-only")?.textContent).toContain("Only an admin");
+
+    // Read content survives — a member is not shown a blank tab.
+    expect(container.textContent).toContain("Press Outreach");
+
+    // No way to flip, uninstall, install or add one.
+    const toggle = container.querySelector('[aria-label="Enable skill"]');
+    expect(toggle?.hasAttribute("data-disabled")).toBe(true);
+    expect(container.querySelector('[aria-label="Uninstall"]')).toBeNull();
+    expect(buttons().some((t) => t.includes("Add skill"))).toBe(false);
+  });
+
+  it("withholds the registry's Install button from a member, once the tab is open", async () => {
+    await show(clientAs("member"));
+    const registryTab = [...container.querySelectorAll('[role="tab"]')].find((t) =>
+      t.textContent?.includes("Registry"),
+    ) as HTMLElement;
+    await act(async () => {
+      registryTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Customer Follow-up");
+    // Word-boundary, not a substring match: the Installed tab's own trigger
+    // text ("Installed (1)") contains "Install" as a prefix.
+    expect(buttons().some((t) => /\bInstall\b/.test(t))).toBe(false);
+  });
+
+  it("offers an admin every write control, with no admin-only notice", async () => {
+    await show(clientAs("admin"));
+
+    expect(at("skills-admin-only")).toBeNull();
+
+    const toggle = container.querySelector('[aria-label="Enable skill"]');
+    expect(toggle?.hasAttribute("data-disabled")).toBe(false);
+    expect(buttons().some((t) => t.includes("Add skill"))).toBe(true);
+  });
+
+  it("offers an admin the registry's Install button, once the tab is open", async () => {
+    await show(clientAs("admin"));
+    const registryTab = [...container.querySelectorAll('[role="tab"]')].find((t) =>
+      t.textContent?.includes("Registry"),
+    ) as HTMLElement;
+    await act(async () => {
+      registryTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(buttons().some((t) => /\bInstall\b/.test(t))).toBe(true);
+  });
+});

--- a/frontend/test/unit/skills-view-admin-gate.test.ts
+++ b/frontend/test/unit/skills-view-admin-gate.test.ts
@@ -60,9 +60,9 @@ function clientAs(role: "admin" | "member"): OpenCompanyClient {
 /** A client whose `/auth/me` never settles, so a test can prove a reset
  *  happened before the new scope's role is known, rather than because it
  *  happened to arrive quickly. */
-function clientWithHungAuth(): OpenCompanyClient {
+function clientWithHungAuth(company = "beta"): OpenCompanyClient {
   return {
-    scopeFor: () => "/api/v1/companies/beta",
+    scopeFor: () => `/api/v1/companies/${company}`,
     get: (path: string) => {
       if (path.endsWith("/auth/me")) return new Promise(() => {});
       if (path.endsWith("/skills/registry")) return Promise.resolve([]);
@@ -180,6 +180,23 @@ describe("SkillsView authority", () => {
     });
 
     expect(document.body.textContent).not.toContain("Add a skill");
+    expect(at("skills-admin-only")?.textContent).toContain("Only an admin");
+    expect(buttons().some((t) => t.includes("Add skill"))).toBe(false);
+  });
+
+  it("closes the write surface on a host reseat, even though `company` stays the same", async () => {
+    await show(clientAs("admin"));
+
+    expect(buttons().some((t) => t.includes("Add skill"))).toBe(true);
+
+    // Same company as `show()` used ("acme"), but a different client — the
+    // reseat a host swap produces. The new host's `/auth/me` never answers,
+    // so anything closed after this render can only be explained by keying
+    // the reset on `client`, not by a fresh (non-)admin result racing in.
+    await act(async () => {
+      root.render(createElement(SkillsView, { client: clientWithHungAuth("acme"), company: "acme" }));
+    });
+
     expect(at("skills-admin-only")?.textContent).toContain("Only an admin");
     expect(buttons().some((t) => t.includes("Add skill"))).toBe(false);
   });


### PR DESCRIPTION
## Summary

Two open PRs make backend routes admin-only and their console halves did not exist. Without this,
a member clicks a live control and gets a 403 into a generic toast:

- **#2125** made the four skills writes admin-only. `SkillsView.tsx` had **no role check anywhere**.
- **#2127** made approvals resolve, decline and extend admin-only. `ApprovalsView` and
  `ApprovalRow` gated only on in-flight state.

Same defect just fixed for Search, Hosting, Domain and SMTP in **#2123** — an enabled control the
backend will refuse.

**Skills**: the enable/disable switch stays visible but disabled for a member, because its position
is itself information; Install, Uninstall and Add-skill are omitted, matching the Hosting and
Domain precedent. The list and the registry browse stay open — those routes remain member-level.

**Approvals**: gated on `!contents_hidden` rather than a second role fetch. `contents_hidden` is
set by `user.may_administer()` (`approval_visibility.rs:44`) — the **identical predicate** the
resolve route's `require_admin` checks (`users/admin.rs:118`) — so it is exactly equivalent, and it
avoids rendering two differently-worded refusals on one card. A member already sees *"Details
hidden by your role. An admin can see what this approval will do and decide it."* That stays the
single explanation; no second notice is added.

Gating `ApprovalRow.tsx` covers three surfaces at once — chat's `MessageTimeline`, the Kanban
board's `TaskItem`, and the workflow run drawer's `RunResultPanel` — because each already passes
whole `ApprovalSummary` objects through.

Bulk Approve-all and Decline-all are withheld when any visible row is hidden, so a member cannot
sweep past the per-row gate.

Nothing is hidden that a member can act on. They still see the skills list, the approval and its
state, and every read-only surface.

## API Or Behavior Changes

Console-only; no route, request or response changed. A member now sees the skills writes and the
approval decide controls disabled or absent, instead of enabled and then failing. Admins are
unaffected.

## Tests

- `skills-view-admin-gate.test.ts` — member sees the notice and no writes but still sees the list;
  admin sees every control.
- `approval-admin-gate.test.ts`, `approval-row-admin-gate.test.ts` — the decide footer, the scope
  fieldsets and the bulk actions are withheld from a member across all three `ApprovalRow`
  surfaces; an admin retains them.
- `approval-card-decide-order.test.ts` — **a pre-existing test pinned the insecure behaviour**,
  asserting working Approve and Decline buttons on a card whose contents are hidden. Inverted to
  assert they do not render. That test was protecting the defect.

Each assertion was observed failing against the pre-fix components first.

- [x] `npm run typecheck` — 0
- [x] `npm run typecheck:unit` — 0
- [x] `npm run typecheck:e2e` — 0
- [x] `npx vitest run` — 0 · 499 files, 4601 tests passed
- [ ] N/A: `cargo fmt` / `clippy` / `build` / `test` — no Rust changed

## Documentation

None needed; the read-only copy already on the approval card explains the rule where it applies.

## Related

**Lifecycle is deliberately untouched.** PR **#2047** already covers it end-to-end — backend
`AdminScopedCompany` on pause and resume, plus `lifecycleAffordances(lifecycle, session, platform)`
and an `explainAdminOnly` alert in `SettingsView`. Confirmed by reading its diff; duplicating it
here would only conflict.

`BlockedNodeApprovals.tsx` needed no change — it renders text links to the Approvals queue and no
decide controls. The per-node decide UI is in `RunResultPanel`, covered by the `ApprovalRow` fix.

**Follow-up worth filing**: #2123 introduces a `use-can-manage` hook and an `admin-only-notice`
component. Those do not exist on `main` yet, so this PR follows the pattern that does — inline
`fetchMe` plus `useState`, as `HostingView`, `McpServersView` and `InferenceView` all use. Once
both land the tree will carry two idioms for one job, and they should be consolidated onto the hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access Control**
  * Approval actions, bulk decisions, and scope controls are hidden when approval details are restricted.
  * Skills remain viewable to all users, while adding, enabling, uninstalling, and registry installation are limited to administrators.

* **Tests**
  * Added coverage for approval decision visibility and administrator-only skills management across supported views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->