### PR TITLE
fix(console): state the false attribution on the read-only Operator feed

### DIFF
--- a/docs/spec/runtime/ports-cognition.md
+++ b/docs/spec/runtime/ports-cognition.md
@@ -140,14 +140,20 @@ drift from reality. Reported on `GET …/capabilities` beside `mediaInBuild`,
 "what can this company actually do" — as `cognition`.
 
 The console consumes it in chat (issue #1734): on anything but `configured` the
-transcript carries a banner naming the cause and, where one exists, the remedy,
-and every company-side row is marked as a placeholder rather than presented as
-the teammate's own words. `ChatMessage` carries no provenance, so a company-level
-state is the only shape that answer has — see `MessageRow`'s `cognition` prop for
-why marking beats suppressing. The same state reaches `ThreadPanel`, because a
-reply read inside a thread is the same false attribution as one read in the
-channel, and the marker's tooltip names the cause it was given rather than
-restating `unconfigured`'s remedy for both.
+pane carries a banner naming the cause and, where one exists, the remedy, and
+every company-side row is marked as a placeholder rather than presented as the
+teammate's own words. The banner is a strip **directly above the composer**
+rather than above the transcript — the caveat and the control it qualifies are
+read together — and below the typing line, so nothing sits between them. It is
+rendered on a read-only channel too, where there is no composer: the sentence is
+about attribution, not about sending, and `#Operator` is precisely a feed of
+company-authored reports rendered under a teammate's name. `ChatMessage`
+carries no provenance, so a company-level state is the only shape that answer
+has — see `MessageRow`'s `cognition` prop for why marking beats suppressing.
+The same state reaches `ThreadPanel`, because a reply read inside a thread is
+the same false attribution as one read in the channel, and the marker's tooltip
+names the cause it was given rather than restating `unconfigured`'s remedy for
+both.
 
 ```rust
 /// Callbacks the brain makes into the host mid-cycle.

--- a/docs/spec/runtime/ports-cognition.md
+++ b/docs/spec/runtime/ports-cognition.md
@@ -142,12 +142,14 @@ drift from reality. Reported on `GET …/capabilities` beside `mediaInBuild`,
 The console consumes it in chat (issue #1734): on anything but `configured` the
 pane carries a banner naming the cause and, where one exists, the remedy, and
 every company-side row is marked as a placeholder rather than presented as the
-teammate's own words. The banner is a strip **directly above the composer**
-rather than above the transcript — the caveat and the control it qualifies are
-read together — and below the typing line, so nothing sits between them. It is
-rendered on a read-only channel too, where there is no composer: the sentence is
-about attribution, not about sending, and `#Operator` is precisely a feed of
-company-authored reports rendered under a teammate's name. `ChatMessage`
+teammate's own words. The banner is a strip at the **foot of the pane, below
+the transcript and the typing line**, rather than above the transcript — the
+caveat and the control it qualifies are read together. It precedes the
+composer rather than being glued to it: `InflightRunBar` renders between the
+two whenever a run is in flight, since stopping a run is not posting. And it is
+rendered on a read-only channel too, where there is no composer at all: the
+sentence is about attribution, not about sending, and `#Operator` is precisely a
+feed of company-authored reports rendered under a teammate's name. `ChatMessage`
 carries no provenance, so a company-level state is the only shape that answer
 has — see `MessageRow`'s `cognition` prop for why marking beats suppressing.
 The same state reaches `ThreadPanel`, because a reply read inside a thread is

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -2707,9 +2707,22 @@ export function ChatView({
                     the order read correct with nobody typing and wrong with someone
                     typing.
 
-                    Suppressed on a read-only channel: nothing can be sent there, so a
-                    caveat about what sending produces has nothing left to qualify —
-                    and the composer it would sit above is not rendered at all.
+                    Kept on a read-only channel, where there is no composer at all.
+                    The suppression this replaced argued that nothing can be sent
+                    there, so a caveat about what sending produces has nothing left to
+                    qualify. But the sentence is not about sending — every state below
+                    says the replies in this conversation come from the echo brain
+                    rather than the teammate they appear under, which is a claim about
+                    the messages already on screen. `readOnly` is
+                    `Boolean(channel?.system)`, i.e. the `#Operator` feed, whose
+                    workflow reports are rendered under a teammate's name and avatar
+                    and are stub output whenever the company has no working model.
+                    Those rows carry only `EchoPlaceholder` — a non-focusable `<span>`
+                    whose explanation lives in a `title`, so it reaches neither
+                    keyboard, touch nor screen reader. And a feed nobody can reply to
+                    is where the reader is least able to test the attribution by
+                    asking, so it is the last place to drop the only visible statement
+                    of it.
 
                     All four states below say "the replies in this conversation", not
                     "the replies below". They said "below" while this strip sat above
@@ -2722,7 +2735,7 @@ export function ChatView({
                     `role="status"` (not `alert`) for the reason
                     `components/ui/alert.tsx` gives — a notice present on mount should
                     not interrupt a screen reader. */}
-                {echoing && !readOnly && (
+                {echoing && (
                   <p
                     role="status"
                     data-testid="chat-cognition-banner"

--- a/frontend/test/unit/chat-readonly-composer.test.ts
+++ b/frontend/test/unit/chat-readonly-composer.test.ts
@@ -12,7 +12,9 @@ import { ChatView } from "@/views/ChatView";
 
 /**
  * The channel composer answers a read-only channel by not existing, and the
- * echo-brain notice sits next to the control it qualifies.
+ * echo-brain notice sits next to the control it qualifies — and stays on the
+ * feed that has no such control, where the attribution it corrects is the one
+ * the reader cannot check by asking.
  *
  * # Why a render test and not a source scan
  *
@@ -226,7 +228,7 @@ describe("a writable channel still renders the whole composer", () => {
   });
 });
 
-describe("the harness-unavailable notice sits next to the composer", () => {
+describe("the harness-unavailable notice sits next to the composer, or without one", () => {
   it("renders the notice on a writable channel, saying all three things", async () => {
     await mount("main", "unavailable");
 
@@ -295,11 +297,55 @@ describe("the harness-unavailable notice sits next to the composer", () => {
     expect(kids.indexOf(composerRoot)).toBe(kids.indexOf(strip) + 1);
   });
 
-  it("is suppressed on a read-only channel, where nothing can be sent", async () => {
+  /**
+   * The read-only feed keeps it, and that is the case it matters most in.
+   *
+   * `#Operator` renders the company's own workflow reports under a teammate's
+   * name and avatar. In an echo state nobody wrote those words — and the only
+   * thing on the row that says so is `EchoPlaceholder`, a non-focusable
+   * `<span>` carrying its reason in a `title`, which reaches neither keyboard,
+   * touch nor screen reader. Suppressing the strip here left the reader with a
+   * status report from a named colleague and no way to ask whether the
+   * colleague sent it, because the feed takes no replies.
+   */
+  it("stays on the read-only feed, which the reader cannot interrogate", async () => {
     await mount("operator", "unavailable");
 
-    expect(banner()).toBeNull();
+    const strip = banner();
+    expect(strip).not.toBeNull();
+    expect(strip?.textContent).toContain(
+      "This host cannot reach a model — no agent harness is available.",
+    );
+    expect(strip?.textContent).toContain(
+      "The replies in this conversation come from the offline echo brain rather than the " +
+        "teammate they appear under. No setting changes that: it takes a host built and " +
+        "started with the harness.",
+    );
+
+    // Restoring the notice restores nothing else: the channel is still
+    // read-only, still says so, and still draws no composer.
     expect(container.textContent).toContain("There is nothing to reply to here");
+    expect(composerInput()).toBeNull();
+    expect(readOnlyComposerInput()).toBeNull();
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+
+  it("sits after the read-only notice, with no composer between them", async () => {
+    await mount("operator", "unavailable");
+
+    const strip = banner()!;
+    const column = strip.parentElement!;
+    const kids = Array.from(column.children);
+    const notice = kids.find((el) => el.textContent?.includes("There is nothing to reply to here"));
+
+    expect(notice).not.toBeUndefined();
+    expect(kids.indexOf(notice!)).toBeLessThan(kids.indexOf(strip));
+
+    // Order relative to the read-only notice only — deliberately NOT "and it is
+    // the last child of the column". `InflightRunBar` renders after this strip
+    // in production, outside the read-only branch on purpose (see its comment
+    // at the render site), and this harness passes no `inflightRuns`, so a
+    // last-child assertion would pass here while being false on screen.
   });
 });
 


### PR DESCRIPTION
Replaces #1997, which was 1,410 commits behind `main` with a 185-line conflict
region in `ChatView.tsx` — all of it re-indentation from #2130 / #2134 wrapping
the Room route in `{routeOpen && (` and extracting the transcript into
`<MessageTimeline>`. The payload is one token, so this is written fresh against
`main` @ `89b1f818a` rather than hand-merged. #1997 had no review of any kind
and none of its verification carries forward; everything below was re-run here.

## The bug

`#Operator` is a feed you can read and cannot write in — the company posts its
own workflow reports and notifications there, each one rendered under an author
line that is not a person: `DurableOperatorChannel` journals them under the
reserved authors `workflow-report` and `owner-fallback-report`
(`src/runtime/channel.rs:52,73`), which `senderOf` titleizes into "Workflow
Report" and "Owner Fallback Report".

When the company has no working model behind it, nobody wrote those words: a
stub generator produced them. Everywhere else in chat a strip at the foot of the
pane says exactly that and points at Settings. On the Operator feed #1984 gated
it off with `!readOnly`. So the operator reads what looks like a status report
from a named colleague, and believes the company did that work and that this is
what it found. The only remaining hint is a small grey "Placeholder" pill whose
explanation lives **only in a `title=`** on a non-focusable `<span>` — no
keyboard, no touch, no screen reader. And because the feed takes no replies,
they cannot ask anybody whether it is real — the feed takes no replies, and the
name on the row belongs to nobody. (I had this wrong in the first draft and said
"under a teammate's name"; codex caught it, and the correction is in dabb017.
It makes the case stronger: there is nobody to ask even in principle.)

It is an attribution defect on the one surface where the reader cannot check the
attribution by asking.

## Why the suppression was wrong on its own terms

It was justified by *"nothing can be sent there, so a caveat about what sending
produces has nothing left to qualify"*. But none of the four states is about
sending. Each says **the replies in this conversation come from the offline echo
brain rather than the teammate they appear under** — a claim about the messages
already on screen.

The premise was checked rather than assumed: `MessageRow` calls
`echoMarkerFor(message, sender, cognition)` for every company-side row with no
`byPerson`, on **every** channel — nothing about it is channel-aware — and
`MessageView::project` sets `by_person: false` on an `AgentReply` "whichever
brain produced it" (`src/server/chat_history.rs:580`). So `#Operator`'s workflow
reports are marked exactly like a channel reply, reading *"Workflow Report did
not write this…"*, and `EchoPlaceholder` really is a non-focusable `<span>`
whose reason lives only in a `title`. `readOnly` is `Boolean(channel?.system)`, i.e. the Operator feed and
nothing else.

Worth knowing how easy this state is to reach: per `src/server/cognition.rs`,
`echo` is not only "no key". It also covers *key configured but the runtime
predates it* and *the `openhuman` feature not compiled in* — and `Cargo.toml`'s
`default` excludes that feature, so a plain `cargo build` host reports `echo`
whatever key is present. That is the host this PR was verified against.

## The change

```diff
-{echoing && !readOnly && (
+{echoing && (
```

Plus the comment above it, which argued the opposite, replaced with the
counter-argument; and the docs paragraph in
`docs/spec/runtime/ports-cognition.md`, which already promised a banner "on
anything but `configured`" and said nothing about where it sits.

Nothing else moves. The composer is still absent on the feed (`suppressed`), the
read-only notice still renders, and `MessageComposer`'s draft still survives a
trip to `#Operator` — all three re-asserted by the tests below.

## Tests

`frontend/test/unit/chat-readonly-composer.test.ts:298` **pinned the broken
behaviour**: `it("is suppressed on a read-only channel, where nothing can be
sent")` asserting `expect(banner()).toBeNull()`. It is rewritten into two:

| Test | Failure with `!readOnly` restored |
|---|---|
| stays on the read-only feed, which the reader cannot interrogate | `AssertionError: expected null not to be null` |
| sits after the read-only notice, with no composer between them | `TypeError: Cannot read properties of null (reading 'parentElement')` |

Both mutation-proved by restoring the token and re-running — the table is that
run's output, not an expectation.

**One thing #1997 got wrong, deliberately not copied.** Its second new test
asserted the notice is "the bottom strip of the pane"
(`expect(kids.indexOf(strip)).toBe(kids.length - 1)`). That became false when
`InflightRunBar` started rendering after it (`ChatView.tsx:2831-2839`), with a
comment saying it is *outside the read-only branch* on purpose. The assertion
still passed only because the unit harness passes no `inflightRuns` /
`onInflightSteered` — so it pinned a claim that is wrong in production. The test
here asserts order **relative to the read-only notice only**, and says in a
comment why not last-child. "Bottom strip of the pane" is also kept out of the
source comment and the docs.

## Verification

```
$ npm run typecheck        # tsc -b --noEmit             → clean
$ npm run typecheck:unit   # tsc -p tsconfig.unit.json   → clean
$ npm run typecheck:e2e    # tsc -p tsconfig.e2e.json    → clean
$ npx vitest run           # Test Files 513 passed · Tests 4820 passed
$ scripts/ci/assert-design-tokens.sh
✓ design tokens: no arbitrary sizes, no palette colours, no stray hex
```

Browser verification is in a follow-up comment.

## Not in scope

`EchoPlaceholder`'s chip carries its reason only in a `title` — a pre-existing
gap that #1984 did not create, whose fix is an accessible name on the chip. With
the strip restored it is no longer the only explanation on any surface. Worth
its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - The cognition notice now appears below the transcript and typing line, before the message composer.
  - When a response is in progress, the activity indicator appears between the notice and composer.
  - The notice is also displayed in read-only channels, including the Operator feed, without adding a composer.
  - Thread replies continue to receive the same cognition context.
- **Bug Fixes**
  - Improved notice placement and visibility across chat and read-only feeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

