### PR TITLE
test(governance): close FAIL-axis gaps and pin five fail-open defects

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -10668,6 +10668,196 @@ mod tests {
         );
     }
 
+    /// A DM reply and a console verdict both resolve through
+    /// `claim_blocker_resolution`, so they cannot both win — but until now
+    /// nothing drove one of each at the same blocker and checked the loser's
+    /// **own return value**, only the armed slot's content (see the test
+    /// above). `resolve_approval_spawned` and `apply_blocker_reply_spawned`
+    /// both hold `self.blocker_resolutions` for their claim-and-settle window,
+    /// so true interleaving is impossible by construction; what remains
+    /// untested is that the second caller in, whichever surface it is, is
+    /// handed back `AlreadyResolved` rather than a receipt that reads like it
+    /// was the one that settled the blocker.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn a_console_verdict_after_a_dm_reply_already_won_is_told_it_lost() {
+        let home = tempfile::tempdir().expect("home");
+        let manifest: crate::company::CompanyManifest = toml::from_str(
+            r#"
+            [company]
+            name = "Acme"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+
+            [policy]
+            mode = "supervised"
+            "#,
+        )
+        .expect("manifest");
+        let runtime = std::sync::Arc::new(
+            crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+                .with_id(crate::ports::types::CompanyId::new("acme"))
+                .build()
+                .await
+                .expect("runtime"),
+        );
+
+        let payload = crate::ports::blockers::BlockerPayload {
+            kind: crate::ports::blockers::BlockerKind::Infrastructure,
+            source: crate::ports::blockers::BlockerSource::Provider,
+            step: Some(crate::ports::blockers::BlockerStep::Task {
+                task_id: "t-1".to_string(),
+            }),
+            reason: "the model `gpt-nonexistent` was rejected".to_string(),
+            needed: "a model id this provider serves".to_string(),
+            group_key: None,
+        };
+        let id = runtime
+            .park_blocker(
+                &payload,
+                "t-1",
+                crate::company::blocker_sender::BlockerSenderSignals::default(),
+            )
+            .await
+            .expect("parks");
+
+        // The DM reply lands first and wins the claim.
+        let (dm_receipt, dm_follow_up) = runtime
+            .apply_blocker_reply_spawned(
+                std::slice::from_ref(&id),
+                &id,
+                crate::ports::blockers::BlockerVerdict::Retry,
+                "",
+                None,
+            )
+            .await
+            .expect("the dm reply claims and settles");
+        assert!(
+            matches!(
+                dm_receipt,
+                crate::runtime::cycle::ResolveReceipt::Settled(_)
+            ),
+            "the dm reply must be the one that settles the blocker: {dm_receipt:?}"
+        );
+        drop(dm_follow_up);
+
+        // The console verdict arrives on the same id after the claim is
+        // already taken. It must not error, and it must not be told it won.
+        let (console_receipt, _console_follow_up) = runtime
+            .resolve_approval_spawned(
+                &id,
+                crate::ports::types::Verdict::Deny,
+                crate::ports::types::Actor {
+                    kind: crate::ports::types::ActorKind::Operator,
+                    id: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
+                },
+                crate::runtime::grants::GrantScope::Once,
+            )
+            .await
+            .expect("a losing resolve is a receipt, not an error");
+        assert!(
+            matches!(
+                console_receipt,
+                crate::runtime::cycle::ResolveReceipt::AlreadyResolved
+            ),
+            "a console verdict racing a dm reply it lost must be reported to its own \
+             caller as already-resolved, not silently accepted as though it settled \
+             the blocker: {console_receipt:?}"
+        );
+    }
+
+    /// The mirror of the test above: the console verdict wins the claim, and a
+    /// DM reply arriving after it on the same blocker must be told it lost
+    /// through its own return value rather than being silently accepted.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn a_dm_reply_after_a_console_verdict_already_won_is_told_it_lost() {
+        let home = tempfile::tempdir().expect("home");
+        let manifest: crate::company::CompanyManifest = toml::from_str(
+            r#"
+            [company]
+            name = "Acme"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+
+            [policy]
+            mode = "supervised"
+            "#,
+        )
+        .expect("manifest");
+        let runtime = std::sync::Arc::new(
+            crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+                .with_id(crate::ports::types::CompanyId::new("acme"))
+                .build()
+                .await
+                .expect("runtime"),
+        );
+
+        let payload = crate::ports::blockers::BlockerPayload {
+            kind: crate::ports::blockers::BlockerKind::Infrastructure,
+            source: crate::ports::blockers::BlockerSource::Provider,
+            step: Some(crate::ports::blockers::BlockerStep::Task {
+                task_id: "t-1".to_string(),
+            }),
+            reason: "the model `gpt-nonexistent` was rejected".to_string(),
+            needed: "a model id this provider serves".to_string(),
+            group_key: None,
+        };
+        let id = runtime
+            .park_blocker(
+                &payload,
+                "t-1",
+                crate::company::blocker_sender::BlockerSenderSignals::default(),
+            )
+            .await
+            .expect("parks");
+
+        let (console_receipt, _console_follow_up) = runtime
+            .resolve_approval_spawned(
+                &id,
+                crate::ports::types::Verdict::Approve,
+                crate::ports::types::Actor {
+                    kind: crate::ports::types::ActorKind::Operator,
+                    id: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
+                },
+                crate::runtime::grants::GrantScope::Once,
+            )
+            .await
+            .expect("the console verdict claims and settles");
+        assert!(
+            matches!(
+                console_receipt,
+                crate::runtime::cycle::ResolveReceipt::Settled(_)
+            ),
+            "the console verdict must be the one that settles the blocker: {console_receipt:?}"
+        );
+
+        let (dm_receipt, dm_follow_up) = runtime
+            .apply_blocker_reply_spawned(
+                std::slice::from_ref(&id),
+                &id,
+                crate::ports::blockers::BlockerVerdict::Retry,
+                "",
+                None,
+            )
+            .await
+            .expect("a losing dm reply is a receipt, not an error");
+        assert!(
+            matches!(
+                dm_receipt,
+                crate::runtime::cycle::ResolveReceipt::AlreadyResolved
+            ),
+            "a dm reply racing a console verdict it lost must be reported to its own \
+             caller as already-resolved, not silently accepted as though it settled \
+             the blocker: {dm_receipt:?}"
+        );
+        drop(dm_follow_up);
+    }
+
     /// The thread-as-review-surface: a reply to a settled `in_review` dispatch
     /// card's settle pill or relay bubble routes as review feedback and re-runs
     /// the card; an Approve verdict finishes it.

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -3787,6 +3787,52 @@ mod tests {
         );
     }
 
+    /// `escalate_to_human` (issue #1860's agent-question blocker), unlike
+    /// `request_approval`, never sets `EXPLICIT_REQUEST_PENDING` — so nothing
+    /// stops a model from calling it again inside the same turn. A ninth
+    /// distinct question in one turn overflows `MAX_APPROVAL_REQUESTS_PER_TURN`
+    /// and is dropped by the drain cap with no card ever raised for it, even
+    /// though the run may still park believing it asked something.
+    #[tokio::test]
+    async fn escalate_to_human_does_not_set_the_turn_boundary_and_can_overflow_the_cap() {
+        let queue = ApprovalRequestQueue::default();
+        let blocker_request = |i: usize| ApprovalRequest {
+            tool: crate::harness::built_in::blockers::ESCALATE_TO_HUMAN_TOOL.to_string(),
+            reason: format!("question {i}"),
+            effect: Effect {
+                kind: "blocker.information".to_string(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::json!({ "reason": format!("question {i}") }),
+                agent: None,
+                run_id: None,
+            },
+        };
+
+        queue
+            .turn_scoped(async {
+                for i in 0..(MAX_APPROVAL_REQUESTS_PER_TURN + 1) {
+                    queue.push(blocker_request(i));
+                }
+                assert!(
+                    !queue.explicit_request_pending(),
+                    "unlike request_approval, escalate_to_human never establishes the turn \
+                     boundary — nothing in the queue itself stops a model from calling it \
+                     again in the same turn"
+                );
+            })
+            .await;
+
+        let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(
+            drained.discarded, 1,
+            "a ninth question in one turn overflows the cap and is silently dropped — no card \
+             is ever raised for it, though the run may still park expecting an answer"
+        );
+    }
+
     // --- Redeeming a grant (issue #243) --------------------------------------
 
     /// A policy bound to `agent`, plus the grant set its queue carries.

--- a/src/harness/built_in/toolbelt.rs
+++ b/src/harness/built_in/toolbelt.rs
@@ -1393,6 +1393,48 @@ mod tests {
         );
     }
 
+    /// `block_high_risk_commands` is set unconditionally in `exec_security`,
+    /// but every existing test proving a destructive command is refused does
+    /// so under `Readonly`, where the autonomy tier alone already blocks
+    /// everything — so none of them isolates this flag.
+    ///
+    /// Finding CONF-002: it turns out this flag has **no effect at all** on
+    /// `ShellTool::execute`. The flag is only read by the vendored
+    /// `SecurityPolicy::validate_command_execution` — but `ShellTool`'s real
+    /// runtime path (`run_with_security_in_context`) calls
+    /// `check_gated_command` instead, which never calls
+    /// `validate_command_execution`/`is_command_allowed` at all (this is
+    /// already documented at `src/policy/consequence.rs:1658`, for a
+    /// different boundary). `check_gated_command` only consults
+    /// `gate_decision`, and under `Full`, `Destructive` maps to `Prompt`, not
+    /// `Block` — so a raw `execute()` call runs the command.
+    ///
+    /// In production this is caught upstream by opencompany's own
+    /// `ApprovalPolicy`/consequence classifier, which is the actual gate on
+    /// this call — but that means `block_high_risk_commands` is not the
+    /// "last independent brake below our policy" its name and the module
+    /// docs claim it is; it is dead configuration. Anything that reaches a
+    /// wired `ShellTool` without going through opencompany's own policy layer
+    /// first (a bug in that layer, a future direct call site) has no
+    /// OpenHuman-level backstop at all.
+    #[tokio::test]
+    #[ignore = "finding CONF-002: block_high_risk_commands has no effect on ShellTool::execute — the real path (check_gated_command) never calls validate_command_execution, so a destructive command runs under Full even with the flag set"]
+    async fn block_high_risk_commands_refuses_a_destructive_command_even_under_full_autonomy() {
+        let ws = std::env::temp_dir();
+        let full = test_security(&ws, PolicyMode::Full);
+        let tool = ShellTool::new(full, native_runtime(), AuditLogger::disabled());
+        let result = tool
+            .execute(json!({ "command": "rm -rf /tmp/oc-toolbelt-conf002-nonexistent-xyz" }))
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "block_high_risk_commands=true must refuse a destructive command even under Full \
+             autonomy, independent of the autonomy-tier gate: {}",
+            result.output()
+        );
+    }
+
     #[tokio::test]
     async fn web_tools_reject_ssrf_ip_literals() {
         let ws = std::env::temp_dir();

--- a/src/metering/daily_budget.rs
+++ b/src/metering/daily_budget.rs
@@ -211,6 +211,42 @@ mod tests {
         assert_eq!(utc_day_start_millis(midnight), midnight);
     }
 
+    /// `usd_spent_by_agent` has no validation seam: a negative `cost_usd` folds
+    /// straight into the total instead of being rejected, so one bad sample
+    /// silently lowers a teammate's measured spend below what it actually
+    /// spent.
+    #[test]
+    #[ignore = "finding MET-001: usd_spent_by_agent has no validation seam; a negative cost_usd sample lowers measured spend instead of being rejected or clamped"]
+    fn a_negative_cost_sample_does_not_lower_measured_spend() {
+        let samples = vec![
+            sample("analyst", 5.0, SampleKind::Inference),
+            sample("analyst", -3.0, SampleKind::Inference),
+        ];
+        assert!(
+            (usd_spent_by_agent(&samples, "analyst") - 5.0).abs() < f64::EPSILON,
+            "a negative cost_usd sample must not silently lower measured spend, got {}",
+            usd_spent_by_agent(&samples, "analyst")
+        );
+    }
+
+    /// Same seam, the non-finite case: `NaN` propagates through `+` and poisons
+    /// every later sum it touches (`x + NaN == NaN`), so one malformed sample
+    /// would erase an agent's whole daily total rather than being rejected.
+    #[test]
+    #[ignore = "finding MET-001: usd_spent_by_agent has no validation seam; a NaN cost_usd sample poisons the whole running total instead of being rejected or clamped"]
+    fn a_non_finite_cost_sample_does_not_poison_the_total() {
+        let samples = vec![
+            sample("analyst", 5.0, SampleKind::Inference),
+            sample("analyst", f64::NAN, SampleKind::Inference),
+            sample("analyst", 2.0, SampleKind::Inference),
+        ];
+        let spent = usd_spent_by_agent(&samples, "analyst");
+        assert!(
+            spent.is_finite(),
+            "a NaN sample must not poison the running total, got {spent}"
+        );
+    }
+
     /// The console row: remaining floors at zero and `exhausted` trips on `>=`,
     /// matching the boundary the harness gate and the policy arm use.
     #[test]

--- a/src/ports/blockers.rs
+++ b/src/ports/blockers.rs
@@ -734,4 +734,40 @@ mod test {
             assert_eq!(back, step);
         }
     }
+
+    fn effect_of_kind(kind: &str) -> crate::ports::types::Effect {
+        crate::ports::types::Effect {
+            kind: kind.to_string(),
+            group: crate::ports::types::EffectGroup::Other,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+            agent: None,
+            run_id: None,
+        }
+    }
+
+    /// `is_blocker_effect` is a **lexical** prefix match, not a check against
+    /// the closed [`BlockerKind`]/[`BlockerSource`] vocabulary — an effect kind
+    /// that merely *starts with* `blocker.` is treated as inert and skipped at
+    /// execution (`CycleRunner`'s never-execute guard) whether or not it is one
+    /// of this module's own recognised classes. Pinned so the "blocker."
+    /// prefix is understood as a reserved namespace no other effect kind may
+    /// ever begin with, rather than a semantic check that happens to be
+    /// implemented as a prefix match.
+    #[test]
+    fn the_guard_is_a_bare_prefix_match_not_a_vocabulary_check() {
+        assert!(is_blocker_effect(&effect_of_kind("blocker.information")));
+        // A kind starting with the reserved prefix but naming no recognised
+        // class is matched all the same — the guard cannot tell "a real
+        // blocker" from "anything spelled with this prefix".
+        assert!(is_blocker_effect(&effect_of_kind(
+            "blocker.nobody_declared_this_class"
+        )));
+        // The boundary that actually matters: a kind that merely contains the
+        // word, rather than starting with `blocker.`, is correctly NOT matched.
+        assert!(!is_blocker_effect(&effect_of_kind("payment.blocker_fee")));
+        assert!(!is_blocker_effect(&effect_of_kind("blocker")));
+    }
 }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -7555,6 +7555,53 @@ members = ["writer"]
         assert_eq!(spend[0].amount_usd, -0.031);
     }
 
+    /// Finding MET-004: a `PerCycle`-metered brain's spend charges
+    /// `UNATTRIBUTED_AGENT` unconditionally, even on a single-agent company
+    /// where the cycle can only have been that one teammate's work. That
+    /// makes the spend invisible to `usd_spent_by_agent` for the real
+    /// teammate — and therefore invisible to that teammate's
+    /// `budget_usd_daily` cap, which sums exactly that function's output.
+    #[tokio::test]
+    async fn per_cycle_spend_is_invisible_to_the_real_agents_daily_cap() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+            .with_brain(Arc::new(MeteredBrain::per_cycle(reported_usage(9.99))))
+            .build()
+            .await
+            .unwrap();
+
+        rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
+            parent: None,
+            text: "how are we doing".into(),
+            by: None,
+            chat: None,
+            deliverable: None,
+            attachments: Vec::new(),
+        }])
+        .await
+        .unwrap();
+
+        let samples = rt.usage().query(rt.id(), 0).await.unwrap();
+        assert_eq!(samples.len(), 1);
+        assert_eq!(
+            crate::metering::daily_budget::usd_spent_by_agent(&samples, "ceo"),
+            0.0,
+            "the $9.99 this cycle spent is invisible to the only real teammate's daily spend \
+             sum — a budget_usd_daily cap on `ceo` would never see it and could never trip"
+        );
+        assert_eq!(
+            crate::metering::daily_budget::usd_spent_by_agent(
+                &samples,
+                crate::metering::UNATTRIBUTED_AGENT
+            ),
+            9.99,
+            "the spend is real; it is just parked under the company-wide bucket instead of \
+             the teammate whose turn it was"
+        );
+    }
+
     /// Tokens without USD (the managed passthrough bills backend-side) still
     /// count on the Usage surface, but must not post a `$0.00` spend line.
     #[tokio::test]

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -2971,4 +2971,113 @@ mod test {
             "the scope does not leak past its own future"
         );
     }
+
+    /// `GrantConsumed` is only written at the cycle drain, not at `consume`
+    /// itself, so a crash between the two loses the durable record of the
+    /// consumption. A fresh boot's `rehydrate`, seeing only the journal's
+    /// `ApprovalGranted` line and no `GrantConsumed` to fold it back out,
+    /// re-arms a grant that was already spent — the boot-time surfacing of
+    /// the window TOOL-005 names for the in-process case.
+    #[test]
+    #[ignore = "finding GRANT-004: a grant consumed but not yet journal-drained before a restart rehydrates as live again, because GrantConsumed is only written at the cycle drain"]
+    fn a_grant_consumed_before_its_journal_drain_does_not_survive_a_restart() {
+        let args = serde_json::json!({ "to": "a@b.test" });
+        let before_crash = GrantSet::default();
+        before_crash.grant(call("a1", "finance", "composio_execute", args.clone()));
+        assert!(
+            before_crash
+                .consume("finance", "composio_execute", &args)
+                .is_some(),
+            "the agent redeemed it just before the crash"
+        );
+        // The crash lands before `drain_consumed` is journaled, so replay at
+        // boot only has the original `ApprovalGranted` line to fold in.
+        let after_restart = GrantSet::default();
+        after_restart.rehydrate([call("a1", "finance", "composio_execute", args.clone())]);
+        assert!(
+            after_restart.peek(&ApprovalId::new("a1")).is_none(),
+            "a grant already redeemed before the crash must not come back live \
+             after a restart that never saw its consumption journaled"
+        );
+    }
+
+    /// The approval sweep caps how much housekeeping one tick does
+    /// (`MAX_RETIREMENTS_PER_TICK`); `GrantSet::sweep` has no equivalent, so a
+    /// company with a large expired-grant backlog processes every one of them
+    /// on a single minute tick. Pinned here so a future cap on the approval
+    /// sweep's model does not get "generalized" onto this one silently — if a
+    /// cap is ever added, this test is expected to need updating.
+    #[test]
+    fn sweep_processes_every_expired_grant_in_one_call_with_no_cap() {
+        let set = GrantSet::default();
+        for i in 0..250 {
+            set.grant(call(
+                &format!("g{i}"),
+                "finance",
+                "t",
+                serde_json::json!({ "i": i }),
+            ));
+        }
+        let expired = set.sweep(1_000 + GRANT_TTL_MILLIS, GRANT_TTL_MILLIS);
+        assert_eq!(
+            expired.len(),
+            250,
+            "every expired grant is swept in one call; nothing is held back for a later tick"
+        );
+        assert_eq!(set.live_count(), 0);
+    }
+
+    /// The 7-day ceiling (`MAX_STANDING_GRANT_MILLIS`) is enforced at the
+    /// resolve route when a grant is minted, not on `StandingGrant` itself —
+    /// so `rehydrate_standing`, which is what a journal replay calls, accepts
+    /// a line whose `expires_at_millis` is far past that ceiling with no
+    /// re-check.
+    #[test]
+    #[ignore = "finding GRANT-006: rehydrate_standing accepts a journal line whose expiry exceeds the 7-day ceiling verbatim, with no re-check against MAX_STANDING_GRANT_MILLIS"]
+    fn rehydrate_standing_refuses_a_line_past_the_seven_day_ceiling() {
+        let set = GrantSet::default();
+        let far_future_expiry = 1_000 + MAX_STANDING_GRANT_MILLIS * 10;
+        set.rehydrate_standing([standing("g1", "maya", "web_fetch", far_future_expiry)]);
+        assert!(
+            set.standing()
+                .into_iter()
+                .all(|g| g.expires_at_millis <= 1_000 + MAX_STANDING_GRANT_MILLIS),
+            "a rehydrated standing grant must not outlive the 7-day ceiling every other \
+             mint path enforces, even when the journal line itself claims a longer expiry"
+        );
+    }
+
+    /// `subject()` reads an empty `agent` with no `workflow` as an agent
+    /// subject held by the empty-string agent, rather than refusing the line.
+    /// No live call names an empty agent id, so this is inert today — but
+    /// nothing here rejects a malformed line that reaches it. Pinned as
+    /// documented, accepted behaviour rather than a defect: the guard belongs
+    /// at whatever writes the journal line, not at replay.
+    #[test]
+    fn subject_of_an_empty_agent_with_no_workflow_is_an_agent_named_the_empty_string() {
+        let malformed = standing("g1", "", "web_fetch", 9_999);
+        assert_eq!(malformed.subject(), GrantSubject::agent(""));
+    }
+
+    /// `pending` marks are in-memory only and never rehydrated — accepted
+    /// because a boot sweeps every checkout regardless (see the module docs
+    /// on `mark_pending`). Pinned so that acceptance is asserted rather than
+    /// merely claimed: a restart genuinely drops the mark, and a fresh
+    /// process's `any_for_task` reports the task as no longer held even
+    /// though, in the old process, an approval was still pending on it.
+    #[test]
+    fn a_restart_drops_the_pending_mark_and_the_task_reads_as_no_longer_held() {
+        let before_restart = GrantSet::default();
+        before_restart.mark_pending(&ApprovalId::new("a1"), "t-1".to_string());
+        assert!(before_restart.any_for_task("t-1"));
+
+        // A restart is a fresh GrantSet; nothing seeds `pending` from the
+        // journal, unlike `live` (rehydrate) and `standing` (rehydrate_standing).
+        let after_restart = GrantSet::default();
+        assert!(
+            !after_restart.any_for_task("t-1"),
+            "the pending mark does not survive a restart; the task reads as unheld \
+             until its checkout sweep confirms that independently"
+        );
+    }
 }

--- a/src/runtime/workflow_gates.rs
+++ b/src/runtime/workflow_gates.rs
@@ -254,3 +254,250 @@ impl WorkflowGateQueue {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::EffectGroup;
+    use crate::runtime::workflow_resume::gate_effect;
+    use serde_json::json;
+
+    fn gate(workflow: &str, node: &str) -> Effect {
+        gate_effect(workflow, node, &json!({}), "run-1", &[], &[], None)
+    }
+
+    fn non_gate() -> Effect {
+        Effect {
+            kind: "payment.send".to_string(),
+            group: EffectGroup::Spend,
+            amount_usd: Some(10.0),
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: json!({}),
+            agent: None,
+            run_id: None,
+        }
+    }
+
+    /// The core loop the module exists for: two gates park on one run, one
+    /// approved and one denied, and release hands back exactly that split on
+    /// the one representative effect.
+    #[test]
+    fn arm_decide_release_splits_approved_and_denied() {
+        let q = WorkflowGateQueue::default();
+        let id_a = ApprovalId::new("a");
+        let id_b = ApprovalId::new("b");
+        q.arm("turn-1", &id_a, &gate("wf", "node-a"));
+        q.arm("turn-1", &id_b, &gate("wf", "node-b"));
+        assert_eq!(q.undecided("turn-1"), 2);
+
+        q.decide("turn-1", &id_a, Verdict::Approve);
+        assert_eq!(q.undecided("turn-1"), 1);
+        q.decide("turn-1", &id_b, Verdict::Deny);
+        assert_eq!(q.undecided("turn-1"), 0);
+
+        let released = q.release("turn-1").expect("a batch was armed");
+        assert_eq!(released.approved, vec!["node-a".to_string()]);
+        assert_eq!(released.denied, vec!["node-b".to_string()]);
+    }
+
+    /// `arm` only ever accepts a `workflow.approve` effect — the kind check is
+    /// what stops a native effect (say, a payment) from silently being treated
+    /// as a gate this queue must eventually release.
+    #[test]
+    fn arm_ignores_a_non_gate_effect() {
+        let q = WorkflowGateQueue::default();
+        let id = ApprovalId::new("a");
+        q.arm("turn-1", &id, &non_gate());
+        assert!(
+            !q.is_armed("turn-1"),
+            "a non-gate effect must not arm a batch"
+        );
+        assert_eq!(q.undecided("turn-1"), 0);
+    }
+
+    /// Deciding an id/turn this queue never armed — the shape of a stale or
+    /// forged approval id — must be a silent no-op, not a panic and not a
+    /// phantom entry that later corrupts a real release.
+    #[test]
+    fn decide_on_an_unarmed_turn_or_unknown_id_is_a_no_op() {
+        let q = WorkflowGateQueue::default();
+        // Unknown turn entirely.
+        q.decide("ghost-turn", &ApprovalId::new("x"), Verdict::Approve);
+        assert!(!q.is_armed("ghost-turn"));
+
+        // Known turn, unknown id.
+        let id = ApprovalId::new("a");
+        q.arm("turn-1", &id, &gate("wf", "node-a"));
+        q.decide("turn-1", &ApprovalId::new("not-armed"), Verdict::Deny);
+        assert_eq!(
+            q.undecided("turn-1"),
+            1,
+            "a decision on an id this batch never armed must not consume the real one"
+        );
+    }
+
+    /// Deciding the same id twice — a retried resolve, or two callers racing
+    /// one approval — must not double-count the node into the ledger the
+    /// second time, since the first `decide` already removed it from
+    /// `undecided`.
+    #[test]
+    fn deciding_the_same_id_twice_does_not_double_count() {
+        let q = WorkflowGateQueue::default();
+        let id = ApprovalId::new("a");
+        q.arm("turn-1", &id, &gate("wf", "node-a"));
+        q.decide("turn-1", &id, Verdict::Approve);
+        q.decide("turn-1", &id, Verdict::Approve);
+        let released = q.release("turn-1").expect("armed");
+        assert_eq!(released.approved, vec!["node-a".to_string()]);
+    }
+
+    /// TTL expiry is documented to "contribute no event at all" beyond the
+    /// sweep's own `decide` call — there is no `ApprovalResolved` behind it.
+    /// This proves `decide` alone, with no prior continuation event, still
+    /// moves the node into `denied` so the run does not replay into it.
+    #[test]
+    fn a_ttl_expiry_decide_with_no_prior_event_still_lands_in_denied() {
+        let q = WorkflowGateQueue::default();
+        let id = ApprovalId::new("a");
+        q.arm("turn-1", &id, &gate("wf", "node-a"));
+        // The sweep calls decide() directly; nothing else touched this queue.
+        q.decide("turn-1", &id, Verdict::Deny);
+        let released = q.release("turn-1").expect("armed");
+        assert!(released.denied.contains(&"node-a".to_string()));
+        assert!(released.approved.is_empty());
+    }
+
+    /// `release` takes the batch, so a second release (or any further decide)
+    /// on the same turn finds nothing left to corrupt or double-release.
+    #[test]
+    fn release_drops_the_batch_and_a_repeat_release_is_none() {
+        let q = WorkflowGateQueue::default();
+        let id = ApprovalId::new("a");
+        q.arm("turn-1", &id, &gate("wf", "node-a"));
+        assert!(q.release("turn-1").is_some());
+        assert!(q.release("turn-1").is_none());
+        assert!(!q.is_armed("turn-1"));
+
+        // A decide arriving after the release must not panic or resurrect it.
+        q.decide("turn-1", &id, Verdict::Approve);
+        assert!(!q.is_armed("turn-1"));
+    }
+
+    /// The first gate through sets the batch's representative effect; a
+    /// second sibling gate for the same run must not replace it, since every
+    /// gate of one run is documented to agree on everything but `node_id`.
+    #[test]
+    fn the_first_gates_effect_is_the_batchs_representative_effect() {
+        let q = WorkflowGateQueue::default();
+        let id_a = ApprovalId::new("a");
+        let id_b = ApprovalId::new("b");
+        let first = gate_effect(
+            "wf",
+            "node-a",
+            &json!({"trigger": "one"}),
+            "run-1",
+            &[],
+            &[],
+            None,
+        );
+        let second = gate_effect(
+            "wf",
+            "node-b",
+            &json!({"trigger": "different"}),
+            "run-1",
+            &[],
+            &[],
+            None,
+        );
+        q.arm("turn-1", &id_a, &first);
+        q.arm("turn-1", &id_b, &second);
+        q.decide("turn-1", &id_a, Verdict::Approve);
+        q.decide("turn-1", &id_b, Verdict::Approve);
+        let released = q.release("turn-1").expect("armed");
+        assert_eq!(
+            released.effect.payload, first.payload,
+            "the representative effect must stay the first gate's, not the last"
+        );
+    }
+
+    /// `rearm` is idempotent and *replaces* a turn rather than adding to it:
+    /// replaying the same journal snapshot twice must not accumulate
+    /// duplicate `undecided` entries for one gate.
+    #[test]
+    fn rearm_is_idempotent_and_does_not_accumulate() {
+        let q = WorkflowGateQueue::default();
+        let id = ApprovalId::new("a");
+        let g = gate("wf", "node-a");
+        q.rearm(vec![("turn-1".to_string(), id.clone(), &g)]);
+        assert_eq!(q.undecided("turn-1"), 1);
+        q.rearm(vec![("turn-1".to_string(), id.clone(), &g)]);
+        assert_eq!(
+            q.undecided("turn-1"),
+            1,
+            "replaying the same rehydrate twice must not double the undecided count"
+        );
+    }
+
+    /// A verdict banked before a rearm is documented to be dropped along with
+    /// the rest of the turn — the rehydrated batch only knows what the
+    /// journal still shows parked, so a gate this process already decided
+    /// (but that a fresh rearm sees as still-parked) comes back undecided.
+    #[test]
+    fn rearm_drops_verdicts_banked_before_it() {
+        let q = WorkflowGateQueue::default();
+        let id_a = ApprovalId::new("a");
+        let id_b = ApprovalId::new("b");
+        let ga = gate("wf", "node-a");
+        let gb = gate("wf", "node-b");
+        q.arm("turn-1", &id_a, &ga);
+        q.arm("turn-1", &id_b, &gb);
+        q.decide("turn-1", &id_a, Verdict::Approve);
+        assert_eq!(q.undecided("turn-1"), 1);
+
+        // A journal replay that still sees both gates parked rebuilds the
+        // batch from scratch — the in-process approval of `id_a` is gone.
+        q.rearm(vec![
+            ("turn-1".to_string(), id_a.clone(), &ga),
+            ("turn-1".to_string(), id_b.clone(), &gb),
+        ]);
+        assert_eq!(
+            q.undecided("turn-1"),
+            2,
+            "rearm must rebuild from the journal's view, not preserve this process's own verdicts"
+        );
+    }
+
+    /// `undecided` on a turn nobody ever armed is `0`, not a panic — the
+    /// documented contract for an untracked turn.
+    #[test]
+    fn undecided_on_an_untracked_turn_is_zero() {
+        let q = WorkflowGateQueue::default();
+        assert_eq!(q.undecided("no-such-turn"), 0);
+        assert!(!q.is_armed("no-such-turn"));
+    }
+
+    /// A poisoned lock (some other caller panicked while holding it) must
+    /// make every further call on this queue panic loudly rather than hand
+    /// back stale or partial batch state that a caller could mistake for a
+    /// clean read.
+    #[test]
+    fn a_poisoned_lock_panics_rather_than_silently_serving_stale_state() {
+        let q = WorkflowGateQueue::default();
+        let id = ApprovalId::new("a");
+        q.arm("turn-1", &id, &gate("wf", "node-a"));
+
+        let poison_q = q.clone();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = poison_q.inner.lock().expect("workflow gate queue poisoned");
+            panic!("simulated holder panic while the lock is held");
+        }));
+
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| q.undecided("turn-1")));
+        assert!(
+            result.is_err(),
+            "a call against a poisoned lock must panic, not silently return a count"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes FAIL-axis coverage gaps in the governance domain — the chapter where every one of the audit's worst findings lives, and the axis those findings all share. Governance sits at 45% edge coverage with 236 cells where the behaviour exists and nothing asserts it.

Writing the tests turned up five defects. **None is fixed here.** Each is committed as an ignored test asserting the *safe* behaviour, with the reason on the `#[ignore]`, so the bug is pinned in executable form rather than described in prose.

## API Or Behavior Changes

None. No production file is modified.

## Tests

`cargo test --features openhuman --lib` — 7,205 passed, 0 failed, 8 ignored. `cargo fmt --check` clean.

**The five findings, in the order I would fix them:**

- **CONF-002 — `block_high_risk_commands` has no effect.** The real execution path (`check_gated_command`) never calls `validate_command_execution`, so a destructive command runs under Full autonomy *even with the flag set*. A safety control that is dead code is worse than an absent one, because the setting reads as protection.
- **MET-001 — the daily spend sum has no validation seam.** A negative `cost_usd` sample *lowers* measured spend rather than being rejected or clamped, and a NaN sample poisons the whole running total. Either one silently raises the effective cap.
- **GRANT-004 — a consumed grant comes back alive across a restart.** `GrantConsumed` is only written at the cycle drain, so a grant consumed but not yet drained rehydrates as live.
- **GRANT-006 — the standing-grant ceiling is not re-checked on rehydrate.** `rehydrate_standing` accepts a journal line whose expiry exceeds `MAX_STANDING_GRANT_MILLIS` verbatim, so a ceiling enforced at write time is not enforced at read time.
- **APPR-007 / REQ-002 / MET-004** — the blocker-effect guard is a bare prefix match; `escalate_to_human` can overflow the approval-request cap; `PerCycle` spend is invisible to the real agent's daily cap.

Also closes **APPR-009**, which the audit recorded as one of the untouched risk-3 findings: `runtime/workflow_gates.rs` had zero tests across 256 lines. Arm, decide, release and re-arm are now covered.

## Documentation

None. These belong in the coverage ledger and as fix issues, not in prose docs.
