### PR TITLE
test(auth): pin the standing-grant routes per principal

### DIFF
--- a/tests/auth_matrix.rs
+++ b/tests/auth_matrix.rs
@@ -11,6 +11,14 @@
 //! they are known authority defects. Runtime `TRACE` probes pin every method
 //! set, and the anonymous column pins route existence.
 //!
+//! The standing-grant routes (`GET`/`DELETE …/grants[/{gid}]`, registered in
+//! `operator.rs`) are a third source, declared the same way as
+//! `EXTERNAL_AUTHORITY_ROUTES` — a manually maintained list, not a scan. Unlike
+//! the ops inventory, nothing asserts this list is the complete set of
+//! `operator.rs` routes; it is an open allowlist that grows by hand as more of
+//! that file earns per-principal coverage. Do not read its presence as
+//! evidence `operator.rs` has no other uncovered authority surface.
+//!
 //! Red-proof log (all temporary edits were restored from `/tmp` copies before
 //! continuing, and `git diff` was byte-identical to the pre-proof tree):
 //! - Removed `clear_policy`'s `require_admin`: the member `DELETE /policy`
@@ -225,6 +233,7 @@ enum Address {
 enum Source {
     Ops,
     ExternalAuthority,
+    Operator,
 }
 
 impl Source {
@@ -232,6 +241,7 @@ impl Source {
         match self {
             Self::Ops => "ops",
             Self::ExternalAuthority => "external",
+            Self::Operator => "operator",
         }
     }
 }
@@ -953,12 +963,47 @@ const fn external_admin(
     }
 }
 
+// Standing-grant routes (issue #2148 part 2): registered via the same
+// `scoped(...)` helper as the ops inventory, so `ScopedCompany` governs both —
+// any member may list or revoke, not just an admin. Declared by hand rather
+// than folded into the `src/server/ops` scan because they are registered from
+// `operator.rs`, which the scan does not walk.
+const OPERATOR_AUTHORITY_ROUTES: &[Route] = &[
+    Route {
+        method: Verb::Get,
+        path: "/grants",
+        address: Address::Dual,
+        source: Source::Operator,
+        access: Access::Scoped,
+        features: &["openhuman"],
+        blast: Blast::Authority,
+        probe: Probe::Empty,
+        note: "Lists every standing permission open on the company, including who granted it and what it admits.",
+        wait: Wait::None,
+        red_cells: RedCells::None,
+    },
+    Route {
+        method: Verb::Delete,
+        path: "/grants/{gid}",
+        address: Address::Dual,
+        source: Source::Operator,
+        access: Access::Scoped,
+        features: &["openhuman"],
+        blast: Blast::Authority,
+        probe: Probe::Empty,
+        note: "Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op.",
+        wait: Wait::None,
+        red_cells: RedCells::None,
+    },
+];
+
 fn all_routes() -> impl Iterator<Item = &'static Route> {
     OPS_SCOPED_ROUTES
         .iter()
         .chain(OPS_EXACT_ROUTES)
         .chain(EXTERNAL_AUTHORITY_ROUTES)
         .chain(OVERLAPPING_EXTERNAL_ROUTES)
+        .chain(OPERATOR_AUTHORITY_ROUTES)
 }
 
 fn routes() -> impl Iterator<Item = &'static Route> {
@@ -1263,11 +1308,12 @@ fn table_counts_and_intentional_widenings_are_explicit() {
     );
     assert_eq!(EXTERNAL_AUTHORITY_ROUTES.len(), 8);
     assert_eq!(OVERLAPPING_EXTERNAL_ROUTES.len(), 1);
+    assert_eq!(OPERATOR_AUTHORITY_ROUTES.len(), 2);
     assert_eq!(
         all_routes()
             .map(|route| route_patterns(route).len())
             .sum::<usize>(),
-        382,
+        386,
         "concrete route-method rows",
     );
     assert_eq!(
@@ -1275,10 +1321,10 @@ fn table_counts_and_intentional_widenings_are_explicit() {
             .flat_map(route_patterns)
             .collect::<BTreeSet<_>>()
             .len(),
-        297,
+        301,
         "concrete paths",
     );
-    assert_eq!(render_snapshot().lines().count(), 2_674);
+    assert_eq!(render_snapshot().lines().count(), 2_702);
     assert_eq!(
         all_routes()
             .map(|route| {

--- a/tests/snapshots/auth-matrix.txt
+++ b/tests/snapshots/auth-matrix.txt
@@ -47,6 +47,13 @@ DELETE /api/v1/companies/{id}/deep-trace/{run_id} must-change-password-admin ref
 DELETE /api/v1/companies/{id}/deep-trace/{run_id} platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
 DELETE /api/v1/companies/{id}/deep-trace/{run_id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
 DELETE /api/v1/companies/{id}/deep-trace/{run_id} tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/companies/{id}/grants/{gid} admin permitted source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/companies/{id}/grants/{gid} anonymous refused:401:unauthorized source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/companies/{id}/grants/{gid} member permitted source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/companies/{id}/grants/{gid} must-change-password-admin refused:403:password_change_required source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/companies/{id}/grants/{gid} platform permitted source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/companies/{id}/grants/{gid} tenant-non-owner refused:403:forbidden source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/companies/{id}/grants/{gid} tenant-owner permitted source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
 DELETE /api/v1/companies/{id}/hosting/key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
 DELETE /api/v1/companies/{id}/hosting/key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
 DELETE /api/v1/companies/{id}/hosting/key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
@@ -222,6 +229,13 @@ DELETE /api/v1/company/deep-trace/{run_id} must-change-password-admin refused:40
 DELETE /api/v1/company/deep-trace/{run_id} platform permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
 DELETE /api/v1/company/deep-trace/{run_id} tenant-non-owner refused:403:forbidden source=ops access=admin features=openhuman blast=destructive note="" wait=-
 DELETE /api/v1/company/deep-trace/{run_id} tenant-owner permitted source=ops access=admin features=openhuman blast=destructive note="" wait=-
+DELETE /api/v1/company/grants/{gid} admin permitted source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/company/grants/{gid} anonymous refused:401:unauthorized source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/company/grants/{gid} member permitted source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/company/grants/{gid} must-change-password-admin refused:403:password_change_required source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/company/grants/{gid} platform permitted source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/company/grants/{gid} tenant-non-owner refused:403:forbidden source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
+DELETE /api/v1/company/grants/{gid} tenant-owner permitted source=operator access=scoped features=openhuman blast=authority note="Revokes one standing permission; 404 when there is nothing to revoke rather than reporting success over a no-op." wait=-
 DELETE /api/v1/company/hosting/key admin permitted source=ops access=admin features=openhuman blast=credential note="" wait=-
 DELETE /api/v1/company/hosting/key anonymous refused:401:unauthorized source=ops access=admin features=openhuman blast=credential note="" wait=-
 DELETE /api/v1/company/hosting/key member refused:403:forbidden source=ops access=admin features=openhuman blast=credential note="" wait=-
@@ -495,6 +509,13 @@ GET /api/v1/companies/{id}/finances must-change-password-admin refused:403:passw
 GET /api/v1/companies/{id}/finances platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 GET /api/v1/companies/{id}/finances tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 GET /api/v1/companies/{id}/finances tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/companies/{id}/grants admin permitted source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/companies/{id}/grants anonymous refused:401:unauthorized source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/companies/{id}/grants member permitted source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/companies/{id}/grants must-change-password-admin refused:403:password_change_required source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/companies/{id}/grants platform permitted source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/companies/{id}/grants tenant-non-owner refused:403:forbidden source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/companies/{id}/grants tenant-owner permitted source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
 GET /api/v1/companies/{id}/harnesses admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 GET /api/v1/companies/{id}/harnesses anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 GET /api/v1/companies/{id}/harnesses member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
@@ -1020,6 +1041,13 @@ GET /api/v1/company/finances must-change-password-admin refused:403:password_cha
 GET /api/v1/company/finances platform permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 GET /api/v1/company/finances tenant-non-owner refused:403:forbidden source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 GET /api/v1/company/finances tenant-owner permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
+GET /api/v1/company/grants admin permitted source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/company/grants anonymous refused:401:unauthorized source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/company/grants member permitted source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/company/grants must-change-password-admin refused:403:password_change_required source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/company/grants platform permitted source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/company/grants tenant-non-owner refused:403:forbidden source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
+GET /api/v1/company/grants tenant-owner permitted source=operator access=scoped features=openhuman blast=authority note="Lists every standing permission open on the company, including who granted it and what it admits." wait=-
 GET /api/v1/company/harnesses admin permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 GET /api/v1/company/harnesses anonymous refused:401:unauthorized source=ops access=scoped features=openhuman blast=ordinary note="" wait=-
 GET /api/v1/company/harnesses member permitted source=ops access=scoped features=openhuman blast=ordinary note="" wait=-


### PR DESCRIPTION
## Summary

Part of #2148, part of #1817. Tests only — no production code changes.

`tests/auth_matrix.rs` pins every route × principal into `tests/snapshots/auth-matrix.txt`, and CI asserts it. Its source scan walks `src/server/ops` only. The standing-grant routes are registered in `src/server/operator.rs`:

```
.merge(scoped("/grants", get(list_grants)))
.merge(scoped("/grants/{gid}", delete(revoke_grant)))
```

so they appeared in that test solely as two path literals in the census set — enumerated, never exercised. The 42 existing rows matching `grants` are all `/tools/grants`, a different plane. The surface that lists and revokes week-long standing permissions had no per-principal pin at all.

This declares them as a third `Source::Operator`, alongside the existing ops scan and `EXTERNAL_AUTHORITY_ROUTES`, and blesses 28 rows.

**Approach, and its honest limit.** Moving the plane under `src/server/ops` would fold these routes into the existing closed-set property and is the better end state. It is not what this PR does, because #2054 is editing `operator.rs` right now and the move would collide with it for no coverage benefit. The cost is stated in the module docs rather than glossed: the operator source is a **manually maintained, open allowlist** — nothing asserts it is the complete set of `operator.rs` routes, unlike `source_path_set_equals_the_ops_matrix_path_set`, which is closed. Its presence must not be read as evidence that `operator.rs` has no other uncovered authority surface. The existing ops assertion is untouched and not weakened.

## API Or Behavior Changes

None. No route, guard or handler is modified. The blessed rows record what the routes already do.

Worth naming, since the rows now say it out loud: **any member — not only an admin — may list every standing permission on the company and revoke one.** Listing discloses who holds which permission over which toolkit. Revoking fails in the safe direction. This PR pins that behaviour rather than changing it; whether the disclosure is the intended reach is a separate question and belongs in its own issue.

## Tests

- `bash scripts/ci/assert-auth-matrix.sh` — clean
- `cargo test --features openhuman --test auth_matrix` — target selected and non-zero (a filter that selects nothing exits 0, so the count was checked, not just the exit code)
- Snapshot re-blessed with the bless env var and the diff read row by row before committing

The enforcing assertions are the existing ones — `committed_snapshot_pins_every_expected_cell` and `runtime_allow_headers_equal_the_declared_method_sets` — which now cover these two routes across every principal the harness drives: anonymous, member, admin, platform, tenant-owner, tenant-non-owner, and must-change-password-admin.

## Documentation

The module docs in `tests/auth_matrix.rs` explain what the operator source is, why it is declared by hand, and — explicitly — that it is an open allowlist rather than the closed set the ops scan gives. The red-proof log kept in those docs gained its entry for this change.