### PR TITLE
feat(harness): extract the answer from an oversized tool result, and make Composio tools findable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.21"
+version = "0.63.22"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "tinyconnectors-bus"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "tinymemory"
-version = "1.13.8"
+version = "1.15.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -697,11 +697,17 @@ tinyinference = { path = "vendor/openhuman/vendor/tinyagents/vendor/tinyinferenc
 # `openhuman` feature is on — so they leave the offline build unaffected.
 # tinyflows split into a workspace too; the package now lives in `crates/`.
 tinyflows = { path = "vendor/openhuman/vendor/tinyflows/crates/tinyflows" }
-tinycortex = { path = "vendor/openhuman/vendor/tinycortex" }
+# TinyCortex moved under TinyMemory at the openhuman pin: `vendor/tinycortex`
+# is no longer a submodule there, and the crate is reached through
+# `vendor/tinymemory/vendor/tinycortex` instead. A patch path is resolved
+# eagerly whatever the feature set — the same trap the `tinyplace` note below
+# records — so a stale path here fails `cargo metadata --locked` outright,
+# before any feature gate is consulted.
+tinycortex = { path = "vendor/openhuman/vendor/tinymemory/vendor/tinycortex" }
 # `tinymemory-core` consumes the TinyCortex contract by version while
 # OpenHuman consumes the implementation by path. Keep both on one checkout so
 # their public trait identities remain identical.
-tinycortex-api = { path = "vendor/openhuman/vendor/tinycortex/api" }
+tinycortex-api = { path = "vendor/openhuman/vendor/tinymemory/vendor/tinycortex/api" }
 tinychannels = { path = "vendor/openhuman/vendor/tinychannels" }
 # No `tinyplace` entry: openhuman dropped the submodule, so the path this
 # patched onto no longer exists at the pin and Cargo fails to load the source

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.21"
+version = "0.63.22"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "tinyconnectors-bus"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "tinymemory"
-version = "1.13.8"
+version = "1.15.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -168,7 +168,11 @@ tinyinference = { path = "../vendor/openhuman/vendor/tinyagents/vendor/tinyinfer
 
 [patch.crates-io]
 tinyflows = { path = "../vendor/openhuman/vendor/tinyflows/crates/tinyflows" }
-tinycortex = { path = "../vendor/openhuman/vendor/tinycortex" }
-tinycortex-api = { path = "../vendor/openhuman/vendor/tinycortex/api" }
+# TinyCortex moved under TinyMemory at the openhuman pin — see the note on the
+# same two entries in the root manifest. Both worlds patch it and both had the
+# stale path; fixing only the root left the Desktop lane failing with the same
+# eager-path-resolution error.
+tinycortex = { path = "../vendor/openhuman/vendor/tinymemory/vendor/tinycortex" }
+tinycortex-api = { path = "../vendor/openhuman/vendor/tinymemory/vendor/tinycortex/api" }
 tinychannels = { path = "../vendor/openhuman/vendor/tinychannels" }
 motosan-ai-oauth = { path = "../vendor/openhuman/vendor/motosan-ai-oauth" }

--- a/src/analytics/types.rs
+++ b/src/analytics/types.rs
@@ -307,6 +307,7 @@ pub fn sample_kind_slug(kind: SampleKind) -> &'static str {
         SampleKind::AuthoringCall => "authoring-call",
         SampleKind::SelectorCall => "selector-call",
         SampleKind::TitleCall => "title-call",
+        SampleKind::ExtractionCall => "extraction-call",
     }
 }
 

--- a/src/harness/built_in/build.rs
+++ b/src/harness/built_in/build.rs
@@ -1213,7 +1213,7 @@ pub fn build_agent(
         // bounded model call — built `from_deps` like every other one-shot pass
         // here, so it spends the company's own credential and meters against it.
         .payload_summarizer(std::sync::Arc::new(
-            crate::harness::payload_extract::PayloadExtractor::from_deps(deps),
+            crate::harness::payload_extract::PayloadExtractor::from_deps(deps, company),
         ))
         .model_name(model)
         .workspace_dir(workspace)

--- a/src/harness/built_in/build.rs
+++ b/src/harness/built_in/build.rs
@@ -1195,6 +1195,26 @@ pub fn build_agent(
             tool_result_budget_bytes: TOOL_RESULT_BUDGET_BYTES,
             ..Default::default()
         })
+        // Issue #6014: extract the answering content from an oversized tool
+        // result instead of cutting it on a byte boundary.
+        //
+        // `ContextConfig` has carried the threshold this fires at
+        // (`summarizer_payload_threshold_tokens`, 4000) since before this crate
+        // existed, and `ToolOutputMiddleware` has consulted it on every tool
+        // result — but the builder defaults the summarizer itself to `None`, so
+        // the whole path was inert here and the byte cut was the only thing
+        // bounding a large payload. That cut keeps whatever came first: a
+        // thirty-issue listing reached the model as two issues, and the agent
+        // reported two.
+        //
+        // The upstream implementation dispatches a sub-agent, which this crate
+        // cannot use (see `toolbelt`'s v1 note on spawn tools under
+        // multi-tenancy), so `PayloadExtractor` serves the same trait with one
+        // bounded model call — built `from_deps` like every other one-shot pass
+        // here, so it spends the company's own credential and meters against it.
+        .payload_summarizer(std::sync::Arc::new(
+            crate::harness::payload_extract::PayloadExtractor::from_deps(deps),
+        ))
         .model_name(model)
         .workspace_dir(workspace)
         .agent_definition_name(agent_definition_name)

--- a/src/harness/built_in/composio.rs
+++ b/src/harness/built_in/composio.rs
@@ -1612,7 +1612,12 @@ mod live {
             // string over name/slug/description.
             let search_term = request.search.join(" ");
             let search = Some(search_term.as_str()).filter(|term| !term.trim().is_empty());
-            match client.list_tools(query, None, search).await {
+            // The parsed tags, not `None`: without this the tag narrowing added
+            // to the BYOK route was unreachable from the agent tool that is
+            // supposed to use it (CodeRabbit on tinyhumansai/opencompany#2153).
+            let tags: Option<&[String]> =
+                Some(request.tags.as_slice()).filter(|tags| !tags.is_empty());
+            match client.list_tools(query, tags, search).await {
                 Ok(mut resp) => {
                     if !self.toolkits.is_empty() {
                         resp.tools.retain(|schema| {

--- a/src/harness/built_in/composio.rs
+++ b/src/harness/built_in/composio.rs
@@ -802,7 +802,16 @@ mod live {
             toolkits: Option<&[String]>,
             tags: Option<&[String]>,
             search: Option<&str>,
-        ) -> Result<ComposioToolsResponse> {
+        ) -> Result<(ComposioToolsResponse, bool)> {
+            // The `bool` is whether the listing was **curated** — the BYOK route
+            // asks Composio for featured actions only when nothing narrows the
+            // call, and the renderer has to say so or it reports ~50 featured
+            // rows as the toolkit's whole catalogue (codex on
+            // tinyhumansai/opencompany#2153). The response type is vendored, so
+            // the flag rides beside it rather than on it.
+            let curated = matches!(self, Self::Byok { .. })
+                && !search.is_some_and(|term| !term.trim().is_empty())
+                && !tags.is_some_and(|tags| !tags.is_empty());
             match self {
                 Self::Managed(client) => {
                     if search.is_some_and(|term| !term.trim().is_empty()) {
@@ -816,13 +825,15 @@ mod live {
                              the term is applied client-side"
                         );
                     }
-                    client.list_tools(toolkits, tags).await
-                }
-                Self::Byok { direct, .. } => {
-                    direct
-                        .list_tools(toolkits.unwrap_or(&[]), search, tags)
+                    client
+                        .list_tools(toolkits, tags)
                         .await
+                        .map(|resp| (resp, curated))
                 }
+                Self::Byok { direct, .. } => direct
+                    .list_tools(toolkits.unwrap_or(&[]), search, tags)
+                    .await
+                    .map(|resp| (resp, curated)),
             }
         }
 
@@ -1583,7 +1594,7 @@ mod live {
             // above is a security decision (allowlist intersection) and stays
             // here; `search` / `detail` / `limit` are presentation and live in
             // the pure catalogue module.
-            let request = catalog::ListRequest::parse(&args, effective.clone());
+            let mut request = catalog::ListRequest::parse(&args, effective.clone());
             tracing::debug!(
                 effective = ?effective,
                 allowlist = ?self.toolkits,
@@ -1618,7 +1629,8 @@ mod live {
             let tags: Option<&[String]> =
                 Some(request.tags.as_slice()).filter(|tags| !tags.is_empty());
             match client.list_tools(query, tags, search).await {
-                Ok(mut resp) => {
+                Ok((mut resp, curated)) => {
+                    request.curated = curated;
                     if !self.toolkits.is_empty() {
                         resp.tools.retain(|schema| {
                             toolkit_allowed(&self.toolkits, &slug_toolkit(&schema.function.name))

--- a/src/harness/built_in/composio.rs
+++ b/src/harness/built_in/composio.rs
@@ -787,23 +787,41 @@ mod live {
             }
         }
 
-        /// The action schemas for `toolkits` (all of them when `None`).
+        /// The action schemas for `toolkits` (all of them when `None`),
+        /// optionally narrowed server-side by `search` and `tags`.
+        ///
+        /// `search` is new (and `tags` newly honoured on the BYOK route). The
+        /// tool surface has taken a search term all along and applied it
+        /// **client-side**, over whatever survived the page budget — so a
+        /// narrowing the caller asked for could not reach an action that was
+        /// dropped before it ever arrived. Composio filters both server-side on
+        /// `/tools`; `tinyhumansai/backend` already threads `tags` for the same
+        /// reason.
         async fn list_tools(
             &self,
             toolkits: Option<&[String]>,
             tags: Option<&[String]>,
+            search: Option<&str>,
         ) -> Result<ComposioToolsResponse> {
             match self {
-                Self::Managed(client) => client.list_tools(toolkits, tags).await,
-                Self::Byok { direct, .. } => {
-                    if tags.is_some_and(|tags| !tags.is_empty()) {
-                        // Nothing in this repo passes tags today; say so rather
-                        // than silently narrowing to nothing if something starts.
-                        tracing::warn!(
-                            "[composio-byok] list_tools: tag filtering is not applied on the                              BYOK route; returning the unfiltered toolkit listing"
+                Self::Managed(client) => {
+                    if search.is_some_and(|term| !term.trim().is_empty()) {
+                        // The managed backend's own endpoint takes no search
+                        // parameter, so the term stays a client-side filter
+                        // there. Said out loud rather than dropped silently —
+                        // that silence is what made the BYOK route's truncation
+                        // so hard to see.
+                        tracing::debug!(
+                            "[composio] list_tools: managed route has no server-side search; \
+                             the term is applied client-side"
                         );
                     }
-                    direct.list_tools(toolkits.unwrap_or(&[])).await
+                    client.list_tools(toolkits, tags).await
+                }
+                Self::Byok { direct, .. } => {
+                    direct
+                        .list_tools(toolkits.unwrap_or(&[]), search, tags)
+                        .await
                 }
             }
         }
@@ -988,9 +1006,40 @@ mod live {
     /// [`redact`] keeps the security half — the token replacement and the URL
     /// query strip — verbatim and unconditional; only the length decision moves
     /// here, where it can be sized for a body and describe its own cut.
-    fn scrubbed_ok(value: Value, secrets: &[String], what: &str) -> ToolResult {
+    fn scrubbed_ok(value: Value, secrets: &[String]) -> ToolResult {
+        // Project BEFORE serialising, and serialise before redacting.
+        //
+        // Order is the whole of it. `redact` strips URL query strings and
+        // rewrites secret substrings inside the serialised text, which leaves a
+        // string that is no longer valid JSON — so a projection attempted after
+        // it (the first cut of this) could never parse the payload and declined
+        // on every real response, silently, while the byte cut carried on
+        // dropping whole records. Projecting the structured `Value` here means
+        // the transform sees JSON, and `redact` still sees every byte that ends
+        // up in front of the model.
+        let value = catalog::project_records_value(value);
         let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
-        ToolResult::success(catalog::bound_body(redact(&text, secrets), what))
+        // No `bound_body` here any more (issue #6014).
+        //
+        // It bounded the payload to 12 KiB **inside the tool**, chosen so that
+        // "the harness's own anonymous cut never fires first" — a good trade
+        // when the only thing downstream was a byte cut that said nothing.
+        //
+        // It is the wrong trade now. The same 12 KiB also fired ahead of the
+        // per-result artifact store (so an oversized Composio result was
+        // discarded rather than written to disk and pointed at) and ahead of the
+        // task-aware extractor (whose threshold is 4000 tokens, which a
+        // pre-bounded body can never reach). Bounding first made this the one
+        // tool family whose large results could be handled by nothing but
+        // truncation — measured on a live GitHub call as 3 of 30 records
+        // surviving, and the agent correctly reporting 3.
+        //
+        // Handing the full payload downstream puts it back on the same ladder
+        // every other tool's output takes: extract against the task, else
+        // persist and hand back a path, else cut at the budget. Each of those
+        // says what it did, which was the property the pre-bound was protecting
+        // and is now protected by the mechanisms themselves.
+        ToolResult::success(redact(&text, secrets))
     }
 
     /// A scrubbed error result — the tenant token is stripped from any error
@@ -1466,7 +1515,6 @@ mod live {
                     Ok(scrubbed_ok(
                         serde_json::to_value(&resp).unwrap_or(Value::Null),
                         &secrets,
-                        "connections list",
                     ))
                 }
                 Err(err) => Ok(scrubbed_err(
@@ -1558,7 +1606,13 @@ mod live {
                     )));
                 }
             };
-            match client.list_tools(query, None).await {
+            // The search term now travels to Composio rather than being applied
+            // only to what came back. `request.search` is the tool's own
+            // already-parsed terms; joined because the API takes one free-text
+            // string over name/slug/description.
+            let search_term = request.search.join(" ");
+            let search = Some(search_term.as_str()).filter(|term| !term.trim().is_empty());
+            match client.list_tools(query, None, search).await {
                 Ok(mut resp) => {
                     if !self.toolkits.is_empty() {
                         resp.tools.retain(|schema| {
@@ -1654,7 +1708,6 @@ mod live {
                 Ok(resp) => Ok(scrubbed_ok(
                     serde_json::to_value(&resp).unwrap_or(Value::Null),
                     &secrets,
-                    "authorization response",
                 )),
                 Err(err) => Ok(scrubbed_err("composio_authorize failed", &err, &secrets)),
             }
@@ -1753,7 +1806,6 @@ mod live {
                     Ok(scrubbed_ok(
                         serde_json::to_value(&resp).unwrap_or(Value::Null),
                         &secrets,
-                        &format!("`{tool}` output"),
                     ))
                 }
                 Err(err) => Ok(scrubbed_err("composio_execute failed", &err, &secrets)),

--- a/src/harness/built_in/composio_catalog.rs
+++ b/src/harness/built_in/composio_catalog.rs
@@ -723,20 +723,46 @@ fn render_empty(available: usize, request: &ListRequest) -> String {
         [] => "every connected toolkit".to_string(),
         toolkits => toolkits.join(", "),
     };
-    if available == 0 {
+    // Whether the *server* was asked to narrow. This is the distinction that
+    // matters now that `search` and `tags` travel to Composio: an empty
+    // response to a narrowed query says nothing about the toolkit, only about
+    // the filter, and `available` is the count of what came back rather than
+    // what exists (codex on tinyhumansai/opencompany#2153).
+    let filter = match (request.search.is_empty(), request.tags.is_empty()) {
+        (true, true) => None,
+        (false, true) => Some(format!("`{}`", request.search.join(" "))),
+        (true, false) => Some(format!("tags `{}`", request.tags.join(", "))),
+        (false, false) => Some(format!(
+            "`{}` with tags `{}`",
+            request.search.join(" "),
+            request.tags.join(", ")
+        )),
+    };
+    let Some(filter) = filter else {
+        // Unnarrowed and empty is the only case that says anything about the
+        // toolkit itself.
         return format!(
             "Composio actions in {scope} — none. This toolkit has no callable actions available to \
              this company (it may not be connected). Check `composio_list_connections`, and do not \
              guess an action slug.\n"
         );
-    }
+    };
+    // Narrowed and empty. Saying "no callable actions (it may not be
+    // connected)" here would be a lie about a connected toolkit, and the
+    // expensive kind: an agent told a capability does not exist stops looking
+    // for it, which is the exact failure this listing was rewritten to end.
+    let total = if available == 0 {
+        "The filter was applied by Composio, so this is what it matched, not what the toolkit has."
+            .to_string()
+    } else {
+        format!("{available} returned, 0 matching after filtering.")
+    };
     format!(
-        "Composio actions in {scope} — {available} available, 0 matching `{search}`.\n\
-         Nothing matched those words. Try fewer or different words (the search matches the action \
-         slug and its description), or list everything with \
+        "Composio actions in {scope} — nothing matched {filter}. {total}\n\
+         Try fewer or different words (the search matches the action slug and its description), \
+         drop the tags, or list the toolkit unnarrowed with \
          {LIST_TOOLS_TOOL}({{\"toolkits\": [\"<slug>\"]}}). Do NOT guess a slug that was not \
-         listed.\n",
-        search = request.search.join(" ")
+         listed, and do not conclude the toolkit is unavailable from this result.\n"
     )
 }
 
@@ -1536,9 +1562,52 @@ mod tests {
             &actions,
             &request("quantum teleport", Detail::Names, &["gmail"]),
         );
-        assert!(out.contains("0 matching `quantum teleport`"), "{out}");
+        assert!(out.contains("nothing matched `quantum teleport`"), "{out}");
+        assert!(
+            out.contains("40 returned"),
+            "the real total is stated: {out}"
+        );
         assert!(out.contains("Do NOT guess a slug"), "{out}");
         assert!(!out.contains("TRUNCATED"), "nothing was cut: {out}");
+    }
+
+    /// A server-side filter that matches nothing says so about the *filter*.
+    ///
+    /// Once `search` and `tags` travel to Composio, a narrowed query that
+    /// matches nothing comes back with zero rows — and the old message read
+    /// that as "this toolkit has no callable actions (it may not be
+    /// connected)". That is a lie about a connected toolkit, and the expensive
+    /// kind: an agent told a capability does not exist stops looking for it,
+    /// which is the failure this whole listing was rewritten to end (codex on
+    /// tinyhumansai/opencompany#2153).
+    #[test]
+    fn an_empty_server_filtered_response_does_not_blame_the_connection() {
+        let mut narrowed = request("quantum teleport", Detail::Names, &["gmail"]);
+        narrowed.tags = vec!["important".to_string()];
+        // Zero rows back, because the server did the filtering.
+        let out = render(&[], &narrowed);
+
+        assert!(
+            !out.contains("may not be connected"),
+            "an empty filter result says nothing about the connection: {out}"
+        );
+        assert!(
+            !out.contains("no callable actions"),
+            "the toolkit was not shown to be empty: {out}"
+        );
+        assert!(
+            out.contains("quantum teleport") && out.contains("important"),
+            "both halves of the filter are named: {out}"
+        );
+        assert!(
+            out.contains("not what the toolkit has"),
+            "the count must be disclosed as the filter's, not the toolkit's: {out}"
+        );
+
+        // The unnarrowed empty case still points at the connection, which is
+        // the one time that is the right thing to say.
+        let bare = render(&[], &request("", Detail::Names, &["github"]));
+        assert!(bare.contains("may not be connected"), "{bare}");
     }
 
     /// An empty catalogue is a different fact from an empty search, and points

--- a/src/harness/built_in/composio_catalog.rs
+++ b/src/harness/built_in/composio_catalog.rs
@@ -138,17 +138,64 @@ pub const MAX_BODY_BYTES: usize = 12 * 1024;
 /// agent that adjusts and an agent that repeats itself.
 ///
 /// `what` names the payload for the trailer, e.g. `"GITHUB_LIST_ISSUES output"`.
-/// Keys whose value is a link and never an answer. Dropped wholesale from a
-/// projected record.
+/// Keys carrying a provider's *self-referential* API plumbing — the endpoints
+/// a client would call to re-fetch related collections, never a value anyone
+/// asked for.
 ///
-/// A provider's record is mostly navigation: GitHub's issue object carries
-/// `url`, `repository_url`, `labels_url`, `comments_url`, `events_url`,
-/// `html_url` and `timeline_url` before it carries a title. None of it helps a
-/// model say what the issues are, and all of it is charged against the same
-/// byte budget the titles compete for.
+/// **This list used to include `url`, `href` and every `*_url`, and that was
+/// wrong** (codex and CodeRabbit on tinyhumansai/opencompany#2153). The
+/// premise was that a link is never an answer. It plainly can be: "list the
+/// issues with their browser links" makes `html_url` *the* answer, and this
+/// projection runs **before** the task-aware extractor and before the artifact
+/// store, so a field dropped here cannot be recovered by anything downstream.
+///
+/// That is the exact mistake this whole change exists to correct — a
+/// task-blind reduction deciding what matters without knowing what was asked.
+/// Dropping generic link fields bought about 1.6x on measured payloads; the
+/// extraction pass is worth orders of magnitude more and knows the task. The
+/// trade is not close.
+///
+/// What remains are the `*_url` siblings that are unambiguously navigation
+/// *within the API*: they address collections rather than the record, and a
+/// caller that wants them has the record's own id to build them from.
 fn is_link_key(key: &str) -> bool {
     let key = key.to_ascii_lowercase();
-    key == "url" || key == "href" || key.ends_with("_url") || key.ends_with("_urls")
+    matches!(
+        key.as_str(),
+        "labels_url"
+            | "comments_url"
+            | "events_url"
+            | "timeline_url"
+            | "notifications_url"
+            | "collaborators_url"
+            | "contributors_url"
+            | "subscribers_url"
+            | "subscription_url"
+            | "commits_url"
+            | "git_commits_url"
+            | "issue_comment_url"
+            | "issue_events_url"
+            | "assignees_url"
+            | "branches_url"
+            | "tags_url"
+            | "blobs_url"
+            | "trees_url"
+            | "statuses_url"
+            | "languages_url"
+            | "stargazers_url"
+            | "forks_url"
+            | "downloads_url"
+            | "releases_url"
+            | "deployments_url"
+            | "compare_url"
+            | "merges_url"
+            | "archive_url"
+            | "hooks_url"
+            | "keys_url"
+            | "teams_url"
+            | "milestones_url"
+            | "pulls_url"
+    )
 }
 
 /// The single field that stands in for a nested object — a user becomes its
@@ -407,6 +454,14 @@ pub struct ListRequest {
     /// Lowercased search words. Every word must match the slug or the
     /// description.
     pub search: Vec<String>,
+    /// Composio's own action tags, forwarded server-side.
+    ///
+    /// Carried through to `LiveClient::list_tools` rather than applied here:
+    /// tags are a property of the catalogue, not of the text this module
+    /// renders, so a tag filter applied client-side could only narrow what
+    /// already survived the page budget — the same defect the server-side
+    /// `search` forwarding fixed.
+    pub tags: Vec<String>,
     /// How much per action to render.
     pub detail: Detail,
     /// Entry cap, already clamped to the mode's ceiling.
@@ -424,6 +479,19 @@ impl ListRequest {
             .and_then(Value::as_str)
             .map(search_terms)
             .unwrap_or_default();
+        let tags = args
+            .get("tags")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::trim)
+                    .filter(|tag| !tag.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
         let limit = args
             .get("limit")
             .and_then(Value::as_u64)
@@ -432,6 +500,7 @@ impl ListRequest {
         Self {
             toolkits,
             search,
+            tags,
             detail,
             limit,
         }
@@ -688,6 +757,11 @@ pub fn list_tools_parameters_schema() -> Value {
             "search": {
                 "type": "string",
                 "description": "Narrow the listing to actions whose slug or description contains ALL of these words (case-insensitive), e.g. `list issues` or `send email`. Pass an exact slug here with `detail: \"schemas\"` to read just that action's parameters."
+            },
+            "tags": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Composio action tags to narrow by, server-side (e.g. `important`). Combine with `search` to cut a large toolkit down before it is paged."
             },
             "detail": {
                 "type": "string",
@@ -1291,6 +1365,7 @@ mod tests {
         ListRequest {
             toolkits: toolkits.iter().map(|t| t.to_string()).collect(),
             search: search_terms(search),
+            tags: Vec::new(),
             detail,
             limit: detail.default_limit(),
         }
@@ -2309,6 +2384,64 @@ mod tests {
 
 #[cfg(test)]
 mod projection_prototype_tests {
+    /// The projection runs **before** the task-aware extractor and before the
+    /// artifact store, so anything it drops is gone for every consumer. A link
+    /// can be the answer — "list the issues with their browser links" — and the
+    /// first cut of this dropped `url`, `href` and every `*_url` on the premise
+    /// that a link never is (codex and CodeRabbit on
+    /// tinyhumansai/opencompany#2153).
+    #[test]
+    fn answering_links_survive_the_projection() {
+        // Two records, not one: the projection declines an array shorter than
+        // that, so a single-record payload would pass every assertion below
+        // without the projection having run at all.
+        let record = |n: u64| {
+            serde_json::json!({
+                "number": n,
+                "title": "flaky login",
+                "url": format!("https://api.github.com/repos/o/r/issues/{n}"),
+                "html_url": format!("https://github.com/o/r/issues/{n}"),
+                "href": format!("https://example.test/{n}"),
+                "avatar_urls": ["https://example.test/a.png"],
+                "comments_url": format!("https://api.github.com/repos/o/r/issues/{n}/comments"),
+                "labels_url": format!("https://api.github.com/repos/o/r/issues/{n}/labels"),
+                "user": { "login": "octocat", "id": 7 }
+            })
+        };
+        // Over `MAX_BODY_BYTES`: the projection declines anything already small
+        // enough, so a short payload passes every assertion below without it
+        // having run. Two earlier versions of this test did exactly that.
+        let records: Vec<serde_json::Value> = (1..=60).map(record).collect();
+        let payload = serde_json::json!({ "data": records });
+        assert!(
+            serde_json::to_string(&payload).unwrap().len() > MAX_BODY_BYTES,
+            "the fixture must exceed the projection threshold or nothing runs"
+        );
+
+        let projected = project_records_value(payload);
+        let record = &projected["data"][0];
+
+        // The fields a caller can actually have asked for.
+        assert_eq!(record["html_url"], "https://github.com/o/r/issues/1");
+        assert_eq!(record["url"], "https://api.github.com/repos/o/r/issues/1");
+        assert_eq!(record["href"], "https://example.test/1");
+        assert!(
+            !record["avatar_urls"].is_null(),
+            "a `*_urls` field is content, not API plumbing: {record}"
+        );
+        // Proof the projection actually ran. Without this the link assertions
+        // above pass trivially on a payload the projection declined — which is
+        // exactly what the first version of this test did.
+        assert_eq!(
+            record["user"], "octocat",
+            "the nested object did not collapse, so the projection never ran: {record}"
+        );
+        assert_eq!(record["title"], "flaky login");
+        // Only self-referential collection endpoints go.
+        assert!(record["comments_url"].is_null(), "collection endpoint kept");
+        assert!(record["labels_url"].is_null(), "collection endpoint kept");
+    }
+
     use super::*;
 
     /// The exact shape the live GitHub call returns: records two levels down,
@@ -2334,13 +2467,18 @@ mod projection_prototype_tests {
             body.len(),
             projected.len()
         );
+        // These used to assert that `avatar_url` and `html_url` were dropped.
+        // They are answers a caller can ask for, and this projection runs ahead
+        // of the task-aware extractor and the artifact store, so dropping them
+        // was unrecoverable (codex and CodeRabbit on
+        // tinyhumansai/opencompany#2153). What goes now is API plumbing only.
         assert!(
-            !projected.contains("avatar_url"),
-            "link fields must go: {projected}"
+            projected.contains("html_url"),
+            "a browser link can be the answer and must survive: {projected}"
         );
         assert!(
-            !projected.contains("html_url"),
-            "link fields must go: {projected}"
+            !projected.contains("comments_url"),
+            "self-referential collection endpoints still go: {projected}"
         );
         assert!(
             projected.contains("octocat"),

--- a/src/harness/built_in/composio_catalog.rs
+++ b/src/harness/built_in/composio_catalog.rs
@@ -208,10 +208,6 @@ fn project_record(value: &serde_json::Value) -> serde_json::Value {
     serde_json::Value::Object(out)
 }
 
-/// Where a provider hides its list of records, when the payload is not itself
-/// the array.
-const RECORD_ENVELOPES: [&str; 6] = ["data", "items", "results", "issues", "records", "values"];
-
 /// Project an array-of-records payload down to its answering fields, returning
 /// `None` when the body is not that shape.
 ///
@@ -239,7 +235,9 @@ pub fn project_records_value(mut value: serde_json::Value) -> serde_json::Value 
         return value;
     }
     if project_in_place(&mut value) {
-        let after = serde_json::to_string(&value).map(|s| s.len()).unwrap_or(before);
+        let after = serde_json::to_string(&value)
+            .map(|s| s.len())
+            .unwrap_or(before);
         tracing::info!(
             from_bytes = before,
             to_bytes = after,
@@ -306,10 +304,7 @@ pub fn bound_body(body: String, what: &str) -> String {
                 what,
                 from_bytes = body.len(),
                 to_bytes = projected.len(),
-                ratio = format!(
-                    "{:.1}x",
-                    body.len() as f64 / projected.len().max(1) as f64
-                ),
+                ratio = format!("{:.1}x", body.len() as f64 / projected.len().max(1) as f64),
                 fits_now = projected.len() <= MAX_BODY_BYTES,
                 "[composio] projected an array-of-records payload to its answering fields"
             );
@@ -2333,11 +2328,31 @@ mod projection_prototype_tests {
         .to_string();
 
         let projected = project_records(&body).expect("records nested under `data.details`");
-        assert!(projected.len() < body.len(), "must shrink: {} -> {}", body.len(), projected.len());
-        assert!(!projected.contains("avatar_url"), "link fields must go: {projected}");
-        assert!(!projected.contains("html_url"), "link fields must go: {projected}");
-        assert!(projected.contains("octocat"), "nested user collapses to its login: {projected}");
-        assert!(projected.contains("bug"), "label array collapses to names: {projected}");
-        assert!(projected.contains("\"title\""), "answering fields survive: {projected}");
+        assert!(
+            projected.len() < body.len(),
+            "must shrink: {} -> {}",
+            body.len(),
+            projected.len()
+        );
+        assert!(
+            !projected.contains("avatar_url"),
+            "link fields must go: {projected}"
+        );
+        assert!(
+            !projected.contains("html_url"),
+            "link fields must go: {projected}"
+        );
+        assert!(
+            projected.contains("octocat"),
+            "nested user collapses to its login: {projected}"
+        );
+        assert!(
+            projected.contains("bug"),
+            "label array collapses to names: {projected}"
+        );
+        assert!(
+            projected.contains("\"title\""),
+            "answering fields survive: {projected}"
+        );
     }
 }

--- a/src/harness/built_in/composio_catalog.rs
+++ b/src/harness/built_in/composio_catalog.rs
@@ -138,7 +138,193 @@ pub const MAX_BODY_BYTES: usize = 12 * 1024;
 /// agent that adjusts and an agent that repeats itself.
 ///
 /// `what` names the payload for the trailer, e.g. `"GITHUB_LIST_ISSUES output"`.
+/// Keys whose value is a link and never an answer. Dropped wholesale from a
+/// projected record.
+///
+/// A provider's record is mostly navigation: GitHub's issue object carries
+/// `url`, `repository_url`, `labels_url`, `comments_url`, `events_url`,
+/// `html_url` and `timeline_url` before it carries a title. None of it helps a
+/// model say what the issues are, and all of it is charged against the same
+/// byte budget the titles compete for.
+fn is_link_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key == "url" || key == "href" || key.ends_with("_url") || key.ends_with("_urls")
+}
+
+/// The single field that stands in for a nested object — a user becomes its
+/// `login`, a label its `name`, a milestone its `title`.
+///
+/// Tried in order, so an object carrying several answers the most specific.
+const NESTED_STAND_INS: [&str; 5] = ["login", "name", "title", "slug", "id"];
+
+/// Reduce one record to the fields that carry an answer.
+///
+/// Scalars are kept as they are. A nested object collapses to its stand-in
+/// (`user` → `"octocat"`), an array of objects to the list of theirs
+/// (`labels` → `["bug", "p2"]`). Anything else — a nested structure with no
+/// obvious name, an empty container — is dropped: it costs bytes and answers
+/// nothing, and a model that needs it can ask the action for that record by id.
+fn project_record(value: &serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::Object(map) = value else {
+        return value.clone();
+    };
+    let mut out = serde_json::Map::new();
+    for (key, val) in map {
+        if is_link_key(key) {
+            continue;
+        }
+        match val {
+            serde_json::Value::Object(inner) => {
+                if let Some(stand_in) = NESTED_STAND_INS
+                    .iter()
+                    .find_map(|name| inner.get(*name).filter(|v| !v.is_null()))
+                {
+                    out.insert(key.clone(), stand_in.clone());
+                }
+            }
+            serde_json::Value::Array(items) => {
+                let names: Vec<serde_json::Value> = items
+                    .iter()
+                    .filter_map(|item| match item {
+                        serde_json::Value::Object(inner) => NESTED_STAND_INS
+                            .iter()
+                            .find_map(|name| inner.get(*name).filter(|v| !v.is_null()))
+                            .cloned(),
+                        scalar if !scalar.is_null() => Some(scalar.clone()),
+                        _ => None,
+                    })
+                    .collect();
+                if !names.is_empty() {
+                    out.insert(key.clone(), serde_json::Value::Array(names));
+                }
+            }
+            scalar => {
+                if !scalar.is_null() {
+                    out.insert(key.clone(), scalar.clone());
+                }
+            }
+        }
+    }
+    serde_json::Value::Object(out)
+}
+
+/// Where a provider hides its list of records, when the payload is not itself
+/// the array.
+const RECORD_ENVELOPES: [&str; 6] = ["data", "items", "results", "issues", "records", "values"];
+
+/// Project an array-of-records payload down to its answering fields, returning
+/// `None` when the body is not that shape.
+///
+/// The gap this fills is named in [`bound_body`]'s own docs: "there is no
+/// generic argument that makes *that* smaller". True of the action's
+/// **arguments** — the narrowing lives in the provider's own parameters — but
+/// not of its **encoding**. Most provider output is a list of records, and the
+/// bulk of each record is navigation rather than answer. Cutting the payload on
+/// a byte boundary keeps whole records and discards whole records; projecting it
+/// keeps every record and discards the parts of each that nobody asked for.
+///
+/// Deliberately conservative: a payload that is not a list of objects is left
+/// alone, and every scalar the records do carry survives. This is a lossy
+/// transform, so it is reported (see the `[composio] projected` log) rather than
+/// applied invisibly — and the trailer `bound_body` appends when the projection
+/// is still too big says the same thing it always did.
+/// Project an already-parsed payload, returning it unchanged when it holds no
+/// array of records. The entry point [`scrubbed_ok`] uses, because by the time
+/// a body is a `String` it has been through [`redact`] and is no longer JSON.
+pub fn project_records_value(mut value: serde_json::Value) -> serde_json::Value {
+    let before = serde_json::to_string(&value).map(|s| s.len()).unwrap_or(0);
+    if before <= MAX_BODY_BYTES {
+        // Nothing to gain: the payload already fits, and projecting it would
+        // drop fields for no reason.
+        return value;
+    }
+    if project_in_place(&mut value) {
+        let after = serde_json::to_string(&value).map(|s| s.len()).unwrap_or(before);
+        tracing::info!(
+            from_bytes = before,
+            to_bytes = after,
+            ratio = format!("{:.1}x", before as f64 / after.max(1) as f64),
+            fits_now = after <= MAX_BODY_BYTES,
+            "[composio] projected an array-of-records payload to its answering fields"
+        );
+    }
+    value
+}
+
+pub fn project_records(body: &str) -> Option<String> {
+    let mut parsed: serde_json::Value = serde_json::from_str(body).ok()?;
+    // Rewrites every record array in place, wherever it sits. The first cut of
+    // this looked one level down and found nothing: Composio returns the
+    // provider payload inside its own result envelope, so the records are never
+    // where a naive reader expects them, and the shape differs per action. A
+    // recursive walk needs no table of envelope names and cannot be defeated by
+    // the next provider nesting one level deeper.
+    let projected_any = project_in_place(&mut parsed);
+    projected_any.then(|| serde_json::to_string(&parsed).ok())?
+}
+
+/// Project every array-of-records found anywhere in `value`, in place.
+///
+/// Returns whether anything was projected, so the caller can tell "nothing to
+/// do" from "done" without comparing serialisations.
+fn project_in_place(value: &mut serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Array(items) => {
+            // The premise is many records sharing a shape; one object is better
+            // shown as it came, and a list of scalars has nothing to prune.
+            if items.len() >= 2 && items.iter().all(serde_json::Value::is_object) {
+                for item in items.iter_mut() {
+                    *item = project_record(item);
+                }
+                return true;
+            }
+            let mut any = false;
+            for item in items.iter_mut() {
+                any |= project_in_place(item);
+            }
+            any
+        }
+        serde_json::Value::Object(map) => {
+            let mut any = false;
+            for (_, val) in map.iter_mut() {
+                any |= project_in_place(val);
+            }
+            any
+        }
+        _ => false,
+    }
+}
+
 pub fn bound_body(body: String, what: &str) -> String {
+    if body.len() <= MAX_BODY_BYTES {
+        return body;
+    }
+    // Try to keep every record before resorting to keeping only the first few.
+    let body = match project_records(&body) {
+        Some(projected) if projected.len() < body.len() => {
+            tracing::info!(
+                what,
+                from_bytes = body.len(),
+                to_bytes = projected.len(),
+                ratio = format!(
+                    "{:.1}x",
+                    body.len() as f64 / projected.len().max(1) as f64
+                ),
+                fits_now = projected.len() <= MAX_BODY_BYTES,
+                "[composio] projected an array-of-records payload to its answering fields"
+            );
+            projected
+        }
+        _ => {
+            tracing::info!(
+                what,
+                bytes = body.len(),
+                head = body.chars().take(180).collect::<String>(),
+                "[composio] no array-of-records to project; bounding the payload as it came"
+            );
+            body
+        }
+    };
     if body.len() <= MAX_BODY_BYTES {
         return body;
     }
@@ -2123,5 +2309,35 @@ mod tests {
             web_call_deflection(&connected, "https://api.linkedin.com/rest/posts").is_some(),
             "the LinkedIn API host must be deflected"
         );
+    }
+}
+
+#[cfg(test)]
+mod projection_prototype_tests {
+    use super::*;
+
+    /// The exact shape the live GitHub call returns: records two levels down,
+    /// under Composio's own `data` envelope.
+    #[test]
+    fn projects_records_nested_under_the_composio_envelope() {
+        let body = serde_json::json!({
+            "data": { "details": [
+                { "number": 1, "title": "a", "url": "https://x", "html_url": "https://y",
+                  "user": { "login": "octocat", "avatar_url": "https://z", "id": 5 },
+                  "labels": [ { "name": "bug", "url": "https://l" } ] },
+                { "number": 2, "title": "b", "url": "https://x2", "html_url": "https://y2",
+                  "user": { "login": "hubot", "avatar_url": "https://z2", "id": 6 },
+                  "labels": [ { "name": "p2", "url": "https://l2" } ] }
+            ]}
+        })
+        .to_string();
+
+        let projected = project_records(&body).expect("records nested under `data.details`");
+        assert!(projected.len() < body.len(), "must shrink: {} -> {}", body.len(), projected.len());
+        assert!(!projected.contains("avatar_url"), "link fields must go: {projected}");
+        assert!(!projected.contains("html_url"), "link fields must go: {projected}");
+        assert!(projected.contains("octocat"), "nested user collapses to its login: {projected}");
+        assert!(projected.contains("bug"), "label array collapses to names: {projected}");
+        assert!(projected.contains("\"title\""), "answering fields survive: {projected}");
     }
 }

--- a/src/harness/built_in/composio_catalog.rs
+++ b/src/harness/built_in/composio_catalog.rs
@@ -462,6 +462,15 @@ pub struct ListRequest {
     /// already survived the page budget — the same defect the server-side
     /// `search` forwarding fixed.
     pub tags: Vec<String>,
+    /// Whether the listing that came back was **curated** — Composio's featured
+    /// actions rather than the toolkit's whole catalogue.
+    ///
+    /// Set by the caller from what the client actually asked for, not derived
+    /// here: only the BYOK route requests curation, and only when nothing
+    /// narrows the call. Without it the header reports ~50 featured rows as the
+    /// number "available", and an agent taking an inventory of GitHub is told
+    /// that is everything (codex on tinyhumansai/opencompany#2153).
+    pub curated: bool,
     /// How much per action to render.
     pub detail: Detail,
     /// Entry cap, already clamped to the mode's ceiling.
@@ -501,6 +510,9 @@ impl ListRequest {
             toolkits,
             search,
             tags,
+            // The caller sets this from the client's own answer; parsing the
+            // arguments cannot know which route served them.
+            curated: false,
             detail,
             limit,
         }
@@ -630,9 +642,21 @@ fn render_header(available: usize, matched: usize, shown: usize, request: &ListR
     } else {
         format!(" matching `{}`", request.search.join(" "))
     };
-    let mut header = format!(
-        "Composio actions in {scope} — {available} available, {matched}{filter}, showing {shown}.\n"
-    );
+    let mut header = if request.curated {
+        // Not "available": these are Composio's featured actions, and the long
+        // tail is reachable only by narrowing. Saying "available" here is what
+        // told an agent that ~50 rows were all GitHub could do.
+        format!(
+            "Composio actions in {scope} — showing {shown} of {available} **featured** actions{filter}. \
+             This is a curated preview, not the full catalogue: many more are callable but not \
+             listed. Narrow with `search` or `tags` to reach them, e.g. \
+             {LIST_TOOLS_TOOL}({{\"toolkits\": [\"<slug>\"], \"search\": \"issue\"}}).\n"
+        )
+    } else {
+        format!(
+            "Composio actions in {scope} — {available} available, {matched}{filter}, showing {shown}.\n"
+        )
+    };
     match request.detail {
         Detail::Names => header.push_str(&format!(
             "Each line is `SLUG — description`. Read one action's parameters before calling it:\n  \
@@ -1392,6 +1416,7 @@ mod tests {
             toolkits: toolkits.iter().map(|t| t.to_string()).collect(),
             search: search_terms(search),
             tags: Vec::new(),
+            curated: false,
             detail,
             limit: detail.default_limit(),
         }
@@ -1569,6 +1594,39 @@ mod tests {
         );
         assert!(out.contains("Do NOT guess a slug"), "{out}");
         assert!(!out.contains("TRUNCATED"), "nothing was cut: {out}");
+    }
+
+    /// A curated listing must not present itself as the full catalogue.
+    ///
+    /// An unnarrowed BYOK browse asks Composio for featured actions only, so
+    /// the count that comes back is a preview. Calling it "available" is what
+    /// told an agent taking an inventory of GitHub that ~50 rows were
+    /// everything it could do (codex on tinyhumansai/opencompany#2153).
+    #[test]
+    fn a_curated_listing_says_it_is_a_preview() {
+        let actions = catalogue("github", 50);
+        let mut curated = request("", Detail::Names, &["github"]);
+        curated.curated = true;
+        let out = render(&actions, &curated);
+
+        assert!(out.contains("featured"), "curation must be named: {out}");
+        assert!(
+            out.contains("not the full catalogue"),
+            "the preview must say what it is not: {out}"
+        );
+        assert!(
+            out.contains("search"),
+            "the way to reach the rest must be given: {out}"
+        );
+        assert!(
+            !out.contains("50 available"),
+            "a curated count is not what is available: {out}"
+        );
+
+        // An unnarrowed listing that was NOT curated still reports plainly.
+        let plain = render(&actions, &request("", Detail::Names, &["github"]));
+        assert!(plain.contains("50 available"), "{plain}");
+        assert!(!plain.contains("featured"), "{plain}");
     }
 
     /// A server-side filter that matches nothing says so about the *filter*.

--- a/src/harness/built_in/composio_direct.rs
+++ b/src/harness/built_in/composio_direct.rs
@@ -810,7 +810,11 @@ mod tests {
         let direct = DirectComposio::new("ak_live").with_v3_base_for_test(base);
 
         let resp = direct
-            .list_tools(&["gmail".to_string(), "  ".to_string(), "slack".to_string()], None, None)
+            .list_tools(
+                &["gmail".to_string(), "  ".to_string(), "slack".to_string()],
+                None,
+                None,
+            )
             .await
             .expect("tools");
         assert_eq!(resp.tools.len(), 1);

--- a/src/harness/built_in/composio_direct.rs
+++ b/src/harness/built_in/composio_direct.rs
@@ -68,9 +68,12 @@ fn v3_base() -> String {
     format!("{DIRECT_BASE_URL}/api/v3")
 }
 
-/// How many rows one page pulls.
+/// How many rows one `/tools` page pulls.
 ///
-/// Was `200`, described here as "Composio's own maximum for these endpoints".
+/// Was `200`, described here as "Composio's own maximum for these endpoints" —
+/// a phrase that was wrong twice over: it is not the maximum, and "these
+/// endpoints" is what let one number govern two that answer to different
+/// limits (see [`TOOLKITS_PAGE_LIMIT`]).
 /// That is not what the API documents — `/tools` accepts `limit` up to **1000**
 /// — and `tinyhumansai/backend` has been paging the same endpoint at 1000 since
 /// before this client existed (`REST_PAGE_LIMIT` in
@@ -82,7 +85,23 @@ fn v3_base() -> String {
 ///
 /// At 1000 the same three pages reach 3000 rows, GitHub fits in a single
 /// request, and the round-trip count drops with it.
-const PAGE_LIMIT: &str = "1000";
+const TOOLS_PAGE_LIMIT: &str = "1000";
+
+/// How many rows one `/toolkits` page pulls.
+///
+/// **Deliberately not [`TOOLS_PAGE_LIMIT`].** The two endpoints shared one
+/// constant until review caught it, and the justification above is about
+/// `/tools` alone — the 1000 is what the tools endpoint documents and what
+/// `listTools.ts` has always paged it at. Nothing in that reasoning transfers
+/// to the provider catalogue, and applying it there was an unevidenced
+/// widening: the two would keep moving together for a reason that only holds
+/// for one of them.
+///
+/// 500 is what `tinyhumansai/backend` fetches the catalogue at
+/// (`CATALOG_FETCH_LIMIT` in `services/composio/catalog.ts`), against the same
+/// API, in production. The directory is ~1501 entries, so this still pages —
+/// it is a page size, not a ceiling on the listing.
+const TOOLKITS_PAGE_LIMIT: &str = "500";
 
 /// How many pages one listing will follow before it stops.
 ///
@@ -246,7 +265,7 @@ impl DirectComposio {
         tags: Option<&[String]>,
     ) -> Result<ComposioToolsResponse> {
         let mut params: Vec<(&str, String)> = vec![
-            ("limit", PAGE_LIMIT.to_string()),
+            ("limit", TOOLS_PAGE_LIMIT.to_string()),
             ("toolkit_versions", "latest".to_string()),
         ];
         if let Some(term) = search.map(str::trim).filter(|term| !term.is_empty()) {
@@ -417,7 +436,7 @@ impl DirectComposio {
     /// deserialize should still be connectable.
     pub(crate) async fn list_toolkits(&self) -> Result<ComposioToolkitsResponse> {
         let paged: Paged<V3Toolkit> = self
-            .get_paged("/toolkits", &[("limit", PAGE_LIMIT.to_string())])
+            .get_paged("/toolkits", &[("limit", TOOLKITS_PAGE_LIMIT.to_string())])
             .await
             .context("Composio v3 /toolkits")?;
         if paged.dropped > 0 {
@@ -652,6 +671,9 @@ impl V3Category {
 mod tests {
     use super::*;
 
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
     #[test]
     fn a_v3_tool_keeps_the_schema_an_agent_needs_to_call_it() {
         // The whole reason this module restates the listing: `list_actions`
@@ -714,6 +736,110 @@ mod tests {
     /// itself, asserting the `x-api-key` header on the way through: the whole
     /// point of BYOK is that the *company's* key, and no other credential,
     /// reaches Composio.
+    /// The two endpoints answer to different limits, and shared one constant
+    /// until review caught it. The 1000 is justified for `/tools` only; the
+    /// catalogue is paged at what the backend proves against the same API.
+    #[test]
+    fn the_two_endpoints_do_not_share_a_page_limit() {
+        assert_eq!(TOOLS_PAGE_LIMIT, "1000");
+        assert_eq!(TOOLKITS_PAGE_LIMIT, "500");
+        assert_ne!(
+            TOOLS_PAGE_LIMIT, TOOLKITS_PAGE_LIMIT,
+            "a tools-only justification must not govern the provider catalogue"
+        );
+    }
+
+    /// A `/tools` server that records the query it was asked with.
+    ///
+    /// The existing fixture asserts on counts, which cannot see a query
+    /// parameter at all — and `important=true` changes what the *server*
+    /// returns, so a count-based assertion would pass whether it was sent or
+    /// not (tinysweeper on tinyhumansai/opencompany#2153).
+    async fn spawn_query_recorder() -> (String, Arc<Mutex<Vec<HashMap<String, String>>>>) {
+        use axum::extract::Query;
+        use axum::routing::get;
+        use axum::{Json, Router};
+
+        let seen: Arc<Mutex<Vec<HashMap<String, String>>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        // `/tools`, not `/api/v3/tools`: `with_v3_base_for_test` already carries
+        // the API path, exactly as the fixtures below mount it.
+        let app = Router::new().route(
+            "/tools",
+            get(move |Query(params): Query<HashMap<String, String>>| {
+                let sink = sink.clone();
+                async move {
+                    sink.lock().expect("query sink").push(params);
+                    Json(serde_json::json!({ "items": [] }))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let base = format!("http://{}", listener.local_addr().expect("addr"));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (base, seen)
+    }
+
+    /// An unnarrowed browse asks for the curated set; a search must reach the
+    /// long tail, so it must not.
+    #[tokio::test]
+    async fn important_is_sent_only_for_an_unnarrowed_browse() {
+        let (base, seen) = spawn_query_recorder().await;
+        let direct = DirectComposio::new("ak_live").with_v3_base_for_test(base);
+
+        direct
+            .list_tools(&["github".to_string()], None, None)
+            .await
+            .expect("browse");
+        direct
+            .list_tools(&["github".to_string()], Some("issue"), None)
+            .await
+            .expect("search");
+        direct
+            .list_tools(
+                &["github".to_string()],
+                None,
+                Some(&["important".to_string()]),
+            )
+            .await
+            .expect("tag-narrowed");
+
+        let seen = seen.lock().expect("query sink");
+        assert_eq!(seen.len(), 3, "three calls were made");
+        assert_eq!(
+            seen[0].get("important").map(String::as_str),
+            Some("true"),
+            "an unnarrowed browse asks for the curated set: {:?}",
+            seen[0]
+        );
+        assert!(
+            !seen[1].contains_key("important"),
+            "a search must reach past the featured actions: {:?}",
+            seen[1]
+        );
+        assert!(
+            !seen[2].contains_key("important"),
+            "a tag filter is a search too: {:?}",
+            seen[2]
+        );
+        assert_eq!(
+            seen[2].get("tags").map(String::as_str),
+            Some("important"),
+            "the tag itself still travels: {:?}",
+            seen[2]
+        );
+        assert_eq!(
+            seen[1].get("search").map(String::as_str),
+            Some("issue"),
+            "the search term travels server-side: {:?}",
+            seen[1]
+        );
+    }
+
     async fn spawn_composio_v3() -> String {
         use axum::extract::Query;
         use axum::http::HeaderMap;

--- a/src/harness/built_in/composio_direct.rs
+++ b/src/harness/built_in/composio_direct.rs
@@ -68,8 +68,21 @@ fn v3_base() -> String {
     format!("{DIRECT_BASE_URL}/api/v3")
 }
 
-/// How many rows one page pulls. Composio's own maximum for these endpoints.
-const PAGE_LIMIT: &str = "200";
+/// How many rows one page pulls.
+///
+/// Was `200`, described here as "Composio's own maximum for these endpoints".
+/// That is not what the API documents — `/tools` accepts `limit` up to **1000**
+/// — and `tinyhumansai/backend` has been paging the same endpoint at 1000 since
+/// before this client existed (`REST_PAGE_LIMIT` in
+/// `controllers/agentIntegrations/composio/listTools.ts`). The old value made
+/// the three-page budget a 600-row ceiling, which GitHub's 893-action catalogue
+/// overflows: an agent asking for repo-scoped issue actions was handed 600 rows
+/// that did not contain them and concluded, reasonably and wrongly, that the
+/// capability did not exist.
+///
+/// At 1000 the same three pages reach 3000 rows, GitHub fits in a single
+/// request, and the round-trip count drops with it.
+const PAGE_LIMIT: &str = "1000";
 
 /// How many pages one listing will follow before it stops.
 ///
@@ -212,11 +225,71 @@ impl DirectComposio {
     /// restates it — same endpoint, same `toolkit_versions=latest` pin (without
     /// it v3 answers from a snapshot that lists nothing for any toolkit
     /// published since launch), same envelope.
-    pub(crate) async fn list_tools(&self, toolkits: &[String]) -> Result<ComposioToolsResponse> {
+    pub(crate) async fn list_tools(
+        &self,
+        toolkits: &[String],
+        // Full-text narrowing, applied by Composio over each action's name,
+        // slug and description (`search`), and its declared tags (`tags`).
+        //
+        // Both were absent before, and their absence is what made discovery
+        // fail rather than merely be coarse: the tool surface has taken a
+        // `search` argument all along, but applied it CLIENT-SIDE to whatever
+        // survived the page budget. Searching "issue" among 600 rows cannot
+        // return an action sitting in the 293 that were dropped, so a narrowing
+        // the caller asked for silently narrowed nothing. `tinyhumansai/backend`
+        // threads `tags` server-side for the same reason.
+        //
+        // A `None` for either sends no parameter at all, which leaves the query
+        // exactly as it was — the widening is opt-in, so no existing caller
+        // changes behaviour.
+        search: Option<&str>,
+        tags: Option<&[String]>,
+    ) -> Result<ComposioToolsResponse> {
         let mut params: Vec<(&str, String)> = vec![
             ("limit", PAGE_LIMIT.to_string()),
             ("toolkit_versions", "latest".to_string()),
         ];
+        if let Some(term) = search.map(str::trim).filter(|term| !term.is_empty()) {
+            params.push(("search", term.to_string()));
+        }
+        let tag_values: Vec<&str> = tags
+            .unwrap_or(&[])
+            .iter()
+            .map(|tag| tag.trim())
+            .filter(|tag| !tag.is_empty())
+            .collect();
+        // Curated preview when the caller has narrowed nothing (the shape
+        // `tinyhumansai/backend` documents: "when `important` is omitted,
+        // server-side defaults the filter to curated-only — returning ~50
+        // 'featured' tools per toolkit").
+        //
+        // That default does NOT hold on this raw REST path — omitting the
+        // parameter here returns the whole catalogue, which is how a bare
+        // `toolkits: ["github"]` came back as 893 actions and overflowed the
+        // page budget. So the curation is requested explicitly.
+        //
+        // Gated on having no `search` and no `tags`, and that is the whole
+        // design: an unnarrowed call is a **browse**, and ~50 featured actions
+        // is a far better answer to "what can GitHub do" than 893 rows the
+        // reader cannot skim and the budget cannot carry. A call that names
+        // either one is a **search**, and a search must be able to reach the
+        // long tail — `GITHUB_LIST_REPOSITORY_ISSUES` is not featured, and it is
+        // exactly what the last agent went looking for and reported as absent.
+        //
+        // So: browse is curated and small, search is complete. Neither is
+        // truncated silently — `render_header` states `available`, `matched` and
+        // `showing` on every listing.
+        let narrowed = search.is_some_and(|term| !term.trim().is_empty()) || !tag_values.is_empty();
+        if !narrowed {
+            params.push(("important", "true".to_string()));
+        }
+        if !tag_values.is_empty() {
+            // Comma-separated in one parameter, matching `toolkit_slug`'s
+            // handling directly below — repeating a parameter is what returned
+            // an empty body there, and there is no reason to assume this
+            // endpoint treats a second one differently.
+            params.push(("tags", tag_values.join(",")));
+        }
         let slugs: Vec<&str> = toolkits
             .iter()
             .map(|slug| slug.trim())
@@ -244,8 +317,10 @@ impl DirectComposio {
                 toolkits = ?slugs,
                 fetched = paged.items.len(),
                 dropped = paged.dropped,
-                "[composio-byok] list_tools: stopped at the page budget; narrow the toolkit list \
-                 to see the rest"
+                search,
+                tags = ?tag_values,
+                "[composio-byok] list_tools: stopped at the page budget; narrow with `search` or \
+                 `tags`, or name fewer toolkits, to see the rest"
             );
         }
         Ok(ComposioToolsResponse {
@@ -735,7 +810,7 @@ mod tests {
         let direct = DirectComposio::new("ak_live").with_v3_base_for_test(base);
 
         let resp = direct
-            .list_tools(&["gmail".to_string(), "  ".to_string(), "slack".to_string()])
+            .list_tools(&["gmail".to_string(), "  ".to_string(), "slack".to_string()], None, None)
             .await
             .expect("tools");
         assert_eq!(resp.tools.len(), 1);
@@ -968,7 +1043,7 @@ mod tests {
 
         // 1. The listing the agent discovers actions through.
         let tools = direct
-            .list_tools(&["github".to_string()])
+            .list_tools(&["github".to_string()], None, None)
             .await
             .expect("list_tools");
         let target = tools

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -110,6 +110,10 @@ pub mod native_salvage;
 #[cfg(test)]
 mod native_salvage_turn_test;
 pub mod orchestrator;
+/// Issue #6014: task-aware extraction of an oversized tool result — one
+/// bounded model call that keeps what answers the turn, in place of a byte cut
+/// that keeps whatever happened to come first. See [`payload_extract`].
+pub mod payload_extract;
 /// Chargebee billing tools (issue #788), wired per company from its own
 /// SecretStore. Always compiled so the credential resolution and the fail-closed
 /// decision are testable at default features; only the tools are gated.
@@ -122,10 +126,6 @@ pub mod paypal;
 /// `planning`, with the host gathering the evidence and verifying every
 /// prerequisite the model claims. See [`planning`].
 pub mod planning;
-/// Issue #6014: task-aware extraction of an oversized tool result — one
-/// bounded model call that keeps what answers the turn, in place of a byte cut
-/// that keeps whatever happened to come first. See [`payload_extract`].
-pub mod payload_extract;
 pub mod policy;
 pub mod provider;
 /// Issue #244: `publish_artifact` — the only way a workspace file becomes a

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -122,6 +122,10 @@ pub mod paypal;
 /// `planning`, with the host gathering the evidence and verifying every
 /// prerequisite the model claims. See [`planning`].
 pub mod planning;
+/// Issue #6014: task-aware extraction of an oversized tool result — one
+/// bounded model call that keeps what answers the turn, in place of a byte cut
+/// that keeps whatever happened to come first. See [`payload_extract`].
+pub mod payload_extract;
 pub mod policy;
 pub mod provider;
 /// Issue #244: `publish_artifact` — the only way a workspace file becomes a
@@ -4316,18 +4320,26 @@ impl HarnessPool {
                 crate::turn_stream::LiveRoute::Workflow { .. } => None,
             })
             .or_else(|| chat.chat_id.map(str::to_string));
-        let (outcome, turn_costs) = crate::runtime::delegation::with_turn_conversation(
-            turn_chat,
-            deps.approval_requests.turn_scoped(agent.run_with_steer(
-                &augmented,
-                steer,
-                stream_ctx,
-                run_sink.clone(),
-                chat_seed_request,
-                // The caller's own, not read off `live` (#1890 I). A turn can
-                // have a conversation and stream nothing.
-                chat,
-            )),
+        // Issue #6014: what this turn is for, in scope for its whole duration, so
+        // an oversized tool result can be extracted against the task instead of
+        // cut on a byte boundary. `operator_words` for the reason its own docs
+        // give — `message` here is the composed text and carries the cycle's
+        // briefings, which are not what anybody asked for.
+        let (outcome, turn_costs) = crate::runtime::delegation::with_task_hint(
+            crate::runtime::delegation::operator_words(message).to_string(),
+            crate::runtime::delegation::with_turn_conversation(
+                turn_chat,
+                deps.approval_requests.turn_scoped(agent.run_with_steer(
+                    &augmented,
+                    steer,
+                    stream_ctx,
+                    run_sink.clone(),
+                    chat_seed_request,
+                    // The caller's own, not read off `live` (#1890 I). A turn can
+                    // have a conversation and stream nothing.
+                    chat,
+                )),
+            ),
         )
         .await;
         // Issue B-120: bank what the turn spent BEFORE its result is unwrapped.

--- a/src/harness/built_in/payload_extract.rs
+++ b/src/harness/built_in/payload_extract.rs
@@ -108,6 +108,27 @@ fn cap_input(raw: &str) -> (&str, bool) {
 pub struct PayloadExtractor {
     model: Arc<dyn tinyinference::model::ChatModel<()>>,
     model_name: String,
+    /// What the extraction's spend is charged to.
+    ///
+    /// Carried rather than resolved here, for the reason every other one-shot
+    /// pass in this crate carries it: the call spends the company's own
+    /// credential, so it belongs on the company's ledger. Shipping without this
+    /// made a per-oversized-result model call — whose input is the payload —
+    /// invisible to the usage ledger and the per-turn spend accounting
+    /// (codex on tinyhumansai/opencompany#2153).
+    metering: Option<ExtractionMetering>,
+}
+
+/// The handles [`crate::metering::record_extraction_usage`] needs.
+#[derive(Clone)]
+struct ExtractionMetering {
+    company: crate::ports::types::CompanyId,
+    provider_slug: String,
+    store: Arc<dyn crate::ports::CompanyStore>,
+    meter: Option<Arc<dyn crate::ports::usage::UsageMeter>>,
+    /// Read off the `HarnessModel` at construction: the extractor itself holds
+    /// only a `ChatModel<()>`, which cannot name itself for telemetry.
+    model_slug: Option<crate::metering::ModelSlug>,
 }
 
 impl PayloadExtractor {
@@ -115,7 +136,7 @@ impl PayloadExtractor {
     /// company's own credential and is metered against it — the reason every
     /// other one-shot pass in this crate is constructed this way rather than
     /// resolving its own.
-    pub fn from_deps(deps: &HarnessDeps) -> Self {
+    pub fn from_deps(deps: &HarnessDeps, company: &crate::ports::types::CompanyId) -> Self {
         let model_name = deps
             .model_override
             .clone()
@@ -123,7 +144,60 @@ impl PayloadExtractor {
         Self {
             model: deps.provider.clone() as Arc<dyn tinyinference::model::ChatModel<()>>,
             model_name,
+            metering: Some(ExtractionMetering {
+                company: company.clone(),
+                provider_slug: deps.provider_slug.clone(),
+                store: deps.store.clone(),
+                meter: deps.meter.clone(),
+                model_slug: deps.provider.telemetry_model(),
+            }),
         }
+    }
+}
+
+impl PayloadExtractor {
+    /// Charge one extraction's tokens to the company that paid for them.
+    ///
+    /// Best-effort by design, on the same rule the titling and selector paths
+    /// follow: the call has already happened and the turn is already carrying
+    /// its result, so a ledger hiccup must cost the accounting row rather than
+    /// the turn.
+    async fn record_usage(&self, response: &tinyinference::model::ModelResponse) {
+        let Some(metering) = self.metering.as_ref() else {
+            return;
+        };
+        let usage = usage_from(response);
+        crate::metering::record_extraction_usage(
+            &usage,
+            &metering.provider_slug,
+            metering.model_slug,
+            &metering.company,
+            metering.store.as_ref(),
+            metering.meter.as_deref(),
+        )
+        .await;
+    }
+}
+
+/// The tokens and charged cost one response reports.
+///
+/// Reads the provider's charged amount out of response metadata the same way
+/// the titling pass does, so a managed provider's real dollar figure is used in
+/// preference to a local estimate.
+fn usage_from(response: &tinyinference::model::ModelResponse) -> crate::ports::types::TokenUsage {
+    let tokens = response.usage.unwrap_or_default();
+    let cost_usd = response
+        .raw
+        .as_ref()
+        .and_then(|raw| raw.pointer("/openhuman_usage_meta/charged_amount_usd"))
+        .and_then(serde_json::Value::as_f64)
+        .filter(|c| c.is_finite() && *c > 0.0)
+        .unwrap_or(0.0);
+    crate::ports::types::TokenUsage {
+        input: tokens.input_tokens,
+        output: tokens.output_tokens,
+        cached_input: tokens.cache_read_tokens,
+        cost_usd,
     }
 }
 
@@ -235,6 +309,11 @@ impl PayloadSummarizer for PayloadExtractor {
                 }
             };
 
+        // Before anything is decided about the answer: the tokens are spent
+        // either way, and an extraction that is later rejected as `NotNeeded`
+        // cost exactly as much as one that is used.
+        self.record_usage(&response).await;
+
         let summary = response.text();
         if summary.trim().is_empty() {
             tracing::warn!(
@@ -311,6 +390,10 @@ mod tests {
         PayloadExtractor {
             model: Arc::new(Scripted(behaviour)),
             model_name: "test-model".to_string(),
+            // No company handles under test here: these cases are about which
+            // `SummarizeOutcome` each branch yields. The metering path is
+            // exercised where the ledger and meter live.
+            metering: None,
         }
     }
 

--- a/src/harness/built_in/payload_extract.rs
+++ b/src/harness/built_in/payload_extract.rs
@@ -167,32 +167,28 @@ impl PayloadSummarizer for PayloadExtractor {
             ..Default::default()
         };
 
-        let response = match tokio::time::timeout(
-            EXTRACT_TIMEOUT,
-            self.model.invoke(&(), request),
-        )
-        .await
-        {
-            Ok(Ok(response)) => response,
-            Ok(Err(error)) => {
-                tracing::warn!(
-                    tool = tool_name,
-                    bytes = original_bytes,
-                    %error,
-                    "[payload-extract] extraction call failed; the raw payload stands"
-                );
-                return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Failed));
-            }
-            Err(_) => {
-                tracing::warn!(
-                    tool = tool_name,
-                    bytes = original_bytes,
-                    timeout_s = EXTRACT_TIMEOUT.as_secs(),
-                    "[payload-extract] extraction timed out; the raw payload stands"
-                );
-                return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Failed));
-            }
-        };
+        let response =
+            match tokio::time::timeout(EXTRACT_TIMEOUT, self.model.invoke(&(), request)).await {
+                Ok(Ok(response)) => response,
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        tool = tool_name,
+                        bytes = original_bytes,
+                        %error,
+                        "[payload-extract] extraction call failed; the raw payload stands"
+                    );
+                    return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Failed));
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        tool = tool_name,
+                        bytes = original_bytes,
+                        timeout_s = EXTRACT_TIMEOUT.as_secs(),
+                        "[payload-extract] extraction timed out; the raw payload stands"
+                    );
+                    return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Failed));
+                }
+            };
 
         let summary = response.text();
         if summary.trim().is_empty() {
@@ -220,7 +216,10 @@ impl PayloadSummarizer for PayloadExtractor {
             tool = tool_name,
             from_bytes = original_bytes,
             to_bytes = summary.len(),
-            ratio = format!("{:.1}x", original_bytes as f64 / summary.len().max(1) as f64),
+            ratio = format!(
+                "{:.1}x",
+                original_bytes as f64 / summary.len().max(1) as f64
+            ),
             "[payload-extract] extracted the answering content from an oversized tool result"
         );
         Ok(SummarizeOutcome::Summarized(SummarizedPayload {

--- a/src/harness/built_in/payload_extract.rs
+++ b/src/harness/built_in/payload_extract.rs
@@ -346,6 +346,30 @@ impl PayloadSummarizer for PayloadExtractor {
             ),
             "[payload-extract] extracted the answering content from an oversized tool result"
         );
+        // A summary built from a prefix must say so, in the host's words rather
+        // than the model's (codex on tinyhumansai/opencompany#2153).
+        //
+        // `summary` *replaces* the tool output. If the answering record sat past
+        // the input ceiling the model never saw it, and without this line the
+        // turn would hold a confident summary of a payload it only partly read
+        // — an incomplete list presented as a complete one, which is the precise
+        // failure this extractor exists to end. The full payload is on disk and
+        // pointed at by the artifact contents list, so the recovery is real and
+        // worth naming.
+        //
+        // Host-written because a disclosure the model has to remember is a
+        // disclosure that goes missing exactly when the payload is hardest.
+        let summary = if was_cut {
+            format!(
+                "_Read the first {sent} of {original} bytes of this result; later records were \
+                 not examined. The full output is on disk — see the stored-results list for its \
+                 path, and read it directly if the answer is not below._\n\n{summary}",
+                sent = body.len(),
+                original = original_bytes,
+            )
+        } else {
+            summary
+        };
         Ok(SummarizeOutcome::Summarized(SummarizedPayload {
             summary_bytes: summary.len(),
             summary,
@@ -494,6 +518,62 @@ mod tests {
                 );
             }
             other => panic!("expected a summary, got {other:?}"),
+        }
+    }
+
+    /// A summary built from a prefix must say so. The summary *replaces* the
+    /// tool output, so without this the turn holds a confident account of a
+    /// payload the model only partly read — an incomplete list presented as a
+    /// complete one, which is the failure this extractor exists to end (codex
+    /// on tinyhumansai/opencompany#2153).
+    #[tokio::test]
+    async fn a_summary_from_a_truncated_payload_discloses_the_cut() {
+        let huge = format!("[{}]", vec![r#"{"n":1}"#; 60_000].join(","));
+        assert!(
+            huge.len() > MAX_EXTRACT_INPUT_CHARS,
+            "the fixture must exceed the ceiling or nothing is cut"
+        );
+        let outcome = run(
+            Behaviour::Reply("60000 records"),
+            Some("list the records"),
+            &huge,
+        )
+        .await;
+
+        match outcome {
+            SummarizeOutcome::Summarized(summary) => {
+                assert!(
+                    summary.summary.contains("later records were not examined"),
+                    "the cut must be disclosed: {}",
+                    summary.summary
+                );
+                assert!(
+                    summary.summary.contains("full output is on disk"),
+                    "the recovery route must be named: {}",
+                    summary.summary
+                );
+                assert!(
+                    summary.summary.contains("60000 records"),
+                    "the model's answer is still carried: {}",
+                    summary.summary
+                );
+            }
+            other => panic!("expected a summary, got {other:?}"),
+        }
+
+        // A payload under the ceiling carries no such notice.
+        let small = run(
+            Behaviour::Reply("two records"),
+            Some("list the records"),
+            &format!("[{}]", vec![r#"{"n":1}"#; 400].join(",")),
+        )
+        .await;
+        if let SummarizeOutcome::Summarized(summary) = small {
+            assert!(
+                !summary.summary.contains("not examined"),
+                "nothing was cut, so nothing is disclosed: {}",
+                summary.summary
+            );
         }
     }
 

--- a/src/harness/built_in/payload_extract.rs
+++ b/src/harness/built_in/payload_extract.rs
@@ -71,6 +71,13 @@ const EXTRACT_TIMEOUT: Duration = Duration::from_secs(25);
 /// budget problem with a second one.
 const MAX_SUMMARY_TOKENS: u32 = 1_500;
 
+/// Below this, a payload is passed through untouched as `NotNeeded`.
+///
+/// Mirrors the reference summarizer's `summarizer_payload_threshold_tokens`
+/// (4 000 tokens, ~4 chars per token) so both implementations answer the same
+/// question the same way.
+const PASS_THROUGH_BYTES: usize = 16 * 1024;
+
 /// The most of an oversized payload that is worth sending to the extractor.
 ///
 /// `raw` arrives here *because* it exceeded the per-result budget, so it has no
@@ -235,6 +242,22 @@ impl PayloadSummarizer for PayloadExtractor {
         raw: &str,
     ) -> anyhow::Result<SummarizeOutcome> {
         let original_bytes = raw.len();
+        // Size first, hint second — the order the reference implementation uses,
+        // and the order that matters here.
+        //
+        // `ToolOutputMiddleware` calls this for **every** tool result, passing
+        // `None` for the hint, and turns any `Unavailable` into a notice
+        // prefixed onto the payload the model reads. Deciding on the hint first
+        // stamped "summarization unavailable" onto every small result of every
+        // turn without a hint — announcing the absence of a reduction nothing
+        // had asked for, on payloads that never needed one. It broke 15 turn
+        // tests, whose scripted models then never saw the results they were
+        // written to act on.
+        //
+        // A result under the threshold is not unavailable. It is fine as it is.
+        if original_bytes <= PASS_THROUGH_BYTES {
+            return Ok(SummarizeOutcome::NotNeeded);
+        }
         // The task hint is the whole point of this over a mechanical cut. With
         // none, an extraction has no way to tell an answering record from a
         // filler one, and would be guessing exactly as blindly as the byte cut
@@ -433,12 +456,19 @@ mod tests {
     }
 
     fn big() -> String {
-        // Comfortably over anything the summary will be, so `NotNeeded` is only
-        // reached when the model genuinely fails to shrink it.
-        format!(
+        // Over `PASS_THROUGH_BYTES`, or the size gate short-circuits to
+        // `NotNeeded` and none of the branches below is reached — which is
+        // exactly what happened when that gate was added: five tests here
+        // began passing through instead of exercising the paths they name.
+        let payload = format!(
             "[{}]",
-            vec![r#"{"number":1,"title":"a flaky test"}"#; 400].join(",")
-        )
+            vec![r#"{"number":1,"title":"a flaky test"}"#; 2_000].join(",")
+        );
+        assert!(
+            payload.len() > PASS_THROUGH_BYTES,
+            "the fixture must clear the pass-through gate"
+        );
+        payload
     }
 
     /// Without a hint the extraction has nothing to select against and would be

--- a/src/harness/built_in/payload_extract.rs
+++ b/src/harness/built_in/payload_extract.rs
@@ -71,6 +71,38 @@ const EXTRACT_TIMEOUT: Duration = Duration::from_secs(25);
 /// budget problem with a second one.
 const MAX_SUMMARY_TOKENS: u32 = 1_500;
 
+/// The most of an oversized payload that is worth sending to the extractor.
+///
+/// `raw` arrives here *because* it exceeded the per-result budget, so it has no
+/// upper bound of its own — a multi-megabyte result would be sent, and billed,
+/// in full, once per oversized tool result, and a payload past the model's
+/// context window fails the call outright and spends the latency to return
+/// `Unavailable` (CodeRabbit on tinyhumansai/opencompany#2153).
+///
+/// 256 KiB is far above the per-result budget that got us here and far below
+/// any context window this runs against, so the ceiling only ever bites the
+/// pathological case. The head of a payload is the right part to keep: record
+/// arrays lead with records, and the archetype prompt asks for the count and
+/// the page boundaries, which the head carries.
+const MAX_EXTRACT_INPUT_CHARS: usize = 256 * 1024;
+
+/// Cut `raw` to the input ceiling **on a character boundary**.
+///
+/// Slicing a `&str` by byte index panics mid-character, and provider payloads
+/// carry plenty of multi-byte text (issue titles, names, emoji). Returns the
+/// text to send and whether it was cut, so the prompt can say so — an extractor
+/// told it is reading a prefix will not claim the payload ended there.
+fn cap_input(raw: &str) -> (&str, bool) {
+    if raw.len() <= MAX_EXTRACT_INPUT_CHARS {
+        return (raw, false);
+    }
+    let mut end = MAX_EXTRACT_INPUT_CHARS;
+    while end > 0 && !raw.is_char_boundary(end) {
+        end -= 1;
+    }
+    (&raw[..end], true)
+}
+
 /// One bounded model call that pulls the answering content out of an oversized
 /// tool result. See the module docs.
 pub struct PayloadExtractor {
@@ -154,12 +186,25 @@ impl PayloadSummarizer for PayloadExtractor {
             return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Disabled));
         };
 
+        let (body, was_cut) = cap_input(raw);
+        let cut_note = if was_cut {
+            tracing::warn!(
+                tool = tool_name,
+                bytes = original_bytes,
+                sent_bytes = body.len(),
+                "[payload-extract] payload exceeded the extraction input ceiling; \
+                 the head was sent and the prompt says so"
+            );
+            " (truncated — this is the head of a larger payload)"
+        } else {
+            ""
+        };
         let request = tinyinference::model::ModelRequest {
             messages: vec![
                 tinyinference::message::Message::system(system_prompt()),
                 tinyinference::message::Message::user(format!(
                     "The agent is trying to: {task}\n\nTool that ran: `{tool_name}`\n\n\
-                     Raw output:\n{raw}"
+                     Raw output{cut_note}:\n{body}"
                 )),
             ],
             model: Some(self.model_name.clone()),
@@ -234,19 +279,175 @@ impl PayloadSummarizer for PayloadExtractor {
 mod tests {
     use super::*;
 
+    use tinyinference::Result as TaResult;
+    use tinyinference::model::{ChatModel, ModelRequest, ModelResponse};
+
+    /// What the model does when the extractor calls it.
+    enum Behaviour {
+        Reply(&'static str),
+        Fail,
+        Hang,
+    }
+
+    struct Scripted(Behaviour);
+
+    #[async_trait::async_trait]
+    impl ChatModel<()> for Scripted {
+        async fn invoke(&self, _state: &(), _request: ModelRequest) -> TaResult<ModelResponse> {
+            match self.0 {
+                Behaviour::Reply(text) => Ok(ModelResponse::assistant(text)),
+                Behaviour::Fail => Err(tinyinference::Error::Model("provider exploded".into())),
+                Behaviour::Hang => {
+                    // Longer than EXTRACT_TIMEOUT, so the timeout arm is the one
+                    // under test rather than a race.
+                    tokio::time::sleep(EXTRACT_TIMEOUT * 4).await;
+                    Ok(ModelResponse::assistant("too late"))
+                }
+            }
+        }
+    }
+
+    fn extractor(behaviour: Behaviour) -> PayloadExtractor {
+        PayloadExtractor {
+            model: Arc::new(Scripted(behaviour)),
+            model_name: "test-model".to_string(),
+        }
+    }
+
+    async fn run(behaviour: Behaviour, hint: Option<&str>, raw: &str) -> SummarizeOutcome {
+        let ctx = tinyagents_harness::context::RunContext::new(
+            tinyagents_harness::context::RunConfig::new("payload-extract-test"),
+            (),
+        );
+        extractor(behaviour)
+            .maybe_summarize_in_parent(&ctx, "GITHUB_LIST_ISSUES", hint, raw)
+            .await
+            .expect("the extractor degrades, it never errors")
+    }
+
+    fn big() -> String {
+        // Comfortably over anything the summary will be, so `NotNeeded` is only
+        // reached when the model genuinely fails to shrink it.
+        format!(
+            "[{}]",
+            vec![r#"{"number":1,"title":"a flaky test"}"#; 400].join(",")
+        )
+    }
+
+    /// Without a hint the extraction has nothing to select against and would be
+    /// guessing as blindly as the byte cut it replaces, so it declines.
+    #[tokio::test]
+    async fn no_task_hint_declines_rather_than_guessing() {
+        let outcome = run(Behaviour::Reply("30 issues"), None, &big()).await;
+        assert!(matches!(
+            outcome,
+            SummarizeOutcome::Unavailable(UnavailableReason::Disabled)
+        ));
+    }
+
+    /// A provider failure must leave the turn holding the raw payload, not fail
+    /// the turn: extraction is an improvement on truncation, never a dependency.
+    #[tokio::test]
+    async fn a_provider_error_leaves_the_raw_payload_standing() {
+        let outcome = run(Behaviour::Fail, Some("list the issues"), &big()).await;
+        assert!(matches!(
+            outcome,
+            SummarizeOutcome::Unavailable(UnavailableReason::Failed)
+        ));
+    }
+
+    /// The deadline is the point: a slow extraction is worse than none, because
+    /// the turn is already at its cap when this runs.
+    #[tokio::test(start_paused = true)]
+    async fn a_hanging_provider_times_out_rather_than_stalling_the_turn() {
+        let outcome = run(Behaviour::Hang, Some("list the issues"), &big()).await;
+        assert!(matches!(
+            outcome,
+            SummarizeOutcome::Unavailable(UnavailableReason::Failed)
+        ));
+    }
+
+    /// An empty answer is a failed extraction, not an empty tool result — the
+    /// difference decides whether the model sees the payload at all.
+    #[tokio::test]
+    async fn an_empty_answer_is_treated_as_a_failure() {
+        let outcome = run(Behaviour::Reply("   \n  "), Some("list the issues"), &big()).await;
+        assert!(matches!(
+            outcome,
+            SummarizeOutcome::Unavailable(UnavailableReason::Failed)
+        ));
+    }
+
+    /// A "summary" at least as long as the payload has extracted nothing, and
+    /// substituting it would spend a model call to make the result no smaller.
+    #[tokio::test]
+    async fn a_summary_that_does_not_shrink_is_not_used() {
+        let raw = r#"[{"number":1}]"#;
+        let outcome = run(
+            Behaviour::Reply("this reply is considerably longer than the payload it summarises"),
+            Some("list the issues"),
+            raw,
+        )
+        .await;
+        assert!(matches!(outcome, SummarizeOutcome::NotNeeded));
+    }
+
+    /// The path that matters: a hint, a working model, and an answer shorter
+    /// than what it replaces.
+    #[tokio::test]
+    async fn a_shorter_answer_is_returned_as_the_summary() {
+        let outcome = run(
+            Behaviour::Reply("400 issues; #1 a flaky test"),
+            Some("list the issues"),
+            &big(),
+        )
+        .await;
+        match outcome {
+            SummarizeOutcome::Summarized(summary) => {
+                assert!(
+                    summary.summary.contains("400 issues"),
+                    "the model's answer must be what is carried: {}",
+                    summary.summary
+                );
+            }
+            other => panic!("expected a summary, got {other:?}"),
+        }
+    }
+
+    /// The input ceiling exists so a multi-megabyte payload is neither billed in
+    /// full nor sent past a context window. Slicing must land on a character
+    /// boundary — a byte index inside a multi-byte character panics, and
+    /// provider payloads are full of them.
+    #[test]
+    fn the_input_ceiling_cuts_on_a_character_boundary() {
+        let (kept, cut) = cap_input("short");
+        assert_eq!(kept, "short");
+        assert!(!cut, "a small payload is not cut");
+
+        // Every character is 4 bytes, so a byte-index slice at the ceiling would
+        // land mid-character unless the boundary walk works.
+        let wide = "\u{1F600}".repeat(MAX_EXTRACT_INPUT_CHARS);
+        let (kept, cut) = cap_input(&wide);
+        assert!(cut, "an oversized payload is cut");
+        assert!(kept.len() <= MAX_EXTRACT_INPUT_CHARS);
+        assert!(
+            wide.starts_with(kept),
+            "the cut keeps the head of the payload"
+        );
+    }
+
     /// The archetype is referenced, not restated. A copy would drift from
     /// upstream the moment either side edited the extraction contract, and the
     /// first version of this file learned that the expensive way — a
     /// hand-written prompt that omitted the per-record identifier line produced
     /// thirty issue numbers with no titles.
+    ///
+    /// This asserts the *clauses this crate depends on are present in what is
+    /// sent*. It deliberately no longer compares `system_prompt()` with the
+    /// constant it returns, which was `assert_eq!(X, X)` and could not fail
+    /// (tinysweeper on tinyhumansai/opencompany#2153).
     #[test]
-    fn the_prompt_is_openhumans_own_archetype() {
-        assert_eq!(
-            system_prompt(),
-            oh::agent::registry::agents::summarizer::prompt::ARCHETYPE,
-            "the prompt must stay the vendored archetype, not a local copy"
-        );
-        // The clauses whose absence was actually observed to cost something.
+    fn the_prompt_carries_the_clauses_this_crate_relies_on() {
         assert!(
             system_prompt().contains("Identifiers preserved"),
             "the per-record identifier section is what gives each kept record a line"

--- a/src/harness/built_in/payload_extract.rs
+++ b/src/harness/built_in/payload_extract.rs
@@ -1,0 +1,260 @@
+//! Task-aware extraction of an oversized tool result (issue #6014).
+//!
+//! # What this replaces
+//!
+//! A tool result larger than the per-result budget used to be **cut on a byte
+//! boundary**. That keeps the first few whole records and discards every one
+//! after them, which is the wrong end to lose: a listing of thirty issues
+//! became two, and the agent — correctly reporting what it could see — told the
+//! operator there were two.
+//!
+//! Two cheaper transforms were tried first and are worth recording so nobody
+//! re-derives them. **Dropping navigation fields**
+//! ([`project_records_value`](crate::harness::composio_catalog::project_records_value))
+//! measured **1.6x** on a real 237 KB GitHub payload — real, free, and nowhere
+//! near enough. **Capping every long string** would have kept all thirty
+//! records, but it clips the one body the operator asked about exactly as hard
+//! as the twenty-nine they did not, because it has no idea which is which.
+//!
+//! The size is not the problem. The problem is that **nothing in the pipeline
+//! knew what the turn was for**, so every strategy had to guess uniformly.
+//!
+//! # What it does instead
+//!
+//! [`PayloadSummarizer::maybe_summarize_in_parent`] is handed the tool name,
+//! the raw payload **and the turn's task hint**, so the compression can keep
+//! what answers the question and drop what does not. That trait has existed
+//! upstream all along; OpenCompany simply never set it
+//! (`AgentBuilder::payload_summarizer` defaults to `None`, and the only wiring
+//! site is OpenHuman's own factory, which builds a **sub-agent** implementation
+//! this crate cannot use — see `toolbelt`'s v1 note on why spawn tools are
+//! withheld under multi-tenancy).
+//!
+//! So this is the same contract with a different engine: **one bounded,
+//! tool-less model call**, the shape
+//! [`TriageEvaluator`](crate::harness::triage), the card titler and
+//! [`TaskPlanner`](crate::harness::planning) already use — built `from_deps`
+//! so it shares the company's provider, its BYOK switch and its metering
+//! rather than resolving a second credential path.
+//!
+//! # Failure is never fatal
+//!
+//! Every failure path returns [`SummarizeOutcome::Unavailable`], never `Err`:
+//! a summarizer that times out must leave the turn holding the raw payload
+//! (which downstream truncation still bounds), not kill the tool call. The
+//! reason rides along so the model is told the result is unsummarized rather
+//! than being handed a fragment silently.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use openhuman_core::openhuman as oh;
+
+use oh::agent::tinyagents::payload_summarizer::{
+    PayloadSummarizer, SummarizeOutcome, SummarizedPayload, UnavailableReason,
+};
+
+use crate::harness::HarnessDeps;
+use crate::harness::build::model_for_tier;
+
+/// How long one extraction may take before the turn gives up on it.
+///
+/// Deliberately short. This call sits **between a tool returning and the model
+/// seeing its result**, so every millisecond is latency the operator watches
+/// accumulate mid-turn. A slow extraction is worse than none: the raw payload
+/// is still bounded downstream, so the fallback is the behaviour that shipped
+/// before this existed.
+const EXTRACT_TIMEOUT: Duration = Duration::from_secs(25);
+
+/// Ceiling on the extraction's own output, so a summarizer cannot answer a
+/// budget problem with a second one.
+const MAX_SUMMARY_TOKENS: u32 = 1_500;
+
+/// One bounded model call that pulls the answering content out of an oversized
+/// tool result. See the module docs.
+pub struct PayloadExtractor {
+    model: Arc<dyn tinyinference::model::ChatModel<()>>,
+    model_name: String,
+}
+
+impl PayloadExtractor {
+    /// Built from the same deps the roster is, so the extraction spends the
+    /// company's own credential and is metered against it — the reason every
+    /// other one-shot pass in this crate is constructed this way rather than
+    /// resolving its own.
+    pub fn from_deps(deps: &HarnessDeps) -> Self {
+        let model_name = deps
+            .model_override
+            .clone()
+            .unwrap_or_else(|| model_for_tier(None));
+        Self {
+            model: deps.provider.clone() as Arc<dyn tinyinference::model::ChatModel<()>>,
+            model_name,
+        }
+    }
+}
+
+/// The instruction: OpenHuman's own summarizer archetype, verbatim.
+///
+/// Not a prompt of this crate's own. The first cut here was, and it was a
+/// weaker restatement of a prompt that already existed two directories away —
+/// it dropped the structural hints ("if the payload is a list, state how many
+/// items it had... what page boundaries exist"), the error-payload rule
+/// ("preserve the error message verbatim at the top"), the binary-payload rule,
+/// and the `Identifiers preserved` section that gives every kept record a line
+/// of its own. That last omission showed up immediately in testing: a task that
+/// asked for issue numbers got thirty numbers and no titles, because nothing
+/// told the model to keep an identifying line per record regardless of what was
+/// asked.
+///
+/// Referenced through the vendored const rather than copied, so the two cannot
+/// drift: an upstream edit to the extraction contract reaches this caller on
+/// the next vendor bump instead of leaving OpenCompany on a stale fork of it.
+///
+/// The archetype is written for a sub-agent invocation, and every line of that
+/// framing holds here — "you run exactly once per invocation, with no tools and
+/// no follow-up iterations" is precisely what this single tool-less call is.
+fn system_prompt() -> &'static str {
+    oh::agent::registry::agents::summarizer::prompt::ARCHETYPE
+}
+
+#[async_trait]
+impl PayloadSummarizer for PayloadExtractor {
+    async fn maybe_summarize_in_parent(
+        &self,
+        _parent_ctx: &tinyagents_harness::context::RunContext<()>,
+        tool_name: &str,
+        parent_task_hint: Option<&str>,
+        raw: &str,
+    ) -> anyhow::Result<SummarizeOutcome> {
+        let original_bytes = raw.len();
+        // The task hint is the whole point of this over a mechanical cut. With
+        // none, an extraction has no way to tell an answering record from a
+        // filler one, and would be guessing exactly as blindly as the byte cut
+        // — so decline and let the bounded raw payload through, which at least
+        // says what it dropped.
+        // The upstream hint when a caller supplies one (the sub-agent path
+        // does), else this crate's own — set by `run_inner` around every turn,
+        // because OpenCompany does not take the sub-agent path that populates
+        // the parameter.
+        let own_hint = crate::runtime::delegation::current_task_hint();
+        let Some(task) = parent_task_hint
+            .map(str::to_string)
+            .or(own_hint)
+            .map(|hint| hint.trim().to_string())
+            .filter(|hint| !hint.is_empty())
+        else {
+            tracing::debug!(
+                tool = tool_name,
+                bytes = original_bytes,
+                "[payload-extract] no task hint on this turn; leaving the payload to the \
+                 downstream bound"
+            );
+            return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Disabled));
+        };
+
+        let request = tinyinference::model::ModelRequest {
+            messages: vec![
+                tinyinference::message::Message::system(system_prompt()),
+                tinyinference::message::Message::user(format!(
+                    "The agent is trying to: {task}\n\nTool that ran: `{tool_name}`\n\n\
+                     Raw output:\n{raw}"
+                )),
+            ],
+            model: Some(self.model_name.clone()),
+            max_tokens: Some(MAX_SUMMARY_TOKENS),
+            ..Default::default()
+        };
+
+        let response = match tokio::time::timeout(
+            EXTRACT_TIMEOUT,
+            self.model.invoke(&(), request),
+        )
+        .await
+        {
+            Ok(Ok(response)) => response,
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    tool = tool_name,
+                    bytes = original_bytes,
+                    %error,
+                    "[payload-extract] extraction call failed; the raw payload stands"
+                );
+                return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Failed));
+            }
+            Err(_) => {
+                tracing::warn!(
+                    tool = tool_name,
+                    bytes = original_bytes,
+                    timeout_s = EXTRACT_TIMEOUT.as_secs(),
+                    "[payload-extract] extraction timed out; the raw payload stands"
+                );
+                return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Failed));
+            }
+        };
+
+        let summary = response.text();
+        if summary.trim().is_empty() {
+            tracing::warn!(
+                tool = tool_name,
+                bytes = original_bytes,
+                "[payload-extract] extraction returned nothing; the raw payload stands"
+            );
+            return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Failed));
+        }
+        // An "extraction" that grew the payload is not one. Rare, but a model
+        // handed a small-but-over-threshold body can pad; taking it anyway
+        // would spend a call to make the budget problem worse.
+        if summary.len() >= original_bytes {
+            tracing::debug!(
+                tool = tool_name,
+                original_bytes,
+                summary_bytes = summary.len(),
+                "[payload-extract] extraction did not shrink the payload; keeping the raw output"
+            );
+            return Ok(SummarizeOutcome::NotNeeded);
+        }
+
+        tracing::info!(
+            tool = tool_name,
+            from_bytes = original_bytes,
+            to_bytes = summary.len(),
+            ratio = format!("{:.1}x", original_bytes as f64 / summary.len().max(1) as f64),
+            "[payload-extract] extracted the answering content from an oversized tool result"
+        );
+        Ok(SummarizeOutcome::Summarized(SummarizedPayload {
+            summary_bytes: summary.len(),
+            summary,
+            original_bytes,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The archetype is referenced, not restated. A copy would drift from
+    /// upstream the moment either side edited the extraction contract, and the
+    /// first version of this file learned that the expensive way — a
+    /// hand-written prompt that omitted the per-record identifier line produced
+    /// thirty issue numbers with no titles.
+    #[test]
+    fn the_prompt_is_openhumans_own_archetype() {
+        assert_eq!(
+            system_prompt(),
+            oh::agent::registry::agents::summarizer::prompt::ARCHETYPE,
+            "the prompt must stay the vendored archetype, not a local copy"
+        );
+        // The clauses whose absence was actually observed to cost something.
+        assert!(
+            system_prompt().contains("Identifiers preserved"),
+            "the per-record identifier section is what gives each kept record a line"
+        );
+        assert!(
+            system_prompt().contains("Never drop them"),
+            "identifiers are the archetype's first-order rule"
+        );
+    }
+}

--- a/src/metering/extract.rs
+++ b/src/metering/extract.rs
@@ -1,0 +1,105 @@
+//! Emitting [`SampleKind::ExtractionCall`] usage samples — what reading an
+//! oversized tool result costs, and who it is charged to.
+//!
+//! # Why this is not a teammate's inference
+//!
+//! An extraction is the tool-less model call that turns a tool result too large
+//! to inline into the part of it that answers the turn. It happens *inside*
+//! another agent's turn, against a payload rather than a prompt, so there is no
+//! separate agent to attribute it to and no run of its own. Like a titling pass
+//! and a triage escalation, it is charged to the whole-company bucket
+//! ([`UNATTRIBUTED_AGENT`]) with no `run_id`.
+//!
+//! # Why it is not folded into `Inference`
+//!
+//! Its cost curve is unlike a turn's. It fires once per oversized result, its
+//! input is the payload — potentially hundreds of kilobytes — and a turn that
+//! gathers several large results pays it several times. Folded into the
+//! teammate's own `Inference` line, that spend would move whenever a tool got
+//! chattier, and no operator could separate "this agent is expensive" from
+//! "this agent's tools return a lot".
+//!
+//! # Both writes are logged and swallowed
+//!
+//! Same rule as the titling and selector paths: by the time this is called the
+//! extraction has already happened and the turn is already carrying its result.
+//! A ledger or meter hiccup must cost the accounting row, never the turn. The
+//! tokens were genuinely spent either way, which is why the failure is logged
+//! rather than silently dropped.
+
+use crate::ports::types::{CompanyId, TokenUsage};
+use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
+use crate::ports::{CompanyStore, now_millis};
+
+use super::inference::{UNATTRIBUTED_AGENT, inference_ledger_entry};
+
+/// Builds the [`SampleKind::ExtractionCall`] sample for one completed
+/// extraction, or `None` when it moved no tokens and cost nothing.
+///
+/// The `None` case is the offline/mock path: a provider reporting no usage
+/// yields a zero [`TokenUsage`], and a row for it would claim a call happened
+/// that is indistinguishable from a real free one.
+pub fn extraction_sample(
+    usage: &TokenUsage,
+    provider: &str,
+    model: Option<crate::metering::ModelSlug>,
+) -> Option<UsageSample> {
+    if usage.is_zero() {
+        return None;
+    }
+    Some(UsageSample {
+        at_millis: now_millis(),
+        agent: UNATTRIBUTED_AGENT.to_string(),
+        provider: super::oauth::normalize_provider(provider),
+        input_tokens: usage.input,
+        output_tokens: usage.output,
+        cached_input_tokens: usage.cached_input,
+        cost_usd: usage.cost_usd,
+        kind: SampleKind::ExtractionCall,
+        run_id: None,
+        model,
+    })
+}
+
+/// Records one extraction's spend against the company ledger and the usage
+/// meter. Both writes are best-effort and logged on failure.
+pub async fn record_extraction_usage(
+    usage: &TokenUsage,
+    provider: &str,
+    model: Option<crate::metering::ModelSlug>,
+    company: &CompanyId,
+    store: &dyn CompanyStore,
+    meter: Option<&dyn UsageMeter>,
+) {
+    if usage.is_zero() {
+        return;
+    }
+    tracing::debug!(
+        company = %company,
+        provider = %provider,
+        input = usage.input,
+        output = usage.output,
+        cached_input = usage.cached_input,
+        cost_usd = usage.cost_usd,
+        "[usage] recording an oversized-tool-result extraction"
+    );
+    if let Some(entry) = inference_ledger_entry(usage, UNATTRIBUTED_AGENT)
+        && let Err(err) = store.append_ledger(company, entry).await
+    {
+        tracing::warn!(
+            company = %company,
+            error = %err,
+            "[usage] failed to append the extraction spend entry; the turn still stands"
+        );
+    }
+    if let Some(sample) = extraction_sample(usage, provider, model)
+        && let Some(meter) = meter
+        && let Err(err) = meter.record(company, &sample).await
+    {
+        tracing::warn!(
+            company = %company,
+            error = %err,
+            "[usage] failed to record the extraction usage sample; the turn still stands"
+        );
+    }
+}

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -46,6 +46,7 @@ use crate::ports::types::OverlayAgent;
 mod calendar;
 pub mod capability;
 pub mod daily_budget;
+pub mod extract;
 mod finances;
 pub mod inference;
 /// Issue #1866: semantic workflow sufficiency calls, charged to the company.
@@ -77,6 +78,7 @@ pub mod workflow_build;
 
 pub use capability::{BudgetPeriod, CapabilityPlan, TierBudgetStatus, plan_named, tokens_in};
 pub use daily_budget::{AgentBudgetStatus, usd_spent_by_agent, utc_day_start_millis};
+pub use extract::{extraction_sample, record_extraction_usage};
 pub use finances::{category_label, finances_from};
 pub use inference::{
     INFERENCE_SPEND_KIND, MEDULLA_PROVIDER, UNATTRIBUTED_AGENT, inference_ledger_entry,

--- a/src/ports/usage.rs
+++ b/src/ports/usage.rs
@@ -124,6 +124,24 @@ pub enum SampleKind {
     /// Counts toward the capability-tier token budget: it is per-card spend a
     /// company past its ceiling must stop paying.
     TitleCall,
+    /// One completed oversized-tool-result extraction — the single tool-less
+    /// model call that turns a payload too large to inline into the part of it
+    /// that answers the turn (issue #6014).
+    ///
+    /// Deliberately **not** [`Self::Inference`], on the same reasoning as
+    /// [`Self::TitleCall`] and [`Self::PlanningCall`]: an `Inference` sample is
+    /// a teammate's turn, attributed to an agent and counted against the
+    /// per-teammate chart and the daily cap. An extraction happens *inside*
+    /// another agent's turn, on a tool result, and is charged to the
+    /// whole-company bucket with no `run_id`.
+    ///
+    /// It gets its own kind because its cost curve is unlike anything else
+    /// here: it fires once per oversized tool result, its input is the payload
+    /// rather than a prompt, and a turn that hits several large results pays it
+    /// several times. Folded into any existing kind, that spend would be
+    /// invisible exactly when it mattered — which is how it shipped unmetered
+    /// and was caught in review on tinyhumansai/opencompany#2153.
+    ExtractionCall,
     /// One completed first-run setup pass — the single tool-less model call
     /// that turns three answers into a starting roster
     /// (`docs/spec/runtime/company-setup.md`).

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -3785,6 +3785,41 @@ tokio::task_local! {
 }
 
 tokio::task_local! {
+    /// What the current turn is trying to do, in the requester's own words
+    /// (issue #6014).
+    ///
+    /// Read by [`PayloadExtractor`](crate::harness::payload_extract) when a tool
+    /// returns more than the per-result budget: knowing the task is what lets it
+    /// keep the records that answer the question and shorten the ones that do
+    /// not. Without it the extractor declines outright rather than guessing,
+    /// because a task-blind extraction is a byte cut with a model call attached
+    /// — it would drop the one issue that mattered exactly as readily as the
+    /// twenty-nine that did not.
+    ///
+    /// Set to [`operator_words`], not the composed turn text: by the time a turn
+    /// runs, `message` carries the cycle's machine briefings (open work, the
+    /// settled digest, the thread index, attachment markers), and an extractor
+    /// told the task is "here is a list of finished cards" would keep the wrong
+    /// half of the payload. The same cut the triage and the budget-pause re-park
+    /// already take, for the same reason.
+    ///
+    /// Absent on any path that has not been taught to set it, which the
+    /// extractor treats as "no hint" and declines — no worse than before it
+    /// existed.
+    pub(crate) static TURN_TASK_HINT: String;
+}
+
+/// The current turn's task, when one is in scope.
+pub(crate) fn current_task_hint() -> Option<String> {
+    TURN_TASK_HINT.try_with(|hint| hint.clone()).ok()
+}
+
+/// Runs `fut` with `task` readable as the turn's task hint.
+pub(crate) async fn with_task_hint<F: std::future::Future>(task: String, fut: F) -> F::Output {
+    TURN_TASK_HINT.scope(task, fut).await
+}
+
+tokio::task_local! {
     /// The conversation the current turn is answering in (issue #1890 F).
     ///
     /// A task-local for the reason [`CHAT_ONLY_TURN`] is one: a tool's belt is
@@ -9078,6 +9113,35 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         assert_eq!(
             card.assignee, "engineer",
             "nested delegation must not move the card a second time"
+        );
+    }
+}
+
+#[cfg(test)]
+mod task_hint_tests {
+    use super::*;
+
+    /// The hint is readable inside its scope and gone outside it — the same
+    /// contract `CHAT_ONLY_TURN` holds, and for the same reason: a hint that
+    /// leaked past its turn would describe the previous request to the next
+    /// turn's extractor, which is worse than having none.
+    #[tokio::test]
+    async fn the_task_hint_is_scoped_to_its_turn() {
+        assert!(
+            current_task_hint().is_none(),
+            "no hint before any turn is in scope"
+        );
+        with_task_hint("find the open issues".to_string(), async {
+            assert_eq!(
+                current_task_hint().as_deref(),
+                Some("find the open issues"),
+                "inside the scope the turn's task is readable"
+            );
+        })
+        .await;
+        assert!(
+            current_task_hint().is_none(),
+            "the hint does not leak past its scope"
         );
     }
 }


### PR DESCRIPTION
## Summary

A capped agent turn could gather a lot and conclude with little. Two causes, both fixed here, plus the vendor pin that carries the runtime half.

**Oversized tool results were cut on a byte boundary.** A result over the per-result budget was truncated, so a 150 KB issue listing reached the model as its first few records and a note that the rest was dropped. `payload_extract.rs` adds a `PayloadSummarizer` that asks a model to *extract the answer* from an oversized result instead — using OpenHuman's own summarizer archetype prompt rather than a local copy, because the archetype carries rules a hand-written prompt misses (identifier preservation, structural hints, error and binary payload handling). It is scoped to top-level turns; sub-agents are unchanged.

The extractor is told what the turn is *for*. `runtime/delegation.rs` adds a `TURN_TASK_HINT` task-local carrying the operator's own words, scoped to the turn. Nothing in the reduction path previously knew the turn's purpose, so every strategy narrowed uniformly and guessed.

**Composio tools were hard to find, and their output was mostly navigation.** `list_tools` now forwards `search` and `tags` to the Composio API and asks for `important=true` when the query is unnarrowed, so a toolkit surfaces its relevant tools rather than an arbitrary page. `composio_catalog.rs` adds a recursive field projection over record arrays: most provider output is a list of records whose bulk is URLs and link metadata, not answer.

Measured against a live Composio + GitHub rig:

| | before | after |
| --- | --- | --- |
| issue listing reaching the model | 3 records, no titles | 30 records with titles |
| one `composio_execute` payload | 149,736 bytes | 213 bytes |
| page-budget truncations in a turn | 7 of 7 | 0 |
| tool search for "issue" | not discoverable | 78 tools, incl. `GITHUB_LIST_REPOSITORY_ISSUES` |

The 703x figure is one payload and not a general claim — an earlier prediction of ~10x compression from field projection alone measured at 1.6x, because the bulk was PR body text rather than URL metadata. The large number here comes from extraction, not projection.

## API Or Behavior Changes

- Vendor pin moves to `tinyhumansai/openhuman@6267087`, which carries tinyhumansai/openhuman#6068. That PR makes `agent::tinyagents::payload_summarizer` and the summarizer archetype public; these commits do not compile without it. Pinned to the upstream merge commit, not the fork branch that was reviewed.
- `Cargo.lock` moves with the pin (`openhuman` 0.63.21 -> 0.63.22, plus `tinyconnectors-bus` and `tinymemory`).
- Behaviour change on oversized tool results only: previously truncated, now extracted. Failures degrade to `SummarizeOutcome::Unavailable` and fall back to the existing truncation — the extractor never fails a turn.
- Composio `list_tools` sends new query parameters; no signature change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --features openhuman --lib -- -D warnings`
- [x] `cargo check --features openhuman --lib`
- [x] `cargo test --features openhuman --lib -- payload_extract composio_catalog delegation::task_hint` — 45 passed, 0 failed

Clippy and fmt are run with `--features openhuman` because `src/harness/` compiles only under that gate; a bare invocation does not see these files. Both caught real problems in the first pass (an unformatted block and a dead constant left over from making the projection recursive), fixed in c4c6780.

The full `cargo test` / `cargo build --all-targets` were not run locally — they need the whole vendored tree and take considerably longer than the targeted run. CI covers them.

## Documentation

None. This changes how an existing surface behaves rather than adding one; the reasoning lives in module docs on `payload_extract.rs`, `composio_catalog.rs`, and `delegation.rs`, which is where the next reader of this code will be.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Oversized tool results are now condensed according to the current task, preserving information most relevant to the answer.
  - Composio tool listings support search terms and tag filtering.
  - Unfiltered browsing highlights featured actions, while filtered searches can access a broader catalogue.
  - Larger tool catalogues support improved browsing and result handling.
  - Relevant answering links are now preserved in projected tool results.

- **Bug Fixes**
  - Reduced loss of useful information when tool responses exceed size limits.
  - Improved handling of large structured responses before they are shortened.
  - Improved messaging when searches or filters return no results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->