### PR TITLE
docs(readme): say plainly whether OpenCompany phones home

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,36 @@ programming. `opencompany check` reports any problems in plain language, and
 adding a new business is a new folder, not a new program.
 [Your first company](gitbooks/get-started/your-first-company.md) walks through it.
 
+## What it reports about itself
+
+Nothing, unless it is a tenant on the TinyHumans hosted platform.
+
+- **A self-hosted or desktop install sends nothing** — and not "nothing by
+  default" in the sense of a switch someone could flip. The network client is
+  behind a cargo feature the shipped default build does not compile in, so
+  there is no code in that binary that could make the request. Getting one out
+  of that state takes a recompile, not a config change.
+- **Hosted tenants report product usage**, because the platform builds their
+  image with that feature on and injects a project token. What it reports is
+  shape and outcome under an opaque id: how many companies are configured,
+  which storage backend is in use, whether a turn finished or failed, and token
+  and cost counts.
+- **No company content ever leaves, on any install.** Not message text,
+  prompts, agent output, file paths, ledger values, tool names or arguments,
+  email addresses, company or agent names, task titles, error messages, or
+  credentials of any kind. That is enforced by construction rather than by
+  review: a reported property is a word compiled into the binary, a count, a
+  number or a boolean, and the type has no `String` variant for runtime text to
+  arrive in.
+- **To turn it off**, set `OPENCOMPANY_ANALYTICS=off`. It outranks everything
+  else, and boot prints one line saying which way it resolved.
+
+[`docs/spec/runtime/analytics.md`](docs/spec/runtime/analytics.md) has every
+event and property, the conditions that must all hold before anything is sent,
+and how the opaque id is derived. Crash reporting is separate, off until you
+configure it, and goes to your own Sentry project rather than ours —
+[`docs/spec/runtime/crash-reporting.md`](docs/spec/runtime/crash-reporting.md).
+
 ## Documentation
 
 | Where | What's there |


### PR DESCRIPTION
## Summary

`README.md` does not mention analytics anywhere today — the only occurrence of the word is an unrelated marketing-agency company template. `docs/spec/runtime/analytics.md` is thorough, but someone evaluating a GPL-3.0, self-hostable project should not have to read `docs/spec/runtime/` to learn whether it phones home.

Adds one short section, **"What it reports about itself"**, between *Make it yours* and *Documentation*. No code change; it describes behaviour already true on `main`.

## What it claims, and where each claim was checked

| Claim | Verified against |
|---|---|
| A self-hosted or desktop install sends nothing, and the guarantee is stronger than a default because the transport is behind a cargo feature the shipped default build does not compile in | `Cargo.toml:456` (`default = ["oauth", "platform-jwt", "documents", "tinymemory"]`) and `Cargo.toml:621` (`analytics = ["dep:reqwest"]`); `Dockerfile:7` (`ARG FEATURES=""`); `src-tauri/Cargo.toml` names `analytics` nowhere; `src/analytics/mixpanel.rs:31,39,51` gate the client on `#[cfg(feature = "analytics")]` |
| Hosted tenants report product usage, because the platform builds with the feature and injects a token | `TENANT_FEATURES` in `.github/workflows/deploy-staging.yml:110` ends `…,analytics,crash-reporting`; `OPENCOMPANY_ANALYTICS_TOKEN` in `src/analytics/config.rs:16` |
| Shape and outcome only — company count, storage backend, turn outcome, token and cost counts | the three-event table in `docs/spec/runtime/analytics.md` |
| No company content, enforced by construction | `docs/spec/runtime/analytics.md:81-101`, and `PropValue` in `src/analytics/types.rs:48-57` — `Word(&'static str) | Count(u64) | Amount(f64) | Flag(bool)`, no `String` variant |
| `OPENCOMPANY_ANALYTICS=off` turns it off and outranks everything | `ENABLE_ENV` in `src/analytics/config.rs:13` and the `Silence` reasons below it |

The section deliberately does **not** give a number for the conditions that must hold, because `docs/spec/runtime/analytics.md` currently says "the four conditions in full" at line 16 while the numbered list under *Configuration* has five. Not fixed here to keep this PR to the README; worth a follow-up.

It also adds one sentence pointing at `docs/spec/runtime/crash-reporting.md`, so the section is not read as covering a channel it does not describe — crash reporting is off until an operator configures a DSN, and goes to the operator's own Sentry project rather than one this project runs.

## Relationship to #1950

Independent of it. #1950 is the analytics instrumentation work and is currently far behind `main`; this describes behaviour that is already true on `main` today, so it is branched from `main` and stands on its own.

## Commands run locally

- `bash scripts/ci/assert-md-line-cap.sh` — ✓ every file 500 lines or fewer (`README.md` is now 231)
- Confirmed both linked paths exist: `docs/spec/runtime/analytics.md`, `docs/spec/runtime/crash-reporting.md`

No Rust changed, so no `cargo` gate applies to this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing analytics and crash-reporting behavior.
  * Clarified that self-hosted and desktop installations do not send analytics data by default.
  * Documented the limited usage data reported by hosted tenants and the types of information excluded.
  * Added instructions for disabling analytics and clarified that crash reporting is separately configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->