### PR TITLE
fix(console): state the always-ask list's real status instead of implying a gate

### DIFF
--- a/frontend/src/api/policy.ts
+++ b/frontend/src/api/policy.ts
@@ -84,6 +84,20 @@ export interface PolicyStatus {
    * because it cannot be a workflow node. Absent on a host predating the field.
    */
   knownTools?: string[];
+  /**
+   * Whether the live gate currently turns policy — the tier, `always_approve`,
+   * the spend cap — into approval requests, rather than allowing everything
+   * the hard denials (read-only, the emergency stop) do not already refuse.
+   *
+   * Read from the host rather than assumed: every build ships this `false`
+   * today (`src/runtime/builder.rs` disables it unconditionally), but that is
+   * a fact about the running gate, not a constant the console gets to invent —
+   * see `src/server/ops/policy.rs`'s module doc for why a copy here would
+   * drift from the gate it claims to describe. Absent on a host predating the
+   * field, which is read the same way an absent field always is here: as the
+   * state every deployed host actually has, not an optimistic guess.
+   */
+  policyHitlEnabled?: boolean;
 }
 
 /**

--- a/frontend/src/components/autonomy-pill.tsx
+++ b/frontend/src/components/autonomy-pill.tsx
@@ -57,7 +57,7 @@ import {
   AUTONOMY_CONFIRM_ACTION,
   AUTONOMY_CONFIRM_CANCEL,
   AUTONOMY_CONFIRM_TITLE,
-  AUTONOMY_PROMPTS_NOTE,
+  autonomyPromptsNote,
   tierWideningExplanation,
   widensAutonomy,
 } from "@/components/policy-settings";
@@ -542,7 +542,7 @@ export function AutonomyPill({
                 : null}
             </AlertDialogDescription>
             <p className="text-sm text-muted-foreground">
-              {AUTONOMY_PROMPTS_NOTE}
+              {autonomyPromptsNote(status.policyHitlEnabled ?? false)}
             </p>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -129,13 +129,19 @@ export const AUTONOMY_CONFIRM_ACTION = "Give more autonomy";
 /**
  * The standing note under a tier widening.
  *
- * True in this build and load-bearing: the gate runs with policy HITL disabled
- * (`src/runtime/builder.rs`), so what still stops an agent is an explicit
- * `request_approval` rather than the tier. An operator agreeing to a wider tier
- * is entitled to read that wherever they can agree to it.
+ * A function of the host's own `policyHitlEnabled`, not a fixed sentence: every
+ * deployed build reports it `false` today, so `false` is also the fallback for
+ * a host predating the field (`PolicyStatus.policyHitlEnabled`) — but the
+ * console states that as what the gate reports, not as a fact it is entitled to
+ * assume, so the sentence changes the day a gate does. An operator agreeing to
+ * a wider tier is entitled to read what still stops an agent under it,
+ * wherever they can agree to it.
  */
-export const AUTONOMY_PROMPTS_NOTE =
-  "Approval prompts remain explicit through request_approval.";
+export function autonomyPromptsNote(policyHitlEnabled: boolean): string {
+  return policyHitlEnabled
+    ? "The always-ask list and the spend cap still apply under the new tier."
+    : "Approval prompts remain explicit through request_approval.";
+}
 
 /**
  * What changes, in the host's own words on both sides of the move.
@@ -595,6 +601,11 @@ export function PolicySettings({ client, company, canManage }: Props) {
   // backend's own matcher (`SHELL` for the `shell` tool, `invoice` for a
   // `invoice.send` kind), so a fence the gate accepts is never called a mistake
   // outright.
+  // Read from the host's own report, not assumed: every deployed build reports
+  // `false` today, so a host predating the field falls back to the same value
+  // every real deployment already has — see `PolicyStatus.policyHitlEnabled`.
+  const policyHitlEnabled = status?.policyHitlEnabled ?? false;
+
   const knownTools = status?.knownTools ?? null;
   const gateableSet = knownTools ?? (wiredToolsLoaded ? wiredTools : null);
   const unmatchedWiredTools = gateableSet
@@ -971,10 +982,25 @@ export function PolicySettings({ client, company, canManage }: Props) {
                 member&rsquo;s. You can see which tier is in force.
               </AdminOnlyNotice>
             )}
-            <div className="rounded-md border border-status-blocked/30 bg-status-blocked-soft p-3 text-xs text-muted-foreground">
-              Policy-based approval prompts are disabled. Teammates ask through{" "}
-              <code>request_approval</code>; read-only mode and the emergency stop still
-              hard-deny applicable calls.
+            <div
+              data-testid="policy-hitl-status"
+              className="rounded-md border border-status-blocked/30 bg-status-blocked-soft p-3 text-xs text-muted-foreground"
+            >
+              {policyHitlEnabled ? (
+                <>
+                  Policy-based approval prompts are active. The selected tier, the
+                  always-ask list below and the spend cap can each raise an approval
+                  card.
+                </>
+              ) : (
+                <>
+                  Policy-based approval prompts are disabled. Teammates ask through{" "}
+                  <code>request_approval</code>; the paid-media tools stage their own
+                  approval and an authored workflow can add its own{" "}
+                  <code>requires_approval</code> gate. Read-only mode and the emergency
+                  stop still hard-deny applicable calls.
+                </>
+              )}
             </div>
             <div
               className="space-y-2"
@@ -1034,10 +1060,13 @@ export function PolicySettings({ client, company, canManage }: Props) {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="spend-cap">Spend approval threshold (inactive)</Label>
+              <Label htmlFor="spend-cap">
+                Spend approval threshold{!policyHitlEnabled && " (inactive)"}
+              </Label>
               <p className="text-xs text-muted-foreground">
-                Stored for a future policy-HITL mode. It does not create approval
-                prompts while policy HITL is disabled.
+                {policyHitlEnabled
+                  ? "Spends strictly under this amount are auto-approved; everything else parks for approval."
+                  : "Stored for a future policy-HITL mode. It does not create approval prompts while policy HITL is disabled."}
               </p>
               <div className="flex flex-wrap items-center gap-2">
                 <Input
@@ -1047,7 +1076,7 @@ export function PolicySettings({ client, company, canManage }: Props) {
                   step="0.01"
                   inputMode="decimal"
                   value={draftSpend}
-                  disabled
+                  disabled={saving || !canManage || !policyHitlEnabled}
                   placeholder="No cap"
                   onChange={(event) => setDraftSpend(event.target.value)}
                   className="max-w-40"
@@ -1057,7 +1086,7 @@ export function PolicySettings({ client, company, canManage }: Props) {
                   size="sm"
                   type="button"
                   variant={noSpendCap ? "secondary" : "outline"}
-                  disabled
+                  disabled={saving || !canManage || !policyHitlEnabled}
                   onClick={() => {
                     setNoSpendCap((current) => !current);
                     if (noSpendCap) setDraftSpend("");
@@ -1065,7 +1094,11 @@ export function PolicySettings({ client, company, canManage }: Props) {
                 >
                   {noSpendCap ? "No cap" : "Set no cap"}
                 </Button>
-                <Button size="sm" disabled onClick={() => void saveSpendCap()}>
+                <Button
+                  size="sm"
+                  disabled={saving || !canManage || !policyHitlEnabled}
+                  onClick={() => void saveSpendCap()}
+                >
                   Save cap
                 </Button>
               </div>
@@ -1098,7 +1131,9 @@ export function PolicySettings({ client, company, canManage }: Props) {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="always-approve">Always ask first (inactive)</Label>
+              <Label htmlFor="always-approve">
+                Always ask first{!policyHitlEnabled && " (inactive)"}
+              </Label>
               {/* Issue #1226: what an entry IS, said here rather than left to
                   the placeholder. `payment.send, filing.submit,
                   external.publish` used to be the only worked example this
@@ -1115,8 +1150,17 @@ export function PolicySettings({ client, company, canManage }: Props) {
                   what `always_approve::matches` implements and nothing in the
                   console said it. */}
               <p className="text-xs text-muted-foreground">
-                Stored for a future policy-HITL mode. These entries do not create
-                prompts now; teammates use <code>request_approval</code> explicitly.
+                {policyHitlEnabled ? (
+                  <>
+                    Every entry here wins over the selected tier, Full included, and
+                    raises an approval card before the matching tool runs.
+                  </>
+                ) : (
+                  <>
+                    Stored for a future policy-HITL mode. These entries do not create
+                    prompts now; teammates use <code>request_approval</code> explicitly.
+                  </>
+                )}
               </p>
               <Input
                 id="always-approve"
@@ -1125,7 +1169,7 @@ export function PolicySettings({ client, company, canManage }: Props) {
                 // head-turn apart. Capped where every other settings field is.
                 className={SETTINGS_FIELD_COLUMN}
                 value={draftAlways}
-                disabled
+                disabled={saving || !canManage || !policyHitlEnabled}
                 list={wiredTools.length > 0 ? "always-approve-tools" : undefined}
                 placeholder={alwaysAskPlaceholder(wiredTools)}
                 onChange={(event) => {
@@ -1151,7 +1195,7 @@ export function PolicySettings({ client, company, canManage }: Props) {
               {dirty && (
                 <Button
                   size="sm"
-                  disabled
+                  disabled={saving || !policyHitlEnabled}
                   onClick={() => void saveAlways()}
                 >
                   Save list
@@ -1290,10 +1334,12 @@ export function PolicySettings({ client, company, canManage }: Props) {
                   </AlertDialogDescription>
                   <p className="text-sm text-muted-foreground">
                     {pendingCapRaise !== null
-                      ? "This threshold remains inactive while policy HITL is disabled."
+                      ? policyHitlEnabled
+                        ? "Raising the cap lets qualifying spends pass without asking; the daily budget still stops spending after its limit."
+                        : "This threshold remains inactive while policy HITL is disabled."
                       : resetAwaitingConfirmation
-                        ? "Reset restores the stored policy fields; approval prompts remain explicit."
-                        : AUTONOMY_PROMPTS_NOTE}
+                        ? `Reset restores the stored policy fields. ${autonomyPromptsNote(policyHitlEnabled)}`
+                        : autonomyPromptsNote(policyHitlEnabled)}
                   </p>
                 </AlertDialogHeader>
                 <AlertDialogFooter>

--- a/frontend/test/e2e/policy-hitl-status.spec.ts
+++ b/frontend/test/e2e/policy-hitl-status.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The policy screen must state whether policy-generated approvals (the
+ * always-ask list, the spend cap, the tier) are actually creating approval
+ * cards, and it must be reading that from the running host rather than
+ * assuming it in the console's own TypeScript.
+ *
+ * The harness company (`companies/e2e_harness/company.toml`) runs with
+ * policy-generated HITL disabled, like every host this suite can drive today
+ * (`src/runtime/builder.rs` disables it unconditionally on the production
+ * path) — so this spec pins the "disabled" half against the real, running
+ * server: the honest banner, the two "(inactive)" fields, and the fact that
+ * neither is a Save an operator can press. It is the case
+ * `settings-authority.spec.ts` does not cover: that spec checks who is
+ * offered the tier controls, not whether the always-ask list and spend cap
+ * tell the truth about their own status.
+ *
+ * Drives a real browser against a live host, like the rest of this
+ * directory, and is not a merge gate (the Playwright config declares no
+ * `webServer` override here beyond the shared one).
+ */
+
+async function openGeneralSettings(page: import("@playwright/test").Page) {
+  await page.goto("/#/settings/general");
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await skip
+    .waitFor({ state: "visible", timeout: 10_000 })
+    .then(() => skip.click())
+    .catch(() => {
+      /* tour already dismissed in this context */
+    });
+}
+
+test("the Approvals card states plainly that policy-generated approvals are disabled", async ({
+  page,
+}) => {
+  await openGeneralSettings(page);
+  const banner = page.getByTestId("policy-hitl-status");
+  await expect(banner).toBeVisible({ timeout: 30_000 });
+  await expect(banner).toContainText("Policy-based approval prompts are disabled");
+  await expect(banner).toContainText("request_approval");
+  await expect(banner).toContainText("paid-media");
+  await expect(banner).toContainText("requires_approval");
+  await expect(banner).not.toContainText("active");
+});
+
+test("the spend cap and always-ask fields say they are inactive and cannot be saved", async ({
+  page,
+}) => {
+  await openGeneralSettings(page);
+  await expect(page.getByText("Spend approval threshold (inactive)")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator("#spend-cap")).toBeDisabled();
+  await expect(page.getByText("Always ask first (inactive)")).toBeVisible();
+  await expect(page.locator("#always-approve")).toBeDisabled();
+  // Typing into the disabled field is a no-op, so no "Save list" button ever
+  // appears — there is nothing here for a save to lie about.
+  await expect(page.getByRole("button", { name: "Save list" })).toHaveCount(0);
+});

--- a/frontend/test/unit/policy-hitl-status.test.ts
+++ b/frontend/test/unit/policy-hitl-status.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { PolicyStatus } from "@/api/policy";
+import { autonomyPromptsNote } from "@/components/policy-settings";
+
+/**
+ * The console must state whether policy-generated approvals (the always-ask
+ * list, the spend cap, the tier) are actually creating approval cards, and it
+ * must read that fact from the host's own `policyHitlEnabled` rather than
+ * assume it. Every deployed build reports it `false` today
+ * (`src/runtime/builder.rs` disables it unconditionally), which is why every
+ * other spec in this directory constructs a `PolicyStatus` with the field
+ * omitted and still sees the disabled copy — that is the correct fallback,
+ * not a hardcoded assumption. These specs pin the other half: what the card
+ * says when the host reports the gate is actually live, which the component
+ * could not previously say at all.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, toasts);
+  return { toast };
+});
+
+const { PolicySettings } = await import("@/components/policy-settings");
+
+const TIERS = [
+  { value: "supervised", label: "Supervised", description: "Conservative execution restrictions." },
+  { value: "full", label: "Full", description: "Broadest execution autonomy." },
+];
+
+function status(overrides: Partial<PolicyStatus> = {}): PolicyStatus {
+  return {
+    mode: "supervised",
+    alwaysApprove: ["shell"],
+    autoApproveUnderUsd: null,
+    approvalTtlHours: 24,
+    manifestMode: "supervised",
+    manifestAlwaysApprove: ["shell"],
+    manifestAutoApproveUnderUsd: null,
+    manifestApprovalTtlHours: null,
+    overridden: false,
+    takesEffect: "on the next turn",
+    tiers: TIERS,
+    ...overrides,
+  };
+}
+
+function makeClient(initial: PolicyStatus) {
+  return {
+    scopeFor: () => "/api/v1/acme",
+    get: async (path: string) =>
+      path.endsWith("/policy") ? initial : { slugs: [], unwired: [] },
+    put: vi.fn(async () => initial),
+    del: vi.fn(async () => initial),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(PolicySettings, { client, company: "acme", canManage: true }));
+    await Promise.resolve();
+  });
+}
+
+describe("stating whether policy HITL is actually live", () => {
+  it("reads the disabled state from the host rather than assuming it", async () => {
+    await mount(makeClient(status({ policyHitlEnabled: false })));
+    const banner = container.querySelector('[data-testid="policy-hitl-status"]');
+    expect(banner?.textContent).toContain("Policy-based approval prompts are disabled");
+    expect(banner?.textContent).toContain("paid-media");
+    expect(banner?.textContent).toContain("requires_approval");
+    expect(container.querySelector<HTMLInputElement>("#spend-cap")?.disabled).toBe(true);
+    expect(container.querySelector<HTMLInputElement>("#always-approve")?.disabled).toBe(true);
+    expect(container.textContent).toContain("Spend approval threshold (inactive)");
+    expect(container.textContent).toContain("Always ask first (inactive)");
+  });
+
+  it("falls back to the disabled state on a host that predates the field", async () => {
+    // No `policyHitlEnabled` key at all — the same shape every other test
+    // fixture in this directory sends.
+    await mount(makeClient(status()));
+    const banner = container.querySelector('[data-testid="policy-hitl-status"]');
+    expect(banner?.textContent).toContain("Policy-based approval prompts are disabled");
+    expect(container.querySelector<HTMLInputElement>("#always-approve")?.disabled).toBe(true);
+  });
+
+  it("renders the always-ask list and spend cap as live when the host reports the gate is on", async () => {
+    await mount(makeClient(status({ policyHitlEnabled: true })));
+    const banner = container.querySelector('[data-testid="policy-hitl-status"]');
+    expect(banner?.textContent).toContain("Policy-based approval prompts are active");
+    // The "inactive" labels must not survive onto a company whose gate really
+    // is turning always_approve into approval cards.
+    expect(container.textContent).not.toContain("(inactive)");
+    expect(container.querySelector<HTMLInputElement>("#always-approve")?.disabled).toBe(false);
+    expect(container.querySelector<HTMLInputElement>("#spend-cap")?.disabled).toBe(false);
+  });
+
+  it("lets an operator actually save the always-ask list once the host reports the gate is live", async () => {
+    const client = makeClient(status({ policyHitlEnabled: true }));
+    await mount(client);
+    const input = container.querySelector<HTMLInputElement>("#always-approve")!;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(input, "shell, http_request");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const save = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Save list"),
+    );
+    expect(save?.disabled).toBe(false);
+    await act(async () => {
+      save?.click();
+      await Promise.resolve();
+    });
+    expect(client.put).toHaveBeenCalledWith("/api/v1/acme/policy", {
+      alwaysApprove: ["shell", "http_request"],
+    });
+  });
+
+  it("keeps the matcher note from claiming anything about live gating either way", async () => {
+    // The "is this a real tool?" note is a naming check, not a gating claim,
+    // and it must read the same regardless of whether the gate is live.
+    for (const policyHitlEnabled of [true, false]) {
+      await mount(makeClient(status({ policyHitlEnabled, knownTools: ["shell"] })));
+      const input = container.querySelector<HTMLInputElement>("#always-approve")!;
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          "value",
+        )?.set;
+        setter?.call(input, "typo_tool");
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      expect(container.textContent).not.toContain("is gated today");
+      expect(container.textContent).not.toContain("this is gated");
+    }
+  });
+});
+
+describe("autonomyPromptsNote", () => {
+  it("names what still applies once the tier changes, honestly, in both states", () => {
+    expect(autonomyPromptsNote(false)).toBe(
+      "Approval prompts remain explicit through request_approval.",
+    );
+    expect(autonomyPromptsNote(true)).not.toBe(
+      "Approval prompts remain explicit through request_approval.",
+    );
+    expect(autonomyPromptsNote(true).length).toBeGreaterThan(0);
+  });
+});

--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -270,6 +270,19 @@ impl ManifestApprovalGate {
         self.ttl_millis.load(Ordering::Relaxed)
     }
 
+    /// Whether this gate currently turns policy (the tier, `always_approve`,
+    /// the spend cap) into approval requests, as opposed to allowing
+    /// everything the hard denials do not already refuse.
+    ///
+    /// Read by [`PolicyDto`](crate::server::ops::policy::PolicyDto) so the
+    /// console states this fact rather than assuming it: every gate built by
+    /// [`with_policy_hitl_disabled`](Self::with_policy_hitl_disabled) reports
+    /// `false` here, and a copy of that assumption in TypeScript would drift
+    /// the moment a gate is built without it.
+    pub fn policy_hitl_enabled(&self) -> bool {
+        self.policy_hitl_enabled.load(Ordering::Relaxed)
+    }
+
     /// The policy snapshot the gate currently evaluates against.
     ///
     /// What [`apply_effective_policy`](Self::apply_effective_policy) last
@@ -880,6 +893,16 @@ mod test {
 
     async fn decide(gate: &ManifestApprovalGate, effect: &Effect) -> PolicyDecision {
         gate.evaluate(&company(), effect).await.unwrap()
+    }
+
+    #[test]
+    fn policy_hitl_enabled_reflects_the_gate_that_reports_it() {
+        let live = ManifestApprovalGate::new(policy("supervised", None));
+        assert!(live.policy_hitl_enabled());
+
+        let disabled =
+            ManifestApprovalGate::new(policy("supervised", None)).with_policy_hitl_disabled();
+        assert!(!disabled.policy_hitl_enabled());
     }
 
     #[tokio::test]

--- a/src/server/graphql/policy.rs
+++ b/src/server/graphql/policy.rs
@@ -135,5 +135,5 @@ pub(crate) async fn resolve_policy(
         .load(runtime.id())
         .await?
         .ok_or_else(|| async_graphql::Error::new("company not found"))?;
-    Ok(PolicyDto::build(&record).into())
+    Ok(PolicyDto::build(&record, runtime.approval_gate.policy_hitl_enabled()).into())
 }

--- a/src/server/ops/policy.rs
+++ b/src/server/ops/policy.rs
@@ -241,6 +241,17 @@ pub(crate) struct PolicyDto {
     /// When a change bites. Stated because "stop the flood now" is what an
     /// operator comes here to do, and this is not quite that.
     pub(crate) takes_effect: &'static str,
+    /// Whether the live gate currently turns policy — the tier,
+    /// `always_approve`, the spend cap — into approval requests, as opposed to
+    /// allowing everything the hard denials (`readonly`, the emergency stop)
+    /// do not already refuse.
+    ///
+    /// Read from [`ManifestApprovalGate::policy_hitl_enabled`]
+    /// (`crate::policy::gate`) rather than assumed, so the console's claim
+    /// about its own always-ask list tracks the gate it describes instead of
+    /// a copy of today's build state — see this module's own doc comment for
+    /// why a copy in TypeScript drifts.
+    pub(crate) policy_hitl_enabled: bool,
     /// Every tool name this build's approval gate can match, for the console's
     /// "is this a real tool?" note (issue #1423).
     ///
@@ -256,7 +267,7 @@ pub(crate) struct PolicyDto {
 }
 
 impl PolicyDto {
-    pub(crate) fn build(record: &CompanyRecord) -> Self {
+    pub(crate) fn build(record: &CompanyRecord, policy_hitl_enabled: bool) -> Self {
         let effective: Policy = record.effective_policy();
         let manifest = &record.manifest.policy;
         Self {
@@ -275,6 +286,7 @@ impl PolicyDto {
             set_at_millis: record.overlay_policy.as_ref().map(|o| o.at_millis),
             tiers: selectable_tiers(),
             takes_effect: TAKES_EFFECT,
+            policy_hitl_enabled,
             known_tools: {
                 let mut tools: Vec<String> = crate::policy::consequence::declared_tools()
                     .map(str::to_owned)
@@ -322,7 +334,10 @@ struct SetPolicy {
 /// and the selectable tiers with their consequences.
 async fn read_policy(company: ScopedCompany) -> Result<Json<PolicyDto>, crate::server::Rejection> {
     let record = load_record(&company).await?;
-    Ok(Json(PolicyDto::build(&record)))
+    Ok(Json(PolicyDto::build(
+        &record,
+        company.runtime.approval_gate.policy_hitl_enabled(),
+    )))
 }
 
 /// `PUT {scope}/policy` — set the tier and/or the always-ask list. Admin-only,
@@ -435,7 +450,10 @@ async fn set_policy(
             .approval_gate
             .apply_effective_ttl(&record.effective_policy());
     }
-    Ok(Json(PolicyDto::build(&record)))
+    Ok(Json(PolicyDto::build(
+        &record,
+        company.runtime.approval_gate.policy_hitl_enabled(),
+    )))
 }
 
 /// `DELETE {scope}/policy` — drop the override so the manifest's `[policy]`
@@ -470,7 +488,10 @@ async fn clear_policy(
             .approval_gate
             .apply_effective_ttl(&record.effective_policy());
     }
-    Ok(Json(PolicyDto::build(&record)))
+    Ok(Json(PolicyDto::build(
+        &record,
+        company.runtime.approval_gate.policy_hitl_enabled(),
+    )))
 }
 
 fn refusal(message: &str) -> Response {
@@ -574,6 +595,55 @@ mod tests {
         state
     }
 
+    /// Same fixture as [`state`], but with an injected gate that has NOT been
+    /// built through the production path's `.with_policy_hitl_disabled()` —
+    /// the only way this suite can exercise `PolicyDto.policyHitlEnabled: true`
+    /// before any code path sets it live.
+    async fn state_with_policy_hitl_enabled(home: &std::path::Path) -> AppState {
+        let manifest: CompanyManifest = toml::from_str(MANIFEST).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                overlay_retired_agents: Vec::new(),
+                overlay_agent_edits: Vec::new(),
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_tool_grants: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+                setup: None,
+                name_confirmed: false,
+                activation_completed_at: None,
+                created_at_millis: None,
+            })
+            .await
+            .unwrap();
+        let gate = std::sync::Arc::new(crate::policy::gate::ManifestApprovalGate::new(
+            manifest.policy.clone(),
+        ));
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .with_approvals(gate)
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
     async fn call(state: &AppState, method: &str, body: Option<Value>) -> (StatusCode, Value) {
         let request = Request::builder()
             .method(method)
@@ -632,6 +702,30 @@ mod tests {
             known_tools.iter().any(|tool| tool == "shell"),
             "the registry still carries the workflow tools"
         );
+    }
+
+    /// `policyHitlEnabled` reports the live gate's own state, and every
+    /// production build reports it `false` — the console's honest "disabled"
+    /// copy must be reading a real fact, not a hardcoded one.
+    #[tokio::test]
+    async fn get_reports_policy_hitl_as_disabled_on_the_production_path() {
+        let dir = home();
+        let state = state(dir.path()).await;
+        let (status, body) = call(&state, "GET", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["policyHitlEnabled"], false);
+    }
+
+    /// The other half of the same fact: a gate that has NOT been built through
+    /// `.with_policy_hitl_disabled()` must report `true`, so the field really
+    /// does track the gate rather than always answering `false`.
+    #[tokio::test]
+    async fn get_reports_policy_hitl_as_enabled_when_the_gate_has_it_on() {
+        let dir = home();
+        let state = state_with_policy_hitl_enabled(dir.path()).await;
+        let (status, body) = call(&state, "GET", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["policyHitlEnabled"], true);
     }
 
     /// A tier `PUT` moves the tier and leaves the always-ask list on the


### PR DESCRIPTION
## Summary

Closes #2149. Part of #1817.

The policy screen presented `[policy].always_approve` as a working gate: it mirrored the backend matcher in TypeScript and showed the operator which targets each entry covered. In production that list creates no approvals. #1925 disabled policy-generated HITL — `ApprovalPolicy::check` returns `Allow` at `src/harness/built_in/policy.rs:1701`, above the `always_approve` arm, and the native-effect gate does the same — and its own PR body says it plainly: "policy `always_approve` rules no longer create approval requests".

So an operator could add a tool to the always-ask list, watch the console confirm it was gated, and never receive a card. That is worse than the control not existing: it reads as oversight that is in place.

The fix is truthfulness, not policy. The gate now reports whether it is turning policy into approvals; the policy DTO carries that as `policyHitlEnabled`; the console renders what it is served. When policy HITL is off the screen says so, names what still does raise a card — an agent's explicit `request_approval`, the paid-media tools that stage their own, an authored workflow `requires_approval` gate, read-only mode, the emergency stop — and marks the now-inert controls `(inactive)` and disables them rather than accepting edits that would do nothing.

**The status is read from the live gate, never re-derived in TypeScript.** `src/server/ops/policy.rs` already documents why a copy of a backend rule in the console drifts from the gate it claims to describe; this follows that argument rather than adding a second one. A host predating the field is treated as HITL-disabled, which matches every real deployment and is the safe direction for a claim about oversight.

## API Or Behavior Changes

`PolicyStatus` / `PolicyDto` gain one boolean, `policyHitlEnabled`, read from `ManifestApprovalGate::policy_hitl_enabled()`. Additive; a client that ignores it is unaffected.

No approval behaviour changes. No tier, gate arm, classification or decision path is touched. Whether `always_approve` should become live again is the #1817 consequence-floor question and is deliberately out of scope.

## Tests

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --features openhuman --no-deps -- -D warnings` — clean
- `cargo test --features openhuman --lib` — 7190 passed, 0 failed, 3 ignored
- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — all clean (plain `typecheck` skips the test dirs, so all three were run)
- `npm run test` — 514 files, **4824 tests passed**
- `npm run build` — clean

New coverage: `policy_hitl_enabled_reflects_the_gate_that_reports_it` in `src/policy/gate.rs`; `frontend/test/unit/policy-hitl-status.test.ts` pinning the honest rendering and that the matcher preview no longer claims an active gate; `frontend/test/e2e/policy-hitl-status.spec.ts` covering the rendered status. Each new assertion was written to fail against the pre-change component.

## Documentation

The new gate accessor and DTO field carry their own reasoning: what "policy HITL" means concretely (the tier, `always_approve`, the spend cap becoming approval requests, as opposed to allowing whatever the hard denials do not refuse), and why the value is served rather than assumed.