### PR TITLE
test(console): pin the in-flight run bar, and name the Operator feed's real author

### DIFF
--- a/docs/spec/runtime/ports-cognition.md
+++ b/docs/spec/runtime/ports-cognition.md
@@ -149,7 +149,10 @@ composer rather than being glued to it: `InflightRunBar` renders between the
 two whenever a run is in flight, since stopping a run is not posting. And it is
 rendered on a read-only channel too, where there is no composer at all: the
 sentence is about attribution, not about sending, and `#Operator` is precisely a
-feed of company-authored reports rendered under a teammate's name. `ChatMessage`
+feed of company-authored reports, marked like any other company-side row but
+rendered under the reserved authors `workflow-report` and
+`owner-fallback-report` — names that belong to no person, so the reader has
+nobody to ask even in principle. `ChatMessage`
 carries no provenance, so a company-level state is the only shape that answer
 has — see `MessageRow`'s `cognition` prop for why marking beats suppressing.
 The same state reaches `ThreadPanel`, because a reply read inside a thread is

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -2714,15 +2714,23 @@ export function ChatView({
                     says the replies in this conversation come from the echo brain
                     rather than the teammate they appear under, which is a claim about
                     the messages already on screen. `readOnly` is
-                    `Boolean(channel?.system)`, i.e. the `#Operator` feed, whose
-                    workflow reports are rendered under a teammate's name and avatar
-                    and are stub output whenever the company has no working model.
-                    Those rows carry only `EchoPlaceholder` — a non-focusable `<span>`
-                    whose explanation lives in a `title`, so it reaches neither
-                    keyboard, touch nor screen reader. And a feed nobody can reply to
-                    is where the reader is least able to test the attribution by
-                    asking, so it is the last place to drop the only visible statement
-                    of it.
+                    `Boolean(channel?.system)`, i.e. the `#Operator` feed.
+
+                    Its rows are NOT under a roster teammate, and the difference
+                    matters (codex review on #2159). `DurableOperatorChannel` journals
+                    them under the reserved authors `workflow-report` and
+                    `owner-fallback-report` (`runtime/channel.rs`), which `senderOf`
+                    titleizes into "Workflow Report" and "Owner Fallback Report" —
+                    author lines naming no person at all. That makes the case for the
+                    strip stronger, not weaker: `MessageRow` still marks every one of
+                    those rows, because `project` sets `by_person: false` on an
+                    `AgentReply` whichever brain produced it, and the marker they get
+                    is `EchoPlaceholder` — a non-focusable `<span>` whose entire
+                    explanation is a `title`, reaching neither keyboard, touch nor
+                    screen reader, and reading "Workflow Report did not write this".
+                    Without this strip the operator is left with a "Placeholder" pill
+                    against a name that is not a person, on a feed that takes no
+                    replies, and nothing anywhere saying what did write it.
 
                     All four states below say "the replies in this conversation", not
                     "the replies below". They said "below" while this strip sat above

--- a/frontend/test/unit/chat-readonly-composer.test.ts
+++ b/frontend/test/unit/chat-readonly-composer.test.ts
@@ -371,13 +371,15 @@ describe("the harness-unavailable notice sits next to the composer, or without o
   /**
    * The read-only feed keeps it, and that is the case it matters most in.
    *
-   * `#Operator` renders the company's own workflow reports under a teammate's
-   * name and avatar. In an echo state nobody wrote those words — and the only
-   * thing on the row that says so is `EchoPlaceholder`, a non-focusable
-   * `<span>` carrying its reason in a `title`, which reaches neither keyboard,
-   * touch nor screen reader. Suppressing the strip here left the reader with a
-   * status report from a named colleague and no way to ask whether the
-   * colleague sent it, because the feed takes no replies.
+   * `#Operator` renders the company's own workflow reports under the reserved
+   * authors `workflow-report` / `owner-fallback-report` — titleized into
+   * "Workflow Report" and "Owner Fallback Report", names belonging to no
+   * person. In an echo state nobody wrote those words, and the only thing on
+   * the row that says so is `EchoPlaceholder`, a non-focusable `<span>`
+   * carrying its reason in a `title`, which reaches neither keyboard, touch nor
+   * screen reader. Suppressing the strip here left the reader with a status
+   * report, a "Placeholder" pill against a name that is not a colleague, and no
+   * way to ask anything — the feed takes no replies.
    */
   it("stays on the read-only feed, which the reader cannot interrogate", async () => {
     await mount("operator", "unavailable");

--- a/frontend/test/unit/chat-readonly-composer.test.ts
+++ b/frontend/test/unit/chat-readonly-composer.test.ts
@@ -92,7 +92,31 @@ afterEach(() => {
   container.remove();
 });
 
-function tree(client: OpenCompanyClient, sub: string, typing: string[] = []): ReactNode {
+/**
+ * One run for the in-flight bar.
+ *
+ * Every other test here passes no `inflightRuns` at all, which is why the
+ * sibling-order tests below could once claim the banner and the composer are
+ * adjacent: `ChatView` gates `InflightRunBar` on the prop being defined, so a
+ * harness that omits it never renders the row that actually sits between them
+ * (codex and CodeRabbit, both on PR #2159).
+ */
+const INFLIGHT_RUN = {
+  taskId: "t-1",
+  key: "run-1",
+  kind: "task",
+  title: "Weekly pipeline review",
+  agentId: "pm",
+  startedAt: 0,
+  pendingAction: null,
+} as const;
+
+function tree(
+  client: OpenCompanyClient,
+  sub: string,
+  typing: string[] = [],
+  inflight = false,
+): ReactNode {
   const view = createElement(ChatView, {
     client,
     company: "acme",
@@ -105,6 +129,10 @@ function tree(client: OpenCompanyClient, sub: string, typing: string[] = []): Re
     // renders nothing at all when nobody is typing and the banner's placement
     // was only ever wrong when it renders something.
     resolveTypingNames: () => typing,
+    // Undefined by default, because that is the shape most of these cases care
+    // about — but a shell in production always passes both, so the in-flight
+    // order test opts in.
+    ...(inflight ? { inflightRuns: [INFLIGHT_RUN], onInflightSteered: vi.fn() } : {}),
     // The live-scope escape hatch `send` reads to decide whether a reply still
     // belongs to the company on screen. Nothing here sends.
     scopeRef: { current: { connection: "local", company: "acme", client } },
@@ -125,9 +153,14 @@ function tree(client: OpenCompanyClient, sub: string, typing: string[] = []): Re
  * have nothing to do with the behaviour under test, and the test would pass
  * against any implementation.
  */
-async function renderAt(client: OpenCompanyClient, sub: string, typing: string[] = []) {
+async function renderAt(
+  client: OpenCompanyClient,
+  sub: string,
+  typing: string[] = [],
+  inflight = false,
+) {
   await act(async () => {
-    root.render(tree(client, sub, typing));
+    root.render(tree(client, sub, typing, inflight));
   });
   // Let the desks / operator / capability reads settle.
   await act(async () => {
@@ -136,9 +169,14 @@ async function renderAt(client: OpenCompanyClient, sub: string, typing: string[]
   });
 }
 
-async function mount(sub: string, cognition: string | null = null, typing: string[] = []) {
+async function mount(
+  sub: string,
+  cognition: string | null = null,
+  typing: string[] = [],
+  inflight = false,
+) {
   const client = stubClient(cognition);
-  await renderAt(client, sub, typing);
+  await renderAt(client, sub, typing, inflight);
   return client;
 }
 
@@ -271,7 +309,7 @@ describe("the harness-unavailable notice sits next to the composer, or without o
     expect(kids.indexOf(strip)).toBeLessThan(kids.indexOf(composerRoot));
   });
 
-  it("stays directly above the composer with somebody typing", async () => {
+  it("stays directly above the composer with somebody typing, nothing in flight", async () => {
     // The order was asserted with nobody typing, which is the one case where
     // `TypingLine` renders nothing — so `["TRANSCRIPT", "BANNER", "COMPOSER"]`
     // read correct while the shipped order was TRANSCRIPT, BANNER, TYPING,
@@ -292,9 +330,42 @@ describe("the harness-unavailable notice sits next to the composer, or without o
     const composerRoot = kids.find((el) => el.contains(input))!;
 
     // Adjacency, not just order: nothing at all between the notice and the
-    // control it qualifies.
+    // control it qualifies. True while the company is idle, which is the case
+    // this one pins — `InflightRunBar` is the one thing that comes between them,
+    // and the test below is where that is pinned instead.
     expect(kids.indexOf(typing!)).toBeLessThan(kids.indexOf(strip));
     expect(kids.indexOf(composerRoot)).toBe(kids.indexOf(strip) + 1);
+    expect(container.querySelector('[data-testid="inflight-run-bar"]')).toBeNull();
+  });
+
+  /**
+   * With a run in flight, the run bar is between the banner and the composer —
+   * on purpose, and the specification says so.
+   *
+   * The adjacency above was asserted with no `inflightRuns` prop at all, and
+   * `ChatView` gates `InflightRunBar` on that prop being defined, so the harness
+   * was pinning a layout no shell in production ever renders. Both reviewers on
+   * PR #2159 caught the same thing in the spec prose; this is the assertion half.
+   */
+  it("lets the in-flight run bar come between it and the composer", async () => {
+    await mount("main", "unavailable", ["Jane"], true);
+
+    const strip = banner()!;
+    const input = composerInput()!;
+    const bar = container.querySelector('[data-testid="inflight-run-bar"]');
+    expect(strip).not.toBeNull();
+    expect(input).not.toBeNull();
+    expect(bar).not.toBeNull();
+
+    const column = strip.parentElement!;
+    const kids = Array.from(column.children);
+    const composerRoot = kids.find((el) => el.contains(input))!;
+    const barRoot = kids.find((el) => el.contains(bar!))!;
+
+    // Still below the transcript and the typing line — the placement this
+    // strip moved for — and still before the composer. Just not glued to it.
+    expect(kids.indexOf(strip)).toBeLessThan(kids.indexOf(barRoot));
+    expect(kids.indexOf(barRoot)).toBeLessThan(kids.indexOf(composerRoot));
   });
 
   /**


### PR DESCRIPTION
Follow-up to #2159, which **merged at `f9324f5` while its review cycle was still
running** — so the two commits that answer the review are not in `main`. This
carries them, rebased onto `main` @ `b2c8f0fe7`. No behaviour change: one test
and three comments.

## 1. The in-flight run bar was pinned by nothing

Both reviewers on #2159 caught the spec claiming the banner sits directly above
the composer with nothing between them. `InflightRunBar` renders between the two
whenever a run is in flight — deliberately, outside the read-only branch,
because a channel nobody may post in is still a place the company's runs are
visible and stopping one is not posting. #2159 fixed the prose (f9324f5). This
is the assertion half, which CodeRabbit asked for and which did not land.

The reason it was never caught is worth naming: the adjacency assertion in
`chat-readonly-composer.test.ts` — `expect(kids.indexOf(composerRoot)).toBe(kids.indexOf(strip) + 1)`,
from #1984 — passed only because **no test in the file ever passed
`inflightRuns`**, and `ChatView` gates the bar on that prop being *defined*. It
pinned a layout no production shell renders.

So:

- the harness takes an in-flight run (`INFLIGHT_RUN`, opted into per test);
- the idle case additionally asserts the bar is **absent**, so "adjacent" is
  scoped to the condition it is true in rather than reading as a universal claim;
- a new case pins the real order: **banner → run bar → composer**.

Mutation-proved by moving `InflightRunBar` above the banner in `ChatView` and
re-running, then reverting:

```
× lets the in-flight run bar come between it and the composer
  → AssertionError: expected 3 to be less than 2
```

## 2. `#Operator` rows are not under a roster teammate — I had this wrong

codex, P2 on #2159, and correct. Checked against the code rather than taken on
trust:

| Fact | Where |
|---|---|
| Reports are journaled under `WORKFLOW_REPLY_AUTHOR = "workflow-report"` | `src/runtime/channel.rs:52` |
| The owner fallback overrides it to `"owner-fallback-report"` | `src/runtime/channel.rs:73` |
| The read path projects `channel: agent_id` | `src/server/chat_history.rs:573` |
| `senderOf` titleizes an unmatched non-company-voice channel | `frontend/src/views/chat/model.ts:1070-1081` |

So those rows read **"Workflow Report"** and **"Owner Fallback Report"**, with no
roster avatar. #2159's source comment, spec paragraph and test docstring all said
"under a teammate's name and avatar". They now say what is actually there.

**The conclusion is unchanged, and stronger.** `MessageView::project` sets
`by_person: false` on an `AgentReply` *"whichever brain produced it"*
(`chat_history.rs:580`), so `echoMarkerFor` marks every one of those rows — the
pill on a workflow report reads *"Workflow Report did not write this. No agent
harness is available on this host, so the offline echo brain answered instead."*
Without the strip #2159 restored, the reader is left with a "Placeholder" pill
against a name that is not a person, on a feed that takes no replies, and
nothing anywhere saying what did write it. There is nobody to ask even in
principle.

## Deliberately not here

Codex's alternative remedy — show the banner only when the feed contains an
actual echo-authored row — is declined and the reasoning is on
[#2159's thread](https://github.com/tinyhumansai/opencompany/pull/2159#discussion_r3959831478).
Short version: `ChatMessage` carries no provenance, which is why #1734 chose a
company-level state; a contents-gated banner would be a guess presented as a
fact. Report-specific copy for the read-only feed is worth doing and is a copy
change with its own review surface, not a rider on this.

## Verification

```
$ npm run typecheck        # tsc -b --noEmit             → clean
$ npm run typecheck:unit   # tsc -p tsconfig.unit.json   → clean
$ npm run typecheck:e2e    # tsc -p tsconfig.e2e.json    → clean
$ npx vitest run           # Test Files 513 passed · Tests 4820 passed
$ scripts/ci/assert-design-tokens.sh
✓ design tokens: no arbitrary sizes, no palette colours, no stray hex
```

All four run on this branch, on `main` @ `b2c8f0fe7`. No browser pass: nothing
here renders differently — the diff is one unit test and three comment blocks.
#2159's browser evidence, light and dark against a default-feature host, is
[here](https://github.com/tinyhumansai/opencompany/pull/2159#issuecomment-5587939893).
