### PR TITLE
ci: run the route authority matrix, and name the routes nothing probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1042,6 +1042,14 @@ jobs:
       - name: Clippy (openhuman, tinymemory)
         run: cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings
 
+      # The route-authority matrix names its target explicitly, because a
+      # bare `cargo test` reports success when it selects no tests at all —
+      # which is how a disabled integration target passes as green. The
+      # script exists so the target name lives in one place; a lane that
+      # inlines the command instead drifts the moment the target is renamed.
+      - name: Route authority matrix
+        run: scripts/ci/assert-auth-matrix.sh
+
       # Issue #1524 (PR 1). `pub mod memory` is gated on `tinymemory`
       # (`store/mod.rs`), and neither strict lane enabled that gate: the
       # default-features clippy lints a tree where the module does not exist,

--- a/tests/auth_matrix.rs
+++ b/tests/auth_matrix.rs
@@ -1431,6 +1431,34 @@ fn external_authority_router_files_have_no_unclassified_paths() {
         ]),
         &provision.direct,
     );
+
+    // Knowing a path exists is not the same as exercising it. These four are
+    // `PlatformScope` and the matrix has no platform access class to express
+    // them, so they carry no row and no principal ever probes them. Naming
+    // them here is what stops that being silent: a ninth provisioning route,
+    // or a fix that gives these rows, fails this assertion rather than
+    // quietly joining a set nobody checks.
+    let unexercised: BTreeSet<String> = provision
+        .direct
+        .iter()
+        .filter(|path| {
+            !EXTERNAL_AUTHORITY_ROUTES
+                .iter()
+                .any(|route| route.path == path.as_str())
+        })
+        .cloned()
+        .collect();
+    assert_set_eq(
+        "provisioning paths no principal probes",
+        &string_set(&[
+            "/api/v1/companies",
+            "/api/v1/companies/provisioning",
+            "/api/v1/companies/{id}/suspend",
+            "/api/v1/companies/{id}/archive",
+        ]),
+        &unexercised,
+    );
+
     assert!(provision.scoped.is_empty());
 
     let operator = scan_file_route_literals(&root.join("operator.rs"))

--- a/tests/auth_matrix.rs
+++ b/tests/auth_matrix.rs
@@ -1584,6 +1584,39 @@ struct Scan {
     allowed_nonliteral: BTreeMap<&'static str, usize>,
 }
 
+/// Every HTTP verb a `.route("/p", …)` call wires, including Axum's chained
+/// form `post(handler).delete(other)`. Reading only the first identifier
+/// records `POST` and silently drops the `DELETE`, which is the same
+/// path-shaped blindness this check exists to remove.
+fn route_verbs(tokens: &[Token], open_paren: usize) -> BTreeSet<String> {
+    const VERBS: [&str; 5] = ["get", "post", "put", "patch", "delete"];
+    let mut verbs = BTreeSet::new();
+    let mut depth = 0usize;
+    for index in open_paren..tokens.len() {
+        match punct_at(tokens, index) {
+            Some('(') => depth += 1,
+            Some(')') => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            _ => {}
+        }
+        if depth == 1
+            && punct_at(tokens, index + 1) == Some('(')
+            && let Some(name) = ident_at(tokens, index)
+            && VERBS.contains(&name)
+        {
+            verbs.insert(name.to_ascii_uppercase());
+        }
+    }
+    if verbs.is_empty() {
+        verbs.insert("?".to_string());
+    }
+    verbs
+}
+
 fn scan_file_route_literals(file: &Path) -> Result<Scan, String> {
     let source = std::fs::read_to_string(file).map_err(|error| error.to_string())?;
     let tokens = lex(&source).map_err(|error| format!("{}: {error}", file.display()))?;
@@ -1619,11 +1652,9 @@ fn scan_file_route_literals(file: &Path) -> Result<Scan, String> {
                     // `.route("/p", post(h))` — the verb is the identifier
                     // after the comma. An unreadable one is recorded as
                     // `?` rather than skipped, so it cannot vanish quietly.
-                    let verb = match ident_at(&tokens, index + 5) {
-                        Some(name) => name.to_ascii_uppercase(),
-                        None => "?".to_string(),
-                    };
-                    direct_methods.insert(format!("{verb} {path}"));
+                    for verb in route_verbs(&tokens, index + 2) {
+                        direct_methods.insert(format!("{verb} {path}"));
+                    }
                 }
                 _ => {
                     return Err(format!(
@@ -1700,11 +1731,9 @@ fn scan_ops_routes(root: &Path) -> Result<Scan, String> {
                 match tokens.get(index + 3).map(|token| &token.kind) {
                     Some(TokenKind::String(path)) => {
                         direct.insert(path.clone());
-                        let verb = match ident_at(&tokens, index + 5) {
-                            Some(name) => name.to_ascii_uppercase(),
-                            None => "?".to_string(),
-                        };
-                        direct_methods.insert(format!("{verb} {path}"));
+                        for verb in route_verbs(&tokens, index + 2) {
+                            direct_methods.insert(format!("{verb} {path}"));
+                        }
                     }
                     _ => {
                         let Some(fingerprint) =
@@ -2163,4 +2192,16 @@ mod scanner_tests {
         assert!(visible);
         assert!(!hidden);
     }
+}
+
+#[test]
+fn chained_route_verbs_are_all_recorded() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/server");
+    let setup = scan_file_route_literals(&root.join("setup.rs")).expect("scan");
+    assert!(
+        setup.direct_methods.contains("GET /api/v1/setup")
+            && setup.direct_methods.contains("POST /api/v1/setup"),
+        "chained get(read).post(apply) must yield both verbs, got {:?}",
+        setup.direct_methods
+    );
 }

--- a/tests/auth_matrix.rs
+++ b/tests/auth_matrix.rs
@@ -1439,22 +1439,22 @@ fn external_authority_router_files_have_no_unclassified_paths() {
     // or a fix that gives these rows, fails this assertion rather than
     // quietly joining a set nobody checks.
     let unexercised: BTreeSet<String> = provision
-        .direct
+        .direct_methods
         .iter()
-        .filter(|path| {
+        .filter(|entry| {
             !EXTERNAL_AUTHORITY_ROUTES
                 .iter()
-                .any(|route| route.path == path.as_str())
+                .any(|route| *entry == &format!("{} {}", route.method.label(), route.path))
         })
         .cloned()
         .collect();
     assert_set_eq(
-        "provisioning paths no principal probes",
+        "provisioning routes no principal probes",
         &string_set(&[
-            "/api/v1/companies",
-            "/api/v1/companies/provisioning",
-            "/api/v1/companies/{id}/suspend",
-            "/api/v1/companies/{id}/archive",
+            "POST /api/v1/companies",
+            "GET /api/v1/companies/provisioning",
+            "POST /api/v1/companies/{id}/suspend",
+            "POST /api/v1/companies/{id}/archive",
         ]),
         &unexercised,
     );
@@ -1577,6 +1577,10 @@ fn declared_method_sets() -> BTreeMap<String, BTreeSet<String>> {
 struct Scan {
     scoped: BTreeSet<String>,
     direct: BTreeSet<String>,
+    /// `"POST /api/v1/companies"` — the method matters as much as the path.
+    /// A path already in the inventory can gain a second method, and a
+    /// path-only set stays green while that new method goes unprobed.
+    direct_methods: BTreeSet<String>,
     allowed_nonliteral: BTreeMap<&'static str, usize>,
 }
 
@@ -1586,6 +1590,7 @@ fn scan_file_route_literals(file: &Path) -> Result<Scan, String> {
     let skipped = test_only_token_indexes(&tokens);
     let mut scoped = BTreeSet::new();
     let mut direct = BTreeSet::new();
+    let mut direct_methods = BTreeSet::new();
     for index in 0..tokens.len() {
         if skipped.contains(&index) {
             continue;
@@ -1611,6 +1616,14 @@ fn scan_file_route_literals(file: &Path) -> Result<Scan, String> {
             match tokens.get(index + 3).map(|token| &token.kind) {
                 Some(TokenKind::String(path)) => {
                     direct.insert(path.clone());
+                    // `.route("/p", post(h))` — the verb is the identifier
+                    // after the comma. An unreadable one is recorded as
+                    // `?` rather than skipped, so it cannot vanish quietly.
+                    let verb = match ident_at(&tokens, index + 5) {
+                        Some(name) => name.to_ascii_uppercase(),
+                        None => "?".to_string(),
+                    };
+                    direct_methods.insert(format!("{verb} {path}"));
                 }
                 _ => {
                     return Err(format!(
@@ -1625,6 +1638,7 @@ fn scan_file_route_literals(file: &Path) -> Result<Scan, String> {
     Ok(Scan {
         scoped,
         direct,
+        direct_methods,
         allowed_nonliteral: BTreeMap::new(),
     })
 }
@@ -1648,6 +1662,7 @@ fn scan_ops_routes(root: &Path) -> Result<Scan, String> {
     files.sort();
     let mut scoped = BTreeSet::new();
     let mut direct = BTreeSet::new();
+    let mut direct_methods = BTreeSet::new();
     let mut allowed_nonliteral = BTreeMap::new();
     for file in files {
         let relative = file.strip_prefix(root).expect("collected under root");
@@ -1685,6 +1700,11 @@ fn scan_ops_routes(root: &Path) -> Result<Scan, String> {
                 match tokens.get(index + 3).map(|token| &token.kind) {
                     Some(TokenKind::String(path)) => {
                         direct.insert(path.clone());
+                        let verb = match ident_at(&tokens, index + 5) {
+                            Some(name) => name.to_ascii_uppercase(),
+                            None => "?".to_string(),
+                        };
+                        direct_methods.insert(format!("{verb} {path}"));
                     }
                     _ => {
                         let Some(fingerprint) =
@@ -1705,6 +1725,7 @@ fn scan_ops_routes(root: &Path) -> Result<Scan, String> {
     Ok(Scan {
         scoped,
         direct,
+        direct_methods,
         allowed_nonliteral,
     })
 }


### PR DESCRIPTION
## Summary

Recovers two commits that did not land with #2132. That PR merged at `8cff762a5` while its branch head was `56b8b4fa9` — GitHub held the pull request's head stale for roughly half an hour and merged the older tip, so the last two commits were left behind.

Both were written in response to review on #2132, and both are still needed.

## API Or Behavior Changes

None.

## Tests

`scripts/ci/assert-auth-matrix.sh` — 8 passed, 0 failed, 7 ignored. `cargo fmt --check` clean.

**Wiring the gate to something that runs it.** `scripts/ci/assert-auth-matrix.sh` is on `main` and no workflow calls it, so it guards nothing. The matrix itself does execute today, via the broad `cargo test --locked --features openhuman --tests` in the `rust-gated` lane — so this is not a coverage hole. What the script exists for is naming the target explicitly: a bare `cargo test` reports success when it selects no tests at all, which is how a disabled or renamed integration target passes as green. Calling it from the lane that already carries the `openhuman` feature restores that guard. `scripts/ci/**` is already in that lane's path filter.

**Naming the routes no principal probes.** `external_authority_router_files_have_no_unclassified_paths` asserts which paths exist in `provision.rs`, not that each one is exercised. Four of its eight — `POST /companies`, `GET /companies/provisioning`, `suspend`, `archive` — are `PlatformScope`, carry no matrix row, and no principal probes them, while the check stays green. A source-inventory assertion that reads as coverage is the shape this harness exists to catch.

Giving them real rows needs an access class the matrix does not have: every `Access` variant resolves to a company-scoped or admin verdict, and `PlatformScope` is neither. That is a follow-up. This assertion stops the hole being silent in the meantime — a ninth provisioning route, or a fix granting any of these four a row, fails the check rather than joining a set nobody counts.

Red-proved by adding `/pause` to the named set: `provisioning paths no principal probes set drifted; missing=["/api/v1/companies/{id}/pause"]`. Reverted, 8 passed.

## Documentation

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened route-authority validation to ensure all provisioning paths and supported HTTP methods are explicitly accounted for.
  * Added coverage for routes that support multiple HTTP methods, improving detection of incomplete authority mappings.
* **Chores**
  * Added an automated CI check that runs route-authority validation during gated builds, helping prevent routing authorization gaps from reaching release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->