### PR TITLE
test: drain approval stubs before browser teardown

### DIFF
--- a/frontend/test/e2e/approval-blocker-verdicts.spec.ts
+++ b/frontend/test/e2e/approval-blocker-verdicts.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Page, type Route } from "@playwright/test";
 
 /**
  * **Issue #2028 — reachability, which only a real click can prove.**
@@ -33,10 +33,10 @@ import { expect, test, type Page } from "@playwright/test";
  * still in flight; context teardown disposed the response underneath it.
  *
  * Thirty isolated Retry runs with tracing passed: a trace showed the company
- * fetch finishing 1.6 ms AFTER After Hooks began, then trace collection kept
- * the context alive another 65 ms. Tracing changed the timing, not the lifetime
- * contract. Drain this spec's routes before context teardown, without ignoring
- * callback errors or adding sleeps to the verdict assertions.
+ * fetch finishing 1.6 ms AFTER After Hooks began; with tracing, the context
+ * stayed alive another 65 ms. This is consistent with tracing masking the
+ * teardown race. Drain this spec's routes before context teardown, without
+ * ignoring callback errors or adding sleeps to the verdict assertions.
  */
 
 const BLOCKER_ID = "e2e-2028-blocker";
@@ -123,7 +123,37 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
+const pendingRoutes = new WeakMap<Page, Set<Promise<void>>>();
+
+async function stubRoute(
+  page: Page,
+  matches: (url: URL) => boolean,
+  handle: (route: Route) => Promise<void>,
+) {
+  let pending = pendingRoutes.get(page);
+  if (!pending) {
+    pending = new Set();
+    pendingRoutes.set(page, pending);
+  }
+  const calls = pending;
+  await page.route(matches, async (route) => {
+    const call = handle(route);
+    calls.add(call);
+    try {
+      await call;
+    } finally {
+      calls.delete(call);
+    }
+  });
+}
+
 test.afterEach(async ({ page }) => {
+  // Drain while handlers remain registered. unrouteAll(wait) alone failed
+  // 5/200 cases: Playwright removed its handler list before waiting,
+  // so one callback finishing could disable interception under another's
+  // pending fulfill, which then failed with "Route is already handled!".
+  const pending = pendingRoutes.get(page);
+  while (pending?.size) await Promise.all(pending);
   await page.unrouteAll({ behavior: "wait" });
 });
 
@@ -134,14 +164,14 @@ test.afterEach(async ({ page }) => {
  */
 async function stubQueue(page: Page, parked: unknown[]) {
   await advertiseFourWayBlockers(page);
-  await page.route(isApprovalList, async (route) => {
+  await stubRoute(page, isApprovalList, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify(parked),
     });
   });
-  await page.route(isCompanyRead, async (route) => {
+  await stubRoute(page, isCompanyRead, async (route) => {
     const response = await route.fetch();
     if (!response.ok()) return route.fulfill({ response });
     const body = await response.json();
@@ -179,7 +209,7 @@ async function stubQueue(page: Page, parked: unknown[]) {
  * side by taking it back off.
  */
 async function advertiseFourWayBlockers(page: Page) {
-  await page.route(isSpec, async (route) => {
+  await stubRoute(page, isSpec, async (route) => {
     const response = await route.fetch();
     if (!response.ok()) return route.fulfill({ response });
     const body = await response.json();
@@ -200,7 +230,7 @@ async function advertiseFourWayBlockers(page: Page) {
 /** Capture the resolve body the console composes, and answer it plausibly. */
 async function captureResolve(page: Page) {
   const bodies: Record<string, unknown>[] = [];
-  await page.route(isApprovalResolve, async (route) => {
+  await stubRoute(page, isApprovalResolve, async (route) => {
     const raw = route.request().postData();
     bodies.push(raw ? JSON.parse(raw) : {});
     await route.fulfill({
@@ -349,7 +379,7 @@ test("a skip is refused, not lowered, on a host that cannot perform it", async (
   const bodies = await captureResolve(page);
   await openApprovals(page, [parkedBlocker()]);
   // Registered after `stubQueue`'s, and Playwright prefers the newest match.
-  await page.route(isSpec, async (route) => {
+  await stubRoute(page, isSpec, async (route) => {
     const response = await route.fetch();
     const body = await response.json();
     await route.fulfill({

--- a/frontend/test/e2e/approval-blocker-verdicts.spec.ts
+++ b/frontend/test/e2e/approval-blocker-verdicts.spec.ts
@@ -26,8 +26,17 @@ import { expect, test, type Page } from "@playwright/test";
  * Real: the host, the console bundle, the session, the routing, the polling
  * feed, and every DOM interaction.
  *
- * Like the rest of `test/e2e`, this drives a running host and is not wired into
- * CI; `npm run typecheck:e2e` compiles it, nothing runs it automatically.
+ * Runs in both Console E2E lanes. On fixed main b4cab3ea3, twenty serial
+ * repetitions without retries failed 10/200 cases across two-step Skip,
+ * single Skip, Cancel, and Retry, all at the company-read stub's response.json.
+ * The verdict assertions finished while the post-resolve company refresh was
+ * still in flight; context teardown disposed the response underneath it.
+ *
+ * Thirty isolated Retry runs with tracing passed: a trace showed the company
+ * fetch finishing 1.6 ms AFTER After Hooks began, then trace collection kept
+ * the context alive another 65 ms. Tracing changed the timing, not the lifetime
+ * contract. Drain this spec's routes before context teardown, without ignoring
+ * callback errors or adding sleeps to the verdict assertions.
  */
 
 const BLOCKER_ID = "e2e-2028-blocker";
@@ -112,6 +121,10 @@ test.beforeEach(async ({ page }) => {
       return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
     };
   });
+});
+
+test.afterEach(async ({ page }) => {
+  await page.unrouteAll({ behavior: "wait" });
 });
 
 /**


### PR DESCRIPTION
Approval-verdict browser assertions could finish while their company-status stub was still reading a response. Browser teardown then disposed that response and randomly failed otherwise-correct Skip, Cancel, or Retry cases. Track this spec's five route handlers per page, await their complete fetch/read/fulfill callbacks, and only then unregister them and allow context teardown. Callback errors still fail the test; verdict assertions and production behavior are unchanged.

The drain deliberately runs while handlers remain registered: `unrouteAll({ behavior: "wait" })` alone removed Playwright's handler list early and reproduced `Route is already handled!` when another callback finished and disabled interception under a pending fulfill (5/200 cases). This PR owns only `frontend/test/e2e/approval-blocker-verdicts.spec.ts`.

Observed reproduction on fixed main `b4cab3ea3e0d458ae301372a82d9ae2bd4d295f0`:

- Twenty complete file repetitions, one worker, no retries and no trace: **10 failed / 190 passed**, exit **1**, 1.8 minutes. Nine of the twenty repetitions failed. Failures occurred at positions 3, 28, 37, 45, 67, 103, 113, 128, 147, and 148: two-step Skip (3), single Skip (1), Cancel (3), Retry (3). Every failure pointed to the company-status stub's `response.json()` and disposed response/context teardown, rather than a particular verdict or fixed run position.
- Thirty isolated Retry cases with tracing: **30 passed**, exit **0**, 25.6 seconds. The trace showed the company fetch completing 1.6 ms after After Hooks began; the context remained alive another 65 ms with tracing enabled. This is consistent with trace collection masking the teardown window. It is not evidence that the original flake was fixed.
- These observations were reported before implementing the fix. `captureResolve` uses `route.fulfill()` throughout; no cross-spec state explanation or response-reading resolve mechanism is assumed.

Validation on signed commit `67ba85877` (each command unpiped, each command's own exit):

| Command | Exit | Result |
| --- | --- | --- |
| `npm run typecheck` | 0 | passed |
| `npm run typecheck:unit` | 0 | passed |
| `npm run typecheck:e2e` | 0 | passed |
| `npx vitest run` | 0 | 500 files, 4,657 tests; 84.21 seconds |
| Default-host command below | 0 | 200/200 cases; 20/20 repetitions; 1.6 minutes |
| Live-brain command below | 0 | 200/200 cases; 20/20 repetitions; 1.1 minutes |

```bash
PW_SKIP_CONSOLE_BUILD=1 PW_HOST_BINARY=/Users/oxoxdev/Work/Zerolend/tinyhumans.ai/opencompany-approval-flake/target/e2e/bin/opencompany-default-b4cab3ea3 npx playwright test test/e2e/approval-blocker-verdicts.spec.ts --repeat-each=20 --retries=0 --reporter=list

PW_LIVE_BRAIN=1 PW_MOCK_BRAIN_BIND=127.0.0.1:17541 PW_MCP_FIXTURE_BIND=127.0.0.1:17542 PW_SKIP_CONSOLE_BUILD=1 PW_HOST_BINARY=/Users/oxoxdev/Work/Zerolend/tinyhumans.ai/opencompany-approval-flake/target/e2e/bin/opencompany-live-b4cab3ea3 npx playwright test test/e2e/approval-blocker-verdicts.spec.ts --repeat-each=20 --retries=0 --reporter=list
```

Both host binaries were built from the fixed production source above: `cargo build --locked --bin opencompany --target-dir ../opencompany-authmatrix/target` and the same command with `--features openhuman,mcp`, each exit 0. No union build. `npm ci`, `npm run build`, and `npm run build:pages-sdk` also exited 0. Hosts and sessions used only this worktree's disposable `target/e2e` root; no credential or persistent company fixture was changed. No stash was used.

Setup-only failures are excluded from reproduction counts: two premature build attempts before recursive submodule initialization completed exited 101; one sandboxed host bind was refused and exited 1 before any test; an anchored isolated-test filter selected zero tests and exited 1. The reported browser loops ran with local host and browser permissions, and each executed the stated nonzero count.

Main currently has no branch protection: `/branches/main/protection` returns 404 and `/rulesets` returns `[]`. That is why reliable, observed-red gates matter here. Repository settings belong to the maintainer and were not changed. Draft only; no production behavior change.
