### PR TITLE
test: make workflow ID validation timers deterministic

### DIFF
--- a/frontend/test/unit/workflow-id-derivation.test.ts
+++ b/frontend/test/unit/workflow-id-derivation.test.ts
@@ -42,7 +42,7 @@ function savedGraph(): WorkflowGraph {
 
 const validationRequests: { path: string; graph: WorkflowGraph }[] = [];
 
-/** A host that answers every read the dialog makes on open. */
+/** A host that answers the dialog's reads and its debounced validation. */
 function stubClient(): OpenCompanyClient {
   return {
     scopeFor: () => "/api/companies/acme",
@@ -55,6 +55,15 @@ function stubClient(): OpenCompanyClient {
     get: async (path: string) => {
       if (path.endsWith("/inference")) return { cognition: "echo" };
       return path.endsWith("/wired-channels") ? { channels: [] } : [];
+    },
+    // A valid edit schedules this request even when a test only edits the
+    // name. Answer it while mounted, however long the worker takes to finish.
+    post: async (path: string, graph: WorkflowGraph) => {
+      if (path !== "/api/companies/acme/workflows/validate") {
+        throw new Error(`Unexpected workflow write: ${path}`);
+      }
+      validationRequests.push({ path, graph });
+      return { valid: true };
     },
   } as unknown as OpenCompanyClient;
 }

--- a/frontend/test/unit/workflow-id-derivation.test.ts
+++ b/frontend/test/unit/workflow-id-derivation.test.ts
@@ -2,7 +2,7 @@
 
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { PrefilledDraft, WorkflowGraph } from "@/api/workflows";
@@ -39,6 +39,8 @@ function savedGraph(): WorkflowGraph {
     edges: [{ from: "start", to: "search" }],
   } as WorkflowGraph;
 }
+
+const validationRequests: { path: string; graph: WorkflowGraph }[] = [];
 
 /** A host that answers every read the dialog makes on open. */
 function stubClient(): OpenCompanyClient {
@@ -157,6 +159,7 @@ async function openCreateForm() {
 }
 
 beforeEach(() => {
+  validationRequests.length = 0;
   (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
     true;
   container = document.createElement("div");
@@ -167,6 +170,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
+  vi.useRealTimers();
 });
 
 afterAll(() => {
@@ -293,6 +297,30 @@ describe("deriving stops the moment the id is somebody's (#1053)", () => {
 });
 
 describe("edit mode never derives (#1053)", () => {
+  it("answers the validation debounce while the saved graph is still mounted", async () => {
+    vi.useFakeTimers();
+    await open({ workflow: savedGraph() });
+
+    // Cross the actual debounce while mounted, rather than hoping a busy
+    // worker happens to keep a name/id test alive long enough to reach it.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700);
+    });
+
+    expect(validationRequests).toEqual([{
+      path: "/api/companies/acme/workflows/validate",
+      graph: expect.objectContaining({
+        id: "weekly_report",
+        name: "Weekly report",
+        nodes: expect.arrayContaining([
+          expect.objectContaining({ id: "start", kind: "trigger" }),
+          expect.objectContaining({ id: "search", kind: "tool_call" }),
+        ]),
+        edges: [{ from: "start", to: "search" }],
+      }),
+    }]);
+  });
+
   it("leaves the saved id alone however the name is edited", async () => {
     await open({ workflow: savedGraph() });
     expect(field("id").value).toBe("weekly_report");


### PR DESCRIPTION
The workflow ID suite mounted a valid saved graph with a client stub that had no `post` method. If the dialog's 700 ms validation debounce fired while that fixture was mounted, `validateWorkflow()` threw synchronously before its promise error handler could attach, producing `TypeError: client.post is not a function` outside the ID assertions.

Complete the fixture's validation endpoint and add a controlled-clock regression that advances the mounted dialog through the debounce and checks the request URL and graph body. The production effect already clears its timer on unmount; no production behavior changes. Only `frontend/test/unit/workflow-id-derivation.test.ts` changes.

### Reproduction and verification

- Clean historical base: `40659a3faf902cf8741abd5be8b3b064192edb16`. Three socket-enabled `npx vitest run` repetitions each exited **0**, with 470 files / 4,381 tests passing (70.69 s, 91.88 s, 69.04 s). Natural timer-flake frequency in this sample: **0/3**. This sample did not reproduce the originally reported intermittent suite failure.
- Three additional sandboxed repetitions each exited **1** because the mock-brain fixture could not bind a local socket. A direct launch confirmed `listen EPERM`; these are environmental failures and are excluded from the timer-flake rate.
- Deterministic proof on fresh-main base `b4cab3ea3e0d458ae301372a82d9ae2bd4d295f0`: signed test-first commit `5f7e50285` mounted the original incomplete stub and advanced the clock 700 ms. `npx vitest run test/unit/workflow-id-derivation.test.ts` exited **1**, naming the exact `client.post is not a function` error at `validateWorkflow` and the dialog's debounce callback, with 9 tests passing / 1 failing. The callback was still mounted; no after-unmount leak is assumed.
- After signed fix commit `72bc875e5`, the same target exited **0**, 10/10 tests passing, including the actual validation request assertion.
- `npm ci`: **0**.
- `npm run typecheck`: **0**.
- `npm run typecheck:unit`: **0**.
- Full post-fix `npx vitest run` repetitions: **0, 0, 0**; each passed 500 files / 4,658 tests with no unhandled errors (72.56 s, 63.18 s, 72.82 s). The baseline requested above predates the implementation's fresh-main base, so the total suite sizes differ; the command and three-run repetition protocol are the same.

Every verification command ran unpiped and after the source under test was committed; dependency installation was setup. No stash, no production-state fixtures, no vendor pin changes. The implementation worktree was created from a fresh fetch of main and held fixed for comparison. Rust was not changed or built for this frontend-only fix.

Main currently has no branch protection: `/branches/main/protection` returned **404**, and `/rulesets` returned **[]**. These frontend gates matter because failing checks do not currently prevent a merge. Repository protection settings are left to the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for edit-mode validation to ensure requests are handled correctly while the saved workflow remains mounted.
  - Improved test isolation and timing reliability for validation scenarios.
  - Added request tracking in test coverage to verify validation interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->