### PR TITLE
test(console): cover the operational views' failure paths

### DIFF
--- a/frontend/test/unit/cov-chat-approval-row-failed.test.ts
+++ b/frontend/test/unit/cov-chat-approval-row-failed.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import { ApprovalRow } from "@/views/chat/ApprovalRow";
+
+/**
+ * `AppShell.decideApproval` (the write behind this row's Approve/Decline) is
+ * `CompanyAuth`, not admin-scoped — any signed-in company principal may
+ * settle a request they can see, so there is no member/admin gate to pin
+ * here. What the row itself owes is honesty once that write fails: `failed`
+ * is keyed per approval id specifically so a batch decision can never read as
+ * "all authorised" when one of them was not (`decideApproval`'s own doc), and
+ * the row must stay retryable rather than stuck on its busy state.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+function approval(over: Partial<ApprovalSummary> & Pick<ApprovalSummary, "id">): ApprovalSummary {
+  return {
+    kind: "web_fetch",
+    amount_usd: null,
+    at_millis: T0,
+    agent: "eng",
+    thread: "eng",
+    ...over,
+  };
+}
+
+interface Decision {
+  id: string;
+  verdict: Verdict;
+  scope: GrantScope;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let decisions: Decision[];
+
+async function render(props: {
+  approvals: ApprovalSummary[];
+  decided?: Record<string, Verdict>;
+  failed?: Record<string, string>;
+}) {
+  await act(async () => {
+    root.render(
+      createElement(ApprovalRow, {
+        approvals: props.approvals,
+        now: T0 + 60_000,
+        askerNames: new Map([["eng", "Engineer"]]),
+        variant: "full" as const,
+        deciding: new Map(),
+        decided: props.decided ?? {},
+        failed: props.failed ?? {},
+        onDecide: (approval: ApprovalSummary, verdict: Verdict, scope: GrantScope) =>
+          decisions.push({ id: approval.id, verdict, scope }),
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  decisions = [];
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function button(label: string): HTMLButtonElement {
+  const match = [...container.querySelectorAll("button")].find((b) =>
+    (b.textContent ?? "").includes(label),
+  );
+  if (!match) throw new Error(`no "${label}" button on the card: ${container.textContent}`);
+  return match as HTMLButtonElement;
+}
+
+async function click(el: HTMLElement) {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("a single approval whose resolveApproval call failed (FAIL)", () => {
+  const A1 = approval({ id: "a1" });
+
+  it("names the failure instead of leaving the card looking merely pending", async () => {
+    await render({ approvals: [A1], failed: { a1: "network error" } });
+
+    expect(container.textContent).toContain("Not recorded — try again");
+  });
+
+  it("keeps Approve and Decline live so the operator can retry, not stuck busy", async () => {
+    await render({ approvals: [A1], failed: { a1: "network error" } });
+
+    const approve = button("Approve");
+    const decline = button("Decline");
+    expect(approve.disabled).toBe(false);
+    expect(decline.disabled).toBe(false);
+
+    await click(approve);
+    expect(decisions).toEqual([{ id: "a1", verdict: "approve", scope: { kind: "once" } }]);
+  });
+
+  it("shows nothing extra when nothing has failed", async () => {
+    await render({ approvals: [A1] });
+
+    expect(container.textContent).not.toContain("try again");
+  });
+});
+
+/**
+ * A batch where one call's decision failed to record and the others landed —
+ * the row must say so per item, never as a single "it worked" or a single
+ * "it failed" that erases which is which (`decideApproval`'s own doc: "a
+ * failure on the third leaves two effects authorised and one not").
+ */
+describe("a batch where only one item's decision failed to record (AUTH — must not claim a false blanket outcome)", () => {
+  const A1 = approval({ id: "a1", batch: "turn-1" });
+  const A2 = approval({ id: "a2", batch: "turn-1", at_millis: T0 + 1 });
+  const A3 = approval({ id: "a3", batch: "turn-1", at_millis: T0 + 2 });
+
+  it("names exactly the one that failed, not the whole batch", async () => {
+    await render({
+      approvals: [A1, A2, A3],
+      decided: { a1: "approve", a2: "approve" },
+      failed: { a3: "network error" },
+    });
+
+    // Two of three settled; the third alone did not record — not the whole
+    // batch, and each item's own row says which it was.
+    expect(container.textContent).toContain("1 of 3 weren't recorded — try again");
+    expect(container.textContent).not.toContain("None of the 3");
+    expect(container.textContent).toContain("Not recorded — network error");
+    // The two that landed still say so, per item — not swallowed by the one
+    // that failed.
+    expect(container.textContent?.match(/Approved/g)?.length).toBe(2);
+  });
+
+  it("still offers a retry for the batch's remaining (failed) item", async () => {
+    await render({
+      approvals: [A1, A2, A3],
+      decided: { a1: "approve", a2: "approve" },
+      failed: { a3: "network error" },
+    });
+
+    const approve = button("Approve");
+    expect(approve.disabled).toBe(false);
+    await click(approve);
+    // `decideAll` re-sends every still-pending item — here just a3, the one
+    // that never recorded — not the two already settled.
+    expect(decisions).toEqual([{ id: "a3", verdict: "approve", scope: { kind: "once" } }]);
+  });
+});

--- a/frontend/test/unit/cov-chat-approval-row.test.ts
+++ b/frontend/test/unit/cov-chat-approval-row.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import { ApprovalRow } from "@/views/chat/ApprovalRow";
+
+/**
+ * The inline chat approval card's Approve/Decline (`resolveApproval`, `POST
+ * {scope}/approvals/{aid}`, `operator.rs`). That route runs behind
+ * `CompanyAuth` — any authenticated principal, not admin-only, the same gate
+ * `pause`/`resume` carry (see `settings-general-admin-only.test.ts`'s note on
+ * lifecycle) — and `ApprovalRow` takes no `canManage`/`isAdmin` prop at all:
+ * every caller gets the same two buttons. This pins that the card is live for
+ * whoever is handed it, and that a decision the host refuses is said on the
+ * card rather than silently dropped or shown as settled.
+ *
+ * The ledger names Approve/Revise and a failure-toast gap on "the Approve/Revise
+ * buttons themselves" — this component's Approve/Decline are that control.
+ * `ThreadPanel`'s own inline Approve is the *other* card the phrasing could
+ * mean (`cov-chat-thread-panel-review-auth.test.ts`, `cov-chat-review-card-
+ * fail.test.ts`) and is a distinct route (`chat/review`, not `approvals`) —
+ * both are covered so the ambiguity in the ledger costs nothing.
+ */
+
+const T0 = Date.UTC(2026, 8, 1, 9, 0, 0);
+
+function approval(id: string): ApprovalSummary {
+  return {
+    id,
+    kind: "web_fetch",
+    amount_usd: null,
+    at_millis: T0,
+    agent: "seo",
+    thread: "desk-marketing",
+    batch: "turn-1",
+    broadly_grantable: true,
+    payload: { url: "https://example.com/items" },
+  };
+}
+
+const CALL = approval("a1");
+
+interface Decision {
+  id: string;
+  verdict: Verdict;
+  scope: GrantScope;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let decisions: Decision[];
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  decisions = [];
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render(
+  failed: Record<string, string> = {},
+  deciding: ReadonlyMap<string, Verdict> = new Map(),
+) {
+  await act(async () => {
+    root.render(
+      createElement(ApprovalRow, {
+        approvals: [CALL],
+        now: T0 + 60_000,
+        askerNames: new Map([["seo", "SEO Specialist"]]),
+        variant: "full",
+        deciding,
+        decided: {},
+        failed,
+        onDecide: (a: ApprovalSummary, verdict: Verdict, scope: GrantScope) =>
+          decisions.push({ id: a.id, verdict, scope }),
+      }),
+    );
+  });
+}
+
+function button(label: string): HTMLButtonElement {
+  const match = [...container.querySelectorAll("button")].find((b) => (b.textContent ?? "").includes(label));
+  if (!match) throw new Error(`no "${label}" button on the card: ${container.textContent}`);
+  return match as HTMLButtonElement;
+}
+
+async function click(el: HTMLElement) {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("the chat approval card, offered with no role prop at all", () => {
+  it("renders live Approve and Decline for whoever the card was shown to", async () => {
+    await render();
+
+    expect(button("Approve").disabled).toBe(false);
+    expect(button("Decline").disabled).toBe(false);
+  });
+
+  it("wires Approve straight to onDecide", async () => {
+    await render();
+    await click(button("Approve"));
+
+    expect(decisions).toEqual([{ id: "a1", verdict: "approve", scope: { kind: "once" } }]);
+  });
+});
+
+describe("a decision the host refuses", () => {
+  it("names the refusal on the card and keeps Approve/Decline live for a retry", async () => {
+    await render({ a1: "the company is paused" });
+
+    expect(container.textContent).toContain("Not recorded — try again");
+    expect(button("Approve").disabled).toBe(false);
+    expect(button("Decline").disabled).toBe(false);
+  });
+
+  it("does not remove the card or claim it settled while a decision is still in flight", async () => {
+    await render({}, new Map([["a1", "approve"]]));
+
+    // Busy, not gone and not claiming success: the row is still asking.
+    expect(container.querySelector("button")).not.toBeNull();
+    expect(container.textContent).not.toContain("Approved");
+  });
+});

--- a/frontend/test/unit/cov-chat-attach-oversized-file.test.ts
+++ b/frontend/test/unit/cov-chat-attach-oversized-file.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import { MessageComposer } from "@/views/chat/MessageComposer";
+
+/**
+ * `uploadChatAttachment` (`api/chat.ts`) enforces no size cap of its own —
+ * the limit, if any, is the host's on `POST …/chat/upload`. `chat-composer-
+ * attach.test.ts` pins the happy path; nothing pinned what a refusal from
+ * that route (an oversized file, most plausibly a `413`) does to the
+ * composer. It must say so and leave no phantom chip staged for a node the
+ * host never created — the same "silent success" shape 's other
+ * findings were about.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function render(upload: ReturnType<typeof vi.fn>) {
+  await act(async () => {
+    root.render(
+      createElement(MessageComposer, {
+        placeholder: "Message engineering",
+        onSend: vi.fn(),
+        uploadAttachment: upload,
+        deleteAttachment: vi.fn(),
+      }),
+    );
+  });
+}
+
+async function pick(file: File) {
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+  Object.defineProperty(input, "files", { value: [file], configurable: true });
+  await act(async () => {
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+const bigFile = () => new File([new Uint8Array(16)], "recording.mov", { type: "video/quicktime" });
+
+describe("a file the host refuses as too large", () => {
+  it("names the host's own refusal rather than a silent failure", async () => {
+    const upload = vi.fn(async () => {
+      throw new ApiError(413, "payload_too_large", "That file is larger than this host allows.");
+    });
+    await render(upload);
+    await pick(bigFile());
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      "That file is larger than this host allows.",
+    );
+  });
+
+  it("stages no chip for the refused upload — nothing to send", async () => {
+    const upload = vi.fn(async () => {
+      throw new ApiError(413, "payload_too_large", "too big");
+    });
+    await render(upload);
+    await pick(bigFile());
+
+    expect(container.textContent).not.toContain("recording.mov");
+    const send = container.querySelector('[aria-label="Send"]') as HTMLButtonElement;
+    // No text typed either, so Send stays disabled either way — the chip is
+    // the thing under test, not the button's overall enabled state.
+    expect(send.disabled).toBe(true);
+  });
+
+  it("clears the paperclip's busy state so a retry is offered, not stuck spinning", async () => {
+    const upload = vi.fn(async () => {
+      throw new ApiError(413, "payload_too_large", "too big");
+    });
+    await render(upload);
+    await pick(bigFile());
+
+    const paperclip = container.querySelector('[aria-label="Attach a file"]') as HTMLButtonElement;
+    expect(paperclip.disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-chat-attachments-download.test.ts
+++ b/frontend/test/unit/cov-chat-attachments-download.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MessageAttachments } from "@/views/chat/MessageAttachments";
+import type { AttachmentDto } from "@/api/types";
+
+/**
+ * `ChatView`'s `resolveAttachmentUrl` wraps `fetchBlobUrl` against the node id
+ * a chat line stored — the node named there can be gone by the time someone
+ * clicks it (deleted from the workspace after the line was written). The
+ * download button's own `catch` sets `downloadError`; before this it was an
+ * unhandled rejection with the button just looking like it did nothing.
+ */
+
+const ATTACHMENT: AttachmentDto = {
+  nodeId: "node-1",
+  name: "report.pdf",
+  mime: "application/pdf",
+  size: 1024,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function downloadButton(): HTMLButtonElement {
+  return container.querySelector("button") as HTMLButtonElement;
+}
+
+describe("MessageAttachments, a node deleted from the workspace after the line was written (FAIL)", () => {
+  it("shows an honest error instead of silently doing nothing", async () => {
+    const resolveUrl = vi.fn(async () => {
+      throw new Error("This file is no longer in the workspace.");
+    });
+    await act(async () => {
+      root.render(createElement(MessageAttachments, { attachments: [ATTACHMENT], resolveUrl }));
+    });
+
+    await act(async () => {
+      downloadButton().click();
+    });
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent).toContain("This file is no longer in the workspace.");
+    // Not stuck showing the spinner either.
+    expect(downloadButton().disabled).toBe(false);
+  });
+
+  it("falls back to a generic message for a non-Error rejection", async () => {
+    const resolveUrl = vi.fn(async () => {
+      throw { status: 404 };
+    });
+    await act(async () => {
+      root.render(createElement(MessageAttachments, { attachments: [ATTACHMENT], resolveUrl }));
+    });
+
+    await act(async () => {
+      downloadButton().click();
+    });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      "Couldn't download this file.",
+    );
+  });
+});
+
+describe("MessageAttachments, no resolver bound (client cannot reach the blob route)", () => {
+  it("renders the chip inert rather than offering a download that can only fail", async () => {
+    await act(async () => {
+      root.render(createElement(MessageAttachments, { attachments: [ATTACHMENT] }));
+    });
+
+    expect(downloadButton().disabled).toBe(true);
+  });
+});

--- a/frontend/test/unit/cov-chat-budget-set-clear.test.ts
+++ b/frontend/test/unit/cov-chat-budget-set-clear.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { ChatView } from "@/views/ChatView";
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: Object.assign(toasts.base, { success: toasts.success, error: toasts.error, warning: vi.fn(), info: vi.fn() }),
+}));
+
+/**
+ * `ChatView.applyBudget`/`resetBudget` — reached only through
+ * `MembersPane`'s `canEditBudget={isAdmin && fromHost}` gate
+ * (`cov-chat-members-budget-auth.test.ts` pins that gate itself) — had no
+ * test for what they actually do once opened: `client.setTeamBudget` and
+ * `client.clearTeamBudgetOverride` are both documented admin-only writes, and
+ * a failed one must surface on screen rather than leave the dialog looking
+ * like nothing happened.
+ */
+
+const DESK_DTO = { id: "main", name: "main", description: "The main channel", members: [] as string[] };
+const MEMBER_DTO = { id: "m1", name: "Ada", role: "engineer" };
+
+function clientAs(opts: {
+  setTeamBudget?: (id: string, cap: number | null) => Promise<unknown>;
+}): OpenCompanyClient {
+  const named: Record<string, unknown> = {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return Promise.resolve({ id: "u1", email: "a@b.c", role: "admin", company: "acme" });
+      }
+      return Promise.resolve([]);
+    },
+    listDesks: () => Promise.resolve([DESK_DTO]),
+    listTeam: () => Promise.resolve([MEMBER_DTO]),
+    getOperatorChannel: () =>
+      Promise.resolve({ id: "operator", name: "Operator", description: "Workflow reports and notifications" }),
+    setTeamBudget: vi.fn(
+      opts.setTeamBudget ??
+        ((_id: string, cap: number | null) => Promise.resolve({ ...MEMBER_DTO, budgetUsdDaily: cap ?? undefined })),
+    ),
+  };
+  return new Proxy(named, {
+    get: (target, prop: string) => target[prop] ?? (() => Promise.resolve([])),
+  }) as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("min-width"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  Object.defineProperty(window, "innerWidth", { value: 1440, writable: true });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  toasts.base.mockClear();
+  toasts.success.mockClear();
+  toasts.error.mockClear();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function tree(client: OpenCompanyClient): ReactNode {
+  const view = createElement(ChatView, {
+    client,
+    company: "acme",
+    sub: "main",
+    onNavigate: vi.fn(),
+    transcripts: {},
+    setTranscripts: vi.fn(),
+    resolveTypingNames: () => [],
+    scopeRef: { current: { connection: "local", company: "acme", client } },
+  });
+  return createElement(ConnectionScopeProvider, {
+    scope: { connection: "local", company: "acme" },
+    children: view,
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(tree(client));
+  });
+  await flush();
+}
+
+function menuItem(testid: string): HTMLElement | null {
+  return document.body.querySelector(`[data-testid="${testid}"]`);
+}
+
+async function openBudgetDialog() {
+  const membersToggle = [...container.querySelectorAll("button")].find((b) =>
+    (b.textContent ?? "").includes("teammates"),
+  ) as HTMLButtonElement;
+  await act(async () => membersToggle.click());
+  await flush();
+
+  const actions = container.querySelector('[aria-label="Actions for Ada"]') as HTMLButtonElement;
+  await act(async () => actions.click());
+  await flush();
+
+  const edit = menuItem("team-budget-edit");
+  await act(async () => edit?.click());
+  await flush();
+}
+
+function setInput(el: HTMLInputElement, text: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+describe("setting a teammate's daily cap from chat", () => {
+  it("writes the cap through client.setTeamBudget and confirms it", async () => {
+    const client = clientAs({});
+    await mount(client);
+    await openBudgetDialog();
+
+    const input = menuItem("team-budget-input") as HTMLInputElement;
+    expect(input).not.toBeNull();
+    setInput(input, "5");
+
+    const save = menuItem("team-budget-save") as HTMLButtonElement;
+    await act(async () => save.click());
+    await flush();
+
+    expect(client.setTeamBudget).toHaveBeenCalledWith("m1", 5, "acme");
+    expect(toasts.success).toHaveBeenCalledWith("Daily cap set to $5.00.");
+    expect(toasts.error).not.toHaveBeenCalled();
+  });
+
+  it("reports a refused write rather than leaving the dialog silent", async () => {
+    const client = clientAs({
+      setTeamBudget: () => Promise.reject(new ApiError(403, "forbidden", "only an admin can do that")),
+    });
+    await mount(client);
+    await openBudgetDialog();
+
+    const input = menuItem("team-budget-input") as HTMLInputElement;
+    setInput(input, "5");
+
+    const save = menuItem("team-budget-save") as HTMLButtonElement;
+    await act(async () => save.click());
+    await flush();
+
+    expect(toasts.error).toHaveBeenCalledWith("only an admin can do that");
+    expect(toasts.success).not.toHaveBeenCalled();
+  });
+
+  it("names a host with no console-budget route rather than the raw 404", async () => {
+    const client = clientAs({
+      setTeamBudget: () => Promise.reject(new ApiError(404, "not_found", "no route")),
+    });
+    await mount(client);
+    await openBudgetDialog();
+
+    const input = menuItem("team-budget-input") as HTMLInputElement;
+    setInput(input, "5");
+
+    const save = menuItem("team-budget-save") as HTMLButtonElement;
+    await act(async () => save.click());
+    await flush();
+
+    expect(toasts.error).toHaveBeenCalledWith("This host doesn't support console budgets yet.");
+  });
+});

--- a/frontend/test/unit/cov-chat-card-team-budget-refusals.test.ts
+++ b/frontend/test/unit/cov-chat-card-team-budget-refusals.test.ts
@@ -1,0 +1,328 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useState, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { BUDGET_PAUSE_NOTICE_PREFIX } from "@/hooks/use-events";
+import { ChatView } from "@/views/ChatView";
+import type { ChatMessage } from "@/lib/chat";
+import type { Transcripts } from "@/views/chat/model";
+import type { TaskStatus } from "@/api/tasks";
+
+/**
+ * `ChatView` wires several inline actions with their own host round trip and
+ * their own catch block — dismissing a card, removing a teammate, redeeming a
+ * budget pause. Every one of those catch blocks was written and never driven
+ * end to end: this file mounts the real view, triggers each control, and has
+ * the client refuse the write the way the host actually does, then asserts
+ * the screen says something true instead of a false success or a silent
+ * nothing.
+ *
+ * (Send, reactions and the settle-pill Approve get the same treatment in
+ * `cov-chat-composer-send-fail.test.ts`, `cov-chat-reaction-404-rollback.test.ts`
+ * and `cov-chat-review-card-fail.test.ts`.)
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  }),
+}));
+
+const DESK_DTO = { id: "main", name: "main", description: "The main channel", members: [] as string[] };
+const OPERATOR_DTO = { id: "operator", name: "Operator", description: "Workflow reports" };
+const MEMBER_DTO = { id: "m1", name: "Ada", role: "engineer" };
+
+interface Overrides {
+  removeTeamMember?: () => Promise<unknown>;
+  del?: () => Promise<unknown>;
+  redeemBudgetPause?: () => Promise<unknown>;
+}
+
+function clientAs(overrides: Overrides): OpenCompanyClient {
+  const named: Record<string, unknown> = {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return Promise.resolve({ id: "u1", email: "a@b.c", role: "member", company: "acme" });
+      }
+      return Promise.resolve([]);
+    },
+    listDesks: () => Promise.resolve([DESK_DTO]),
+    listTeam: () => Promise.resolve([MEMBER_DTO]),
+    mentionables: () => Promise.resolve([]),
+    getOperatorChannel: () => Promise.resolve(OPERATOR_DTO),
+    capabilityStatus: () => Promise.resolve({ cognition: null }),
+    removeTeamMember: vi.fn(overrides.removeTeamMember ?? (() => Promise.resolve())),
+    del: vi.fn(overrides.del ?? (() => Promise.resolve())),
+    getBudgetPause: vi.fn(() => Promise.resolve(null)),
+    redeemBudgetPause: vi.fn(overrides.redeemBudgetPause ?? (() => Promise.resolve())),
+  };
+  return new Proxy(named, {
+    get: (target, prop: string) => target[prop] ?? (() => Promise.resolve([])),
+  }) as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("min-width"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  Object.defineProperty(window, "innerWidth", { value: 1440, writable: true });
+  // jsdom does not implement scrollTo; `MessageTimeline` calls it to follow
+  // new messages, which would otherwise throw on every render with content.
+  Element.prototype.scrollTo = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  toasts.base.mockClear();
+  toasts.success.mockClear();
+  toasts.error.mockClear();
+  toasts.info.mockClear();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+/**
+ * `transcripts`/`setTranscripts` are controlled props the shell owns — every
+ * action under test here (`clearCardEverywhere`, the approve pill's own
+ * re-render) writes through `setTranscripts`, so a `vi.fn()` stub would
+ * silently discard every one of them. This holds the real state a host page
+ * would.
+ */
+function Harness({
+  client,
+  initialTranscripts,
+  taskStatusByTaskId,
+}: {
+  client: OpenCompanyClient;
+  initialTranscripts: Transcripts;
+  taskStatusByTaskId?: Record<string, TaskStatus>;
+}) {
+  const [transcripts, setTranscripts] = useState<Transcripts>(initialTranscripts);
+  const view = createElement(ChatView, {
+    client,
+    company: "acme",
+    sub: "main",
+    onNavigate: vi.fn(),
+    transcripts,
+    setTranscripts,
+    resolveTypingNames: () => [],
+    scopeRef: { current: { connection: "local", company: "acme", client } },
+    taskStatusByTaskId,
+  });
+  return createElement(ConnectionScopeProvider, {
+    scope: { connection: "local", company: "acme" },
+    children: view,
+  });
+}
+
+function tree(client: OpenCompanyClient, transcripts: Transcripts, taskStatusByTaskId?: Record<string, TaskStatus>): ReactNode {
+  return createElement(Harness, { client, initialTranscripts: transcripts, taskStatusByTaskId });
+}
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+async function mount(client: OpenCompanyClient, transcripts: Transcripts = {}, taskStatusByTaskId?: Record<string, TaskStatus>) {
+  await act(async () => {
+    root.render(tree(client, transcripts, taskStatusByTaskId));
+  });
+  await flush();
+}
+
+function bodyButton(text: string): HTMLButtonElement | undefined {
+  return [...document.body.querySelectorAll("button")].find((b) => (b.textContent ?? "").includes(text)) as
+    | HTMLButtonElement
+    | undefined;
+}
+
+/** A dropdown/menu item — base-ui renders these as `[role="menuitem"]`, not `<button>`. */
+function bodyMenuItem(text: string): HTMLElement | undefined {
+  return [...document.body.querySelectorAll('[role="menuitem"]')].find((b) =>
+    (b.textContent ?? "").includes(text),
+  ) as HTMLElement | undefined;
+}
+
+/**
+ * `dismissCard` is deliberately NOT optimistic — the chip must stay
+ * exactly where it was on a refusal, unlike `react`'s rollback, because a chip
+ * that vanished while the card survives on the board is the false state this
+ * function's own doc says it exists to avoid.
+ */
+describe("dismissing a card the host refuses to delete (AUTH — the console must not lie about it)", () => {
+  const MESSAGE: ChatMessage = { id: "h2", from: "company", text: "opened a card", at: 0, taskId: "task-1" };
+
+  async function openConfirm() {
+    const dismiss = container.querySelector('[aria-label="Dismiss this card"]') as HTMLButtonElement;
+    expect(dismiss).not.toBeNull();
+    await act(async () => dismiss.click());
+    await flush();
+    const confirm = bodyButton("Dismiss card");
+    expect(confirm).not.toBeUndefined();
+    await act(async () => confirm?.click());
+    await flush();
+  }
+
+  it("keeps the chip in place and reports the refusal, rather than clearing it", async () => {
+    const client = clientAs({
+      del: () => Promise.reject(new ApiError(409, "conflict", "This card still has work running.")),
+    });
+    await mount(client, { main: [MESSAGE] }, { "task-1": { column: "in_review" } });
+    await openConfirm();
+
+    expect(toasts.error).toHaveBeenCalledWith("This card still has work running.");
+    // Still there: the link half of the chip survives a refused delete.
+    expect(container.querySelector('a[href="#/tasks/task-1"]')).not.toBeNull();
+  });
+
+  it("clears the chip when the host says the card is already gone (404)", async () => {
+    const client = clientAs({
+      del: () => Promise.reject(new ApiError(404, "not_found", "no such card")),
+    });
+    await mount(client, { main: [MESSAGE] }, { "task-1": { column: "in_review" } });
+    await openConfirm();
+
+    expect(toasts.success).toHaveBeenCalledWith("That card was already gone — chip cleared.");
+    expect(container.querySelector('a[href="#/tasks/task-1"]')).toBeNull();
+  });
+});
+
+/**
+ * `POST/DELETE …/team` are `ScopedCompany` — any signed-in member
+ * may add or remove a teammate — so there is no role gate to pin here. What
+ * had no coverage was the one refusal the host still enforces (a company's
+ * last teammate) and an ordinary write failure, neither silently swallowed.
+ */
+describe("removing a teammate from the chat member pane", () => {
+  async function openRemove() {
+    const toggle = [...container.querySelectorAll("button")].find((b) =>
+      (b.textContent ?? "").includes("teammate"),
+    ) as HTMLButtonElement;
+    expect(toggle, "the members-pane toggle").not.toBeUndefined();
+    await act(async () => toggle.click());
+    await flush();
+    const actions = container.querySelector('[aria-label="Actions for Ada"]') as HTMLButtonElement;
+    expect(actions, "the row's actions trigger").not.toBeNull();
+    await act(async () => actions.click());
+    await flush();
+    const remove = bodyMenuItem("Remove from roster");
+    expect(remove, "the Remove from roster item").not.toBeUndefined();
+    await act(async () => remove?.click());
+    await flush();
+  }
+
+  it("names the host's last-teammate refusal (AUTH — a removal the host will not allow)", async () => {
+    const client = clientAs({
+      removeTeamMember: () =>
+        Promise.reject(new ApiError(409, "conflict", "You can't remove your company's last teammate.")),
+    });
+    await mount(client);
+    await openRemove();
+
+    expect(toasts.error).toHaveBeenCalledWith("You can't remove your company's last teammate.");
+  });
+
+  it("reports an ordinary failure rather than leaving the row untouched with no explanation (FAIL)", async () => {
+    const client = clientAs({
+      removeTeamMember: () => Promise.reject(new ApiError(500, "server_error", "temporarily unavailable")),
+    });
+    await mount(client);
+    await openRemove();
+
+    expect(toasts.error).toHaveBeenCalledWith("temporarily unavailable");
+  });
+});
+
+/**
+ * `redeemBudgetPause`'s two documented, non-retryable refusals — a
+ * 404 (already redeemed elsewhere) read as a delayed success, and a 409 (the
+ * marker changed since the notice was shown, e.g. the company is paused) told
+ * to the operator as "look again" rather than silently retried against the
+ * wrong marker.
+ */
+describe("redeeming a parked budget pause from its chat notice (AUTH — a stale/paused refusal)", () => {
+  function pauseMessage(): ChatMessage {
+    return {
+      id: "h4",
+      from: "system",
+      text: `${BUDGET_PAUSE_NOTICE_PREFIX} Paused — agent1's turn ran out of inference budget/credits.`,
+      at: 0,
+    };
+  }
+
+  async function clickResend() {
+    const btn = [...container.querySelectorAll("button")].find((b) =>
+      (b.textContent ?? "").includes("Add credits & resend"),
+    );
+    expect(btn, "the Add credits & resend button").not.toBeUndefined();
+    await act(async () => (btn as HTMLButtonElement).click());
+    await flush();
+  }
+
+  it("reads a 404 as already handled, not as an error", async () => {
+    const client = clientAs({
+      redeemBudgetPause: () => Promise.reject(new ApiError(404, "not_found", "no such pause")),
+    });
+    await mount(client, { main: [pauseMessage()] });
+    await clickResend();
+
+    expect(toasts.base).toHaveBeenCalledWith("Nothing to resend — that pause was already handled.");
+    expect(toasts.error).not.toHaveBeenCalled();
+  });
+
+  it("tells the operator to look again on a 409 (stale-marker/paused-company refusal), rather than silently retrying", async () => {
+    const client = clientAs({
+      redeemBudgetPause: () => Promise.reject(new ApiError(409, "conflict", "marker changed")),
+    });
+    await mount(client, { main: [pauseMessage()] });
+    await clickResend();
+
+    expect(toasts.base).toHaveBeenCalledWith(
+      "That pause has changed since it was shown — check the latest message and try again.",
+    );
+    expect(toasts.error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to an honest error toast for any other refusal", async () => {
+    const client = clientAs({
+      redeemBudgetPause: () => Promise.reject(new ApiError(500, "server_error", "temporarily unavailable")),
+    });
+    await mount(client, { main: [pauseMessage()] });
+    await clickResend();
+
+    expect(toasts.error).toHaveBeenCalledWith("temporarily unavailable");
+  });
+});

--- a/frontend/test/unit/cov-chat-channel-create-dialog.test.ts
+++ b/frontend/test/unit/cov-chat-channel-create-dialog.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { TeamMember } from "@/lib/team";
+import { ChannelCreateDialog } from "@/views/chat/ChannelCreateDialog";
+
+/**
+ * The channel-create dialog's own field validation, independently traced.
+ *
+ * An empty-member channel is unroutable on the host by construction (the
+ * responder selector has no candidate) — the dialog's own doc says a control
+ * that will be refused is not offered a hopeful submit, so a member-less
+ * submit must never reach `client.createDesk` at all. What it does reach —
+ * a name the host still refuses for some other reason — must land as an
+ * honest, retryable message rather than a stuck "Creating…" button.
+ */
+
+const MEMBERS: TeamMember[] = [
+  {
+    id: "m1",
+    name: "Ada",
+    role: "engineer",
+    description: "",
+    tone: "blue",
+    avatar: "ada",
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+  },
+];
+
+function clientAs(createDesk: ReturnType<typeof vi.fn>): OpenCompanyClient {
+  return { createDesk } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let onCreated: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  // jsdom does not implement scrollIntoView; the blank-name refusal focuses
+  // and scrolls the name field to it.
+  Element.prototype.scrollIntoView = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  onCreated = vi.fn();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function render(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(ChannelCreateDialog, {
+        client,
+        company: "acme",
+        members: MEMBERS,
+        open: true,
+        onOpenChange: vi.fn(),
+        onCreated,
+      }),
+    );
+  });
+}
+
+function at(label: string): HTMLElement {
+  const el = [...document.body.querySelectorAll("label")].find((l) => l.textContent === label);
+  const id = el?.getAttribute("for");
+  const input = id ? document.getElementById(id) : null;
+  if (!input) throw new Error(`no field labelled "${label}"`);
+  return input;
+}
+
+function submitButton(): HTMLButtonElement {
+  return [...document.body.querySelectorAll("button")].find((b) => (b.textContent ?? "").includes("Create channel"))
+    ?.closest("button") as HTMLButtonElement;
+}
+
+async function type(input: HTMLElement, text: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  await act(async () => {
+    setter.call(input, text);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function submit() {
+  await act(async () => submitButton().click());
+}
+
+describe("submitting with nobody picked (AUTH — a submit the host would refuse as unroutable)", () => {
+  it("shows the members error and never calls client.createDesk", async () => {
+    const createDesk = vi.fn(async () => ({ id: "d1" }));
+    await render(clientAs(createDesk));
+
+    await type(at("Name"), "Launch week");
+    await submit();
+
+    expect(document.body.textContent).toContain("Pick at least one member");
+    expect(createDesk).not.toHaveBeenCalled();
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  it("clears the members error the moment a member is picked", async () => {
+    const createDesk = vi.fn(async () => ({ id: "d1" }));
+    await render(clientAs(createDesk));
+
+    await type(at("Name"), "Launch week");
+    await submit();
+    expect(document.body.textContent).toContain("Pick at least one member");
+
+    await act(async () => {
+      (document.body.querySelector('button[aria-pressed="false"]') as HTMLButtonElement)?.click();
+    });
+
+    expect(document.body.textContent).not.toContain("Pick at least one member");
+  });
+});
+
+describe("submitting with a blank name", () => {
+  it("shows the name error and never calls client.createDesk", async () => {
+    const createDesk = vi.fn(async () => ({ id: "d1" }));
+    await render(clientAs(createDesk));
+
+    await submit();
+
+    expect(document.body.textContent).toContain("Give the channel a name");
+    expect(createDesk).not.toHaveBeenCalled();
+  });
+});
+
+describe("a name and a member the host still refuses (FAIL)", () => {
+  async function fillValidForm() {
+    await type(at("Name"), "Launch week");
+    await act(async () => {
+      (document.body.querySelector('button[aria-pressed="false"]') as HTMLButtonElement)?.click();
+    });
+  }
+
+  it("shows the host's own refusal and leaves Create pressable again", async () => {
+    const createDesk = vi.fn(async () => {
+      throw new Error("a channel named Launch week already exists");
+    });
+    await render(clientAs(createDesk));
+    await fillValidForm();
+    await submit();
+
+    expect(createDesk).toHaveBeenCalledOnce();
+    expect(document.body.textContent).toContain("a channel named Launch week already exists");
+    expect(submitButton().disabled).toBe(false);
+    expect(submitButton().textContent).toBe("Create channel");
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a generic message for a non-Error rejection", async () => {
+    const createDesk = vi.fn(async () => {
+      throw { status: 500 };
+    });
+    await render(clientAs(createDesk));
+    await fillValidForm();
+    await submit();
+
+    expect(document.body.textContent).toContain("could not create the channel");
+  });
+});

--- a/frontend/test/unit/cov-chat-channel-create.test.ts
+++ b/frontend/test/unit/cov-chat-channel-create.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { DeskDto } from "@/api/types";
+import type { TeamMember } from "@/lib/team";
+import { ChannelCreateDialog } from "@/views/chat/ChannelCreateDialog";
+
+/**
+ * `POST {scope}/desks` (`create_desk`, `operator.rs`) is `scoped(…)` — any
+ * company member, not admin-only — and `ChannelCreateDialog` carries no role
+ * check of its own; `ChatView`'s own trigger (`onAddChannel`) is likewise
+ * gated only on `fromHost && members.length > 0`, never on `isAdmin`. This
+ * pins the dialog completes end to end for a plain member, and that a
+ * refused create shows an honest, retryable error rather than closing on a
+ * write that never landed.
+ */
+
+const MEMBER: TeamMember = {
+  id: "m1",
+  name: "Ada",
+  role: "engineer",
+  description: "",
+  tone: "blue",
+  avatar: "ada",
+  inboxEnabled: false,
+  effectiveTools: [],
+  desks: [],
+};
+
+const CREATED: DeskDto = {
+  id: "launch-week",
+  name: "Launch week",
+  description: "",
+  members: ["m1"],
+};
+
+function clientAs(createDesk: () => Promise<DeskDto>): OpenCompanyClient {
+  return {
+    createDesk: vi.fn(createDesk),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function render(client: OpenCompanyClient, onCreated = vi.fn()) {
+  await act(async () => {
+    root.render(
+      createElement(ChannelCreateDialog, {
+        client,
+        company: "acme",
+        members: [MEMBER],
+        open: true,
+        onOpenChange: vi.fn(),
+        onCreated,
+      }),
+    );
+  });
+  return onCreated;
+}
+
+function nameInput(): HTMLInputElement {
+  return document.body.querySelector('input[placeholder="e.g. Launch week"]') as HTMLInputElement;
+}
+
+function memberToggle(): HTMLButtonElement {
+  return Array.from(document.body.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes("Ada"),
+  ) as HTMLButtonElement;
+}
+
+function createButton(): HTMLButtonElement {
+  return Array.from(document.body.querySelectorAll("button")).find(
+    (b) => b.textContent === "Create channel" || b.textContent === "Creating…",
+  ) as HTMLButtonElement;
+}
+
+function setInput(el: HTMLInputElement, text: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("creating a channel, for a plain member (no role check in this dialog)", () => {
+  it("completes end to end with no admin gate anywhere in the flow", async () => {
+    const client = clientAs(() => Promise.resolve(CREATED));
+    const onCreated = await render(client);
+
+    setInput(nameInput(), "Launch week");
+    await act(async () => memberToggle().click());
+    await act(async () => createButton().click());
+    await flush();
+
+    expect(client.createDesk).toHaveBeenCalledWith(
+      { name: "Launch week", description: undefined, members: ["m1"], responder: "auto" },
+      "acme",
+    );
+    expect(onCreated).toHaveBeenCalledWith(CREATED);
+  });
+});
+
+describe("creating a channel the host refuses", () => {
+  it("shows an honest error and keeps the form open for a retry", async () => {
+    const client = clientAs(() => Promise.reject(new Error("that name is already taken")));
+    const onCreated = await render(client);
+
+    setInput(nameInput(), "Launch week");
+    await act(async () => memberToggle().click());
+    await act(async () => createButton().click());
+    await flush();
+
+    expect(document.body.textContent).toContain("that name is already taken");
+    expect(onCreated).not.toHaveBeenCalled();
+    // Not stuck disabled — the operator can fix the name and try again.
+    expect(createButton().disabled).toBe(false);
+    expect(createButton().textContent).toBe("Create channel");
+  });
+});

--- a/frontend/test/unit/cov-chat-composer-send-fail.test.ts
+++ b/frontend/test/unit/cov-chat-composer-send-fail.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useState, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import type { Transcripts } from "@/views/chat/model";
+import { ChatView } from "@/views/ChatView";
+
+/**
+ * `ChatView.send`'s own `catch`: a host that refuses
+ * the POST — an over-length body, a 4xx of any other shape — must leave an
+ * honest line in the transcript rather than dropping the operator's message
+ * or leaving it looking sent. `MessageComposer` clears the draft the instant
+ * `onSend` is called, so the only place a refusal can still be said is the
+ * transcript this function appends to in its `catch`.
+ *
+ * No client-side length cap exists anywhere in the composer or `chat.ts` to
+ * test against — this exercises the one path that
+ * genuinely stands between a refused send and a silently lost message: the
+ * host's own rejection, whatever shape it takes.
+ */
+
+const DESK_DTO = { id: "main", name: "main", description: "The main channel", members: [] as string[] };
+
+function clientAs(chat: () => Promise<never>): OpenCompanyClient {
+  const named: Record<string, unknown> = {
+    scopeFor: () => "/api/v1/companies/acme",
+    listDesks: () => Promise.resolve([DESK_DTO]),
+    getOperatorChannel: () =>
+      Promise.resolve({ id: "operator", name: "Operator", description: "Workflow reports and notifications" }),
+    chat: vi.fn(chat),
+  };
+  return new Proxy(named, {
+    get: (target, prop: string) => target[prop] ?? (() => Promise.resolve([])),
+  }) as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("min-width"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  Object.defineProperty(window, "innerWidth", { value: 1440, writable: true });
+  // jsdom does not implement scrollTo; `MessageTimeline` calls it to follow
+  // new messages, which would otherwise throw on every render with content.
+  Element.prototype.scrollTo = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+/** Owns `transcripts` state itself, the way `AppShell` does for the real view. */
+function Harness({ client }: { client: OpenCompanyClient }) {
+  const [transcripts, setTranscripts] = useState<Transcripts>({});
+  return createElement(ChatView, {
+    client,
+    company: "acme",
+    sub: "main",
+    onNavigate: vi.fn(),
+    transcripts,
+    setTranscripts,
+    resolveTypingNames: () => [],
+    scopeRef: { current: { connection: "local", company: "acme", client } },
+  });
+}
+
+function tree(client: OpenCompanyClient): ReactNode {
+  return createElement(ConnectionScopeProvider, {
+    scope: { connection: "local", company: "acme" },
+    children: createElement(Harness, { client }),
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(tree(client));
+  });
+  await flush();
+}
+
+function composerInput(): HTMLTextAreaElement {
+  return container.querySelector('textarea[aria-label^="Message "]') as HTMLTextAreaElement;
+}
+
+function type(el: HTMLTextAreaElement, text: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function send() {
+  const button = container.querySelector('[aria-label="Send"]') as HTMLButtonElement;
+  await act(async () => {
+    button.click();
+  });
+  await flush();
+}
+
+describe("a chat send the host refuses", () => {
+  it("leaves an honest line in the transcript instead of dropping the message", async () => {
+    const client = clientAs(() =>
+      Promise.reject(new ApiError(413, "message_too_long", "That message is too long to send.")),
+    );
+    await mount(client);
+
+    type(composerInput(), "a message the host will refuse");
+    await send();
+
+    expect(client.chat).toHaveBeenCalled();
+    // The draft is cleared optimistically (`MessageComposer.send`) — the
+    // refusal must not leave the operator's words looking lost.
+    expect(composerInput().value).toBe("");
+    expect(container.textContent).toContain(
+      "Couldn't send — That message is too long to send.",
+    );
+  });
+
+  it("names a generic problem for a refusal with no host message", async () => {
+    const client = clientAs(() => Promise.reject(new Error("network down")));
+    await mount(client);
+
+    type(composerInput(), "hello");
+    await send();
+
+    expect(container.textContent).toContain("Couldn't send — something went wrong");
+  });
+});

--- a/frontend/test/unit/cov-chat-members-add-remove.test.ts
+++ b/frontend/test/unit/cov-chat-members-add-remove.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { TeamMember } from "@/lib/team";
+import { AddMemberDialog } from "@/views/chat/AddMemberDialog";
+import { MembersPane } from "@/views/chat/MembersPane";
+
+/**
+ * Add/remove a teammate from chat's member pane. `POST {scope}/team`
+ * (`add_member`) and `DELETE {scope}/team/{agent_id}` (`remove_member`) are
+ * both `scoped(…)` — any company member, not admin-only (a `budget_usd_daily`
+ * at creation is the one thing that needs an admin, and the chat dialog never
+ * collects one — `NewMemberFields` has no such field). `MembersPane` carries
+ * no role check around "Add teammate" or "Remove from roster" the way it
+ * does around the budget menu (`canEditBudget`, `cov-chat-members-budget-
+ * auth.test.ts`) — this pins both stay live for a plain member, and that a
+ * refused add is not silently swallowed.
+ */
+
+const MEMBER: TeamMember = {
+  id: "m1",
+  name: "Ada",
+  role: "engineer",
+  description: "",
+  tone: "blue",
+  avatar: "ada",
+  inboxEnabled: false,
+  effectiveTools: [],
+  desks: [],
+};
+
+function paneProps(overrides: Record<string, unknown> = {}) {
+  return {
+    channelMembers: null,
+    others: [MEMBER],
+    people: [],
+    loading: false,
+    fromHost: true,
+    onToggleInbox: vi.fn(),
+    onRemove: vi.fn(),
+    onAdd: vi.fn(),
+    onMessage: vi.fn(),
+    canEditBudget: false,
+    onEditBudget: vi.fn(),
+    onRemoveCap: vi.fn(),
+    onResetBudget: vi.fn(),
+    setByLabel: () => undefined,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function openMemberMenu() {
+  const trigger = container.querySelector('[aria-label="Actions for Ada"]') as HTMLButtonElement;
+  await act(async () => trigger.click());
+}
+
+function menuItem(text: string): HTMLElement | undefined {
+  return Array.from(document.body.querySelectorAll('[role="menuitem"]')).find((el) =>
+    (el.textContent ?? "").includes(text),
+  ) as HTMLElement | undefined;
+}
+
+describe("MembersPane's Add/Remove, for a plain member (canEditBudget: false)", () => {
+  it("still offers Add teammate — no admin gate on this control", async () => {
+    await act(async () => {
+      root.render(createElement(MembersPane, paneProps()));
+    });
+
+    const add = container.querySelector('[aria-label="Add teammate"]') as HTMLButtonElement;
+    expect(add).not.toBeNull();
+    expect(add.disabled).toBe(false);
+
+    await act(async () => add.click());
+    expect(paneProps().onAdd).not.toBeUndefined(); // sanity: prop exists
+  });
+
+  it("wires the Add trigger straight to onAdd", async () => {
+    const onAdd = vi.fn();
+    await act(async () => {
+      root.render(createElement(MembersPane, paneProps({ onAdd })));
+    });
+
+    const add = container.querySelector('[aria-label="Add teammate"]') as HTMLButtonElement;
+    await act(async () => add.click());
+
+    expect(onAdd).toHaveBeenCalled();
+  });
+
+  it("still offers Remove from roster, beside a budget menu that stays absent", async () => {
+    await act(async () => {
+      root.render(createElement(MembersPane, paneProps()));
+    });
+    await openMemberMenu();
+
+    expect(menuItem("Remove from roster")).not.toBeUndefined();
+    expect(menuItem("Set daily budget")).toBeUndefined();
+  });
+
+  it("wires Remove straight to onRemove with the member's id", async () => {
+    const onRemove = vi.fn();
+    await act(async () => {
+      root.render(createElement(MembersPane, paneProps({ onRemove })));
+    });
+    await openMemberMenu();
+    await act(async () => menuItem("Remove from roster")?.click());
+
+    expect(onRemove).toHaveBeenCalledWith("m1");
+  });
+});
+
+describe("AddMemberDialog, when the write is refused", () => {
+  function clientAs(): OpenCompanyClient {
+    return {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: (path: string) =>
+        path.endsWith("/inference") ? Promise.resolve({ cognition: "echo" }) : Promise.resolve({}),
+    } as unknown as OpenCompanyClient;
+  }
+
+  async function flush() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("keeps the dialog open and the typed fields intact for a retry, rather than closing on a write that never landed", async () => {
+    const onAdd = vi.fn(async () => false);
+    const onOpenChange = vi.fn();
+    await act(async () => {
+      root.render(
+        createElement(AddMemberDialog, {
+          open: true,
+          onOpenChange,
+          onAdd,
+          client: clientAs(),
+          company: "acme",
+        }),
+      );
+    });
+    await flush();
+
+    const setInput = (el: HTMLInputElement, text: string) => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+      act(() => {
+        setter.call(el, text);
+        el.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+    };
+    setInput(document.body.querySelector("#member-name") as HTMLInputElement, "Nova");
+    setInput(document.body.querySelector("#member-role") as HTMLInputElement, "Growth Marketer");
+
+    const create = Array.from(document.body.querySelectorAll("button")).find(
+      (b) => b.textContent === "Add teammate" || b.textContent === "Adding…",
+    ) as HTMLButtonElement;
+    await act(async () => create.click());
+    await flush();
+
+    expect(onAdd).toHaveBeenCalledWith({
+      name: "Nova",
+      role: "Growth Marketer",
+      description: "",
+      inbox: false,
+    });
+    // Not closed on a failed write — the caller's own toast (ChatView.addMember)
+    // is the visible error; this dialog's honest half is staying open and
+    // retryable rather than claiming the write landed.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect((document.body.querySelector("#member-name") as HTMLInputElement).value).toBe("Nova");
+    const retry = Array.from(document.body.querySelectorAll("button")).find(
+      (b) => b.textContent === "Add teammate",
+    ) as HTMLButtonElement | undefined;
+    expect(retry).not.toBeUndefined();
+    expect(retry?.disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-chat-members-budget-auth.test.ts
+++ b/frontend/test/unit/cov-chat-members-budget-auth.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MembersPane } from "@/views/chat/MembersPane";
+import type { TeamMember } from "@/lib/team";
+
+/**
+ * `MemberRow`'s budget menu is gated `canEditBudget={isAdmin && fromHost}`
+ * (`ChatView.tsx`) — a member with no admin session must not see "Set daily
+ * budget…" at all, since `PUT …/team/{id}/budget` is admin-only on the host.
+ */
+
+const MEMBER: TeamMember = {
+  id: "m1",
+  name: "Ada",
+  role: "engineer",
+  description: "",
+  tone: "blue",
+  avatar: "ada",
+  inboxEnabled: false,
+  effectiveTools: [],
+  desks: [],
+};
+
+function baseProps(canEditBudget: boolean) {
+  return {
+    channelMembers: null,
+    others: [MEMBER],
+    people: [],
+    loading: false,
+    fromHost: true,
+    onToggleInbox: vi.fn(),
+    onRemove: vi.fn(),
+    onAdd: vi.fn(),
+    onMessage: vi.fn(),
+    canEditBudget,
+    onEditBudget: vi.fn(),
+    onRemoveCap: vi.fn(),
+    onResetBudget: vi.fn(),
+    setByLabel: () => undefined,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function openMenu() {
+  const trigger = container.querySelector('[aria-label="Actions for Ada"]') as HTMLButtonElement;
+  await act(async () => trigger.click());
+}
+
+// The menu content renders through a `MenuPrimitive.Portal` (base-ui), not
+// into `container`.
+function menuAt(testid: string): HTMLElement | null {
+  return document.body.querySelector(`[data-testid="${testid}"]`);
+}
+
+describe("MembersPane budget menu, by canEditBudget (ChatView's isAdmin && fromHost)", () => {
+  it("offers no budget entry point to a member", async () => {
+    await act(async () => {
+      root.render(createElement(MembersPane, baseProps(false)));
+    });
+    await openMenu();
+
+    expect(menuAt("team-budget-edit")).toBeNull();
+    expect(menuAt("team-budget-remove")).toBeNull();
+    expect(menuAt("team-budget-reset")).toBeNull();
+  });
+
+  it("offers the budget entry point to an admin", async () => {
+    await act(async () => {
+      root.render(createElement(MembersPane, baseProps(true)));
+    });
+    await openMenu();
+
+    expect(menuAt("team-budget-edit")).not.toBeNull();
+  });
+
+  it("still withholds the budget entry point from an admin viewing a starter-roster teammate (fromHost false)", async () => {
+    // `canEditBudget` is computed as `isAdmin && fromHost` in ChatView — a
+    // starter-roster row has no budget record on the host to edit.
+    await act(async () => {
+      root.render(createElement(MembersPane, baseProps(false)));
+    });
+    await openMenu();
+
+    expect(menuAt("team-budget-edit")).toBeNull();
+  });
+});

--- a/frontend/test/unit/cov-chat-reaction-404-rollback.test.ts
+++ b/frontend/test/unit/cov-chat-reaction-404-rollback.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useState, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { ChatMessage } from "@/lib/chat";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import type { Transcripts } from "@/views/chat/model";
+import { ChatView } from "@/views/ChatView";
+
+const toasts = vi.hoisted(() => ({ base: vi.fn(), success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({
+  toast: Object.assign(toasts.base, { success: toasts.success, error: toasts.error, warning: vi.fn(), info: vi.fn() }),
+}));
+
+/**
+ * `ChatView.react` is optimistic — the chip flips before the
+ * round trip — and rolls back only on a refusal it can actually read. The
+ * idempotent `on` write itself is straightforward; what had no test is the
+ * rollback: a host with no reactions route (`404`) has to leave the chip
+ * exactly where it was before the click, with a toast naming why, rather
+ * than a chip that quietly disagrees with the host until the next reload.
+ */
+
+const DESK_DTO = { id: "main", name: "main", description: "The main channel", members: [] as string[] };
+const MESSAGE: ChatMessage = { id: "h1", from: "company", text: "shipped it", at: Date.UTC(2026, 8, 1, 9, 0, 0) };
+
+function clientAs(reactToMessage: (seq: string, emoji: string, on: boolean) => Promise<void>): OpenCompanyClient {
+  const named: Record<string, unknown> = {
+    scopeFor: () => "/api/v1/companies/acme",
+    listDesks: () => Promise.resolve([DESK_DTO]),
+    getOperatorChannel: () =>
+      Promise.resolve({ id: "operator", name: "Operator", description: "Workflow reports and notifications" }),
+    reactToMessage: vi.fn(reactToMessage),
+  };
+  return new Proxy(named, {
+    get: (target, prop: string) => target[prop] ?? (() => Promise.resolve([])),
+  }) as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("min-width"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  Object.defineProperty(window, "innerWidth", { value: 1440, writable: true });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  toasts.base.mockClear();
+  toasts.success.mockClear();
+  toasts.error.mockClear();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+/** Owns `transcripts` state itself, the way `AppShell` does for the real view. */
+function Harness({ client }: { client: OpenCompanyClient }) {
+  const [transcripts, setTranscripts] = useState<Transcripts>({ main: [MESSAGE] });
+  return createElement(ChatView, {
+    client,
+    company: "acme",
+    sub: "main",
+    onNavigate: vi.fn(),
+    transcripts,
+    setTranscripts,
+    resolveTypingNames: () => [],
+    scopeRef: { current: { connection: "local", company: "acme", client } },
+  });
+}
+
+function tree(client: OpenCompanyClient): ReactNode {
+  return createElement(ConnectionScopeProvider, {
+    scope: { connection: "local", company: "acme" },
+    children: createElement(Harness, { client }),
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(tree(client));
+  });
+  await flush();
+}
+
+function thumbsUp(): HTMLButtonElement {
+  return container.querySelector('button[aria-label^="React with "]') as HTMLButtonElement;
+}
+
+function reactionChip(): HTMLButtonElement | null {
+  const article = container.querySelector('[data-message-id="h1"]');
+  if (!article) return null;
+  return (
+    ([...article.querySelectorAll("button[aria-pressed]")].find(
+      (b) => !(b.getAttribute("aria-label") ?? "").startsWith("React with "),
+    ) as HTMLButtonElement | undefined) ?? null
+  );
+}
+
+describe("reacting to a message, when the host's write fails", () => {
+  it("rolls the optimistic chip back on a 404 and says the host has no reactions route", async () => {
+    const client = clientAs(() =>
+      Promise.reject(new ApiError(404, "not_found", "no reactions route")),
+    );
+    await mount(client);
+
+    await act(async () => thumbsUp().click());
+    await flush();
+
+    expect(client.reactToMessage).toHaveBeenCalledWith("1", "👍", true, "acme");
+    expect(reactionChip()).toBeNull();
+    expect(toasts.error).toHaveBeenCalledWith("This host doesn't keep reactions yet.");
+  });
+
+  it("rolls back the same way on any other refusal, with the host's own message", async () => {
+    const client = clientAs(() =>
+      Promise.reject(new ApiError(500, "internal", "reactions store is down")),
+    );
+    await mount(client);
+
+    await act(async () => thumbsUp().click());
+    await flush();
+
+    expect(reactionChip()).toBeNull();
+    expect(toasts.error).toHaveBeenCalledWith("reactions store is down");
+  });
+
+  it("keeps the chip and reports nothing when the write lands", async () => {
+    const client = clientAs(() => Promise.resolve());
+    await mount(client);
+
+    await act(async () => thumbsUp().click());
+    await flush();
+
+    expect(reactionChip()).not.toBeNull();
+    expect(toasts.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/test/unit/cov-chat-redeem-budget-pause-auth.test.ts
+++ b/frontend/test/unit/cov-chat-redeem-budget-pause-auth.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useState, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BUDGET_PAUSE_NOTICE_PREFIX } from "@/hooks/use-events";
+import type { OpenCompanyClient } from "@/api/client";
+import type { ChatMessage } from "@/lib/chat";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import type { Transcripts } from "@/views/chat/model";
+import { ChatView } from "@/views/ChatView";
+
+/**
+ * `POST {scope}/agents/{agent_id}/budget-pause/redeem`
+ * (`server/ops/budget_pause.rs`) is `ScopedCompany` — any company member, not
+ * `AdminScopedCompany` — and `ChatView` wires `onRedeemBudgetPause`
+ * unconditionally, with no `isAdmin` check anywhere near it. That is the
+ * opposite gate from the daily-budget menu item a few rows away in the same
+ * pane (`canEditBudget={isAdmin && fromHost}`,
+ * `cov-chat-members-budget-auth.test.ts`) — deliberately, per that route's
+ * own doc comment. This pins "Add credits & resend" stays live for a plain
+ * member.
+ */
+
+const DESK_DTO = { id: "main", name: "main", description: "The main channel", members: [] as string[] };
+const MEMBER_DTO = { id: "m1", name: "Ada", role: "engineer" };
+const NOTICE_TEXT = `${BUDGET_PAUSE_NOTICE_PREFIX} Paused — seo's turn ran out of inference budget/credits.`;
+const NOTICE: ChatMessage = { id: "h1", from: "system", text: NOTICE_TEXT, at: Date.UTC(2026, 8, 1, 9, 0, 0) };
+
+function clientAs(role: "admin" | "member"): OpenCompanyClient {
+  const named: Record<string, unknown> = {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme" });
+      }
+      return Promise.resolve([]);
+    },
+    listDesks: () => Promise.resolve([DESK_DTO]),
+    listTeam: () => Promise.resolve([MEMBER_DTO]),
+    getOperatorChannel: () =>
+      Promise.resolve({ id: "operator", name: "Operator", description: "Workflow reports and notifications" }),
+    redeemBudgetPause: vi.fn(async () => ({})),
+  };
+  return new Proxy(named, {
+    get: (target, prop: string) => target[prop] ?? (() => Promise.resolve([])),
+  }) as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("min-width"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  Object.defineProperty(window, "innerWidth", { value: 1440, writable: true });
+  Element.prototype.scrollTo = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+/** Owns `transcripts` state itself, the way `AppShell` does for the real view. */
+function Harness({ client }: { client: OpenCompanyClient }) {
+  const [transcripts, setTranscripts] = useState<Transcripts>({ main: [NOTICE] });
+  return createElement(ChatView, {
+    client,
+    company: "acme",
+    sub: "main",
+    onNavigate: vi.fn(),
+    transcripts,
+    setTranscripts,
+    resolveTypingNames: () => [],
+    scopeRef: { current: { connection: "local", company: "acme", client } },
+  });
+}
+
+function tree(client: OpenCompanyClient): ReactNode {
+  return createElement(ConnectionScopeProvider, {
+    scope: { connection: "local", company: "acme" },
+    children: createElement(Harness, { client }),
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(tree(client));
+  });
+  await flush();
+}
+
+function redeemButton(): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find((b) =>
+    (b.textContent ?? "").includes("Add credits & resend"),
+  );
+}
+
+describe("the budget-pause redeem CTA, for a plain member", () => {
+  it("offers a live Add-credits button, matching the host's any-member redeem route", async () => {
+    await mount(clientAs("member"));
+
+    const btn = redeemButton();
+    expect(btn).not.toBeUndefined();
+    expect(btn?.disabled).toBe(false);
+  });
+
+  it("actually calls client.redeemBudgetPause for a member session", async () => {
+    const client = clientAs("member");
+    await mount(client);
+
+    await act(async () => redeemButton()?.click());
+    await flush();
+
+    expect(client.redeemBudgetPause).toHaveBeenCalledWith("seo", "acme", undefined);
+  });
+
+  it("renders the same live button for an admin, so the control does not differ by role", async () => {
+    await mount(clientAs("admin"));
+
+    expect(redeemButton()?.disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-chat-review-card-fail.test.ts
+++ b/frontend/test/unit/cov-chat-review-card-fail.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useState, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { ChatMessage } from "@/lib/chat";
+import type { TaskStatus } from "@/api/tasks";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import type { Transcripts } from "@/views/chat/model";
+import { ChatView } from "@/views/ChatView";
+
+/**
+ * `ChatView.reviewCard` — the settle pill's Approve, `POST {scope}/chat/review`
+ * (`review_card`, `operator.rs`) — already has a `catch`; nothing pinned it.
+ * A refused verdict must not remove the card or claim it settled: the row
+ * stays exactly as it was, Approve returns to `disabled: false`, and the
+ * failure is said on screen rather than only in the console the operator
+ * cannot see. Same route the ThreadPanel inline Approve calls
+ * (`cov-chat-thread-panel-review-auth.test.ts`) — its own failure toast is
+ * the same `catch`, exercised here at the channel-pill surface.
+ */
+
+const toasts = vi.hoisted(() => ({ base: vi.fn(), success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({
+  toast: Object.assign(toasts.base, { success: toasts.success, error: toasts.error, warning: vi.fn(), info: vi.fn() }),
+}));
+
+const DESK_DTO = { id: "main", name: "main", description: "The main channel", members: [] as string[] };
+const CARD: ChatMessage = {
+  id: "h1",
+  from: "system",
+  text: "Task done — Ship the thing",
+  at: Date.UTC(2026, 8, 1, 9, 0, 0),
+  taskId: "t1",
+};
+
+function clientAs(reviewCard: () => Promise<never>): OpenCompanyClient {
+  const named: Record<string, unknown> = {
+    scopeFor: () => "/api/v1/companies/acme",
+    listDesks: () => Promise.resolve([DESK_DTO]),
+    getOperatorChannel: () =>
+      Promise.resolve({ id: "operator", name: "Operator", description: "Workflow reports and notifications" }),
+    reviewCard: vi.fn(reviewCard),
+  };
+  return new Proxy(named, {
+    get: (target, prop: string) => target[prop] ?? (() => Promise.resolve([])),
+  }) as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("min-width"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  Object.defineProperty(window, "innerWidth", { value: 1440, writable: true });
+  Element.prototype.scrollTo = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  toasts.base.mockClear();
+  toasts.success.mockClear();
+  toasts.error.mockClear();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+/** Owns `transcripts` state itself, the way `AppShell` does for the real view. */
+function Harness({ client }: { client: OpenCompanyClient }) {
+  const [transcripts, setTranscripts] = useState<Transcripts>({ main: [CARD] });
+  return createElement(ChatView, {
+    client,
+    company: "acme",
+    sub: "main",
+    onNavigate: vi.fn(),
+    transcripts,
+    setTranscripts,
+    resolveTypingNames: () => [],
+    scopeRef: { current: { connection: "local", company: "acme", client } },
+    taskStatusByTaskId: { t1: { column: "in_review" } as TaskStatus },
+  });
+}
+
+function tree(client: OpenCompanyClient): ReactNode {
+  return createElement(ConnectionScopeProvider, {
+    scope: { connection: "local", company: "acme" },
+    children: createElement(Harness, { client }),
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(tree(client));
+  });
+  await flush();
+}
+
+function approveButton(): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent === "Approve" || b.textContent === "Approving…",
+  );
+}
+
+describe("a card review the host refuses", () => {
+  it("reports the refusal and leaves the card exactly as it was", async () => {
+    const client = clientAs(() =>
+      Promise.reject(new ApiError(404, "not_found", "no card is awaiting review")),
+    );
+    await mount(client);
+
+    await act(async () => approveButton()?.click());
+    await flush();
+
+    expect(client.reviewCard).toHaveBeenCalled();
+    expect(toasts.error).toHaveBeenCalledWith("no card is awaiting review");
+    expect(toasts.success).not.toHaveBeenCalled();
+    // Not silently dropped, not stuck "Approving…" — a retry is still on offer.
+    const btn = approveButton();
+    expect(btn?.textContent).toBe("Approve");
+    expect(btn?.disabled).toBe(false);
+  });
+
+  it("names a generic problem for a refusal with no host message", async () => {
+    const client = clientAs(() => Promise.reject(new Error()));
+    await mount(client);
+
+    await act(async () => approveButton()?.click());
+    await flush();
+
+    expect(toasts.error).toHaveBeenCalledWith("Couldn't record that review.");
+  });
+});

--- a/frontend/test/unit/cov-chat-review-pill.test.ts
+++ b/frontend/test/unit/cov-chat-review-pill.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MessageRow } from "@/views/chat/MessageRow";
+import { makeMessage } from "@/lib/chat";
+import type { TimelineEntry } from "@/views/chat/model";
+import type { TaskStatus } from "@/api/tasks";
+
+/**
+ * The settle pill's Approve control (`ChatView.reviewCard`, `POST
+ * …/chat/review`). The backend route is `ScopedCompany` (`operator.rs`),
+ * not admin-only — any company member may settle a card they are reviewing
+ * — so the console rightly offers Approve to every viewer; what it must not
+ * do is offer it once the card has left `in_review`, which is the only gate
+ * `review_card` actually enforces (a 404 "no card is awaiting review").
+ */
+
+const SYSTEM_MESSAGE = makeMessage("system", "Task done — Ship the thing", { taskId: "t1" });
+
+function entry(overrides: Partial<TimelineEntry> = {}): TimelineEntry {
+  return {
+    message: SYSTEM_MESSAGE,
+    sender: { key: "system", name: "system", kind: "system" },
+    continuation: false,
+    replies: [],
+    replySenders: [],
+    ...overrides,
+  } as TimelineEntry;
+}
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    entry: entry(),
+    threadOpen: false,
+    onOpenThread: vi.fn(),
+    onReact: vi.fn(),
+    onDismissCard: vi.fn(),
+    dismissingCardId: null,
+    onReviewCard: vi.fn(),
+    reviewingCardIds: new Set<string>(),
+    taskStatusByTaskId: { t1: { column: "in_review" } as TaskStatus },
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function approveButton(): HTMLButtonElement | null {
+  return Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent === "Approve" || b.textContent === "Approving…",
+  ) as HTMLButtonElement | undefined ?? null;
+}
+
+describe("chat settle pill Approve, by whether the card is still in review", () => {
+  it("offers Approve to any viewer while the card is in review", async () => {
+    await act(async () => {
+      root.render(createElement(MessageRow, baseProps()));
+    });
+    const btn = approveButton();
+    expect(btn).not.toBeNull();
+    expect(btn?.disabled).toBe(false);
+  });
+
+  it("wires a click straight to onReviewCard with the approve decision", async () => {
+    const onReviewCard = vi.fn();
+    await act(async () => {
+      root.render(createElement(MessageRow, baseProps({ onReviewCard })));
+    });
+    await act(async () => approveButton()?.click());
+
+    expect(onReviewCard).toHaveBeenCalledWith("t1", "approve");
+  });
+
+  it("withdraws Approve once the card has left review — the only gate the host enforces", async () => {
+    await act(async () => {
+      root.render(
+        createElement(
+          MessageRow,
+          baseProps({ taskStatusByTaskId: { t1: { column: "done" } as TaskStatus } }),
+        ),
+      );
+    });
+
+    expect(approveButton()).toBeNull();
+  });
+
+  it("disables Approve and shows it in flight while a verdict is already submitting", async () => {
+    await act(async () => {
+      root.render(
+        createElement(MessageRow, baseProps({ reviewingCardIds: new Set(["t1"]) })),
+      );
+    });
+
+    const btn = approveButton();
+    expect(btn?.textContent).toBe("Approving…");
+    expect(btn?.disabled).toBe(true);
+  });
+});

--- a/frontend/test/unit/cov-chat-thread-panel-review-auth.test.ts
+++ b/frontend/test/unit/cov-chat-thread-panel-review-auth.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeMessage } from "@/lib/chat";
+import type { Channel } from "@/views/chat/model";
+import { ThreadPanel } from "@/views/chat/ThreadPanel";
+
+/**
+ * `ThreadPanel`'s own inline Approve — the settle pill's twin for a card
+ * whose review folded into an open thread. It reaches the same `POST {scope}/chat/review`
+ * (`review_card`, `operator.rs`) as `MessageRow`'s pill
+ * (`cov-chat-review-pill.test.ts`), which is `scoped(…)` — any company
+ * member, not admin-only. `ThreadPanel` carries no role check of its own:
+ * `onReviewCard` is wired unconditionally whenever `reviewing` is true, so
+ * this pins Approve is offered to whichever viewer opened the thread.
+ */
+
+const CHANNEL: Channel = { id: "main", name: "main", kind: "channel", purpose: "The main channel" };
+const PARENT = makeMessage("company", "Ship the thing?", { taskId: "t1" });
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    channel: CHANNEL,
+    members: [],
+    parent: PARENT,
+    replies: [],
+    sending: false,
+    onSend: vi.fn(),
+    onClose: vi.fn(),
+    reviewing: true,
+    reviewTaskId: "t1",
+    onReviewCard: vi.fn(),
+    reviewInFlight: false,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function approveButton(): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent === "Approve" || b.textContent === "Approving…",
+  );
+}
+
+describe("ThreadPanel's inline review Approve, by viewer", () => {
+  it("offers a live Approve with no role check of its own", async () => {
+    await act(async () => {
+      root.render(createElement(ThreadPanel, baseProps()));
+    });
+
+    const btn = approveButton();
+    expect(btn).not.toBeUndefined();
+    expect(btn?.disabled).toBe(false);
+  });
+
+  it("wires a click straight to onReviewCard with the approve decision", async () => {
+    const onReviewCard = vi.fn();
+    await act(async () => {
+      root.render(createElement(ThreadPanel, baseProps({ onReviewCard })));
+    });
+    await act(async () => approveButton()?.click());
+
+    expect(onReviewCard).toHaveBeenCalledWith("t1", "approve");
+  });
+
+  it("withdraws Approve once nothing is reviewing — the only gate this panel enforces", async () => {
+    await act(async () => {
+      root.render(createElement(ThreadPanel, baseProps({ reviewing: false, reviewTaskId: undefined })));
+    });
+
+    expect(approveButton()).toBeUndefined();
+  });
+});

--- a/frontend/test/unit/cov-chat-upload-auth.test.ts
+++ b/frontend/test/unit/cov-chat-upload-auth.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AttachmentDto } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { ChatView } from "@/views/ChatView";
+
+/**
+ * `POST {scope}/chat/upload` (`workspace.rs`) sits under the same `scoped(…)`
+ * guard as every other chat write — any company member, not admin-only — and
+ * `ChatView` wires `uploadAttachment` into the composer unconditionally
+ * (`useCallback(… uploadChatAttachment …)`, no `isAdmin` check anywhere near
+ * it). That is the opposite gate from the daily-budget menu item a few rows
+ * away in the same pane (`canEditBudget={isAdmin && fromHost}`,
+ * `cov-chat-members-budget-auth.test.ts`), so this pins the paperclip stays
+ * live for a plain member rather than having quietly inherited an admin-only
+ * check the way that field once needed adding.
+ */
+
+const REFERENCE: AttachmentDto = { nodeId: "n1", name: "diagram.png", mime: "image/png", size: 2048 };
+const DESK_DTO = { id: "main", name: "main", description: "The main channel", members: [] as string[] };
+const MEMBER_DTO = { id: "m1", name: "Ada", role: "engineer" };
+
+function clientAs(role: "admin" | "member"): OpenCompanyClient {
+  const named: Record<string, unknown> = {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme" });
+      }
+      return Promise.resolve([]);
+    },
+    listDesks: () => Promise.resolve([DESK_DTO]),
+    listTeam: () => Promise.resolve([MEMBER_DTO]),
+    getOperatorChannel: () =>
+      Promise.resolve({ id: "operator", name: "Operator", description: "Workflow reports and notifications" }),
+    postForm: vi.fn(async () => REFERENCE),
+  };
+  return new Proxy(named, {
+    get: (target, prop: string) => target[prop] ?? (() => Promise.resolve([])),
+  }) as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("min-width"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  Object.defineProperty(window, "innerWidth", { value: 1440, writable: true });
+  Element.prototype.scrollTo = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function tree(client: OpenCompanyClient): ReactNode {
+  const view = createElement(ChatView, {
+    client,
+    company: "acme",
+    sub: "main",
+    onNavigate: vi.fn(),
+    transcripts: {},
+    setTranscripts: vi.fn(),
+    resolveTypingNames: () => [],
+    scopeRef: { current: { connection: "local", company: "acme", client } },
+  });
+  return createElement(ConnectionScopeProvider, {
+    scope: { connection: "local", company: "acme" },
+    children: view,
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(tree(client));
+  });
+  await flush();
+}
+
+function paperclip(): HTMLButtonElement | null {
+  return container.querySelector('[aria-label="Attach a file"]');
+}
+
+describe("the chat attach control, for a plain member", () => {
+  it("offers a live paperclip, matching the host's any-member upload route", async () => {
+    await mount(clientAs("member"));
+
+    const clip = paperclip();
+    expect(clip).not.toBeNull();
+    expect(clip?.disabled).toBe(false);
+  });
+
+  it("actually uploads through client.postForm for a member session", async () => {
+    const client = clientAs("member");
+    await mount(client);
+
+    const file = new File(["bytes"], "diagram.png", { type: "image/png" });
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    Object.defineProperty(input, "files", { value: [file], configurable: true });
+    await act(async () => {
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await flush();
+
+    expect(client.postForm).toHaveBeenCalledWith("/api/v1/companies/acme/chat/upload", expect.anything());
+    expect(container.textContent).toContain("diagram.png");
+  });
+
+  it("renders the same live paperclip for an admin, so the control does not differ by role", async () => {
+    await mount(clientAs("admin"));
+
+    expect(paperclip()?.disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-rest-agent-detail-not-found.test.ts
+++ b/frontend/test/unit/cov-rest-agent-detail-not-found.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { AgentDetailDto } from "@/api/types";
+import { AgentDetailView } from "@/views/team/AgentDetailView";
+
+/**
+ * `classifyFailure` (`views/team/AgentDetailView.tsx`) turns a `GET
+ * …/team/{id}` failure into three distinct honest states by re-asking the
+ * roster — `missing` (the teammate is really gone), `unsupported` (the host
+ * predates the detail route), `error` (nothing answered). No test anywhere
+ * exercised the render for any of the three, or the roster-based branching
+ * that tells them apart.
+ */
+
+function detail(): AgentDetailDto {
+  return {
+    id: "jamie",
+    name: "Jamie",
+    role: "Growth",
+    source: "overlay",
+    editable: [],
+    isOrchestrator: false,
+    tools: { requested: [], companyAllow: [], deskAllow: [], deskCeilingActive: false, effective: [] },
+    desks: [],
+    inboxEnabled: false,
+  };
+}
+
+function clientWith(opts: {
+  getAgent: () => Promise<AgentDetailDto>;
+  listTeam?: () => Promise<{ id: string }[]>;
+}): OpenCompanyClient {
+  return {
+    getAgent: vi.fn(opts.getAgent),
+    listTeam: vi.fn(opts.listTeam ?? (() => Promise.resolve([]))),
+    updateAgent: vi.fn(),
+    get: vi.fn(() => Promise.resolve({ role: "member" })),
+    listHarnesses: vi.fn(() => Promise.resolve([])),
+    scopeFor: () => "",
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient, agentId = "jamie") {
+  await act(async () => {
+    root.render(
+      createElement(AgentDetailView, { client, company: null, agentId, onBack: () => {} }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("an agent detail read that fails answers with the right one of three honest states", () => {
+  it("says the teammate is gone when the roster no longer lists it", async () => {
+    const client = clientWith({
+      getAgent: () => Promise.reject(new ApiError(404, "not_found", "no such agent")),
+      listTeam: () => Promise.resolve([{ id: "somebody-else" }]),
+    });
+    await show(client);
+
+    expect(container.textContent).toContain("no longer on the roster");
+  });
+
+  it("says the host is too old when the roster still lists the agent", async () => {
+    const client = clientWith({
+      getAgent: () => Promise.reject(new ApiError(404, "not_found", "route not found")),
+      listTeam: () => Promise.resolve([{ id: "jamie" }]),
+    });
+    await show(client);
+
+    expect(container.textContent).toContain("can't open a teammate yet");
+  });
+
+  it("says the host didn't answer for a transport failure, never blank", async () => {
+    const client = clientWith({
+      getAgent: () => Promise.reject(new ApiError(0, "network_error", "fetch failed")),
+    });
+    await show(client);
+
+    expect(container.textContent).toContain("Couldn't load this teammate");
+  });
+
+  it("treats a genuine access refusal as an honest failure too, not a blank screen", async () => {
+    const client = clientWith({
+      getAgent: () => Promise.reject(new ApiError(403, "forbidden", "not on this desk")),
+      listTeam: () => Promise.reject(new Error("roster also refused")),
+    });
+    await show(client);
+
+    expect(container.textContent).toContain("Couldn't load this teammate");
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("renders the teammate normally once the read actually succeeds", async () => {
+    const client = clientWith({ getAgent: () => Promise.resolve(detail()) });
+    await show(client);
+
+    expect(container.textContent).toContain("Jamie");
+    expect(container.textContent).not.toContain("no longer on the roster");
+  });
+});

--- a/frontend/test/unit/cov-rest-artifacts-tab-edit.test.ts
+++ b/frontend/test/unit/cov-rest-artifacts-tab-edit.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { ArtifactView } from "@/api/artifacts";
+import { ArtifactsTab } from "@/views/ArtifactsTab";
+
+/**
+ * The Artifacts tab's append route (`POST …/artifacts/{id}/versions`) is
+ * `ScopedCompany` (`ops/artifacts.rs:211`), not `AdminScopedCompany` — any
+ * member who can open the card may record an operator edit, and the tab
+ * offers "Edit as operator" with no role check of its own, which matches.
+ *
+ * The property this file actually pins is what makes two tabs appending
+ * concurrently safe with no version token on the wire at all: a save sends
+ * only `{ body }`, and the tab replaces its whole local copy with whatever
+ * the host answers rather than bumping a version count itself — so a second
+ * tab's append is reflected exactly, never guessed at or clobbered by a
+ * stale in-memory copy.
+ */
+
+const ARTIFACT: ArtifactView = {
+  id: "a1",
+  taskId: "t1",
+  title: "launch-notes.md",
+  kind: "markdown",
+  versions: [
+    {
+      version: 1,
+      body: "agent draft",
+      author: "agent",
+      authorId: "theorist",
+      createdAtMillis: 1000,
+    },
+  ],
+  createdAtMillis: 1000,
+  updatedAtMillis: 1000,
+};
+
+function clientAs(opts: {
+  post?: (path: string, body: unknown) => Promise<ArtifactView>;
+}): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: () => Promise.resolve([ARTIFACT]),
+    post: vi.fn(opts.post ?? (() => Promise.resolve(ARTIFACT))),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(element: React.ReactElement) {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+function findButton(text: string): HTMLButtonElement | null {
+  return (
+    (Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes(text),
+    ) as HTMLButtonElement | undefined) ?? null
+  );
+}
+
+/** Set a controlled textarea's value the way React's onChange expects. */
+async function type(el: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value",
+  )!.set!;
+  await act(async () => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("ArtifactsTab, an operator edit with no admin gate", () => {
+  it("offers the edit control on a plain member client — the append route carries no admin check", async () => {
+    const client = clientAs({});
+    await show(createElement(ArtifactsTab, { client, company: "acme", taskId: "t1" }));
+
+    findButton("launch-notes.md")!.click();
+    await act(async () => {});
+
+    expect(findButton("Edit as operator")).not.toBeNull();
+  });
+
+  it("sends only the body on save, with no stale version stamp two concurrent tabs could collide on", async () => {
+    const client = clientAs({});
+    await show(createElement(ArtifactsTab, { client, company: "acme", taskId: "t1" }));
+
+    findButton("launch-notes.md")!.click();
+    await act(async () => {});
+    findButton("Edit as operator")!.click();
+    await act(async () => {});
+
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    await type(textarea, "operator's cleaned-up draft");
+    findButton("Save")!.click();
+    await act(async () => {});
+
+    expect(client.post).toHaveBeenCalledWith(
+      "/api/v1/companies/acme/artifacts/a1/versions",
+      { body: "operator's cleaned-up draft" },
+    );
+  });
+
+  it("shows the version the host actually stored, not a locally-guessed count — the other tab's append is never clobbered", async () => {
+    const afterSecondTabAppended: ArtifactView = {
+      ...ARTIFACT,
+      versions: [
+        ...ARTIFACT.versions,
+        {
+          version: 2,
+          body: "the OTHER tab's edit, already landed before this save resolved",
+          author: "operator",
+          authorId: "other-tab",
+          createdAtMillis: 2000,
+        },
+        {
+          version: 3,
+          body: "this tab's edit",
+          author: "operator",
+          authorId: "this-tab",
+          createdAtMillis: 3000,
+        },
+      ],
+      updatedAtMillis: 3000,
+    };
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      // The background refresh after a save re-reads the list — by the time it
+      // lands, the host's own roster already agrees with what the append
+      // answered, exactly as it would once the write is durable.
+      get: () => Promise.resolve([afterSecondTabAppended]),
+      post: vi.fn(() => Promise.resolve(afterSecondTabAppended)),
+    } as unknown as OpenCompanyClient;
+    await show(createElement(ArtifactsTab, { client, company: "acme", taskId: "t1" }));
+
+    findButton("launch-notes.md")!.click();
+    await act(async () => {});
+    findButton("Edit as operator")!.click();
+    await act(async () => {});
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    await type(textarea, "this tab's edit");
+    findButton("Save")!.click();
+    await act(async () => {});
+
+    // Three versions on screen — the intervening v2 this tab never typed is
+    // present because the tab trusts the host's answer wholesale rather than
+    // appending its own guess onto what it had in memory.
+    expect(container.textContent).toContain("v3");
+    expect(container.textContent).toContain("operator");
+  });
+});

--- a/frontend/test/unit/cov-rest-artifacts-tab-edit.test.ts
+++ b/frontend/test/unit/cov-rest-artifacts-tab-edit.test.ts
@@ -145,18 +145,24 @@ describe("ArtifactsTab, an operator edit with no admin gate", () => {
       ],
       updatedAtMillis: 3000,
     };
+    // Initial mount sees only v1 — the stale copy this tab actually had —
+    // so "v3 on screen" can only mean the save's own response replaced it,
+    // not that the fixture handed v3 to every render from the start.
+    let getCalls = 0;
     const client = {
       scopeFor: () => "/api/v1/companies/acme",
       // The background refresh after a save re-reads the list — by the time it
       // lands, the host's own roster already agrees with what the append
       // answered, exactly as it would once the write is durable.
-      get: () => Promise.resolve([afterSecondTabAppended]),
+      get: () => Promise.resolve([getCalls++ === 0 ? ARTIFACT : afterSecondTabAppended]),
       post: vi.fn(() => Promise.resolve(afterSecondTabAppended)),
     } as unknown as OpenCompanyClient;
     await show(createElement(ArtifactsTab, { client, company: "acme", taskId: "t1" }));
 
     findButton("launch-notes.md")!.click();
     await act(async () => {});
+    // Confirms the stale-v1 premise: nothing has shown v3 yet.
+    expect(container.textContent).not.toContain("v3");
     findButton("Edit as operator")!.click();
     await act(async () => {});
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement;

--- a/frontend/test/unit/cov-rest-artifacts-version-immutability.test.ts
+++ b/frontend/test/unit/cov-rest-artifacts-version-immutability.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { ArtifactView } from "@/api/artifacts";
+import { ArtifactsTab } from "@/views/ArtifactsTab";
+
+/**
+ * The Artifacts tab has no role gate at all — `POST …/artifacts/{id}/versions`
+ * is `ScopedCompany` (any signed-in teammate), not admin-only — so the control
+ * this axis actually turns on is version, not role: `PATCH`-a-version does not
+ * exist, and the one control that could rewrite history —
+ * "Edit as operator" — must appear only on the *latest* revision of a
+ * text/markdown artifact and never on an older one, however it is reached.
+ */
+
+const ARTIFACT: ArtifactView = {
+  id: "art-1",
+  taskId: "task-1",
+  title: "Launch brief",
+  kind: "markdown",
+  createdAtMillis: 1,
+  updatedAtMillis: 2,
+  versions: [
+    { version: 1, body: "First draft.", author: "agent", authorId: "writer", createdAtMillis: 1 },
+    { version: 2, body: "Second draft.", author: "agent", authorId: "writer", createdAtMillis: 2 },
+  ],
+};
+
+function clientWith(artifact: ArtifactView): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn(() => Promise.resolve([artifact])),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(artifact: ArtifactView, openVersion?: number) {
+  const client = clientWith(artifact);
+  await act(async () => {
+    root.render(
+      createElement(ArtifactsTab, {
+        client,
+        company: "acme",
+        taskId: "task-1",
+        openArtifactId: artifact.id,
+        openVersion,
+      }),
+    );
+  });
+}
+
+function editButton(): HTMLElement | null {
+  return Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === "Edit as operator",
+  ) ?? null;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("the artifact version surface offers Edit only on the latest revision", () => {
+  it("offers no edit control while an older version is shown", async () => {
+    await show(ARTIFACT, 1);
+
+    // Deep-linked to v1, so this must show v1, not silently jump to latest.
+    expect(container.textContent).toContain("First draft.");
+  });
+
+  it("withholds the edit control from a past revision, even though the kind is editable", async () => {
+    await show(ARTIFACT, 1);
+    expect(editButton()).toBeNull();
+  });
+
+  it("offers the edit control on the latest revision of the same artifact", async () => {
+    await show(ARTIFACT, 2);
+    expect(editButton()).not.toBeNull();
+  });
+});

--- a/frontend/test/unit/cov-rest-comp-autonomy-pill.test.ts
+++ b/frontend/test/unit/cov-rest-comp-autonomy-pill.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { PolicyStatus } from "@/api/policy";
+import { AutonomyPill } from "@/components/autonomy-pill";
+import { useAutonomy } from "@/hooks/use-autonomy";
+import { ConsoleProvider } from "@/lib/console-context";
+
+/**
+ * Two gaps `autonomy-pill.test.ts` leaves open. Its own list-fidelity and
+ * confirm-gate cases fix the tier list at four-or-five entries and never at
+ * zero, and none of them puts the write itself under contention with the
+ * confirm dialog.
+ */
+
+const toasts = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: toasts.success, error: toasts.error, warning: vi.fn(), info: vi.fn() } }));
+
+function policy(overrides: Partial<PolicyStatus> = {}): PolicyStatus {
+  return {
+    mode: "auto",
+    alwaysApprove: [],
+    autoApproveUnderUsd: 5,
+    approvalTtlHours: 24,
+    manifestMode: "auto",
+    manifestAlwaysApprove: [],
+    manifestAutoApproveUnderUsd: 5,
+    manifestApprovalTtlHours: null,
+    overridden: false,
+    tiers: [
+      { value: "readonly", label: "Read-only", description: "Looks only." },
+      { value: "supervised", label: "Supervised", description: "A person signs off." },
+      { value: "auto", label: "Auto", description: "Acts on its own." },
+      { value: "full", label: "Full", description: "No ceiling." },
+    ],
+    takesEffect: "on the next turn",
+    ...overrides,
+  };
+}
+
+function client(over: {
+  get?: () => Promise<PolicyStatus>;
+  put?: (path: string, body: unknown) => Promise<PolicyStatus>;
+}): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn(over.get ?? (() => Promise.resolve(policy()))),
+    put: vi.fn(over.put ?? (() => Promise.resolve(policy()))),
+  } as unknown as OpenCompanyClient;
+}
+
+function Harness({ api }: { api: OpenCompanyClient }): ReactNode {
+  const status = useAutonomy(api, "acme");
+  return createElement(ConsoleProvider, {
+    client: api,
+    company: "acme",
+    children: createElement(AutonomyPill, { status, canManage: true }),
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function mount(api: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(Harness, { api }));
+  });
+}
+
+function pill(): HTMLElement | null {
+  return container.querySelector("[data-testid=autonomy-pill]");
+}
+
+async function openMenu() {
+  await act(async () => {
+    (pill() as HTMLButtonElement).click();
+  });
+}
+
+function row(mode: string): HTMLElement | null {
+  return document.querySelector(`[data-testid=autonomy-tier-${mode}]`);
+}
+
+async function pick(mode: string) {
+  await act(async () => {
+    row(mode)!.click();
+  });
+}
+
+function confirmButton(): HTMLButtonElement | null {
+  return document.querySelector("[data-testid=autonomy-tier-confirm]");
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  toasts.success.mockClear();
+  toasts.error.mockClear();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("the menu never falls back to a hardcoded four tiers", () => {
+  it("opens with no tier rows at all when the host names none", async () => {
+    // A host that answers `tiers: []` — not four modes this console invented,
+    // an empty menu, exactly as the host stated it.
+    const api = client({ get: () => Promise.resolve(policy({ tiers: [] })) });
+    await mount(api);
+    await openMenu();
+
+    for (const mode of ["readonly", "supervised", "auto", "full"]) {
+      expect(row(mode), `row(${mode}) should not exist`).toBeNull();
+    }
+  });
+
+  it("still states the current mode word on the pill itself with no tiers to match it against", async () => {
+    const api = client({ get: () => Promise.resolve(policy({ tiers: [], mode: "auto" })) });
+    await mount(api);
+
+    expect(pill()!.textContent).toContain("auto");
+  });
+});
+
+describe("widening is blocked from the title bar until it is accepted", () => {
+  it("sends no write while the confirm dialog is still up", async () => {
+    const api = client({ get: () => Promise.resolve(policy({ mode: "readonly" })) });
+    await mount(api);
+    await openMenu();
+    await pick("full");
+
+    // The confirm dialog is open; the PUT must not have fired yet.
+    expect(confirmButton()).not.toBeNull();
+    expect(api.put).not.toHaveBeenCalled();
+  });
+
+  it("only writes the wider tier once Confirm is pressed", async () => {
+    const api = client({ get: () => Promise.resolve(policy({ mode: "readonly" })) });
+    await mount(api);
+    await openMenu();
+    await pick("full");
+    await act(async () => {
+      confirmButton()!.click();
+    });
+
+    expect(api.put).toHaveBeenCalledTimes(1);
+    expect(api.put).toHaveBeenCalledWith("/api/v1/company/acme/policy", { mode: "full" });
+  });
+
+  it("skips the confirm dialog entirely for a narrowing pick, and writes at once", async () => {
+    const api = client({ get: () => Promise.resolve(policy({ mode: "full" })) });
+    await mount(api);
+    await openMenu();
+    await pick("readonly");
+
+    expect(confirmButton()).toBeNull();
+    expect(api.put).toHaveBeenCalledTimes(1);
+    expect(api.put).toHaveBeenCalledWith("/api/v1/company/acme/policy", { mode: "readonly" });
+  });
+});

--- a/frontend/test/unit/cov-rest-inbox-isolation-and-fail.test.ts
+++ b/frontend/test/unit/cov-rest-inbox-isolation-and-fail.test.ts
@@ -120,5 +120,9 @@ describe("a failed mailbox read is never mistaken for an empty one", () => {
     expect(errorPane).not.toBeNull();
     expect(errorPane?.textContent).toContain("mailbox host unreachable");
     expect(container.querySelector('[data-testid="inbox-empty"]')).toBeNull();
+    const retry = Array.from(errorPane?.querySelectorAll("button") ?? []).find((b) =>
+      b.textContent?.includes("Try again"),
+    );
+    expect(retry).toBeDefined();
   });
 });

--- a/frontend/test/unit/cov-rest-inbox-isolation-and-fail.test.ts
+++ b/frontend/test/unit/cov-rest-inbox-isolation-and-fail.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { InboxDto, InboxMessageDto } from "@/api/types";
+import { InboxView } from "@/views/InboxView";
+
+/**
+ * Each teammate's inbox is its own scope — `client.inboxMessages(key, …)` —
+ * and nothing else in this view narrows who can read it, so the property
+ * worth pinning is isolation: switching the selector must never let a slow
+ * response for the inbox the operator left land under the one they moved to.
+ * Paired with the honest-failure half no test exercises either: a rejected
+ * read must say so, not blank the pane or spin forever.
+ */
+
+function inbox(over: Partial<InboxDto> = {}): InboxDto {
+  return { key: "alex", name: "Alex", address: "alex@acme.test", enabled: true, unread: 0, ...over };
+}
+
+function msg(over: Partial<InboxMessageDto> = {}): InboxMessageDto {
+  return {
+    id: "m1",
+    inbox: "alex",
+    fromEmail: "x@y.com",
+    fromName: "X",
+    subject: "hi",
+    body: "hi there",
+    read: true,
+    outbound: false,
+    atMillis: 1,
+    ...over,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(InboxView, { client, company: "acme" }));
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("switching teammates never leaks a slower read across the boundary", () => {
+  it("drops a late response for the inbox the operator has already left", async () => {
+    let resolveAlex: ((rows: InboxMessageDto[]) => void) | null = null;
+    const inboxMessages = vi.fn((key: string) => {
+      if (key === "alex") {
+        return new Promise<InboxMessageDto[]>((resolve) => {
+          resolveAlex = resolve;
+        });
+      }
+      return Promise.resolve([msg({ id: "b1", subject: "Blair's mail" })]);
+    });
+
+    const client = {
+      listInboxes: vi.fn(() => Promise.resolve([inbox({ key: "alex" }), inbox({ key: "blair", name: "Blair" })])),
+      inboxMessages,
+    } as unknown as OpenCompanyClient;
+
+    await show(client);
+    // The view lands on the first enabled inbox ("alex"), whose read is still
+    // pending — `resolveAlex` has not fired.
+
+    await act(async () => {
+      const select = container.querySelector('[data-testid="inbox-select"]') as HTMLElement;
+      select.click();
+    });
+    const blairOption = Array.from(document.querySelectorAll('[role="option"]')).find((o) =>
+      o.textContent?.includes("Blair"),
+    ) as HTMLElement | undefined;
+    await act(async () => {
+      blairOption?.click();
+    });
+
+    expect(container.querySelector('[data-testid="inbox-message"]')?.textContent).toContain(
+      "Blair's mail",
+    );
+
+    // Alex's slow read now resolves — after the operator has moved on.
+    await act(async () => {
+      resolveAlex?.([msg({ id: "a1", subject: "Alex's mail" })]);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).not.toContain("Alex's mail");
+    expect(container.querySelector('[data-testid="inbox-message"]')?.textContent).toContain(
+      "Blair's mail",
+    );
+  });
+});
+
+describe("a failed mailbox read is never mistaken for an empty one", () => {
+  it("says the read failed and offers a retry, instead of a blank list", async () => {
+    const client = {
+      listInboxes: vi.fn(() => Promise.resolve([inbox()])),
+      inboxMessages: vi.fn(() => Promise.reject(new Error("mailbox host unreachable"))),
+    } as unknown as OpenCompanyClient;
+
+    await show(client);
+
+    const errorPane = container.querySelector('[data-testid="inbox-messages-error"]');
+    expect(errorPane).not.toBeNull();
+    expect(errorPane?.textContent).toContain("mailbox host unreachable");
+    expect(container.querySelector('[data-testid="inbox-empty"]')).toBeNull();
+  });
+});

--- a/frontend/test/unit/cov-rest-inbox-view.test.ts
+++ b/frontend/test/unit/cov-rest-inbox-view.test.ts
@@ -114,5 +114,9 @@ describe("InboxView, a failed read", () => {
     expect(at("inbox-messages-error")).not.toBeNull();
     expect(at("inbox-messages-error")!.textContent).toContain("the store timed out");
     expect(at("inbox-empty")).toBeNull();
+    const retry = Array.from(at("inbox-messages-error")!.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Try again"),
+    );
+    expect(retry).toBeDefined();
   });
 });

--- a/frontend/test/unit/cov-rest-inbox-view.test.ts
+++ b/frontend/test/unit/cov-rest-inbox-view.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { InboxDto, InboxMessageDto } from "@/api/types";
+import { ApiError } from "@/api/types";
+import { InboxView } from "@/views/InboxView";
+
+/**
+ * Both host routes behind this view (`GET …/inboxes`, `GET …/inboxes/{key}/
+ * messages`) are `ScopedCompany` (`ops/mail.rs:30-32`), not admin-gated — a
+ * member reads exactly what an admin reads, and the view offers nothing it
+ * withholds by role. What is worth pinning here is the honesty half: a roster
+ * read or a message read that fails must say so and offer a retry, never sit
+ * on a blank list or an endless skeleton that looks the same as "no mail".
+ */
+
+const INBOX: InboxDto = {
+  key: "sales",
+  name: "Sales",
+  address: "sales@acme.test",
+  enabled: true,
+  unread: 1,
+};
+
+const MESSAGE: InboxMessageDto = {
+  id: "m1",
+  inbox: "sales",
+  fromName: "A Customer",
+  fromEmail: "customer@example.com",
+  subject: "Quote request",
+  body: "Hi, can you send a quote?",
+  atMillis: 1_700_000_000_000,
+  read: false,
+  outbound: false,
+};
+
+function clientAs(opts: {
+  listInboxes?: () => Promise<InboxDto[]>;
+  inboxMessages?: () => Promise<InboxMessageDto[]>;
+}): OpenCompanyClient {
+  return {
+    listInboxes: vi.fn(opts.listInboxes ?? (() => Promise.resolve([INBOX]))),
+    inboxMessages: vi.fn(opts.inboxMessages ?? (() => Promise.resolve([MESSAGE]))),
+    markInboxRead: vi.fn(() => Promise.resolve({ unread: 0 })),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(element: React.ReactElement) {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("InboxView, a surface with no role gate at all", () => {
+  it("shows a plain member the same inbox and mail an admin would see — the reads carry no admin check", async () => {
+    const client = clientAs({});
+    await show(createElement(InboxView, { client, company: "acme" }));
+    await act(async () => {});
+
+    expect(at("inbox-list")).not.toBeNull();
+    expect(container.textContent).toContain("Quote request");
+    expect(at("inbox-select")).not.toBeNull();
+  });
+});
+
+describe("InboxView, a failed read", () => {
+  it("says the roster failed and offers a retry, rather than an empty inbox list", async () => {
+    const client = clientAs({
+      listInboxes: () => Promise.reject(new ApiError(0, "network_error", "cannot reach the company host")),
+    });
+    await show(createElement(InboxView, { client, company: "acme" }));
+    await act(async () => {});
+
+    expect(container.textContent).toContain("Inboxes unavailable");
+    expect(container.textContent).toContain("cannot reach the company host");
+    expect(at("inbox-list")).toBeNull();
+    const retry = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Try again"),
+    );
+    expect(retry).toBeDefined();
+  });
+
+  it("says a message read failed and offers a retry, rather than an honest-looking empty mailbox", async () => {
+    const client = clientAs({
+      inboxMessages: () => Promise.reject(new ApiError(500, "server_error", "the store timed out")),
+    });
+    await show(createElement(InboxView, { client, company: "acme" }));
+    await act(async () => {});
+
+    expect(at("inbox-messages-error")).not.toBeNull();
+    expect(at("inbox-messages-error")!.textContent).toContain("the store timed out");
+    expect(at("inbox-empty")).toBeNull();
+  });
+});

--- a/frontend/test/unit/cov-rest-mem-fact-crud-auth.test.ts
+++ b/frontend/test/unit/cov-rest-mem-fact-crud-auth.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
+import type { MemoryEntry, MemoryList, MemoryStats } from "@/api/memory";
+import { MemoryView } from "@/views/MemoryView";
+
+/**
+ * `memory.rs`'s fact CRUD (`create_fact`, `delete_fact`, list, stats) is all
+ * `ScopedCompany` — no admin gate, unlike the engine picker underneath it
+ * (`memory_engine.rs`, `AdminScopedCompany`, covered separately). What this
+ * file pins: a plain member gets the same create/delete affordances an admin
+ * would, matching that route; and a delete that the host actually refuses
+ * puts the card straight back and says so — it is never dropped for good on a
+ * client that merely believed it worked.
+ */
+
+const STATS: MemoryStats = {
+  facts: 1,
+  factsUpdatedAtMillis: 1000,
+  lastUpdatedAtMillis: 1000,
+  totalItems: 1,
+  teammateMemory: 0,
+  documentMemory: 0,
+  taskOutcomes: 0,
+};
+
+function entry(over: Partial<MemoryEntry> = {}): MemoryEntry {
+  return {
+    id: "f1",
+    kind: "fact",
+    origin: "fact",
+    editable: true,
+    title: "Renewal window",
+    body: "Acme renews every March.",
+    source: "operator",
+    updatedAt: 1000,
+    ...over,
+  };
+}
+
+function clientAs(opts: {
+  del?: (path: string) => Promise<void>;
+  memoryList?: MemoryEntry[];
+}): OpenCompanyClient {
+  const list: MemoryList = {
+    items: opts.memoryList ?? [entry()],
+    totalContext: 0,
+    contextTruncated: false,
+  } as MemoryList;
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: (path: string) => {
+      if (path.endsWith("/memory/stats")) return Promise.resolve(STATS);
+      if (path.endsWith("/memory/engine")) {
+        // Admin-only route; a member's own read fails, which `EngineSection`
+        // renders as its own error state — not this file's concern.
+        return Promise.reject(new ApiError(403, "forbidden", "only an admin can do that"));
+      }
+      return Promise.resolve(list);
+    },
+    post: vi.fn(() => Promise.resolve(entry())),
+    del: vi.fn(opts.del ?? (() => Promise.resolve())),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(element: React.ReactElement) {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("MemoryView, fact CRUD with no admin gate", () => {
+  it("offers a plain member both New memory and per-card delete, matching the ungated fact routes", async () => {
+    const client = clientAs({});
+    await show(createElement(MemoryView, { client, company: "acme" }));
+    await act(async () => {});
+
+    expect(at("memory-add")).not.toBeNull();
+    const card = at("memory-card")!;
+    expect(card.querySelector("button[aria-label='Delete memory']")).not.toBeNull();
+  });
+
+  it("puts the card back and says why when the host refuses the delete", async () => {
+    const client = clientAs({
+      del: () => Promise.reject(new ApiError(409, "conflict", "this fact was already removed")),
+    });
+    await show(createElement(MemoryView, { client, company: "acme" }));
+    await act(async () => {});
+
+    expect(container.textContent).toContain("Renewal window");
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>("button[aria-label='Delete memory']")!
+        .click();
+    });
+    // The optimistic remove and the failed write both settle inside this act.
+    expect(container.textContent).toContain("Renewal window");
+  });
+});

--- a/frontend/test/unit/cov-rest-memory-crud.test.ts
+++ b/frontend/test/unit/cov-rest-memory-crud.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { MemoryEntry, MemoryStats } from "@/api/memory";
+import { MemoryView } from "@/views/MemoryView";
+
+/**
+ * The Brain's fact CRUD has zero role gate of its own — `POST`/`DELETE
+ * …/memory` are `ScopedCompany`, not admin-only — so the authority this axis
+ * actually tests is per-row: `editable` (`api/memory.ts`) is what separates an
+ * operator's own fact, which Delete may touch, from the agents' own read-only
+ * memory, which must never offer one. Paired with the CRUD path itself, which
+ * had no test at all: a delete that the host refuses must put the card back,
+ * not leave it silently gone.
+ */
+
+function entry(over: Partial<MemoryEntry> = {}): MemoryEntry {
+  return {
+    id: "m1",
+    origin: "fact",
+    kind: "fact",
+    editable: true,
+    title: "Client prefers Friday reviews",
+    body: "Always confirm before Thursday.",
+    source: "operator",
+    updatedAt: 0,
+    ...over,
+  };
+}
+
+const STATS: MemoryStats = {
+  facts: 1,
+  factsUpdatedAtMillis: 0,
+  lastUpdatedAtMillis: 0,
+  totalItems: 1,
+  teammateMemory: 0,
+  documentMemory: 0,
+  taskOutcomes: 0,
+};
+
+function clientWith(opts: {
+  entries: MemoryEntry[];
+  del?: () => Promise<void>;
+}): OpenCompanyClient {
+  const get = vi.fn((path: string) => {
+    if (path.endsWith("/memory/stats")) return Promise.resolve(STATS);
+    if (path.endsWith("/memory/engine")) return Promise.reject(new Error("no engine route"));
+    if (path.includes("/memory")) {
+      return Promise.resolve({ items: opts.entries, totalContext: 0, contextTruncated: false });
+    }
+    return Promise.reject(new Error(`unexpected GET ${path}`));
+  });
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get,
+    post: vi.fn(() => Promise.resolve(entry())),
+    del: vi.fn(opts.del ?? (() => Promise.resolve())),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(MemoryView, { client, company: "acme" }));
+  });
+}
+
+function cards(): HTMLElement[] {
+  return Array.from(container.querySelectorAll('[data-testid="memory-card"]'));
+}
+
+function deleteButtonIn(card: HTMLElement): HTMLElement | null {
+  return card.querySelector('[aria-label="Delete memory"]');
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("delete is offered per row, by what the row itself is", () => {
+  it("offers no delete control on the agents' own read-only memory", async () => {
+    const client = clientWith({
+      entries: [entry({ id: "ctx1", origin: "agent-memory", editable: false, title: "Learned fact" })],
+    });
+    await show(client);
+
+    const card = cards()[0];
+    expect(card).toBeTruthy();
+    expect(deleteButtonIn(card)).toBeNull();
+  });
+
+  it("offers delete on an operator-authored fact", async () => {
+    const client = clientWith({ entries: [entry()] });
+    await show(client);
+
+    const card = cards()[0];
+    expect(deleteButtonIn(card)).not.toBeNull();
+  });
+});
+
+describe("a refused delete puts the card back, honestly", () => {
+  it("re-inserts the entry and reports the failure when the host refuses the delete", async () => {
+    const client = clientWith({
+      entries: [entry()],
+      del: () => Promise.reject(new Error("memory engine is unreachable")),
+    });
+    await show(client);
+
+    await act(async () => {
+      deleteButtonIn(cards()[0])!.click();
+    });
+
+    // A false success is exactly what this file exists to catch: the card
+    // must come back once the host has actually refused the write.
+    expect(cards()).toHaveLength(1);
+    expect(container.textContent).toContain("Client prefers Friday reviews");
+  });
+});

--- a/frontend/test/unit/cov-rest-memory-drop-report-status.test.ts
+++ b/frontend/test/unit/cov-rest-memory-drop-report-status.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { Ingested } from "@/api/memory";
+import { DropZone } from "@/views/memory/DropZone";
+
+/**
+ * `memory_ingest.rs` reports one status per dropped source rather than a
+ * batch verdict, and `DropReport` (`DropZone.tsx`) is the only place that
+ * renders it — a folder always contains something that could not be read, so
+ * the per-item detail is what tells an operator WHICH files landed and which
+ * did not. Nothing had pinned that the report actually renders each item's
+ * real status and message, as opposed to a blanket "done" the moment any part
+ * of a mixed batch stored successfully.
+ */
+
+const MIXED: Ingested = {
+  chunks: 3,
+  stored: 1,
+  items: [
+    { source: "https://acme.test/pricing", status: "stored", chunks: 3 },
+    {
+      source: "https://acme.test/dead-link",
+      status: "failed",
+      chunks: 0,
+      detail: "the host answered 404",
+    },
+  ],
+};
+
+function clientAs(ingestLinks: () => Promise<Ingested>): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    post: vi.fn((path: string) => {
+      if (path.endsWith("/memory/ingest/links")) return ingestLinks();
+      return Promise.reject(new Error(`unexpected POST ${path}`));
+    }),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.spyOn(window, "prompt").mockReturnValue("https://acme.test/pricing");
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function findButton(text: string): HTMLButtonElement | null {
+  return (
+    (Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes(text),
+    ) as HTMLButtonElement | undefined) ?? null
+  );
+}
+
+describe("DropZone's per-item report, on a mixed batch", () => {
+  it("names the failed item and its real reason, and counts only the actual successes as remembered", async () => {
+    const client = clientAs(() => Promise.resolve(MIXED));
+    await act(async () => {
+      root.render(
+        createElement(DropZone, {
+          client,
+          company: "acme",
+          onIngested: () => {},
+          discarding: false,
+        }),
+      );
+    });
+
+    await act(async () => {
+      findButton("Add link")!.click();
+    });
+
+    const report = container.querySelector('[data-testid="memory-drop-report"]')!;
+    expect(report.textContent).toContain("1 remembered");
+    expect(report.textContent).toContain("1 skipped");
+    expect(report.textContent).toContain("https://acme.test/dead-link");
+    expect(report.textContent).toContain("the host answered 404");
+    // The item that actually stored must not also appear in the failure list.
+    const failureRows = Array.from(report.querySelectorAll("li")).map((li) => li.textContent ?? "");
+    expect(failureRows.some((row) => row.includes("pricing"))).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-rest-memory-dropzone-discarding.test.ts
+++ b/frontend/test/unit/cov-rest-memory-dropzone-discarding.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { DropZone } from "@/views/memory/DropZone";
+
+/**
+ * MEM-003's backend half (`memory_ingest.rs`) accepts and discards every
+ * write while the null engine is bound — the host has no lever to refuse an
+ * ingest into a sink that keeps nothing. The console's own lever is
+ * `discarding`, and `DropZone` is where it has to hold: a raw drag-and-drop
+ * bypasses the two buttons' `disabled` prop entirely, so the guard inside
+ * `onDrop` is the only thing standing between an operator's drop and a write
+ * that would confer nothing while looking like it worked.
+ */
+
+function dataTransferWith(files: File[]): DataTransfer {
+  return {
+    items: files.map((file) => ({
+      kind: "file",
+      webkitGetAsEntry: () => ({
+        isFile: true,
+        isDirectory: false,
+        name: file.name,
+        file: (cb: (f: File) => void) => cb(file),
+      }),
+    })),
+    getData: () => "",
+    files,
+  } as unknown as DataTransfer;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient, discarding: boolean) {
+  await act(async () => {
+    root.render(
+      createElement(DropZone, {
+        client,
+        company: "acme",
+        discarding,
+        onIngested: () => {},
+      }),
+    );
+  });
+}
+
+function dropzone(): HTMLElement {
+  return container.querySelector('[data-testid="memory-dropzone"]') as HTMLElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("a drop onto a discarding engine ingests nothing", () => {
+  it("refuses a raw drop, which the two disabled buttons cannot stop", async () => {
+    const postForm = vi.fn(() => Promise.resolve({ items: [] }));
+    const client = {
+      scopeFor: () => "/api/v1/company/acme",
+      postForm,
+      post: vi.fn(),
+    } as unknown as OpenCompanyClient;
+    await show(client, true);
+
+    const file = new File(["hello"], "note.txt", { type: "text/plain" });
+    await act(async () => {
+      const event = new Event("drop", { bubbles: true, cancelable: true }) as unknown as Event & {
+        dataTransfer: DataTransfer;
+        preventDefault: () => void;
+      };
+      Object.defineProperty(event, "dataTransfer", { value: dataTransferWith([file]) });
+      dropzone().dispatchEvent(event);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(postForm).not.toHaveBeenCalled();
+  });
+
+  it("ingests normally once the engine actually retains what is dropped", async () => {
+    const postForm = vi.fn(() => Promise.resolve({ items: [{ source: "note.txt", status: "stored" }] }));
+    const client = {
+      scopeFor: () => "/api/v1/company/acme",
+      postForm,
+      post: vi.fn(),
+    } as unknown as OpenCompanyClient;
+    await show(client, false);
+
+    const file = new File(["hello"], "note.txt", { type: "text/plain" });
+    await act(async () => {
+      const event = new Event("drop", { bubbles: true, cancelable: true }) as unknown as Event & {
+        dataTransfer: DataTransfer;
+      };
+      Object.defineProperty(event, "dataTransfer", { value: dataTransferWith([file]) });
+      dropzone().dispatchEvent(event);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(postForm).toHaveBeenCalled();
+  });
+});

--- a/frontend/test/unit/cov-rest-memory-engine-auth.test.ts
+++ b/frontend/test/unit/cov-rest-memory-engine-auth.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
+import type { EngineOption, MemoryEngineState } from "@/api/memory";
+import { EngineSection } from "@/views/memory/EngineSection";
+
+/**
+ * The three engine routes (`GET/POST/PUT …/memory/engine*`) are all
+ * `AdminScopedCompany` (`memory_engine.rs:438,567,681`) — unlike the fact CRUD
+ * beside it on the same page. `EngineSection` carries no `canManage` prop of
+ * its own; it happens to land in the right place anyway because its very
+ * first read is that same admin-gated route, and a 403 there renders the
+ * section's own error state before the picker — with its Test/Apply buttons
+ * — ever mounts. This pins that the accident holds: a member never reaches
+ * the buttons, and an admin gets both. It also pins the one thing a frontend
+ * test can prove about the test/apply split named in the audit: the probe
+ * button calls only the probe route, never the persisting one.
+ */
+
+const OPTIONS: EngineOption[] = [
+  {
+    id: "supermemory",
+    label: "Supermemory",
+    description: "A hosted engine.",
+    available: true,
+    requiresUrl: true,
+    requiresKey: true,
+    durable: true,
+  },
+];
+
+function state(): MemoryEngineState {
+  return {
+    active: "supermemory",
+    capabilities: [],
+    selected: "supermemory",
+    apiKeySet: false,
+    layer: "default",
+    editable: true,
+    configPath: "config.toml",
+    options: OPTIONS,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(element: React.ReactElement) {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("EngineSection, a member whose read the host actually refuses", () => {
+  it("shows the refusal, not a live picker with buttons the write will 403 on", async () => {
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: () => Promise.reject(new ApiError(403, "forbidden", "only an admin can do that")),
+    } as unknown as OpenCompanyClient;
+    await show(createElement(EngineSection, { client, company: "acme" }));
+
+    expect(container.textContent).toContain("only an admin can do that");
+    expect(
+      Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Test connection"),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("EngineSection, an admin whose read the host answers", () => {
+  it("gets the picker, Test connection and all", async () => {
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: () => Promise.resolve(state()),
+    } as unknown as OpenCompanyClient;
+    await show(createElement(EngineSection, { client, company: "acme" }));
+
+    expect(
+      Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Test connection"),
+      ),
+    ).toBeDefined();
+  });
+});
+
+describe("the probe/persist split", () => {
+  it("clicking Test connection calls only the probe route, never the one that binds it", async () => {
+    const testEngine = vi.fn((_body: unknown) => Promise.resolve({ healthy: true, capabilities: [] }));
+    const applyEngine = vi.fn((_body: unknown) => Promise.resolve({ engine: "embedded" }));
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: () => Promise.resolve(state()),
+      post: (path: string, body: unknown) => {
+        if (path.endsWith("/memory/engine/test")) return testEngine(body);
+        return Promise.reject(new Error(`unexpected POST ${path}`));
+      },
+      put: (path: string, body: unknown) => {
+        if (path.endsWith("/memory/engine")) return applyEngine(body);
+        return Promise.reject(new Error(`unexpected PUT ${path}`));
+      },
+    } as unknown as OpenCompanyClient;
+    await show(createElement(EngineSection, { client, company: "acme" }));
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button"))
+        .find((b) => b.textContent?.includes("Test connection"))!
+        .click();
+    });
+
+    expect(testEngine).toHaveBeenCalledTimes(1);
+    expect(applyEngine).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/test/unit/cov-rest-memory-engine-probe-non-persistent.test.ts
+++ b/frontend/test/unit/cov-rest-memory-engine-probe-non-persistent.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { EngineProbe, MemoryEngineState } from "@/api/memory";
+import { EngineSection } from "@/views/memory/EngineSection";
+
+/**
+ * MEM-002's backend half (`memory_engine.rs`) is a test-then-apply pair: a
+ * probe that must never persist, and an apply that does. The console side of
+ * that contract is `EngineSection` — "Test connection" hits `POST
+ * …/memory/engine/test`, "Use this engine" hits `PUT …/memory/engine` — and
+ * nothing here can prove the host's own race safety, but the console's own
+ * half of the contract is fully testable: a probe must never be the call that
+ * changes what is bound, and the bound state on screen must not move until an
+ * apply actually answers.
+ */
+
+const STATE: MemoryEngineState = {
+  active: "store",
+  capabilities: [],
+  selected: "store",
+  apiKeySet: false,
+  layer: "config.toml",
+  editable: true,
+  configPath: "/data/config.toml",
+  options: [
+    { id: "store", label: "Store", description: "Built-in.", available: true, requiresUrl: false, requiresKey: false, durable: true },
+    {
+      id: "supermemory",
+      label: "Supermemory",
+      description: "Hosted.",
+      available: true,
+      requiresUrl: true,
+      requiresKey: true,
+      durable: true,
+    },
+  ],
+};
+
+function clientWith(probe: EngineProbe): { client: OpenCompanyClient; put: ReturnType<typeof vi.fn> } {
+  const put = vi.fn(() => Promise.reject(new Error("apply should not be called by a probe")));
+  const client = {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn(() => Promise.resolve(STATE)),
+    post: vi.fn(() => Promise.resolve(probe)),
+    put,
+  } as unknown as OpenCompanyClient;
+  return { client, put };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(EngineSection, { client, company: "acme" }));
+  });
+}
+
+function tile(id: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="engine-tile-${id}"]`);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("the probe path never binds anything", () => {
+  it("tests a candidate engine without applying it, whatever the probe answers", async () => {
+    const { client, put } = clientWith({ healthy: true, capabilities: ["core"] });
+    await show(client);
+
+    await act(async () => {
+      tile("supermemory")!.click();
+    });
+    const test = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Test connection",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      test.click();
+    });
+
+    // A healthy probe still must not have bound anything: the standing engine
+    // on screen is unchanged, and the write route was never called.
+    expect(put).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="memory-engine-health"]')?.textContent).toContain(
+      "store",
+    );
+  });
+
+  it("leaves the bound engine on screen unchanged after a failed probe too", async () => {
+    const { client, put } = clientWith({ healthy: false, capabilities: [], detail: "connection refused" });
+    await show(client);
+
+    await act(async () => {
+      tile("supermemory")!.click();
+    });
+    const test = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Test connection",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      test.click();
+    });
+
+    expect(put).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="memory-engine-health"]')?.textContent).toContain(
+      "store",
+    );
+  });
+});

--- a/frontend/test/unit/cov-rest-memory-engine-probe-non-persistent.test.ts
+++ b/frontend/test/unit/cov-rest-memory-engine-probe-non-persistent.test.ts
@@ -41,15 +41,21 @@ const STATE: MemoryEngineState = {
   ],
 };
 
-function clientWith(probe: EngineProbe): { client: OpenCompanyClient; put: ReturnType<typeof vi.fn> } {
+function clientWith(
+  probe: EngineProbe,
+): { client: OpenCompanyClient; put: ReturnType<typeof vi.fn>; test: ReturnType<typeof vi.fn> } {
   const put = vi.fn(() => Promise.reject(new Error("apply should not be called by a probe")));
+  const test = vi.fn((_body: unknown) => Promise.resolve(probe));
   const client = {
     scopeFor: () => "/api/v1/company/acme",
     get: vi.fn(() => Promise.resolve(STATE)),
-    post: vi.fn(() => Promise.resolve(probe)),
+    post: (path: string, body: unknown) => {
+      if (path.endsWith("/memory/engine/test")) return test(body);
+      return Promise.reject(new Error(`unexpected POST ${path}`));
+    },
     put,
   } as unknown as OpenCompanyClient;
-  return { client, put };
+  return { client, put, test };
 }
 
 let container: HTMLDivElement;
@@ -80,21 +86,25 @@ afterEach(() => {
 
 describe("the probe path never binds anything", () => {
   it("tests a candidate engine without applying it, whatever the probe answers", async () => {
-    const { client, put } = clientWith({ healthy: true, capabilities: ["core"] });
+    const { client, put, test } = clientWith({ healthy: true, capabilities: ["core"] });
     await show(client);
 
     await act(async () => {
       tile("supermemory")!.click();
     });
-    const test = Array.from(container.querySelectorAll("button")).find(
+    const testButton = Array.from(container.querySelectorAll("button")).find(
       (b) => b.textContent?.trim() === "Test connection",
     ) as HTMLButtonElement;
     await act(async () => {
-      test.click();
+      testButton.click();
     });
 
     // A healthy probe still must not have bound anything: the standing engine
-    // on screen is unchanged, and the write route was never called.
+    // on screen is unchanged, and the write route was never called — but the
+    // click must have actually reached the probe route for the candidate,
+    // not just left the screen looking untouched.
+    expect(test).toHaveBeenCalledTimes(1);
+    expect(test).toHaveBeenCalledWith(expect.objectContaining({ engine: "supermemory" }));
     expect(put).not.toHaveBeenCalled();
     expect(container.querySelector('[data-testid="memory-engine-health"]')?.textContent).toContain(
       "store",
@@ -102,19 +112,25 @@ describe("the probe path never binds anything", () => {
   });
 
   it("leaves the bound engine on screen unchanged after a failed probe too", async () => {
-    const { client, put } = clientWith({ healthy: false, capabilities: [], detail: "connection refused" });
+    const { client, put, test } = clientWith({
+      healthy: false,
+      capabilities: [],
+      detail: "connection refused",
+    });
     await show(client);
 
     await act(async () => {
       tile("supermemory")!.click();
     });
-    const test = Array.from(container.querySelectorAll("button")).find(
+    const testButton = Array.from(container.querySelectorAll("button")).find(
       (b) => b.textContent?.trim() === "Test connection",
     ) as HTMLButtonElement;
     await act(async () => {
-      test.click();
+      testButton.click();
     });
 
+    expect(test).toHaveBeenCalledTimes(1);
+    expect(test).toHaveBeenCalledWith(expect.objectContaining({ engine: "supermemory" }));
     expect(put).not.toHaveBeenCalled();
     expect(container.querySelector('[data-testid="memory-engine-health"]')?.textContent).toContain(
       "store",

--- a/frontend/test/unit/cov-rest-observatory-no-role-gate.test.ts
+++ b/frontend/test/unit/cov-rest-observatory-no-role-gate.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ObservatoryView } from "@/views/observatory/ObservatoryView";
+
+/**
+ * `Company.agentRuns` (the GraphQL field this view reads) is answered the
+ * same for every session that can open the company at all — there is no
+ * admin-only slice of run history the way Settings gates a write. This pins
+ * that the view never adds a role check of its own: no `/auth/me`-shaped
+ * `client.get` call precedes the read, so a member sees exactly what an
+ * admin does.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("the observatory reads run history with no role check of its own", () => {
+  it("never calls a member/admin resolving read before fetching runs", async () => {
+    const get = vi.fn(() => Promise.reject(new Error("no REST reads expected here")));
+    const graphqlRequest = vi.fn(() => Promise.resolve({ data: { runs: [] } }));
+    const client = { get, graphqlRequest } as unknown as OpenCompanyClient;
+
+    await act(async () => {
+      root.render(
+        createElement(ObservatoryView, { client, company: "acme", runId: null, eventTick: 0 }),
+      );
+    });
+    await act(async () => {});
+
+    expect(graphqlRequest).toHaveBeenCalled();
+    expect(get).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/test/unit/cov-rest-observatory-view-load.test.ts
+++ b/frontend/test/unit/cov-rest-observatory-view-load.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ObservatoryView } from "@/views/observatory/ObservatoryView";
+
+/**
+ * `ObservatoryView` has deep unit coverage for its hash grammar
+ * (`observatory-hash.test.ts`, `observatory-model.test.ts`, …) but nothing
+ * had mounted the component itself. It carries no admin gate — `Company.
+ * agentRuns` is read the same for every session that can open the company at
+ * all — so what is worth pinning is the FAIL half: a read that genuinely
+ * fails must land on an honest, retryable error rather than an empty run list
+ * a reader could mistake for "nothing has run yet", and a refused query
+ * (`graphql_refused`) must say so without offering a retry that would only
+ * repeat the same refusal.
+ */
+
+function clientAs(
+  graphqlRequest: () => Promise<{ data?: unknown; errors?: unknown[] }>,
+): OpenCompanyClient {
+  return {
+    graphqlRequest: vi.fn(graphqlRequest),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(element: React.ReactElement) {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("ObservatoryView, a genuinely failed read", () => {
+  it("shows the failure and offers a retry, not an empty run list that reads as 'nothing has run'", async () => {
+    const client = clientAs(() => Promise.reject(new Error("network is offline")));
+    await show(
+      createElement(ObservatoryView, {
+        client,
+        company: "acme",
+        runId: null,
+        eventTick: 0,
+      }),
+    );
+    await act(async () => {});
+
+    expect(container.textContent).toContain("network is offline");
+    const retry = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Try again"),
+    );
+    expect(retry).toBeDefined();
+  });
+
+  it("says a refused query was refused, and offers no retry that would only repeat the same refusal", async () => {
+    const client = clientAs(() =>
+      Promise.resolve({ errors: [{ message: "forbidden" }] }),
+    );
+    await show(
+      createElement(ObservatoryView, {
+        client,
+        company: "acme",
+        runId: null,
+        eventTick: 0,
+      }),
+    );
+    await act(async () => {});
+
+    expect(container.textContent).toContain("isn't visible to your account");
+    const retry = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Try again"),
+    );
+    expect(retry).toBeUndefined();
+  });
+});

--- a/frontend/test/unit/cov-rest-pages-list-read-fail.test.ts
+++ b/frontend/test/unit/cov-rest-pages-list-read-fail.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { PageManifestDto } from "@/api/types";
+import { PagesView } from "@/views/PagesView";
+
+/**
+ * The Pages list read itself failing — `client.listPages` rejecting, not the
+ * bridged GraphQL request `cov-rest-pages-view.test.ts` covers.
+ *
+ * The view holds three load states and the failing one has to be reached: a
+ * host that cannot serve pages must say so and offer a retry that really
+ * re-reads, rather than leaving the four skeleton rows up forever or falling
+ * through to the empty-state copy, which reads as "this company has no pages"
+ * — a different, false claim.
+ */
+
+function page(over: Partial<PageManifestDto> = {}): PageManifestDto {
+  return { slug: "metrics", title: "Metrics", navVisible: true, ...over };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(PagesView, { client, company: "acme" }));
+  });
+}
+
+function text(): string {
+  return container.textContent ?? "";
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes(label));
+}
+
+function listItems(): HTMLElement[] {
+  return Array.from(container.querySelectorAll('[data-testid="pages-list-item"]'));
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("PagesView, a page-list read the host never answers", () => {
+  it("names the failure and offers a retry, rather than an empty list or a permanent skeleton", async () => {
+    const client = {
+      listPages: () => Promise.reject(new ApiError(0, "network_error", "cannot reach the company host")),
+      pageUrl: (slug: string) => `/api/v1/company/pages/${slug}`,
+    } as unknown as OpenCompanyClient;
+
+    await show(client);
+
+    expect(text()).toContain("Pages unavailable");
+    expect(text()).toContain("cannot reach the company host");
+    expect(text()).not.toContain("No pages");
+    expect(listItems()).toHaveLength(0);
+    expect(button("Try again")).toBeDefined();
+  });
+
+  it("says a refused read was refused, in the host's own words", async () => {
+    const client = {
+      listPages: () => Promise.reject(new ApiError(403, "forbidden", "only an admin can do that", true)),
+      pageUrl: (slug: string) => `/api/v1/company/pages/${slug}`,
+    } as unknown as OpenCompanyClient;
+
+    await show(client);
+
+    expect(text()).toContain("Pages unavailable");
+    expect(text()).toContain("only an admin can do that");
+  });
+
+  it("recovers the real list once the retry lands", async () => {
+    const listPages = vi
+      .fn()
+      .mockRejectedValueOnce(new ApiError(500, "server_error", "pages index is rebuilding", true))
+      .mockResolvedValueOnce([page()]);
+    const client = {
+      listPages,
+      pageUrl: (slug: string) => `/api/v1/company/pages/${slug}`,
+      graphqlRequest: () => Promise.resolve({ data: {}, errors: undefined }),
+    } as unknown as OpenCompanyClient;
+
+    await show(client);
+    expect(text()).toContain("pages index is rebuilding");
+
+    await act(async () => {
+      button("Try again")?.click();
+    });
+
+    expect(text()).not.toContain("Pages unavailable");
+    expect(listItems().map((el) => el.textContent).join(" ")).toContain("Metrics");
+    expect(listPages).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/test/unit/cov-rest-pages-view.test.ts
+++ b/frontend/test/unit/cov-rest-pages-view.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { MessageChannel, MessagePort } from "node:worker_threads";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { PageManifestDto } from "@/api/types";
+import { PagesView } from "@/views/PagesView";
+
+/**
+ * Two gaps in `PagesView`, unrelated to the postMessage-bridge property
+ * `pages-view-bridge.test.ts` already pins.
+ *
+ * PAGE-001: `page.toml`'s `nav_visible = false` is meant to keep a page off
+ * the sidebar and reachable only by a direct address — nothing in this file
+ * gives it one, so the property actually enforceable here is the other half:
+ * it must never be discoverable through the sidebar list, nor become the
+ * view's own default selection.
+ *
+ * PAGE-002: every `oc:graphql` request crosses the bridge under the
+ * operator's own full session (`server/graphql/mod.rs`) with no per-page
+ * scope narrowing — a backend fact this file cannot test. What it can pin is
+ * the FAIL half: a request the host refuses must answer the waiting page with
+ * an honest `errors` array over the same port, never silence that leaves its
+ * promise hanging.
+ */
+
+Object.assign(globalThis, { MessageChannel, MessagePort });
+
+function page(over: Partial<PageManifestDto> = {}): PageManifestDto {
+  return { slug: "metrics", title: "Metrics", navVisible: true, ...over };
+}
+
+function clientWith(pages: PageManifestDto[], graphqlRequest?: OpenCompanyClient["graphqlRequest"]): OpenCompanyClient {
+  return {
+    listPages: () => Promise.resolve(pages),
+    pageUrl: (slug: string) => `/api/v1/company/pages/${slug}`,
+    graphqlRequest: graphqlRequest ?? (() => Promise.resolve({ data: {}, errors: undefined })),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient, company = "acme") {
+  await act(async () => {
+    root.render(createElement(PagesView, { client, company }));
+  });
+}
+
+function listItems(): HTMLElement[] {
+  return Array.from(container.querySelectorAll('[data-testid="pages-list-item"]'));
+}
+
+function iframe(): HTMLIFrameElement | null {
+  return container.querySelector("iframe");
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("a nav_visible:false page is never surfaced through the console's own nav", () => {
+  it("lists only the nav-visible page in the sidebar, even when the host lists the hidden one first", async () => {
+    const client = clientWith([
+      page({ slug: "internal-audit", title: "Internal Audit", navVisible: false }),
+      page({ slug: "metrics", title: "Metrics", navVisible: true }),
+    ]);
+    await show(client);
+
+    const titles = listItems().map((el) => el.textContent);
+    expect(titles.some((t) => t?.includes("Metrics"))).toBe(true);
+    expect(titles.some((t) => t?.includes("Internal Audit"))).toBe(false);
+  });
+
+  it("never defaults the open document onto the hidden page, even though the host listed it first", async () => {
+    const client = clientWith([
+      page({ slug: "internal-audit", title: "Internal Audit", navVisible: false }),
+      page({ slug: "metrics", title: "Metrics", navVisible: true }),
+    ]);
+    await show(client);
+
+    expect(iframe()?.getAttribute("src")).toBe("/api/v1/company/pages/metrics");
+  });
+});
+
+describe("a rejected bridged GraphQL request answers the page honestly", () => {
+  it("posts an errors array back over the port instead of leaving the request hanging", async () => {
+    const graphqlRequest = vi.fn().mockRejectedValue(new Error("company host refused the request"));
+    const client = clientWith([page()], graphqlRequest);
+    await show(client);
+
+    const frame = iframe()!;
+    const contentWindow = frame.contentWindow as Window;
+    const postMessage = vi.spyOn(contentWindow, "postMessage").mockImplementation(() => {});
+    await act(async () => {
+      frame.dispatchEvent(new Event("load"));
+    });
+    const init = postMessage.mock.calls.find(
+      ([msg]) => (msg as { type?: string })?.type === "oc:init",
+    ) as unknown as [message: { capability?: string }, origin: string, transfer: MessagePort[]];
+    const capability = init[0].capability!;
+    const pagePort = init[2][0];
+
+    const reply = new Promise((resolve) => {
+      pagePort.addEventListener("message", (e) => resolve((e as { data?: unknown }).data), {
+        once: true,
+      });
+    });
+    await act(async () => {
+      pagePort.postMessage({ type: "oc:graphql", id: "q1", query: "{ ping }", capability });
+      await new Promise((r) => setTimeout(r, 0));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const data = (await reply) as { type: string; id: string; errors?: { message: string }[] };
+    expect(data.type).toBe("oc:graphql:result");
+    expect(data.id).toBe("q1");
+    expect(data.errors?.[0]?.message).toContain("company host refused the request");
+  });
+});

--- a/frontend/test/unit/cov-rest-people-me-fetch-failure.test.ts
+++ b/frontend/test/unit/cov-rest-people-me-fetch-failure.test.ts
@@ -53,17 +53,22 @@ afterEach(() => {
 
 describe("PeopleView, /auth/me merely failing to answer (not a real member)", () => {
   it("still offers no control — the safe half of fail-closed holds even on a network failure", async () => {
-    const client = clientAs((path) => {
+    const get = vi.fn((path: string) => {
       if (path.endsWith("/auth/me")) {
         return Promise.reject(new ApiError(0, "network_error", "cannot reach the company host"));
       }
       return Promise.reject(new Error(`unexpected GET ${path}`));
     });
+    const client = clientAs(get);
     await show(createElement(PeopleView, { client, company: "acme" }));
     await act(async () => {});
 
     expect(container.textContent).not.toContain("Invite");
     expect(container.querySelector("[aria-label^='Manage']")).toBeNull();
+    // The safe outcome must come from an actual failed /auth/me read, not
+    // from PeopleView never asking in the first place — either would leave
+    // the screen looking identical above.
+    expect(get).toHaveBeenCalledWith(expect.stringMatching(/\/auth\/me$/));
   });
 
   // FINDING: fails today. The failure renders "Only an admin can manage

--- a/frontend/test/unit/cov-rest-people-me-fetch-failure.test.ts
+++ b/frontend/test/unit/cov-rest-people-me-fetch-failure.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
+import { PeopleView } from "@/views/PeopleView";
+
+/**
+ * FINDING, not a passing pin: `PeopleView`'s own `isAdmin` gate
+ * (`me?.role === "admin"`) fails closed the same way whether `/auth/me`
+ * answered "member" or never answered at all — both leave `me` null-ish and
+ * land on the `!isAdmin` branch. That branch is safe (no control is
+ * offered either way) but it is not honest: a genuine read failure — a
+ * dropped connection, a 500 — renders the identical "Only an admin can
+ * manage people" notice a real member would see, rather than the page's own
+ * `error` alert a few lines below it, which this failure mode can never
+ * reach because the `!isAdmin` return fires first. Skipped because fixing it
+ * is a `frontend/src` change, out of scope here; the safe half (no control
+ * leaks) already holds and is asserted below.
+ */
+
+function clientAs(get: (path: string) => Promise<unknown>): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get,
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(element: React.ReactElement) {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("PeopleView, /auth/me merely failing to answer (not a real member)", () => {
+  it("still offers no control — the safe half of fail-closed holds even on a network failure", async () => {
+    const client = clientAs((path) => {
+      if (path.endsWith("/auth/me")) {
+        return Promise.reject(new ApiError(0, "network_error", "cannot reach the company host"));
+      }
+      return Promise.reject(new Error(`unexpected GET ${path}`));
+    });
+    await show(createElement(PeopleView, { client, company: "acme" }));
+    await act(async () => {});
+
+    expect(container.textContent).not.toContain("Invite");
+    expect(container.querySelector("[aria-label^='Manage']")).toBeNull();
+  });
+
+  // FINDING: fails today. The failure renders "Only an admin can manage
+  // people" (the isAdmin=false branch) instead of the page's own honest
+  // "Couldn't load people" error state, because that branch returns before
+  // the `error` alert is ever reached. A dropped connection reads exactly
+  // like being told you lack access, which is a false explanation even
+  // though no control leaks. See the file's doc comment.
+  it.skip("says the read failed, not that the viewer lacks access — currently shows the wrong reason", async () => {
+    const client = clientAs((path) => {
+      if (path.endsWith("/auth/me")) {
+        return Promise.reject(new ApiError(0, "network_error", "cannot reach the company host"));
+      }
+      return Promise.reject(new Error(`unexpected GET ${path}`));
+    });
+    await show(createElement(PeopleView, { client, company: "acme" }));
+    await act(async () => {});
+
+    expect(container.textContent).toContain("cannot reach the company host");
+    expect(container.textContent).not.toContain("Only an admin can manage people");
+  });
+});

--- a/frontend/test/unit/cov-rest-people-view.test.ts
+++ b/frontend/test/unit/cov-rest-people-view.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
+import type { Person } from "@/api/auth";
+import { PeopleView } from "@/views/PeopleView";
+
+const toasts = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: toasts.success, error: toasts.error, warning: vi.fn(), info: vi.fn() } }));
+
+/**
+ * People is admin-only, but courtesy only — `/users` writes 403 a member
+ * regardless. Three properties, none pinned anywhere before this:
+ *
+ * PEOPLE-001: a member gets the notice and nothing else, and — the actual
+ * enforcement-adjacent property — the roster is never even fetched for one,
+ * so nothing about who else can sign in reaches a member's client at all.
+ *
+ * PEOPLE-002: the last-admin disable is a client-side courtesy over
+ * `activeAdmins.length`, computed from whatever roster happened to load. It
+ * can be stale. The property that actually matters is downstream of that:
+ * when the roster made a write look safe and the host's own last-admin guard
+ * refuses it anyway, the refusal has to surface honestly, not read as success.
+ *
+ * PEOPLE-003: role change, reset password, and sign-out-everywhere are three
+ * independent writes with three independent failure paths, never isolated
+ * from each other in a unit test before.
+ */
+
+function person(over: Partial<Person> = {}): Person {
+  return {
+    id: "p1",
+    email: "alex@acme.test",
+    role: "member",
+    status: "active",
+    hasPassword: true,
+    mustChangePassword: false,
+    createdAtMillis: 0,
+    ...over,
+  };
+}
+
+function clientAs(opts: {
+  role: "admin" | "member";
+  people?: Person[];
+  patch?: () => Promise<Person>;
+  post?: () => Promise<Person>;
+  del?: () => Promise<{ revoked: number }>;
+}): OpenCompanyClient {
+  const get = vi.fn((path: string) => {
+    if (path.endsWith("/auth/me")) {
+      return Promise.resolve({ id: "me", email: "me@acme.test", role: opts.role, company: "acme", hasPassword: true, mustChangePassword: false });
+    }
+    if (path.endsWith("/users")) return Promise.resolve(opts.people ?? []);
+    if (path.endsWith("/users/invites")) return Promise.resolve([]);
+    return Promise.reject(new Error(`unexpected GET ${path}`));
+  });
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get,
+    patch: vi.fn(opts.patch ?? (() => Promise.resolve(person()))),
+    post: vi.fn(opts.post ?? (() => Promise.resolve(person()))),
+    del: vi.fn(opts.del ?? (() => Promise.resolve({ revoked: 1 }))),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(PeopleView, { client, company: "acme" }));
+  });
+}
+
+function menuButtonFor(email: string): HTMLButtonElement {
+  const row = Array.from(container.querySelectorAll("div")).find((d) =>
+    d.textContent?.includes(email) && d.querySelector('[aria-label^="Manage"]'),
+  );
+  return row?.querySelector('[aria-label^="Manage"]') as HTMLButtonElement;
+}
+
+async function openMenuFor(email: string) {
+  await act(async () => {
+    menuButtonFor(email).click();
+  });
+}
+
+function menuItem(label: string): HTMLElement {
+  const found = Array.from(document.querySelectorAll('[role="menuitem"]')).find(
+    (el) => el.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no "${label}" menu item in:\n${document.body.innerHTML}`);
+  return found as HTMLElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+  toasts.success.mockClear();
+  toasts.error.mockClear();
+});
+
+describe("People is admin-only, and a member's client never even sees the roster", () => {
+  it("shows a member the notice, no roster, and no invite control", async () => {
+    const client = clientAs({ role: "member", people: [person({ email: "somebody@acme.test" })] });
+    await show(client);
+
+    expect(container.textContent).toContain("Only an admin can manage people");
+    expect(container.textContent).not.toContain("Invite");
+    expect(
+      (client.get as ReturnType<typeof vi.fn>).mock.calls.some((call: unknown[]) =>
+        String(call[0]).endsWith("/users"),
+      ),
+    ).toBe(false);
+  });
+
+  it("gives an admin the roster and the invite control", async () => {
+    const client = clientAs({ role: "admin", people: [person({ email: "somebody@acme.test" })] });
+    await show(client);
+
+    expect(container.textContent).toContain("somebody@acme.test");
+    expect(container.textContent).toContain("Invite");
+  });
+});
+
+describe("a stale-looking last-admin guard still surfaces the host's real refusal", () => {
+  it("does not pretend the demote succeeded when the host refuses it as the last admin", async () => {
+    // Two active admins on the loaded roster, so the client-side mirror does
+    // NOT mark either as the last admin — the button is live. The host
+    // refuses anyway (a concurrent change elsewhere already made this one
+    // the last admin), and that refusal must read as a refusal.
+    const client = clientAs({
+      role: "admin",
+      people: [
+        person({ id: "p1", email: "alex@acme.test", role: "admin" }),
+        person({ id: "p2", email: "sam@acme.test", role: "admin" }),
+      ],
+      patch: () => Promise.reject(new ApiError(409, "conflict", "this is the company's last admin")),
+    });
+    await show(client);
+
+    await openMenuFor("alex@acme.test");
+    await act(async () => {
+      menuItem("Make member").click();
+    });
+
+    // A false success is exactly the risk this cell names: the client-side
+    // mirror said this write was safe, and the host refused it anyway.
+    expect(toasts.error).toHaveBeenCalledWith(expect.stringContaining("last admin"));
+    expect(toasts.success).not.toHaveBeenCalled();
+  });
+});
+
+describe("the three per-person actions fail independently and honestly", () => {
+  it("reset password: the toast reports the host's refusal rather than a silent no-op", async () => {
+    const client = clientAs({
+      role: "admin",
+      people: [person()],
+      post: () => Promise.reject(new ApiError(400, "bad_request", "cannot set a password for a wallet-only account")),
+    });
+    await show(client);
+
+    await openMenuFor("alex@acme.test");
+    await act(async () => {
+      menuItem("Set a temporary password").click();
+    });
+    const input = document.getElementById("temp-password") as HTMLInputElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(input, "a-long-enough-password");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const save = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Set it",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      save.click();
+    });
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(toasts.error).toHaveBeenCalledWith(
+      expect.stringContaining("cannot set a password for a wallet-only account"),
+    );
+    expect(toasts.success).not.toHaveBeenCalled();
+  });
+
+  it("sign out everywhere: a refusal is reported rather than silently accepted", async () => {
+    const del = vi.fn(() => Promise.reject(new ApiError(500, "server_error", "could not revoke sessions")));
+    const client = clientAs({ role: "admin", people: [person()], del });
+    await show(client);
+
+    await openMenuFor("alex@acme.test");
+    await act(async () => {
+      menuItem("Sign out everywhere").click();
+    });
+
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(toasts.error).toHaveBeenCalledWith(expect.stringContaining("could not revoke sessions"));
+    expect(toasts.success).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/test/unit/cov-rest-runs-agent-scope.test.ts
+++ b/frontend/test/unit/cov-rest-runs-agent-scope.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { listRuns } from "@/api/runs";
+
+/**
+ * `api/runs.ts` documents that `?agent=` is sent to the host rather than
+ * applied client-side, and that a caller must not assume every returned row
+ * is that desk's own (a host predating the selector answers unfiltered).
+ * `agent-runs.test.ts` already proves the *consuming* component drops a
+ * misattributed row; this pins the api module itself, at the one place a
+ * future edit could silently stop sending the selector at all.
+ */
+
+describe("listRuns sends the agent selector the host is asked to narrow by", () => {
+  it("puts ?agent= on the wire rather than filtering a fetched page", async () => {
+    const get = vi.fn((_path: string) => Promise.resolve([]));
+    const client = { scopeFor: () => "/api/v1/company/acme", get } as unknown as OpenCompanyClient;
+
+    await listRuns(client, "acme", { agent: "designer" });
+
+    expect(get).toHaveBeenCalledTimes(1);
+    const [path] = get.mock.calls[0];
+    expect(path).toContain("agent=designer");
+  });
+});

--- a/frontend/test/unit/cov-rest-runs-api-readonly.test.ts
+++ b/frontend/test/unit/cov-rest-runs-api-readonly.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { getRun, listRuns } from "@/api/runs";
+
+/**
+ * `api/runs.ts`'s own doc header: "Read-only on purpose … There is no write
+ * here at all." There is therefore no control for this axis to withhold by
+ * role — a run is minted, begun and settled by the dispatch path, never by
+ * this module. What is worth pinning, given that promise, is that it still
+ * holds: both exports resolve through nothing but `client.get`, so neither
+ * one could quietly grow a write a future edit forgets to gate.
+ */
+
+function readOnlyClient(): OpenCompanyClient {
+  // No post/put/patch/del at all — if either export under test reached for
+  // one, the call would throw "is not a function" rather than silently pass.
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: vi.fn(() => Promise.resolve([])),
+  } as unknown as OpenCompanyClient;
+}
+
+describe("the runs API, read-only end to end", () => {
+  it("lists runs through a client that offers no write method at all", async () => {
+    const client = readOnlyClient();
+    await expect(listRuns(client, "acme")).resolves.toEqual([]);
+    expect(client.get).toHaveBeenCalledWith("/api/v1/companies/acme/runs");
+  });
+
+  it("reads one run through a client that offers no write method at all", async () => {
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: vi.fn(() => Promise.resolve({ id: "r1" })),
+    } as unknown as OpenCompanyClient;
+    await expect(getRun(client, "acme", "r1")).resolves.toEqual({ id: "r1" });
+    expect(client.get).toHaveBeenCalledWith("/api/v1/companies/acme/runs/r1");
+  });
+});

--- a/frontend/test/unit/cov-rest-skills-install-lifecycle.test.ts
+++ b/frontend/test/unit/cov-rest-skills-install-lifecycle.test.ts
@@ -8,12 +8,18 @@ import type { OpenCompanyClient } from "@/api/client";
 import type { RegistrySkill, Skill } from "@/api/skills";
 import { SkillsView } from "@/views/SkillsView";
 
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
+}));
+const { toast } = await import("sonner");
+
 /**
- * `install`/`uninstall` (`server/ops/skills.rs:306,373`) are `ScopedCompany`
- * — the slug-traversal guard the existing Rust suite covers is the only
- * thing gating them, not a role — so `SkillsView` offering both to a plain
- * member with no `canManage` check of its own is correct, matching the
- * route. What had no test at all was the lifecycle itself: install landing
+ * `install`/`uninstall` (`server/ops/skills.rs:370,440`) are
+ * `AdminScopedCompany` — a skill's content lands in every agent's effective
+ * prompt company-wide, so a member's write here would only ever earn a
+ * 403 — and `SkillsView` mirrors that with its own `canManage` gate read
+ * from `/auth/me`, withholding "Install" before the write route is ever
+ * asked. What had no test at all was the lifecycle itself: install landing
  * moves a registry tile to "Installed", and uninstall a refusal must leave
  * the card in place with an honest toast rather than vanishing it on a
  * write that never actually landed.
@@ -38,17 +44,19 @@ const INSTALLED: Skill = {
 
 function clientAs(opts: {
   skills?: Skill[];
+  role?: "admin" | "member";
   install?: () => Promise<Skill>;
   uninstall?: () => Promise<void>;
 }): OpenCompanyClient {
   const install = opts.install ?? (() => Promise.resolve(INSTALLED));
   const uninstall = opts.uninstall ?? (() => Promise.resolve());
+  const role = opts.role ?? "admin";
   return {
     scopeFor: () => "/api/v1/companies/acme",
     get: (path: string) => {
       if (path.includes("/skills/registry")) return Promise.resolve([REGISTRY]);
       if (path.endsWith("/auth/me"))
-        return Promise.resolve({ id: "u1", email: "a@b.c", role: "admin", company: "acme", hasPassword: true });
+        return Promise.resolve({ id: "u1", email: "a@b.c", role, company: "acme", hasPassword: true });
       return Promise.resolve(opts.skills ?? []);
     },
     post: vi.fn((path: string) => {
@@ -88,15 +96,17 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("SkillsView, a member with no canManage gate of its own", () => {
-  it("offers install on the registry tab, matching the ungated ScopedCompany route", async () => {
-    const client = clientAs({ skills: [] });
+describe("SkillsView, a member without canManage", () => {
+  it("withholds Install on the registry tab, matching the host's AdminScopedCompany route", async () => {
+    const client = clientAs({ skills: [], role: "member" });
     await show(createElement(SkillsView, { client, company: "acme" }));
     await act(async () => {});
     findButton("Registry")!.click();
     await act(async () => {});
 
-    expect(findButton("Install")).not.toBeNull();
+    const card = container.querySelector('[data-testid="registry-card"]')!;
+    expect(card.textContent).toContain("Standup writer");
+    expect(card.querySelector("button")).toBeNull();
   });
 });
 
@@ -139,5 +149,6 @@ describe("uninstall lifecycle", () => {
 
     // Still on screen — the refusal must not have removed the card.
     expect(container.textContent).toContain("Standup writer");
+    expect(toast.error).toHaveBeenCalledWith("this skill is pinned by the manifest");
   });
 });

--- a/frontend/test/unit/cov-rest-skills-install-lifecycle.test.ts
+++ b/frontend/test/unit/cov-rest-skills-install-lifecycle.test.ts
@@ -47,6 +47,8 @@ function clientAs(opts: {
     scopeFor: () => "/api/v1/companies/acme",
     get: (path: string) => {
       if (path.includes("/skills/registry")) return Promise.resolve([REGISTRY]);
+      if (path.endsWith("/auth/me"))
+        return Promise.resolve({ id: "u1", email: "a@b.c", role: "admin", company: "acme", hasPassword: true });
       return Promise.resolve(opts.skills ?? []);
     },
     post: vi.fn((path: string) => {

--- a/frontend/test/unit/cov-rest-skills-install-lifecycle.test.ts
+++ b/frontend/test/unit/cov-rest-skills-install-lifecycle.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { RegistrySkill, Skill } from "@/api/skills";
+import { SkillsView } from "@/views/SkillsView";
+
+/**
+ * `install`/`uninstall` (`server/ops/skills.rs:306,373`) are `ScopedCompany`
+ * — the slug-traversal guard the existing Rust suite covers is the only
+ * thing gating them, not a role — so `SkillsView` offering both to a plain
+ * member with no `canManage` check of its own is correct, matching the
+ * route. What had no test at all was the lifecycle itself: install landing
+ * moves a registry tile to "Installed", and uninstall a refusal must leave
+ * the card in place with an honest toast rather than vanishing it on a
+ * write that never actually landed.
+ */
+
+const REGISTRY: RegistrySkill = {
+  id: "s-standup",
+  name: "Standup writer",
+  description: "Drafts a standup update.",
+  category: "productivity",
+  publisher: "opencompany",
+};
+
+const INSTALLED: Skill = {
+  id: "s-standup",
+  name: "Standup writer",
+  description: "Drafts a standup update.",
+  category: "productivity",
+  enabled: true,
+  source: "registry",
+};
+
+function clientAs(opts: {
+  skills?: Skill[];
+  install?: () => Promise<Skill>;
+  uninstall?: () => Promise<void>;
+}): OpenCompanyClient {
+  const install = opts.install ?? (() => Promise.resolve(INSTALLED));
+  const uninstall = opts.uninstall ?? (() => Promise.resolve());
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: (path: string) => {
+      if (path.includes("/skills/registry")) return Promise.resolve([REGISTRY]);
+      return Promise.resolve(opts.skills ?? []);
+    },
+    post: vi.fn((path: string) => {
+      if (path.endsWith("/uninstall")) return uninstall();
+      return install();
+    }),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(element: React.ReactElement) {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+function findButton(text: string): HTMLButtonElement | null {
+  return (
+    (Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes(text),
+    ) as HTMLButtonElement | undefined) ?? null
+  );
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("SkillsView, a member with no canManage gate of its own", () => {
+  it("offers install on the registry tab, matching the ungated ScopedCompany route", async () => {
+    const client = clientAs({ skills: [] });
+    await show(createElement(SkillsView, { client, company: "acme" }));
+    await act(async () => {});
+    findButton("Registry")!.click();
+    await act(async () => {});
+
+    expect(findButton("Install")).not.toBeNull();
+  });
+});
+
+describe("install lifecycle", () => {
+  it("flips the registry tile from Install to Installed once the write actually lands", async () => {
+    const client = clientAs({ skills: [] });
+    await show(createElement(SkillsView, { client, company: "acme" }));
+    await act(async () => {});
+    findButton("Registry")!.click();
+    await act(async () => {});
+
+    const card = container.querySelector('[data-testid="registry-card"]')!;
+    expect(card.textContent).toContain("Install");
+
+    await act(async () => {
+      (card.querySelector("button") as HTMLButtonElement).click();
+    });
+
+    expect(card.querySelector("button")).toBeNull();
+    expect(card.textContent).toContain("Installed");
+  });
+});
+
+describe("uninstall lifecycle", () => {
+  it("leaves the card installed and says why when the host refuses the uninstall", async () => {
+    const client = clientAs({
+      skills: [INSTALLED],
+      uninstall: () => Promise.reject(new Error("this skill is pinned by the manifest")),
+    });
+    await show(createElement(SkillsView, { client, company: "acme" }));
+    await act(async () => {});
+
+    expect(container.textContent).toContain("Standup writer");
+    const uninstallButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="installed-card"] button[aria-label="Uninstall"]',
+    )!;
+    await act(async () => {
+      uninstallButton.click();
+    });
+
+    // Still on screen — the refusal must not have removed the card.
+    expect(container.textContent).toContain("Standup writer");
+  });
+});

--- a/frontend/test/unit/cov-rest-skills-lifecycle.test.ts
+++ b/frontend/test/unit/cov-rest-skills-lifecycle.test.ts
@@ -37,6 +37,8 @@ function clientWith(opts: { skills: Skill[]; post?: (path: string) => Promise<un
     get: vi.fn((path: string) => {
       if (path.endsWith("/skills")) return Promise.resolve(opts.skills);
       if (path.endsWith("/skills/registry")) return Promise.resolve([]);
+      if (path.endsWith("/auth/me"))
+        return Promise.resolve({ id: "u1", email: "a@b.c", role: "admin", company: "acme", hasPassword: true });
       return Promise.reject(new Error(`unexpected GET ${path}`));
     }),
     post,

--- a/frontend/test/unit/cov-rest-skills-lifecycle.test.ts
+++ b/frontend/test/unit/cov-rest-skills-lifecycle.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { Skill } from "@/api/skills";
+import { SkillsView } from "@/views/SkillsView";
+
+/**
+ * SKILL-001's Rust half (`ops/skills.rs`) has slug-validation coverage but no
+ * direct REST-route test for install/uninstall. The console's own lifecycle
+ * surface — `SkillsView` — had none at all. Two properties: a company
+ * (manifest-baked) skill offers no Uninstall, the one authority split this
+ * screen actually draws; and an uninstall the host refuses puts the card back
+ * rather than dropping it for good on a client that merely believed it
+ * worked.
+ */
+
+function skill(over: Partial<Skill> = {}): Skill {
+  return {
+    id: "s1",
+    name: "Refund policy",
+    description: "How to handle refund requests.",
+    category: "Support",
+    source: "registry",
+    enabled: true,
+    ...over,
+  };
+}
+
+function clientWith(opts: { skills: Skill[]; post?: (path: string) => Promise<unknown> }): OpenCompanyClient {
+  const post = vi.fn(opts.post ?? (() => Promise.resolve(undefined)));
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn((path: string) => {
+      if (path.endsWith("/skills")) return Promise.resolve(opts.skills);
+      if (path.endsWith("/skills/registry")) return Promise.resolve([]);
+      return Promise.reject(new Error(`unexpected GET ${path}`));
+    }),
+    post,
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(SkillsView, { client, company: "acme" }));
+  });
+}
+
+function cards(): HTMLElement[] {
+  return Array.from(container.querySelectorAll('[data-testid="installed-card"]'));
+}
+
+function uninstallButtonIn(card: HTMLElement): HTMLElement | null {
+  return card.querySelector('[aria-label="Uninstall"]');
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("a manifest-baked skill offers no uninstall", () => {
+  it("withholds Uninstall from a company skill, and offers it on a registry one", async () => {
+    const client = clientWith({
+      skills: [
+        skill({ id: "baked", name: "Baked-in playbook", source: "company" }),
+        skill({ id: "installed", name: "Installed skill", source: "registry" }),
+      ],
+    });
+    await show(client);
+
+    const [baked, installed] = cards();
+    expect(uninstallButtonIn(baked)).toBeNull();
+    expect(uninstallButtonIn(installed)).not.toBeNull();
+  });
+});
+
+describe("a refused uninstall puts the skill back", () => {
+  it("re-lists the skill and reports the failure when the host refuses the uninstall", async () => {
+    const client = clientWith({
+      skills: [skill()],
+      post: () => Promise.reject(new Error("skill is pinned by an active workflow")),
+    });
+    await show(client);
+
+    await act(async () => {
+      uninstallButtonIn(cards()[0])!.click();
+    });
+
+    expect(cards()).toHaveLength(1);
+    expect(container.textContent).toContain("Refund policy");
+  });
+});

--- a/frontend/test/unit/cov-rest-team-tools-ceiling-warning.test.ts
+++ b/frontend/test/unit/cov-rest-team-tools-ceiling-warning.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { AgentDetailDto } from "@/api/types";
+import { AgentDetailView } from "@/views/team/AgentDetailView";
+
+/**
+ * The tools editor's ceiling warning (`agent-tools-uncovered`) is,
+ * deliberately, a soft guard: a glob outside `grantCeiling` "can only ever
+ * take capability away — never add to it" (`lib/agent.ts` doc), because
+ * `agent_scoped_grants` on the host narrows to the same ceiling this warning
+ * is drawn from. Saving anyway is therefore safe by construction, not a
+ * bypass — but nothing had verified that this is the actual, current
+ * behaviour: that the warning appears AND that Save stays live through it,
+ * rather than the warning silently doing nothing or Save silently blocking.
+ */
+
+function overlay(over: Partial<AgentDetailDto> = {}): AgentDetailDto {
+  return {
+    id: "agent-overlay",
+    name: "Nova",
+    role: "Growth Marketer",
+    source: "overlay",
+    editable: ["name", "role", "description", "tools", "instructions"],
+    isOrchestrator: false,
+    tools: { requested: [], companyAllow: ["docs.*"], deskAllow: [], deskCeilingActive: false, effective: [] },
+    desks: [],
+    inboxEnabled: false,
+    description: "Runs paid acquisition.",
+    instructions: "Always confirm the budget before launching.",
+    instructionsOverridden: false,
+    ...over,
+  };
+}
+
+function clientAs(agent: AgentDetailDto, updateAgent = vi.fn(async () => agent)): OpenCompanyClient {
+  return {
+    getAgent: vi.fn(async () => agent),
+    updateAgent,
+    get: vi.fn(async () => ({ role: "admin" })),
+    listHarnesses: vi.fn(async () => []),
+    scopeFor: () => "",
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+async function type(text: string) {
+  const el = at("agent-tools-field") as HTMLInputElement;
+  const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  await act(async () => {
+    setValue?.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+describe("agent tools editor, a grant outside the company ceiling", () => {
+  it("warns, but still leaves Save live — the write is harmless, the host ignores what it does not allow", async () => {
+    const client = clientAs(overlay());
+    await act(async () => {
+      root.render(
+        createElement(AgentDetailView, { client, company: "acme", agentId: "agent-overlay", onBack: vi.fn() }),
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => at("agent-tools-edit")?.click());
+    await type("docs.*, media.*");
+
+    const warning = at("agent-tools-uncovered");
+    expect(warning).not.toBeNull();
+    expect(warning?.textContent).toContain("media.*");
+
+    const saveButtons = Array.from(container.querySelectorAll("button")).filter(
+      (b) => b.textContent === "Save",
+    );
+    expect(saveButtons).toHaveLength(1);
+    expect(saveButtons[0].disabled).toBe(false);
+  });
+
+  it("saves the over-ceiling glob byte for byte — the console never silently drops what the operator typed", async () => {
+    const updateAgent = vi.fn(async () => overlay());
+    const client = clientAs(overlay(), updateAgent);
+    await act(async () => {
+      root.render(
+        createElement(AgentDetailView, { client, company: "acme", agentId: "agent-overlay", onBack: vi.fn() }),
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => at("agent-tools-edit")?.click());
+    await type("docs.*, media.*");
+    const saveButton = Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "Save");
+    await act(async () => saveButton?.click());
+
+    expect(updateAgent).toHaveBeenCalledWith(
+      "agent-overlay",
+      { tools: ["docs.*", "media.*"] },
+      "acme",
+    );
+  });
+
+  it("shows no ceiling warning for a grant the company already covers", async () => {
+    const client = clientAs(overlay());
+    await act(async () => {
+      root.render(
+        createElement(AgentDetailView, { client, company: "acme", agentId: "agent-overlay", onBack: vi.fn() }),
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => at("agent-tools-edit")?.click());
+    await type("docs.read");
+
+    expect(at("agent-tools-uncovered")).toBeNull();
+  });
+});

--- a/frontend/test/unit/cov-rest-workspace-move-race-honesty.test.ts
+++ b/frontend/test/unit/cov-rest-workspace-move-race-honesty.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { TeamMemberDto } from "@/api/types";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+const toasts = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({
+  toast: { success: toasts.success, error: toasts.error, warning: vi.fn(), info: vi.fn() },
+}));
+
+/**
+ * `renameMoveNode` (`PATCH …/workspace/{id}`) carries no version token at
+ * all, so two operators moving the same note from two tabs is resolved
+ * entirely by whichever PATCH the host answers last — there is nothing
+ * client-side to arbitrate. What a frontend test CAN prove about that race
+ * is the losing tab's half: `move()` applies the host's answer only after
+ * `await`ing it (`WorkspaceView.tsx`), never optimistically, so a PATCH the
+ * host refuses — the ordinary shape of losing a race, since the node the
+ * losing tab named may already be gone or already moved — must leave the
+ * tree exactly as it was and say so, not silently believe the move landed.
+ */
+
+function node(over: { id: string; name: string; kind: "folder" | "file"; parentId?: string }) {
+  return { ...over, updatedAt: 1 };
+}
+
+const TREE = [
+  node({ id: "product", name: "Product", kind: "folder" }),
+  node({ id: "archive", name: "Archive", kind: "folder" }),
+  node({ id: "note", name: "Plan.md", kind: "file" }),
+];
+
+let container: HTMLDivElement;
+let root: Root;
+let client: {
+  scopeFor: () => string;
+  get: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  listTeam: ReturnType<typeof vi.fn>;
+};
+
+function host(team: TeamMemberDto[], patch: ReturnType<typeof vi.fn>) {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(TREE),
+    patch,
+    listTeam: vi.fn().mockResolvedValue(team),
+  };
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+  toasts.success.mockClear();
+  toasts.error.mockClear();
+});
+
+function menuItem(label: string): HTMLElement {
+  const found = Array.from(document.querySelectorAll('[role="menuitem"]')).find(
+    (el) => el.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no "${label}" menu item in:\n${document.body.innerHTML}`);
+  return found as HTMLElement;
+}
+
+function actionsButtonFor(name: string): HTMLButtonElement {
+  const row = Array.from(container.querySelectorAll("div.group")).find((d) =>
+    d.textContent?.includes(name),
+  );
+  const found = row?.querySelector('[aria-label="Actions"]');
+  if (!found) throw new Error(`no Actions button for "${name}"`);
+  return found as HTMLButtonElement;
+}
+
+async function openMoveDialog(patch: ReturnType<typeof vi.fn>) {
+  client = host([], patch);
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client as unknown as OpenCompanyClient,
+          company: "acme",
+        }),
+      }),
+    );
+  });
+  await act(async () => {
+    actionsButtonFor("Plan").click();
+  });
+  await act(async () => {
+    menuItem("Move to…").click();
+  });
+  await act(async () => {
+    (
+      Array.from(
+        document.querySelectorAll<HTMLButtonElement>('[data-testid="workspace-move-dest"]'),
+      ).find((d) => d.textContent?.includes("Archive")) ?? null
+    )?.click();
+  });
+}
+
+describe("losing a move race: the host's PATCH is refused", () => {
+  it("leaves the note exactly where it was and reports the refusal, rather than believing the move landed", async () => {
+    const patch = vi.fn(() =>
+      Promise.reject(
+        new ApiError(404, "not_found", "this item no longer exists — it may have just been moved or deleted"),
+      ),
+    );
+    await openMoveDialog(patch);
+
+    await act(async () => {
+      (
+        document.querySelector('[data-testid="workspace-move-confirm"]') as HTMLButtonElement
+      ).click();
+    });
+
+    expect(patch).toHaveBeenCalledTimes(1);
+    // Still at the workspace root's own depth, not nested one level in under
+    // Archive — a client that applied the move optimistically would indent
+    // this row regardless of what the host answered.
+    const planName = container.querySelector('[data-testid="workspace-tree-name"][title="Plan"]');
+    const planRow = planName?.closest<HTMLElement>('[style*="padding-left"]');
+    expect(planRow).toBeTruthy();
+    expect(planRow!.style.paddingLeft).toBe("6px");
+    expect(toasts.error).toHaveBeenCalledWith(
+      "this item no longer exists — it may have just been moved or deleted",
+    );
+  });
+});

--- a/frontend/test/unit/cov-rest-workspace-rename-race.test.ts
+++ b/frontend/test/unit/cov-rest-workspace-rename-race.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * WS-001: the two-writer race on rename/move, never independently checked.
+ *
+ * The Rename dialog fires-and-forgets (`void rename(...)`, then closes
+ * immediately) rather than waiting on the `PATCH`, so an operator — or a
+ * second tab on the same node — can start a second rename before the first
+ * one's response lands. `rename()` applies whichever response resolves last,
+ * unconditionally (`setNodes(all => all.map(n => n.id === updated.id ?
+ * updated : n))`), with no per-node request generation the way every other
+ * network-racy surface in this codebase (`InboxView`, `ArtifactsTab`,
+ * `PagesView`, `TaskDetailView`) carries. This test proves which behaviour
+ * the code actually has.
+ */
+
+function node(over: { id: string; name: string; kind: "folder" | "file"; parentId?: string }) {
+  return { ...over, updatedAt: 1 };
+}
+
+const TREE = [node({ id: "note", name: "Plan.md", kind: "file" })];
+
+let container: HTMLDivElement;
+let root: Root;
+
+function menuItem(label: string): HTMLElement {
+  const found = Array.from(document.querySelectorAll('[role="menuitem"]')).find(
+    (el) => el.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no "${label}" menu item`);
+  return found as HTMLElement;
+}
+
+function actionsButtonFor(name: string): HTMLButtonElement {
+  const row = Array.from(container.querySelectorAll("div.group")).find((d) =>
+    d.textContent?.includes(name),
+  );
+  const found = row?.querySelector('[aria-label="Actions"]');
+  if (!found) throw new Error(`no Actions button for "${name}"`);
+  return found as HTMLButtonElement;
+}
+
+async function openRename() {
+  await act(async () => {
+    actionsButtonFor("Plan").click();
+  });
+  await act(async () => {
+    menuItem("Rename").click();
+  });
+}
+
+async function submitRename(name: string) {
+  const input = document.getElementById("fs-name") as HTMLInputElement;
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    setter?.call(input, name);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await act(async () => {
+    (Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Rename",
+    ) as HTMLButtonElement).click();
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  localStorage.clear();
+});
+
+describe("two overlapping renames of the same node race on the network, not on the operator's intent", () => {
+  // FINDING (see report): `rename()` has no per-node request ordering guard —
+  // unlike InboxView / ArtifactsTab / PagesView / TaskDetailView, all of which
+  // carry a generation counter or an `isActive()` check specifically so a
+  // late, superseded response cannot overwrite a newer one. This is the
+  // console's only rename path; it applies whichever PATCH response settles
+  // last, so a slow first request finishing after a fast second one reverts
+  // the node to the stale name. Kept as `it.skip` with the desired (safe)
+  // assertion — see the report's Findings section rather than a passing test
+  // asserting the current, unsafe behaviour.
+  it.skip("keeps the operator's second, newer rename even when the first request's response arrives after it", async () => {
+    let resolveFirst: ((node: unknown) => void) | null = null;
+    let resolveSecond: ((node: unknown) => void) | null = null;
+    let call = 0;
+    const patch = vi.fn(() => {
+      call += 1;
+      if (call === 1) return new Promise((resolve) => (resolveFirst = resolve));
+      return new Promise((resolve) => (resolveSecond = resolve));
+    });
+    const client = {
+      scopeFor: () => "/api/v1/company/acme",
+      get: vi.fn().mockResolvedValue(TREE),
+      patch,
+      listTeam: vi.fn().mockResolvedValue([]),
+    } as unknown as OpenCompanyClient;
+
+    await act(async () => {
+      root.render(
+        createElement(ConnectionScopeProvider, {
+          scope: { connection: "c1", company: "acme" },
+          children: createElement(WorkspaceView, { client, company: "acme" }),
+        }),
+      );
+    });
+
+    await openRename();
+    await submitRename("First.md");
+    // The dialog closed on submit, fire-and-forget — the operator can already
+    // rename again before the first PATCH has answered.
+    await openRename();
+    await submitRename("Second.md");
+
+    expect(patch).toHaveBeenCalledTimes(2);
+
+    // Resolve out of order: the SECOND (newer) request's response lands
+    // first, then the stale first request's response lands after it.
+    await act(async () => {
+      resolveSecond?.(node({ id: "note", name: "Second.md", kind: "file" }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      resolveFirst?.(node({ id: "note", name: "First.md", kind: "file" }));
+      await Promise.resolve();
+    });
+
+    const label = container.querySelector('[data-testid="workspace-tree-name"]');
+    expect(label?.textContent).toBe("Second.md");
+  });
+});

--- a/frontend/test/unit/cov-rest-workspace-write-refusal.test.ts
+++ b/frontend/test/unit/cov-rest-workspace-write-refusal.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * `writeFile` (`PUT …/workspace/file/{id}`) is what the host's
+ * `workspace().write` guard sits behind — `derived/` and a handful of other
+ * paths refuse it outright. `lib/workspace-save-buffer.ts` unit-tests the
+ * buffer's own bookkeeping in isolation; nothing before this proved that a
+ * refused write actually reaches the operator's eye through the mounted
+ * editor rather than reading as a silent "Saved".
+ */
+
+function node(over: { id: string; name: string; kind: "folder" | "file"; parentId?: string }) {
+  return { ...over, updatedAt: 1 };
+}
+
+const TREE = [node({ id: "note", name: "Plan.md", kind: "file" })];
+
+function clientWith(put: () => Promise<unknown>): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn((path: string) => {
+      if (path.endsWith("/workspace")) return Promise.resolve(TREE);
+      if (path.includes("/workspace/file/")) {
+        return Promise.resolve({
+          id: "note",
+          name: "Plan.md",
+          content: "original text",
+          updatedAt: 1,
+          backlinks: [],
+        });
+      }
+      return Promise.reject(new Error(`unexpected GET ${path}`));
+    }),
+    put,
+    listTeam: vi.fn(() => Promise.resolve([])),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, { client, company: "acme" }),
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  localStorage.clear();
+});
+
+describe("a write the host refuses shows an honest error, never a false Saved", () => {
+  it("says the note was not saved once the host refuses the PUT", async () => {
+    const put = vi.fn(() => Promise.reject(new Error("write refused: read-only path")));
+    const client = clientWith(put);
+    await show(client);
+
+    await act(async () => {
+      const row = Array.from(container.querySelectorAll("div.group")).find((d) =>
+        d.textContent?.includes("Plan"),
+      ) as HTMLElement;
+      (row.querySelector("button") as HTMLButtonElement).click();
+    });
+    await act(async () => {
+      (Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Edit",
+      ) as HTMLButtonElement).click();
+    });
+    const editor = container.querySelector('[data-testid="workspace-editor"]') as HTMLTextAreaElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setter?.call(editor, "original text, plus an edit");
+      editor.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      editor.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 0));
+      await Promise.resolve();
+    });
+
+    expect(put).toHaveBeenCalled();
+    const status = container.querySelector('[data-testid="workspace-save-state"]');
+    expect(status?.textContent).toContain("Not saved");
+    expect(status?.textContent).not.toBe("Saved");
+  });
+});

--- a/frontend/test/unit/cov-task-a-control-bar-dispatch-auth-fail.test.ts
+++ b/frontend/test/unit/cov-task-a-control-bar-dispatch-auth-fail.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { Task } from "@/api/tasks";
+
+/**
+ * `ControlBar`'s Dispatch/Retry/Resume (`patchColumn`, `column: "working"`) —
+ * `patch_task` is `ScopedCompany`, so a plain member dispatching a card is
+ * correct, not a gap, and the click has to really send the `PATCH`. Also pins
+ * that a finished card genuinely drops the control from the DOM rather than
+ * merely disabling it — `task-detail-control-bar.test.ts` covers that shape for
+ * blocked-on-approval; this is the same claim for `finished`.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { ControlBar } = await import("@/views/TaskDetailView");
+const { ApiError } = await import("@/api/types");
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Reconcile the ledger",
+    column: "pending",
+    stage: "pending",
+    priority: "medium",
+    assignee: "finance",
+    ...over,
+  } as Task;
+}
+
+function clientAs(patch: (path: string, body: unknown) => Promise<Task>): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async (path: string) => {
+      if (path.endsWith("/auth/me")) {
+        return { id: "u1", email: "a@b.c", role: "member", company: "acme" };
+      }
+      throw new Error("the control bar must not read on mount");
+    },
+    patch,
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function buttons(): HTMLButtonElement[] {
+  return [...document.querySelectorAll("button")] as HTMLButtonElement[];
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return buttons().find((b) => b.textContent?.trim() === label);
+}
+
+async function render(client: OpenCompanyClient, over: Partial<Task> = {}, finished = false) {
+  const onChanged = vi.fn();
+  await act(async () => {
+    root.render(
+      createElement(ControlBar, {
+        task: task(over),
+        inflight: null,
+        irreversible: [],
+        historyIncomplete: false,
+        blockedOnApproval: false,
+        neverStarted: true,
+        finished,
+        client,
+        company: "acme",
+        onChanged,
+        onEdit: () => {},
+      }),
+    );
+  });
+  return { onChanged };
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("Dispatch, for a plain member session", () => {
+  it("is offered, and clicking it really sends the PATCH", async () => {
+    const patch = vi.fn(async (_path: string, _body: unknown) => task({ column: "working" }));
+    const { onChanged } = await render(clientAs(patch));
+
+    await act(async () => {
+      button("Dispatch")!.click();
+    });
+
+    expect(patch).toHaveBeenCalledTimes(1);
+    const [, body] = patch.mock.calls[0] as [string, { column?: string }];
+    expect(body.column).toBe("working");
+    expect(onChanged).toHaveBeenCalled();
+    expect(toasts.success).toHaveBeenCalled();
+  });
+
+  it("drops the control entirely once the card is finished", async () => {
+    const patch = vi.fn(async () => task());
+    await render(clientAs(patch), { column: "done", stage: "done" }, true);
+    expect(button("Dispatch")).toBeUndefined();
+    expect(button("Retry")).toBeUndefined();
+    expect(button("Resume")).toBeUndefined();
+  });
+});
+
+describe("Dispatch, when the host refuses the write", () => {
+  it("says so and stays put — never a false 'Dispatched'", async () => {
+    const patch = vi.fn(async () => {
+      throw new ApiError(0, "network_error", "cannot reach the company host");
+    });
+    const { onChanged } = await render(clientAs(patch));
+
+    await act(async () => {
+      button("Dispatch")!.click();
+    });
+
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(toasts.error).toHaveBeenCalledWith(
+      expect.stringContaining("cannot reach the company host"),
+    );
+    expect(toasts.success).not.toHaveBeenCalled();
+    expect(onChanged).not.toHaveBeenCalled();
+    // Still offered — a failed dispatch is retryable, not a dead end.
+    expect(button("Dispatch")).toBeDefined();
+  });
+});

--- a/frontend/test/unit/cov-task-a-create-authority.test.ts
+++ b/frontend/test/unit/cov-task-a-create-authority.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { Task } from "@/api/tasks";
+
+/**
+ * `POST …/tasks` (`create_task`) sits behind `ScopedCompany` — any signed-in
+ * company member, the same authority every other task write answers to — not
+ * an admin-only guard. `CreateTaskDialog` never asks who the operator is
+ * before offering the prompt box, which is the correct answer here: gating
+ * task creation on a role would take away a capability this product
+ * deliberately gives every member (`scope.rs`'s own words for the family).
+ *
+ * This is the cell's AUTH axis only. The prompt box's own gap — no length
+ * cap, client or server — is reported as a finding rather than pinned here,
+ * since inventing a cap this component does not have would pin a lie.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { CreateTaskDialog } = await import("@/views/CreateTaskDialog");
+
+/** A member-shaped client: every read this dialog makes, and no `/auth/me`. */
+function fakeClient(post: (path: string, body?: unknown) => Promise<Task>) {
+  const paths: string[] = [];
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/company/${company ?? "acme"}`,
+    get: vi.fn(async (path: string) => {
+      paths.push(path);
+      if (path.includes("/ledgers")) return { ledgers: [] };
+      return {};
+    }),
+    listDesks: vi.fn(async () => []),
+    listTeam: vi.fn(async () => []),
+    post,
+  } as unknown as OpenCompanyClient;
+  return { client, paths };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function mount(client: OpenCompanyClient) {
+  const onClose = vi.fn();
+  const onCreated = vi.fn();
+  await act(async () => {
+    root.render(
+      createElement(CreateTaskDialog, {
+        open: true,
+        onClose,
+        onCreated,
+        client,
+        company: "acme",
+      }),
+    );
+  });
+  await act(async () => {});
+  await act(async () => {});
+  return { onClose, onCreated };
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return [...document.querySelectorAll("button")].find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined;
+}
+
+function setValue(el: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("New task, by authority (create_task's ScopedCompany write)", () => {
+  it("offers a plain member client the prompt box and a live Create, asking no role question first", async () => {
+    const post = vi.fn(async () => ({ id: "task-9" }) as unknown as Task);
+    const { client, paths } = fakeClient(post);
+    await mount(client);
+
+    const prompt = document.querySelector("#new-prompt") as HTMLTextAreaElement;
+    expect(prompt).not.toBeNull();
+    expect(prompt.disabled).toBe(false);
+
+    await act(async () => {
+      setValue(prompt, "reconcile March invoices");
+    });
+    expect(button("Create")!.disabled).toBe(false);
+
+    expect(paths.some((p) => p.includes("/auth/me"))).toBe(false);
+  });
+
+  it("actually creates the card for that member, matching what create_task accepts from any member", async () => {
+    const post = vi.fn(async () => ({ id: "task-9" }) as unknown as Task);
+    const { client } = fakeClient(post);
+    const { onCreated } = await mount(client);
+
+    const prompt = document.querySelector("#new-prompt") as HTMLTextAreaElement;
+    await act(async () => {
+      setValue(prompt, "reconcile March invoices");
+    });
+    await act(async () => {
+      button("Create")!.click();
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(onCreated).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/test/unit/cov-task-a-delete-fail.test.ts
+++ b/frontend/test/unit/cov-task-a-delete-fail.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { Task } from "@/api/tasks";
+
+/**
+ * `DELETE …/tasks/{id}` (`delete_task`) is `ScopedCompany` too — any company
+ * member, refused only for an in-flight card (`409`, pinned by
+ * `task-edit-dialog-gates.test.ts`). What that file never drives is delete
+ * actually failing for a reason other than the in-flight guard — a host that
+ * is simply down when the confirm fires — and this pins the card staying put,
+ * with an honest error, rather than the dialog closing on a delete that never
+ * landed.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { TaskEditDialog } = await import("@/views/TaskEditDialog");
+
+const TASK: Task = {
+  id: "task-1",
+  title: "Pay the invoice",
+  note: "the original note",
+  column: "pending",
+  stage: "pending",
+  priority: "medium",
+  assignee: "",
+  updatedAt: 1_700_000_000_000,
+};
+
+const LEDGERS = {
+  ledgers: [
+    {
+      slug: "tasks",
+      title: "Tasks",
+      purpose: "The company's work board.",
+      source: "native",
+      derived: "derived/TASKS.md",
+      writtenBy: "the board",
+      builtin: true,
+      fields: [],
+      statuses: [
+        { name: "pending", label: "Pending" },
+        { name: "working", label: "Working" },
+        { name: "done", label: "Done", closed: true },
+      ],
+      sections: [],
+      open: 1,
+      closed: 0,
+    },
+  ],
+  faults: [],
+  remaining: 3,
+};
+
+/** A member-shaped client — every read this dialog makes, and no `/auth/me`. */
+function fakeClient(delImpl: (path: string) => Promise<void>) {
+  const paths: string[] = [];
+  const del = vi.fn(delImpl);
+  const patch = vi.fn(async () => TASK);
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/company/${company ?? "acme"}`,
+    get: vi.fn(async (path: string) => {
+      paths.push(path);
+      return path.endsWith("/ledgers") ? LEDGERS : [];
+    }),
+    patch,
+    del,
+    listDesks: vi.fn(async () => []),
+    listTeam: vi.fn(async () => []),
+  } as unknown as OpenCompanyClient;
+  return { client, del, paths };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function buttons(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll("button"));
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = buttons().find((b) => b.textContent?.trim() === label);
+  if (!found) {
+    throw new Error(
+      `no “${label}” button; saw: ${buttons().map((b) => b.textContent?.trim()).join(" | ")}`,
+    );
+  }
+  return found;
+}
+
+async function mount(client: OpenCompanyClient) {
+  const onClose = vi.fn();
+  const onSaved = vi.fn();
+  const onDeleted = vi.fn();
+  await act(async () => {
+    root.render(
+      createElement(TaskEditDialog, {
+        task: TASK,
+        onClose,
+        onSaved,
+        onDeleted,
+        client,
+        company: "acme",
+        irreversible: [],
+        historyIncomplete: false,
+      }),
+    );
+  });
+  await act(async () => {});
+  await act(async () => {});
+  return { onClose, onSaved, onDeleted };
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("Edit → Delete, by authority (delete_task's ScopedCompany write)", () => {
+  it("offers a plain member client a live Delete on a card nothing is running, asking no role question first", async () => {
+    const { client, paths } = fakeClient(async () => undefined);
+    await mount(client);
+
+    const remove = button("Delete");
+    expect(remove.disabled).toBe(false);
+    expect(paths.some((p) => p.includes("/auth/me"))).toBe(false);
+  });
+});
+
+describe("Edit → Delete, a DELETE the host refuses", () => {
+  it("shows the host's own message and leaves the card in place", async () => {
+    const { client, del } = fakeClient(async () => {
+      throw new ApiError(500, "internal", "the task store could not process this", true);
+    });
+    const { onDeleted } = await mount(client);
+
+    await act(async () => {
+      button("Delete").click();
+    });
+    await act(async () => {
+      button("Delete task").click();
+    });
+
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(toasts.error).toHaveBeenCalledWith("the task store could not process this");
+    expect(onDeleted).not.toHaveBeenCalled();
+    // Not silently vanished: the dialog is still open on the same card.
+    expect(document.querySelector("#task-title")).not.toBeNull();
+  });
+
+  it("re-enables Delete rather than leaving the form stuck busy on a network failure", async () => {
+    const { client } = fakeClient(async () => {
+      throw new ApiError(0, "network_error", "cannot reach the company host");
+    });
+    await mount(client);
+
+    await act(async () => {
+      button("Delete").click();
+    });
+    await act(async () => {
+      button("Delete task").click();
+    });
+
+    expect(toasts.error).toHaveBeenCalledWith("cannot reach the company host");
+    expect(button("Delete").disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-task-a-detail-load.test.ts
+++ b/frontend/test/unit/cov-task-a-detail-load.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { TaskDetail } from "@/api/tasks";
+
+/**
+ * The Task Detail screen's own read (`GET …/tasks/{id}`, `task_detail`), which
+ * — like every other task route — sits behind `ScopedCompany`: any signed-in
+ * company member, not an admin-only guard. There is no role check anywhere in
+ * `load()` to get wrong, so what this file pins is that absence staying true
+ * (a member sees exactly what an admin would), and that a load failure is an
+ * honest, recoverable state rather than a blank pane or a permanent spinner.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+function detail(over: Partial<TaskDetail> = {}): TaskDetail {
+  return {
+    task: {
+      id: "task-1",
+      title: "Reconcile the ledger",
+      column: "working",
+      stage: "in_review",
+      priority: "medium",
+      assignee: "finance",
+      updatedAt: T0,
+    },
+    timeline: [],
+    durations: {
+      workedMillis: 60_000,
+      workedLive: false,
+      waitingMillis: 0,
+      waitingLive: false,
+      asOfMillis: T0,
+    },
+    approvals: [],
+    irreversibleEffects: [],
+    historyIncomplete: false,
+    discussion: [],
+    discussionHasMore: false,
+    lineage: { children: [] },
+    runs: [],
+    ...over,
+  } as TaskDetail;
+}
+
+/**
+ * A member-shaped client: no `/auth/me` handler at all. If `load()` ever asked
+ * this screen's own role before rendering the card, this client has no answer
+ * for it and the read would reject — which is exactly the failure a stray
+ * `useCanManage` call would produce here.
+ */
+function client(reads: Array<() => Promise<unknown>>): {
+  client: OpenCompanyClient;
+  paths: string[];
+} {
+  let n = 0;
+  const paths: string[] = [];
+  const c = {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    listTeam: async () => [],
+    get: async (path: string) => {
+      paths.push(path);
+      if (path.endsWith("/tasks/inflight")) return [];
+      if (path.includes("/tasks/task-1")) {
+        const read = reads[Math.min(n, reads.length - 1)];
+        n += 1;
+        return read();
+      }
+      if (path.includes("/ledgers")) return { ledgers: [] };
+      return {};
+    },
+  } as unknown as OpenCompanyClient;
+  return { client: c, paths };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+const { TaskDetailView } = await import("@/views/TaskDetailView");
+
+async function render(c: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(TaskDetailView, {
+        client: c,
+        company: "acme",
+        taskId: "task-1",
+        onBack: () => {},
+        onNavigate: () => {},
+        onDeleted: () => {},
+      }),
+    );
+  });
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return [...document.querySelectorAll("button")].find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("Task Detail load, by authority", () => {
+  it("loads and renders the card for a plain member client, asking no role question first", async () => {
+    const { client: c, paths } = client([async () => detail()]);
+    await render(c);
+
+    expect(container.textContent).toContain("Reconcile the ledger");
+    expect(paths.some((p) => p.includes("/auth/me"))).toBe(false);
+  });
+});
+
+describe("Task Detail load, a rejected read", () => {
+  it("shows the host's own message on a network failure, not a blank pane", async () => {
+    const { client: c } = client([
+      async () =>
+        Promise.reject(new ApiError(0, "network_error", "cannot reach the company host")),
+    ]);
+    await render(c);
+
+    expect(container.textContent).toContain("cannot reach the company host");
+    expect(button("Try again")).toBeDefined();
+  });
+
+  it("shows the host's own message on a host-side rejection, not a blank pane", async () => {
+    const { client: c } = client([
+      async () =>
+        Promise.reject(
+          new ApiError(503, "unavailable", "the task store is temporarily unavailable", true),
+        ),
+    ]);
+    await render(c);
+
+    expect(container.textContent).toContain("the task store is temporarily unavailable");
+    expect(button("Try again")).toBeDefined();
+  });
+
+  it("never leaves the card unnamed and spinning forever — the retry recovers it", async () => {
+    const reads: Array<() => Promise<unknown>> = [
+      async () => Promise.reject(new ApiError(0, "network_error", "cannot reach the company host")),
+      async () => detail(),
+    ];
+    const { client: c } = client(reads);
+    await render(c);
+
+    expect(container.textContent).not.toContain("Reconcile the ledger");
+    expect(container.querySelector(".animate-spin")).toBeNull();
+
+    await act(async () => {
+      button("Try again")!.click();
+    });
+
+    expect(container.textContent).toContain("Reconcile the ledger");
+    expect(button("Try again")).toBeUndefined();
+  });
+});

--- a/frontend/test/unit/cov-task-a-edit-save-fail.test.ts
+++ b/frontend/test/unit/cov-task-a-edit-save-fail.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { Task } from "@/api/tasks";
+
+/**
+ * `PATCH …/tasks/{id}` (`patch_task`) is `ScopedCompany` — any company member,
+ * the same authority `create_task` and every other task write answer to — so
+ * Save is not, and must not become, an admin-only control. And no e2e ever
+ * drove an actual PATCH from this dialog: `task-edit-dialog-gates.test.ts`
+ * pins the dispatch confirmation and the roster/cancel/delete states, all
+ * against a client that resolves. What is missing is the honest case — the
+ * host refuses the write — which this file drives.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { TaskEditDialog } = await import("@/views/TaskEditDialog");
+
+const TASK: Task = {
+  id: "task-1",
+  title: "Pay the invoice",
+  note: "the original note",
+  column: "pending",
+  stage: "pending",
+  priority: "medium",
+  assignee: "",
+  updatedAt: 1_700_000_000_000,
+};
+
+const LEDGERS = {
+  ledgers: [
+    {
+      slug: "tasks",
+      title: "Tasks",
+      purpose: "The company's work board.",
+      source: "native",
+      derived: "derived/TASKS.md",
+      writtenBy: "the board",
+      builtin: true,
+      fields: [],
+      statuses: [
+        { name: "pending", label: "Pending" },
+        { name: "working", label: "Working" },
+        { name: "done", label: "Done", closed: true },
+      ],
+      sections: [],
+      open: 1,
+      closed: 0,
+    },
+  ],
+  faults: [],
+  remaining: 3,
+};
+
+/** A member-shaped client — every read this dialog makes, and no `/auth/me`. */
+function fakeClient(patchImpl: (path: string, body: unknown) => Promise<Task>) {
+  const paths: string[] = [];
+  const patch = vi.fn(patchImpl);
+  const del = vi.fn(async () => undefined);
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/company/${company ?? "acme"}`,
+    get: vi.fn(async (path: string) => {
+      paths.push(path);
+      return path.endsWith("/ledgers") ? LEDGERS : [];
+    }),
+    patch,
+    del,
+    listDesks: vi.fn(async () => []),
+    listTeam: vi.fn(async () => []),
+  } as unknown as OpenCompanyClient;
+  return { client, patch, del, paths };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function buttons(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll("button"));
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = buttons().find((b) => b.textContent?.trim() === label);
+  if (!found) {
+    throw new Error(
+      `no “${label}” button; saw: ${buttons().map((b) => b.textContent?.trim()).join(" | ")}`,
+    );
+  }
+  return found;
+}
+
+function setValue(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(el),
+    "value",
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function mount(client: OpenCompanyClient) {
+  const onClose = vi.fn();
+  const onSaved = vi.fn();
+  const onDeleted = vi.fn();
+  await act(async () => {
+    root.render(
+      createElement(TaskEditDialog, {
+        task: TASK,
+        onClose,
+        onSaved,
+        onDeleted,
+        client,
+        company: "acme",
+        irreversible: [],
+        historyIncomplete: false,
+      }),
+    );
+  });
+  await act(async () => {});
+  await act(async () => {});
+  return { onClose, onSaved, onDeleted };
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("Edit → Save, by authority (patch_task's ScopedCompany write)", () => {
+  it("offers a plain member client a live Save, asking no role question first", async () => {
+    const { client, paths } = fakeClient(async () => ({ ...TASK, title: "x" }));
+    await mount(client);
+
+    const save = button("Save");
+    expect(save.disabled).toBe(false);
+    expect(paths.some((p) => p.includes("/auth/me"))).toBe(false);
+  });
+});
+
+describe("Edit → Save, a PATCH the host refuses", () => {
+  it("shows the host's own message and leaves the dialog open, unsaved", async () => {
+    const { client, patch } = fakeClient(async () => {
+      throw new ApiError(409, "conflict", "this card was moved since you opened it", true);
+    });
+    const { onSaved, onClose } = await mount(client);
+
+    const title = document.querySelector("#task-title") as HTMLInputElement;
+    await act(async () => {
+      setValue(title, "Pay the March invoice");
+    });
+    await act(async () => {
+      button("Save").click();
+    });
+
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(toasts.error).toHaveBeenCalledWith("this card was moved since you opened it");
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    // The typed edit is not thrown away by a failed save — it is still there
+    // to retry or copy out.
+    expect((document.querySelector("#task-title") as HTMLInputElement).value).toBe(
+      "Pay the March invoice",
+    );
+  });
+
+  it("re-enables Save rather than leaving the form stuck busy", async () => {
+    const { client } = fakeClient(async () => {
+      throw new ApiError(0, "network_error", "cannot reach the company host");
+    });
+    await mount(client);
+
+    const title = document.querySelector("#task-title") as HTMLInputElement;
+    await act(async () => {
+      setValue(title, "Pay the March invoice");
+    });
+    await act(async () => {
+      button("Save").click();
+    });
+
+    expect(toasts.error).toHaveBeenCalledWith("cannot reach the company host");
+    expect(button("Save").disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-task-a-pause-fail.test.ts
+++ b/frontend/test/unit/cov-task-a-pause-fail.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { InflightRun, IrreversibleEffect, Task } from "@/api/tasks";
+
+/**
+ * Pause — the control bar's "Stop" button, `steer(inflight.key, "pause")`
+ * against `POST …/tasks/{id}/steer` (`steer_task`, `src/server/ops/tasks.rs`).
+ * That route is `ScopedCompany` like the rest of the task family, so pausing
+ * a run is not, and must not become, admin-gated — a member's Pause really
+ * does steer the run, same as `pause`/`resume` on the company itself
+ * (`settings-general-admin-only.test.ts` documents the same shape for those).
+ *
+ * No e2e ever steered a real pause; this drives the click through `steer()`
+ * both ways — a live client, and a client the host refuses.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { ControlBar } = await import("@/views/TaskDetailView");
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Reconcile the ledger",
+    column: "working",
+    stage: "in_review",
+    priority: "medium",
+    assignee: "finance",
+    ...over,
+  } as Task;
+}
+
+const RUNNING: InflightRun = {
+  key: "run-key-1",
+  taskId: "task-1",
+} as InflightRun;
+
+/** A member-shaped client that reads nothing and asks no role question. */
+function fakeClient(postImpl: (path: string, body: unknown) => Promise<void>) {
+  const post = vi.fn(postImpl);
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async () => {
+      throw new Error("the control bar must not read on mount");
+    },
+    post,
+  } as unknown as OpenCompanyClient;
+  return { client, post };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(client: OpenCompanyClient, onChanged = vi.fn()) {
+  await act(async () => {
+    root.render(
+      createElement(ControlBar, {
+        task: task(),
+        inflight: RUNNING,
+        irreversible: [] as IrreversibleEffect[],
+        historyIncomplete: false,
+        blockedOnApproval: false,
+        neverStarted: false,
+        finished: false,
+        client,
+        company: "acme",
+        onChanged,
+        onEdit: () => {},
+      }),
+    );
+  });
+  return { onChanged };
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return [...document.querySelectorAll("button")].find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("Pause (Stop), by authority (steer_task's ScopedCompany write)", () => {
+  it("offers a plain member client a live Stop on a running task, reading no role first", async () => {
+    const { client } = fakeClient(async () => undefined);
+    await render(client);
+
+    const stop = button("Stop");
+    expect(stop).toBeDefined();
+    expect(stop!.disabled).toBe(false);
+  });
+
+  it("actually steers the run: pauses it and refreshes the screen", async () => {
+    const { client, post } = fakeClient(async () => undefined);
+    const { onChanged } = await render(client);
+
+    await act(async () => {
+      button("Stop")!.click();
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0][0]).toContain("/tasks/run-key-1/steer");
+    expect(post.mock.calls[0][1]).toEqual({ action: "pause" });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Pause, a steer the host refuses", () => {
+  it("reports the host's own message rather than claiming the run stopped", async () => {
+    const { client, post } = fakeClient(async () => {
+      throw new ApiError(409, "conflict", "this run already settled", true);
+    });
+    const { onChanged } = await render(client);
+
+    await act(async () => {
+      button("Stop")!.click();
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(toasts.error).toHaveBeenCalledWith("this run already settled");
+    expect(toasts.success).not.toHaveBeenCalled();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it("re-enables Stop rather than leaving it stuck busy on a network failure", async () => {
+    const { client } = fakeClient(async () => {
+      throw new ApiError(0, "network_error", "cannot reach the company host");
+    });
+    await render(client);
+
+    await act(async () => {
+      button("Stop")!.click();
+    });
+
+    expect(toasts.error).toHaveBeenCalledWith("cannot reach the company host");
+    expect(button("Stop")!.disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-task-a-plan-first-fail.test.ts
+++ b/frontend/test/unit/cov-task-a-plan-first-fail.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { IrreversibleEffect, Task } from "@/api/tasks";
+
+/**
+ * "Plan first" — `planFirst()` on the detail screen's control bar, the
+ * `PATCH { column: "planning" }` that buys one planning pass before any work
+ * is dispatched. Offered only for a card still in `pending`,
+ * and otherwise wired exactly like Dispatch: the same `patch_task` route,
+ * the same `ScopedCompany` authority (any company member), and the same
+ * try/catch that had never actually been driven to a rejection.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { ControlBar } = await import("@/views/TaskDetailView");
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Reconcile the ledger",
+    column: "pending",
+    stage: "pending",
+    priority: "medium",
+    assignee: "finance",
+    ...over,
+  } as Task;
+}
+
+/** A member-shaped client that reads nothing and asks no role question. */
+function fakeClient(patchImpl: () => Promise<Task>) {
+  const patch = vi.fn(patchImpl);
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async () => {
+      throw new Error("the control bar must not read on mount");
+    },
+    patch,
+  } as unknown as OpenCompanyClient;
+  return { client, patch };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(client: OpenCompanyClient, onChanged = vi.fn()) {
+  await act(async () => {
+    root.render(
+      createElement(ControlBar, {
+        task: task(),
+        inflight: null,
+        irreversible: [] as IrreversibleEffect[],
+        historyIncomplete: false,
+        blockedOnApproval: false,
+        neverStarted: true,
+        finished: false,
+        client,
+        company: "acme",
+        onChanged,
+        onEdit: () => {},
+      }),
+    );
+  });
+  return { onChanged };
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return [...document.querySelectorAll("button")].find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("Plan first, by authority (patch_task's ScopedCompany write)", () => {
+  it("offers a plain member client a live Plan first, reading no role first", async () => {
+    const { client } = fakeClient(async () => task({ column: "planning" }));
+    await render(client);
+
+    const planFirst = button("Plan first");
+    expect(planFirst).toBeDefined();
+    expect(planFirst!.disabled).toBe(false);
+  });
+});
+
+describe("Plan first, a PATCH the host refuses", () => {
+  it("reports the host's own message rather than claiming a brief is being written", async () => {
+    const { client, patch } = fakeClient(async () => {
+      throw new ApiError(422, "invalid_column", "planning is not open for this card", true);
+    });
+    const { onChanged } = await render(client);
+
+    await act(async () => {
+      button("Plan first")!.click();
+    });
+
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(toasts.error).toHaveBeenCalledWith("planning is not open for this card");
+    expect(toasts.success).not.toHaveBeenCalled();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it("re-enables Plan first rather than leaving it stuck busy on a network failure", async () => {
+    const { client } = fakeClient(async () => {
+      throw new ApiError(0, "network_error", "cannot reach the company host");
+    });
+    await render(client);
+
+    await act(async () => {
+      button("Plan first")!.click();
+    });
+
+    expect(toasts.error).toHaveBeenCalledWith("cannot reach the company host");
+    expect(button("Plan first")!.disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-task-a-redirect-fail.test.ts
+++ b/frontend/test/unit/cov-task-a-redirect-fail.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { InflightRun, IrreversibleEffect, Task } from "@/api/tasks";
+
+/**
+ * The redirect composer's Send — `steer(inflight.key, "redirect", {
+ * instruction })` against the same `ScopedCompany` `steer_task` route Pause
+ * and Cancel use. The composer's `Input` carries no `maxlength`, but the
+ * host does cap a redirect at `MAX_REDIRECT_CHARS` (`src/company/steer.rs`)
+ * and refuses a longer one outright rather than silently truncating it — so
+ * the console's honest job is not enforcing a limit it does not display, it
+ * is surfacing that refusal when it comes back. This drives Send both ways:
+ * a live client, and the host's `422` for an over-long instruction.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { ControlBar } = await import("@/views/TaskDetailView");
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Reconcile the ledger",
+    column: "working",
+    stage: "in_review",
+    priority: "medium",
+    assignee: "finance",
+    ...over,
+  } as Task;
+}
+
+const RUNNING: InflightRun = {
+  key: "run-key-1",
+  taskId: "task-1",
+} as InflightRun;
+
+/** A member-shaped client that reads nothing and asks no role question. */
+function fakeClient(postImpl: (path: string, body: unknown) => Promise<void>) {
+  const post = vi.fn(postImpl);
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async () => {
+      throw new Error("the control bar must not read on mount");
+    },
+    post,
+  } as unknown as OpenCompanyClient;
+  return { client, post };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(client: OpenCompanyClient, onChanged = vi.fn()) {
+  await act(async () => {
+    root.render(
+      createElement(ControlBar, {
+        task: task(),
+        inflight: RUNNING,
+        irreversible: [] as IrreversibleEffect[],
+        historyIncomplete: false,
+        blockedOnApproval: false,
+        neverStarted: false,
+        finished: false,
+        client,
+        company: "acme",
+        onChanged,
+        onEdit: () => {},
+      }),
+    );
+  });
+  return { onChanged };
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return [...document.querySelectorAll("button")].find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined;
+}
+
+function setValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/** Opens the composer and types an instruction into it. */
+async function compose(text: string) {
+  await act(async () => {
+    button("Redirect")!.click();
+  });
+  const input = container.querySelector("input") as HTMLInputElement;
+  await act(async () => {
+    setValue(input, text);
+  });
+  return input;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("Redirect, by authority (steer_task's ScopedCompany write)", () => {
+  it("offers a plain member client a live composer and Send, reading no role first", async () => {
+    const { client } = fakeClient(async () => undefined);
+    await render(client);
+
+    const input = await compose("check the invoice total first");
+    expect(input.value).toBe("check the invoice total first");
+    expect(button("Send")!.disabled).toBe(false);
+  });
+});
+
+describe("Redirect, a steer the host refuses", () => {
+  it("shows the host's own over-length refusal rather than claiming it was sent", async () => {
+    const { client, post } = fakeClient(async () => {
+      throw new ApiError(
+        422,
+        "redirect_too_long",
+        "redirect instruction is 2500 characters; the limit is 2000",
+        true,
+      );
+    });
+    const { onChanged } = await render(client);
+
+    const input = await compose("a".repeat(2500));
+    await act(async () => {
+      button("Send")!.click();
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(toasts.error).toHaveBeenCalledWith(
+      "redirect instruction is 2500 characters; the limit is 2000",
+    );
+    expect(toasts.success).not.toHaveBeenCalled();
+    expect(onChanged).not.toHaveBeenCalled();
+    // Not silently cleared: the composer still holds what was typed, exactly
+    // as the settled-run case (`task-detail-control-bar.test.ts`) keeps it.
+    expect(input.value.length).toBe(2500);
+  });
+
+  it("re-enables Send rather than leaving the composer stuck busy on a network failure", async () => {
+    const { client } = fakeClient(async () => {
+      throw new ApiError(0, "network_error", "cannot reach the company host");
+    });
+    await render(client);
+
+    await compose("check the invoice total first");
+    await act(async () => {
+      button("Send")!.click();
+    });
+
+    expect(toasts.error).toHaveBeenCalledWith("cannot reach the company host");
+    expect(button("Send")!.disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-task-b-assignee-select.test.ts
+++ b/frontend/test/unit/cov-task-b-assignee-select.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { AssigneeSelect } from "@/views/AssigneeSelect";
+
+/**
+ * `AssigneeSelect` carries no role check of its own — every call site
+ * (`TaskDetailView`'s reassign row, `TaskEditDialog`, `CreateTaskDialog`)
+ * drives its `disabled` prop off a local save-in-flight flag, never off a
+ * viewer's role. That matches the host: `PATCH …/tasks/{id}`, which is where
+ * an `assignee` write lands, is `ScopedCompany` (`src/server/ops/tasks.rs`),
+ * open to any member. `assignee-roster-gap.test.ts` already pins the roster
+ * read's own honesty (the gap notice, and the off-roster flag); it never
+ * checks `disabled` itself, and never drives a pick through past a failed
+ * half of the roster — both closed here.
+ */
+
+const DESKS = [{ id: "engineering", name: "Engineering", members: ["eng-lead"] }];
+const TEAM = [{ id: "eng-lead", name: "Eng Lead", role: "engineer" }];
+
+function fakeClient(
+  over: { desks?: () => Promise<unknown>; team?: () => Promise<unknown> } = {},
+): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/company/${company ?? "acme"}`,
+    listDesks: vi.fn(over.desks ?? (async () => DESKS)),
+    listTeam: vi.fn(over.team ?? (async () => TEAM)),
+  } as unknown as OpenCompanyClient;
+}
+
+const fails = () => Promise.reject(new Error("host unreachable"));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+async function mount(
+  client: OpenCompanyClient,
+  opts: { value?: string; disabled?: boolean; onChange?: (next: string) => void } = {},
+) {
+  const onChange = opts.onChange ?? vi.fn();
+  await act(async () => {
+    root.render(
+      createElement(AssigneeSelect, {
+        id: "assignee",
+        client,
+        company: "acme",
+        value: opts.value ?? "",
+        disabled: opts.disabled,
+        onChange,
+      }),
+    );
+  });
+  // The two roster reads settle in microtasks, and the state they set lands a
+  // tick later — the same double flush `assignee-roster-gap.test.ts` uses.
+  await act(async () => {});
+  await act(async () => {});
+  return onChange;
+}
+
+function trigger(): HTMLElement {
+  return document.querySelector("#assignee") as HTMLElement;
+}
+
+async function open() {
+  await act(async () => {
+    trigger().click();
+  });
+}
+
+function option(label: string): HTMLElement {
+  const found = Array.from(document.querySelectorAll('[role="option"]')).find(
+    (o) => o.textContent?.trim().startsWith(label),
+  );
+  if (!found) throw new Error(`no “${label}” option; saw: ${document.body.innerHTML}`);
+  return found as HTMLElement;
+}
+
+describe("AssigneeSelect — reassignment offered to every member, not just an admin", () => {
+  it("is not disabled and reaches the whole roster when the caller does not lock it", async () => {
+    await mount(fakeClient());
+    expect(trigger().getAttribute("aria-disabled")).not.toBe("true");
+    expect(trigger().hasAttribute("disabled")).toBe(false);
+
+    await open();
+    // Both the desk and the teammate the roster carries are pickable — a
+    // member gets the same full picker an admin would, since neither role is
+    // ever asked here.
+    expect(document.body.textContent).toContain("Engineering");
+    expect(document.body.textContent).toContain("Eng Lead");
+  });
+
+  it("only ever disables through the prop the caller passes it (busy, never role)", async () => {
+    await mount(fakeClient(), { disabled: true });
+    expect(trigger().getAttribute("data-disabled")).not.toBeNull();
+  });
+});
+
+describe("AssigneeSelect — a roster read that failed", () => {
+  it("still lets Unassigned go through, rather than a stuck or dead picker", async () => {
+    const onChange = await mount(fakeClient({ team: fails }));
+    await open();
+
+    expect(document.querySelector('[data-testid="assignee-roster-gap"]')).not.toBeNull();
+
+    await act(async () => {
+      option("Unassigned").click();
+    });
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("still lets a pick from the half that did arrive go through", async () => {
+    const onChange = await mount(fakeClient({ team: fails }));
+    await open();
+
+    await act(async () => {
+      option("Engineering").click();
+    });
+    expect(onChange).toHaveBeenCalledWith("engineering");
+  });
+});

--- a/frontend/test/unit/cov-task-b-control-bar-steer-and-export.test.ts
+++ b/frontend/test/unit/cov-task-b-control-bar-steer-and-export.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { InflightRun, Task } from "@/api/tasks";
+
+/**
+ * `ControlBar`'s Cancel and Export, exercised through the same client a
+ * signed-in company member carries.
+ *
+ * Both routes are `ScopedCompany` (`server::ops::tasks`, `task_export.rs`) —
+ * any member, not admin-only — and neither `ControlBar` nor `ExportButton`
+ * ever reads a role before rendering: there is no `useCanManage` in this file.
+ * `task-detail-control-bar.test.ts` pins the composer and the Retry/Resume
+ * labels, but its `CLIENT` defines no `post` and no `getDocument` at all, so
+ * nothing there ever presses Cancel or Export through to the client — the
+ * confirm gate and the button text are unit-tested, and the request a real
+ * click sends is not.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { ControlBar } = await import("@/views/TaskDetailView");
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Reconcile the ledger",
+    column: "working",
+    stage: "in_review",
+    priority: "medium",
+    assignee: "finance",
+    ...over,
+  } as Task;
+}
+
+const RUNNING: InflightRun = {
+  taskId: "task-1",
+  key: "run-key-1",
+  kind: "task",
+  title: "Reconcile the ledger",
+  agentId: "finance",
+  startedAt: 1_700_000_000_000,
+  pendingAction: null,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(client: OpenCompanyClient, over: Partial<Task> = {}) {
+  await act(async () => {
+    root.render(
+      createElement(ControlBar, {
+        task: task(over),
+        inflight: RUNNING,
+        irreversible: [],
+        historyIncomplete: false,
+        blockedOnApproval: false,
+        neverStarted: false,
+        finished: false,
+        client,
+        company: "acme",
+        onChanged: () => {},
+        onEdit: () => {},
+      }),
+    );
+  });
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no "${label}" button in:\n${document.body.innerHTML}`);
+  return found as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("Cancel reaches a live run through an ordinary member client", () => {
+  /** A client that would fail if `ControlBar` ever asked who the viewer is. */
+  function memberClient(post: (path: string, body: unknown) => Promise<unknown>): OpenCompanyClient {
+    return {
+      scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+      get: async () => {
+        throw new Error("ControlBar must not read a role before offering Cancel");
+      },
+      post: async (path: string, body: unknown) => post(path, body),
+    } as unknown as OpenCompanyClient;
+  }
+
+  it("opens the confirm gate, then steers by key with confirm:true and refreshes the card", async () => {
+    const seen: Array<{ path: string; body: unknown }> = [];
+    let changed = 0;
+    await act(async () => {
+      root.render(
+        createElement(ControlBar, {
+          task: task(),
+          inflight: RUNNING,
+          irreversible: [],
+          historyIncomplete: false,
+          blockedOnApproval: false,
+          neverStarted: false,
+          finished: false,
+          client: memberClient(async (path, body) => {
+            seen.push({ path, body });
+            return undefined;
+          }),
+          company: "acme",
+          onChanged: async () => {
+            changed += 1;
+          },
+          onEdit: () => {},
+        }),
+      );
+    });
+
+    // The trigger alone must not steer anything — that is the confirm gate
+    // `task-detail-control-bar.test.ts` already pins. What was never proven is
+    // what pressing the dialog's own confirm button actually sends.
+    await act(async () => {
+      button("Cancel").click();
+    });
+    expect(seen).toHaveLength(0);
+
+    await act(async () => {
+      button("Cancel run").click();
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].path).toContain("/tasks/run-key-1/steer");
+    expect(seen[0].body).toEqual({ action: "cancel", confirm: true });
+    expect(changed).toBe(1);
+  });
+
+  it("offers Stop, Redirect and Cancel with no role read at all — matching the route's member-open authority", async () => {
+    await render(memberClient(async () => undefined));
+    expect(button("Stop")).toBeDefined();
+    expect(button("Redirect")).toBeDefined();
+    expect(button("Cancel")).toBeDefined();
+  });
+});
+
+describe("a cancel the host refuses", () => {
+  it("says so honestly, and leaves the control pressable again — never a silent success", async () => {
+    await render({
+      scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+      post: async () => {
+        throw new Error("the host fell over");
+      },
+    } as unknown as OpenCompanyClient);
+
+    await act(async () => {
+      button("Cancel").click();
+    });
+    await act(async () => {
+      button("Cancel run").click();
+    });
+
+    expect(toasts.error).toHaveBeenCalledTimes(1);
+    expect(toasts.success).not.toHaveBeenCalled();
+    // `busy` cleared in `finally`: the operator can try again rather than
+    // finding every steer control dead after one failed request.
+    expect(button("Stop").disabled).toBe(false);
+  });
+});
+
+describe("Export offers no role gate either", () => {
+  it("renders live for a client that would fail on any role read", async () => {
+    await render({
+      scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+      get: async () => {
+        throw new Error("ControlBar must not read a role before offering Export");
+      },
+    } as unknown as OpenCompanyClient);
+    const exportButton = button("Export");
+    expect(exportButton.disabled).toBe(false);
+  });
+
+  it("says so honestly when the document read fails, rather than downloading nothing silently", async () => {
+    await render({
+      scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+      getDocument: async () => {
+        throw new Error("could not reach the host");
+      },
+    } as unknown as OpenCompanyClient);
+
+    await act(async () => {
+      button("Export").click();
+    });
+
+    expect(toasts.error).toHaveBeenCalledTimes(1);
+    expect(toasts.success).not.toHaveBeenCalled();
+    expect(button("Export").disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-task-b-discussion-redaction.test.ts
+++ b/frontend/test/unit/cov-task-b-discussion-redaction.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { DiscussionMessage } from "@/api/tasks";
+
+/**
+ * Withdrawing a discussion message.
+ *
+ * `redactTaskDiscussion` is an append-only tombstone — the journal keeps the
+ * original event, and the host substitutes its fixed placeholder on every
+ * later read. `task-detail-discussion-limits.test.ts` pins the in-flight
+ * state a repeat click cannot double-fire, but no test ever checks the thing
+ * the withdrawal is *for*: that once the row lands, the original text this
+ * tab itself was just rendering is gone from the screen, not just replaced by
+ * something sitting beside it. Nor does anything pin what happens when the
+ * `DELETE` is refused — a silent no-op there would leave the operator
+ * believing a leaked credential was pulled when it was not.
+ *
+ * `redactTaskDiscussion` is `ScopedCompany` in `server::ops::tasks` — any
+ * member, the same authority `DELETE …/tasks/{id}` carries — and `DiscussionTab`
+ * matches that: it reads no role before rendering the Remove control.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { DiscussionTab } = await import("@/views/TaskDetailView");
+
+const SECRET = "sk-live-not-a-real-credential-abc123";
+
+const MESSAGE: DiscussionMessage = {
+  seq: 7,
+  author: "ops",
+  atMillis: new Date("2026-03-02T10:00:00Z").getTime(),
+  text: `rotate this key please: ${SECRET}`,
+};
+
+const TOMBSTONE: DiscussionMessage = {
+  seq: 7,
+  author: "ops",
+  atMillis: MESSAGE.atMillis,
+  text: "This message was removed.",
+  redacted: true,
+  redactedBy: "finance",
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(DiscussionTab, {
+        messages: [MESSAGE],
+        hasMore: false,
+        taskId: "task-1",
+        client,
+        company: "acme",
+        onPosted: async () => {},
+      }),
+    );
+  });
+}
+
+/** Presses Remove and confirms it in the portalled dialog. */
+async function withdraw() {
+  const trigger = container.querySelector(
+    '[data-testid="discussion-redact"]',
+  ) as HTMLButtonElement;
+  await act(async () => trigger.click());
+  const confirm = [...document.querySelectorAll("button")].find(
+    (b) => b.textContent?.trim() === "Remove it",
+  ) as HTMLButtonElement;
+  await act(async () => confirm.click());
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("a successful withdrawal leaves nothing client-side to read", () => {
+  it("replaces the secret with the host's tombstone once the DELETE lands", async () => {
+    await render({
+      scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+      del: async () => TOMBSTONE,
+    } as unknown as OpenCompanyClient);
+
+    expect(container.textContent).toContain(SECRET);
+    await withdraw();
+
+    // Not "also shows a tombstone" — the original text must be gone, because
+    // this thread is the read surface the withdrawal exists to close.
+    expect(container.textContent).not.toContain(SECRET);
+    expect(container.textContent).toContain("This message was removed.");
+    expect(container.textContent).toContain("Removed by finance.");
+  });
+
+  it("lands on the row's own seq, so it does not need the next 4s poll", async () => {
+    // `absorb([row])` runs straight off the DELETE's response, not off a
+    // re-read — a polled surface withdrawing late is the risk this proves is
+    // not also true of the row that requested it.
+    await render({
+      scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+      del: async () => TOMBSTONE,
+    } as unknown as OpenCompanyClient);
+    await withdraw();
+    expect(
+      container.querySelector('[data-testid="discussion-message"]')?.getAttribute(
+        "data-redacted",
+      ),
+    ).toBe("true");
+  });
+});
+
+describe("a withdrawal the host refuses", () => {
+  it("leaves the secret on screen and says so, rather than a silent success", async () => {
+    await render({
+      scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+      del: async () => {
+        throw new Error("could not reach the host");
+      },
+    } as unknown as OpenCompanyClient);
+
+    await withdraw();
+
+    expect(container.textContent).toContain(SECRET);
+    expect(container.textContent).not.toContain("This message was removed.");
+    expect(toasts.error).toHaveBeenCalledTimes(1);
+    expect(toasts.success).not.toHaveBeenCalled();
+    // The control comes back rather than staying stuck mid-request.
+    expect(
+      (container.querySelector('[data-testid="discussion-redact"]') as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+});
+
+describe("Remove is offered with no role read at all", () => {
+  it("renders live for a client that would fail on any role read", async () => {
+    await render({
+      scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+      get: async () => {
+        throw new Error("DiscussionTab must not read a role before offering Remove");
+      },
+    } as unknown as OpenCompanyClient);
+
+    const trigger = container.querySelector(
+      '[data-testid="discussion-redact"]',
+    ) as HTMLButtonElement;
+    expect(trigger).not.toBeNull();
+    expect(trigger.disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-task-b-inflight-list.test.ts
+++ b/frontend/test/unit/cov-task-b-inflight-list.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { listInflight, type InflightRun } from "@/api/tasks";
+import { InflightRunBar } from "@/views/chat/InflightRunBar";
+
+/**
+ * Reading `GET …/tasks/inflight` and reaching the steer controls it feeds.
+ *
+ * `listInflight` itself has zero prior coverage — `inflight-run-cancel.test.ts`
+ * and `inflight-run-surface.test.ts` are thorough on `InflightRunBar`/
+ * `InflightRunRow`, but every one of them hands `runs` in as a prop and never
+ * calls the actual read. `GET …/tasks/inflight` is `ScopedCompany`
+ * (`src/server/ops/tasks.rs`, `list_inflight`) — the same "any member" guard
+ * `POST …/steer` carries, not `AdminScopedCompany` — and this is the AUTH
+ * claim worth pinning: the read uses no elevated credential a member's session
+ * does not already have, and its response reaches a steerable control with no
+ * role check in between.
+ *
+ * Polling interval, page size and the read's own failure handling (the rest
+ * of the ledger's gap text) are the shell's concern (`app-shell.tsx`'s
+ * `refreshTaskStatuses`, which already treats a failed inflight poll as
+ * best-effort) — informational here, not forced into this AUTH-only cell.
+ */
+
+const DELEGATION: InflightRun = {
+  taskId: null,
+  key: "run_7f3c9a",
+  kind: "delegation",
+  title: "Research the competitor pricing",
+  agentId: "analyst",
+  startedAt: 1_700_000_000_000,
+  pendingAction: null,
+};
+
+function clientAs(get: (path: string) => Promise<unknown>): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/companies/${company ?? "acme"}`,
+    get: async (path: string) => get(path),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("listInflight — the same session a member already carries", () => {
+  it("reads the company-scoped inflight route, addressing nothing an ordinary session lacks", async () => {
+    const get = vi.fn(async (_path: string) => [DELEGATION]);
+    const runs = await listInflight(clientAs(get), "acme");
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0][0]).toBe("/api/v1/companies/acme/tasks/inflight");
+    expect(runs).toEqual([DELEGATION]);
+  });
+});
+
+describe("listInflight's response reaches steerable controls with no role gate", () => {
+  it("renders a Cancel control for a run listInflight actually returned", async () => {
+    const get = vi.fn(async (_path: string) => [DELEGATION]);
+    const client = clientAs(get);
+    const runs = await listInflight(client, "acme");
+
+    await act(async () => {
+      root.render(
+        createElement(InflightRunBar, {
+          client,
+          company: "acme",
+          runs,
+          onSteered: () => {},
+        }),
+      );
+    });
+
+    // No admin check stands between the read and the control: the same
+    // client that fetched the list is offered the cancel it feeds.
+    const cancel = container.querySelector(
+      `button[aria-label="Cancel ${DELEGATION.title}"]`,
+    );
+    expect(cancel).not.toBeNull();
+    expect((cancel as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("renders nothing when the read comes back empty, rather than a stale or default control", async () => {
+    const client = clientAs(async () => []);
+    const runs = await listInflight(client, "acme");
+
+    await act(async () => {
+      root.render(
+        createElement(InflightRunBar, {
+          client,
+          company: "acme",
+          runs,
+          onSteered: () => {},
+        }),
+      );
+    });
+
+    expect(container.querySelector('[data-testid="inflight-run-bar"]')).toBeNull();
+  });
+});

--- a/frontend/test/unit/cov-task-b-taskcard-decide.test.ts
+++ b/frontend/test/unit/cov-task-b-taskcard-decide.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { Task } from "@/api/tasks";
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import { taskApprovalRows } from "@/lib/task-approvals";
+import { TaskItem } from "@/views/TaskCard";
+import type { DecidedApproval } from "@/views/chat/model";
+
+/**
+ * Deciding a blocked approval from the board card.
+ *
+ * `task-blocked-card.test.ts` already drives Approve/Decline clicks through to
+ * a recording `onDecide`, so "a real decide from the card" in the ordinary
+ * sense is covered. Two edges are not:
+ *
+ * - **The read-only gate.** `ApprovalRow`'s own doc: "a surface with no
+ *   handler renders no decide controls rather than live buttons that do
+ *   nothing. Every board in this console is handed one" — so `onDecide` being
+ *   absent is the actual authority axis here, not admin-vs-member (the host
+ *   asks nothing about role for a decide either). No test mounts the card
+ *   without one.
+ * - **A decide that failed.** `failed` is threaded through every render in
+ *   `task-blocked-card.test.ts` as `{}`; nothing there ever puts an id in it
+ *   and checks the card still says so, with live buttons to retry.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+function card(): Task {
+  return {
+    id: "task-1",
+    title: "Triage the release blockers",
+    column: "working",
+    stage: "paused",
+    priority: "high",
+    assignee: "qa",
+    updatedAt: T0,
+  } as Task;
+}
+
+function parked(id: string): ApprovalSummary {
+  return {
+    id,
+    kind: "web_fetch",
+    amount_usd: null,
+    at_millis: T0,
+    agent: "qa",
+    task: { link: "task", id: "task-1" },
+    payload: { url: "https://example.com/a" },
+    batch: "turn-1",
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(opts: {
+  approvals?: ApprovalSummary[];
+  onDecide?:
+    | ((approval: ApprovalSummary, verdict: Verdict, scope: GrantScope) => void)
+    | undefined;
+  failed?: Record<string, string>;
+  decided?: Record<string, DecidedApproval>;
+  deciding?: ReadonlyMap<string, Verdict>;
+}) {
+  const approvals = opts.approvals ?? [];
+  await act(async () => {
+    root.render(
+      createElement(TaskItem, {
+        task: card(),
+        dragging: false,
+        rows: taskApprovalRows(approvals, opts.decided ?? {}, "task-1"),
+        now: T0 + 60_000,
+        askerNames: new Map([["qa", "QA Engineer"]]),
+        deciding: opts.deciding ?? new Map<string, Verdict>(),
+        failed: opts.failed ?? {},
+        onDecide: opts.onDecide,
+        onOpen: () => {},
+        onResume: () => {},
+      }),
+    );
+  });
+}
+
+function blockedRow(): HTMLElement | null {
+  return container.querySelector<HTMLElement>('[data-approval-inline="card"]');
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes(label),
+  ) as HTMLButtonElement | undefined;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("Decide from the card — gated on whether a decide handler was wired at all", () => {
+  it("offers Approve/Decline when a handler is wired — the ordinary board", async () => {
+    await render({ approvals: [parked("a1")], onDecide: () => {} });
+    expect(blockedRow()).not.toBeNull();
+    expect(button("Approve")).toBeDefined();
+    expect(button("Decline")).toBeDefined();
+  });
+
+  it("renders no decide controls at all on a card with no handler, rather than live buttons wired to nothing", async () => {
+    await render({ approvals: [parked("a1")], onDecide: undefined });
+    expect(blockedRow()).toBeNull();
+    expect(button("Approve")).toBeUndefined();
+    expect(button("Decline")).toBeUndefined();
+  });
+});
+
+describe("A decide that did not land", () => {
+  it("says so on the card, and leaves live buttons to retry rather than hiding or freezing them", async () => {
+    const a1 = parked("a1");
+    await render({
+      approvals: [a1],
+      onDecide: () => {},
+      failed: { a1: "network error" },
+    });
+
+    expect(blockedRow()?.textContent).toContain("Not recorded — try again");
+    // The item is still pending, not silently marked decided — the operator
+    // can press Approve again.
+    const approve = button("Approve");
+    expect(approve).toBeDefined();
+    expect(approve!.disabled).toBe(false);
+  });
+
+  it("names how many of a batch failed, not just that something did", async () => {
+    const a1 = parked("a1");
+    const a2 = { ...parked("a2"), payload: { url: "https://example.com/b" } };
+    await render({
+      approvals: [a1, a2],
+      onDecide: () => {},
+      failed: { a1: "network error" },
+    });
+
+    expect(blockedRow()?.textContent).toContain("1 of 2 weren't recorded — try again");
+  });
+});

--- a/frontend/test/unit/cov-task-b-taskcard-resume-doubleclick.test.ts
+++ b/frontend/test/unit/cov-task-b-taskcard-resume-doubleclick.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Task } from "@/api/tasks";
+import { taskApprovalRows } from "@/lib/task-approvals";
+import { TaskItem } from "@/views/TaskCard";
+
+/**
+ * A real double-click on the board card's Resume button.
+ *
+ * `task-blocked-card.test.ts` proves Resume is *disabled* whenever the card's
+ * own approvals are outstanding — the derived-state half of the rule. It never
+ * drives two rapid clicks through the button while the card is clear to
+ * resume, which is the other half: nothing in `resumeButton`'s `onClick`
+ * depends on anything that changes between the two clicks of a real
+ * double-click, so a debounce would have to live in the handler itself.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+function card(): Task {
+  return {
+    id: "task-1",
+    title: "Triage the release blockers",
+    column: "working",
+    stage: "paused",
+    priority: "high",
+    assignee: "qa",
+    updatedAt: T0,
+  } as Task;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(onResume: () => void) {
+  await act(async () => {
+    root.render(
+      createElement(TaskItem, {
+        task: card(),
+        dragging: false,
+        // No approvals outstanding: the card is clear to resume, which is the
+        // only state a real double-click on a live Resume is possible in.
+        rows: taskApprovalRows([], {}, "task-1"),
+        now: T0 + 60_000,
+        askerNames: new Map(),
+        deciding: new Map(),
+        failed: {},
+        onDecide: () => {},
+        onOpen: () => {},
+        onResume,
+      }),
+    );
+  });
+}
+
+function resumeButton(): HTMLButtonElement {
+  const found = Array.from(container.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes("Resume"),
+  );
+  if (!found) throw new Error(`no Resume button in:\n${container.innerHTML}`);
+  return found as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("A real double-click on Resume", () => {
+  // FINDING: `TaskItem`'s Resume button has no click-time debounce of its own
+  // — `disabled={rows.length > 0}` is the only gate, and `rows` does not
+  // change between two synchronous clicks. Two clicks before the caller's
+  // `onResume` has had a chance to do anything both reach it, so a real
+  // double-click can fire two re-dispatches. Confirmed failing against the
+  // current source (frontend/src/views/TaskCard.tsx, the Resume `onClick`
+  // handler) before being marked skip; not fixed here (frontend-only,
+  // test-only task) — see the report.
+  it.skip("reaches the resume handler once, not twice, for two clicks before either settles", async () => {
+    const onResume = vi.fn();
+    await render(onResume);
+
+    const button = resumeButton();
+    expect(button.disabled).toBe(false);
+
+    // Two synchronous handler invocations, exactly as two real clicks would
+    // land before a re-render (or any async work `onResume` kicks off) has a
+    // chance to run.
+    await act(async () => {
+      button.click();
+      button.click();
+    });
+
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("A resume that did not land", () => {
+  it("leaves Resume live rather than stuck disabled — the card holds no busy state of its own", async () => {
+    // A rejected `patchTask` inside the caller's `onResume` (e.g. `LedgersView`'s
+    // `resume()`, which toasts the failure) — represented here as a promise
+    // the card is never given back, since `onResume: () => void` is
+    // fire-and-forget from `TaskItem`'s own point of view.
+    const onResume = vi.fn(() => {
+      void Promise.reject(new Error("network_error")).catch(() => {});
+    });
+    await render(onResume);
+
+    const button = resumeButton();
+    expect(button.disabled).toBe(false);
+
+    await act(async () => {
+      button.click();
+    });
+    // Never held down waiting on a caller's own async work — the card holds
+    // no "resuming" state of its own that a rejection could leave stuck.
+    expect(button.disabled).toBe(false);
+
+    await act(async () => {
+      button.click();
+    });
+    expect(onResume).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/test/unit/cov-task-b-taskcard-resume-doubleclick.test.ts
+++ b/frontend/test/unit/cov-task-b-taskcard-resume-doubleclick.test.ts
@@ -105,6 +105,17 @@ describe("A real double-click on Resume", () => {
   });
 });
 
+describe("Resume is offered from props alone", () => {
+  it("renders live with no client and no role prop at all — nothing to gate it by role", async () => {
+    await render(() => {});
+
+    // `TaskItem` takes no `client` and no `canManage`: there is no read it
+    // could make to withhold Resume, which matches `patch_task`'s member-open
+    // authority. A live button here is the whole of the AUTH property.
+    expect(resumeButton().disabled).toBe(false);
+  });
+});
+
 describe("A resume that did not land", () => {
   it("leaves Resume live rather than stuck disabled — the card holds no busy state of its own", async () => {
     // A rejected `patchTask` inside the caller's `onResume` (e.g. `LedgersView`'s

--- a/frontend/test/unit/cov-task-b-workflow-proposal-apply.test.ts
+++ b/frontend/test/unit/cov-task-b-workflow-proposal-apply.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { Task, TaskWorkflowProposal } from "@/api/tasks";
+import { TaskWorkflowProposalPanel } from "@/views/TaskWorkflowProposalPanel";
+
+/**
+ * Approving a built workflow proposal.
+ *
+ * `POST …/tasks/{id}/workflow-proposal/apply` is `ScopedCompany`
+ * (`src/server/ops/tasks.rs`), the same guard every other task write carries —
+ * not `AdminScopedCompany`. `TaskWorkflowProposalPanel` matches: no role check
+ * gates the Apply button, so the AUTH claim is that the control genuinely
+ * reaches the host for any viewer.
+ *
+ * `task-workflow-proposal.test.ts` pins the pure adapter (`taskProposalDiff`)
+ * and the refusal-breakdown decision; it never renders this panel or clicks
+ * Apply, so a refusal keeping the card in review — rather than moving it or
+ * claiming success — has never actually been driven through the DOM.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+/** A valid, renderable proposal — `taskProposalDiff` accepts this shape. */
+const PROPOSAL: TaskWorkflowProposal = {
+  summary: "Posts a weekly summary of dev activity.",
+  generatedAtMillis: 1_700_000_000_000,
+  runId: "run-1",
+  ops: {
+    id: "weekly_summary",
+    name: "Weekly summary",
+    nodes: [
+      { id: "cron", kind: "trigger", name: "Weekly", schedule: "0 9 * * 1" },
+      { id: "gather", kind: "agent", name: "Gather", agent: "analyst" },
+      { id: "post", kind: "output", name: "Post", destination: { kind: "owner" } },
+    ],
+    edges: [
+      { from: "cron", to: "gather" },
+      { from: "gather", to: "post" },
+    ],
+  },
+};
+
+function task(): Task {
+  return {
+    id: "task-1",
+    title: "Build the weekly summary",
+    column: "working",
+    stage: "in_review",
+    priority: "medium",
+    assignee: "analyst",
+    updatedAt: 0,
+    workflowProposal: PROPOSAL,
+  } as Task;
+}
+
+function clientAs(post: (path: string, body?: unknown) => Promise<unknown>): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/companies/${company ?? "acme"}`,
+    post: async (path: string, body?: unknown) => post(path, body),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(client: OpenCompanyClient, onReload = vi.fn()) {
+  await act(async () => {
+    root.render(
+      createElement(TaskWorkflowProposalPanel, {
+        client,
+        company: "acme",
+        task: task(),
+        onReload,
+      }),
+    );
+  });
+  return onReload;
+}
+
+function applyButton(): HTMLButtonElement {
+  const found = document.querySelector('[data-testid="task-workflow-proposal-apply"]');
+  if (!found) throw new Error(`no Apply control in:\n${container.innerHTML}`);
+  return found as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("Apply a workflow proposal — offered to every member, not just an admin", () => {
+  it("reaches the host's apply on click, with no admin-only gate", async () => {
+    const post = vi.fn(async (_path: string, _body?: unknown) => ({ ...task(), workflowProposal: undefined, column: "done" }));
+    const onReload = await render(clientAs(post));
+
+    expect(applyButton().disabled).toBe(false);
+    await act(async () => {
+      applyButton().click();
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0][0]).toBe(
+      "/api/v1/companies/acme/tasks/task-1/workflow-proposal/apply",
+    );
+    expect(onReload).toHaveBeenCalledTimes(1);
+    expect(toasts.success).toHaveBeenCalled();
+  });
+});
+
+describe("Apply a workflow proposal — the host refuses it", () => {
+  it("keeps the card in review, shows the host's reason, and never claims success", async () => {
+    const post = vi.fn(async () => {
+      throw new ApiError(400, "conflict", "a workflow named “weekly_summary” already exists", true);
+    });
+    const onReload = await render(clientAs(post));
+
+    await act(async () => {
+      applyButton().click();
+    });
+
+    expect(toasts.success).not.toHaveBeenCalled();
+    // Never reloads the card into whatever "settled" state the caller would
+    // otherwise assume — a refused Apply is not a state transition.
+    expect(onReload).not.toHaveBeenCalled();
+    const error = document.querySelector('[data-testid="task-workflow-proposal-error"]');
+    expect(error?.textContent).toContain(
+      "a workflow named “weekly_summary” already exists",
+    );
+    // The proposal panel — and its Apply control — is still on screen: the
+    // card stayed in review rather than the panel simply vanishing.
+    expect(applyButton()).toBeDefined();
+    expect(applyButton().disabled).toBe(false);
+  });
+});

--- a/frontend/test/unit/cov-task-b-workflow-proposal-reject.test.ts
+++ b/frontend/test/unit/cov-task-b-workflow-proposal-reject.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import type { Task, TaskWorkflowProposal } from "@/api/tasks";
+import { TaskWorkflowProposalPanel } from "@/views/TaskWorkflowProposalPanel";
+
+/**
+ * Rejecting a built workflow proposal.
+ *
+ * `POST …/tasks/{id}/workflow-proposal/reject` is `ScopedCompany`
+ * (`src/server/ops/tasks.rs`) — the same "any member" guard `apply` carries,
+ * not `AdminScopedCompany`. The Reject control (unlike Apply) is also offered
+ * on a proposal the diff adapter refused to render, so it is the one way off a
+ * stuck card and is worth pinning that it stays reachable even then.
+ *
+ * `task-workflow-proposal.test.ts` never renders this panel, so a real reject
+ * click reaching the host — and a refused reject leaving the proposal intact
+ * — is untested until this file.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const PROPOSAL: TaskWorkflowProposal = {
+  summary: "Posts a weekly summary of dev activity.",
+  generatedAtMillis: 1_700_000_000_000,
+  runId: "run-1",
+  ops: {
+    id: "weekly_summary",
+    name: "Weekly summary",
+    nodes: [
+      { id: "cron", kind: "trigger", name: "Weekly", schedule: "0 9 * * 1" },
+      { id: "gather", kind: "agent", name: "Gather", agent: "analyst" },
+      { id: "post", kind: "output", name: "Post", destination: { kind: "owner" } },
+    ],
+    edges: [
+      { from: "cron", to: "gather" },
+      { from: "gather", to: "post" },
+    ],
+  },
+};
+
+/** A proposal the diff adapter refuses to render — Apply is withheld on this. */
+const UNRENDERABLE_PROPOSAL: TaskWorkflowProposal = {
+  ...PROPOSAL,
+  ops: { id: "x", name: "Y", nodes: [], edges: [] },
+};
+
+function task(proposal: TaskWorkflowProposal): Task {
+  return {
+    id: "task-1",
+    title: "Build the weekly summary",
+    column: "working",
+    stage: "in_review",
+    priority: "medium",
+    assignee: "analyst",
+    updatedAt: 0,
+    workflowProposal: proposal,
+  } as Task;
+}
+
+function clientAs(post: (path: string, body?: unknown) => Promise<unknown>): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/companies/${company ?? "acme"}`,
+    post: async (path: string, body?: unknown) => post(path, body),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(
+  client: OpenCompanyClient,
+  proposal: TaskWorkflowProposal = PROPOSAL,
+  onReload = vi.fn(),
+) {
+  await act(async () => {
+    root.render(
+      createElement(TaskWorkflowProposalPanel, {
+        client,
+        company: "acme",
+        task: task(proposal),
+        onReload,
+      }),
+    );
+  });
+  return onReload;
+}
+
+function rejectButton(): HTMLButtonElement {
+  const found = document.querySelector('[data-testid="task-workflow-proposal-reject"]');
+  if (!found) throw new Error(`no Reject control in:\n${container.innerHTML}`);
+  return found as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("Reject a workflow proposal — offered to every member, not just an admin", () => {
+  it("reaches the host's reject on click, with no admin-only gate", async () => {
+    const post = vi.fn(async (_path: string, _body?: unknown) => ({ ...task(PROPOSAL), workflowProposal: undefined, column: "todo" }));
+    const onReload = await render(clientAs(post));
+
+    await act(async () => {
+      rejectButton().click();
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0][0]).toBe(
+      "/api/v1/companies/acme/tasks/task-1/workflow-proposal/reject",
+    );
+    expect(onReload).toHaveBeenCalledTimes(1);
+    expect(toasts.success).toHaveBeenCalled();
+  });
+
+  it("stays reachable even on a proposal Apply withholds", async () => {
+    const post = vi.fn(async () => ({ ...task(UNRENDERABLE_PROPOSAL), workflowProposal: undefined }));
+    await render(clientAs(post), UNRENDERABLE_PROPOSAL);
+
+    // Apply is withheld — the adapter could not render this graph — but
+    // Reject is the one way off a card stuck like this, so it must not be
+    // withheld along with it.
+    expect(
+      document.querySelector('[data-testid="task-workflow-proposal-apply"]'),
+    ).toBeNull();
+    expect(rejectButton().disabled).toBe(false);
+  });
+});
+
+describe("Reject a workflow proposal — the host refuses it", () => {
+  it("keeps the proposal intact, shows the host's reason, and never claims success", async () => {
+    const post = vi.fn(async () => {
+      throw new ApiError(409, "conflict", "this card no longer has a proposal to reject", true);
+    });
+    const onReload = await render(clientAs(post));
+
+    await act(async () => {
+      rejectButton().click();
+    });
+
+    expect(toasts.success).not.toHaveBeenCalled();
+    expect(onReload).not.toHaveBeenCalled();
+    const error = document.querySelector('[data-testid="task-workflow-proposal-error"]');
+    expect(error?.textContent).toContain(
+      "this card no longer has a proposal to reject",
+    );
+    expect(rejectButton().disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 59 unit files over the console's operational surface — the weakest chapter in the product for edge coverage, with several modules previously at zero tests. Each asserts what a view says when its fetch or action **fails**, rather than what it renders on the happy path.

Three real defects surfaced while writing them. None is fixed here: each is committed as a skipped test asserting the safe behaviour, so the bug is pinned rather than described.

## API Or Behavior Changes

None. No file under `frontend/src` is touched.

## Tests

59 new files, 174 passing, 3 skipped.

**The three skipped tests are findings, not gaps:**

- **`TaskCard` Resume double-fires.** `disabled={rows.length > 0}` is the only guard, and `rows` cannot change between two synchronous clicks, so a real double-click sends two re-dispatches — a second agent turn on work already re-queued. Fails 2 ≠ 1 against unmodified source.
- **Workspace rename is fire-and-forget.** The dialog does `void rename(...)` and closes; a slow first response can land after a newer second rename and win, discarding the operator's later intent.
- **`PeopleView` reports the wrong reason** when `/auth/me` fails to answer. The gate collapses "member" and "never answered" into one branch. The safe half holds — no control is offered either way — so this is a truthfulness bug, not an authority hole.

**On the authority axis, a correction worth recording.** Many of these cells were recorded as authority gaps. They are not: every task and chat write behind these controls is `ScopedCompany`/`CompanyAuth` on the host, not `AdminScopedCompany`, so there is no member/admin split to assert and the console correctly invents no gate. Forcing `useCanManage` to always-allow leaves the entire suite green — which is the honest confirmation that these were never authority cells. What the tests pin instead is the mirror property: no spurious gate, and the write really does land for a member. The two genuinely admin-gated surfaces, the chat daily-budget menu and the memory engine picker, do gate, and are now pinned.

Two fixtures needed an admin session after the skill write routes moved to the admin boundary — they had established no role at all, so they were asserting against a surface that no longer exists.

## Documentation

None. The axis correction above belongs in the coverage ledger rather than in a doc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage across chat, tasks, workspace, inbox, memory, pages, people, skills, artifacts, and observatory views.
  - Added validation for role-based access, successful and failed actions, retry behavior, optimistic update rollback, loading states, and error messaging.
  - Added coverage for file uploads, approvals, reactions, budgets, task controls, workflow proposals, and concurrent operations.
  - Documented known edge cases and currently skipped scenarios for future fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->