### PR TITLE
fix(console): mark a failed send on its own row, and route which conversation is open

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -62,6 +62,7 @@ import { startVisiblePolling } from "@/lib/visible-poll";
 import { withReadTimeout } from "@/lib/read-timeout";
 import {
   hasOtherOpenTurns,
+  isDuplicateLiveReply,
   mergeOpenTurns,
   openTurnsFromRuns,
   PendingSyncPosts,
@@ -2266,6 +2267,14 @@ export function AppShell({
   // resolves, instead of the shell needing a second copy of this logic.
   const renderAgentReply = useCallback(
     (event: AgentReplyEvent) => {
+      // `replyVoice`, not a literal: a live frame attributed to the runtime
+      // itself — `SYSTEM_AUTHOR` on the Rust side, which covers both B-101's
+      // mention-ambiguity note and the iteration-cap pause notice (issue
+      // #2068) — renders as the centred system pill `fromHistory` already
+      // gives it on reload, never as a named teammate's bubble with an
+      // avatar and reply/reaction controls, which is what unconditionally
+      // passing `"company"` here used to produce (Codex review, PR #2052).
+      const from = replyVoice(event.agentId);
       // The event names a thread; `chatChannelByThread` is the only thing that
       // knows which channel renders it. An id no channel owns is a no-op:
       // better silent than in the wrong place.
@@ -2305,20 +2314,32 @@ export function AppShell({
         // history's own order rather than appending to the recent tail this
         // scans. Live-then-hydrate was the one route neither guard covered,
         // and it doubled every reply that arrived while its channel was closed.
-        const dup = existing
-          .slice(-8)
-          .some((m) => m.from === "company" && m.text === event.text);
+        //
+        // **The content check alone is too broad** (Codex review, PR #2052):
+        // two genuinely different events can carry identical text — an
+        // operator repeating the same ambiguous `@name` produces two
+        // B-101 notices with the same wording — and content matching then
+        // suppressed the second one outright, not merely deduped it.
+        // `isDuplicateLiveReply` checks this event's own durable identity
+        // first (`event.seq`) and only falls back to content for a row that
+        // has not yet been reconciled to a durable id — see its own doc for
+        // why that scoping is what keeps two same-text-but-different events
+        // from being conflated. Named and extracted for the same reason
+        // every rule in `live-reply.ts` is: this is exactly the kind of
+        // regression that shows up nowhere but a repeated-mention screenshot.
+        const dup = isDuplicateLiveReply(existing.slice(-8), event, from);
         if (dup) return t;
         return {
           ...t,
           [channelId]: [
             ...existing,
-            // `replyVoice`, not a literal: a host-authored line (the
-            // iteration-cap pause) is projected with `agentId: "system"` and
-            // must render as the same centred row `fromHistory` gives it, or
-            // whoever watched the turn live keeps an agent-style bubble that
-            // hydration will never correct.
-            makeMessage(replyVoice(event.agentId), event.text, {
+            // `from` is `replyVoice(event.agentId)`, computed once above and
+            // reused by the `dup` check too — a host-authored line (B-101's
+            // ambiguity note, the iteration-cap pause notice) must render as
+            // the same centred row `fromHistory` gives it, or whoever watched
+            // the turn live keeps an agent-style bubble hydration never
+            // corrects.
+            makeMessage(from, event.text, {
               channel: event.agentId,
               taskId: event.taskId,
               mentions: event.mentions,
@@ -2355,7 +2376,20 @@ export function AppShell({
       // still be listed. That only defers the clear to its own settle, which
       // then runs the re-read above — the conservative direction, and the one
       // that never erases a running turn's rows.
-      if (!hasOtherOpenTurns(openTurnsRef.current, event.chatId)) {
+      //
+      // Also guarded on `from !== "system"` (Codex review, PR #2052). A
+      // system-attributed frame — B-101's mention-ambiguity note among them —
+      // is emitted mid-turn, before the cycle that answers has even run, and
+      // is never itself the turn's completion. `onSendFailed` can release such
+      // a frame (held while the POST was in flight) before its own async
+      // `/runs` lookup below has had a chance to install the still-running
+      // turn into `openTurnsRef` — so at the instant this runs, `openTurns`
+      // legitimately knows nothing about it yet, `hasOtherOpenTurns` reads
+      // `false`, and treating the advisory as "the end of that turn" would
+      // erase the live tool trace of a turn that is, per the very lookup
+      // racing it, still running. Only the actual reply — never an advisory
+      // interleaved before it — is a completion signal.
+      if (from !== "system" && !hasOtherOpenTurns(openTurnsRef.current, event.chatId)) {
         setLiveStepsByThread((prev) =>
           prev[event.chatId]?.length ? { ...prev, [event.chatId]: [] } : prev,
         );
@@ -2489,8 +2523,15 @@ export function AppShell({
     return gen;
   }, []);
   const onSendEnd = useCallback(
-    (threadId: string, gen?: number) => {
-      pendingPostThreadsRef.current.ended(threadId);
+    (threadId: string, gen?: number, responseTexts?: readonly string[]) => {
+      // `ended` hands back any held system-attributed frame the settled
+      // response did NOT already carry (issue #101 review, PR #2052) — B-101's
+      // mention-ambiguity note, never returned in the response body by design.
+      // Rendered here rather than discarded: see `ended`'s own doc for why the
+      // response's own text, only available at this call site, is what makes
+      // this safe without double-rendering the frames the response DOES carry.
+      const released = pendingPostThreadsRef.current.ended(threadId, responseTexts);
+      released.forEach((frame) => renderAgentReply(frame));
       if (activeTurnThreadRef.current === threadId) activeTurnThreadRef.current = null;
       setLiveStepsByThread((prev) => {
         if (!prev[threadId]?.length) return prev;
@@ -2498,7 +2539,7 @@ export function AppShell({
       });
       clearReceipt(threadId, gen);
     },
-    [clearReceipt],
+    [clearReceipt, renderAgentReply],
   );
   /**
    * A chat POST that resolved for a company the operator has since left

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -251,6 +251,47 @@ export interface ChatMessage {
    * a host that predates the field.
    */
   mentions?: Mention[];
+  /**
+   * This console tried to send this line and the request never completed
+   * (B-099), carrying the reason the network or the host gave.
+   *
+   * **A property of the message, not a line beside it.** The failure used to be
+   * reported by appending a separate `system` bubble underneath ("Couldn't
+   * send — …"), which left the message itself styled exactly like the delivered
+   * ones above it: same avatar, same timestamp, nothing red, nothing struck
+   * through, and no way to try again. Scroll away and back, or write a message
+   * long enough that the note falls off screen, and what remains reads as sent
+   * and was not — while the composer had already cleared, so the only copy of
+   * the text was the pixels on screen.
+   *
+   * So the fact rides the row it is about. A renderer cannot draw the bubble
+   * without seeing this, which is the property a sibling line could never have.
+   *
+   * Set only on a line this console originated (`from: "you"`), and never by
+   * {@link fromHistory}: a message the host handed back is by definition one it
+   * kept. A reload therefore clears it, which is correct — the reload re-reads
+   * what was actually journaled, and a send whose request died may well have
+   * landed (see `ChatView`'s `send` on why a throw is ambiguous).
+   */
+  sendFailed?: string;
+}
+
+/**
+ * Mark the line `id` as one that could not be sent (B-099), leaving the rest
+ * alone.
+ *
+ * Returns the same array reference when nothing matched, so the caller's
+ * `setState` is a no-op rather than a re-render, for a message no longer in
+ * this transcript — a send's target can be re-homed by a company switch while
+ * its POST is still in flight.
+ */
+export function markSendFailed(
+  messages: ChatMessage[],
+  id: string,
+  reason: string,
+): ChatMessage[] {
+  if (!messages.some((m) => m.id === id)) return messages;
+  return messages.map((m) => (m.id === id ? { ...m, sendFailed: reason } : m));
 }
 
 /**

--- a/frontend/src/lib/live-reply.ts
+++ b/frontend/src/lib/live-reply.ts
@@ -8,6 +8,46 @@
 // As a closure over a ref it could only be exercised by driving the whole shell;
 // as a rule with a name it can be asserted transition by transition.
 
+import { hostMessageId, isHostMessageId, type ChatMessage } from "./chat";
+
+/**
+ * Whether a live `agent_reply` frame is a duplicate of something already in
+ * the recent tail of a transcript — never render it if so (PR #2052 review).
+ *
+ * Two checks, because one alone fails in a different direction each:
+ *
+ * - **Identity first.** Every frame carries a durable id via its own `seq`
+ *   (`hostMessageId(String(event.seq))`, the same value `liveReplyIdentity`
+ *   spreads into the row it renders as `messageId`). A row already bearing
+ *   that exact id is unambiguously this same event, rendered before —
+ *   whatever its content, it is always a duplicate.
+ * - **Content, but only against an unreconciled row.** The operator's own
+ *   turn is rendered locally, immediately, under an ephemeral `m<n>` id from
+ *   the awaited POST response; the backend also journals and broadcasts that
+ *   same reply, and the SSE echo can arrive first, mid-await, before the
+ *   POST resolves and reconciles that row to its durable id. In that narrow
+ *   window identity cannot recognise the echo as the same message — only
+ *   content can. Scoping this check to `!isHostMessageId(m.id)` is what
+ *   keeps it from over-firing once that window closes: two *different*
+ *   events that merely share wording — an operator repeating the same
+ *   ambiguous `@name` produces two B-101 notices with identical text — both
+ *   carry durable ids from the start, so neither is `!isHostMessageId`, and
+ *   content matching never gets a chance to conflate them. Before this
+ *   distinction existed, content matching alone silently dropped the second
+ *   one outright, which is a stronger failure than a duplicate render: this
+ *   check exists to prevent noise, not to swallow a genuinely new refusal.
+ */
+export function isDuplicateLiveReply(
+  recentTail: readonly Pick<ChatMessage, "id" | "from" | "text">[],
+  event: { seq: number; text: string },
+  from: ChatMessage["from"],
+): boolean {
+  const eventId = hostMessageId(String(event.seq));
+  return recentTail.some(
+    (m) => m.id === eventId || (!isHostMessageId(m.id) && m.from === from && m.text === event.text),
+  );
+}
+
 /**
  * The one field {@link PendingSyncPosts.capture} needs off a live `agent_reply`
  * frame. A local shape rather than importing the hook's event type, matching
@@ -16,6 +56,45 @@
  */
 export interface LiveReplyFrame {
   chatId: string;
+  /**
+   * The frame's `agentId`, when its type carries one (`AgentReplyEvent`
+   * always does). Read only by {@link PendingSyncPosts.ended}, to tell a held
+   * system-attributed frame the settled response duplicates from one it
+   * never will — see that method's doc for why the distinction only matters
+   * for this one attribution.
+   */
+  agentId?: string;
+  /**
+   * The frame's own reply text, when its type carries one (`AgentReplyEvent`
+   * always does). Read only by {@link PendingSyncPosts.ended}, compared
+   * against the settled response's own reply text(s) for the same reason
+   * `agentId` is.
+   */
+  text?: string;
+}
+
+/**
+ * Whose voice a live `agent_reply` frame renders as: the runtime's own
+ * centred system pill, or a named teammate's bubble (issue #101 / B-101
+ * review, PR #2052).
+ *
+ * `SYSTEM_AUTHOR` on the Rust side (`crate::ports::SYSTEM_AUTHOR`, the string
+ * `"system"`) is the one `agentId` that names the runtime itself rather than
+ * a roster agent — a mention-ambiguity notice is journaled under it precisely
+ * so a reader can tell "the runtime is reporting its own refusal" from "a
+ * teammate replied". `fromHistory` (`lib/chat.ts`) already makes this same
+ * distinction for a rehydrated row (`entry.author === "system"`); this is the
+ * **live**-path twin of that rule.
+ *
+ * Extracted for the same reason every rule in this module is (see the file
+ * doc above): inlined as a closure inside `renderAgentReply`, a regression to
+ * a hard-coded `"company"` shows up nowhere but a live screenshot taken
+ * during a detached send, between the SSE frame landing and the next history
+ * reload silently correcting it — and no test would ever see it (tinysweeper
+ * review). Named, it can be asserted directly.
+ */
+export function liveReplyAttribution(agentId: string): "system" | "company" {
+  return agentId === "system" ? "system" : "company";
 }
 
 /**
@@ -155,19 +234,43 @@ export class PendingSyncPosts<F extends LiveReplyFrame = LiveReplyFrame> {
   }
 
   /**
-   * The synchronous POST resolved with a body; its reply is already rendered.
+   * The synchronous POST resolved with a body; `responseTexts` is every reply
+   * line that body itself carried.
    *
-   * Whatever {@link capture} held for this thread was, by the same reasoning,
-   * a live echo of that same reply — the awaited response is authoritative, so
-   * the held frames are discarded rather than replayed.
+   * A held frame attributed to the operator's own turn (any `agentId` other
+   * than `SYSTEM_AUTHOR`) is discarded unconditionally, as it always was: it
+   * is, by the same reasoning as the class doc, a live echo of that same
+   * reply, and the awaited response is authoritative for it.
+   *
+   * **A held *system*-attributed frame needs `responseTexts` to answer the
+   * same question, because the blanket assumption is false for it** (Codex
+   * review, PR #2052). Some system-authored lines ARE folded into
+   * `channel_responses` the same way any reply is — `system_notice`'s
+   * approval-overflow and `"Acknowledged."` fallback among them — and for
+   * those the assumption above still holds. Others never are: B-101's
+   * mention-ambiguity note is deliberately journaled outside that pipeline
+   * (`post_mention_ambiguity_note`'s own doc: "Journaled, not returned in the
+   * POST response"), specifically so it reaches an API poster who renders no
+   * chip at all. Discarding every held system frame here would silently
+   * swallow that note on a synchronous send; rendering every one instead
+   * would double-render whichever ones the response DOES carry, next to the
+   * identical `"company"` bubble `ChatView` appends from `responseTexts`
+   * itself. So a held system frame is discarded only when its text is
+   * present in `responseTexts` — the response already carries it — and
+   * released, for the caller to render, when it is not — the response never
+   * will.
    *
    * Scoped to a POST that *resolved*. A POST that threw resolved nothing and
    * belongs in {@link failed}; sending it here discards a reply the console is
    * never going to be handed again.
    */
-  ended(threadId: string): void {
+  ended(threadId: string, responseTexts: readonly string[] = []): F[] {
     this.threads.delete(threadId);
+    const held = this.held.get(threadId) ?? [];
     this.held.delete(threadId);
+    return held.filter(
+      (frame) => frame.agentId === "system" && !responseTexts.includes(frame.text ?? ""),
+    );
   }
 
   /**
@@ -206,6 +309,16 @@ export class PendingSyncPosts<F extends LiveReplyFrame = LiveReplyFrame> {
    * identity — is this thread's POST still unresolved — never by how long it
    * has been unresolved. See {@link detached} for why that distinction is the
    * whole fix.
+   *
+   * Holds a system-attributed frame exactly like any other while a POST is in
+   * flight — earlier code exempted it here instead (Codex review, PR #2052),
+   * which fixed the case that motivated it (the ambiguity note lost to
+   * `ended`'s blanket discard) but broke a different one: a `system_notice`
+   * fallback the response body DOES carry then rendered twice, once from this
+   * bypass and once from `ChatView`'s own append of `responseTexts`. See
+   * {@link ended}'s doc for why the fix belongs on release, where the
+   * response's own text is available to reconcile against, not on capture,
+   * where it never was.
    */
   capture(frame: F): boolean {
     if (!this.suppressesLiveReply(frame.chatId)) return false;

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -40,6 +40,7 @@ import {
   fromHistory,
   isGeneralChannel,
   makeMessage,
+  markSendFailed,
   reconcileIds,
   replyVoice,
   toHostMessageId,
@@ -228,7 +229,18 @@ interface Props {
   resolveTypingNames?: (chatId: string, parentId?: string) => string[];
   /** Called as a composer is typed in; the caller throttles. */
   onTyping?: (chatId: string, parentId?: string) => void;
-  onSendEnd?: (threadId: string, gen?: number) => void;
+  /**
+   * `responseTexts` is every reply line this settled POST's own body carried
+   * (issue #101 review, PR #2052) — what `PendingSyncPosts.ended` needs to
+   * tell a held **system**-attributed live frame (never the operator's own
+   * reply, which is always in the response) apart from one the response never
+   * carried: a `system_notice` fallback (approval overflow, "Acknowledged.")
+   * is folded into this same response body, but B-101's mention-ambiguity
+   * note deliberately never is. Without it, either every held system frame
+   * had to be discarded (silently losing the ambiguity note) or none did
+   * (double-rendering the ones the response does carry).
+   */
+  onSendEnd?: (threadId: string, gen?: number, responseTexts?: readonly string[]) => void;
   /**
    * The host accepted the turn and answered `202` instead of the reply
    * (issue #983). Distinct from `onSendEnd`, which says the turn is *over*:
@@ -993,50 +1005,46 @@ export function ChatView({
     });
   }, [client, company, roomVisits]);
 
-  /**
-   * Re-entering Chat with no channel in the hash returns the operator to the
-   * one they were last reading (issue #412).
-   *
-   * Leaving Chat drops the hash's second segment, so coming back used to fall
-   * straight through to `firstChannel` — which is not memory, it is whichever
-   * channel sorts first, and it cost a re-navigation on every trip.
-   *
-   * The remembered id is written into the **hash**, not held here, for three
-   * reasons: the channel on screen stays shareable, it survives a reload, and a
-   * remembered channel that has since been removed then falls through the exact
-   * same stale-id path as a bad deep link — so it raises the unknown-channel
-   * notice from issue #370 rather than needing a second one, and lands on the
-   * fallback visibly rather than silently. The `onChannelViewed` report for
-   * whatever it fell back to re-remembers that instead, so a vanished channel
-   * corrects itself after one visit.
-   *
-   * A hash that already names a channel is a deep link and always outranks
-   * memory; this only runs when there is nothing to override. The ref makes it
-   * one attempt per bare-hash entry, so it can never fight a navigation.
-   */
+  /** One attempt per bare-hash entry; see the effect below `channel`, which
+   * is the single owner of what a bare `#/chat` resolves to. */
   const restoredFor = useRef<string | null | undefined>(undefined);
-  useEffect(() => {
-    // Never off Room. This view is mounted on every route since #2130, and a
-    // route that names no second segment — `#/workflows`, `#/connections` —
-    // reaches this effect with a bare `sub` and no channel in the hash. Writing
-    // the remembered channel into the hash there does not restore anything: it
-    // navigates the operator OUT of the section they just opened, which is what
-    // clicking Flows did before this guard (it landed on `#/chat/main`).
-    if (!routeOpen) return;
-    if (sub) {
-      // A channel is named, so the next bare `#/chat` is a fresh re-entry.
-      restoredFor.current = undefined;
-      return;
-    }
-    // Scoped like `readLastChannel(scope)`: two connections serving the same
-    // company must each restore their own remembered channel, so a host switch
-    // cannot be mistaken for a re-entry into the previous host's state.
-    const scopeKey = `${scope.connection}::${scope.company ?? "single"}`;
-    if (restoredFor.current === scopeKey) return;
-    restoredFor.current = scopeKey;
-    const remembered = readLastChannel(scope);
-    if (remembered) onNavigate(remembered);
-  }, [company, routeOpen, scope, sub, onNavigate]);
+
+  /**
+   * What a failed send needs to be sent again (B-099), by the optimistic id of
+   * the row it failed on.
+   *
+   * A ref, not state: nothing rendered depends on it — `message.sendFailed` is
+   * what draws the row — and a re-render per failed send would be a re-render
+   * for a value only a click ever reads.
+   *
+   * It is deliberately not stored on the `ChatMessage`. Two of these five
+   * fields are not on the bubble and cannot be recovered from it: the wire
+   * `mentions` carry a target the rendered chip does not, and an `attachment`
+   * is a workspace node reference rather than the projection the row shows. A
+   * Retry rebuilt from the rendered message would quietly send a *different*
+   * message — chip-less, or without its file — which is a worse failure than
+   * the one being fixed.
+   *
+   * Declared **here**, beside the other long-lived refs, rather than beside
+   * `retrySend` where it is read: three early returns sit between the two
+   * (`desksError`, `!desks`, `!channel`), and a hook below them runs on some
+   * renders and not others. That is React error 310 — a blank console with no
+   * composer at all, on exactly the first paint, where `desks` is still `null`.
+   * Every hook in this component belongs above those returns.
+   */
+  const failedSends = useRef<
+    Map<
+      string,
+      {
+        target: string;
+        text: string;
+        intent?: MessageIntent;
+        parentId?: string;
+        attachments?: AttachmentDto[];
+        mentions?: Mention[];
+      }
+    >
+  >(new Map());
 
   // No channels exist until the host has answered. Resolving against a
   // half-built list is exactly the first-paint swap issue #370 describes.
@@ -1117,6 +1125,82 @@ export function ChatView({
       directMessageForId(members, generalSub ?? resolvedSub ?? decodedSub) ??
       firstChannel(sections))
     : null;
+
+  /**
+   * A bare `#/chat` is resolved **into the hash**, so which conversation is open
+   * is routed state rather than derived state (B-096).
+   *
+   * Two facts made a draft escape into somebody else's DM. The first is that a
+   * bare hash never named a channel: the magic-link landing route puts the
+   * console on `#/chat` with no second segment, `useHashView` canonicalises the
+   * *view* and knows nothing about chat's channels, and nothing else wrote one —
+   * so `channel` above stayed the value of an expression over `members`,
+   * `desks`, `transcripts` and `operator`, every one of which lands
+   * asynchronously and can re-order what `firstChannel` answers. The second is
+   * that the composer is deliberately ONE instance shared by every channel, and
+   * its draft deliberately survives a channel change (see `MessageComposer`'s
+   * `suppressed` doc, PR #1984) — so when the derived channel moved, the
+   * half-written message moved with it and `send` addressed whatever `channel`
+   * had become. The founder watched a message they wrote in `#general` post into
+   * a private DM with a teammate.
+   *
+   * Keeping a draft across a switch is right and stays. What is wrong is a
+   * conversation that can change with no navigation behind it, so this closes
+   * the gap at that end: the moment there is a channel to name, its id goes in
+   * the hash, and from then on `decodedSub` pins it. A deep link outranks
+   * everything (`sub` short-circuits), so this can never fight one.
+   *
+   * It also subsumes issue #412's restore, which used to be its own effect
+   * above. That is not a merge of convenience — two effects both writing the
+   * hash for a bare entry raced, and the loser silently won: memory would
+   * navigate to the remembered channel and the normaliser would immediately
+   * replace it with `firstChannel`. One effect, one decision, memory first.
+   *
+   * `restoredFor` keeps this to one attempt per bare-hash entry per scope, so a
+   * remembered channel the operator then navigates away from is not yanked back;
+   * `sub` becoming truthy re-arms it for the next re-entry. The `!channel` guard
+   * sits BEFORE the ref is stamped, so an entry that arrives before `/desks` has
+   * answered waits for a real channel instead of burning its one attempt on
+   * nothing.
+   *
+   * **Only while Chat is the open route** — `routeOpen`, PR #2134. This view is
+   * mounted on *every* route since #2130, and a route that names no second
+   * segment (`#/workflows`, `#/connections`) reaches this effect with a bare
+   * `sub` and no channel in the hash, indistinguishable from a bare `#/chat`.
+   * Writing a channel into the hash there restores nothing: it navigates the
+   * operator straight OUT of the section they just opened, which is what
+   * clicking Flows did before that guard — it landed on `#/chat/main`.
+   *
+   * That guard matters *more* here than it did before this change, not less.
+   * The old effect only navigated when there was something remembered
+   * (`if (remembered)`), so an operator who had never opened a channel was
+   * accidentally spared; this one always resolves — memory, else `channel.id` —
+   * which is the entire point of routing the decision instead of deriving it,
+   * and would bounce every such operator out of Flows on the first paint.
+   */
+  useEffect(() => {
+    if (!routeOpen) return;
+    if (sub) {
+      // A channel is named, so the next bare `#/chat` is a fresh re-entry.
+      restoredFor.current = undefined;
+      return;
+    }
+    // Nothing to normalise *to* yet. `channel` is null until `/desks` answers.
+    if (!channel) return;
+    // Scoped like `readLastChannel(scope)`: two connections serving the same
+    // company must each restore their own remembered channel, so a host switch
+    // cannot be mistaken for a re-entry into the previous host's state.
+    const scopeKey = `${scope.connection}::${scope.company ?? "single"}`;
+    if (restoredFor.current === scopeKey) return;
+    restoredFor.current = scopeKey;
+    // Memory outranks the fallback, and is written into the hash rather than
+    // held here (issue #412): the channel on screen stays shareable, survives a
+    // reload, and a remembered channel that has since been removed falls through
+    // the same stale-id path as a bad deep link — raising issue #370's
+    // unknown-channel notice rather than landing somewhere else in silence.
+    onNavigate(readLastChannel(scope) ?? channel.id);
+  }, [routeOpen, scope, sub, channel, onNavigate]);
+
   /**
    * The hash named a channel this company doesn't have, and the first-channel
    * fallback answered instead.
@@ -1836,6 +1920,38 @@ export function ChatView({
   const append = (channelId: string, ...added: ChatMessage[]) =>
     setTranscripts((t) => ({ ...t, [channelId]: [...(t[channelId] ?? []), ...added] }));
 
+
+  /**
+   * Send a failed line again (B-099).
+   *
+   * The failed row is dropped first, because `send` appends its own optimistic
+   * bubble: keeping both would show the operator their message twice, one of
+   * them a corpse. Its retry payload goes with it, so a Retry cannot be
+   * replayed twice from one click; a second failure re-registers a fresh one
+   * under the new row's id.
+   *
+   * Nothing is retried automatically. A throw is ambiguous — the host may have
+   * journaled the message before the request died (see `send`'s doc) — so an
+   * automatic resend would risk posting the same instruction twice. Whether
+   * that is worth it is the operator's call, which is exactly what a button is.
+   */
+  const retrySend = (messageId: string) => {
+    // `send` itself no-ops while a POST is already in flight (`if (sending)
+    // return false`). Checked here too, before the payload and failed row are
+    // consumed, because otherwise a Retry clicked mid-send would drop both —
+    // silently losing the only copy of the retry (CodeRabbit review) — and
+    // `send`'s own guard would have nothing left to return `false` about.
+    if (sending) return;
+    const payload = failedSends.current.get(messageId);
+    if (!payload) return;
+    failedSends.current.delete(messageId);
+    setTranscripts((t) => ({
+      ...t,
+      [payload.target]: (t[payload.target] ?? []).filter((m) => m.id !== messageId),
+    }));
+    void send(payload.text, payload.intent, payload.parentId, payload.attachments, payload.mentions);
+  };
+
   /**
    * Post a line and thread the company's answer back into the same place.
    * `parentId` set means the exchange stays inside the thread panel.
@@ -1939,15 +2055,33 @@ export function ChatView({
     // cross-company-reused) thread id — see `shouldClearReceipt`.
     // Armed under the same key the reload leg folds runs into, or the two
     // legs describe the same turn under two names and the indicator that
-    // survives a reload is not the one the POST armed. Unthreaded sends key at
-    // the channel exactly as before — `turnStateKey` returns `chatId` for them.
-    // Derived from `openThreadId`, not from `parentId`. A review reply is
-    // anchored to a *reply* (`threadReviewAnchor.anchorId`), not to the thread
-    // root, so keying on the parent would arm a key the panel's own lookup —
-    // which keys on the open thread — could never match. `parentId` stays what
-    // it was: the host's `parent`, for `client.chat` alone.
+    // survives a reload is not the one the POST armed.
+    //
+    // **Unthreaded (`parentId` unset) always keys the channel outright** —
+    // `turnStateKey(chatId)` with no root — regardless of what thread happens
+    // to be open in the panel beside it. The channel composer always sends
+    // `parentId: undefined`, and the channel row's own Retry button lives on
+    // that same top-level transcript, so both a fresh top-level send and a
+    // top-level failure's Retry can fire while an *unrelated* thread in this
+    // channel is open in the panel (`openThreadId` naming that other thread's
+    // root). Keying on `openThreadId` there used to mis-file the whole send —
+    // its receipt and open-turn recovery registered under a thread it never
+    // touched, so the panel showed work it did not start while the channel
+    // that actually ran it showed nothing (codex P2, PR #2052 review). A
+    // threaded retry cannot hit this: its Retry button only renders inside
+    // the thread panel for the thread it belongs to, so `openThreadId`
+    // already names that same thread whenever it is clickable.
+    //
+    // **Threaded (`parentId` set) still keys off `openThreadId`, not
+    // `parentId` itself.** A review reply is anchored to a *reply*
+    // (`threadReviewAnchor.anchorId`), not to the thread root, so keying on
+    // the parent would arm a key the panel's own lookup — which keys on the
+    // open thread — could never match. `parentId` stays what it was: the
+    // host's `parent`, for `client.chat` alone.
     const stateKey = chatId
-      ? turnStateKey(chatId, threadRootOf(openThreadId ?? undefined))
+      ? parentId === undefined
+        ? turnStateKey(chatId)
+        : turnStateKey(chatId, threadRootOf(openThreadId ?? undefined))
       : undefined;
     const gen = stateKey ? onSendStart?.(stateKey) : undefined;
     // Which of the POST's three outcomes actually happened, decided here and
@@ -1957,6 +2091,11 @@ export function ChatView({
     // working row down mid-turn (detached) or throw away the reply it was
     // holding (failed). See `PendingSyncPosts` for the table.
     let outcome: "resolved" | "detached" | "failed" | "stale" = "resolved";
+    // Every reply line a settled response actually carries, read by
+    // `onSendEnd` (issue #101 review) to tell a held system frame the
+    // response duplicates from one it never will. Declared here, not inside
+    // the `try` block that fills it in, so `finally` below can still see it.
+    let responseTexts: string[] = [];
     try {
       const answer = await client.chat(
         text,
@@ -2020,6 +2159,22 @@ export function ChatView({
         return true;
       }
       const reply = answer;
+      // What `onSendEnd` hands `PendingSyncPosts.ended`, unconditionally —
+      // even the `(no reply)` / review-feedback branches count as "this
+      // response carried nothing", which is exactly what an empty array
+      // already says correctly.
+      responseTexts = reply.responses.map((r) => r.text);
+      // Fired here, BEFORE `append` below, and not from the `finally` block
+      // this used to run from (Codex review, PR #2052). `onSendEnd` releases
+      // any held system frame the response above didn't carry — B-101's
+      // mention-ambiguity note, always journaled on the host *before* the
+      // reply it is about. Releasing it after `append` would render the
+      // reply first and the note second, the reverse of `chat/history`'s own
+      // order, so the note visibly jumps backward past the answer on the
+      // very next reload. Firing it here instead keeps the live order and
+      // the durable order the same. `finally` below no longer fires it for
+      // the `"resolved"` case this is the only path that reaches.
+      if (stateKey) onSendEnd?.(stateKey, gen, responseTexts);
       const replies = reply.responses.length
         ? reply.responses.map((r) =>
             // Same rule as the live path and `fromHistory`: a host-authored
@@ -2098,10 +2253,34 @@ export function ChatView({
       // Still said, even when the reply arrives on the stream a moment later:
       // the request did fail, and an operator not told that has no way to know
       // whether their message was taken at all. The two facts are not in
-      // competition — this line reports the request, the shell renders whatever
-      // the turn goes on to produce.
+      // competition — this marks the request, the shell renders whatever the
+      // turn goes on to produce.
+      //
+      // Marked ON the message rather than appended beside it (B-099). The old
+      // sibling `system` line left the bubble itself indistinguishable from a
+      // delivered one — same avatar, same timestamp, no warning of any kind —
+      // so scrolling away, or a message long enough to push the note off
+      // screen, left something that reads as sent and was not. `sendFailed` is
+      // a field of the row, so no renderer can draw the bubble without it, and
+      // the row can carry its own Retry.
       const msg = err instanceof ApiError ? err.message : "something went wrong";
-      append(target, makeMessage("system", `Couldn't send — ${msg}`, { parentId }));
+      setTranscripts((t) => ({
+        ...t,
+        [target]: markSendFailed(t[target] ?? [], local.id, msg),
+      }));
+      // What Retry needs to send this line again, kept off the message: the
+      // wire `mentions` carry targets the rendered chips do not, and an
+      // attachment is a node reference rather than the projection on the
+      // bubble. Keyed by the optimistic id, which is the id the failed row
+      // still has — a throw never reaches the `reconcileIds` above it.
+      failedSends.current.set(local.id, {
+        target,
+        text,
+        intent,
+        parentId,
+        attachments,
+        mentions,
+      });
       // Ambiguous, not a confirmed non-send — see this function's doc comment.
       return undefined;
     } finally {
@@ -2116,10 +2295,12 @@ export function ChatView({
       // carries on regardless, so the frame it holds is the only copy of the
       // answer. Routing the throw here is the drop this whole change removes,
       // put back on the one path the feature exists for.
-      if (stateKey) {
-        if (outcome === "resolved") onSendEnd?.(stateKey, gen);
-        else if (outcome === "failed") onSendFailed?.(stateKey, gen);
-      }
+      //
+      // The `"resolved"` case no longer fires `onSendEnd` from here (issue
+      // #101 review, PR #2052) — it fires earlier, in the try block, before
+      // `append` renders the response's own replies. See that call site's
+      // comment for why the order matters. This block still owns `"failed"`.
+      if (stateKey && outcome === "failed") onSendFailed?.(stateKey, gen);
       setSending(false);
     }
   }
@@ -2624,6 +2805,7 @@ export function ChatView({
                   reviewingCardIds={reviewingCardIds}
                   resolveAttachmentUrl={resolveAttachmentUrl}
                   taskStatusByTaskId={taskStatusByTaskId}
+                  onRetrySend={retrySend}
                   onStartBrief={() =>
                     setComposerPrefill((current) => ({
                       text: FIRST_TEAM_BRIEF,
@@ -2921,6 +3103,7 @@ export function ChatView({
                   typingNames={resolveTypingNames?.(active.id, parent.id) ?? []}
                   openTurn={threadTurn}
                   onTyping={() => onTyping?.(active.id, parent.id)}
+                  onRetrySend={retrySend}
                   // A thread is not a lesser transcript (issue #1734): an echoed
                   // reply read here is the same false attribution as one read in
                   // the channel, so the panel marks its rows from the same state.

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -1,4 +1,4 @@
-import { MessageSquareReply } from "lucide-react";
+import { MessageSquareReply, TriangleAlert } from "lucide-react";
 
 import type { TaskStatus } from "@/api/tasks";
 import type { CognitionState, TurnStep } from "@/api/types";
@@ -67,6 +67,14 @@ interface Props {
   resolveAttachmentUrl?: (nodeId: string) => Promise<string>;
   /** Board task id -> live state for card-linked background turns (#1758). */
   taskStatusByTaskId?: Readonly<Record<string, TaskStatus>>;
+  /**
+   * Sends a line whose POST never completed again (B-099), by its id.
+   *
+   * Absent on a surface that cannot resend — the thread panel's rows today — in
+   * which case the failed row still says so and simply offers no button. Saying
+   * nothing is the bug; saying it with no way out is merely less good.
+   */
+  onRetrySend?: (messageId: string) => void;
   /** Shared shell clock for elapsed background-work copy. */
   now?: number;
   /**
@@ -244,6 +252,7 @@ export function MessageRow({
   reviewingCardIds,
   resolveAttachmentUrl,
   taskStatusByTaskId,
+  onRetrySend,
   now = Date.now(),
   cognition,
   onRedeemBudgetPause,
@@ -326,7 +335,34 @@ export function MessageRow({
             placeholder={echoMarkerFor(message, sender, cognition)}
           />
         )}
-        <Markdown mentions={message.mentions} className="text-sm leading-6 break-words prose-p:my-0 prose-pre:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-headings:my-1">{message.text}</Markdown>
+        <Markdown
+          mentions={message.mentions}
+          className={cn(
+            "text-sm leading-6 break-words prose-p:my-0 prose-pre:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-headings:my-1",
+            // A line that never left the browser is dimmed, so the difference
+            // between sent and not-sent is visible in the text itself and not
+            // only in a note under it (B-099). Muted rather than struck
+            // through: the words are still the operator's own draft, and Retry
+            // means they may yet be delivered.
+            //
+            // `!== undefined` rather than truthy: an `ApiError` can carry an
+            // empty `message` when the host's envelope sends `error: ""`
+            // (`httpError`'s `envelope?.error ?? statusMessage(res)` keeps an
+            // empty string as-is, since `??` only falls back on nullish). A
+            // truthy check would silently hide the failed styling, the notice,
+            // and the Retry control for exactly that response (CodeRabbit
+            // review).
+            message.sendFailed !== undefined && "text-muted-foreground",
+          )}
+        >
+          {message.text}
+        </Markdown>
+        {message.sendFailed !== undefined && (
+          <FailedSendNotice
+            reason={message.sendFailed || "something went wrong"}
+            onRetry={onRetrySend ? () => onRetrySend(message.id) : undefined}
+          />
+        )}
 
         {message.attachments && message.attachments.length > 0 && (
           <MessageAttachments
@@ -402,6 +438,53 @@ export function MessageRow({
         offersReactions={!readOnly}
       />
     </article>
+  );
+}
+
+/**
+ * The failure notice on a line that never left the browser (B-099).
+ *
+ * Attached under the message it belongs to rather than appended as its own
+ * transcript row, which is the whole point: a sibling line scrolls away from
+ * the bubble it describes, and a long enough message pushes it off screen
+ * entirely, leaving something that reads as sent and was not. This cannot be
+ * separated from its message, because it is drawn by the message's own row.
+ *
+ * It is a `role="status"` rather than an `alert`: a failed send is worth
+ * announcing, and it is not an interruption — the operator is looking at the
+ * transcript they just posted into.
+ *
+ * **Retry is the escape, and it is manual.** A throw is ambiguous (see
+ * `ChatView`'s `send`): the host may have journaled the message before the
+ * request died, so a resend can post the same instruction twice. That is the
+ * operator's trade to make, and it is the reason this is a button rather than a
+ * background retry loop.
+ *
+ * Exported so `ThreadPanel`'s own `Line` can render the identical notice for a
+ * failed threaded reply (Codex review, PR #2052) instead of growing a second
+ * copy of this markup the way `senderOf` already warns against for sender
+ * resolution.
+ */
+export function FailedSendNotice({ reason, onRetry }: { reason: string; onRetry?: () => void }) {
+  return (
+    <div
+      role="status"
+      className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-destructive/40 bg-destructive/5 px-2 py-1"
+    >
+      <TriangleAlert className="size-3.5 shrink-0 text-destructive" aria-hidden />
+      <span className="min-w-0 text-2xs text-destructive">Not sent — {reason}</span>
+      {onRetry && (
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="h-5 px-1.5 text-2xs text-destructive hover:bg-destructive/10 hover:text-destructive"
+          onClick={onRetry}
+        >
+          Retry
+        </Button>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -91,6 +91,8 @@ interface Props {
   resolveAttachmentUrl?: (nodeId: string) => Promise<string>;
   /** Board task id -> live state for card-linked background turns (#1758). */
   taskStatusByTaskId?: Readonly<Record<string, TaskStatus>>;
+  /** Sends a line whose POST never completed again (B-099), by its id. */
+  onRetrySend?: (messageId: string) => void;
   /**
    * Places a first brief into the composer on an empty channel.
    * Optional so the thread panel — which renders no intro — need not pass it.
@@ -188,6 +190,7 @@ export function MessageTimeline({
   reviewingCardIds,
   resolveAttachmentUrl,
   taskStatusByTaskId,
+  onRetrySend,
   onStartBrief,
   onAddPeople,
   now,
@@ -409,6 +412,7 @@ export function MessageTimeline({
                 reviewingCardIds={reviewingCardIds}
                 resolveAttachmentUrl={resolveAttachmentUrl}
                 taskStatusByTaskId={taskStatusByTaskId}
+                onRetrySend={onRetrySend}
                 now={now ?? Date.now()}
                 cognition={cognition}
                 onRedeemBudgetPause={onRedeemBudgetPause}

--- a/frontend/src/views/chat/ThreadPanel.tsx
+++ b/frontend/src/views/chat/ThreadPanel.tsx
@@ -7,8 +7,10 @@ import type { MessageIntent } from "@/api/tasks";
 import type { AttachmentDto, CognitionState, TurnStep } from "@/api/types";
 import type { ChatMessage } from "@/lib/chat";
 import type { TeamMember } from "@/lib/team";
+import { cn } from "@/lib/utils";
 import { BudgetPauseNoticeCard } from "./BudgetPauseNoticeCard";
 import { EchoPlaceholder, echoMarkerFor } from "./EchoPlaceholder";
+import { FailedSendNotice } from "./MessageRow";
 import { MessageAttachments } from "./MessageAttachments";
 import { StepTimeline } from "./StepTimeline";
 import { MessageComposer } from "./MessageComposer";
@@ -201,6 +203,14 @@ interface Props {
   onRedeemBudgetPause?: (agentId: string, noticeMessageId: string) => void;
   redeemingBudgetPauseAgent?: string | null;
   latestBudgetPauseMessageIdByAgent?: Map<string, string>;
+  /**
+   * Retries a reply that failed to send from *this thread's* composer
+   * (B-099). `MessageRow` gets the same prop of the same name; without it a
+   * threaded reply's `sendFailed` field had nowhere to go, because `Line` is
+   * its own renderer and never received it — a failed reply read as
+   * delivered, with no way to send it again (Codex review, PR #2052).
+   */
+  onRetrySend?: (messageId: string) => void;
 }
 
 /**
@@ -238,6 +248,7 @@ export function ThreadPanel({
   onRedeemBudgetPause,
   redeemingBudgetPauseAgent,
   latestBudgetPauseMessageIdByAgent,
+  onRetrySend,
 }: Props) {
   // Absent `inlineReplyIds` counts everything, which is what every caller did
   // before the prop existed: a panel that cannot know what the channel
@@ -269,6 +280,7 @@ export function ThreadPanel({
           onRedeemBudgetPause={onRedeemBudgetPause}
           redeemingBudgetPauseAgent={redeemingBudgetPauseAgent}
           latestBudgetPauseMessageIdByAgent={latestBudgetPauseMessageIdByAgent}
+          onRetrySend={onRetrySend}
         />
         <div className="flex items-center gap-2 px-4 py-2">
           <span className="text-xs font-medium text-muted-foreground">
@@ -288,6 +300,7 @@ export function ThreadPanel({
             cognition={cognition}
             onRedeemBudgetPause={onRedeemBudgetPause}
             redeemingBudgetPauseAgent={redeemingBudgetPauseAgent}
+            onRetrySend={onRetrySend}
             latestBudgetPauseMessageIdByAgent={latestBudgetPauseMessageIdByAgent}
           />
         ))}
@@ -394,6 +407,7 @@ function Line({
   onRedeemBudgetPause,
   redeemingBudgetPauseAgent,
   latestBudgetPauseMessageIdByAgent,
+  onRetrySend,
 }: {
   channel: Channel;
   members: TeamMember[];
@@ -406,6 +420,7 @@ function Line({
   onRedeemBudgetPause?: (agentId: string, noticeMessageId: string) => void;
   redeemingBudgetPauseAgent?: string | null;
   latestBudgetPauseMessageIdByAgent?: Map<string, string>;
+  onRetrySend?: (messageId: string) => void;
 }) {
   // Four arguments, not three: `youAvatar` is the last parameter, and omitting
   // it left your own line with no avatar to seed from but the name "You" —
@@ -461,7 +476,24 @@ function Line({
             {formatTime(message.at)}
           </span>
         </div>
-        <Markdown mentions={message.mentions} className="text-sm leading-6 break-words prose-p:my-0 prose-pre:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-headings:my-1">{message.text}</Markdown>
+        <Markdown
+          mentions={message.mentions}
+          className={cn(
+            "text-sm leading-6 break-words prose-p:my-0 prose-pre:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-headings:my-1",
+            // Same rule and the same reason as `MessageRow` (B-099): a threaded
+            // reply that never left the browser must not read as delivered just
+            // because this panel draws replies with its own renderer.
+            message.sendFailed !== undefined && "text-muted-foreground",
+          )}
+        >
+          {message.text}
+        </Markdown>
+        {message.sendFailed !== undefined && (
+          <FailedSendNotice
+            reason={message.sendFailed || "something went wrong"}
+            onRetry={onRetrySend ? () => onRetrySend(message.id) : undefined}
+          />
+        )}
         {message.attachments && message.attachments.length > 0 && (
           <MessageAttachments
             attachments={message.attachments}

--- a/frontend/test/e2e/chat-bare-hash-normalises.spec.ts
+++ b/frontend/test/e2e/chat-bare-hash-normalises.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * End-to-end proof for B-096 — which conversation is open is **routed** state,
+ * never derived state.
+ *
+ * The founder bug: a message composed in `#general` was delivered to a private
+ * DM. The console had changed conversation underneath the draft with no
+ * navigation behind it. Two facts made that possible, and only one is wrong.
+ *
+ * The right one is that the composer is a single instance shared by every
+ * channel, whose draft deliberately survives a channel change — see
+ * `MessageComposer`'s `suppressed` doc; unmounting it is what discards a
+ * half-written message, and PR #1984 restored that on purpose.
+ *
+ * The wrong one is that a bare `#/chat` — where the magic-link landing route
+ * puts you, because `useHashView` canonicalises the *view* and knows nothing
+ * about chat's channels — left the open channel as the value of an expression
+ * over `members`, `desks`, `transcripts` and `operator`. Each lands
+ * asynchronously, so any re-derivation could answer differently from the
+ * channel the founder was shown, and `send` addresses whatever that expression
+ * currently names.
+ *
+ * # Why this is an e2e spec and not a unit test
+ *
+ * The defect *is* the URL, and only a browser has one. The behaviour spans
+ * `useHashView`'s canonicalisation, `ChatView`'s channel resolution and the
+ * `hashchange` round trip between them; a unit test of any one of the three
+ * passes with the bug fully present, which is how it survived.
+ *
+ * Like the rest of `test/e2e` this drives a running host — see
+ * `playwright.config.ts`.
+ */
+
+/** The hash a resolved chat address has: `#/chat/<channel id>`. */
+const RESOLVED = /^#\/chat\/[^/]+$/;
+
+/** Issue #370's notice, raised when an address names no channel this company has. */
+const UNKNOWN_CHANNEL = /isn't a channel here/;
+
+/**
+ * The first-run product tour renders a modal over the console and swallows
+ * every click beneath it. Answer "already skipped" for whatever company id the
+ * host resolves to rather than hard-coding the harness's.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+/**
+ * The landing case: nothing is remembered, so there is no memory to restore and
+ * the address has to be written from the channel that was actually resolved.
+ *
+ * This is the exact state of a founder arriving on a magic link — a fresh
+ * profile with an empty `oc.chat.last-channel` — and it is the one that left
+ * the hash bare indefinitely, because the console reported the *derived*
+ * channel as viewed and remembered that, so memory could never disagree with
+ * the fallback and never triggered a navigation of its own.
+ */
+test("a bare #/chat resolves into the address with nothing remembered", async ({ page }) => {
+  await page.addInitScript(() => {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith("oc.chat.last-channel")) localStorage.removeItem(key);
+    }
+  });
+
+  await page.goto("/#/chat");
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+
+  await expect.poll(() => new URL(page.url()).hash, { timeout: 15_000 }).toMatch(RESOLVED);
+  // A real channel, not merely a syntactically resolved address: an id this
+  // company does not have would raise issue #370's notice over the fallback,
+  // which is the same silent-substitution bug wearing a URL.
+  await expect(page.getByText(UNKNOWN_CHANNEL)).toHaveCount(0);
+});
+
+/**
+ * The two properties the normalisation must not cost: a deep link is honoured
+ * verbatim, and a bare re-entry returns to what was last read (issue #412).
+ *
+ * Guards the fix from collapsing into "always navigate to `firstChannel`",
+ * which would pass the test above while silently retiring re-entry memory.
+ */
+test("a deep link is honoured verbatim and a bare re-entry restores it", async ({ page }) => {
+  await page.goto("/#/chat");
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+  await expect.poll(() => new URL(page.url()).hash, { timeout: 15_000 }).toMatch(RESOLVED);
+  const deepLink = new URL(page.url()).hash;
+
+  await page.goto(`/${deepLink}`);
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+  // Long enough for a stray normalisation to have fired had one been armed.
+  await page.waitForTimeout(1_500);
+  expect(new URL(page.url()).hash).toBe(deepLink);
+
+  await page.goto("/#/chat");
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+  await expect.poll(() => new URL(page.url()).hash, { timeout: 15_000 }).toBe(deepLink);
+});
+
+/**
+ * The #2134 regression, guarded end-to-end.
+ *
+ * `ChatView` is mounted on every route since #2130, and `#/workflows` names no
+ * second segment — so it reaches this effect looking exactly like a bare
+ * `#/chat`. Writing a channel into the hash there restores nothing: it
+ * navigates the operator straight out of the section they just opened.
+ * Clicking **Flows** landed on `#/chat/main`, which is what `routeOpen` fixed.
+ *
+ * It matters more after B-096, not less: the effect this replaced only
+ * navigated when something was remembered, so an operator with an empty
+ * `oc.chat.last-channel` was accidentally spared. This one always resolves —
+ * memory, else the resolved channel — so without the guard *every* operator
+ * would be bounced, and both halves are asserted below.
+ */
+for (const remembered of [true, false] as const) {
+  test(`another section keeps its own address (remembered channel: ${remembered})`, async ({
+    page,
+  }) => {
+    if (!remembered) {
+      await page.addInitScript(() => {
+        for (const key of Object.keys(localStorage)) {
+          if (key.startsWith("oc.chat.last-channel")) localStorage.removeItem(key);
+        }
+      });
+    } else {
+      // Read a channel first, so there IS something to restore — the branch the
+      // pre-B-096 effect could reach.
+      await page.goto("/#/chat");
+      await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+      await expect.poll(() => new URL(page.url()).hash, { timeout: 15_000 }).toMatch(RESOLVED);
+    }
+
+    await page.goto("/#/workflows");
+    // Long enough for a stray normalisation to have fired had one been armed.
+    await page.waitForTimeout(2_000);
+    expect(new URL(page.url()).hash).toBe("#/workflows");
+  });
+}

--- a/frontend/test/e2e/chat-detached-post-failure.spec.ts
+++ b/frontend/test/e2e/chat-detached-post-failure.spec.ts
@@ -337,8 +337,8 @@ test("a chat POST killed in flight still shows the reply the host went on to wri
     // Recorded, never thrown — the same discipline `repliesAtCut` below is
     // written with, and for the same reason stated there: an exception inside
     // a route handler aborts the HANDLER, so `route.abort` never runs, the
-    // POST never fails, and the run dies waiting for a `Couldn't send` line
-    // that was never going to appear. That reports a premise violation as a
+    // POST never fails, and the run dies waiting for a `Not sent` line that
+    // was never going to appear. That reports a premise violation as a
     // timeout somewhere else entirely, which is precisely the misdirection
     // this spec is being fixed to stop making.
     premiseFailure = await awaitJournaledReply();
@@ -392,8 +392,12 @@ test("a chat POST killed in flight still shows the reply the host went on to wri
   // The operator is told the request failed, and that stays true — a reply
   // arriving later does not mean the send worked, and a console that quietly
   // swallowed the error would leave them unable to tell a delivered message
-  // from a dropped one.
-  await expect(page.getByText(/Couldn't send/).first()).toBeVisible({ timeout: 60_000 });
+  // from a dropped one. B-099 moved this off a sibling `system` bubble onto
+  // the message row itself (`ChatMessage.sendFailed`, rendered by
+  // `MessageRow`'s `FailedSendNotice` as "Not sent — {reason}") — see the doc
+  // comment on `sendFailed` in `src/lib/chat.ts` for why the old bubble was
+  // replaced.
+  await expect(page.getByText(/Not sent/).first()).toBeVisible({ timeout: 60_000 });
   await cutReadyPromise;
   expect(cuts, "the chat POST must actually have been cut").toBe(1);
   // With the frame observed to have arrived (`awaitCapturedFrame`), this is no

--- a/frontend/test/unit/chat-failed-send.test.ts
+++ b/frontend/test/unit/chat-failed-send.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeMessage, markSendFailed, type ChatMessage } from "@/lib/chat";
+import { MessageRow } from "@/views/chat/MessageRow";
+import type { TimelineEntry } from "@/views/chat/model";
+
+/**
+ * B-099: a message that failed to send must not render as a delivered one.
+ *
+ * What was wrong was not the wording, it was where the fact lived. The failure
+ * was appended as its own `system` bubble underneath, so the message itself
+ * kept the styling of the delivered lines above it — same avatar, same
+ * timestamp, nothing red — and the note scrolled away from it. A long enough
+ * message pushed the note off screen entirely, leaving something that reads as
+ * sent and was not, with the composer already cleared so the only copy of the
+ * text was the pixels on screen.
+ *
+ * `sendFailed` is a field of the message now, so no renderer can draw the
+ * bubble without seeing it, and the row carries its own Retry.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function entryFor(message: ChatMessage): TimelineEntry {
+  return {
+    key: message.id,
+    message,
+    sender: { kind: "you", name: "You" },
+    continuation: false,
+    replies: 0,
+  } as unknown as TimelineEntry;
+}
+
+async function render(message: ChatMessage, onRetrySend?: (id: string) => void) {
+  await act(async () => {
+    root.render(
+      createElement(MessageRow, {
+        entry: entryFor(message),
+        threadOpen: false,
+        onOpenThread: () => {},
+        onReact: () => {},
+        onDismissCard: () => {},
+        dismissingCardId: null,
+        onRetrySend,
+      }),
+    );
+  });
+}
+
+/** The Retry control, however it is currently laid out. */
+function retryButton(): HTMLButtonElement | null {
+  return (
+    Array.from(container.querySelectorAll("button")).find(
+      (b) => (b.textContent ?? "").trim() === "Retry",
+    ) ?? null
+  );
+}
+
+describe("markSendFailed", () => {
+  it("marks only the line it names", () => {
+    const kept = makeMessage("you", "first");
+    const failed = makeMessage("you", "second");
+    const marked = markSendFailed([kept, failed], failed.id, "cannot reach the company host");
+
+    expect(marked.find((m) => m.id === failed.id)?.sendFailed).toBe(
+      "cannot reach the company host",
+    );
+    expect(marked.find((m) => m.id === kept.id)?.sendFailed).toBeUndefined();
+  });
+
+  /**
+   * A send's target can be re-homed by a company switch while its POST is in
+   * flight, and the transcript it aimed at is then somebody else's. Returning
+   * the same reference makes the caller's `setState` a no-op rather than a
+   * re-render that changes nothing.
+   */
+  it("returns the same array when the line is no longer in this transcript", () => {
+    const messages = [makeMessage("you", "still here")];
+    expect(markSendFailed(messages, "m-gone", "whatever")).toBe(messages);
+  });
+});
+
+describe("a failed message's row", () => {
+  it("says it was not sent, and offers Retry", async () => {
+    const message: ChatMessage = {
+      ...makeMessage("you", "Please pull last month's sales by scent."),
+      sendFailed: "cannot reach the company host at this origin",
+    };
+    const onRetrySend = vi.fn();
+    await render(message, onRetrySend);
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Not sent");
+    expect(text).toContain("cannot reach the company host at this origin");
+
+    const retry = retryButton();
+    expect(retry, "a failed message must offer a way to send it again").not.toBeNull();
+    await act(async () => {
+      retry!.click();
+    });
+    expect(onRetrySend).toHaveBeenCalledWith(message.id);
+  });
+
+  /**
+   * The negative half, and the one that actually pins the bug: a delivered
+   * message must carry none of this. Without it the assertions above pass for a
+   * renderer that decorates every row.
+   */
+  it("is distinguishable from a delivered one", async () => {
+    await render(makeMessage("you", "Please pull last month's sales by scent."));
+    expect(container.textContent ?? "").not.toContain("Not sent");
+    expect(retryButton()).toBeNull();
+  });
+
+  /**
+   * A surface with no resend wired still says the message failed. Silence is
+   * the bug; a notice with no button is merely less good.
+   */
+  it("still reports the failure where no resend is wired", async () => {
+    const message: ChatMessage = {
+      ...makeMessage("you", "Please pull last month's sales by scent."),
+      sendFailed: "cannot reach the company host at this origin",
+    };
+    await render(message, undefined);
+    expect(container.textContent ?? "").toContain("Not sent");
+    expect(retryButton()).toBeNull();
+  });
+});

--- a/frontend/test/unit/chat-receipt-scope-reset.test.ts
+++ b/frontend/test/unit/chat-receipt-scope-reset.test.ts
@@ -85,7 +85,17 @@ describe("clearReceipt is generation-guarded (issue #1935 review)", () => {
     // The three callbacks that still clear the receipt keep the #1935 guard:
     // they take the generation their own `onSendStart` returned and hand it to
     // `clearReceipt`, so a stale cross-company clear is a no-op.
-    expect(appShell).toMatch(/const onSendEnd = useCallback\(\s*\n\s*\(threadId: string, gen\?: number\) =>/);
+    //
+    // `onSendEnd` also gained a third, unrelated parameter (issue #101 review,
+    // PR #2052) — the settled response's own reply text(s), which `ended`
+    // needs to tell a held system frame the response duplicates from one it
+    // never will. The regex tolerates it (`(?:, responseTexts\?: readonly
+    // string\[\])?`) rather than pinning its exact name: this test's whole
+    // job is the generation guard, and a future rename of that third param
+    // should not have to touch this file.
+    expect(appShell).toMatch(
+      /const onSendEnd = useCallback\(\s*\n\s*\(threadId: string, gen\?: number(?:, responseTexts\?: readonly string\[\])?\) =>/,
+    );
     expect(appShell).toMatch(/const onSendStale = useCallback\(\s*\n\s*\(threadId: string, gen\?: number\) =>/);
     expect(appShell).toMatch(/const onSendFailed = useCallback\(\s*\n\s*\(threadId: string, gen\?: number\) =>/);
   });
@@ -148,10 +158,12 @@ describe("ChatView's send surface generation-tags its receipt clears", () => {
 
   it("forwards that generation to all three terminal outcomes", () => {
     // `gen` pinned by position, with the argument list left open: #2044 added
-    // a fourth (`chatId`) and the generation being third is the whole of what
-    // this asserts. Its own contract is `appShell`'s signature check above.
+    // a fourth (`chatId`) to `onSendDetached`, and `onSendEnd` gained a third
+    // of its own (`responseTexts`, issue #101 review, PR #2052 — see the
+    // `appShell` signature check above for why). The generation being second
+    // is the whole of what this asserts.
     expect(chatViewTsx).toMatch(/onSendDetached\?\.\(stateKey, answer\.turnId, gen[,)]/);
-    expect(chatViewTsx).toMatch(/onSendEnd\?\.\(stateKey, gen\);/);
+    expect(chatViewTsx).toMatch(/onSendEnd\?\.\(stateKey, gen(?:, responseTexts)?\);/);
     expect(chatViewTsx).toMatch(/onSendFailed\?\.\(stateKey, gen\);/);
   });
 

--- a/frontend/test/unit/chat-retry-scope-not-open-thread.test.ts
+++ b/frontend/test/unit/chat-retry-scope-not-open-thread.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A top-level send's live-turn state must key on the **channel**, never on
+ * whatever thread the panel happens to have open beside it (codex P2, PR
+ * #2052 fresh review round).
+ *
+ * `send`'s `stateKey` used to be `turnStateKey(chatId,
+ * threadRootOf(openThreadId ?? undefined))` unconditionally — derived from
+ * the currently-open thread panel, not from the send's own `parentId`. Two
+ * ingresses can carry `parentId: undefined` (a genuine top-level send) while
+ * `openThreadId` still names some *other* thread in the same channel:
+ *
+ * - the channel composer itself, which always sends `parentId: undefined`
+ *   regardless of whether a thread panel happens to be open beside it
+ *   (`onSend={(text, intent, attachments, mentions) => send(text, intent,
+ *   undefined, attachments, mentions)}`);
+ * - a Retry click on a top-level failed send's row, whose saved payload
+ *   (`failedSends`) never carried a `parentId` either, and which can be
+ *   clicked from the channel timeline while any other thread in the channel
+ *   is open in the panel.
+ *
+ * Either one, before this fix, armed the send's receipt / open-turn recovery
+ * under `chatId#<the-open-thread's-root>` instead of the bare `chatId`. The
+ * thread panel for the unrelated thread then showed work it never started
+ * (its own read, `threadTurnKey`, keys on exactly that same
+ * `turnStateKey(activeThreadId, threadRootOf(openThreadId))`), while the
+ * channel's own row excludes anything matching `threadTurnKey` (`key !==
+ * threadTurnKey`) and so showed nothing for a turn that was, in fact, its
+ * own.
+ *
+ * Asserted against the source, matching this file's established style for
+ * `ChatView.send` (see `chat-send-state-key-symmetry.test.ts`,
+ * `chat-receipt-scope-reset.test.ts`): `send` sits inside a large host
+ * component this suite declines to mount for a wiring/branching assertion,
+ * and the failure mode here is exactly "the key formula used the wrong
+ * input", which a source read pins precisely.
+ */
+const here = dirname(fileURLToPath(import.meta.url));
+const chatView = readFileSync(resolve(here, "../../src/views/ChatView.tsx"), "utf8");
+
+describe("send's stateKey does not borrow the open thread for a top-level send", () => {
+  it("keys an unthreaded send on the bare channel, not on openThreadId", () => {
+    expect(chatView).toMatch(
+      /const stateKey = chatId\s*\n\s*\? parentId === undefined\s*\n\s*\? turnStateKey\(chatId\)\s*\n\s*: turnStateKey\(chatId, threadRootOf\(openThreadId \?\? undefined\)\)\s*\n\s*: undefined;/,
+    );
+  });
+
+  it("no longer derives every send's key from openThreadId unconditionally", () => {
+    // The pre-fix shape: one branch, always consulting `openThreadId`, with no
+    // read of `parentId` at all.
+    expect(chatView).not.toMatch(
+      /const stateKey = chatId\s*\n\s*\? turnStateKey\(chatId, threadRootOf\(openThreadId \?\? undefined\)\)\s*\n\s*: undefined;/,
+    );
+  });
+
+  it("still keys a threaded send off openThreadId, not off its own parentId", () => {
+    // The case the original shape was right about: a review reply's
+    // `parentId` is an anchor *reply*, not the thread root, so the threaded
+    // branch must keep consulting `openThreadId` — the same value the panel's
+    // own `threadTurnKey` read uses — rather than switching to
+    // `threadRootOf(parentId)`.
+    expect(chatView).toMatch(/turnStateKey\(chatId, threadRootOf\(openThreadId \?\? undefined\)\)/);
+    expect(chatView).not.toMatch(/turnStateKey\(chatId, threadRootOf\(parentId/);
+  });
+
+  it("retry replays the failed payload's own parentId, so an unthreaded retry keeps parentId undefined", () => {
+    // `retrySend` must still forward `payload.parentId` verbatim into `send` —
+    // this fix depends on that being `undefined` for a top-level failure, not
+    // on `retrySend` inferring scope from the UI.
+    expect(chatView).toMatch(
+      /void send\(payload\.text, payload\.intent, payload\.parentId, payload\.attachments, payload\.mentions\);/,
+    );
+  });
+});

--- a/frontend/test/unit/chat-system-frame-no-completion-cleanup.test.ts
+++ b/frontend/test/unit/chat-system-frame-no-completion-cleanup.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A system-attributed live frame must never trigger `renderAgentReply`'s
+ * "the reply is the end of that turn" live-step cleanup (Codex review, PR
+ * #2052).
+ *
+ * B-101's mention-ambiguity note is emitted mid-turn, before the cycle that
+ * answers has even run — it is never itself a completion signal. But
+ * `onSendFailed` can release a held system frame (via `PendingSyncPosts`)
+ * synchronously, before its own async `listRuns` lookup below it has had a
+ * chance to install the still-running turn into `openTurnsRef`. At that
+ * instant `openTurns` legitimately knows nothing about the turn yet,
+ * `hasOtherOpenTurns` reads `false`, and treating the advisory as "the turn
+ * is over" would erase the live tool trace of a turn that — per the very
+ * lookup racing it — is still running on the host.
+ *
+ * `AppShell` is too large to mount in a unit test (SSE, the authenticated
+ * client, routing — see `chat-receipt-scope-reset.test.ts`'s own doc for the
+ * precedent this file follows).
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appShell = readFileSync(resolve(here, "../../src/components/app-shell.tsx"), "utf8");
+
+function renderAgentReplyBody(): string {
+  const start = appShell.indexOf("const renderAgentReply = useCallback(");
+  expect(start, "renderAgentReply's declaration").toBeGreaterThan(-1);
+  const end = appShell.indexOf("// `useEvents` holds its callbacks in refs", start);
+  expect(end, "renderAgentReply's trailing comment before its dependency array").toBeGreaterThan(
+    start,
+  );
+  return appShell.slice(start, end);
+}
+
+describe("renderAgentReply never treats a system frame as turn completion", () => {
+  it("computes `from` via replyVoice before the cleanup guard reads it", () => {
+    const body = renderAgentReplyBody();
+    expect(body).toMatch(/const from = replyVoice\(event\.agentId\);/);
+  });
+
+  it("guards the live-step cleanup on `from !== \"system\"`", () => {
+    const body = renderAgentReplyBody();
+    expect(body).toMatch(
+      /if \(from !== "system" && !hasOtherOpenTurns\(openTurnsRef\.current, event\.chatId\)\) \{/,
+    );
+    // The bug this pins: the guard existing anywhere in the file would not
+    // prove it protects the right call — confirm the specific cleanup call
+    // (the `setLiveStepsByThread` clear) is the one immediately gated by it.
+    const guardAt = body.indexOf(
+      'if (from !== "system" && !hasOtherOpenTurns(openTurnsRef.current, event.chatId)) {',
+    );
+    const cleanupAt = body.indexOf("setLiveStepsByThread((prev) =>", guardAt);
+    expect(cleanupAt, "the live-steps clear inside the guarded block").toBeGreaterThan(guardAt);
+  });
+});

--- a/frontend/test/unit/chat-system-frame-reconcile-wiring.test.ts
+++ b/frontend/test/unit/chat-system-frame-reconcile-wiring.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Cross-module wiring for the settled-response reconciliation
+ * (`PendingSyncPosts.ended`'s own suite proves the reconciliation logic
+ * itself; Codex review, PR #2052).
+ *
+ * The bug this exists to catch cannot be seen from either module alone: it
+ * is `ChatView` computing `responseTexts` but never handing them to
+ * `onSendEnd`, or `app-shell` receiving them but never forwarding them to
+ * `ended()`, or `ended()`'s released frames never reaching `renderAgentReply`.
+ * Any one of those silently regresses back to the double-render bug (a
+ * `system_notice` fallback shown as both a live system pill and a settled
+ * `"company"` bubble) or the original swallowed-note bug (B-101's
+ * mention-ambiguity note lost to a blanket discard), with nothing but a
+ * live screenshot mid-send to catch it.
+ *
+ * `AppShell` is too large to mount in a unit test (SSE, the authenticated
+ * client, routing — see `chat-receipt-scope-reset.test.ts`'s own doc for the
+ * precedent this file follows: read the source, assert the wiring is real
+ * rather than merely present somewhere in the file).
+ *
+ * `onSendEnd`'s call site also pins an ordering fix (Codex review round 2,
+ * PR #2052): it fires from the try block, before `append` renders the
+ * settled response's own replies — not from `finally`, which used to run it
+ * strictly after. B-101's mention-ambiguity note is always journaled on the
+ * host *before* the reply it is about; releasing the held note after
+ * `append` rendered the reply first put them on screen in the reverse of
+ * `chat/history`'s own order, so the note visibly jumped backward past the
+ * answer on the very next reload.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const chatView = readFileSync(resolve(here, "../../src/views/ChatView.tsx"), "utf8");
+const appShell = readFileSync(resolve(here, "../../src/components/app-shell.tsx"), "utf8");
+
+describe("ChatView computes and forwards the settled response's own texts", () => {
+  it("captures every response line's text before onSendEnd can see it", () => {
+    expect(chatView).toMatch(/responseTexts = reply\.responses\.map\(\(r\) => r\.text\);/);
+  });
+
+  it("fires onSendEnd before append renders the response's own replies", () => {
+    const marker = "if (stateKey) onSendEnd?.(stateKey, gen, responseTexts);";
+    const onSendEndAt = chatView.indexOf(marker);
+    expect(onSendEndAt, "the responseTexts-carrying onSendEnd call").toBeGreaterThan(-1);
+    const appendAt = chatView.indexOf("append(target, ...replies);", onSendEndAt);
+    expect(appendAt, "append(target, ...replies) after that call").toBeGreaterThan(onSendEndAt);
+  });
+
+  it("no longer fires onSendEnd a second time for the resolved outcome, from finally", () => {
+    // The bug this pins: firing it twice would release (and render) the same
+    // held frame twice, on top of getting the order wrong either way.
+    const finallyAt = chatView.indexOf("} finally {");
+    expect(finallyAt, "the send() finally block").toBeGreaterThan(-1);
+    const finallyBody = chatView.slice(finallyAt, chatView.indexOf("\n  }\n", finallyAt));
+    expect(finallyBody).not.toMatch(/onSendEnd\?\.\(stateKey, gen, responseTexts\)/);
+  });
+});
+
+describe("app-shell forwards responseTexts to ended() and renders what it releases", () => {
+  function onSendEndBody(): string {
+    const start = appShell.indexOf("const onSendEnd = useCallback(");
+    expect(start, "onSendEnd's declaration").toBeGreaterThan(-1);
+    const end = appShell.indexOf("[clearReceipt, renderAgentReply],", start);
+    expect(end, "onSendEnd's dependency array").toBeGreaterThan(start);
+    return appShell.slice(start, end);
+  }
+
+  it("threads responseTexts into ended(), rather than calling it bare", () => {
+    const body = onSendEndBody();
+    expect(body).toMatch(/pendingPostThreadsRef\.current\.ended\(threadId, responseTexts\)/);
+    // The old bare call this replaced discarded every held frame
+    // unconditionally — its absence here is the fix, not merely the new
+    // call's presence.
+    expect(body).not.toMatch(/pendingPostThreadsRef\.current\.ended\(threadId\);/);
+  });
+
+  it("renders every frame ended() releases, rather than dropping them on the floor", () => {
+    const body = onSendEndBody();
+    expect(body).toMatch(/const released = pendingPostThreadsRef\.current\.ended\(/);
+    expect(body).toMatch(/released\.forEach\(\(frame\) => renderAgentReply\(frame\)\);/);
+  });
+});

--- a/frontend/test/unit/chat-thread-failed-send.test.ts
+++ b/frontend/test/unit/chat-thread-failed-send.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ChatMessage } from "@/lib/chat";
+import type { TeamMember } from "@/lib/team";
+import { ThreadPanel } from "@/views/chat/ThreadPanel";
+import type { Channel } from "@/views/chat/model";
+
+/**
+ * B-099 follow-up (Codex review, PR #2052): a reply that failed to send from
+ * the *thread* composer must not read as delivered.
+ *
+ * `MessageRow` grew `sendFailed` styling and a Retry control for the main
+ * timeline, but `ThreadPanel` draws replies with its own `Line` renderer,
+ * which never read `sendFailed` or received `onRetrySend` at all — so the
+ * previous sibling `system` line's removal (this same PR) left a threaded
+ * failure completely invisible: no dimming, no "Not sent" notice, no way to
+ * send it again.
+ */
+
+const CHANNEL: Channel = {
+  id: "engineering",
+  name: "engineering",
+  voice: "Engineering",
+  kind: "channel",
+  purpose: "",
+};
+
+const MEMBERS: TeamMember[] = [];
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function render(over: Partial<Parameters<typeof ThreadPanel>[0]> = {}) {
+  await act(async () => {
+    root.render(
+      createElement(ThreadPanel, {
+        channel: CHANNEL,
+        members: MEMBERS,
+        parent: { id: "p", from: "you", text: "root", at: 0 },
+        replies: [],
+        sending: false,
+        onSend: vi.fn(),
+        onClose: vi.fn(),
+        ...over,
+      }),
+    );
+  });
+}
+
+/** The Retry control, however it is currently laid out. */
+function retryButton(): HTMLButtonElement | null {
+  return (
+    Array.from(container.querySelectorAll("button")).find(
+      (b) => (b.textContent ?? "").trim() === "Retry",
+    ) ?? null
+  );
+}
+
+describe("a failed threaded reply", () => {
+  const failedReply: ChatMessage = {
+    id: "r",
+    parentId: "p",
+    from: "you",
+    text: "will this land",
+    at: 1,
+    sendFailed: "cannot reach the company host at this origin",
+  };
+
+  it("says it was not sent, and offers Retry", async () => {
+    const onRetrySend = vi.fn();
+    await render({ replies: [failedReply], onRetrySend });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Not sent");
+    expect(text).toContain("cannot reach the company host at this origin");
+
+    const retry = retryButton();
+    expect(retry, "a failed threaded reply must offer a way to send it again").not.toBeNull();
+    await act(async () => {
+      retry!.click();
+    });
+    expect(onRetrySend).toHaveBeenCalledWith("r");
+  });
+
+  /** The negative half, pinning the bug: a delivered reply carries none of this. */
+  it("is distinguishable from a delivered reply", async () => {
+    await render({ replies: [{ ...failedReply, sendFailed: undefined }] });
+    expect(container.textContent ?? "").not.toContain("Not sent");
+    expect(retryButton()).toBeNull();
+  });
+
+  it("still reports the failure where no resend is wired", async () => {
+    await render({ replies: [failedReply], onRetrySend: undefined });
+    expect(container.textContent ?? "").toContain("Not sent");
+    expect(retryButton()).toBeNull();
+  });
+
+  /** CodeRabbit review: an empty ApiError message must still count as failed. */
+  it("renders the failed state for an empty failure reason", async () => {
+    await render({ replies: [{ ...failedReply, sendFailed: "" }] });
+    const text = container.textContent ?? "";
+    expect(text).toContain("Not sent");
+    expect(text).toContain("something went wrong");
+  });
+});

--- a/frontend/test/unit/live-reply-duplicate-by-identity.test.ts
+++ b/frontend/test/unit/live-reply-duplicate-by-identity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { isDuplicateLiveReply } from "@/lib/live-reply";
+
+/**
+ * A live `agent_reply` frame is a duplicate only when it is genuinely the
+ * same event as one already on screen — never merely because the text
+ * matches (Codex review, PR #2052).
+ *
+ * The recent-tail content check `renderAgentReply` used existed for one
+ * narrow reason: the operator's own turn renders locally, immediately, under
+ * an ephemeral `m<n>` id, and the backend's own SSE echo of that same reply
+ * can arrive before the awaited POST resolves and reconciles that row to its
+ * durable id — in that window only content can recognise the echo. Content
+ * matching with no further check is too broad: an operator who repeats the
+ * same ambiguous `@name` produces two B-101 notices with identical wording,
+ * and the second one was silently dropped outright rather than merely
+ * deduped — a stronger failure than a duplicate render, since the second
+ * refusal never appeared until a reload.
+ */
+describe("isDuplicateLiveReply", () => {
+  it("is a duplicate when this event's own durable id is already on screen", () => {
+    const tail = [{ id: "h7", from: "system" as const, text: "pinged nobody" }];
+    expect(isDuplicateLiveReply(tail, { seq: 7, text: "pinged nobody" }, "system")).toBe(true);
+    // Even with different text — the id match is decisive on its own.
+    expect(isDuplicateLiveReply(tail, { seq: 7, text: "different wording" }, "system")).toBe(
+      true,
+    );
+  });
+
+  it("is a duplicate of an unreconciled optimistic echo matched by content", () => {
+    // `m3` is the ephemeral id the operator's own optimistic bubble carries
+    // before `reconcileIds` runs — never a host id.
+    const tail = [{ id: "m3", from: "company" as const, text: "here is your answer" }];
+    expect(
+      isDuplicateLiveReply(tail, { seq: 12, text: "here is your answer" }, "company"),
+    ).toBe(true);
+  });
+
+  it("is NOT a duplicate of a different durable event with identical text", () => {
+    // The bug this pins: a second, genuinely distinct B-101 notice (its own
+    // seq, its own durable id) must render even though an operator repeating
+    // the same `@name` gives it the exact same wording as the first.
+    const tail = [{ id: "h4", from: "system" as const, text: "you meant one of two teammates" }];
+    expect(
+      isDuplicateLiveReply(
+        tail,
+        { seq: 9, text: "you meant one of two teammates" },
+        "system",
+      ),
+    ).toBe(false);
+  });
+
+  it("is not a duplicate when neither id nor content matches", () => {
+    const tail = [{ id: "h4", from: "company" as const, text: "unrelated" }];
+    expect(isDuplicateLiveReply(tail, { seq: 9, text: "something else" }, "system")).toBe(
+      false,
+    );
+  });
+
+  it("ignores a content match against a different `from`", () => {
+    // Same text, same (durable) tail row, but a different voice — not the
+    // same event by any measure this function uses.
+    const tail = [{ id: "m1", from: "you" as const, text: "hello" }];
+    expect(isDuplicateLiveReply(tail, { seq: 2, text: "hello" }, "company")).toBe(false);
+  });
+});

--- a/frontend/test/unit/live-reply-system-attribution.test.ts
+++ b/frontend/test/unit/live-reply-system-attribution.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { liveReplyAttribution } from "@/lib/live-reply";
+
+/**
+ * A live `agent_reply` frame attributed to the runtime itself
+ * (`SYSTEM_AUTHOR` = `"system"` on the Rust side, B-101's mention-ambiguity
+ * notice) must render as the centred system pill, not a named teammate's
+ * bubble.
+ *
+ * Before this rule was named, `renderAgentReply` (app-shell.tsx) always built
+ * the live frame with `from: "company"` — so a detached-delivery ambiguity
+ * note rendered with an avatar and reply/reaction controls, exactly the
+ * "small lie about who decided" `post_mention_ambiguity_note`'s own doc
+ * comment says attributing to `SYSTEM_AUTHOR` exists to avoid — until the
+ * next history reload silently swapped it to the pill `fromHistory` gives
+ * every `entry.author === "system"` row (tinysweeper / Codex review, PR
+ * #2052). This pins the rule so a regression to a hard-coded `"company"`
+ * fails a test instead of only a live screenshot mid-send.
+ */
+describe("liveReplyAttribution", () => {
+  it("attributes the runtime's own agentId to the system pill", () => {
+    expect(liveReplyAttribution("system")).toBe("system");
+  });
+
+  it("attributes every named agent to the company voice", () => {
+    expect(liveReplyAttribution("engineer")).toBe("company");
+    expect(liveReplyAttribution("")).toBe("company");
+  });
+});

--- a/frontend/test/unit/live-reply-system-frame-not-held.test.ts
+++ b/frontend/test/unit/live-reply-system-frame-not-held.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { PendingSyncPosts } from "@/lib/live-reply";
+
+/**
+ * A held system-attributed live `agent_reply` frame (`SYSTEM_AUTHOR`, B-101's
+ * mention-ambiguity notice among others) must survive `ended()` exactly when
+ * the settled response's own body never carried it — and must NOT survive
+ * when the response did (CodeRabbit review, PR #2052).
+ *
+ * `ended` used to discard every held frame unconditionally on the assumption
+ * that the awaited response already rendered it — true for the operator's
+ * own reply, which is always in the response, but false for a system frame:
+ * some (`system_notice`'s approval-overflow / `"Acknowledged."` fallback) ARE
+ * folded into the same response body a normal reply is; B-101's
+ * mention-ambiguity note deliberately never is
+ * (`post_mention_ambiguity_note`'s own doc: "Journaled, not returned in the
+ * POST response"). An earlier fix here exempted every system frame from
+ * suppression at *capture* time instead, which fixed the ambiguity note but
+ * then double-rendered a `system_notice` fallback the response DOES carry —
+ * once from the unsuppressed live frame, once from `ChatView`'s own append
+ * of that same response text. The fix that does not trade one bug for the
+ * other belongs at *release*, where the response's own text is available:
+ * `ended(threadId, responseTexts)` discards a held system frame only when
+ * its text is present in `responseTexts`, and releases it — for the caller
+ * to render — otherwise.
+ */
+describe("PendingSyncPosts.ended reconciles held system frames against the response", () => {
+  it("still holds a system-attributed frame while the thread's POST is in flight", () => {
+    const pending = new PendingSyncPosts();
+    pending.started("main");
+
+    // `true` means held, exactly like any other frame — the fix is not at
+    // capture time (see the class's own `capture` doc for why that was tried
+    // and reverted).
+    expect(pending.capture({ chatId: "main", agentId: "system", text: "note" })).toBe(true);
+  });
+
+  it("releases a held system frame the settled response never carried", () => {
+    const pending = new PendingSyncPosts();
+    pending.started("main");
+    const note = { chatId: "main", agentId: "system", text: "you meant one of two teammates" };
+    pending.capture(note);
+
+    // The response body carried only the operator's own reply text — never
+    // this note, which is B-101's whole point.
+    expect(pending.ended("main", ["here is your answer"])).toEqual([note]);
+  });
+
+  it("discards a held system frame the settled response DID carry", () => {
+    const pending = new PendingSyncPosts();
+    pending.started("main");
+    const fallback = { chatId: "main", agentId: "system", text: "Acknowledged." };
+    pending.capture(fallback);
+
+    // `system_notice`'s fallback IS folded into `channel_responses` the same
+    // way any reply is — releasing it here would double it against
+    // `ChatView`'s own append of the identical response text.
+    expect(pending.ended("main", ["Acknowledged."])).toEqual([]);
+  });
+
+  it("still discards an ordinary company frame unconditionally, regardless of the response", () => {
+    const pending = new PendingSyncPosts();
+    pending.started("main");
+    const reply = { chatId: "main", agentId: "engineer", text: "here is your answer" };
+    pending.capture(reply);
+
+    // The operator's own reply is always in the response — no responseTexts
+    // needed to know that, and none given here.
+    expect(pending.ended("main")).toEqual([]);
+  });
+
+  it("defaults to an empty response, releasing every held system frame", () => {
+    // A caller with no response text to reconcile against (the legacy
+    // Conversation surface's `onSendEnd?.(threadId, gen)`, which passes only
+    // two arguments) must not silently swallow the notice either — the safe
+    // default is "the response carried nothing", same as before any system
+    // frame existed to reconcile.
+    const pending = new PendingSyncPosts();
+    pending.started("main");
+    const note = { chatId: "main", agentId: "system", text: "note" };
+    pending.capture(note);
+
+    expect(pending.ended("main")).toEqual([note]);
+  });
+
+  it("still releases a held system frame on detached() and failed(), unfiltered", () => {
+    // Neither outcome has a response body to reconcile against — `detached`
+    // and `failed` are untouched by this fix and keep releasing everything.
+    const detachedCase = new PendingSyncPosts();
+    detachedCase.started("main");
+    const note = { chatId: "main", agentId: "system", text: "note" };
+    detachedCase.capture(note);
+    expect(detachedCase.detached("main")).toEqual([note]);
+
+    const failedCase = new PendingSyncPosts();
+    failedCase.started("main");
+    failedCase.capture(note);
+    expect(failedCase.failed("main")).toEqual([note]);
+  });
+});

--- a/frontend/test/unit/room-rail-pinned.test.ts
+++ b/frontend/test/unit/room-rail-pinned.test.ts
@@ -43,9 +43,16 @@ describe("ChatView, mounted off its own route", () => {
   const chatView = read("views/ChatView.tsx");
 
   it("refuses to restore the remembered channel while another section is open", () => {
+    // Anchored on the effect's own body rather than on `const restoredFor =
+    // useRef`: since B-096 the ref is declared with the other long-lived refs,
+    // well above the three early returns, while the effect that reads it moved
+    // below `channel` — so slicing from the declaration now runs through other
+    // hooks and finds their dependency arrays first.
+    const body = chatView.indexOf("restoredFor.current = undefined;");
+    expect(body).toBeGreaterThan(-1);
+    const effect = chatView.slice(chatView.lastIndexOf("useEffect(() => {", body));
     // The guard, and that it is the FIRST thing the effect does — after the
     // `if (sub)` line it is already too late for a bare `#/workflows`.
-    const effect = chatView.slice(chatView.indexOf("const restoredFor = useRef"));
     const guard = effect.indexOf("if (!routeOpen) return;");
     const subCheck = effect.indexOf("if (sub) {");
     expect(guard).toBeGreaterThan(-1);
@@ -54,8 +61,14 @@ describe("ChatView, mounted off its own route", () => {
     // And it is a dependency, so arriving on Room re-runs the restore rather
     // than skipping it for the life of the mount.
     expect(effect.slice(0, effect.indexOf("}, [") + 200)).toContain(
-      "[company, routeOpen, scope, sub, onNavigate]",
+      "[routeOpen, scope, sub, channel, onNavigate]",
     );
+    // B-096 made this guard matter MORE, not less. The effect it replaced only
+    // navigated when something was remembered (`if (remembered)`), so an
+    // operator who had never opened a channel was accidentally spared; this one
+    // always resolves — memory, else `channel.id` — and without the guard would
+    // bounce every such operator out of Flows on the first paint.
+    expect(effect).toContain("onNavigate(readLastChannel(scope) ?? channel.id);");
   });
 
   it("renders the transcript only on its own route", () => {


### PR DESCRIPTION
Split 2 of 2 from #2052 (`fix/chat-delivery-cluster`), rebased onto current `upstream/main`. This is the **console side**; the host half is #2161. #2052 was a 21-commit, 2487-line, seven-bug cluster whose review churned; splitting it is the point.

## What a person hit

1. **A failed send looked identical to a successful one.** Same avatar, same timestamp, nothing red — just a grey sibling note that scrolled away, after the composer had already cleared. The only copy of what you wrote was pixels.
2. **You wrote in `#general` and it posted into a DM.** The console never *decided* which conversation was open; it re-derived it from data arriving asynchronously, and your draft went with it when the answer changed.
3. **Two live replies with identical text — the second never appeared.**
4. **The typing indicator appeared in an unrelated thread** while the channel actually working showed nothing.

## What changed

### 1. `sendFailed` is a property of the message, not a line beside it

The failure used to be a separate `system` bubble appended underneath. A sibling line scrolls away from the row it describes, and a long enough message pushes it off screen entirely — leaving something that reads as sent and was not.

`ChatMessage.sendFailed` carries the reason, so **no renderer can draw the bubble without seeing it**. The text is muted, and a `role="status"` notice with a **Retry** button rides the row. `!== undefined`, not truthy: `httpError` keeps an empty `error: ""` envelope as-is, and a truthy check would silently hide the styling, the notice and the Retry for exactly that response.

Retry replays the **wire payload**, kept in a ref keyed by the optimistic id — not rebuilt from the rendered row. Two of the five fields cannot be recovered from the bubble: the wire `mentions` carry targets the rendered chips do not, and an attachment is a workspace node reference rather than the projection the row shows. A Retry rebuilt from the message would quietly send a *different* message — chip-less, or without its file.

It is **manual**. A throw is ambiguous — the host may have journaled the message before the request died — so an automatic resend risks posting the same instruction twice. Whether that is worth it is the operator's call, which is what a button is. `retrySend` no-ops while a POST is in flight, checked *before* the payload and the failed row are consumed, so a mid-send click cannot drop the only copy of the retry.

Both renderers show it. `ThreadPanel`'s `Line` is a second renderer that never received the field, so a failed *threaded* reply read as delivered with no way to send it again; `FailedSendNotice` is exported and shared rather than copied.

`fromHistory` never sets it: a message the host handed back is by definition one it kept, so a reload clears it — correct, because the reload re-reads what was actually journaled.

### 2. Which conversation is open is routed state (B-096)

Two facts made a draft escape into somebody else's DM, and only one is wrong.

The right one: the composer is deliberately **one instance** shared by every channel, and its draft deliberately survives a channel change (`MessageComposer`'s `suppressed` doc, PR #1984). Unmounting it is what discards a half-written message.

The wrong one: a bare `#/chat` — where the magic-link landing route puts you, because `useHashView` canonicalises the *view* and knows nothing about chat's channels — left the open channel as the value of an expression over `members`, `desks`, `transcripts` and `operator`. Each lands asynchronously and can re-order what `firstChannel` answers, so the conversation could change with **no navigation behind it**, and `send` addressed whatever it had become.

The channel id now goes into the hash the moment there is one to name, and `decodedSub` pins it from then on. A deep link short-circuits and always outranks it. This also **subsumes issue #412's restore**, which was a second effect writing the same hash for a bare entry: the two raced and the loser silently won — memory navigated to the remembered channel and the normaliser immediately replaced it with `firstChannel`. One effect, one decision, memory first.

**This is re-authored on top of #2134's `routeOpen` model, not merged into it.** #2052 deleted that effect and rebuilt it with no guard, which would have restored the bug #2134 fixed on 2026-09-07 (clicking **Flows** landing on `#/chat/main`). The guard is the first thing the effect does, and it matters *more* after this change, not less: the old effect only navigated when something was remembered (`if (remembered)`), so an operator with an empty `oc.chat.last-channel` was accidentally spared; this one always resolves — memory, else `channel.id` — and without the guard would bounce **every** such operator out of Flows on the first paint.

Guarded three ways: `room-rail-pinned.test.ts` (#2134's own source guard) is re-anchored on the effect's *body*, since the ref now sits with the other long-lived refs ~170 lines above it, and additionally asserts the unconditional resolve is present; and `chat-bare-hash-normalises.spec.ts` asserts in a real browser that `#/workflows` keeps its own address, **with and without** a remembered channel.

The ref is declared above the three early returns (`desksError`, `!desks`, `!channel`) rather than beside where it is read. A hook below them runs on some renders and not others — React error 310, a blank console with no composer at all on exactly the first paint.

### 3. Live replies dedupe by identity, not text alone

`isDuplicateLiveReply` checks the frame's own durable id (`hostMessageId(String(event.seq))`) first — a row already bearing it is unambiguously this same event, whatever its content. Content matching is kept, but **only against a row not yet reconciled to a durable id** (`!isHostMessageId(m.id)`): the narrow window where the SSE echo of your own turn arrives mid-await, before the POST resolves and names the row. Two genuinely different events that merely share wording — an operator repeating the same ambiguous `@name` produces two identical host notices — both carry durable ids from the start, so content matching never gets a chance to conflate them. The old check dropped the second one outright.

### 4. An unthreaded send keys the channel, not whatever thread is open

`stateKey` derived from `openThreadId` regardless of `parentId`. The channel composer always sends `parentId: undefined`, and a top-level row's Retry lives on that same transcript — so both could fire while an *unrelated* thread was open in the panel, filing the receipt and open-turn recovery under a thread they never touched. The panel showed work it did not start; the channel that ran it showed nothing. Unthreaded now keys `turnStateKey(chatId)` outright. Threaded still keys `openThreadId` rather than `parentId`, because a review reply anchors to a *reply* and the panel's own lookup keys on the open thread.

### 5. A system-attributed live frame

Rendered with `replyVoice`, so it is the centred pill `fromHistory` gives it on reload rather than a named teammate's bubble with an avatar and reply controls — otherwise whoever watched the turn live keeps a reading hydration never corrects. It is also never treated as a turn's completion: it is emitted mid-turn, before the cycle that answers has run, so clearing the live tool trace on it erases a turn that is still running. And `PendingSyncPosts.ended` now takes the settled response's own reply texts, so a held system frame is discarded when the response carries it and released when the response never will — some system lines are folded into `channel_responses` (`system_notice`'s approval overflow, `"Acknowledged."`) and some are deliberately not.

## Verified locally

**Commands run:**

- `npm run typecheck` — clean
- `npm run typecheck:unit` — clean
- `npm run typecheck:e2e` — clean
- `npx vitest run` — **521 files, 4852 tests, 0 failures**
- `scripts/ci/assert-design-tokens.sh` — clean

Browser verification (light and dark, screenshots in the thread below).

Supersedes the console half of #2052.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear “Not sent” notices for failed messages, including the failure reason.
  - Added a Retry option for failed messages in chats and threads, preserving mentions and attachments.
  - Bare Chat links now resolve to a specific conversation while respecting remembered channels and direct links.

- **Bug Fixes**
  - Improved live-reply handling to prevent duplicate messages.
  - System notices now appear correctly without interrupting active tool traces.
  - Settled responses and live system notices are reconciled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->