### PR TITLE
fix(config): refuse to boot a hosted tenant with no explicit backend URL

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -14,6 +14,16 @@
 //! Resolution never touches the process environment directly: it reads through
 //! the [`EnvSource`] seam, which tests satisfy with an in-memory map (no
 //! `std::env::set_var` races).
+//!
+//! `api_url` and `tinyplace_api_url` default to the production TinyHumans and
+//! tiny.place hubs, which is the right built-in for a deployment an operator
+//! owns (self-hosted, desktop) — there is nothing else it could mean. A
+//! [`Deployment::HostedTenant`] container instead receives every setting from
+//! the platform that provisions it, so the same silent default there is a
+//! platform bug wearing a working boot: the tenant looks configured and talks
+//! to production regardless. `resolve` refuses to fill either field for a
+//! hosted tenant and fails loudly instead, naming the variable that must be
+//! set.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -21,6 +31,7 @@ use std::str::FromStr;
 
 use serde::Deserialize;
 
+use crate::app::deployment::Deployment;
 use crate::error::{OpenCompanyError, Result};
 use crate::ports::types::SecretValue;
 
@@ -773,6 +784,7 @@ pub fn resolve(
     manifest: &crate::company::CompanyManifest,
 ) -> Result<(RuntimeConfig, ConfigProvenance)> {
     let mut prov = ConfigProvenance::default();
+    let deployment = Deployment::from_env(env);
 
     let bind = resolve_str(
         &mut prov,
@@ -792,23 +804,25 @@ pub fn resolve(
         default_data_dir_str(env),
     );
 
-    let api_url = resolve_str(
+    let api_url = resolve_base_url(
         &mut prov,
         "api_url",
+        "TINYHUMANS_API_URL",
+        deployment,
         env.get("TINYHUMANS_API_URL"),
         config_toml.and_then(|c| c.api_url.clone()),
-        None,
         DEFAULT_API_URL.to_string(),
-    );
+    )?;
 
-    let tinyplace_api_url = resolve_str(
+    let tinyplace_api_url = resolve_base_url(
         &mut prov,
         "tinyplace_api_url",
+        "TINYPLACE_API_URL",
+        deployment,
         env.get("TINYPLACE_API_URL"),
         config_toml.and_then(|c| c.tinyplace_api_url.clone()),
-        None,
         DEFAULT_TINYPLACE_API_URL.to_string(),
-    );
+    )?;
 
     // brain_mode: env <- config.toml <- manifest (always present) <- default.
     let brain_raw = resolve_str(
@@ -981,6 +995,52 @@ fn resolve_str(
         prov.set(field, ConfigLayer::Default);
         default_val
     }
+}
+
+/// Resolves a base-URL field that names which real backend this process talks
+/// to (`api_url`, `tinyplace_api_url`).
+///
+/// Behaves exactly like [`resolve_str`] for [`Deployment::SelfHosted`] and
+/// [`Deployment::Desktop`]: env, then `config.toml`, then the built-in
+/// default — the operator running either owns the choice, and the default
+/// (production) *is* that choice when they name nothing.
+///
+/// For [`Deployment::HostedTenant`] the default is refused instead: a tenant
+/// container is handed its entire environment by the platform that
+/// provisions it, so nobody ever chose the destination that a silent default
+/// would apply. The caller gets a config error naming `var_name` rather than
+/// a container that boots and quietly talks to production.
+///
+/// An env or `config.toml` value that is empty (after trimming) counts as
+/// unset in both branches — a launcher that exported the variable with
+/// nothing in it has said nothing.
+fn resolve_base_url(
+    prov: &mut ConfigProvenance,
+    field: &'static str,
+    var_name: &str,
+    deployment: Deployment,
+    env_val: Option<String>,
+    toml_val: Option<String>,
+    default_val: String,
+) -> Result<String> {
+    if let Some(value) = env_val.filter(|v| !v.trim().is_empty()) {
+        prov.set(field, ConfigLayer::Env);
+        return Ok(value);
+    }
+    if let Some(value) = toml_val.filter(|v| !v.trim().is_empty()) {
+        prov.set(field, ConfigLayer::ConfigToml);
+        return Ok(value);
+    }
+    if deployment == Deployment::HostedTenant {
+        return Err(OpenCompanyError::Config(format!(
+            "{var_name} is not set. This is a hosted-tenant deployment, which is handed its \
+             whole environment by the platform that provisions it — so this refuses to boot \
+             rather than silently default to production. Set {var_name} explicitly (the \
+             production hub, or the staging hub for a staging tenant)."
+        )));
+    }
+    prov.set(field, ConfigLayer::Default);
+    Ok(default_val)
 }
 
 /// Resolves an optional string field, recording its winning layer (`Default`
@@ -1543,6 +1603,110 @@ mod test {
         let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
         assert_eq!(cfg.bind, DEFAULT_BIND);
         assert_eq!(prov.layer("bind"), Some(ConfigLayer::Default));
+    }
+
+    // -----------------------------------------------------------------
+    // resolve_base_url (AD-001 / AD-014): a hosted tenant is handed its
+    // whole environment by the platform that provisions it, so an unset
+    // api_url/tinyplace_api_url must refuse to boot instead of silently
+    // becoming production. Every other deployment kind is unaffected — the
+    // pinned decision in `defaults_fill_in_when_nothing_set` above still
+    // holds for an undeclared (self-hosted) process.
+    // -----------------------------------------------------------------
+
+    fn hosted_tenant_env<const N: usize>(pairs: [(&str, &str); N]) -> MapEnv {
+        let mut all = vec![("OPENCOMPANY_DEPLOYMENT", "hosted-tenant")];
+        all.extend(pairs);
+        MapEnv::new(all)
+    }
+
+    #[test]
+    fn hosted_tenant_refuses_to_boot_with_no_api_url() {
+        let env = hosted_tenant_env([]);
+        let err = resolve(&env, None, &default_manifest()).unwrap_err();
+        assert_eq!(err.code(), "config_error");
+        let message = err.to_string();
+        assert!(message.contains("TINYHUMANS_API_URL"), "{message}");
+    }
+
+    #[test]
+    fn hosted_tenant_refuses_to_boot_with_no_tinyplace_api_url() {
+        // api_url set so the failure under test is unambiguously about
+        // tinyplace_api_url, not the sibling field checked above.
+        let env = hosted_tenant_env([("TINYHUMANS_API_URL", "https://api.tinyhumans.ai")]);
+        let err = resolve(&env, None, &default_manifest()).unwrap_err();
+        assert_eq!(err.code(), "config_error");
+        let message = err.to_string();
+        assert!(message.contains("TINYPLACE_API_URL"), "{message}");
+    }
+
+    #[test]
+    fn hosted_tenant_treats_an_empty_api_url_as_unset() {
+        let env = hosted_tenant_env([
+            ("TINYHUMANS_API_URL", "   "),
+            ("TINYPLACE_API_URL", "https://api.tiny.place"),
+        ]);
+        let err = resolve(&env, None, &default_manifest()).unwrap_err();
+        assert!(err.to_string().contains("TINYHUMANS_API_URL"));
+    }
+
+    #[test]
+    fn hosted_tenant_uses_an_explicitly_set_api_url_unchanged() {
+        let env = hosted_tenant_env([
+            ("TINYHUMANS_API_URL", "https://staging-api.tinyhumans.ai"),
+            ("TINYPLACE_API_URL", "https://staging-api.tiny.place"),
+        ]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        assert_eq!(cfg.api_url, "https://staging-api.tinyhumans.ai");
+        assert_eq!(prov.layer("api_url"), Some(ConfigLayer::Env));
+        assert_eq!(cfg.tinyplace_api_url, "https://staging-api.tiny.place");
+        assert_eq!(prov.layer("tinyplace_api_url"), Some(ConfigLayer::Env));
+    }
+
+    /// A hosted tenant may also state the URL in `config.toml` rather than
+    /// the environment — the gate is "was it stated", not "which layer".
+    #[test]
+    fn hosted_tenant_accepts_api_url_from_config_toml() {
+        let env = hosted_tenant_env([]);
+        let file = ConfigFile {
+            api_url: Some("https://staging-api.tinyhumans.ai".into()),
+            tinyplace_api_url: Some("https://staging-api.tiny.place".into()),
+            ..ConfigFile::default()
+        };
+        let (cfg, prov) = resolve(&env, Some(&file), &default_manifest()).unwrap();
+        assert_eq!(cfg.api_url, "https://staging-api.tinyhumans.ai");
+        assert_eq!(prov.layer("api_url"), Some(ConfigLayer::ConfigToml));
+    }
+
+    /// The other side of the split: self-hosted and desktop deployments keep
+    /// defaulting. Forcing every plain `serve` to name a backend it never
+    /// had to before would break the documented zero-config quickstart for a
+    /// deployment kind that owns the choice by construction.
+    #[test]
+    fn self_hosted_and_desktop_still_default_api_url_when_unset() {
+        for kind in ["self-hosted", ""] {
+            let env = MapEnv::new([("OPENCOMPANY_DEPLOYMENT", kind)]);
+            let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+            assert_eq!(cfg.api_url, DEFAULT_API_URL, "deployment={kind:?}");
+            assert_eq!(prov.layer("api_url"), Some(ConfigLayer::Default));
+        }
+
+        let env = MapEnv::new([("OPENCOMPANY_DEPLOYMENT", "desktop")]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        assert_eq!(cfg.api_url, DEFAULT_API_URL);
+        assert_eq!(cfg.tinyplace_api_url, DEFAULT_TINYPLACE_API_URL);
+        assert_eq!(prov.layer("api_url"), Some(ConfigLayer::Default));
+    }
+
+    /// The tenant-namespace inference (`OPENCOMPANY_TENANT_ID` alone, no
+    /// explicit `OPENCOMPANY_DEPLOYMENT`) names a hosted tenant too — see
+    /// `Deployment::from_env` — so it must gate the same as an explicit
+    /// declaration rather than being read as self-hosted.
+    #[test]
+    fn tenant_namespace_alone_also_gates_as_hosted_tenant() {
+        let env = MapEnv::new([("OPENCOMPANY_TENANT_ID", "acme")]);
+        let err = resolve(&env, None, &default_manifest()).unwrap_err();
+        assert!(err.to_string().contains("TINYHUMANS_API_URL"));
     }
 
     // -----------------------------------------------------------------

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -1862,25 +1862,31 @@ fn log_filter(rust_log: Option<&str>) -> tracing_subscriber::EnvFilter {
 
 /// Resolves a base-URL env var (`TINYHUMANS_API_URL`, `TINYPLACE_API_URL`)
 /// for `serve`'s manual `AppConfig` build. Mirrors
-/// `opencompany::app::config::resolve_base_url`'s hosted-tenant gate — kept as
-/// a small local twin because `serve` builds `AppConfig` field-by-field
-/// rather than through `app::config::resolve`, and reads only the process
-/// environment (`config.toml` is not part of this manual build's precedence).
+/// `opencompany::app::config::resolve_base_url`'s precedence — kept as a
+/// small local twin because `serve` builds `AppConfig` field-by-field rather
+/// than through `app::config::resolve` — including the `config.toml`
+/// candidate, so `doctor` (which goes through `resolve_base_url`) and `serve`
+/// agree on whether a hosted tenant's backend URL counts as set.
 ///
 /// A hosted tenant is handed its whole environment by the platform that
-/// provisions it, so an unset value there refuses to boot instead of
-/// silently applying `default_val` — which for both callers is a production
-/// base URL. Every other deployment kind keeps the default: the operator
-/// running it owns the choice, and no-override *is* that choice.
+/// provisions it, so a value named by neither the env var nor `config.toml`
+/// refuses to boot instead of silently applying `default_val` — which for
+/// both callers is a production base URL. Every other deployment kind keeps
+/// the default: the operator running it owns the choice, and no-override *is*
+/// that choice.
 fn resolve_serve_base_url(
     var_name: &str,
     deployment: opencompany::app::deployment::Deployment,
+    toml_val: Option<String>,
     default_val: String,
 ) -> Result<String> {
     if let Some(value) = std::env::var(var_name)
         .ok()
         .filter(|value| !value.trim().is_empty())
     {
+        return Ok(value);
+    }
+    if let Some(value) = toml_val.filter(|value| !value.trim().is_empty()) {
         return Ok(value);
     }
     if deployment == opencompany::app::deployment::Deployment::HostedTenant {
@@ -2065,6 +2071,9 @@ async fn async_main() -> Result<()> {
             let tinyplace_api_url = resolve_serve_base_url(
                 "TINYPLACE_API_URL",
                 deployment,
+                config_file
+                    .as_ref()
+                    .and_then(|c| c.tinyplace_api_url.clone()),
                 opencompany::app::config::DEFAULT_TINYPLACE_API_URL.to_string(),
             )?;
             let public_url = std::env::var("OPENCOMPANY_PUBLIC_URL")
@@ -2118,6 +2127,7 @@ async fn async_main() -> Result<()> {
             let api_url = resolve_serve_base_url(
                 "TINYHUMANS_API_URL",
                 deployment,
+                config_file.as_ref().and_then(|c| c.api_url.clone()),
                 AppConfig::default().api_url,
             )?;
             // The listener address, across every layer that may name it. Until
@@ -3214,5 +3224,74 @@ mod test {
             matches!(&err, opencompany::error::OpenCompanyError::Config(_)),
             "expected a Config refusal, got: {err:?}"
         );
+    }
+
+    // These use a var name no environment (local or CI) ever sets, so the
+    // env-var branch of `resolve_serve_base_url` never fires here — no
+    // `std::env::set_var` needed, and so nothing to race against the rest of
+    // this binary's tests.
+    const UNSET_VAR: &str = "OPENCOMPANY_TEST_RESOLVE_SERVE_BASE_URL_UNSET_PROBE";
+
+    /// Codex review finding on PR #2141: `doctor` (via
+    /// `app::config::resolve_base_url`) accepts a hosted tenant's backend URL
+    /// from `config.toml`, but `serve`'s manual `AppConfig` build checked only
+    /// the process environment — so a tenant configured entirely through
+    /// `config.toml` passed `doctor` and then refused to boot.
+    #[test]
+    fn serve_base_url_accepts_config_toml_for_a_hosted_tenant() {
+        let resolved = resolve_serve_base_url(
+            UNSET_VAR,
+            opencompany::app::deployment::Deployment::HostedTenant,
+            Some("https://toml.example".to_string()),
+            "https://default.example".to_string(),
+        )
+        .expect("a config.toml value must satisfy the hosted-tenant gate");
+
+        assert_eq!(resolved, "https://toml.example");
+    }
+
+    #[test]
+    fn serve_base_url_still_refuses_a_hosted_tenant_with_neither_env_nor_toml() {
+        let err = resolve_serve_base_url(
+            UNSET_VAR,
+            opencompany::app::deployment::Deployment::HostedTenant,
+            None,
+            "https://default.example".to_string(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            &err,
+            opencompany::error::OpenCompanyError::Config(_)
+        ));
+    }
+
+    #[test]
+    fn serve_base_url_ignores_a_blank_config_toml_value() {
+        let err = resolve_serve_base_url(
+            UNSET_VAR,
+            opencompany::app::deployment::Deployment::HostedTenant,
+            Some("   ".to_string()),
+            "https://default.example".to_string(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            &err,
+            opencompany::error::OpenCompanyError::Config(_)
+        ));
+    }
+
+    #[test]
+    fn serve_base_url_self_hosted_still_defaults_when_neither_env_nor_toml() {
+        let resolved = resolve_serve_base_url(
+            UNSET_VAR,
+            opencompany::app::deployment::Deployment::SelfHosted,
+            None,
+            "https://default.example".to_string(),
+        )
+        .expect("self-hosted must not refuse to boot");
+
+        assert_eq!(resolved, "https://default.example");
     }
 }

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -1860,6 +1860,40 @@ fn log_filter(rust_log: Option<&str>) -> tracing_subscriber::EnvFilter {
     }
 }
 
+/// Resolves a base-URL env var (`TINYHUMANS_API_URL`, `TINYPLACE_API_URL`)
+/// for `serve`'s manual `AppConfig` build. Mirrors
+/// `opencompany::app::config::resolve_base_url`'s hosted-tenant gate — kept as
+/// a small local twin because `serve` builds `AppConfig` field-by-field
+/// rather than through `app::config::resolve`, and reads only the process
+/// environment (`config.toml` is not part of this manual build's precedence).
+///
+/// A hosted tenant is handed its whole environment by the platform that
+/// provisions it, so an unset value there refuses to boot instead of
+/// silently applying `default_val` — which for both callers is a production
+/// base URL. Every other deployment kind keeps the default: the operator
+/// running it owns the choice, and no-override *is* that choice.
+fn resolve_serve_base_url(
+    var_name: &str,
+    deployment: opencompany::app::deployment::Deployment,
+    default_val: String,
+) -> Result<String> {
+    if let Some(value) = std::env::var(var_name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Ok(value);
+    }
+    if deployment == opencompany::app::deployment::Deployment::HostedTenant {
+        return Err(opencompany::error::OpenCompanyError::Config(format!(
+            "{var_name} is not set. This is a hosted-tenant deployment, which is handed its \
+             whole environment by the platform that provisions it — so this refuses to boot \
+             rather than silently default to production. Set {var_name} explicitly (the \
+             production hub, or the staging hub for a staging tenant)."
+        )));
+    }
+    Ok(default_val)
+}
+
 async fn async_main() -> Result<()> {
     // Crash reporting first, before the subscriber and before any other work.
     // The panic hook is installed inside `init`, so anything that panics ahead
@@ -2020,13 +2054,19 @@ async fn async_main() -> Result<()> {
                     );
                 }
             }
+            // Which kind of install this process is — a hosted tenant gets its
+            // whole environment from the platform that provisions it, so the
+            // production defaults below are refused rather than silently
+            // applied for that kind alone. See `resolve_serve_base_url`.
+            let deployment = opencompany::app::deployment::Deployment::from_env(&ProcessEnv);
             // tiny.place economy + public-card configuration resolved from the
             // environment (with built-in defaults); the a2a routes and boot
             // going-public flow read these off `AppConfig`.
-            let tinyplace_api_url = std::env::var("TINYPLACE_API_URL")
-                .ok()
-                .filter(|value| !value.trim().is_empty())
-                .unwrap_or_else(|| opencompany::app::config::DEFAULT_TINYPLACE_API_URL.to_string());
+            let tinyplace_api_url = resolve_serve_base_url(
+                "TINYPLACE_API_URL",
+                deployment,
+                opencompany::app::config::DEFAULT_TINYPLACE_API_URL.to_string(),
+            )?;
             let public_url = std::env::var("OPENCOMPANY_PUBLIC_URL")
                 .ok()
                 .filter(|value| !value.trim().is_empty());
@@ -2075,10 +2115,11 @@ async fn async_main() -> Result<()> {
             // Honor TINYHUMANS_API_URL (e.g. staging) — the config layer reads
             // it, but this manual AppConfig build otherwise falls to the prod
             // default, so a staging credential could never reach staging.
-            let api_url = std::env::var("TINYHUMANS_API_URL")
-                .ok()
-                .filter(|value| !value.trim().is_empty())
-                .unwrap_or_else(|| AppConfig::default().api_url);
+            let api_url = resolve_serve_base_url(
+                "TINYHUMANS_API_URL",
+                deployment,
+                AppConfig::default().api_url,
+            )?;
             // The listener address, across every layer that may name it. Until
             // issue #425 only the flag reached this struct, so the manager's
             // injected `OPENCOMPANY_BIND` (and any `config.toml` `bind`) moved


### PR DESCRIPTION
## Summary

`resolve_str` falls back to a hardcoded default when a value is unset or empty, and
`TINYHUMANS_API_URL`'s default is **production**. `patch-tenant-env.yml`'s own header confirms the
consequence: a freshly-provisioned hosted tenant talks to production until an operator patches it.

A silently-applied production default is the worst kind: the deployment behaves as though it were
configured, and the failure surfaces as production traffic rather than as an error.

**The split is by deployment kind, not by field.** `Deployment::HostedTenant` now refuses to boot
with an unset or empty `api_url` / `tinyplace_api_url`. `SelfHosted` and `Desktop` keep defaulting.

That distinction is the substance of the change. `docs/spec/runtime/config.md:115` documents the
production default as the intended zero-config quickstart, and a self-hosted install has no wrong
org to accidentally join — forcing every plain `serve` to name a backend would break a documented
contract for no safety gain. A hosted tenant is the opposite case: it is handed its whole
environment by the platform, so a missing value there is a platform bug, not an operator's choice.

## API Or Behavior Changes

A hosted tenant with no `TINYHUMANS_API_URL` (or `TINYPLACE_API_URL`) now **refuses to start**,
with a message naming the variable and the deployment kind, instead of booting against production.
An empty or whitespace-only value is treated as unset. A value from either the environment or
`config.toml` is honoured unchanged. Self-hosted and desktop boots are unaffected.

Both fallthrough paths the defect named are covered: `resolve()` and `serve`'s separate,
`config.toml`-blind `AppConfig` build.

## Tests

**The brief's premise was wrong and is corrected here.** It claimed *"api_url and every other
`resolve_str` field"* falls open to a production default. Checking every field, only two matter:

- `bind` (loopback) and `data_dir` (`$HOME/.opencompany`) have genuinely safe local defaults with
  no external effect.
- `brain_mode` and `auth_mode` route through the company manifest, whose `mode` field always
  carries a serde default, so `resolve_str`'s `default_val` arm is unreachable for them in every
  real caller — and they already fail loudly via `FromStr` on garbage.

**The test pinning the old behaviour did not need changing.** `defaults_fill_in_when_nothing_set`
(`config.rs:1078`) uses `MapEnv::default()`, which `Deployment::from_env` resolves to `SelfHosted`,
so it still asserts the production default and passes unmodified. The documented decision is
preserved for every deployment except the one the defect is actually about.

**Red proof, observed.** Reverting just the two `resolve_base_url` call sites to plain
`resolve_str` makes three tests fail — `hosted_tenant_refuses_to_boot_with_no_api_url`,
`..._with_no_tinyplace_api_url`, and `..._treats_an_empty_api_url_as_unset` — each panicking on
`unwrap_err()` against an `Ok` carrying `api_url: "https://api.tinyhumans.ai"`. That is AD-001 and
AD-014 reproduced live. The two tests asserting explicit values are honoured stayed green, as they
should, since that path was never broken.

- [x] `cargo fmt --check` — 0
- [x] `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings` — 0
- [x] `cargo test --features openhuman --lib app::` — 0 · 136 passed
- [x] `cargo build --features openhuman --bin opencompany` — 0

## Documentation

None changed. `config.md:115` still documents the self-hosted default accurately; the hosted-tenant
requirement is enforced in code with a message that names the variable.
