### PR TITLE
fix(server): require admin authority to resolve or extend an approval

### DIFF
--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -15346,7 +15346,6 @@ mode = "full"
         for scope in APPROVAL_SCOPES {
             let home_dir = home();
             let state = state_with_company(home_dir.path(), "running").await;
-            crate::server::test_support::seed_fixed_admin(&state, "acme").await;
             let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
             let id = park_for_extend(&runtime, "appr-admin-resolve", 1_000).await;
             let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -15369,7 +15368,6 @@ mode = "full"
         for scope in APPROVAL_SCOPES {
             let home_dir = home();
             let state = state_with_company(home_dir.path(), "running").await;
-            crate::server::test_support::seed_fixed_admin(&state, "acme").await;
             let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
             let id = park_for_extend(&runtime, "appr-admin-ext", 1_000).await;
             let cookie = crate::server::test_support::fixed_cookie("acme");

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -49,7 +49,7 @@ use crate::server::chat_history::{
 use crate::server::error::ApiError;
 use crate::server::graphql::auth::GqlAuth;
 use crate::server::ops::language::{self, DEFAULT_DESK};
-use crate::server::ops::{ScopedCompany, scoped};
+use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 use crate::server::platform_auth::{CompanyAuth, authorize_address, refuse_until_password_changed};
 use crate::server::provision::{emit_cycle_webhooks, emit_feedback_webhook};
 
@@ -71,14 +71,6 @@ pub fn router() -> Router<AppState> {
             post(react_to_message_scoped),
         )
         .route("/api/v1/companies/{id}/approvals", get(list_approvals))
-        .route(
-            "/api/v1/companies/{id}/approvals/{aid}",
-            post(resolve_approval),
-        )
-        .route(
-            "/api/v1/companies/{id}/approvals/{aid}/extend",
-            post(extend_approval),
-        )
         // Single-company aliases (no id; resolved via the sole registered company).
         .route("/api/v1/company/chat", post(operator_chat_single))
         .route("/api/v1/company/chat/history", get(chat_history_single))
@@ -91,14 +83,12 @@ pub fn router() -> Router<AppState> {
             post(react_to_message_single),
         )
         .route("/api/v1/company/approvals", get(list_approvals_single))
-        .route(
-            "/api/v1/company/approvals/{aid}/extend",
-            post(extend_approval_single),
-        )
-        .route(
-            "/api/v1/company/approvals/{aid}",
-            post(resolve_approval_single),
-        )
+        // Deciding an approval, and extending the deadline that would otherwise
+        // decide it by default, settle an effect for the whole company, so both
+        // demand authority over it rather than membership in it. Registered
+        // through `scoped` so the two address forms cannot drift apart.
+        .merge(scoped("/approvals/{aid}", post(resolve_approval)))
+        .merge(scoped("/approvals/{aid}/extend", post(extend_approval)))
         // The company's desks (group chats), under both scope forms — the
         // console builds its chat threads from these (issue #53). `POST` creates
         // a desk through the operator overlay (the manifest is never rewritten).
@@ -4959,20 +4949,28 @@ async fn run_resolve(
     .into_response())
 }
 
-/// `POST /api/v1/companies/{id}/approvals/{aid}`.
+/// The approval a resolve or an extend addresses, under either scope form.
+///
+/// Named rather than positional because the two forms carry different path
+/// tuples — `{id}` plus `{aid}`, or `{aid}` alone — and a named capture
+/// deserializes identically from both. The company is not read here:
+/// [`AdminScopedCompany`] has already resolved and authorized it.
+#[derive(Debug, Deserialize)]
+struct ApprovalPath {
+    aid: String,
+}
+
+/// `POST {scope}/approvals/{aid}` — decide a parked approval.
 async fn resolve_approval(
+    admin: AdminScopedCompany,
     CompanyAuth(auth): CompanyAuth,
     State(state): State<AppState>,
-    Path((id, aid)): Path<(String, String)>,
+    Path(ApprovalPath { aid }): Path<ApprovalPath>,
     Json(body): Json<ResolveApproval>,
 ) -> Result<Response, crate::server::Rejection> {
-    let company = CompanyId::new(&id);
-    if let Some(resp) = authorize_address(&state, &auth, &company) {
-        return Err(resp.into());
-    }
-    let runtime = lookup(&state, &id)?;
+    let company = admin.id().clone();
     let actor = resolving_actor(auth);
-    run_resolve(&state, &company, runtime, aid, body, actor)
+    run_resolve(&state, &company, admin.runtime, aid, body, actor)
         .await
         .map_err(|error| IntoResponse::into_response(error).into())
 }
@@ -4994,27 +4992,6 @@ fn resolving_actor(auth: GqlAuth) -> Actor {
         },
         GqlAuth::Platform(_) => platform_actor(),
     }
-}
-
-/// `POST /api/v1/company/approvals/{aid}` (single-company alias).
-async fn resolve_approval_single(
-    CompanyAuth(auth): CompanyAuth,
-    State(state): State<AppState>,
-    Path(aid): Path<String>,
-    Json(body): Json<ResolveApproval>,
-) -> Result<Response, crate::server::Rejection> {
-    let runtime = sole(&state)?;
-    let id = runtime.id().clone();
-    if let Some(resp) = authorize_address(&state, &auth, &id) {
-        return Err(resp.into());
-    }
-    if let Some(resp) = refuse_until_password_changed(&auth) {
-        return Err(resp.into());
-    }
-    let actor = resolving_actor(auth);
-    run_resolve(&state, &id, runtime, aid, body, actor)
-        .await
-        .map_err(|error| IntoResponse::into_response(error).into())
 }
 
 /// The answer to an extend: the approval's new deadline, so the console can
@@ -5048,39 +5025,15 @@ async fn run_extend(
     .into_response())
 }
 
-/// `POST /api/v1/companies/{id}/approvals/{aid}/extend` (issue #1805).
+/// `POST {scope}/approvals/{aid}/extend` — push the default-deny deadline out
+/// (issue #1805).
 async fn extend_approval(
+    admin: AdminScopedCompany,
     CompanyAuth(auth): CompanyAuth,
-    State(state): State<AppState>,
-    Path((id, aid)): Path<(String, String)>,
+    Path(ApprovalPath { aid }): Path<ApprovalPath>,
 ) -> Result<Response, crate::server::Rejection> {
-    let company = CompanyId::new(&id);
-    if let Some(resp) = authorize_address(&state, &auth, &company) {
-        return Err(resp.into());
-    }
-    let runtime = lookup(&state, &id)?;
     let actor = resolving_actor(auth);
-    run_extend(runtime, aid, actor)
-        .await
-        .map_err(|error| IntoResponse::into_response(error).into())
-}
-
-/// `POST /api/v1/company/approvals/{aid}/extend` (single-company alias).
-async fn extend_approval_single(
-    CompanyAuth(auth): CompanyAuth,
-    State(state): State<AppState>,
-    Path(aid): Path<String>,
-) -> Result<Response, crate::server::Rejection> {
-    let runtime = sole(&state)?;
-    let id = runtime.id().clone();
-    if let Some(resp) = authorize_address(&state, &auth, &id) {
-        return Err(resp.into());
-    }
-    if let Some(resp) = refuse_until_password_changed(&auth) {
-        return Err(resp.into());
-    }
-    let actor = resolving_actor(auth);
-    run_extend(runtime, aid, actor)
+    run_extend(admin.runtime, aid, actor)
         .await
         .map_err(|error| IntoResponse::into_response(error).into())
 }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -10716,28 +10716,6 @@ mode = "full"
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
-    /// The route is guarded by the same company auth as resolve: a member — an
-    /// authenticated user of the company — may extend a deadline, exactly as
-    /// they may resolve. Keeping a stalled run alive is not an admin-only lever.
-    #[tokio::test]
-    async fn a_member_may_extend_an_approval_deadline() {
-        let home_dir = home();
-        let state = state_with_company(home_dir.path(), "running").await;
-        crate::server::test_support::seed_fixed_member(&state, "acme").await;
-        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
-        let id = park_for_extend(&runtime, "appr-member-ext", 1_000).await;
-
-        let app = router(state);
-        let response = app
-            .oneshot(extend_request_with_cookie(
-                &id,
-                crate::server::test_support::member_cookie("acme"),
-            ))
-            .await
-            .unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
-    }
-
     /// Whether the stalled brain's follow-up turn has journaled its marker yet.
     fn continued(runtime: &Arc<CompanyRuntime>) -> bool {
         runtime
@@ -15267,5 +15245,206 @@ mode = "full"
         assert_eq!(after.column, crate::ports::tasks::COLUMN_IN_PROGRESS);
         let note = after.note.expect("note");
         assert!(note.contains("send it back"), "{note}");
+    }
+
+    // -- Approval authority: deciding for the company, not addressing it -----
+
+    /// Both address forms. Every ops route is registered under two, and this
+    /// pair had already drifted apart: only the alias carried the
+    /// temporary-password refusal, so every assertion below runs against both.
+    const APPROVAL_SCOPES: [&str; 2] = ["/api/v1/companies/acme", "/api/v1/company"];
+
+    fn resolve_as(scope: &str, approval_id: &str, cookie: Option<&str>) -> Request<Body> {
+        let builder = Request::builder()
+            .method("POST")
+            .uri(format!("{scope}/approvals/{approval_id}"))
+            .header("content-type", "application/json");
+        let builder = match cookie {
+            Some(cookie) => builder.header("cookie", cookie),
+            None => builder,
+        };
+        builder
+            .body(Body::from(
+                serde_json::json!({ "verdict": "deny" }).to_string(),
+            ))
+            .unwrap()
+    }
+
+    fn extend_as(scope: &str, approval_id: &str, cookie: Option<&str>) -> Request<Body> {
+        let builder = Request::builder()
+            .method("POST")
+            .uri(format!("{scope}/approvals/{approval_id}/extend"));
+        let builder = match cookie {
+            Some(cookie) => builder.header("cookie", cookie),
+            None => builder,
+        };
+        builder.body(Body::empty()).unwrap()
+    }
+
+    /// The sharpest case in this file. `may_read_approval_contents` already
+    /// refuses a member the payload and the amount an approval carries, so
+    /// before this guard a member could approve a payment they were forbidden
+    /// to look at.
+    ///
+    /// The approval id is deliberately one that does not exist: authority is
+    /// settled before the approval is resolved, so the answer must be `403` and
+    /// not the `404` a permitted caller would get.
+    #[tokio::test]
+    async fn a_member_may_not_resolve_an_approval() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        crate::server::test_support::seed_fixed_member(&state, "acme").await;
+        let cookie = crate::server::test_support::member_cookie("acme");
+        let app = router(state);
+
+        for scope in APPROVAL_SCOPES {
+            let denied = app
+                .clone()
+                .oneshot(resolve_as(scope, "appr-nobody-parked", Some(&cookie)))
+                .await
+                .unwrap();
+            assert_eq!(
+                denied.status(),
+                StatusCode::FORBIDDEN,
+                "{scope} let a member decide an approval"
+            );
+        }
+    }
+
+    /// Extending is the deadline's other side: an approval nobody decides
+    /// default-denies when its window runs out, so being able to push that
+    /// window out indefinitely is a decision about the effect, made for the
+    /// company. It is held to the same authority as deciding it outright.
+    #[tokio::test]
+    async fn a_member_may_not_extend_an_approval_deadline() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        crate::server::test_support::seed_fixed_member(&state, "acme").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let id = park_for_extend(&runtime, "appr-member-ext", 1_000).await;
+        let cookie = crate::server::test_support::member_cookie("acme");
+        let app = router(state);
+
+        for scope in APPROVAL_SCOPES {
+            let denied = app
+                .clone()
+                .oneshot(extend_as(scope, id.as_ref(), Some(&cookie)))
+                .await
+                .unwrap();
+            assert_eq!(
+                denied.status(),
+                StatusCode::FORBIDDEN,
+                "{scope} let a member extend an approval deadline"
+            );
+        }
+    }
+
+    /// The other half of the guard: refusing a member must not also refuse the
+    /// admin the routes exist for, under either address form.
+    #[tokio::test]
+    async fn an_admin_may_still_resolve_an_approval() {
+        for scope in APPROVAL_SCOPES {
+            let home_dir = home();
+            let state = state_with_company(home_dir.path(), "running").await;
+            crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+            let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+            let id = park_for_extend(&runtime, "appr-admin-resolve", 1_000).await;
+            let cookie = crate::server::test_support::fixed_cookie("acme");
+            let app = router(state);
+
+            let allowed = app
+                .oneshot(resolve_as(scope, id.as_ref(), Some(&cookie)))
+                .await
+                .unwrap();
+            assert_eq!(
+                allowed.status(),
+                StatusCode::OK,
+                "{scope} refused an admin the decision"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn an_admin_may_still_extend_an_approval_deadline() {
+        for scope in APPROVAL_SCOPES {
+            let home_dir = home();
+            let state = state_with_company(home_dir.path(), "running").await;
+            crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+            let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+            let id = park_for_extend(&runtime, "appr-admin-ext", 1_000).await;
+            let cookie = crate::server::test_support::fixed_cookie("acme");
+            let app = router(state);
+
+            let allowed = app
+                .oneshot(extend_as(scope, id.as_ref(), Some(&cookie)))
+                .await
+                .unwrap();
+            assert_eq!(
+                allowed.status(),
+                StatusCode::OK,
+                "{scope} refused an admin the extension"
+            );
+        }
+    }
+
+    /// No credential at all is `401`, not `403` — the authority guard must not
+    /// turn an anonymous request into a role decision.
+    #[tokio::test]
+    async fn an_unauthenticated_caller_cannot_decide_or_extend_an_approval() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let app = router(state);
+
+        for scope in APPROVAL_SCOPES {
+            for request in [
+                resolve_as(scope, "appr-anon", None),
+                extend_as(scope, "appr-anon", None),
+            ] {
+                let uri = request.uri().to_string();
+                let denied = app.clone().oneshot(request).await.unwrap();
+                assert_eq!(
+                    denied.status(),
+                    StatusCode::UNAUTHORIZED,
+                    "{uri} answered an anonymous caller with {}",
+                    denied.status()
+                );
+            }
+        }
+    }
+
+    /// The second defect these routes carried: the temporary-password boundary
+    /// lived only on the single-company alias, so an admin who had never set a
+    /// password could decide and extend every approval through the `{id}` form.
+    ///
+    /// An admin is the right principal to prove it with — the role check passes,
+    /// so a refusal here can only be the password boundary.
+    #[tokio::test]
+    async fn an_admin_on_a_temporary_password_may_not_decide_or_extend() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let cookie = crate::server::test_support::seed_temp_password_admin(&state, "acme").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let id = park_for_extend(&runtime, "appr-temp-pass", 1_000).await;
+        let app = router(state);
+
+        for scope in APPROVAL_SCOPES {
+            for request in [
+                resolve_as(scope, id.as_ref(), Some(&cookie)),
+                extend_as(scope, id.as_ref(), Some(&cookie)),
+            ] {
+                let uri = request.uri().to_string();
+                let denied = app.clone().oneshot(request).await.unwrap();
+                assert_eq!(
+                    denied.status(),
+                    StatusCode::FORBIDDEN,
+                    "{uri} served an admin who has not set a password"
+                );
+                assert_eq!(
+                    body_json(denied).await["code"],
+                    "password_change_required",
+                    "{uri} refused for the wrong reason"
+                );
+            }
+        }
     }
 }

--- a/src/server/test_support.rs
+++ b/src/server/test_support.rs
@@ -28,6 +28,16 @@ use crate::server::users::token::{OsTokens, mint_session_token, sha256_hex};
 /// tests exercise the same resolution path production does — the only shortcut
 /// is skipping the magic-link round trip.
 pub(crate) async fn seed_session(state: &AppState, company: &str, role: UserRole) -> String {
+    seed_session_with(state, company, role, false).await
+}
+
+/// [`seed_session`], plus whether the account is still on a temporary password.
+pub(crate) async fn seed_session_with(
+    state: &AppState,
+    company: &str,
+    role: UserRole,
+    must_change_password: bool,
+) -> String {
     let id = CompanyId::new(company);
     let runtime = state
         .registry()
@@ -47,7 +57,7 @@ pub(crate) async fn seed_session(state: &AppState, company: &str, role: UserRole
                 role,
                 status: UserStatus::Active,
                 password_hash: None,
-                must_change_password: false,
+                must_change_password,
                 created_at_millis: now,
                 last_seen_at_millis: None,
                 updated_at_millis: now,
@@ -84,6 +94,16 @@ pub(crate) async fn seed_session(state: &AppState, company: &str, role: UserRole
 /// Seeds an admin session — the common case for tests that drive write routes.
 pub(crate) async fn seed_admin(state: &AppState, company: &str) -> String {
     seed_session(state, company, UserRole::Admin).await
+}
+
+/// Seeds an admin still on the temporary password they were issued.
+///
+/// The account that clears every role check and is still refused: proving a
+/// route honours the password-change boundary needs a principal whose *only*
+/// disqualification is that boundary, so a passing assertion cannot be the role
+/// gate answering instead.
+pub(crate) async fn seed_temp_password_admin(state: &AppState, company: &str) -> String {
+    seed_session_with(state, company, UserRole::Admin, true).await
 }
 
 /// A fixed session token for the harnesses whose request helpers do not thread

--- a/tests/auth_matrix.rs
+++ b/tests/auth_matrix.rs
@@ -894,25 +894,25 @@ const EXTERNAL_AUTHORITY_ROUTES: &[Route] = &[
         Verb::Post,
         "/api/v1/companies/{id}/approvals/{aid}",
         Probe::Json(r#"{"verdict":"deny","amended_payload":{}}"#),
-        RedCells::MemberAndTempPassword,
+        RedCells::TempPassword,
     ),
     external_admin(
         Verb::Post,
         "/api/v1/company/approvals/{aid}",
         Probe::Json(r#"{"verdict":"deny","amended_payload":{}}"#),
-        RedCells::Member,
+        RedCells::None,
     ),
     external_admin(
         Verb::Post,
         "/api/v1/companies/{id}/approvals/{aid}/extend",
         Probe::Empty,
-        RedCells::MemberAndTempPassword,
+        RedCells::TempPassword,
     ),
     external_admin(
         Verb::Post,
         "/api/v1/company/approvals/{aid}/extend",
         Probe::Empty,
-        RedCells::Member,
+        RedCells::None,
     ),
 ];
 
@@ -1289,7 +1289,7 @@ fn table_counts_and_intentional_widenings_are_explicit() {
                         .count()
             })
             .sum::<usize>(),
-        55,
+        51,
         "ignored red principal cells",
     );
     assert_eq!(
@@ -1445,21 +1445,19 @@ fn external_authority_router_files_have_no_unclassified_paths() {
             "/api/v1/companies/{id}/chat/attribution-audit",
             "/api/v1/companies/{id}/chat/messages/{seq}/reactions",
             "/api/v1/companies/{id}/approvals",
-            "/api/v1/companies/{id}/approvals/{aid}",
-            "/api/v1/companies/{id}/approvals/{aid}/extend",
             "/api/v1/company/chat",
             "/api/v1/company/chat/history",
             "/api/v1/company/chat/attribution-audit",
             "/api/v1/company/chat/messages/{seq}/reactions",
             "/api/v1/company/approvals",
-            "/api/v1/company/approvals/{aid}",
-            "/api/v1/company/approvals/{aid}/extend",
         ]),
         &operator.direct,
     );
     assert_set_eq(
         "operator scoped suffix",
         &string_set(&[
+            "/approvals/{aid}",
+            "/approvals/{aid}/extend",
             "/desks",
             "/desks/{desk_id}",
             "/desks/{desk_id}/members",

--- a/tests/auth_matrix.rs
+++ b/tests/auth_matrix.rs
@@ -274,7 +274,6 @@ impl Wait {
 enum RedCells {
     None,
     Member,
-    MemberAndTempPassword,
     TenantOwnerAndPlatform,
     TempPassword,
 }
@@ -284,10 +283,6 @@ impl RedCells {
         match self {
             Self::None => false,
             Self::Member => matches!(principal, Principal::Member),
-            Self::MemberAndTempPassword => matches!(
-                principal,
-                Principal::Member | Principal::MustChangePasswordAdmin
-            ),
             Self::TenantOwnerAndPlatform => {
                 matches!(principal, Principal::TenantOwner | Principal::Platform)
             }

--- a/tests/snapshots/auth-matrix.txt
+++ b/tests/snapshots/auth-matrix.txt
@@ -1477,14 +1477,14 @@ POST /api/v1/companies/{id}/agents/{agent_id}/budget-pause/redeem tenant-non-own
 POST /api/v1/companies/{id}/agents/{agent_id}/budget-pause/redeem tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
 POST /api/v1/companies/{id}/approvals/{aid} admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/companies/{id}/approvals/{aid} anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
-POST /api/v1/companies/{id}/approvals/{aid} member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/companies/{id}/approvals/{aid} member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/companies/{id}/approvals/{aid} must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
 POST /api/v1/companies/{id}/approvals/{aid} platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/companies/{id}/approvals/{aid} tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/companies/{id}/approvals/{aid} tenant-owner permitted source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/companies/{id}/approvals/{aid}/extend admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/companies/{id}/approvals/{aid}/extend anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
-POST /api/v1/companies/{id}/approvals/{aid}/extend member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/companies/{id}/approvals/{aid}/extend member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/companies/{id}/approvals/{aid}/extend must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
 POST /api/v1/companies/{id}/approvals/{aid}/extend platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/companies/{id}/approvals/{aid}/extend tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
@@ -1904,14 +1904,14 @@ POST /api/v1/company/agents/{agent_id}/budget-pause/redeem tenant-non-owner refu
 POST /api/v1/company/agents/{agent_id}/budget-pause/redeem tenant-owner permitted source=ops access=scoped features=openhuman blast=authority note="Members may resume an agent after the budget interruption is cleared." wait=-
 POST /api/v1/company/approvals/{aid} admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/approvals/{aid} anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
-POST /api/v1/company/approvals/{aid} member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/company/approvals/{aid} member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/approvals/{aid} must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/approvals/{aid} platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/approvals/{aid} tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/approvals/{aid} tenant-owner permitted source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/approvals/{aid}/extend admin permitted source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/approvals/{aid}/extend anonymous refused:401:unauthorized source=external access=admin features=openhuman blast=authority note="" wait=-
-POST /api/v1/company/approvals/{aid}/extend member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=fix/auth-role-dimension-on-authorize-address
+POST /api/v1/company/approvals/{aid}/extend member refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/approvals/{aid}/extend must-change-password-admin refused:403:password_change_required source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/approvals/{aid}/extend platform permitted source=external access=admin features=openhuman blast=authority note="" wait=-
 POST /api/v1/company/approvals/{aid}/extend tenant-non-owner refused:403:forbidden source=external access=admin features=openhuman blast=authority note="" wait=-


### PR DESCRIPTION
## Summary

On `main` today, `resolve_approval` and `extend_approval` take `CompanyAuth` and nothing else: **any signed-in member can settle or extend an approval**. #2047 closed the lifecycle routes yesterday and did not touch approvals, so this gap is still open.

This is #2127's remaining content, rebuilt on current `main`. Its lifecycle commits are now redundant — #2047 landed that work — and only the approvals half survives here. #2127 can be closed once this lands.

## API Or Behavior Changes

`POST …/approvals/{aid}` and `POST …/approvals/{aid}/extend` now require an admin, on both the company-scoped and self-scoped address forms. A member receives `403 forbidden`.

**One decision is deliberately left to the maintainer**: whether `extend` should be admin-only at all, or restored to any member. It is isolated in its own commit so it can be dropped without touching the rest.

## Tests

`cargo test --features openhuman --lib` — 7,214 passed, 0 failed. `--test auth_matrix` — 8 passed. `cargo clippy … -D warnings` 0, `cargo fmt --check` 0.

The route-authority matrix had **already recorded this defect**. Those four cells carried `Wait::AuthRoleBranch` — known-red, waiting for exactly this change — so the matrix was excusing them rather than checking them. Clearing the member cells drops the ignored-red count from **55 to 51**: the four this closes, and no others.

Two things surfaced while rebuilding it on main:

The matrix's completeness check failed with `operator direct path set drifted; missing=[…approvals/{aid}, …/extend]`. The four routes moved from `.route(...)` registration into the `scoped(...)` helper, so the inventory needed to follow them. That check merged yesterday and caught a sibling PR within a day.

Two tests failed on `another user already has the email harness-admin@example.test`. The shared state helper now seeds the fixed admin itself, so seeding again conflicts rather than being idempotent — the second seed is removed.

Also drops the `MemberAndTempPassword` red class, whose only users were these four rows.

## Documentation

`docs/spec/company-brain/approvals.md` states that deciding or extending an approval requires admin authority.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Approval updates and deadline extensions now consistently enforce administrative access across supported company URL formats.
  - Members can no longer modify approvals.
  - Anonymous users and administrators using temporary passwords receive consistent authentication and access restrictions.
  - Authorization behavior is now aligned across equivalent approval endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->