### PR TITLE
feat(policy): measure what a consequence floor would stop (shadow only, decides nothing)

### DIFF
--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -1811,8 +1811,8 @@ const MAX_BLOCKING_THREADS: usize = 512;
 /// The log filter used when `RUST_LOG` says nothing.
 ///
 /// The bare `error` is exactly what `EnvFilter::from_default_env()` fell back to,
-/// so no target in this binary becomes chattier than it was. The one added
-/// directive is the exception the default cannot express, and it is not cosmetic.
+/// so no target in this binary becomes chattier than it was. Each added
+/// directive is an exception the default cannot express, and neither is cosmetic.
 ///
 /// `tinyagents::observability` is the target the vendored durable-append writer
 /// (`AppendWorker`, in
@@ -1834,9 +1834,17 @@ const MAX_BLOCKING_THREADS: usize = 512;
 /// is `pub(crate)` in tinyagents and cannot be read from here, so the subscriber
 /// is the only channel we have (see `docs/spec/runtime/workspace-layout.md`).
 ///
+/// `policy::shadow_floor` is the target the consequence-floor shadow reader
+/// (`ApprovalPolicy::record_shadow_floor`, `src/harness/built_in/policy.rs`,
+/// issue #2147) reports on. It emits `info!`, one line per call the floor would
+/// have stopped, and that line is the entire measurement: no container image,
+/// compose file or deploy workflow sets `RUST_LOG` either, so a bare `error`
+/// filter would run the whole staging measurement and record nothing — the same
+/// shape as the durable-append gap above, one level quieter.
+///
 /// Setting `RUST_LOG` replaces this string wholesale — the operator keeps full
 /// control, and behaviour with `RUST_LOG` set is unchanged.
-const DEFAULT_LOG_FILTER: &str = "error,tinyagents::observability=warn";
+const DEFAULT_LOG_FILTER: &str = "error,tinyagents::observability=warn,policy::shadow_floor=info";
 
 fn main() -> Result<()> {
     tokio::runtime::Builder::new_multi_thread()
@@ -3149,6 +3157,48 @@ mod test {
         assert!(
             !seen("tinyagents::observability", tracing::Level::INFO),
             "the exception stops at `warn`; captured {events:?}"
+        );
+    }
+
+    /// Issue #2147: the consequence-floor shadow reader's whole output is one
+    /// `info!` per call it would have stopped. Without a named exception a
+    /// bare `error` filter drops every line of it, so a week of staging
+    /// traffic measures nothing and nobody notices — the same failure mode
+    /// `the_default_filter_passes_durable_append_warnings_and_still_drops_other_ones`
+    /// pins for the durable-append worker, one level quieter. Revert the
+    /// `policy::shadow_floor=info` directive and this fails.
+    #[test]
+    fn the_default_filter_passes_the_shadow_floor_measurement() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry()
+            .with(Captured(std::sync::Arc::clone(&captured)))
+            .with(log_filter(None));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(
+                target: "policy::shadow_floor",
+                "[policy:shadow-floor] agent=- tool='gmail_send_email' would_stop=irreversible_send \
+                 mode=Auto hitl=false issue=2147"
+            );
+            // An unrelated `info!` stays dropped: this is one named target,
+            // not a global level bump.
+            tracing::info!(target: "opencompany::unrelated", "ordinary chatter");
+        });
+
+        let events = captured.lock().expect("capture lock").clone();
+        let seen = |target: &str, level: tracing::Level| {
+            events.iter().any(|(t, l)| t == target && *l == level)
+        };
+
+        assert!(
+            seen("policy::shadow_floor", tracing::Level::INFO),
+            "the shadow-floor measurement must survive the default filter; captured {events:?}"
+        );
+        assert!(
+            !seen("opencompany::unrelated", tracing::Level::INFO),
+            "the exception is one target, not a global level bump; captured {events:?}"
         );
     }
 

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -1306,6 +1306,53 @@ impl ApprovalPolicy {
     /// **untouched at cap**. A spend cap caps spend; making a teammate unable to
     /// answer a question because it spent its budget this morning would be a
     /// different feature, and a worse one.
+    /// Record what a consequence floor would have done with this call, and
+    /// change nothing (issue #2147).
+    ///
+    /// Epic #1817 asks for outward, irreversible acts — publish, send, sign,
+    /// hire, identity, spend that leaves — to reach a person whatever tier the
+    /// company runs. Since #1925 nothing does: the bypass immediately below
+    /// this call site allows every classification-derived decision. Whether to
+    /// re-introduce a stop is a product question, and the honest input to it is
+    /// how often such a stop would actually fire on live traffic — a
+    /// taxonomically narrow floor can still be practically wide.
+    ///
+    /// So this emits one line per call the floor would have stopped, tagged
+    /// with the reason, the tier, and whether HITL was on at the time. Silent
+    /// calls emit nothing: the denominator is the tool-call trace the runs
+    /// already record, and logging every allowed call to count it would bury
+    /// the signal it exists to produce.
+    ///
+    /// [`floor::deferred_group`] is reported on its own axis so #658's
+    /// `publish_artifact` carve-out can be revisited with a number instead of
+    /// two opinions — it is counted, never folded into the floor's own count.
+    fn record_shadow_floor(&self, tool: &str, args: &serde_json::Value) {
+        // The per-call allowance, which is the cap a single call is measured
+        // against. The daily budget is a different question and has its own arm.
+        let verdict = crate::policy::floor::evaluate(tool, args, self.auto_approve_under_usd);
+        if verdict.requires_human() {
+            log::info!(
+                "[policy:shadow-floor] agent={} tool='{}' would_stop={} mode={:?} hitl={} issue=2147",
+                self.agent.as_deref().unwrap_or("-"),
+                tool,
+                verdict.reason_word(),
+                self.mode,
+                self.policy_hitl_enabled,
+            );
+        }
+        if let Some(group) = crate::policy::floor::deferred_group(tool, args) {
+            log::info!(
+                "[policy:shadow-floor] agent={} tool='{}' deferred_group={:?} mode={:?} hitl={} \
+                 issue=2147",
+                self.agent.as_deref().unwrap_or("-"),
+                tool,
+                group,
+                self.mode,
+                self.policy_hitl_enabled,
+            );
+        }
+    }
+
     fn is_priced_call(tool: &str, args: &serde_json::Value, declared_amount: Option<f64>) -> bool {
         declared_amount.is_some() || classify_group(tool, args) == EffectGroup::Spend
     }
@@ -1693,6 +1740,19 @@ impl ToolPolicy for ApprovalPolicy {
                 format!("'{tool}' explicitly stages a paid media generation for approval"),
             );
         }
+
+        // Shadow measurement for issue #2147 — reads, records, decides nothing.
+        //
+        // Immediately ABOVE the bypass because that is the position the
+        // consequence floor epic #1817 proposes for a real arm, and a
+        // measurement taken anywhere else would be measuring a different
+        // question. Everything above has already returned for the calls it owns
+        // — a hard deny, a redeemed grant, a paid-media card — so what reaches
+        // here is exactly the population a floor would decide.
+        //
+        // It must stay incapable of changing an outcome: no early return, no
+        // mutation, no queue write. The only observable is a log line.
+        self.record_shadow_floor(tool, &request.arguments);
 
         // General approvals come only from `request_approval`; specialized
         // approval-producing tools such as paid media stage themselves above.
@@ -2127,6 +2187,64 @@ mod tests {
             .await,
             ToolPolicyDecision::Allow
         );
+    }
+
+    /// The shadow floor observes; it never decides (issue #2147).
+    ///
+    /// Every tool below is one the consequence floor names — a send, a launch,
+    /// an identity change, a call carrying money. With policy HITL disabled,
+    /// which is the production build, all of them must still be allowed. A
+    /// failure here means the measurement grew teeth, which is the one way this
+    /// instrumentation could do harm.
+    #[tokio::test]
+    async fn the_shadow_floor_decides_nothing_with_hitl_disabled() {
+        for mode in ["auto", "supervised", "full"] {
+            let p = policy(mode, &[], None).with_policy_hitl_disabled();
+            for (tool, args) in [
+                ("chargebee_send_invoice", serde_json::json!({})),
+                ("hosting_launch_site", serde_json::json!({})),
+                ("composio_authorize", serde_json::json!({})),
+                ("publish_artifact", serde_json::json!({})),
+                ("file_write", serde_json::json!({ "amount_usd": 500.0 })),
+                (
+                    "composio_execute",
+                    serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" }),
+                ),
+            ] {
+                assert_eq!(
+                    p.check(&request(tool, args)).await,
+                    ToolPolicyDecision::Allow,
+                    "{tool} under {mode}: the shadow floor must observe, not gate"
+                );
+            }
+        }
+    }
+
+    /// The floor's own reading of a call agrees with what the tier does with it
+    /// while HITL is on.
+    ///
+    /// Not a tautology: it pins that the population the shadow counts is the
+    /// population a real floor arm would decide. If a later change moved the
+    /// shadow call site above a hard deny or below the tier, this is what
+    /// notices — the count would silently start describing a different
+    /// question, which is the failure mode a measurement cannot self-report.
+    #[tokio::test]
+    async fn what_the_shadow_counts_is_what_full_autonomy_already_stops() {
+        let p = policy("full", &[], None);
+        for tool in ["chargebee_send_invoice", "hosting_launch_site"] {
+            let args = serde_json::json!({});
+            assert!(
+                crate::policy::floor::evaluate(tool, &args, None).requires_human(),
+                "{tool} is a floor call"
+            );
+            assert!(
+                matches!(
+                    p.check(&request(tool, args)).await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "{tool} is stopped by the judgement arm under full autonomy today"
+            );
+        }
     }
 
     /// Every tier is reachable from a manifest, parses to its own variant, and

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -1326,12 +1326,22 @@ impl ApprovalPolicy {
     /// [`floor::deferred_group`] is reported on its own axis so #658's
     /// `publish_artifact` carve-out can be revisited with a number instead of
     /// two opinions — it is counted, never folded into the floor's own count.
+    ///
+    /// Emitted through `tracing`, at the `policy::shadow_floor` target
+    /// `DEFAULT_LOG_FILTER` (`src/bin/opencompany.rs`) names explicitly. The
+    /// binary's default filter is bare `error`, and no container image,
+    /// compose file or deploy workflow sets `RUST_LOG` — the same shape issue
+    /// #450 already found once for the durable-append worker's `warn!` lines.
+    /// An `info!` with no matching exception is exactly as silent as those
+    /// were: a week of staging traffic would produce this measurement's
+    /// entire denominator and record none of it.
     fn record_shadow_floor(&self, tool: &str, args: &serde_json::Value) {
         // The per-call allowance, which is the cap a single call is measured
         // against. The daily budget is a different question and has its own arm.
         let verdict = crate::policy::floor::evaluate(tool, args, self.auto_approve_under_usd);
         if verdict.requires_human() {
-            log::info!(
+            tracing::info!(
+                target: "policy::shadow_floor",
                 "[policy:shadow-floor] agent={} tool='{}' would_stop={} mode={:?} hitl={} issue=2147",
                 self.agent.as_deref().unwrap_or("-"),
                 tool,
@@ -1341,7 +1351,8 @@ impl ApprovalPolicy {
             );
         }
         if let Some(group) = crate::policy::floor::deferred_group(tool, args) {
-            log::info!(
+            tracing::info!(
+                target: "policy::shadow_floor",
                 "[policy:shadow-floor] agent={} tool='{}' deferred_group={:?} mode={:?} hitl={} \
                  issue=2147",
                 self.agent.as_deref().unwrap_or("-"),

--- a/src/policy/floor.rs
+++ b/src/policy/floor.rs
@@ -51,6 +51,13 @@ use crate::ports::types::EffectGroup;
 /// money arm moved here with it.
 pub const AMOUNT_KEY: &str = "amount_usd";
 
+/// The alias [`AMOUNT_KEY`] accepts. `ApprovalPolicy::amount_usd`
+/// (`src/harness/built_in/policy.rs`) reads both `amount_usd` and `amount`,
+/// so [`declared_amount_usd`] has to as well — reading only [`AMOUNT_KEY`]
+/// would undercount every `amount`-only call the shadow measurement exists to
+/// count.
+const AMOUNT_KEY_ALIAS: &str = "amount";
+
 /// Tools withheld from the consequence rule by an explicit product ruling.
 ///
 /// `publish_artifact` publishes into the company's own shared workspace, which
@@ -203,10 +210,14 @@ pub fn evaluate_consequence(
 
 /// The dollar amount this call declares, when it declares a positive one.
 ///
+/// Reads [`AMOUNT_KEY`] first and [`AMOUNT_KEY_ALIAS`] second, same order and
+/// same two keys as `ApprovalPolicy::amount_usd`.
+///
 /// Zero and negative are not "money leaving": a zero-amount call moves nothing,
 /// and a negative one is a refund shape this layer has no business guessing at.
 pub fn declared_amount_usd(args: &Value) -> Option<f64> {
     args.get(AMOUNT_KEY)
+        .or_else(|| args.get(AMOUNT_KEY_ALIAS))
         .and_then(Value::as_f64)
         .filter(|amount| *amount > 0.0)
 }
@@ -348,6 +359,29 @@ mod tests {
             evaluate("file_write", &json!({ AMOUNT_KEY: 0.01 }), None),
             FloorVerdict::MoneyLeaves,
             "this is the caller judge passes, and it must keep judge's answer"
+        );
+    }
+
+    /// `ApprovalPolicy::amount_usd` (`src/harness/built_in/policy.rs`) reads
+    /// both `amount_usd` and `amount`; this reader has to recognise the same
+    /// two keys or the shadow measurement undercounts every call that
+    /// declares money under the alias.
+    #[test]
+    fn the_amount_alias_is_read_too() {
+        assert_eq!(
+            declared_amount_usd(&json!({ "amount": 12.5 })),
+            Some(12.5),
+            "amount is the alias ApprovalPolicy::amount_usd also accepts"
+        );
+        assert_eq!(
+            declared_amount_usd(&json!({ AMOUNT_KEY: 5.0, "amount": 99.0 })),
+            Some(5.0),
+            "amount_usd outranks amount when a call declares both"
+        );
+        assert_eq!(
+            evaluate("file_write", &json!({ "amount": 0.01 }), None),
+            FloorVerdict::MoneyLeaves,
+            "evaluate must see money declared under the alias too"
         );
     }
 

--- a/src/policy/floor.rs
+++ b/src/policy/floor.rs
@@ -258,7 +258,16 @@ mod tests {
         );
     }
 
+    /// A Composio call is classified from its action, and the curated
+    /// catalogue that does the classifying is compiled only under `openhuman`.
+    ///
+    /// Both builds are pinned, in separate tests, because the difference is a
+    /// deliberate seam rather than an accident: without the catalogue every
+    /// action is read as a send, which is the cautious direction and the answer
+    /// a default build must keep giving. Asserting only the catalogued answer
+    /// is what made this test green locally and red on the `tinyplace` lane.
     #[test]
+    #[cfg(feature = "openhuman")]
     fn a_composio_read_is_silent_and_a_composio_send_is_not() {
         assert_eq!(
             evaluate(
@@ -277,6 +286,28 @@ mod tests {
             .requires_human(),
             "sending mail from the company's account is the archetype of a commitment"
         );
+    }
+
+    /// Without the curated catalogue there is nothing to tell a read from a
+    /// send, so every Composio action is a send — including the read.
+    ///
+    /// Pinned rather than tolerated: this is the build a self-hoster gets, and
+    /// "the floor is stricter where it can see less" has to be a stated
+    /// property, not an artefact nobody checked.
+    #[test]
+    #[cfg(not(feature = "openhuman"))]
+    fn without_the_catalogue_every_composio_action_is_a_commitment() {
+        for slug in ["GITHUB_LIST_REPOSITORY_ISSUES", "GMAIL_SEND_EMAIL"] {
+            assert!(
+                evaluate(
+                    crate::policy::consequence::COMPOSIO_EXECUTE,
+                    &composio_args(slug),
+                    None,
+                )
+                .requires_human(),
+                "{slug}: with no catalogue compiled in, cautious is the only honest answer"
+            );
+        }
     }
 
     #[test]

--- a/src/policy/floor.rs
+++ b/src/policy/floor.rs
@@ -1,0 +1,353 @@
+//! The consequence floor: which calls commit the company, and would stop for a
+//! human whatever tier the company runs (issue #2147, epic #1817).
+//!
+//! ## What this module is for
+//!
+//! Since #1925 no policy classification creates an approval request in
+//! production: [`ApprovalPolicy::check`](crate::harness::policy::ApprovalPolicy)
+//! returns `Allow` before `always_approve`, the daily cap, the tier dispatch and
+//! [`judge`](crate::policy::judge), and the roster build disables policy HITL on
+//! both the tool path and the native-effect gate. Whether an outward,
+//! irreversible act reaches a person is therefore decided by the agent choosing
+//! to call `request_approval`.
+//!
+//! Epic #1817 asks for that decision to be enforced again, on **consequence**
+//! rather than on which tool was reached for. Before proposing to enforce
+//! anything, #2147 measures: this module owns the predicate, and a shadow
+//! reader records what it *would* have stopped without changing any decision.
+//!
+//! ## One implementation, not two
+//!
+//! The predicate is not new behaviour invented here — it is the pair of
+//! consequence arms [`judge`] already applies, lifted out so the shadow reader
+//! and `judge` cannot drift. [`always_approve`](crate::policy::always_approve)
+//! exists because that drift already happened once (#684: one operator list,
+//! two matchers, two answers). `judge` calls [`evaluate`] with no cap, which is
+//! exactly its previous behaviour; the shadow reader calls it with the
+//! company's cap.
+//!
+//! ## What the floor deliberately does not cover
+//!
+//! `judge`'s other two arms — an undeclared tool, and a declared tool whose
+//! reach is unbounded — stop on *mechanism*: `shell` stops for `ls`, and a tool
+//! stops for being unrecognised. That is the interruption #1925 removed, and
+//! re-proposing it under a new name would earn the same rejection. They stay in
+//! `judge` and are not part of the floor.
+//!
+//! [`DEFERRED`] is likewise honoured rather than quietly reversed: #658 ruled
+//! that a `full` company publishes its own artifact unattended. A shadow reader
+//! that silently counted it would be measuring a rule nobody has agreed to, so
+//! [`deferred_group`] reports it on its own axis instead — the cost of that
+//! carve-out becomes visible without this module pre-judging it.
+
+use serde_json::Value;
+
+use crate::policy::consequence::{Reach, consequence_of, declared_tools};
+use crate::ports::types::EffectGroup;
+
+/// The argument key a call declares a dollar amount under.
+///
+/// The same key [`judge`](crate::policy::judge) reads. Kept here because the
+/// money arm moved here with it.
+pub const AMOUNT_KEY: &str = "amount_usd";
+
+/// Tools withheld from the consequence rule by an explicit product ruling.
+///
+/// `publish_artifact` publishes into the company's own shared workspace, which
+/// #658 ruled is not an outward commitment: the artifact chain versions it and
+/// the company can undo it alone. The floor does not silently overturn that —
+/// see [`deferred_group`] for how it is measured instead.
+pub const DEFERRED: &[&str] = &["publish_artifact"];
+
+/// Is this tool withheld from the consequence rule by [`DEFERRED`]?
+pub fn is_deferred(tool: &str) -> bool {
+    DEFERRED.contains(&tool.to_ascii_lowercase().as_str())
+}
+
+/// What the floor says about one call.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FloorVerdict {
+    /// Nothing about this call commits the company.
+    Silent,
+    /// The call's declared consequence class is one the company cannot take
+    /// back: a publish, a send, a signature, a hire, an identity change, or a
+    /// spend that leaves.
+    Irreversible(EffectGroup),
+    /// The call carries a dollar amount at or above the cap in force — or any
+    /// amount at all, when no cap is set.
+    MoneyLeaves,
+}
+
+impl FloorVerdict {
+    /// Would this call stop for a human?
+    pub fn requires_human(self) -> bool {
+        !matches!(self, Self::Silent)
+    }
+
+    /// A short, stable word for logs and counters.
+    ///
+    /// Stable because a shadow measurement is aggregated across a week of a
+    /// staging tenant's logs: renaming these mid-run splits one count into two.
+    pub fn reason_word(self) -> &'static str {
+        match self {
+            Self::Silent => "silent",
+            Self::Irreversible(EffectGroup::Spend) => "irreversible_spend",
+            Self::Irreversible(EffectGroup::Send) => "irreversible_send",
+            Self::Irreversible(EffectGroup::Sign) => "irreversible_sign",
+            Self::Irreversible(EffectGroup::Publish) => "irreversible_publish",
+            Self::Irreversible(EffectGroup::Hire) => "irreversible_hire",
+            Self::Irreversible(EffectGroup::Identity) => "irreversible_identity",
+            Self::Irreversible(EffectGroup::Other) => "irreversible_other",
+            Self::MoneyLeaves => "money_leaves",
+        }
+    }
+}
+
+/// Does this consequence class commit the company in a way it cannot take back?
+pub fn is_irreversible_group(group: EffectGroup) -> bool {
+    match group {
+        EffectGroup::Spend
+        | EffectGroup::Send
+        | EffectGroup::Sign
+        | EffectGroup::Publish
+        | EffectGroup::Hire
+        | EffectGroup::Identity => true,
+        EffectGroup::Other => false,
+    }
+}
+
+/// The consequence class a [`DEFERRED`] tool would have carried, or `None` for
+/// every other tool.
+///
+/// The measurement axis for #658's carve-out. `judge` and [`evaluate`] both
+/// stay silent on these tools; this reports what the silence is costing, so the
+/// question "should a publish be human?" is answered with a number rather than
+/// with two opinions.
+pub fn deferred_group(tool: &str, args: &Value) -> Option<EffectGroup> {
+    let name = tool.to_ascii_lowercase();
+    if !DEFERRED.contains(&name.as_str()) {
+        return None;
+    }
+    let consequence = consequence_of(tool, args);
+    is_irreversible_group(consequence.group).then_some(consequence.group)
+}
+
+/// Whether one call commits the company.
+///
+/// `cap_usd` is the spend the company allows without asking. `None` means no
+/// cap is configured, and then **any** declared amount is a stop — which is
+/// both the cautious reading and the behaviour
+/// [`judge`](crate::policy::judge) has always had, since it is the caller that
+/// passes `None`.
+///
+/// Pure, total and deterministic, for the reason `judge` is: a stop has to be
+/// explainable from the trace long after the run.
+pub fn evaluate(tool: &str, args: &Value, cap_usd: Option<f64>) -> FloorVerdict {
+    let name = tool.to_ascii_lowercase();
+    if is_deferred(&name) {
+        return FloorVerdict::Silent;
+    }
+
+    let consequence = consequence_of(tool, args);
+    let declared = declared_tools().any(|d| d == name);
+
+    // Declared, named as a consequence class, and this call actually has one.
+    //
+    // Both halves are load-bearing, and the pairing is not obvious — the same
+    // reasoning `judge` records. The group names *what kind* of consequence a
+    // tool has; the reach says whether this call has one at all. `web_search`
+    // and the media tools declare `Spend` because the backend bills per
+    // request, but their reach is `Money`: nothing leaves and nothing changes,
+    // the money buys the call itself. Stopping on the group alone parks every
+    // search, and an agent with no search invents citations. The daily cap is
+    // the boundary for that spend.
+    //
+    // Restricted to declared tools for the same reason: an undeclared tool is
+    // given a group by matching words in its name, a fallback that exists to
+    // label a card rather than to decide one.
+    if declared
+        && is_irreversible_group(consequence.group)
+        && consequence.reach == Reach::Consequence
+    {
+        return FloorVerdict::Irreversible(consequence.group);
+    }
+
+    // Then the arguments of this actual call: a tool the table calls
+    // unclassified can still be carrying money.
+    if let Some(amount) = declared_amount_usd(args)
+        && cap_usd.is_none_or(|cap| amount >= cap)
+    {
+        return FloorVerdict::MoneyLeaves;
+    }
+
+    FloorVerdict::Silent
+}
+
+/// The dollar amount this call declares, when it declares a positive one.
+///
+/// Zero and negative are not "money leaving": a zero-amount call moves nothing,
+/// and a negative one is a refund shape this layer has no business guessing at.
+pub fn declared_amount_usd(args: &Value) -> Option<f64> {
+    args.get(AMOUNT_KEY)
+        .and_then(Value::as_f64)
+        .filter(|amount| *amount > 0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::consequence::{Consequence, Standing};
+    use crate::policy::test_support::composio_args;
+    use serde_json::json;
+
+    fn verdict(tool: &str) -> FloorVerdict {
+        evaluate(tool, &json!({}), None)
+    }
+
+    #[test]
+    fn the_floor_stops_every_irreversible_declared_class() {
+        for tool in [
+            "chargebee_send_invoice",
+            "hosting_launch_site",
+            "composio_authorize",
+        ] {
+            assert!(
+                verdict(tool).requires_human(),
+                "{tool} commits the company and must reach a person"
+            );
+        }
+    }
+
+    /// The maintainer-facing proof that this is not what #1925 deleted.
+    ///
+    /// #1925 removed interruption keyed on which tool was reached for. Every
+    /// name below is exactly that shape — a tool whose *mechanism* is broad —
+    /// and the floor is silent on all of them.
+    #[test]
+    fn the_floor_is_silent_on_mechanism_alone() {
+        for tool in [
+            "shell",
+            "curl",
+            "http_request",
+            "git_operations",
+            "workspace_write",
+        ] {
+            assert_eq!(
+                verdict(tool),
+                FloorVerdict::Silent,
+                "{tool} is broad in mechanism, not a commitment — the floor must not speak"
+            );
+        }
+    }
+
+    #[test]
+    fn an_undeclared_tool_is_not_the_floors_business() {
+        assert_eq!(
+            evaluate("some_tool_nobody_declared", &json!({}), None),
+            FloorVerdict::Silent,
+            "fail-closed on an unknown tool is judge's mechanism arm, deliberately not the floor's"
+        );
+    }
+
+    #[test]
+    fn a_metered_read_is_not_a_commitment() {
+        assert_eq!(
+            verdict("web_search"),
+            FloorVerdict::Silent,
+            "declared Spend, but its reach is Money: the money buys the call, nothing leaves"
+        );
+    }
+
+    #[test]
+    fn a_composio_read_is_silent_and_a_composio_send_is_not() {
+        assert_eq!(
+            evaluate(
+                crate::policy::consequence::COMPOSIO_EXECUTE,
+                &composio_args("GITHUB_LIST_REPOSITORY_ISSUES"),
+                None,
+            ),
+            FloorVerdict::Silent
+        );
+        assert!(
+            evaluate(
+                crate::policy::consequence::COMPOSIO_EXECUTE,
+                &composio_args("GMAIL_SEND_EMAIL"),
+                None,
+            )
+            .requires_human(),
+            "sending mail from the company's account is the archetype of a commitment"
+        );
+    }
+
+    #[test]
+    fn an_amount_under_the_cap_does_not_stop_and_at_the_cap_does() {
+        let args = json!({ AMOUNT_KEY: 10.0 });
+        assert_eq!(
+            evaluate("file_write", &args, Some(25.0)),
+            FloorVerdict::Silent
+        );
+        assert_eq!(
+            evaluate("file_write", &args, Some(10.0)),
+            FloorVerdict::MoneyLeaves,
+            "at the cap is over the allowance, not under it"
+        );
+    }
+
+    #[test]
+    fn without_a_cap_any_declared_amount_stops() {
+        assert_eq!(
+            evaluate("file_write", &json!({ AMOUNT_KEY: 0.01 }), None),
+            FloorVerdict::MoneyLeaves,
+            "this is the caller judge passes, and it must keep judge's answer"
+        );
+    }
+
+    #[test]
+    fn the_deferred_publish_is_silent_but_countable() {
+        assert_eq!(verdict("publish_artifact"), FloorVerdict::Silent);
+        assert_eq!(
+            deferred_group("publish_artifact", &json!({})),
+            Some(EffectGroup::Publish),
+            "#658's carve-out has to be measurable, or the ruling cannot be revisited with evidence"
+        );
+        assert_eq!(deferred_group("shell", &json!({})), None);
+    }
+
+    /// The floor and the standing-grant set must not overlap.
+    ///
+    /// A grantable tool is one an operator may hand a teammate for a week
+    /// unattended. A floor tool is one that must reach a person every time.
+    /// A tool in both would mean a grant that the floor then re-parks — the
+    /// approval-never-authorises-anything failure the single-use grant arm
+    /// already argues against in `ApprovalPolicy::check`.
+    #[test]
+    fn no_declared_tool_is_both_floor_covered_and_standing_grantable() {
+        for tool in declared_tools() {
+            let Consequence { standing, .. } = consequence_of(tool, &json!({}));
+            if standing == Standing::Grantable {
+                assert_eq!(
+                    evaluate(tool, &json!({}), None),
+                    FloorVerdict::Silent,
+                    "{tool} may run unattended for a week AND commits the company — pick one"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_reason_word_is_stable_for_every_group() {
+        for group in [
+            EffectGroup::Spend,
+            EffectGroup::Send,
+            EffectGroup::Sign,
+            EffectGroup::Publish,
+            EffectGroup::Hire,
+            EffectGroup::Identity,
+            EffectGroup::Other,
+        ] {
+            assert!(!FloorVerdict::Irreversible(group).reason_word().is_empty());
+        }
+        assert_eq!(FloorVerdict::Silent.reason_word(), "silent");
+        assert_eq!(FloorVerdict::MoneyLeaves.reason_word(), "money_leaves");
+    }
+}

--- a/src/policy/floor.rs
+++ b/src/policy/floor.rs
@@ -42,7 +42,7 @@
 
 use serde_json::Value;
 
-use crate::policy::consequence::{Reach, consequence_of, declared_tools};
+use crate::policy::consequence::{Consequence, Reach, consequence_of, declared_tools};
 use crate::ports::types::EffectGroup;
 
 /// The argument key a call declares a dollar amount under.
@@ -143,12 +143,30 @@ pub fn deferred_group(tool: &str, args: &Value) -> Option<EffectGroup> {
 /// Pure, total and deterministic, for the reason `judge` is: a stop has to be
 /// explainable from the trace long after the run.
 pub fn evaluate(tool: &str, args: &Value, cap_usd: Option<f64>) -> FloorVerdict {
+    evaluate_consequence(tool, consequence_of(tool, args), args, cap_usd)
+}
+
+/// Same verdict as [`evaluate`], for a caller that has already computed the
+/// call's [`Consequence`].
+///
+/// [`judge`](crate::policy::judge) is exactly that caller: it needs its own
+/// `consequence_of` result for the fail-closed arm below this one regardless,
+/// and `consequence_of` is not free of side effect for `composio_execute` — an
+/// uncatalogued or unrecognised-toolkit slug logs a `catalogue_miss` warning
+/// each time it runs. Computing it twice per call would double that telemetry
+/// for exactly the traffic issue #754 exists to make visible, which is the
+/// wrong direction to be wrong in.
+pub fn evaluate_consequence(
+    tool: &str,
+    consequence: Consequence,
+    args: &Value,
+    cap_usd: Option<f64>,
+) -> FloorVerdict {
     let name = tool.to_ascii_lowercase();
     if is_deferred(&name) {
         return FloorVerdict::Silent;
     }
 
-    let consequence = consequence_of(tool, args);
     let declared = declared_tools().any(|d| d == name);
 
     // Declared, named as a consequence class, and this call actually has one.

--- a/src/policy/judgement.rs
+++ b/src/policy/judgement.rs
@@ -831,14 +831,14 @@ mod tests {
         );
     }
 
-    /// Review finding on PR #2152: `judge` computes `consequence_of` for its
-    /// own fail-closed arm and then, before this fix, `floor::evaluate`
-    /// computed it again — for an uncatalogued `composio_execute` slug that
-    /// runs `consequence_of` a second time and doubles the `catalogue_miss`
-    /// warning it logs (issues #754, #1818). Counts every `WARN` emitted by
-    /// one `judge` call rather than reading a captured field: under this
-    /// fixture the only `WARN` either run produces is that one line, so a
-    /// count of 2 is the regression and 1 is the fix.
+    /// `judge` computes `consequence_of` once for its own fail-closed arm and
+    /// must not ask `floor::evaluate` to compute it a second time — for an
+    /// uncatalogued `composio_execute` slug that call is not free of side
+    /// effect, and running it twice doubles the `catalogue_miss` warning it
+    /// logs (issues #754, #1818). Counts every `WARN` emitted by one `judge`
+    /// call rather than reading a captured field: under this fixture the
+    /// only `WARN` either run produces is that one line, so a count of 2 is
+    /// the regression and 1 is the fix.
     ///
     /// `openhuman`-gated: the catalogue-miss path only exists once a catalogue
     /// is linked in to miss against — see `CatalogLookup::CatalogueAbsent`.

--- a/src/policy/judgement.rs
+++ b/src/policy/judgement.rs
@@ -454,11 +454,16 @@ pub fn judge(tool: &str, args: &Value, path: CallPath) -> Judgement {
     // the caller that has one, and this one does not — `auto_approve_under_usd`
     // and the daily budget have both already spoken above.
     //
+    // `evaluate_consequence`, not `evaluate`: `consequence` above is already
+    // this call's answer, and `evaluate` would compute it a second time —
+    // doubling the `catalogue_miss` warning an uncatalogued `composio_execute`
+    // logs on every `consequence_of` call.
+    //
     // The two arms below stay here on purpose. They stop on *mechanism* — a
     // tool nobody declared, or one whose reach cannot be bounded — which is a
     // different question from whether the call commits the company, and one the
     // floor deliberately does not ask.
-    match floor::evaluate(tool, args, None) {
+    match floor::evaluate_consequence(tool, consequence, args, None) {
         floor::FloorVerdict::Irreversible(group) => {
             return Judgement::Stop(StopReason::Irreversible(group));
         }
@@ -823,6 +828,51 @@ mod tests {
         assert_eq!(
             judge_agent("composio_execute", &args),
             Judgement::Stop(StopReason::Irreversible(EffectGroup::Send))
+        );
+    }
+
+    /// Review finding on PR #2152: `judge` computes `consequence_of` for its
+    /// own fail-closed arm and then, before this fix, `floor::evaluate`
+    /// computed it again — for an uncatalogued `composio_execute` slug that
+    /// runs `consequence_of` a second time and doubles the `catalogue_miss`
+    /// warning it logs (issues #754, #1818). Counts every `WARN` emitted by
+    /// one `judge` call rather than reading a captured field: under this
+    /// fixture the only `WARN` either run produces is that one line, so a
+    /// count of 2 is the regression and 1 is the fix.
+    ///
+    /// `openhuman`-gated: the catalogue-miss path only exists once a catalogue
+    /// is linked in to miss against — see `CatalogLookup::CatalogueAbsent`.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn an_uncatalogued_composio_call_logs_the_catalogue_miss_once_not_twice() {
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::layer::SubscriberExt;
+
+        struct CountWarnings(Arc<Mutex<usize>>);
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CountWarnings {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                if *event.metadata().level() == tracing::Level::WARN {
+                    *self.0.lock().expect("count lock") += 1;
+                }
+            }
+        }
+
+        let warnings = Arc::new(Mutex::new(0usize));
+        let subscriber = tracing_subscriber::registry().with(CountWarnings(Arc::clone(&warnings)));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let args = json!({ "tool": "SOME_TOOLKIT_ACTION_NOBODY_CLASSIFIED" });
+            judge_agent("composio_execute", &args);
+        });
+
+        assert_eq!(
+            *warnings.lock().expect("count lock"),
+            1,
+            "consequence_of must run once per judge call, not twice"
         );
     }
 

--- a/src/policy/judgement.rs
+++ b/src/policy/judgement.rs
@@ -147,6 +147,7 @@
 use serde_json::Value;
 
 use crate::policy::consequence::{Consequence, Reach, consequence_of, declared_tools};
+use crate::policy::floor;
 use crate::ports::types::EffectGroup;
 
 /// Why a call stopped, in the operator's terms.
@@ -245,17 +246,10 @@ impl Judgement {
 /// rather than a "harmless" one — it is where a tool lands when the classifier
 /// found no particular consequence to name — so it is decided by reach below
 /// instead of being waved through here.
-fn is_irreversible_group(group: EffectGroup) -> bool {
-    match group {
-        EffectGroup::Spend
-        | EffectGroup::Send
-        | EffectGroup::Sign
-        | EffectGroup::Publish
-        | EffectGroup::Hire
-        | EffectGroup::Identity => true,
-        EffectGroup::Other => false,
-    }
-}
+///
+/// Lives in [`crate::policy::floor`] with the rest of the consequence rule, and
+/// is re-exported here so this module's own tests keep reading one definition.
+pub use crate::policy::floor::is_irreversible_group;
 
 /// The tools whose reach this layer cannot bound: arbitrary code, an arbitrary
 /// address, or a saved workflow that performs whatever it performs.
@@ -346,10 +340,7 @@ fn is_unbounded(tool: &str, consequence: Consequence) -> bool {
 /// authored-node path and by #338 on the agent path — which is a scoping of the
 /// rule, not an exclusion from it, so it is expressed by [`CallPath`] rather
 /// than here. See the module docs.
-const DEFERRED: &[&str] = &[
-    // Issue #658 — see the note above. Ruled, not pending.
-    "publish_artifact",
-];
+pub use crate::policy::floor::DEFERRED;
 
 /// The prefix tinyflows gives an expression bound at run time.
 ///
@@ -407,21 +398,14 @@ fn any_argument_is_templated(args: &Value) -> bool {
     }
 }
 
-/// The argument key a declared amount of money arrives under.
+/// The argument key a declared amount of money arrives under, and the reader
+/// for it.
 ///
-/// Mirrors the harness policy's own reader, which is where the spend arms
-/// already look. Kept in sync by `amount_key_matches_the_harness_reader`.
-const AMOUNT_KEY: &str = "amount_usd";
-
-/// Money named in the arguments, when it is a positive number.
-///
-/// Zero and negative are not "money leaving": a zero-amount call moves nothing,
-/// and a negative one is a refund shape this layer has no business guessing at.
-fn declared_amount_usd(args: &Value) -> Option<f64> {
-    args.get(AMOUNT_KEY)
-        .and_then(Value::as_f64)
-        .filter(|amount| *amount > 0.0)
-}
+/// Both moved to [`crate::policy::floor`] with the money arm they serve, and
+/// are re-exported so this module's tests keep reading one definition. The key
+/// mirrors the harness policy's own reader, which is where the spend arms
+/// already look; `amount_key_matches_the_harness_reader` keeps them in sync.
+pub use crate::policy::floor::{AMOUNT_KEY, declared_amount_usd};
 
 /// Should this call stop for a human on its own merits?
 ///
@@ -455,43 +439,31 @@ pub fn judge(tool: &str, args: &Value, path: CallPath) -> Judgement {
 
     // Carved out on both paths — see `DEFERRED` and issue #658. Ahead of every
     // rule, so none of them can reach it and so the exclusion is impossible to
-    // miss.
-    if DEFERRED.contains(&name.as_str()) {
+    // miss. It stays here as well as inside the floor because the two arms
+    // below are this module's own: a deferred tool must clear the mechanism
+    // rules too, and the floor does not own those.
+    if floor::is_deferred(&name) {
         return Judgement::Silent;
     }
 
-    // Declared first: a named consequence class is the honest answer and the
-    // one the operator's card already shows.
+    // The consequence arms live in
+    // [`crate::policy::floor`] — the same rule the shadow measurement above the
+    // `policy_hitl_enabled` bypass reads (issue #2147). `None` for the cap is
+    // what preserves this path's answer exactly: with no cap, any declared
+    // amount stops, which is what this arm has always done. The cap belongs to
+    // the caller that has one, and this one does not — `auto_approve_under_usd`
+    // and the daily budget have both already spoken above.
     //
-    // Restricted to DECLARED tools, which is not a detail. An undeclared tool
-    // is given a group by matching words in its name — a fallback that exists
-    // to label a card, not to decide one. `write_file` contains "file" and is
-    // therefore labelled `Sign`; gating on that would stop it while telling the
-    // operator it "signs or files a document". Undeclared tools stop below, on
-    // the honest ground that nobody has said what they do.
-    //
-    // Both halves are required, and the pairing is not obvious. The group names
-    // *what kind* of consequence a tool has; the reach says whether this call
-    // actually has one. `web_search` and the `media_generate_*` tools are
-    // declared `Spend` because the backend bills per request, but their reach is
-    // `Money`: nothing changes anywhere and nothing leaves the company — the
-    // money buys the call itself. Stopping them on the group alone parked every
-    // search, which is worse than useless: openhuman resolves a
-    // `RequireApproval` inline, so a parked search is a search that never
-    // happens and an agent with no search invents citations. The per-company
-    // daily cap is the boundary for that spend, and it has already had its say
-    // above.
-    if declared
-        && is_irreversible_group(consequence.group)
-        && consequence.reach == Reach::Consequence
-    {
-        return Judgement::Stop(StopReason::Irreversible(consequence.group));
-    }
-
-    // Then the arguments of this actual call. A tool the table calls
-    // unclassified can still be carrying money.
-    if declared_amount_usd(args).is_some() {
-        return Judgement::Stop(StopReason::MoneyLeaves);
+    // The two arms below stay here on purpose. They stop on *mechanism* — a
+    // tool nobody declared, or one whose reach cannot be bounded — which is a
+    // different question from whether the call commits the company, and one the
+    // floor deliberately does not ask.
+    match floor::evaluate(tool, args, None) {
+        floor::FloorVerdict::Irreversible(group) => {
+            return Judgement::Stop(StopReason::Irreversible(group));
+        }
+        floor::FloorVerdict::MoneyLeaves => return Judgement::Stop(StopReason::MoneyLeaves),
+        floor::FloorVerdict::Silent => {}
     }
 
     // Fail closed on anything nobody declared that is not a pure read. The

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -16,6 +16,12 @@
 //! console card) while the tool policy that parks calls compiles only under the
 //! `openhuman` feature.
 
+//! The [`floor`] module owns the consequence rule itself — which calls commit
+//! the company — read by [`judgement`] and by the shadow measurement above the
+//! `policy_hitl_enabled` bypass (issue #2147). It is one implementation with
+//! two readers for the reason [`always_approve`] is: this is the second time a
+//! single approval rule has needed to be read from two places.
+//!
 //! The [`judgement`] module answers the question neither of the above asks:
 //! which calls should stop for a human *on their own merits*, in the gap the
 //! static configuration leaves (issue #338). Always compiled for the same
@@ -24,6 +30,7 @@
 
 pub mod always_approve;
 pub mod consequence;
+pub mod floor;
 pub mod gate;
 pub mod judgement;
 


### PR DESCRIPTION
## Summary

Part of #2147, part of #1817. **No decision changes.** This adds the consequence rule as a module with one implementation, and a reader above the `policy_hitl_enabled` bypass that records what a floor *would* have stopped.

#1925 made approvals explicit agent requests and disabled policy-generated HITL: `ApprovalPolicy::check` returns `Allow` before `always_approve`, the daily cap, the tier dispatch and `judge`, and the roster build applies `with_policy_hitl_disabled()` on the tool path and the native-effect gate. That removed a real problem — interruption keyed on which tool was reached for, which deadlocked auto desks on ordinary reads.

It also means nothing now enforces that an outward, irreversible act reaches a person. Epic #1817 asks for that to be enforced on **consequence** rather than mechanism. Before proposing an arm, this measures how often one would fire on live traffic — a taxonomically narrow floor can still be practically wide, and a floor that parks constantly converts into a stream of TTL default-denials rather than into oversight.

Two commits:

1. `judge`'s two consequence arms plus #658's carve-out move into `src/policy/floor.rs`; `judge` reads them. `judge` passes no cap, which preserves its answer exactly (any declared amount stops). `always_approve` exists because one approval rule read from two places drifted into two answers (#684) — this puts the consequence rule on that footing *before* it gains a second reader, rather than after.
2. The shadow reader, called immediately above the bypass. It logs and returns.

**What the floor covers**: a declared tool whose consequence class is irreversible and whose reach is `Consequence`, plus a call carrying an amount at or above the cap in force.

**What it deliberately excludes**: `judge`'s other two arms — an undeclared tool, and a declared tool whose reach cannot be bounded. Those stop on mechanism (`shell` stops for `ls`), which is precisely what #1925 removed. A test walks that list and asserts silence, so the distinction is executable rather than asserted in prose.

`publish_artifact` stays deferred per #658's ruling. It is counted on its own axis so that ruling can be revisited with a number rather than two opinions.

## API Or Behavior Changes

None. The reader takes no lock, writes no queue, and returns `()`; the call site ignores it. Placement is above the bypass so the measured population matches what an arm there would decide, and below every hard deny and grant arm so the population excludes calls those already resolved.

Verified by giving the reader teeth locally — returning `RequireApproval` on a floor verdict — which turns the new guard test red along with four existing tier tests. Reverted before commit; the failure output is what the second commit message records.

## Tests

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --features openhuman --no-deps -- -D warnings` — clean
- `cargo test --features openhuman` — 7198 passed, 0 failed, 3 ignored, plus all integration targets green

New:
- `src/policy/floor.rs`: 10 unit tests — every irreversible class stops; silence on `shell` / `curl` / `http_request` / `git_operations` / `workspace_write`; silence on an undeclared tool; a metered read (`web_search`) is not a commitment; a Composio read is silent and a send is not; at the cap stops and under it does not; without a cap any amount stops (the caller `judge` passes); the deferred publish is silent but countable.
- `no_declared_tool_is_both_floor_covered_and_standing_grantable` — walks the declared table. A tool an operator may hand over unattended for a week must not also be one that has to reach a person every time; the two sets must stay disjoint by construction, not by review.
- `src/harness/built_in/policy.rs`: `the_shadow_floor_decides_nothing_with_hitl_disabled` (every floor tool, every tier, still `Allow`) and `what_the_shadow_counts_is_what_full_autonomy_already_stops` (pins that the counted population is the one an arm would decide, so a later move of the call site cannot silently change the question).

## Documentation

Module docs on `src/policy/floor.rs` carry the reasoning: why the rule is one implementation, what the floor excludes and why re-proposing mechanism stops would earn #1925's rejection again, and why the deferred publish is measured rather than reversed. `src/policy/mod.rs` gains the module in its map.

The measurement itself is the deliverable: a week of staging logs on `[policy:shadow-floor]`, aggregated per reason word, posted back to #2147 and carried into the #1817 proposal. #2147 stays open until those counts exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consequence-based policy evaluation for irreversible actions and declared monetary amounts.
  - Added spending thresholds and deferred-action classification.
  - Added non-blocking visibility into actions that would be stopped, including the reason, operating mode, human-review status, and deferred consequences.
  - Shadow policy observations are available in the default logs.

- **Reliability**
  - Confirmed monitoring does not change existing decisions or queue behavior, including when human review is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->