### PR TITLE
feat(hive): cross-desk referral on the chat path, and deliberation fixes from live runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,16 @@ jobs:
       - name: Assert toolchain pins agree
         run: scripts/ci/assert-toolchain-pin.sh
 
+      # Issue #592, second instance. Also config-only, also before the
+      # toolchain: `deploy-staging.yml` sets `submodules: false` and names its
+      # vendored checkouts by hand, and it does not run on pull requests — so a
+      # vendored path dependency missing from that list is green here and fails
+      # only on deploy. Cargo reads every path dependency's manifest during
+      # resolution whatever the feature selection, so the break is the default
+      # build, not the feature that added the crate.
+      - name: Assert vendored path dependencies are checked out
+        run: scripts/ci/assert-vendored-deps-checked-out.sh
+
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.98.0"
@@ -617,6 +627,15 @@ jobs:
       # tree.
       - name: Test the export bundle
         run: scripts/ci/run-scoped-suite.sh "export bundle" export store::export
+
+      # `hivemind`: the `tinyhivemind` session adapter (`runtime::hivemind`).
+      # The feature gates one module and its tests, and nothing on the default
+      # path enables it — which is exactly the shape #770 was filed about, so it
+      # gets its lane in the same breath as the code rather than after somebody
+      # notices. Offline and dependency-free at this job's expense: the crate is
+      # already vendored and pure, so this costs one recompile of the lib.
+      - name: Test the hivemind session adapter
+        run: scripts/ci/run-scoped-suite.sh "hivemind adapter" hivemind runtime::hivemind
 
       # `imap`/`smtp`: the mail surface. One gated test runs here today — the
       # RFC822 parser — and it is a parser, which is precisely the kind of code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3569,6 +3569,8 @@ dependencies = [
  "thiserror 2.0.20",
  "tinyagents-harness",
  "tinyflows",
+ "tinyhivemind",
+ "tinyhivemind-core",
  "tinyhivemind-hive",
  "tinyinference",
  "tinymcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,28 @@ tinyinference = { path = "vendor/openhuman/vendor/tinyagents/vendor/tinyinferenc
 # module: `tinyhosts` is linked as a library, so nothing here loads a cdylib.
 openhuman_core = { package = "openhuman", path = "vendor/openhuman", optional = true, default-features = false, features = ["skills", "mcp", "hosting"] }
 
+# Desks, rosters, mentions and shared session transcripts — the pure algebra
+# behind a group chat several teammates share (`vendor/tinyhivemind`). It is the
+# one place conversation identity is decided, so the history fold, thread
+# resumption and an agent's context seed cannot drift apart about which stored
+# chat id names which conversation.
+#
+# NOT optional, unlike every other vendored crate here. Conversation identity is
+# read on the default build — `ports::types` and `server::chat_history` both
+# need it with no feature enabled — so gating it would break the offline build
+# rather than trim it. It costs almost nothing to carry: no async runtime, no
+# transport, no HTTP client, no web framework — its own CI asserts that — and
+# its only dependencies, `serde` and `thiserror`, are already in this lockfile.
+tinyhivemind-core = { path = "vendor/tinyhivemind/crates/tinyhivemind-core" }
+
+# The session-runtime half of the same vendored library: the `SessionLog` paging
+# port, and the **attributed** transcript projection over it. Optional, and off
+# by default, unlike `tinyhivemind-core` above — nothing on the default path
+# calls it yet. The adapter that implements the port lives in
+# `runtime::hivemind` behind the `hivemind` feature, and no turn is wired to it;
+# vendoring it enabled would claim a behavior change this build does not make.
+tinyhivemind = { path = "vendor/tinyhivemind/crates/tinyhivemind", optional = true }
+
 # The MCP client, extracted out of OpenHuman into its own crate. OpenHuman's
 # `oh::mcp::http_client` facade still re-exports the transport and the payload
 # types under their old spellings, but not `tinymcp::Error` — and the typed 401
@@ -529,6 +551,11 @@ medulla = ["dep:reqwest"]
 # second one, which is the outcome worth avoiding: two curves, or two base58
 # key parsers, is how a signature check comes to differ between two callers.
 tinyplace = ["dep:reqwest"]
+
+# The `tinyhivemind` session adapter (`runtime::hivemind`). Off by default and
+# wired to nothing: it compiles the port implementation and runs its tests, so
+# the projection can be adopted by a later change that is only about adoption.
+hivemind = ["dep:tinyhivemind"]
 # The Agent Client Protocol: the `/acp` endpoint's session/permission surface
 # and the `RunTurn` implementation over an ACP agent.
 #

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -271,11 +271,46 @@ export interface CreateDeskInput {
  * projection logic with the GraphQL `Chat.history` resolver, so the two can
  * never disagree about a desk's history (issue #65).
  */
+/**
+ * Where a message came from when another desk caused it (tinyhivemind P15).
+ *
+ * A crossing referral runs a turn on a desk the asker is not a member of, so
+ * the message needs to say so on its face — otherwise a turn that exists only
+ * because engineering asked reads as design's own idea.
+ *
+ * The labels are **captured with the row**, never resolved at render, for the
+ * reason `SessionAuthor` captures its own: a desk renamed later must not
+ * rewrite what the transcript said at the time.
+ */
+export interface ReferredFromDto {
+  deskId: string;
+  deskName: string;
+  askerId: string;
+  askerLabel: string;
+  /** The asking message, so the chip can link straight to it. */
+  sequence: number;
+  /**
+   * Which leg of the referral this message is: the outbound ask, or the answer
+   * arriving home.
+   *
+   * The host says it because only the host can. Both legs are agent-authored
+   * lines on a desk, so `from`, `byPerson` and the author all read identically
+   * on each — a console that guesses from those gets every return wrong, which
+   * is exactly what it did before this field existed.
+   *
+   * Optional: a host that predates it says nothing, and the chip then falls
+   * back to "asked", which is what every marker written before the return leg
+   * shipped actually was.
+   */
+  direction?: "asked" | "answered";
+}
+
 export interface ChatHistoryMessageDto {
   id: string;
   channel: string;
   author: string;
   text: string;
+  referredFrom?: ReferredFromDto;
   atMillis: number;
   mine: boolean;
   /**

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -213,6 +213,18 @@ export interface ChatMessage {
    */
   parentId?: string;
   /**
+   * The desk that caused this message, when another desk's agent referred the
+   * work here (tinyhivemind P15). Renders as a chip on the bubble — provenance
+   * of the message itself, which is why it rides here and not as a separate
+   * system line.
+   *
+   * A crossing referral cannot be threaded — the library lands one on the
+   * target's desk channel, "never in a thread, because a thread root is a
+   * sequence number in the conversation that owns it" — so this chip is the
+   * only link back to the conversation that asked.
+   */
+  referredFrom?: import("@/api/types").ReferredFromDto;
+  /**
    * Who reacted to this line with what — one row per person per emoji, not a
    * count (issue #364).
    *
@@ -566,6 +578,9 @@ export function fromHistory(entries: ChatHistoryMessageDto[]): ChatMessage[] {
       // namespace as `entry.id` — so it takes the same prefix, or the reply
       // would point at a line no console id matches (issue #364).
       parentId: entry.parentId ? hostMessageId(entry.parentId) : undefined,
+      // Straight through, like `byPerson`: only the host knows another desk
+      // caused this line, and nothing here may infer it.
+      referredFrom: entry.referredFrom,
       // Reactions come through whoever the host said reacted; nothing is
       // inferred here, `mine` included.
       reactions: entry.reactions?.length ? entry.reactions : undefined,

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -23,7 +23,7 @@ import {
   type TimelineEntry,
 } from "./model";
 import { EchoPlaceholder, echoMarkerFor } from "./EchoPlaceholder";
-import { CardChip, StepTimeline } from "./StepTimeline";
+import { CardChip, ReferralChip, StepTimeline } from "./StepTimeline";
 import { WorkingIndicator } from "./WorkingIndicator";
 
 interface Props {
@@ -377,6 +377,19 @@ export function MessageRow({
             above them is what the reader came for — there is no answer yet, and
             these rows are the only account of what is happening. */}
         {!!liveSteps?.length && <StepTimeline steps={[...liveSteps]} defaultOpen />}
+        {/* Provenance for a crossing referral: this turn exists because another
+            desk asked, and the reader of THIS desk cannot tell otherwise. */}
+        {message.referredFrom && (
+          <ReferralChip
+            deskId={message.referredFrom.deskId}
+            deskName={message.referredFrom.deskName}
+            sequence={message.referredFrom.sequence}
+            // The host's word, never a guess off `from`: both legs of a
+            // referral are `company` lines, so that test called every answer
+            // an ask. Falling back to "asked" matches a host too old to say.
+            direction={message.referredFrom.direction ?? "asked"}
+          />
+        )}
         {message.taskId && (
           <div className="flex flex-wrap items-center gap-2">
             <CardChip

--- a/frontend/src/views/chat/StepTimeline.tsx
+++ b/frontend/src/views/chat/StepTimeline.tsx
@@ -4,6 +4,7 @@ import {
   Brain,
   ChevronDown,
   ChevronRight,
+  CornerUpLeft,
   Hourglass,
   Loader2,
   Scissors,
@@ -201,6 +202,51 @@ function formatElapsed(ms: number | undefined, status: TurnStep["status"]): stri
  * that has no card-delete route — the thread panel, a future read-only
  * transcript — still renders the link half rather than a control that throws.
  */
+/**
+ * Where a crossing referral came from, or went (tinyhivemind P15).
+ *
+ * Modelled on {@link CardChip} deliberately: both are provenance on the bubble
+ * — "this message is connected to something not on this screen" — and a reader
+ * should not have to learn two shapes for one idea. It is NOT a centred system
+ * pill; a pill is a line the runtime wrote *about* the conversation, and this
+ * is a fact about the message under it.
+ *
+ * Two directions, two words, because the reader's question differs. In the
+ * desk that was asked, the question is "why is this here?" — `Asked by
+ * Engineering`. In the desk that asked, an answer has arrived from a teammate
+ * who is not on this desk, and without saying so it reads as local work —
+ * `Answered by Product & Design`.
+ *
+ * The label is whatever the host captured with the row; this never resolves a
+ * desk id at render, and never shows one — an id in operator copy is the thing
+ * `DiscussionMessage.author` refuses for the same reason.
+ */
+export function ReferralChip({
+  deskId,
+  deskName,
+  sequence,
+  direction,
+}: {
+  deskId: string;
+  deskName: string;
+  sequence: number;
+  direction: "asked" | "answered";
+}) {
+  const label = direction === "asked" ? `Asked by ${deskName}` : `Answered by ${deskName}`;
+  return (
+    <span className="mt-1.5 flex w-fit items-center rounded-full bg-accent text-accent-foreground">
+      <a
+        href={`#/chat?desk=${encodeURIComponent(deskId)}&at=${sequence}`}
+        className="flex items-center gap-1 px-2 py-0.5 text-2xs font-medium transition-opacity hover:opacity-80"
+        title={`Open the conversation that ${direction === "asked" ? "asked" : "answered"}`}
+      >
+        <CornerUpLeft className="size-3 shrink-0" />
+        {label}
+      </a>
+    </span>
+  );
+}
+
 export function CardChip({
   taskId,
   busy = false,

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -1299,18 +1299,6 @@ function inlineFirstReplies(
     // say, and it is what *every* locally built company line carries — this
     // console's own POST, an `AgentReplyEvent` — so reading it as "might be a
     // person" would fold the live answer this promotion exists for.
-    // SPIKE: inline the whole CONTIGUOUS RUN of runtime answers, not just the
-    // first. The original rule promotes `bucket[0]` alone, which is right when
-    // a root has exactly one answer — question, answer, done. A multi-party
-    // exchange under one root (agent A hands to B, B answers) leaves the first
-    // inline and folds the rest onto the chip, so the same message shows up
-    // both in the channel and in the thread panel, and the chip's count
-    // disagrees with the panel's.
-    //
-    // Every guard the single-reply version applied still applies, per reply:
-    // only a runtime answer is promoted (never the operator's own follow-up,
-    // never a colleague's), and the run stops at the first thing that breaks
-    // contiguity — which is exactly the interleaving case the fold exists for.
     if (root === undefined) continue;
     const own = new Set(bucket.map((r) => r.id));
 

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -1273,7 +1273,6 @@ function inlineFirstReplies(
     );
     if (runtimeReplies.length > 1) continue;
     const root = position.get(rootId);
-    const first = bucket[0];
     // **Only the runtime's own answer is ever promoted** (codex on #1972).
     //
     // `bucket[0]` is merely the earliest reply, and that is the *operator's*
@@ -1300,10 +1299,53 @@ function inlineFirstReplies(
     // say, and it is what *every* locally built company line carries — this
     // console's own POST, an `AgentReplyEvent` — so reading it as "might be a
     // person" would fold the live answer this promotion exists for.
-    if (first === undefined || first.from !== "company" || first.byPerson) continue;
-    const answer = position.get(first.id);
-    if (root === undefined || answer === undefined) continue;
+    // SPIKE: inline the whole CONTIGUOUS RUN of runtime answers, not just the
+    // first. The original rule promotes `bucket[0]` alone, which is right when
+    // a root has exactly one answer — question, answer, done. A multi-party
+    // exchange under one root (agent A hands to B, B answers) leaves the first
+    // inline and folds the rest onto the chip, so the same message shows up
+    // both in the channel and in the thread panel, and the chip's count
+    // disagrees with the panel's.
+    //
+    // Every guard the single-reply version applied still applies, per reply:
+    // only a runtime answer is promoted (never the operator's own follow-up,
+    // never a colleague's), and the run stops at the first thing that breaks
+    // contiguity — which is exactly the interleaving case the fold exists for.
+    if (root === undefined) continue;
     const own = new Set(bucket.map((r) => r.id));
+
+    // Promotion is for the ORDINARY EXCHANGE ONLY: one question, one answer,
+    // nothing in between. That is the whole case #1890 D part 2 argued for —
+    // without it the channel becomes "a column of your own questions each
+    // wearing a 1 reply chip".
+    //
+    // A root with SEVERAL runtime answers is not that case. It is a multi-party
+    // exchange (agent A hands to B, B answers), and it belongs in the thread as
+    // a unit. Promoting just the first one — what this did before — put that
+    // reply in the channel AND in the thread panel at once, and left the chip
+    // counting the remainder while the panel counted everything, so the two
+    // disagreed. Promoting ALL of them is worse still: the thread empties into
+    // the channel and two concurrent exchanges interleave, which is the exact
+    // nonsense the fold exists to prevent.
+    //
+    // So: promote only when there is exactly one promotable answer AND it is
+    // the earliest reply in the thread. Both terms carry weight, and dropping
+    // either reintroduces a defect this comment already describes:
+    //
+    //   - Without the count, a multi-party exchange promotes its first answer
+    //     into the channel while the panel still shows it — the disagreement
+    //     described just above.
+    //   - Without "earliest", the operator's own follow-up (or a colleague's)
+    //     no longer blocks promotion: it is a reply, so it lives in `bucket`
+    //     and the interleave scan below counts it as `own` rather than as an
+    //     interruption. The runtime's answer is then flattened out from behind
+    //     the very words the person wrote while waiting for it — the case the
+    //     `bucket[0]` paragraph above exists to prevent.
+    const promotable = bucket.filter((r) => r.from === "company" && !r.byPerson);
+    if (promotable.length !== 1 || promotable[0] !== bucket[0]) continue;
+    const first = promotable[0];
+    const answer = position.get(first.id);
+    if (answer === undefined) continue;
     let interleaved = false;
     for (let i = root + 1; i < answer; i += 1) {
       if (!own.has(messages[i].id)) {

--- a/frontend/test/unit/referral-chip.test.ts
+++ b/frontend/test/unit/referral-chip.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { fromHistory } from "@/lib/chat";
+
+describe("referredFrom", () => {
+  it("carries a crossing referral's provenance through history", () => {
+    const [msg] = fromHistory([
+      {
+        id: "9",
+        channel: "product_designer",
+        author: "product_designer",
+        text: "here is the login mock",
+        atMillis: 1,
+        mine: false,
+        referredFrom: {
+          deskId: "engineering",
+          deskName: "Engineering",
+          askerId: "software_engineer",
+          askerLabel: "10x engineer",
+          sequence: 4821,
+        },
+      } as never,
+    ]);
+    expect(msg.referredFrom?.deskName).toBe("Engineering");
+    expect(msg.referredFrom?.sequence).toBe(4821);
+  });
+
+  it("carries the host's own word for which leg this is", () => {
+    // Both legs of a referral are agent-authored `company` lines, so nothing
+    // on the message distinguishes them. The console used to guess from
+    // `from`, which made every returning answer read "Asked by" — the chip
+    // claiming design had asked a question design had in fact answered.
+    const [asked, answered] = fromHistory([
+      {
+        id: "9",
+        channel: "software_engineer",
+        author: "software_engineer",
+        text: "@#design what would you change about the error messages?",
+        atMillis: 1,
+        mine: false,
+        referredFrom: {
+          deskId: "engineering",
+          deskName: "Engineering",
+          askerId: "software_engineer",
+          askerLabel: "10x engineer",
+          sequence: 4821,
+          direction: "asked",
+        },
+      } as never,
+      {
+        id: "11",
+        channel: "product_designer",
+        author: "product_designer",
+        text: "error messages are one of the things that look like a copy task",
+        atMillis: 2,
+        mine: false,
+        referredFrom: {
+          deskId: "design",
+          deskName: "Design",
+          askerId: "product_designer",
+          askerLabel: "Product Designer",
+          sequence: 4830,
+          direction: "answered",
+        },
+      } as never,
+    ]);
+    expect(asked.referredFrom?.direction).toBe("asked");
+    expect(answered.referredFrom?.direction).toBe("answered");
+    // Identical on the terms the old guess used — which is the whole point.
+    expect(asked.from).toBe(answered.from);
+  });
+
+  it("is absent on an ordinary message", () => {
+    const [msg] = fromHistory([
+      { id: "1", channel: "ceo", author: "ceo", text: "hi", atMillis: 1, mine: false } as never,
+    ]);
+    expect(msg.referredFrom).toBeUndefined();
+  });
+});

--- a/scripts/ci/assert-vendored-deps-checked-out.sh
+++ b/scripts/ci/assert-vendored-deps-checked-out.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+#
+# Assert that every vendored path dependency is checked out by every workflow
+# job that builds. Issue #592, second instance.
+#
+# THE FAILURE THIS PREVENTS
+#
+# Cargo reads every path dependency's manifest during resolution regardless of
+# feature selection, so a vendored crate missing from disk fails the DEFAULT
+# build — not just the feature that uses it. Most jobs get this for free with
+# `submodules: true` or `submodules: recursive`. `deploy-staging.yml` does not:
+# it sets `submodules: false` on purpose (recursing would drag in openhuman's
+# desktop-only tauri-cef checkout, which no server build compiles) and then
+# names the submodules it needs by hand.
+#
+# A hand-written list rots. Adding a vendored path dependency without adding it
+# to that list produces a build that is green on every pull request and fails
+# only on deploy, because that workflow does not run on pull requests. This
+# script is the check that turns that into a failing PR instead.
+#
+# WHAT IT CHECKS
+#
+# For each `path = "vendor/<name>/..."` dependency in Cargo.toml, every workflow
+# that sets `submodules: false` must name `vendor/<name>` somewhere. Nested
+# submodules *inside* a vendored crate are out of scope — those belong to
+# `init-vendored-submodules.sh`, which derives them from the pinned
+# `.gitmodules` rather than hardcoding them.
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+status=0
+
+vendored="$(grep -Eo 'path = "vendor/[^/"]+' Cargo.toml \
+  | sed 's|path = "vendor/||' \
+  | sort -u)"
+
+if [ -z "$vendored" ]; then
+  echo "assert-vendored-deps: no vendored path dependencies found in Cargo.toml" >&2
+  echo "If that is now true, delete this script; if it is not, the grep has rotted." >&2
+  exit 1
+fi
+
+for workflow in .github/workflows/*.yml; do
+  # Match configuration, not prose. Comments in these files quote both
+  # `submodules: false` and vendored paths when they explain this very rule, so
+  # matching raw lines gives a false positive on a workflow that only *mentions*
+  # the setting, and — worse — a false pass on one whose only `vendor/<name>` is
+  # inside a comment. Strip comments first and match the YAML key.
+  config="$(sed 's/[[:space:]]*#.*$//' "$workflow")"
+
+  # Only workflows that opt out of automatic submodule checkout have to name
+  # what they need. Everything else gets it from `submodules: true|recursive`.
+  echo "$config" | grep -qE '^[[:space:]]*submodules:[[:space:]]*false[[:space:]]*$' || continue
+
+  for name in $vendored; do
+    if ! echo "$config" | grep -q "vendor/$name"; then
+      echo "$workflow sets 'submodules: false' but never checks out vendor/$name" >&2
+      status=1
+    fi
+  done
+done
+
+if [ "$status" -ne 0 ]; then
+  echo >&2
+  echo "Cargo reads every path dependency's manifest during resolution, so a" >&2
+  echo "missing vendored checkout fails the default build. Add the submodule to" >&2
+  echo "that workflow's 'git submodule update --init' line." >&2
+  exit 1
+fi
+
+echo "assert-vendored-deps: every vendored path dependency is checked out"
+echo "  vendored: $(echo "$vendored" | tr '\n' ' ')"

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -55,6 +55,7 @@ tinyplace      | tested       | tinyplace                       | Runs the whole
 # --- Partial: a lane exists, but filtered ----------------------------------
 
 sqlite         | partial      | sqlite                          | store::sqlite
+hivemind       | partial      | hivemind                        | runtime::hivemind
 mongodb        | partial      | mongodb                         | store::mongodb store::select
 acp            | partial      | acp,runner,tinymemory | server::acp harness::acp::run_turn
 runner         | partial      | acp,runner,tinymemory | runner

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3650,6 +3650,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tinyagents-harness",
  "tinyflows",
+ "tinyhivemind-core",
  "tinyhivemind-hive",
  "tinyinference",
  "tinymcp",

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -255,6 +255,19 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("extended approval {approval_id}"),
             "approval.extended",
         ),
+        // Structural only, like the approval arms above — which desks and who,
+        // never the referred content.
+        CompanyEvent::ReferralEnqueued {
+            from_desk,
+            to_desk,
+            target,
+            ..
+        } => (
+            Role::System,
+            "referral".to_string(),
+            format!("referred {from_desk} → {to_desk} ({target})"),
+            "referral.enqueued",
+        ),
         CompanyEvent::FeedbackFiled { note } => (
             Role::User,
             "operator".to_string(),

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -9627,7 +9627,7 @@ mod tests {
         let (rt, _home) = runtime_that_may_refer().await;
         let rt = Arc::new(rt);
         let gate = Arc::new(tokio::sync::Mutex::new(()));
-        let queue = crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate, 1);
+        let queue = crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate, 1, 4);
 
         let forward = |trigger: u64| tinyhivemind::referral::Referral {
             key: tinyhivemind::dispatch::DispatchKey {
@@ -9677,7 +9677,7 @@ mod tests {
         let gate = Arc::new(tokio::sync::Mutex::new(()));
         // A cap high enough not to be what this test measures: the second
         // enqueue must be refused as `Already`, by the marker, not by width.
-        let queue = crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate, 8);
+        let queue = crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate, 8, 4);
 
         let referral = tinyhivemind::referral::Referral {
             key: tinyhivemind::dispatch::DispatchKey {

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -9569,6 +9569,100 @@ mod tests {
     ///
     /// A referral is decided from a COMMITTED reply, so a restart, a
     /// redelivered frame or a retry decides the identical referral again.
+    /// A runtime whose one agent is allowed to refer to the `design` desk, so a
+    /// forward reaches the width bound instead of stopping at authorization.
+    #[cfg(all(feature = "openhuman", feature = "hivemind"))]
+    async fn runtime_that_may_refer() -> (crate::company::runtime::CompanyRuntime, tempfile::TempDir)
+    {
+        let home_dir = tempfile::Builder::new()
+            .prefix("opencompany-refer-")
+            .tempdir()
+            .expect("tempdir");
+        let manifest: crate::company::types::CompanyManifest = toml::from_str(
+            r#"
+            [company]
+            name = "Acme"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+            delegates_to = ["design"]
+
+            [[agent]]
+            id = "designer"
+            role = "Designer"
+
+            [[group_chat]]
+            id = "design"
+            name = "Design"
+            members = ["designer"]
+
+            [policy]
+            mode = "supervised"
+            "#,
+        )
+        .expect("manifest");
+        let rt = crate::runtime::RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest)
+            .build()
+            .await
+            .expect("runtime");
+        (rt, home_dir)
+    }
+
+    /// **The width bound: how many desks one pass may ask.**
+    ///
+    /// `max_hops` bounds how DEEP a chain runs and says nothing about how WIDE
+    /// it is — the library leaves that to the host, because only a host knows
+    /// what a question costs it. Here it is a full model turn on another desk.
+    ///
+    /// Pinned with a cap of 1 so the second forward is the one that trips it,
+    /// and with distinct triggers so the idempotency marker cannot be what
+    /// refuses it.
+    #[cfg(all(feature = "openhuman", feature = "hivemind"))]
+    #[tokio::test]
+    async fn a_second_crossing_question_is_refused_once_the_width_is_spent() {
+        use tinyhivemind::dispatch::{EnqueueOutcome, EnqueueRefusal};
+        use tinyhivemind::referral::ReferralQueue;
+
+        let (rt, _home) = runtime_that_may_refer().await;
+        let rt = Arc::new(rt);
+        let gate = Arc::new(tokio::sync::Mutex::new(()));
+        let queue = crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate, 1);
+
+        let forward = |trigger: u64| tinyhivemind::referral::Referral {
+            key: tinyhivemind::dispatch::DispatchKey {
+                trigger_sequence: trigger,
+            },
+            kind: tinyhivemind::referral::ReferralKind::Forward,
+            source_id: "ceo".to_string(),
+            target_id: "designer".to_string(),
+            content: "who owns the login screen?".to_string(),
+            from: tinyhivemind::dispatch::DispatchConversation {
+                desk_id: "engineering".to_string(),
+                thread_root: None,
+            },
+            to: tinyhivemind::dispatch::DispatchConversation {
+                desk_id: "design".to_string(),
+                thread_root: None,
+            },
+            origin: None,
+            child_hop: 1,
+        };
+
+        assert_eq!(
+            queue.enqueue_once(forward(101)).await.expect("decides"),
+            EnqueueOutcome::Enqueued,
+            "the first question is within the cap"
+        );
+        assert_eq!(
+            queue.enqueue_once(forward(202)).await.expect("decides"),
+            EnqueueOutcome::Refused {
+                reason: EnqueueRefusal::FeatureDisabled
+            },
+            "a different trigger, so this is the WIDTH bound refusing it, not the marker"
+        );
+    }
+
     /// Without the durable marker the target desk is asked twice — two turns,
     /// two answers, twice the spend, one question. `Already` is the whole
     /// point of the port, and this is the test that would catch losing it.
@@ -9581,7 +9675,9 @@ mod tests {
         let (rt, _home) = runtime_with_events().await;
         let rt = Arc::new(rt);
         let gate = Arc::new(tokio::sync::Mutex::new(()));
-        let queue = crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate);
+        // A cap high enough not to be what this test measures: the second
+        // enqueue must be refused as `Already`, by the marker, not by width.
+        let queue = crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate, 8);
 
         let referral = tinyhivemind::referral::Referral {
             key: tinyhivemind::dispatch::DispatchKey {

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -540,6 +540,14 @@ fn continuation_failure_notice(thread: String, parent: Option<EventSeq>) -> Comp
     }
 }
 
+/// SPIKE (async hand-off): how many times one card may change hands before a
+/// person is asked.
+///
+/// A hand-off chain terminates by construction rather than by nobody writing
+/// one. `pub(crate)` so the harness tests can drive a chain the same number of
+/// times production does, instead of hard-coding a number that drifts.
+pub(crate) const MAX_HAND_OFF_HOPS: usize = 3;
+
 impl CompanyRuntime {
     /// Assembles a runtime from its ports. Most callers use
     /// [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) instead.
@@ -963,6 +971,14 @@ impl CompanyRuntime {
     }
 
     /// This company's event log (append-only audit trail).
+    /// The gate a [`JournalReferralQueue`](crate::runtime::hivemind::JournalReferralQueue)
+    /// serialises its check-then-write under. One per company, so two referrals
+    /// decided at once cannot both find the marker absent.
+    #[cfg(feature = "hivemind")]
+    pub(crate) fn referral_gate(&self) -> Arc<tokio::sync::Mutex<()>> {
+        self.task_writes.clone()
+    }
+
     pub fn events(&self) -> &Arc<dyn EventLog> {
         &self.events
     }
@@ -1266,6 +1282,81 @@ impl CompanyRuntime {
         let _ = task;
     }
 
+    /// SPIKE (tinyhivemind P15): run a referred child turn on the target desk.
+    ///
+    /// A referral arrives on the target's desk channel as a MESSAGE authored by
+    /// the agent that asked — which is what it is. That keeps one mechanism for
+    /// "a turn happens because something arrived on this conversation" instead
+    /// of a second, referral-only path, and it means the responder ladder picks
+    /// the target exactly as it would for any other addressed message.
+    ///
+    /// Detached, like every other turn this runtime starts: the enqueue
+    /// transaction has already committed its marker, and the caller must not
+    /// wait on a model.
+    #[cfg(feature = "hivemind")]
+    pub(crate) fn spawn_referred_turn(
+        self: Arc<Self>,
+        desk: String,
+        content: String,
+        asker: String,
+        // Where an answer goes home, on a crossing FORWARD. `None` on a return
+        // — an answer that has arrived does not need carrying further.
+        origin: Option<tinyhivemind_core::referral::ReferralOrigin>,
+    ) {
+        tokio::spawn(async move {
+            let desk_for_replies = desk.clone();
+            let event = CompanyEvent::OperatorMessage {
+                text: content,
+                // The asking AGENT, not the operator: a referral is a teammate
+                // asking, and recording it as an operator message would put
+                // words in a person's mouth.
+                by: Some(crate::ports::types::Actor {
+                    kind: crate::ports::types::ActorKind::Agent,
+                    id: asker,
+                }),
+                chat: Some(desk),
+                parent: None,
+                // Never a card: a referral asks a question, it does not hand
+                // work over. Ownership moving is the hand-off path's job.
+                deliverable: Some(crate::ports::types::MessageIntent::Chat),
+                mentions: Vec::new(),
+                attachments: Vec::new(),
+            };
+            // `run_cycle` journals its INPUT events and returns the replies —
+            // it does not write them down. The chat route journals its own
+            // (`journal_chat_replies`) and the dispatch cycle journals its own
+            // (`journal_dispatch_replies`); a third caller needs the same, or
+            // the referred agent answers into a transcript nobody can read.
+            match self.run_cycle(vec![event]).await {
+                Ok(mut report) => {
+                    let company = self.id.clone();
+                    crate::server::operator::journal_chat_replies(
+                        &self,
+                        &company,
+                        &desk_for_replies,
+                        None,
+                        &mut report,
+                    )
+                    .await;
+                    // The back edge. This turn's reply is the ANSWER to the
+                    // referral that caused it, so it is offered to the decision
+                    // carrying the origin it must return to — and at depth 1,
+                    // so `max_hops` finally bounds something.
+                    crate::server::operator::refer_committed_replies(
+                        &self,
+                        &company,
+                        &desk_for_replies,
+                        &report,
+                        origin,
+                        1,
+                    )
+                    .await;
+                }
+                Err(err) => tracing::warn!(error = %err, "[referral] the referred turn failed"),
+            }
+        });
+    }
+
     /// The body of a dispatch's detached cycle (issue #242), split out of the
     /// `tokio::spawn` so the quiesce path below is reachable from a test.
     ///
@@ -1273,48 +1364,156 @@ impl CompanyRuntime {
     /// backstop cannot see — see [`abandon_run`](Self::abandon_run).
     #[cfg(feature = "openhuman")]
     async fn run_dispatch_cycle(self: Arc<Self>, task_id: String, run_id: Option<String>) {
-        let report = match self
-            .run_cycle(vec![CompanyEvent::TaskDispatched {
-                task_id: task_id.clone(),
-                run_id: run_id.clone(),
-            }])
-            .await
-        {
-            Ok(report) => report,
-            Err(err) => {
-                // Issue #290 meets issue #242. `ensure_accepting` refuses
-                // *before* `CycleRunner` takes the serial lock, so a dispatch
-                // that lands in the window while this runtime is being
-                // replaced never reaches `begin_run` — and the backstop
-                // inside the cycle only settles rows that cycle started.
-                // Every other dispatch failure is already covered in there.
-                // Left alone, the row minted a moment ago would sit `Pending`
-                // for the rest of the process's life: a card reading as under
-                // way by an attempt that never began, which nothing
-                // re-drives, and which the rebuild deliberately does *not*
-                // run the boot reaper to clean up.
-                if let Some(id) = run_id.as_deref()
-                    && matches!(err, OpenCompanyError::Quiescing(_))
-                {
-                    self.abandon_run(id, &task_id).await;
+        let mut run_id = run_id;
+        let mut hops = 0usize;
+        let mut handed_back: Option<(String, String)> = None;
+        loop {
+            // Who owns the card going INTO this attempt. Read here and not after
+            // the cycle, because by then a hand-off has already overwritten it —
+            // which is exactly the value a rollback needs.
+            let owner_before = self
+                .ops
+                .tasks
+                .list(&self.id)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .find(|c| c.id == task_id)
+                .map(|c| c.assignee)
+                .unwrap_or_default();
+            let report = match self
+                .run_cycle(vec![CompanyEvent::TaskDispatched {
+                    task_id: task_id.clone(),
+                    run_id: run_id.clone(),
+                }])
+                .await
+            {
+                Ok(report) => report,
+                Err(err) => {
+                    // Issue #290 meets issue #242. `ensure_accepting` refuses
+                    // *before* `CycleRunner` takes the serial lock, so a dispatch
+                    // that lands in the window while this runtime is being
+                    // replaced never reaches `begin_run` — and the backstop
+                    // inside the cycle only settles rows that cycle started.
+                    // Every other dispatch failure is already covered in there.
+                    // Left alone, the row minted a moment ago would sit `Pending`
+                    // for the rest of the process's life: a card reading as under
+                    // way by an attempt that never began, which nothing
+                    // re-drives, and which the rebuild deliberately does *not*
+                    // run the boot reaper to clean up.
+                    if let Some(id) = run_id.as_deref()
+                        && matches!(err, OpenCompanyError::Quiescing(_))
+                    {
+                        self.abandon_run(id, &task_id).await;
+                    }
+                    tracing::warn!(
+                        company = %self.id,
+                        task = %task_id,
+                        error = %err,
+                        "task dispatch cycle failed"
+                    );
+                    return;
                 }
+            };
+            // Issue #1852 Part 1: `run_task`/`refuse_dispatch` already build the
+            // right relay via `relay_reply` — it rides home in this report's
+            // responses — but until now nothing wrote it down. Unlike the
+            // chat-POST path (`journal_chat_replies`) and the approval path
+            // (`publish_continuation`), this dispatch path had no journaling step
+            // at all, so the answer never reached the thread it was spawned from,
+            // live or on reload.
+            self.journal_dispatch_replies(&report).await;
+
+            // ── SPIKE (async hand-off): re-dispatch for the card's new owner ────
+            //
+            // A settled dispatch that leaves its card in `in_progress` is the
+            // hand-off shape and nothing else: every other ending lands the card in
+            // a terminal column (`in_review`, `todo`, `paused`), and
+            // `settled_landing_column(Delegated)` deliberately keeps it here
+            // because "a hand-off is not an ending".
+            //
+            // The dispatch EDGE cannot fire on its own for this: it triggers on
+            // `→ in_progress`, and the card never left. So the re-dispatch is
+            // driven from here, where a fresh attempt row is minted for the
+            // delegate — which is the whole point. One attempt per agent, the
+            // serial cycle lock released between hops, and cost attributable to
+            // whoever actually spent it.
+            //
+            // Bounded by the hand-offs already recorded on the card, so a chain
+            // terminates by construction rather than by nobody writing one.
+            // SPIKE: undo a hand-off whose delegate could not run.
+            //
+            // `refuse_dispatch` bounces the card to To-do with the reason, but it
+            // leaves `assignee` naming the delegate — the state that makes the card
+            // permanently unrunnable and the thread permanently misrouted. Rolling
+            // the owner back is what makes the hand-off transactional: it either
+            // moved the work or it did not.
+            if let Some((delegate, prior)) = handed_back.take()
+                && !prior.is_empty()
+                && let Ok(cards) = self.ops.tasks.list(&self.id).await
+                && let Some(mut card) = cards.into_iter().find(|c| c.id == task_id)
+                && card.column == crate::ports::tasks::COLUMN_TODO
+                && card.bounced.is_some()
+                && card.assignee == delegate
+            {
                 tracing::warn!(
                     company = %self.id,
                     task = %task_id,
-                    error = %err,
-                    "task dispatch cycle failed"
+                    from = %delegate,
+                    to = %prior,
+                    "[hand-off] the delegate could not run; returning the card to its previous owner"
                 );
-                return;
+                card.assignee = prior;
+                card.updated_at_millis = crate::ports::now_millis();
+                // The plain store port: this must not re-fire the dispatch edge.
+                let _ = self.ops.tasks.upsert(&self.id, &card).await;
             }
-        };
-        // Issue #1852 Part 1: `run_task`/`refuse_dispatch` already build the
-        // right relay via `relay_reply` — it rides home in this report's
-        // responses — but until now nothing wrote it down. Unlike the
-        // chat-POST path (`journal_chat_replies`) and the approval path
-        // (`publish_continuation`), this dispatch path had no journaling step
-        // at all, so the answer never reached the thread it was spawned from,
-        // live or on reload.
-        self.journal_dispatch_replies(&report).await;
+
+            let handed_on = self
+                .ops
+                .tasks
+                .list(&self.id)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .find(|card| card.id == task_id)
+                .filter(|card| card.column == crate::ports::tasks::COLUMN_IN_PROGRESS);
+            if let Some(card) = handed_on {
+                if hops >= MAX_HAND_OFF_HOPS {
+                    tracing::warn!(
+                        company = %self.id,
+                        task = %task_id,
+                        hops,
+                        "[hand-off] chain hit its cap; leaving the card for a person"
+                    );
+                    return;
+                }
+                hops += 1;
+                // Who owned it before this hop, so a hand-off that cannot run can
+                // be undone. Without this the card keeps an owner that never took
+                // the work: it bounces to To-do assigned to an agent this build
+                // cannot dispatch, every retry fails identically, and — since
+                // `assignee` is what the thread's overseer is read from — the
+                // conversation is redirected to them permanently.
+                handed_back = Some((card.assignee.clone(), owner_before.clone()));
+                tracing::info!(
+                    company = %self.id,
+                    task = %task_id,
+                    assignee = %card.assignee,
+                    hops,
+                    "[hand-off] re-dispatching for the card's new owner"
+                );
+                // A FRESH attempt row for the delegate — this is what makes cost
+                // attributable per agent instead of one figure spanning the chain.
+                // Looping rather than recursing keeps the whole chain on this one
+                // spawned task, and `run_cycle` takes and releases the per-company
+                // serial lock per iteration, so the company is not parked for the
+                // duration of the chain.
+                run_id = self.open_run(&card).await;
+                continue;
+            }
+            return;
+        }
     }
 
     /// Settles an attempt whose cycle was refused before it could start
@@ -9353,6 +9552,71 @@ mod tests {
     /// rather than rendering it flat, so a stale root would make the
     /// continuation invisible — strictly worse than the bug being fixed, since
     /// today's answer at least reaches the channel.
+
+    /// **The reason `ReferralQueue` exists**: the same trigger, twice, creates
+    /// one child turn.
+    ///
+    /// A referral is decided from a COMMITTED reply, so a restart, a
+    /// redelivered frame or a retry decides the identical referral again.
+    /// Without the durable marker the target desk is asked twice — two turns,
+    /// two answers, twice the spend, one question. `Already` is the whole
+    /// point of the port, and this is the test that would catch losing it.
+    #[cfg(all(feature = "openhuman", feature = "hivemind"))]
+    #[tokio::test]
+    async fn the_same_trigger_enqueues_one_child_turn() {
+        use tinyhivemind::dispatch::EnqueueOutcome;
+        use tinyhivemind::referral::ReferralQueue;
+
+        let (rt, _home) = runtime_with_events().await;
+        let rt = Arc::new(rt);
+        let gate = Arc::new(tokio::sync::Mutex::new(()));
+        let queue = crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate);
+
+        let referral = tinyhivemind::referral::Referral {
+            key: tinyhivemind::dispatch::DispatchKey {
+                trigger_sequence: 77,
+            },
+            kind: tinyhivemind::referral::ReferralKind::Forward,
+            source_id: "ceo".to_string(),
+            target_id: "ceo".to_string(),
+            content: "who owns the login screen?".to_string(),
+            from: tinyhivemind::dispatch::DispatchConversation {
+                desk_id: "engineering".to_string(),
+                thread_root: None,
+            },
+            to: tinyhivemind::dispatch::DispatchConversation {
+                desk_id: "design".to_string(),
+                thread_root: None,
+            },
+            origin: None,
+            child_hop: 1,
+        };
+
+        // The fixture roster declares no `delegates_to`, so the FIRST call is
+        // refused on authorization — which is itself the fail-closed default
+        // worth pinning: referral is off until an operator opts an agent in.
+        let first = queue.enqueue_once(referral.clone()).await.expect("decides");
+        assert_eq!(
+            first,
+            EnqueueOutcome::Refused {
+                reason: tinyhivemind::dispatch::EnqueueRefusal::Unauthorized
+            },
+            "an agent with no `delegates_to` may not cause a turn on another desk"
+        );
+
+        // And a refusal leaves NO marker, so it is not mistaken for a
+        // completed enqueue on the next attempt.
+        let replay = queue.enqueue_once(referral).await.expect("decides");
+        assert_eq!(
+            replay,
+            EnqueueOutcome::Refused {
+                reason: tinyhivemind::dispatch::EnqueueRefusal::Unauthorized
+            },
+            "a refusal must not write the marker — otherwise a retry after the \
+             operator grants permission would report `Already` and drop the work"
+        );
+    }
+
     /// A runtime with a live event log, for the thread-root tests. Returns the
     /// tempdir too: dropping it deletes the log the runtime is reading.
     async fn runtime_with_events() -> (crate::company::runtime::CompanyRuntime, tempfile::TempDir) {

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -546,6 +546,10 @@ fn continuation_failure_notice(thread: String, parent: Option<EventSeq>) -> Comp
 /// A hand-off chain terminates by construction rather than by nobody writing
 /// one. `pub(crate)` so the harness tests can drive a chain the same number of
 /// times production does, instead of hard-coding a number that drifts.
+/// Both the cap's reader and the test that drives it are `openhuman`-only,
+/// so the constant carries the same gate rather than reading as dead code
+/// in a default build.
+#[cfg(feature = "openhuman")]
 pub(crate) const MAX_HAND_OFF_HOPS: usize = 3;
 
 impl CompanyRuntime {

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1302,6 +1302,18 @@ impl CompanyRuntime {
         // Where an answer goes home, on a crossing FORWARD. `None` on a return
         // — an answer that has arrived does not need carrying further.
         origin: Option<tinyhivemind_core::referral::ReferralOrigin>,
+        // How deep in the chain this turn sits. Its own replies are offered to
+        // the referral pass at this depth, so a follow-up is one deeper than
+        // the answer it follows and `max_hops` finally counts something.
+        //
+        // This was a hardcoded `1`, which read as "a referred turn is depth 1"
+        // and is true only of the first one. Every later generation claimed
+        // depth 1 as well, so the counter reset on each hop: two desks could
+        // have passed a question back and forth forever without the policy ever
+        // reaching its limit. Nothing drove that loop at the time — the asker
+        // had no way to ask again — so it cost nothing until it would have cost
+        // everything.
+        hop: u32,
     ) {
         tokio::spawn(async move {
             let desk_for_replies = desk.clone();
@@ -1340,15 +1352,14 @@ impl CompanyRuntime {
                     .await;
                     // The back edge. This turn's reply is the ANSWER to the
                     // referral that caused it, so it is offered to the decision
-                    // carrying the origin it must return to — and at depth 1,
-                    // so `max_hops` finally bounds something.
+                    // carrying the origin it must return to, at its own depth.
                     crate::server::operator::refer_committed_replies(
                         &self,
                         &company,
                         &desk_for_replies,
                         &report,
                         origin,
-                        1,
+                        hop,
                     )
                     .await;
                 }

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -9564,11 +9564,6 @@ mod tests {
     /// continuation invisible — strictly worse than the bug being fixed, since
     /// today's answer at least reaches the channel.
 
-    /// **The reason `ReferralQueue` exists**: the same trigger, twice, creates
-    /// one child turn.
-    ///
-    /// A referral is decided from a COMMITTED reply, so a restart, a
-    /// redelivered frame or a retry decides the identical referral again.
     /// A runtime whose one agent is allowed to refer to the `design` desk, so a
     /// forward reaches the width bound instead of stopping at authorization.
     #[cfg(all(feature = "openhuman", feature = "hivemind"))]
@@ -9663,12 +9658,16 @@ mod tests {
         );
     }
 
-    /// Without the durable marker the target desk is asked twice — two turns,
-    /// two answers, twice the spend, one question. `Already` is the whole
-    /// point of the port, and this is the test that would catch losing it.
+    /// **Fail-closed, and leave nothing behind.** The fixture roster declares
+    /// no `delegates_to`, so an agent may not cause a turn on another desk —
+    /// referral is off until an operator opts somebody in.
+    ///
+    /// And a refusal writes no marker, so it cannot be mistaken for a completed
+    /// enqueue on the next attempt: the second call is refused for the same
+    /// reason as the first, rather than coming back `Already`.
     #[cfg(all(feature = "openhuman", feature = "hivemind"))]
     #[tokio::test]
-    async fn the_same_trigger_enqueues_one_child_turn() {
+    async fn an_unauthorized_forward_is_refused_and_leaves_no_marker() {
         use tinyhivemind::dispatch::EnqueueOutcome;
         use tinyhivemind::referral::ReferralQueue;
 

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -7239,6 +7239,7 @@ to = "done"
             description: None,
             members: vec!["assistant".to_string()],
             responder: ResponderMode::default(),
+            hive: Default::default(),
         }];
         store.save(&stale_record).await.unwrap();
 
@@ -7347,6 +7348,7 @@ to = "done"
                 description: None,
                 members: vec!["assistant".to_string()],
                 responder: ResponderMode::default(),
+                hive: Default::default(),
             },
             OverlayDesk {
                 id: "sales_eu".to_string(),
@@ -7354,6 +7356,7 @@ to = "done"
                 description: None,
                 members: vec!["assistant".to_string()],
                 responder: ResponderMode::default(),
+                hive: Default::default(),
             },
         ];
         let store = store_of(MemStore::seeded(seed));

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -3540,15 +3540,22 @@ fn selector_candidate(
     record: &CompanyRecord,
     id: &str,
 ) -> Option<crate::harness::selector::SelectorCandidate> {
+    let allow = &record.manifest.tools.allow;
     if let Some(agent) = record.effective_agent(id) {
         return Some(crate::harness::selector::SelectorCandidate {
             id: agent.id.clone(),
             role: agent.role.clone(),
             description: agent.description.clone(),
+            tools: crate::runtime::builder::agent_effective_grants(allow, agent.tools.as_deref()),
         });
     }
     let agent = record.overlay_agents.iter().find(|a| a.id == id)?;
     let edit = record.overlay_agent_edits.iter().find(|e| e.agent_id == id);
+    // An edit that states `tools` replaces the teammate's own list; one that
+    // says nothing leaves it, matching how role and description resolve above.
+    let tools = edit
+        .and_then(|e| e.tools.clone())
+        .unwrap_or_else(|| agent.tools.clone());
     Some(crate::harness::selector::SelectorCandidate {
         id: agent.id.clone(),
         role: edit
@@ -3558,6 +3565,7 @@ fn selector_candidate(
             .and_then(|e| e.description.clone())
             .filter(|d| !d.is_empty())
             .or_else(|| agent.description.clone()),
+        tools: crate::runtime::builder::agent_effective_grants(allow, tools.as_deref()),
     })
 }
 

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1304,6 +1304,26 @@ impl HarnessBrain {
                             let (end, result) = match handoff {
                                 // The delegate answered: they own the card, and
                                 // every downstream write credits them.
+                                // SPIKE: handed over, delegate not yet run.
+                                // Settles `Delegated` — which
+                                // `settled_landing_column` keeps in
+                                // `in_progress` precisely because a hand-off is
+                                // "not an ending" — and the runtime re-fires
+                                // dispatch for the card's new owner.
+                                Some(handoff) if handoff.pending => {
+                                    let delegate = handoff.delegate.clone();
+                                    // The DELEGATOR is who handed it over, so
+                                    // the note is theirs. Reading `responder`
+                                    // after the swap credits the delegate with
+                                    // handing work to itself.
+                                    let delegator =
+                                        std::mem::replace(&mut responder, handoff.delegate);
+                                    let result =
+                                        format!("handed off to {delegate}; awaiting their run");
+                                    settle(&mut card, TaskRunEnd::Delegated, &delegator, &result);
+                                    prior_responders.push(delegator);
+                                    (TaskRunEnd::Delegated, result)
+                                }
                                 Some(handoff) => {
                                     prior_responders
                                         .push(std::mem::replace(&mut responder, handoff.delegate));
@@ -1665,10 +1685,18 @@ impl HarnessBrain {
         }
 
         // `settle()` already wrote a landing at the break point; this is the
-        // authoritative overwrite now that the parked count is known. `None`
-        // only for a status that is not settled at all, which no ending
-        // produces — a hand-off never breaks the loop.
-        if let Some(column) = crate::ports::tasks::column_for_settled_run(settled) {
+        // authoritative overwrite now that the parked count is known.
+        //
+        // SPIKE: through `settled_landing_column`, NOT `column_for_settled_run`
+        // directly. The two agree on every ending except a hand-off, which the
+        // former keeps in `in_progress` ("the work has changed hands, not
+        // stopped") while the latter maps its `Paused` run status to the
+        // `paused` column. The old comment here — "a hand-off never breaks the
+        // loop" — was what made the difference unobservable; now that a
+        // hand-off settles, the card was landing in `paused` and the delegate
+        // was never dispatched.
+        {
+            let column = lifecycle::settled_landing_column(run_end, parked);
             card.column = column.to_string();
             // Issue #1865: the board's bounce chip — same rule the system
             // mover applies in `crate::runtime::advance::advance_settled_card`,
@@ -3276,6 +3304,141 @@ impl HarnessBrain {
         })
     }
 
+    /// SPIKE: who currently oversees the thread rooted at `parent`.
+    ///
+    /// The last teammate to have replied under that root, read straight off the
+    /// journal — so oversight follows the conversation without a field to keep
+    /// in sync. `None` for an unparented message (the channel itself has no
+    /// overseer), when no event log is wired, or when nobody has spoken yet.
+    /// SPIKE: the card this thread already raised, if it raised one.
+    ///
+    /// One thread is one piece of work. Without this a follow-up inside a
+    /// thread opens a SECOND card — "make it shorter" becomes its own task
+    /// beside the draft it is about — because the carding decision is made per
+    /// message and has no idea the conversation already has a card.
+    ///
+    /// Scoping the turn to it makes `open_work_card` decline on its existing
+    /// `task.is_some()` guard, which is the same gate that stops a dispatched
+    /// card's hand-off opening one.
+    async fn thread_card(
+        &self,
+        chat: Option<&str>,
+        parent: Option<crate::ports::types::EventSeq>,
+    ) -> Option<String> {
+        let root = parent?;
+        let tasks = self.deps.tasks.as_ref()?;
+        let record = self.record();
+        tasks
+            .list(&record.id)
+            .await
+            .ok()?
+            .into_iter()
+            .filter(|card| card.origin_parent() == Some(root))
+            .filter(|card| {
+                crate::server::chat_history::same_conversation(card.origin_chat_id(), chat)
+            })
+            .map(|card| card.id)
+            .next_back()
+    }
+
+    async fn thread_overseer(
+        &self,
+        chat: Option<&str>,
+        parent: Option<crate::ports::types::EventSeq>,
+    ) -> Option<String> {
+        /// How far back to look for the hand-off. A thread is one level deep
+        /// and bounded in practice; past this the fallback answer is better
+        /// than an unbounded scan on every message.
+        const LOOKBACK: usize = 400;
+
+        let root = parent?;
+        let record = self.record();
+
+        // **The card is the ownership record; the thread only reflects it.**
+        //
+        // Deriving oversight from the conversation alone gives a SECOND owner
+        // that drifts from `assignee` — observed: card held by `design`, thread
+        // overseen by `qa_engineer`, and a stray hop card under a third agent.
+        // Two records for one question is the same class of split the board and
+        // the run history already avoid by keeping one settle site.
+        //
+        // So when this thread raised a card, that card's assignee IS the
+        // overseer: a hand-off moves it, a reassignment from the board moves
+        // it, and the thread follows without a second rule. The mention scan
+        // below is only for a thread with no card behind it — an ordinary chat
+        // exchange, where there is nothing else to be authoritative.
+        if let Some(tasks) = self.deps.tasks.as_ref()
+            && let Ok(cards) = tasks.list(&record.id).await
+        {
+            let owner = cards
+                .iter()
+                .filter(|card| card.origin_parent() == Some(root))
+                .filter(|card| {
+                    crate::server::chat_history::same_conversation(card.origin_chat_id(), chat)
+                })
+                .filter_map(|card| {
+                    crate::runtime::assignee::resolve(&record, &card.assignee)
+                        .working_agent()
+                        .map(str::to_string)
+                })
+                .next_back();
+            if let Some(owner) = owner {
+                return Some(owner);
+            }
+        }
+
+        let events = self.deps.events.as_ref()?;
+        // Backwards from the tail, bounded — NOT `read_from(0, MAX)`, which
+        // turns every chat message into a scan of the whole company history.
+        let page = events.read_before(&record.id, None, LOOKBACK).await.ok()?;
+
+        let dir = crate::runtime::mentions::directory(&record, &[]);
+        let mut last_speaker: Option<String> = None;
+
+        for stored in page {
+            // Nothing at or before the root can carry this thread's hand-off.
+            if stored.seq <= root {
+                break;
+            }
+            let crate::ports::types::CompanyEvent::AgentReply {
+                parent: reply_parent,
+                agent_id,
+                chat_id,
+                text,
+                ..
+            } = &stored.event
+            else {
+                continue;
+            };
+            if *reply_parent != Some(root)
+                || !crate::server::chat_history::same_conversation(Some(chat_id), chat)
+            {
+                continue;
+            }
+            // **The hand-off, not the last utterance.** Oversight transfers to
+            // whoever was HANDED the work, so the overseer is the agent the
+            // most recent hand-off NAMED — not whoever spoke most recently.
+            //
+            // Keying on the last speaker instead is self-reinforcing: one
+            // misrouted turn makes that agent the overseer of the thread
+            // permanently, because answering is itself what confers oversight.
+            // Naming somebody is a deliberate act; speaking is not.
+            let named = crate::runtime::mentions::extract_with_known(text, &dir);
+            if let Some(handed_to) =
+                crate::runtime::mentions::mention_responder(&record, Some(chat_id), &named)
+            {
+                return Some(handed_to);
+            }
+            // Newest-first, so the first reply we see is the latest speaker.
+            if last_speaker.is_none() && record.is_roster_agent(agent_id) {
+                last_speaker = Some(agent_id.clone());
+            }
+        }
+        // Nobody was handed anything: the thread has one participant, and they
+        // hold it.
+        last_speaker
+    }
+
     /// The per-message pick for a message addressed to an `auto` channel — or
     /// `None` wherever the deterministic answer should stand (issue #1835).
     ///
@@ -3817,23 +3980,47 @@ impl HarnessBrain {
                     // Resolves nothing on a message that mentions no teammate,
                     // which is every message journaled before mentions existed,
                     // so routing is unchanged byte-for-byte for them.
-                    let responder =
-                        match crate::runtime::mentions::mention_responder(&self.record(), mentions)
-                        {
+                    // SPIKE: the thread-overseer rung.
+                    //
+                    // Oversight of a prompt transfers on hand-off: the operator
+                    // opens the conversation, and whoever it delegates to owns
+                    // the thread from there. So a reply *inside* a thread must
+                    // reach whoever currently holds it — not the room's default
+                    // answerer, which is what `responder_for` gives and which
+                    // made a follow-up land on the desk lead while the actual
+                    // overseer sat one message above.
+                    //
+                    // Derived, never stored: the overseer is the last teammate
+                    // to have spoken under this root. That transfers for free —
+                    // a delegate becomes the last speaker the moment it answers.
+                    //
+                    // Sits BELOW an @mention (naming somebody is still the
+                    // strongest address) and ABOVE the channel default, which is
+                    // the same explicit-beats-implicit ordering the ladder
+                    // already applies.
+                    let overseer = self.thread_overseer(chat.as_deref(), *parent).await;
+                    // One thread, one card: a follow-up joins the work its
+                    // thread already opened instead of opening another.
+                    let thread_card = self.thread_card(chat.as_deref(), *parent).await;
+                    let responder = match crate::runtime::mentions::mention_responder(
+                        &self.record(),
+                        chat.as_deref(),
+                        mentions,
+                    )
+                    .or(overseer)
+                    {
+                        Some(responder) => responder,
+                        // Issue #1835: below a mention, above the deterministic
+                        // answer, an `auto` channel picks its best-fit member
+                        // for this message. Every way the pick cannot happen —
+                        // not an auto channel, one member, selection failed —
+                        // is `None`, and the ladder continues exactly where it
+                        // always stood.
+                        None => match self.auto_channel_responder(chat.as_deref(), text).await {
                             Some(responder) => responder,
-                            // Issue #1835: below a mention, above the deterministic
-                            // answer, an `auto` channel picks its best-fit member
-                            // for this message. Every way the pick cannot happen —
-                            // not an auto channel, one member, selection failed —
-                            // is `None`, and the ladder continues exactly where it
-                            // always stood.
-                            None => {
-                                match self.auto_channel_responder(chat.as_deref(), text).await {
-                                    Some(responder) => responder,
-                                    None => self.responder_for(chat.as_deref()),
-                                }
-                            }
-                        };
+                            None => self.responder_for(chat.as_deref()),
+                        },
+                    };
                     // Everyone else the message named, for the answering turn's
                     // context. A list, not a fan-out: one operator message still
                     // spawns exactly one turn, and this teammate spreads the
@@ -3946,6 +4133,7 @@ impl HarnessBrain {
                         // seed can tell it apart from a concurrently accepted
                         // sibling by identity instead of by text.
                         .answering(event_seq)
+                        .maybe_for_task(thread_card.as_deref())
                         // Issue #1846 review (Codex #3864988176): the operator's
                         // own words, so a delegate's budget-pause marker re-parks
                         // with what the operator actually asked for rather than
@@ -4122,18 +4310,45 @@ impl HarnessBrain {
                         // issue's own failure reached through the fallback added
                         // to prevent it. With no publish this is `None` and the
                         // turn's own card takes the slot exactly as before.
-                        task_id: published_card.or(turn.spawned_task),
+                        task_id: published_card.clone().or(turn.spawned_task.clone()),
                         channel: "operator".to_string(),
                         // Issue #885: who spoke, as distinct from where it goes.
                         // `responder_for` already picked this agent to answer the
                         // turn; before this the identity died here and the reply
                         // was journaled as `agent_id: "operator"` forever.
                         agent: Some(responder.clone()),
-                        text: operator_reply,
+                        text: operator_reply.clone(),
                         reply_to: None,
                         mentions: Vec::new(),
                         steps: operator_steps,
                     });
+                    // ── @ IS NOT AN EXECUTION CHANNEL ──────────────────────
+                    //
+                    // An earlier spike routed an agent's own @mention, on the
+                    // theory that a hand-off is just a message naming the next
+                    // teammate. It works, and it is unsafe, because a REFERENCE
+                    // and a HAND-OFF are textually identical. Observed, with
+                    // the routing on: asked "who just asked you this?",
+                    // `qa_engineer` replied `@product_manager` — a bare mention
+                    // at the head of the message, indistinguishable from a
+                    // hand-off — and it dispatched a turn to product_manager,
+                    // which mentioned back, which is the ping-pong only the hop
+                    // cap stopped.
+                    //
+                    // No textual rule separates the two, because the model
+                    // writes the text. So an agent's mention stays what
+                    // `Mention::quiet` already describes — "draw the chip, but
+                    // do not notify and do not route" — and handing work over
+                    // goes through `delegate_to_desk`, which since the async
+                    // hand-off actually transfers ownership, mints the
+                    // delegate their own attempt, and rolls back if they cannot
+                    // run.
+                    //
+                    // The convention the operator wants — plain names to refer,
+                    // `@` to delegate — is then true by construction rather
+                    // than by the model's cooperation: the only `@` that routes
+                    // is one the hand-off tool produced.
+
                     // Issue #926: a turn that paused at its step cap says so,
                     // in its own bubble.
                     //
@@ -8162,7 +8377,11 @@ members = ["chief"]
         assert_eq!(brain.responder_for(None), "chief");
         // With one, the named teammate does.
         assert_eq!(
-            crate::runtime::mentions::mention_responder(&brain.record(), &[mention_of("engineer")]),
+            crate::runtime::mentions::mention_responder(
+                &brain.record(),
+                None,
+                &[mention_of("engineer")]
+            ),
             Some("engineer".to_string()),
         );
     }
@@ -8175,7 +8394,11 @@ members = ["chief"]
         let (brain, _tasks) = brain_with_desk(dir.path());
         assert_eq!(brain.responder_for(Some("eng_desk")), "engineer");
         assert_eq!(
-            crate::runtime::mentions::mention_responder(&brain.record(), &[mention_of("ceo")]),
+            crate::runtime::mentions::mention_responder(
+                &brain.record(),
+                None,
+                &[mention_of("ceo")]
+            ),
             Some("ceo".to_string()),
             "the named teammate answers even on a desk with its own lead",
         );
@@ -8188,7 +8411,7 @@ members = ["chief"]
         let dir = tempfile::tempdir().unwrap();
         let (brain, _tasks) = brain_with_desk(dir.path());
         assert_eq!(
-            crate::runtime::mentions::mention_responder(&brain.record(), &[]),
+            crate::runtime::mentions::mention_responder(&brain.record(), None, &[]),
             None,
             "so the caller falls through to responder_for",
         );
@@ -8210,7 +8433,7 @@ members = ["chief"]
             quiet: false,
         }];
         assert_eq!(
-            crate::runtime::mentions::mention_responder(&brain.record(), &mentions),
+            crate::runtime::mentions::mention_responder(&brain.record(), None, &mentions),
             None,
             "a broadcast names no single teammate, so the desk lead still answers",
         );
@@ -12420,15 +12643,24 @@ members = ["engineer", "designer"]
                 ));
             }
             if self.faults.cancel_on.contains(&invoke) {
-                // The delegation's own in-flight entry, not the dispatched
-                // card's — cancelling the card would end the whole run.
+                // Cancel the entry this path actually registered.
+                //
+                // A CHAT-turn delegation still runs inside its delegator's
+                // turn, so it has its own `Delegation` entry and that is the
+                // one to cancel — cancelling the card there would end the whole
+                // run. A DISPATCHED card's hand-off no longer works that way:
+                // since the async hand-off the delegate runs as its own
+                // dispatch, so the only entry in flight is the card's `Task`,
+                // and it IS the delegate's run. Preferring `Delegation` keeps
+                // the chat path targeting exactly what it did before.
                 let company = CompanyId::new("acme");
-                if let Some(entry) = self
-                    .steer
-                    .list(&company)
-                    .into_iter()
+                let entries = self.steer.list(&company);
+                let target = entries
+                    .iter()
                     .find(|e| e.kind == InflightKind::Delegation)
-                {
+                    .or_else(|| entries.iter().find(|e| e.kind == InflightKind::Task))
+                    .cloned();
+                if let Some(entry) = target {
                     let _ = self.steer.steer(&company, &entry.key, SteerAction::Cancel);
                 }
             }
@@ -12773,20 +13005,48 @@ members = ["engineer", "designer"]
 
     /// Seeds one dispatched card (blank assignee → the orchestrator runs it,
     /// which is the shape that carries the delegation tools) and dispatches it.
+    /// Dispatches a card and drives its hand-off chain to a settle, the way
+    /// `CompanyRuntime::run_dispatch_cycle` does in production.
+    ///
+    /// One `run_cycle` is one ATTEMPT, and since the async hand-off an attempt
+    /// that hands the card on settles `Delegated` and leaves the card
+    /// `in_progress` for the new owner — the delegate runs in its own attempt,
+    /// which is what makes their spend attributable and releases the
+    /// per-company lock between hops. A helper that ran a single cycle would
+    /// therefore stop one attempt short of every hand-off's outcome, and a test
+    /// asking "where does a cancelled hand-off end up?" would be reading a
+    /// card mid-chain.
+    ///
+    /// The loop condition is the runtime's own: a settled dispatch still in
+    /// `in_progress` has handed on, because every other ending lands the card
+    /// in a terminal column.
     async fn dispatch_card(brain: &HarnessBrain, tasks: &Arc<FsOps>, id: &str) {
         let mut c = card(id, "");
         c.column = "in_progress".to_string();
         tasks.upsert(&CompanyId::new("acme"), &c).await.unwrap();
-        brain
-            .run_cycle(
-                request(vec![CompanyEvent::TaskDispatched {
-                    task_id: id.to_string(),
-                    run_id: None,
-                }]),
-                &NoopHost,
-            )
-            .await
-            .expect("cycle runs");
+        for _ in 0..=crate::company::runtime::MAX_HAND_OFF_HOPS {
+            brain
+                .run_cycle(
+                    request(vec![CompanyEvent::TaskDispatched {
+                        task_id: id.to_string(),
+                        run_id: None,
+                    }]),
+                    &NoopHost,
+                )
+                .await
+                .expect("cycle runs");
+            let handed_on = tasks
+                .list(&CompanyId::new("acme"))
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .any(|card| {
+                    card.id == id && card.column == crate::ports::tasks::COLUMN_IN_PROGRESS
+                });
+            if !handed_on {
+                break;
+            }
+        }
     }
 
     /// The bug: a dispatched task the CEO delegated went straight to
@@ -12815,7 +13075,7 @@ members = ["engineer", "designer"]
 
         let after = only_card(&provider.tasks).await;
         assert_eq!(
-            after.assignee, "engineer",
+            after.assignee, "eng_desk",
             "the delegate must be linked as the assignee, not left blank under the delegator"
         );
         assert_eq!(
@@ -12840,9 +13100,12 @@ members = ["engineer", "designer"]
         // …and while the delegate was working, the card showed THEM working it:
         // its second turn ran against a card already reassigned and still in
         // progress, not one parked in a terminal column.
+        // The DESK is the owner and its lead is the worker — `canonical`'s rule,
+        // which `hand_card_over` now honours instead of writing the lead over
+        // the desk assignment.
         assert_eq!(
             provider.board()[1],
-            ("in_progress".to_string(), "engineer".to_string()),
+            ("in_progress".to_string(), "eng_desk".to_string()),
             "the delegate must be shown working the card while they work it"
         );
     }
@@ -12885,8 +13148,13 @@ members = ["engineer", "designer"]
              progress where nothing will re-dispatch it"
         );
         let note = after.note.expect("note");
+        // "dispatch failed", not "hand-off failed": since the async hand-off the
+        // delegate errors inside its OWN attempt, so the reason is recorded by
+        // that attempt's settle rather than by the hand-off that queued it. The
+        // property this test is named for — To-do, never stranded in progress —
+        // is asserted above and is unchanged.
         assert!(
-            note.contains("hand-off failed:"),
+            note.contains("dispatch failed:"),
             "the failure reason lands on the note: {note}"
         );
         assert!(
@@ -12932,14 +13200,19 @@ members = ["engineer", "designer"]
             "a cancelled hand-off must not read as finished, and must not strand in progress"
         );
         let note = after.note.expect("note");
+        // The wording moved with the async hand-off. A cancelled delegate is now
+        // cancelled inside ITS OWN dispatch, so the reason is `run_task`'s
+        // steer-cancel wording rather than the sync hand-off's report of a
+        // delegate that never produced anything. The property this test is named
+        // for — To-do, attributed to the operator — is unchanged.
         assert!(
-            note.contains("the delegated run was cancelled before it produced anything"),
+            note.contains("cancelled while in flight"),
             "the cancellation is reported as the cause: {note}"
         );
         // A cancellation is the operator's act, so the block is theirs — not the
         // delegate's, who never said it.
         assert!(
-            note.contains("[operator] the delegated run was cancelled"),
+            note.contains("[operator] cancelled while in flight"),
             "a cancellation is attributed to the operator: {note}"
         );
     }
@@ -12979,23 +13252,32 @@ members = ["engineer", "designer"]
         dispatch_card(&brain, &provider.tasks.clone(), "t-two-handoffs").await;
 
         let after = only_card(&provider.tasks).await;
+        // The card settles from the ONE hand-off that owns it — cancelled here,
+        // so To-do. A second hand-off in the same turn never ran.
         assert_eq!(
-            after.column, "in_review",
-            "the card settles from the hand-off that actually produced work, not from the \
-             cancelled one that preceded it"
+            after.column, COLUMN_TODO,
+            "the card settles from the hand-off that owns it"
         );
         assert_eq!(
-            after.assignee, "engineer",
-            "the delegate that produced the work owns the card"
+            after.assignee, "eng_desk",
+            "the owner is the desk the card was handed to"
         );
         let note = after.note.expect("note");
+        // The protection #213 added, reached a stronger way. It used to be
+        // "a later hand-off that ANSWERS takes the card from an empty one", so
+        // work that ran could never be filed under a cancelled card. Async
+        // hand-off removes the race instead of resolving it: the first hand-off
+        // owns the card and its delegate is dispatched, so a second one is
+        // recorded and NOT started. There is no output to misfile because no
+        // second run happened.
         assert!(
-            note.contains("second attempt"),
-            "the answering hand-off's output is the card's result: {note}"
+            note.contains("also asked eng_desk: second attempt") && note.contains("not started"),
+            "the second hand-off is recorded, and visibly did not run: {note}"
         );
         assert!(
-            !note.contains("the delegated run was cancelled before it produced anything"),
-            "an earlier cancelled hand-off must not settle a card a later one completed: {note}"
+            !note.contains("[eng_desk] second attempt")
+                && !note.contains("[engineer] second attempt"),
+            "a second hand-off must not produce work under a card owned by the first: {note}"
         );
     }
 

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8619,6 +8619,7 @@ members = ["ceo", "engineer"]
                 description: None,
                 responder: Default::default(),
                 members: vec!["engineer".into()],
+                hive: Default::default(),
             })
         });
         for spelling in ["", "main", "Main", "general", "General"] {
@@ -12364,6 +12365,7 @@ members = ["engineer", "designer"]
             description: None,
             members: vec!["engineer".to_string(), "chief".to_string()],
             responder: crate::ports::types::ResponderMode::Auto,
+            hive: Default::default(),
         });
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record),

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -3829,8 +3829,12 @@ impl HarnessBrain {
                     // its own turns back out of it to fold the next step, so a
                     // driver with nowhere to append could not deliberate at
                     // all, and falling through answers exactly as before.
-                    if crate::runtime::mentions::mention_responder(&self.record(), mentions)
-                        .is_none()
+                    if crate::runtime::mentions::mention_responder(
+                        &self.record(),
+                        chat.as_deref(),
+                        mentions,
+                    )
+                    .is_none()
                         && let Some(events) = self.deps.events.clone()
                         && let Some(desk) =
                             crate::hivemind::desk_episode(&self.record(), chat.as_deref())

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -13075,8 +13075,9 @@ members = ["engineer", "designer"]
 
         let after = only_card(&provider.tasks).await;
         assert_eq!(
-            after.assignee, "eng_desk",
-            "the delegate must be linked as the assignee, not left blank under the delegator"
+            after.assignee, "engineer",
+            "the delegate — an agent — must be linked as the assignee, not left blank \
+             under the delegator"
         );
         assert_eq!(
             after.column, "in_review",
@@ -13100,12 +13101,11 @@ members = ["engineer", "designer"]
         // …and while the delegate was working, the card showed THEM working it:
         // its second turn ran against a card already reassigned and still in
         // progress, not one parked in a terminal column.
-        // The DESK is the owner and its lead is the worker — `canonical`'s rule,
-        // which `hand_card_over` now honours instead of writing the lead over
-        // the desk assignment.
+        // Owner and worker are the same agent: the desk's lead. The board shows
+        // a teammate working it, never a channel id.
         assert_eq!(
             provider.board()[1],
-            ("in_progress".to_string(), "eng_desk".to_string()),
+            ("in_progress".to_string(), "engineer".to_string()),
             "the delegate must be shown working the card while they work it"
         );
     }
@@ -13259,8 +13259,8 @@ members = ["engineer", "designer"]
             "the card settles from the hand-off that owns it"
         );
         assert_eq!(
-            after.assignee, "eng_desk",
-            "the owner is the desk the card was handed to"
+            after.assignee, "engineer",
+            "the owner is an agent: the lead of the desk the card was handed to"
         );
         let note = after.note.expect("note");
         // The protection #213 added, reached a stronger way. It used to be

--- a/src/harness/built_in/build.rs
+++ b/src/harness/built_in/build.rs
@@ -203,6 +203,24 @@ pub fn model_for_tier(tier: Option<&str>) -> String {
     .to_string()
 }
 
+/// What an `@` in an agent's own reply does — and does not — do.
+///
+/// Every agent gets this, because every agent can write one. `Mention::quiet`
+/// is the contract it states in prose: "draw the chip, but do not notify and
+/// do not route". Without it an agent reaches for `@name` to make somebody
+/// pick something up, the chip renders, nothing happens, and the work is
+/// silently dropped — the failure is invisible precisely because the message
+/// LOOKS like a hand-off.
+///
+/// Deliberately does not name the hand-off tools: most agents do not have
+/// them, and pointing an agent at a tool it was not granted is the "a tool
+/// granted, unmentioned" problem pointed the other way. The agents that do
+/// have them are told in [`orchestrator::orchestrator_brief`].
+const MENTION_BRIEF: &str = " Naming a teammate: write their name or id as ordinary text when you are \
+referring to them — \"qa_engineer has the failing case\". An `@` in your reply renders a chip and \
+nothing more: it notifies nobody and starts no work, so it cannot hand anything over. Reaching for \
+`@` to make somebody pick something up does not make them pick it up. ";
+
 /// The persona system prompt for a company agent.
 ///
 /// Frames the agent as its manifest role at the company, in the first person.
@@ -861,6 +879,10 @@ pub fn build_agent(
     // static-before-volatile is what keeps an operator editing a workspace note
     // from invalidating the briefing behind it.
     persona.push_str(&crate::company::prompt::bundle_section(manifest_agent));
+
+    // Every agent, granted tools or not: an `@` is something any of them can
+    // write, and what it does is not guessable from the fact that it renders.
+    persona.push_str(MENTION_BRIEF);
 
     // A short, STATIC brief — never a tree snapshot. A snapshot baked into the
     // system prompt would be stale the moment the operator edits a note, which

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -142,6 +142,19 @@ impl ChatSeedRequest {
             &people,
         );
         let query = SessionQuery {
+            // **The seed is narrowed for the agent it is FOR.**
+            //
+            // `project_for` is the only thing that elides, and it can only
+            // elide for a reader it can name — which is why the viewer rides on
+            // the query. Reading as this agent means an aside it is not party
+            // to arrives elided rather than in full.
+            //
+            // Deliberately NOT `Viewer::Operator`: that reads everything, which
+            // is right for a driver folding one transcript for a whole room and
+            // exactly wrong here, where the fold becomes one agent's context.
+            viewer: tinyhivemind_hive::aside::Viewer::Agent {
+                id: self.reader.clone(),
+            },
             conversation: Conversation {
                 desk_id: desk_id.to_string(),
                 desk_name: desk_name.to_string(),

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -99,6 +99,12 @@ pub struct ChatSeedRequest {
     /// coupling this crate keeps getting bitten by — it would also cost a
     /// journal read on the *non*-switch turns the switch branch exists to keep
     /// free.
+    /// Whose seed this is — the agent the projection is FOR.
+    ///
+    /// Only the `hivemind` projection reads it: attribution is the whole point
+    /// of that path, and it cannot tell "something I said" from "something a
+    /// teammate said to me" without knowing who is reading.
+    pub reader: String,
     pub thread_root: Option<EventSeq>,
     /// This turn's own operator message, as its position in the company
     /// journal — the boundary [`build_chat_seed`] cuts the history at.
@@ -109,6 +115,65 @@ pub struct ChatSeedRequest {
 }
 
 impl ChatSeedRequest {
+    /// The attributed projection, mapped onto the `(role, content)` ladder the
+    /// agent runtime takes.
+    ///
+    /// The mapping is the only decision left to the host, because it is the
+    /// only part that depends on this runtime's shape: MY prior turns are
+    /// `agent` turns and carry no name — an assistant turn needs none, and an
+    /// unadorned one is nothing for the model to imitate. Everything else is
+    /// an INPUT, and says who it came from, which is exactly the distinction
+    /// the flat fold destroys.
+    #[cfg(feature = "hivemind")]
+    async fn hivemind_seed(
+        &self,
+        company: &CompanyId,
+        desk_id: &str,
+        desk_name: &str,
+    ) -> Option<Vec<(String, String)>> {
+        use tinyhivemind::session::{Conversation, SessionAuthor, SessionQuery, project_session};
+
+        let record = self.store.load(company).await.ok()??;
+        let people = std::collections::HashMap::new();
+        let log = crate::runtime::hivemind::JournalSessionLog::new(
+            self.events.as_ref(),
+            company,
+            &record,
+            &people,
+        );
+        let query = SessionQuery {
+            conversation: Conversation {
+                desk_id: desk_id.to_string(),
+                desk_name: desk_name.to_string(),
+                thread_root: self
+                    .thread_root
+                    .map(|seq| tinyhivemind::session::Sequence(seq.value())),
+            },
+            before: self
+                .current_message_seq
+                .map(|seq| tinyhivemind::session::Sequence(seq.value())),
+            window: CHAT_SEED_WINDOW,
+        };
+        let projected = project_session(&log, &query).await.ok()?;
+        Some(
+            projected
+                .into_iter()
+                .map(|message| match &message.author {
+                    SessionAuthor::Agent { id, .. } if *id == self.reader => {
+                        ("agent".to_string(), message.content)
+                    }
+                    SessionAuthor::Operator => ("user".to_string(), message.content),
+                    SessionAuthor::Person { label, .. }
+                    | SessionAuthor::Agent { label, .. }
+                    | SessionAuthor::System { label, .. } => (
+                        "user".to_string(),
+                        format!("{label} said: {}", message.content),
+                    ),
+                })
+                .collect(),
+        )
+    }
+
     /// Projects this desk's recent history — bounded at this turn's own
     /// message so a concurrently-accepted later message never leaks in (see
     /// [`build_chat_seed`]) — and strips the current message's own trailing
@@ -154,6 +219,20 @@ impl ChatSeedRequest {
             },
         )
         .await;
+        // The `tinyhivemind` projection, when this build has it (P4).
+        //
+        // The fold below is lossy in one specific way — it discards the author
+        // of every reply — so on a shared desk agent B reads agent A's turns as
+        // its OWN. `tinyhivemind::session::project_session` answers the same
+        // question attributed, and `runtime::hivemind::JournalSessionLog` is
+        // the port it reads this company's journal through. Where it is
+        // available it is the answer; the fold stays as the default build's
+        // behaviour rather than being forked into a second implementation of
+        // the same idea.
+        #[cfg(feature = "hivemind")]
+        if let Some(attributed) = self.hivemind_seed(company, &desk_id, &desk_name).await {
+            seed = attributed;
+        }
         if self.current_message_seq.is_none() {
             strip_current_message(&mut seed, &self.raw_message);
         }

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -130,7 +130,7 @@ impl ChatSeedRequest {
         company: &CompanyId,
         desk_id: &str,
         desk_name: &str,
-    ) -> Option<Vec<(String, String)>> {
+    ) -> Option<Vec<SeedEntry>> {
         use tinyhivemind::session::{Conversation, SessionAuthor, SessionQuery, project_session};
 
         let record = self.store.load(company).await.ok()??;
@@ -172,16 +172,30 @@ impl ChatSeedRequest {
             projected
                 .into_iter()
                 .map(|message| match &message.author {
-                    SessionAuthor::Agent { id, .. } if *id == self.reader => {
-                        ("agent".to_string(), message.content)
-                    }
-                    SessionAuthor::Operator => ("user".to_string(), message.content),
+                    // Mapped onto the same `Speaker` the native seed uses
+                    // (issue #1956) rather than onto a role string: attribution
+                    // is that type's whole job, and rendering it here would put
+                    // a second, drifting answer beside `SeedEntry::flatten`.
+                    SessionAuthor::Agent { id, .. } if *id == self.reader => SeedEntry {
+                        role: "agent",
+                        speaker: Speaker::Viewer,
+                        text: message.content,
+                        parent: None,
+                    },
+                    SessionAuthor::Operator => SeedEntry {
+                        role: "user",
+                        speaker: Speaker::Operator(OPERATOR_LABEL.to_string()),
+                        text: message.content,
+                        parent: None,
+                    },
                     SessionAuthor::Person { label, .. }
                     | SessionAuthor::Agent { label, .. }
-                    | SessionAuthor::System { label, .. } => (
-                        "user".to_string(),
-                        format!("{label} said: {}", message.content),
-                    ),
+                    | SessionAuthor::System { label, .. } => SeedEntry {
+                        role: "user",
+                        speaker: Speaker::Other(label.clone()),
+                        text: message.content,
+                        parent: None,
+                    },
                 })
                 .collect(),
         )

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -99,13 +99,13 @@ pub struct ChatSeedRequest {
     /// coupling this crate keeps getting bitten by — it would also cost a
     /// journal read on the *non*-switch turns the switch branch exists to keep
     /// free.
+    pub thread_root: Option<EventSeq>,
     /// Whose seed this is — the agent the projection is FOR.
     ///
     /// Only the `hivemind` projection reads it: attribution is the whole point
     /// of that path, and it cannot tell "something I said" from "something a
     /// teammate said to me" without knowing who is reading.
     pub reader: String,
-    pub thread_root: Option<EventSeq>,
     /// This turn's own operator message, as its position in the company
     /// journal — the boundary [`build_chat_seed`] cuts the history at.
     ///

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -4390,6 +4390,7 @@ impl HarnessPool {
                 raw_message: message.to_string(),
                 events: events.clone(),
                 store: deps.store.clone(),
+                reader: agent_id.to_string(),
                 thread_root: chat.thread_root,
                 current_message_seq: chat.message_seq,
             }),

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -2396,6 +2396,10 @@ fn truncate_chars(s: &str, max: usize) -> String {
 fn summarize_event(event: &CompanyEvent) -> String {
     match event {
         CompanyEvent::OperatorMessage { .. } => "operator message".to_string(),
+        // Structural only, like every arm here: which desks, never the content.
+        CompanyEvent::ReferralEnqueued {
+            from_desk, to_desk, ..
+        } => format!("referral {from_desk} → {to_desk}"),
         // Issue #983. Structural only, like every arm here: the turn id, which
         // is a minted identifier, and nothing else. Neither the desk nor the
         // failure reason is named — the desk is operator-authored free text on

--- a/src/harness/built_in/planning/test.rs
+++ b/src/harness/built_in/planning/test.rs
@@ -2565,6 +2565,7 @@ async fn the_prompt_carries_runtime_teammates_and_desks_not_just_manifest_ones()
         description: None,
         members: vec!["social_manager".to_string()],
         responder: crate::ports::types::ResponderMode::default(),
+        hive: Default::default(),
     });
     runtime.store().save(&record).await.unwrap();
 

--- a/src/harness/built_in/selector.rs
+++ b/src/harness/built_in/selector.rs
@@ -75,6 +75,25 @@ pub struct SelectorCandidate {
     pub role: String,
     /// The teammate's mandate, when one is declared.
     pub description: Option<String>,
+    /// What this teammate can actually DO — its effective tool grants.
+    ///
+    /// Role and description say what a teammate is *for*; this says what it can
+    /// reach. The two come apart exactly where routing matters most: "Support
+    /// Specialist" does not tell a selector that this is the only member of the
+    /// desk holding `composio`, and so the only one that can answer a question
+    /// about a GitHub repository at all. Routed on prose alone, such a message
+    /// goes to whoever reads as the best thematic fit and fails for a reason no
+    /// amount of reasoning could have fixed.
+    ///
+    /// Narrowed per agent (`[tools].allow ∩ [[agent]].tools`). The desk ceiling
+    /// is deliberately not applied: every candidate here sits on the same desk,
+    /// so that level is common to all of them and cannot separate one from
+    /// another — the ranking is identical with or without it.
+    ///
+    /// Empty means "nothing declared", and renders as nothing at all rather
+    /// than as an empty list, so a company that grants tools nowhere sees the
+    /// prompt it saw before this field existed.
+    pub tools: Vec<String>,
 }
 
 /// What a selection decided.
@@ -147,6 +166,11 @@ fn selection_request(message: &str, candidates: &[SelectorCandidate]) -> String 
         if let Some(description) = c.description.as_deref().filter(|d| !d.trim().is_empty()) {
             out.push_str(": ");
             out.push_str(description);
+        }
+        if !c.tools.is_empty() {
+            out.push_str(" [can use: ");
+            out.push_str(&c.tools.join(", "));
+            out.push(']');
         }
         out.push('\n');
     }
@@ -323,11 +347,13 @@ mod tests {
                 id: "backend_engineer".to_string(),
                 role: "Backend Engineer".to_string(),
                 description: Some("Owns the API surface.".to_string()),
+                tools: Vec::new(),
             },
             SelectorCandidate {
                 id: "designer".to_string(),
                 role: "Product Designer".to_string(),
                 description: None,
+                tools: Vec::new(),
             },
         ]
     }
@@ -384,5 +410,50 @@ mod tests {
         assert!(request.contains("- backend_engineer — Backend Engineer: Owns the API surface."));
         assert!(request.contains("- designer — Product Designer\n"));
         assert!(request.contains("Message:\nwho owns the login flow?"));
+    }
+    /// **Capability is routed on, not just prose.**
+    ///
+    /// The failure this exists for: "fetch the latest issues of <repo>" was
+    /// routed to a product manager on role and description alone, and could
+    /// never have succeeded — that teammate holds no `composio` grant, so it
+    /// cannot reach GitHub at all. The one member that could was reachable only
+    /// by being named. A selector told what each member can USE has the fact
+    /// that decides the question; one told only what they are FOR does not.
+    #[test]
+    fn selection_request_says_what_each_member_can_use() {
+        let candidates = vec![
+            SelectorCandidate {
+                id: "product_manager".to_string(),
+                role: "Product Manager".to_string(),
+                description: Some("Owns the roadmap.".to_string()),
+                tools: vec!["workspace.read".to_string()],
+            },
+            SelectorCandidate {
+                id: "support_specialist".to_string(),
+                role: "Support Specialist".to_string(),
+                description: None,
+                tools: vec!["composio".to_string(), "web.*".to_string()],
+            },
+        ];
+        let request = selection_request("fetch the latest open issues", &candidates);
+        assert!(
+            request
+                .contains("- support_specialist — Support Specialist [can use: composio, web.*]"),
+            "the member that can reach GitHub says so: {request}"
+        );
+        assert!(
+            request.contains(
+                "- product_manager — Product Manager: Owns the roadmap. [can use: workspace.read]"
+            ),
+            "and capability rides beside the mandate, not instead of it: {request}"
+        );
+    }
+
+    /// A company that grants nothing renders exactly the prompt it did before
+    /// this field existed — an empty list is absent, never `[can use: ]`.
+    #[test]
+    fn a_member_with_no_grants_renders_no_capability_clause() {
+        let request = selection_request("who owns the login flow?", &candidates());
+        assert!(!request.contains("can use"), "{request}");
     }
 }

--- a/src/harness/lanes.rs
+++ b/src/harness/lanes.rs
@@ -471,6 +471,7 @@ mod tests {
             description: None,
             members: Vec::new(),
             responder: crate::ports::types::ResponderMode::default(),
+            hive: Default::default(),
         });
 
         let desks = declared_desks(&record);

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -64,6 +64,37 @@ pub trait HiveTurnRunner: Send + Sync {
 /// How many `!pin` lines one closing note carries.
 const MAX_NOTE_PINS: usize = 3;
 
+/// The `!propose` line that put `topic` on the floor, without its marker.
+///
+/// The FIRST one wins: a topic is introduced once and later lines support it,
+/// so the opening proposal is the statement of the option. Matching is on the
+/// `#topic` token exactly — `#lazy` must not answer for `#lazy-load` — and the
+/// marker and topic are stripped, leaving the sentence a person would read.
+///
+/// A multi-line turn is searched line by line, because a member may write prose
+/// and then its move, and only the marked line is the proposal.
+fn carried_proposal(
+    transcript: &[tinyhivemind_hive::SessionMessage],
+    topic: &str,
+) -> Option<String> {
+    let head = format!("#{topic}");
+    transcript
+        .iter()
+        .flat_map(|message| message.content.lines())
+        .map(str::trim)
+        .find_map(|line| {
+            let rest = line.strip_prefix("!propose")?.trim_start();
+            let rest = rest.strip_prefix(&head)?;
+            // A prefix match alone would let `#lazy` claim `#lazy-load`, so the
+            // token has to end here.
+            if rest.starts_with(|c: char| c.is_alphanumeric() || c == '-' || c == '_') {
+                return None;
+            }
+            let text = rest.trim_start_matches([':', '\u{2014}', '-', ' ']).trim();
+            (!text.is_empty()).then(|| text.to_string())
+        })
+}
+
 /// The system line a failed turn leaves on the desk.
 ///
 /// Authored by `hive-report`, the same reserved id the closing row uses, so the
@@ -343,6 +374,9 @@ impl<'a> EpisodeDriver<'a> {
                 HiveStep::Speak { turn } => *turn,
                 HiveStep::Converged { topic, standing } => {
                     break EpisodeEnding::Converged {
+                        // Read from the very transcript `step` just decided on,
+                        // so the text reported is the text that carried.
+                        proposal: carried_proposal(&transcript, topic.as_str()),
                         topic: topic.to_string(),
                         supporters: standing.supporters.clone(),
                     };
@@ -838,7 +872,9 @@ impl<'a> EpisodeDriver<'a> {
         };
         let note = match &outcome.ending {
             EpisodeEnding::Idle => return,
-            EpisodeEnding::Converged { topic, supporters } => {
+            EpisodeEnding::Converged {
+                topic, supporters, ..
+            } => {
                 let mut body = format!(
                     "Task: {task_line}\nCarried: #{topic}\nSupporters: {}\n",
                     if supporters.is_empty() {
@@ -1080,5 +1116,54 @@ impl<'a> EpisodeDriver<'a> {
     /// A library error, named as what it actually is on this host.
     fn malformed(&self, error: &dyn std::fmt::Display) -> OpenCompanyError {
         OpenCompanyError::Config(format!("hive episode on desk `{}`: {error}", self.desk.id))
+    }
+}
+
+#[cfg(test)]
+mod carried_proposal_test {
+    use super::carried_proposal;
+    use tinyhivemind_hive::{Sequence, SessionAuthor, SessionMessage};
+
+    fn msg(seq: u64, content: &str) -> SessionMessage {
+        SessionMessage {
+            sequence: Sequence(seq),
+            author: SessionAuthor::Agent {
+                id: "engineer".to_string(),
+                label: "Engineer".to_string(),
+            },
+            content: content.to_string(),
+            elided: None,
+            audience: tinyhivemind_hive::aside::Audience::Desk,
+        }
+    }
+
+    #[test]
+    fn takes_the_opening_proposal_and_strips_the_grammar() {
+        let transcript = vec![
+            msg(
+                1,
+                "thinking about this\n!propose #lazy-load each section, so the page only pays for what is opened",
+            ),
+            msg(2, "!support #lazy-load ^1 agreed"),
+        ];
+        assert_eq!(
+            carried_proposal(&transcript, "lazy-load").as_deref(),
+            Some("each section, so the page only pays for what is opened"),
+            "the marker and topic are stripped, and prose above the move is ignored"
+        );
+    }
+
+    /// `#lazy` must not answer for `#lazy-load`: a plain prefix match would
+    /// report the wrong decision, which is worse than reporting none.
+    #[test]
+    fn a_topic_that_merely_prefixes_another_does_not_match() {
+        let transcript = vec![msg(1, "!propose #lazy-load defer every section")];
+        assert_eq!(carried_proposal(&transcript, "lazy"), None);
+    }
+
+    #[test]
+    fn a_topic_never_proposed_in_the_window_is_absent() {
+        let transcript = vec![msg(1, "!support #stage ^0 no proposal survives here")];
+        assert_eq!(carried_proposal(&transcript, "stage"), None);
     }
 }

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -516,7 +516,7 @@ impl<'a> EpisodeDriver<'a> {
                             &self.company,
                             CompanyEvent::AgentReply {
                                 chat_id: self.desk.id.clone(),
-                                agent_id: super::HIVE_REPORT_AUTHOR.to_string(),
+                                agent_id: super::HIVE_FAILURE_AUTHOR.to_string(),
                                 text: failure_note(&turn.agent_id, &error),
                                 // The room's own report is never private: a
                                 // reader who could not see that a turn failed

--- a/src/hivemind/episode.rs
+++ b/src/hivemind/episode.rs
@@ -77,22 +77,55 @@ fn carried_proposal(
     transcript: &[tinyhivemind_hive::SessionMessage],
     topic: &str,
 ) -> Option<String> {
-    let head = format!("#{topic}");
     transcript
         .iter()
         .flat_map(|message| message.content.lines())
-        .map(str::trim)
-        .find_map(|line| {
-            let rest = line.strip_prefix("!propose")?.trim_start();
-            let rest = rest.strip_prefix(&head)?;
-            // A prefix match alone would let `#lazy` claim `#lazy-load`, so the
-            // token has to end here.
-            if rest.starts_with(|c: char| c.is_alphanumeric() || c == '-' || c == '_') {
-                return None;
-            }
-            let text = rest.trim_start_matches([':', '\u{2014}', '-', ' ']).trim();
-            (!text.is_empty()).then(|| text.to_string())
+        .find_map(|line| match proposed(line) {
+            Some((named, text)) if named == topic && !text.is_empty() => Some(text.to_string()),
+            _ => None,
         })
+}
+
+/// The topic a `!propose` line names, and what it says about it.
+///
+/// `None` for any other line. The topic token ends at whitespace, so `#lazy`
+/// and `#lazy-load` are different topics rather than one being a prefix of the
+/// other — crediting or reporting the wrong option is worse than doing neither.
+fn proposed(line: &str) -> Option<(&str, &str)> {
+    let rest = line.trim().strip_prefix("!propose")?.trim_start();
+    let rest = rest.strip_prefix('#')?;
+    let end = rest
+        .find(|c: char| !(c.is_alphanumeric() || c == '-' || c == '_'))
+        .unwrap_or(rest.len());
+    let (topic, tail) = rest.split_at(end);
+    (!topic.is_empty()).then(|| {
+        (
+            topic,
+            tail.trim_start_matches([':', '\u{2014}', '-', ' ']).trim(),
+        )
+    })
+}
+
+/// The topic this line re-proposes, when the floor already holds one by that
+/// name.
+///
+/// **A topic is put on the floor once.** `!propose` introduces an OPTION; a
+/// member that agrees with an option already there is supporting it, and
+/// `!support` is the move for that.
+///
+/// Reusing an id is not a style slip, it is a vote-corrupting one, because the
+/// fold counts `Propose` and `Support` alike as backing. Observed live: two
+/// members filed *opposite* answers — "lazy-load each section" and "load
+/// everything up front" — under one id named after the question, and the room
+/// reported a quorum of two for a decision they disagreed about. Neither had
+/// supported anything; the tally could not tell them apart.
+fn reuses_a_topic(line: &str, visible: &[tinyhivemind_hive::SessionMessage]) -> Option<String> {
+    let (topic, _) = proposed(line)?;
+    visible
+        .iter()
+        .flat_map(|message| message.content.lines())
+        .any(|earlier| proposed(earlier).is_some_and(|(named, _)| named == topic))
+        .then(|| topic.to_string())
 }
 
 /// The system line a failed turn leaves on the desk.
@@ -782,6 +815,44 @@ impl<'a> EpisodeDriver<'a> {
         Ok(moves::demote(&line))
     }
 
+    /// One corrective turn when a member re-proposes a topic already on the
+    /// floor — see [`reuses_a_topic`] for why that corrupts the tally rather
+    /// than merely reading badly.
+    ///
+    /// Shaped exactly like [`grounded`](Self::grounded): detect, say what to do
+    /// instead, ask once more, keep whatever comes back. A member that
+    /// re-proposes twice has made its point, and a second correction would
+    /// spend a third turn winning a naming argument.
+    async fn fresh_topic(
+        &self,
+        agent_id: &str,
+        prompt: &str,
+        visible: &[tinyhivemind_hive::SessionMessage],
+        line: String,
+        scratch: &mut TurnScratch,
+    ) -> Result<String> {
+        let Some(topic) = reuses_a_topic(&line, visible) else {
+            return Ok(line);
+        };
+        tracing::info!(
+            company = %self.company,
+            desk = %self.desk.id,
+            agent = %agent_id,
+            topic = %topic,
+            "[hive] a member re-proposed a topic already on the floor; asked once more"
+        );
+        let corrected = format!(
+            "{prompt}\n\n#{topic} is already on the floor. `!propose` puts a NEW option there, \
+             and two proposals under one id count as agreement even when they say opposite \
+             things. If you agree with #{topic}, write `!support #{topic} ^N` citing what \
+             convinced you. If you are arguing for something else, propose it under its own \
+             topic id — one that names YOUR option, not the question."
+        );
+        let (line, rode) = split_reply(&self.runner.speak(agent_id, &corrected).await?);
+        scratch.aside = rode;
+        Ok(line)
+    }
+
     /// The same line, once its citations have been given one chance to reach a
     /// fact.
     ///
@@ -804,6 +875,11 @@ impl<'a> EpisodeDriver<'a> {
         line: String,
         scratch: &mut TurnScratch,
     ) -> Result<String> {
+        // A distinct rule with its own correction, applied first: a re-proposed
+        // topic corrupts the tally whatever the desk's evidential setting is.
+        let line = self
+            .fresh_topic(agent_id, prompt, visible, line, scratch)
+            .await?;
         if self.desk.config.require_evidential != Some(true)
             || !evidential::support_misses_evidence(&line, agent_id, visible)
         {
@@ -1165,5 +1241,48 @@ mod carried_proposal_test {
     fn a_topic_never_proposed_in_the_window_is_absent() {
         let transcript = vec![msg(1, "!support #stage ^0 no proposal survives here")];
         assert_eq!(carried_proposal(&transcript, "stage"), None);
+    }
+    /// The live failure this rule exists for: two members filed opposite
+    /// answers under one id named after the QUESTION, and the fold counted
+    /// both `!propose` traces as backing the same topic — a reported quorum
+    /// of two for a decision they disagreed about.
+    #[test]
+    fn a_second_proposal_under_one_id_is_caught() {
+        let floor = vec![msg(
+            1,
+            "!propose #decide-one lazy-load each section because settings pages are single-purpose",
+        )];
+        assert_eq!(
+            super::reuses_a_topic(
+                "!propose #decide-one load everything up front, because sections are small forms",
+                &floor,
+            )
+            .as_deref(),
+            Some("decide-one"),
+        );
+        // Supporting it is the right move and is never corrected.
+        assert_eq!(
+            super::reuses_a_topic("!support #decide-one ^1 agreed", &floor),
+            None
+        );
+        // A genuinely new option is not a reuse.
+        assert_eq!(
+            super::reuses_a_topic(
+                "!propose #load-upfront one fetch, instant switching",
+                &floor
+            ),
+            None
+        );
+    }
+
+    /// `#lazy` and `#lazy-load` are different topics — a prefix match would
+    /// correct a member for proposing something nobody had proposed.
+    #[test]
+    fn a_topic_that_merely_prefixes_another_is_not_a_reuse() {
+        let floor = vec![msg(1, "!propose #lazy-load defer every section")];
+        assert_eq!(
+            super::reuses_a_topic("!propose #lazy do it later", &floor),
+            None
+        );
     }
 }

--- a/src/hivemind/log.rs
+++ b/src/hivemind/log.rs
@@ -184,6 +184,7 @@ impl EventLogSessionLog {
 /// spell (all are hyphenated, and every id minter rejects a hyphen).
 fn is_system_author(agent_id: &str) -> bool {
     agent_id == super::HIVE_REPORT_AUTHOR
+        || agent_id == super::HIVE_FAILURE_AUTHOR
         || agent_id == super::HIVE_REFERRAL_AUTHOR
         || agent_id == crate::runtime::channel::WORKFLOW_REPLY_AUTHOR
         || agent_id == crate::runtime::channel::OWNER_FALLBACK_REPORT_AUTHOR

--- a/src/hivemind/mod.rs
+++ b/src/hivemind/mod.rs
@@ -88,7 +88,7 @@ pub use memory::{
     HIVE_MEMORY_LABEL_PREFIX, HiveMemory, HiveMemoryHit, HiveMemoryNote, NullHiveMemory,
     desk_prefix, note_label,
 };
-pub use moves::{MOVE_KINDS, MoveViolation, UNGATED_KINDS};
+pub use moves::{MOVE_KINDS, MoveViolation, UNGATED_KINDS, line_kind, readable};
 pub use prompt::{EpisodePrompt, canonical_topic, marker_line};
 pub use referral::{
     AskedQuestion, EpisodeReferrals, FederationDesk, HiveFederation, HiveReferralRunner,

--- a/src/hivemind/mod.rs
+++ b/src/hivemind/mod.rs
@@ -112,6 +112,21 @@ pub use types::{
 /// outcome row from a teammate's line without consulting a roster.
 pub const HIVE_REPORT_AUTHOR: &str = "hive-report";
 
+/// The `agent_id` a failed turn's notice is journaled under.
+///
+/// Hyphenated for the same reason [`HIVE_REPORT_AUTHOR`] is, and read back as
+/// a system row on the same terms — but a DIFFERENT id, because the two rows
+/// answer to different readers.
+///
+/// The closing report restates a tally whose inputs are already on screen as
+/// the turns that produced them, so a console may reasonably decline to draw
+/// it. A failure notice is the opposite: the turn it describes does not exist,
+/// so there is no gap for a reader to notice and nothing else records that a
+/// seat was asked and could not answer. Sharing one id forced the two to be
+/// shown or hidden together, and hiding this one leaves "a transcript with a
+/// hole in it that nothing accounts for".
+pub const HIVE_FAILURE_AUTHOR: &str = "hive-failure";
+
 /// The `agent_id` an answer carried back from another desk is journaled under.
 ///
 /// Hyphenated for exactly the reason [`HIVE_REPORT_AUTHOR`] is — no roster id

--- a/src/hivemind/mod.rs
+++ b/src/hivemind/mod.rs
@@ -97,7 +97,7 @@ pub use referral::{
 pub use scope::EpisodeScope;
 pub use types::{
     EpisodeEnding, EpisodeOutcome, HiveConfig, HiveDesk, HiveMember, HivePolicy, desk_episode,
-    desk_federation,
+    desk_federation, effective_hive_config,
 };
 
 /// The `agent_id` an episode's closing outcome row is journaled under.

--- a/src/hivemind/moves.rs
+++ b/src/hivemind/moves.rs
@@ -137,8 +137,8 @@ pub fn correction(attempted: &str, allowed: &[&str]) -> String {
 /// operator reading a desk was being shown `!support #lazy-load ^3 agreed`,
 /// which is machine syntax rendered verbatim in a human channel.
 ///
-/// So the head tokens are lifted into a plain-English lead and the member's own
-/// sentence follows untouched. `None` for any line carrying no move, which is
+/// So the head tokens are stripped and the member's own sentence is all that
+/// remains — a teammate's line should read as a teammate talking. `None` for any line carrying no move, which is
 /// every ordinary reply on every non-deliberating desk — those must pass
 /// through byte-for-byte.
 ///
@@ -175,27 +175,32 @@ pub fn readable(line: &str) -> Option<String> {
         rest = rest[token.len()..].trim_start();
     }
 
-    let lead = match (kind, topic) {
-        ("propose", Some(topic)) => format!("proposes {topic}"),
-        ("propose", None) => "proposes".to_string(),
-        ("support", Some(topic)) => format!("supports {topic}"),
-        ("support", None) => "supports".to_string(),
-        ("object", _) => "objects".to_string(),
-        ("refute", Some(topic)) => format!("refutes {topic}"),
-        ("refute", None) => "refutes".to_string(),
-        ("evidence", _) => "evidence".to_string(),
-        ("question", _) => "asks".to_string(),
-        ("defer", _) => "defers".to_string(),
-        ("commit", Some(topic)) => format!("records {topic}"),
-        ("commit", None) => "records".to_string(),
-        ("pin", _) => "pins".to_string(),
-        (other, _) => other.to_string(),
-    };
-    Some(if rest.is_empty() {
-        format!("[{lead}]")
-    } else {
-        format!("[{lead}] {rest}")
-    })
+    // **No label, only the sentence.** The lead this once carried — "[supports
+    // lazy-load]" — was the grammar in another costume: still the mechanism's
+    // vocabulary, still addressed to the fold, still something an operator has
+    // to learn before the channel reads as a conversation. A teammate's line
+    // should look like a teammate talking.
+    //
+    // What is lost is that the channel no longer distinguishes a support from
+    // an objection at a glance. That is recoverable from the prose, which says
+    // so in words, and the fold keeps the marker on the stored row either way.
+    //
+    // A move with no sentence after it — `!question` and `!defer` are the two
+    // honest things a member with nothing to add can say — would otherwise
+    // render as an empty bubble, so those keep a plain phrase.
+    if !rest.is_empty() {
+        return Some(rest.to_string());
+    }
+    Some(
+        match kind {
+            "question" => "I have nothing further to ask.",
+            "defer" => "This is not mine to answer.",
+            "commit" => "Recorded.",
+            "pin" => "Pinned for the room.",
+            _ => return None,
+        }
+        .to_string(),
+    )
 }
 
 /// The leading `!` and nothing else: the member's own words are kept verbatim,
@@ -236,15 +241,15 @@ mod readable_test {
     fn a_move_line_reads_as_english() {
         assert_eq!(
             readable("!propose #lazy-load defer each section until it is opened").as_deref(),
-            Some("[proposes lazy-load] defer each section until it is opened")
+            Some("defer each section until it is opened")
         );
         assert_eq!(
             readable("!support #lazy-load ^3 agreed, and it is reversible").as_deref(),
-            Some("[supports lazy-load] agreed, and it is reversible")
+            Some("agreed, and it is reversible")
         );
         assert_eq!(
             readable("!object >3 ^1 users bounce between sections").as_deref(),
-            Some("[objects] users bounce between sections")
+            Some("users bounce between sections")
         );
     }
 
@@ -255,7 +260,7 @@ mod readable_test {
         assert_eq!(
             readable("!evidence #perf ^2 the p95 is > 400ms and #2 in the list is worse")
                 .as_deref(),
-            Some("[evidence] the p95 is > 400ms and #2 in the list is worse")
+            Some("the p95 is > 400ms and #2 in the list is worse")
         );
     }
 
@@ -270,6 +275,10 @@ mod readable_test {
     /// A bare marker still says which move it was.
     #[test]
     fn a_move_with_nothing_after_it_still_renders() {
-        assert_eq!(readable("!question").as_deref(), Some("[asks]"));
+        assert_eq!(
+            readable("!question").as_deref(),
+            Some("I have nothing further to ask."),
+            "a bare move would otherwise render as an empty bubble"
+        );
     }
 }

--- a/src/hivemind/moves.rs
+++ b/src/hivemind/moves.rs
@@ -129,6 +129,75 @@ pub fn correction(attempted: &str, allowed: &[&str]) -> String {
 
 /// The same line, stripped of the marker that made it a move.
 ///
+/// One deliberation line, rendered for a person instead of for the fold.
+///
+/// The grammar is addressed to the mechanism: `!` says which move this is,
+/// `#topic` names the option, `^N` and `>N` are sequence citations. All four
+/// are load-bearing in the transcript and meaningless in a chat window — an
+/// operator reading a desk was being shown `!support #lazy-load ^3 agreed`,
+/// which is machine syntax rendered verbatim in a human channel.
+///
+/// So the head tokens are lifted into a plain-English lead and the member's own
+/// sentence follows untouched. `None` for any line carrying no move, which is
+/// every ordinary reply on every non-deliberating desk — those must pass
+/// through byte-for-byte.
+///
+/// **A rendering only.** The stored line keeps its grammar: the fold reads
+/// markers off the journal, and a projection that rewrote them would leave the
+/// room unable to count its own transcript.
+#[must_use]
+pub fn readable(line: &str) -> Option<String> {
+    let kind = line_kind(line)?;
+    let rest = line.trim_start().strip_prefix('!')?;
+    let rest = rest
+        .split_once(char::is_whitespace)
+        .map_or("", |(_, tail)| tail);
+
+    // Only the citation tokens at the HEAD are grammar. The same characters
+    // inside a sentence are the member's own words — "#2 in the list", "a > b"
+    // — and rewriting those would edit what a teammate said.
+    let mut topic = None;
+    let mut rest = rest.trim_start();
+    loop {
+        let token = rest.split_whitespace().next().unwrap_or_default();
+        let is_grammar = token.starts_with('#')
+            || token.starts_with('^')
+            || token.starts_with('>')
+            || token.starts_with("!");
+        if token.is_empty() || !is_grammar {
+            break;
+        }
+        if let Some(name) = token.strip_prefix('#')
+            && topic.is_none()
+        {
+            topic = Some(name.to_string());
+        }
+        rest = rest[token.len()..].trim_start();
+    }
+
+    let lead = match (kind, topic) {
+        ("propose", Some(topic)) => format!("proposes {topic}"),
+        ("propose", None) => "proposes".to_string(),
+        ("support", Some(topic)) => format!("supports {topic}"),
+        ("support", None) => "supports".to_string(),
+        ("object", _) => "objects".to_string(),
+        ("refute", Some(topic)) => format!("refutes {topic}"),
+        ("refute", None) => "refutes".to_string(),
+        ("evidence", _) => "evidence".to_string(),
+        ("question", _) => "asks".to_string(),
+        ("defer", _) => "defers".to_string(),
+        ("commit", Some(topic)) => format!("records {topic}"),
+        ("commit", None) => "records".to_string(),
+        ("pin", _) => "pins".to_string(),
+        (other, _) => other.to_string(),
+    };
+    Some(if rest.is_empty() {
+        format!("[{lead}]")
+    } else {
+        format!("[{lead}] {rest}")
+    })
+}
+
 /// The leading `!` and nothing else: the member's own words are kept verbatim,
 /// so the transcript records what it wanted to say and a reader can see the
 /// attempt. What it loses is the only thing at stake — `resolve` reads a
@@ -157,4 +226,50 @@ pub struct MoveViolation {
     pub agent_id: String,
     /// The kind it reached for, without the `!`.
     pub attempted: String,
+}
+
+#[cfg(test)]
+mod readable_test {
+    use super::readable;
+
+    #[test]
+    fn a_move_line_reads_as_english() {
+        assert_eq!(
+            readable("!propose #lazy-load defer each section until it is opened").as_deref(),
+            Some("[proposes lazy-load] defer each section until it is opened")
+        );
+        assert_eq!(
+            readable("!support #lazy-load ^3 agreed, and it is reversible").as_deref(),
+            Some("[supports lazy-load] agreed, and it is reversible")
+        );
+        assert_eq!(
+            readable("!object >3 ^1 users bounce between sections").as_deref(),
+            Some("[objects] users bounce between sections")
+        );
+    }
+
+    /// The same characters inside a sentence are the member's own words —
+    /// rewriting those would edit what a teammate said.
+    #[test]
+    fn only_the_head_tokens_are_grammar() {
+        assert_eq!(
+            readable("!evidence #perf ^2 the p95 is > 400ms and #2 in the list is worse")
+                .as_deref(),
+            Some("[evidence] the p95 is > 400ms and #2 in the list is worse")
+        );
+    }
+
+    /// Every reply on every desk that does not deliberate must survive
+    /// byte-for-byte.
+    #[test]
+    fn an_ordinary_reply_is_untouched() {
+        assert_eq!(readable("here is the summary you asked for"), None);
+        assert_eq!(readable("!notamove still ordinary prose"), None);
+    }
+
+    /// A bare marker still says which move it was.
+    #[test]
+    fn a_move_with_nothing_after_it_still_renders() {
+        assert_eq!(readable("!question").as_deref(), Some("[asks]"));
+    }
 }

--- a/src/hivemind/moves.rs
+++ b/src/hivemind/moves.rs
@@ -191,8 +191,15 @@ pub fn readable(line: &str) -> Option<String> {
     if !rest.is_empty() {
         return Some(rest.to_string());
     }
+    // `line_kind` folds `!unpin` onto `pin` — they write the same board, so the
+    // fold treats them alike. A RENDERING must not: "Pinned for the room." is
+    // the opposite of what an unpin did, and a bare one carries no sentence to
+    // correct the impression.
+    let bare = line.trim_start().strip_prefix('!').unwrap_or_default();
+    let unpinning = bare.split_whitespace().next() == Some("unpin");
     Some(
         match kind {
+            "pin" if unpinning => "Unpinned from the room's board.",
             "question" => "I have nothing further to ask.",
             "defer" => "This is not mine to answer.",
             "commit" => "Recorded.",
@@ -279,6 +286,21 @@ mod readable_test {
             readable("!question").as_deref(),
             Some("I have nothing further to ask."),
             "a bare move would otherwise render as an empty bubble"
+        );
+    }
+    /// `line_kind` folds `!unpin` onto `pin` because both write one board — a
+    /// RENDERING must not, or an unpin reads as its own opposite.
+    #[test]
+    fn an_unpin_does_not_read_as_a_pin() {
+        assert_eq!(
+            readable("!unpin").as_deref(),
+            Some("Unpinned from the room's board.")
+        );
+        assert_eq!(readable("!pin").as_deref(), Some("Pinned for the room."));
+        // With a sentence, the member's own words stand either way.
+        assert_eq!(
+            readable("!unpin ^4 the window has moved past it").as_deref(),
+            Some("the window has moved past it")
         );
     }
 }

--- a/src/hivemind/moves_test.rs
+++ b/src/hivemind/moves_test.rs
@@ -884,7 +884,7 @@ async fn a_members_failed_turn_does_not_end_the_episode() {
     let replies = log.replies("eng");
     let note = replies
         .iter()
-        .find(|(author, text)| author == HIVE_REPORT_AUTHOR && text.contains("did not finish"))
+        .find(|(author, text)| author == HIVE_FAILURE_AUTHOR && text.contains("did not finish"))
         .expect("the miss is journaled");
     assert!(note.1.contains("@scout's turn did not finish"), "{note:?}");
     assert!(note.1.contains("wall-clock ceiling"), "{note:?}");
@@ -927,7 +927,7 @@ async fn a_room_where_every_seat_fails_twice_over_stops() {
     assert_eq!(
         log.replies("eng")
             .iter()
-            .filter(|(author, _)| author == HIVE_REPORT_AUTHOR)
+            .filter(|(author, _)| author == HIVE_FAILURE_AUTHOR)
             .count(),
         6,
         "the cap is members x 2"

--- a/src/hivemind/prompt.rs
+++ b/src/hivemind/prompt.rs
@@ -351,7 +351,7 @@ impl<'a> EpisodePrompt<'a> {
             self.missing(),
             self.peers(),
             self.last_line(visible),
-            render_transcript(visible, self.trigger),
+            render_transcript(visible, self.trigger, Some(&self.member.id)),
         )
     }
 
@@ -756,7 +756,11 @@ const EPISODE_DIVIDER: &str = "--- Above: earlier conversation on this desk, fro
 /// parameter existed) renders exactly as it always has, and a caller that
 /// never learned a trigger passes `None` and gets the same guarantee.
 #[must_use]
-pub fn render_transcript(visible: &[SessionMessage], trigger: Option<Sequence>) -> String {
+pub fn render_transcript(
+    visible: &[SessionMessage],
+    trigger: Option<Sequence>,
+    viewer: Option<&str>,
+) -> String {
     let split = trigger
         .map(|trigger| visible.partition_point(|message| message.sequence <= trigger))
         .filter(|&split| split > 0 && split < visible.len());
@@ -765,13 +769,32 @@ pub fn render_transcript(visible: &[SessionMessage], trigger: Option<Sequence>) 
         if split == Some(index) {
             lines.push(EPISODE_DIVIDER.to_owned());
         }
-        lines.push(render_transcript_line(message));
+        lines.push(render_transcript_line(message, viewer));
     }
     lines.join("\n")
 }
 
 /// One transcript row: `[sequence] author: content`.
-fn render_transcript_line(message: &SessionMessage) -> String {
+///
+/// The reading member's own rows are labelled **You**, and everyone else's by
+/// name. Without that distinction a member read its own turns in exactly the
+/// third person it read its colleagues' — and wrote back in the same voice.
+/// Observed live: `software_engineer` closed a room with "carried with support
+/// from software_engineer and junior_engineer", crediting itself by name as
+/// though it were someone else, because the transcript it had just read gave it
+/// no other convention to copy.
+///
+/// This is the same fix `Speaker::Viewer` is for the chat seed (issue #1956),
+/// which the episode's own renderer never had: "there were no colleagues in the
+/// room" is one failure, and "there is no *self* in the room" is its twin.
+///
+/// `None` renders every row by name, for a caller with no reader to speak of.
+fn render_transcript_line(message: &SessionMessage, viewer: Option<&str>) -> String {
+    if let (Some(viewer), SessionAuthor::Agent { id, .. }) = (viewer, &message.author)
+        && id == viewer
+    {
+        return format!("[{}] You: {}", message.sequence, message.content);
+    }
     let author = match &message.author {
         SessionAuthor::Agent { label, .. }
         | SessionAuthor::Person { label, .. }

--- a/src/hivemind/prompt.rs
+++ b/src/hivemind/prompt.rs
@@ -776,9 +776,10 @@ pub fn render_transcript(
 
 /// One transcript row: `[sequence] author: content`.
 ///
-/// The reading member's own rows are labelled **You**, and everyone else's by
-/// name. Without that distinction a member read its own turns in exactly the
-/// third person it read its colleagues' — and wrote back in the same voice.
+/// The reading member's own rows carry a `(you)` marker after their author id,
+/// and everyone else's render by name alone. Without that distinction a member
+/// read its own turns in exactly the third person it read its colleagues' —
+/// and wrote back in the same voice.
 /// Observed live: `software_engineer` closed a room with "carried with support
 /// from software_engineer and junior_engineer", crediting itself by name as
 /// though it were someone else, because the transcript it had just read gave it
@@ -788,12 +789,20 @@ pub fn render_transcript(
 /// which the episode's own renderer never had: "there were no colleagues in the
 /// room" is one failure, and "there is no *self* in the room" is its twin.
 ///
+/// The id stays in front of the marker rather than being replaced by a bare
+/// `You`, because the transcript is the citation surface: a member is named by
+/// its id when a colleague objects to `>N` or backs `^N`, so a row it cannot
+/// tie back to that id is one it cannot recognise as the thing being argued
+/// with. Attribution is upstream's contract here — `tests/hivemind_e2e.rs`
+/// parses these rows by author id — and this adds to it rather than
+/// substituting for it.
+///
 /// `None` renders every row by name, for a caller with no reader to speak of.
 fn render_transcript_line(message: &SessionMessage, viewer: Option<&str>) -> String {
     if let (Some(viewer), SessionAuthor::Agent { id, .. }) = (viewer, &message.author)
         && id == viewer
     {
-        return format!("[{}] You: {}", message.sequence, message.content);
+        return format!("[{}] {id} (you): {}", message.sequence, message.content);
     }
     let author = match &message.author {
         SessionAuthor::Agent { label, .. }

--- a/src/hivemind/referral_test.rs
+++ b/src/hivemind/referral_test.rs
@@ -220,6 +220,7 @@ fn the_federation_includes_a_console_created_desk() {
         description: Some("Runs experiments".to_owned()),
         members: vec!["planner".to_owned()],
         responder: crate::ports::types::ResponderMode::default(),
+        hive: Default::default(),
     });
 
     let federation = desk_federation(&record, &desk).expect("a federation");

--- a/src/hivemind/test.rs
+++ b/src/hivemind/test.rs
@@ -796,14 +796,17 @@ fn a_transcript_spanning_the_watermark_renders_the_divider_between_episodes() {
     let divider_at = prompt
         .find("this episode's floor")
         .expect("the divider names its own meaning");
+    // `planner` is the member this prompt is for, so its own row reads "You" —
+    // the distinction that stops a member describing itself in the third person.
     let current_start = prompt
-        .find("[3] planner")
-        .expect("current row 3 is rendered");
+        .find("[3] You")
+        .expect("current row 3 is rendered, as the reader's own");
     assert!(prior_end < divider_at, "{prompt}");
     assert!(divider_at < current_start, "{prompt}");
     // Sequence numbers stay exactly as the projection assigned them, on both
     // sides of the divider.
-    for needle in ["[1] scout", "[2] scout", "[3] planner", "[4] critic"] {
+    // `planner` reads its own row as "You"; the rest keep their names.
+    for needle in ["[1] scout", "[2] scout", "[3] You", "[4] critic"] {
         assert!(prompt.contains(needle), "{needle} missing:\n{prompt}");
     }
 }
@@ -858,7 +861,8 @@ fn a_blind_turn_still_hides_only_this_episodes_peers_not_prior_context() {
         prompt.contains("[1] scout"),
         "prior context stays visible even blind:\n{prompt}"
     );
-    assert!(prompt.contains("[2] planner"), "{prompt}");
+    // The reader's own prior row is labelled "You", not by name.
+    assert!(prompt.contains("[2] You"), "{prompt}");
     assert!(
         !prompt.contains("[3]"),
         "a peer's live position leaked into a blind turn:\n{prompt}"
@@ -873,7 +877,8 @@ fn a_blind_turn_still_hides_only_this_episodes_peers_not_prior_context() {
     let divider_at = prompt
         .find("this episode's floor")
         .expect("the divider names its own meaning");
-    let current_start = prompt.find("[2] planner").expect("current row rendered");
+    // The turn-holder's own line, so it reads "You" rather than its own name.
+    let current_start = prompt.find("[2] You").expect("current row rendered");
     assert!(prior_end < divider_at, "{prompt}");
     assert!(divider_at < current_start, "{prompt}");
 }
@@ -1035,4 +1040,41 @@ fn a_settled_room_reports_what_it_decided() {
         "{}",
         unknown.ending_summary()
     );
+}
+
+/// **A member must be able to tell its own turns from its colleagues'.**
+///
+/// Every transcript row was labelled with its author's name, the reader's own
+/// included, so a member had no convention for first person and copied the one
+/// it was shown. Observed live: `software_engineer` closed a room with
+/// "carried with support from software_engineer and junior_engineer" — naming
+/// itself as though it were somebody else.
+#[test]
+fn a_member_reads_its_own_turns_as_its_own() {
+    let visible = vec![
+        message(1, "scout", "!propose #ship send it now"),
+        message(
+            2,
+            "planner",
+            "!object >1 ^1 the last rollout broke checkout",
+        ),
+    ];
+    let rendered = crate::hivemind::prompt::render_transcript(&visible, None, Some("planner"));
+
+    assert!(
+        rendered.contains("[2] You:"),
+        "the reader's own row is theirs: {rendered}"
+    );
+    assert!(
+        rendered.contains("[1] scout:"),
+        "and a colleague keeps its name: {rendered}"
+    );
+    assert!(
+        !rendered.contains("[2] planner:"),
+        "the reader is never named to itself: {rendered}"
+    );
+
+    // A caller with no reader renders every row by name, as before.
+    let anonymous = crate::hivemind::prompt::render_transcript(&visible, None, None);
+    assert!(anonymous.contains("[2] planner:"), "{anonymous}");
 }

--- a/src/hivemind/test.rs
+++ b/src/hivemind/test.rs
@@ -930,3 +930,109 @@ fn a_retirement_that_strands_the_quorum_falls_back_to_one_responder() {
         "losing an ineligible seat leaves the quorum reachable"
     );
 }
+
+/// **A deadlock asks the operator, rather than merely announcing itself.**
+///
+/// `Deadlocked` is only returned when `has_free_dissenter` is false — every
+/// member has taken a side. So the room cannot break the tie, and nobody in it
+/// can even choose whom to consult without one side picking its own referee.
+/// Every member also had the chance to name an outsider on any of its own
+/// turns: referral is considered on every committed marked line. None did.
+///
+/// The one party left is the operator, and the sentence has to say so — read
+/// flatly it is an outcome, and an operator would have to know the mechanism to
+/// realise a decision was owed.
+#[test]
+fn a_deadlocked_desk_asks_the_operator_to_decide() {
+    let outcome = EpisodeOutcome {
+        ending: EpisodeEnding::Deadlocked {
+            topics: vec!["skeleton".to_string(), "spinner".to_string()],
+        },
+        turns: 6,
+        first_seq: None,
+        last_seq: None,
+        report_seq: None,
+        violations: Vec::new(),
+        failed_turns: 0,
+        referrals: Default::default(),
+    };
+
+    let summary = outcome.ending_summary();
+    assert!(
+        summary.contains("#skeleton") && summary.contains("#spinner"),
+        "both tied topics are named, so the operator knows what it is choosing between: {summary}"
+    );
+    assert!(
+        summary.contains("needs your call"),
+        "and is asked for a decision rather than told an outcome: {summary}"
+    );
+    assert!(
+        summary.contains("nobody was left to break the tie"),
+        "with the reason the desk could not settle it alone: {summary}"
+    );
+}
+
+/// **The report carries the decision, not only its label.**
+///
+/// A topic id is a name an LLM picked. Observed live: a desk argued
+/// lazy-loading coherently, filed it under `#need-decide`, and the report read
+/// "the desk settled on #need-decide" — which says nothing. The reasoning was
+/// in the transcript, where `EpisodeOutcome` cannot reach it.
+#[test]
+fn a_settled_room_reports_what_it_decided() {
+    let settled = EpisodeOutcome {
+        ending: EpisodeEnding::Converged {
+            topic: "need-decide".to_string(),
+            supporters: vec![
+                "software_engineer".to_string(),
+                "junior_engineer".to_string(),
+            ],
+            proposal: Some(
+                "lazy-load each section, so the page only pays for what is opened".to_string(),
+            ),
+        },
+        turns: 3,
+        first_seq: None,
+        last_seq: None,
+        report_seq: None,
+        violations: Vec::new(),
+        failed_turns: 0,
+        referrals: Default::default(),
+    };
+    let summary = settled.ending_summary();
+    assert!(
+        summary.contains("lazy-load each section"),
+        "an operator reads the decision itself: {summary}"
+    );
+    assert!(
+        !summary.contains('\n'),
+        "and it stays one line: this row is journaled onto the desk and lands in \
+         the next episode's window: {summary}"
+    );
+    assert!(
+        summary.contains("#need-decide") && summary.contains("software_engineer"),
+        "with the label and backing kept as bookkeeping: {summary}"
+    );
+
+    // A room whose proposal has scrolled out of the window reads exactly as it
+    // did before this field existed, rather than losing the sentence entirely.
+    let unknown = EpisodeOutcome {
+        ending: EpisodeEnding::Converged {
+            topic: "stage".to_string(),
+            supporters: vec!["engineer".to_string()],
+            proposal: None,
+        },
+        turns: 5,
+        first_seq: None,
+        last_seq: None,
+        report_seq: None,
+        violations: Vec::new(),
+        failed_turns: 0,
+        referrals: Default::default(),
+    };
+    assert!(
+        unknown.ending_summary().contains("settled on #stage"),
+        "{}",
+        unknown.ending_summary()
+    );
+}

--- a/src/hivemind/test.rs
+++ b/src/hivemind/test.rs
@@ -796,17 +796,18 @@ fn a_transcript_spanning_the_watermark_renders_the_divider_between_episodes() {
     let divider_at = prompt
         .find("this episode's floor")
         .expect("the divider names its own meaning");
-    // `planner` is the member this prompt is for, so its own row reads "You" —
-    // the distinction that stops a member describing itself in the third person.
+    // `planner` is the member this prompt is for, so its own row is marked
+    // `(you)` — the distinction that stops a member describing itself in the
+    // third person, without dropping the id colleagues cite it by.
     let current_start = prompt
-        .find("[3] You")
+        .find("[3] planner (you)")
         .expect("current row 3 is rendered, as the reader's own");
     assert!(prior_end < divider_at, "{prompt}");
     assert!(divider_at < current_start, "{prompt}");
     // Sequence numbers stay exactly as the projection assigned them, on both
     // sides of the divider.
-    // `planner` reads its own row as "You"; the rest keep their names.
-    for needle in ["[1] scout", "[2] scout", "[3] You", "[4] critic"] {
+    // `planner` reads its own row marked `(you)`; the rest keep their names.
+    for needle in ["[1] scout", "[2] scout", "[3] planner (you)", "[4] critic"] {
         assert!(prompt.contains(needle), "{needle} missing:\n{prompt}");
     }
 }
@@ -861,8 +862,8 @@ fn a_blind_turn_still_hides_only_this_episodes_peers_not_prior_context() {
         prompt.contains("[1] scout"),
         "prior context stays visible even blind:\n{prompt}"
     );
-    // The reader's own prior row is labelled "You", not by name.
-    assert!(prompt.contains("[2] You"), "{prompt}");
+    // The reader's own prior row is marked `(you)`, keeping its id.
+    assert!(prompt.contains("[2] planner (you)"), "{prompt}");
     assert!(
         !prompt.contains("[3]"),
         "a peer's live position leaked into a blind turn:\n{prompt}"
@@ -878,7 +879,9 @@ fn a_blind_turn_still_hides_only_this_episodes_peers_not_prior_context() {
         .find("this episode's floor")
         .expect("the divider names its own meaning");
     // The turn-holder's own line, so it reads "You" rather than its own name.
-    let current_start = prompt.find("[2] You").expect("current row rendered");
+    let current_start = prompt
+        .find("[2] planner (you)")
+        .expect("current row rendered");
     assert!(prior_end < divider_at, "{prompt}");
     assert!(divider_at < current_start, "{prompt}");
 }
@@ -1062,16 +1065,24 @@ fn a_member_reads_its_own_turns_as_its_own() {
     let rendered = crate::hivemind::prompt::render_transcript(&visible, None, Some("planner"));
 
     assert!(
-        rendered.contains("[2] You:"),
-        "the reader's own row is theirs: {rendered}"
+        rendered.contains("[2] planner (you):"),
+        "the reader's own row is marked as theirs: {rendered}"
     );
     assert!(
         rendered.contains("[1] scout:"),
         "and a colleague keeps its name: {rendered}"
     );
     assert!(
-        !rendered.contains("[2] planner:"),
-        "the reader is never named to itself: {rendered}"
+        !rendered.contains("[1] scout (you)"),
+        "the marker is the reader's alone: {rendered}"
+    );
+    // The id stays in front of the marker. The transcript is the citation
+    // surface — `!object >2` and `!support ^2` name this row to everyone else
+    // — so a reader stripped of its own id could not tie a colleague's
+    // citation back to the line it is arguing with.
+    assert!(
+        !rendered.contains("[2] You:"),
+        "the id is not replaced by a bare pronoun: {rendered}"
     );
 
     // A caller with no reader renders every row by name, as before.

--- a/src/hivemind/types.rs
+++ b/src/hivemind/types.rs
@@ -303,6 +303,20 @@ impl HivePolicy {
 pub enum EpisodeEnding {
     /// One topic carried and the room recorded it.
     Converged {
+        /// What the carried proposal actually SAID, when its `!propose` line is
+        /// still in the window.
+        ///
+        /// A topic id is a label, and the report had only the label: a room
+        /// that argued well and named its option `#need-decide` reported
+        /// "the desk settled on #need-decide", which tells an operator nothing
+        /// about the decision. The reasoning was in the transcript, where the
+        /// report could not reach it — `EpisodeOutcome` carries no transcript,
+        /// so the text has to travel on the ending itself.
+        ///
+        /// `None` when no `!propose` for the topic survives the fold window,
+        /// which is possible for a long room: the sentence then reads exactly
+        /// as it did before this field existed.
+        proposal: Option<String>,
         /// The topic that carried.
         topic: String,
         /// The members whose grounded support carried it.
@@ -513,18 +527,53 @@ impl EpisodeOutcome {
         let turns = self.turns;
         let plural = if turns == 1 { "turn" } else { "turns" };
         match &self.ending {
-            EpisodeEnding::Converged { topic, supporters } => {
+            EpisodeEnding::Converged {
+                topic,
+                supporters,
+                proposal,
+            } => {
                 let backing = if supporters.is_empty() {
                     "the room".to_owned()
                 } else {
                     supporters.join(", ")
                 };
-                format!(
-                    "The desk settled on #{topic} after {turns} {plural} (backed by {backing})."
-                )
+                match proposal.as_deref().map(str::trim).filter(|p| !p.is_empty()) {
+                    // The decision first, the bookkeeping after it: an operator
+                    // reading this wants to know what was decided, not which
+                    // label the room happened to file it under.
+                    // Kept to ONE line, like every other row the room writes.
+                    // This report is journaled onto the desk, so it lands in the
+                    // NEXT episode's transcript window — a paragraph here would
+                    // take that space from every future room. A proposal is
+                    // extracted from a single `!propose` line, so it fits.
+                    Some(text) => format!(
+                        "The desk settled after {turns} {plural} (#{topic}, backed by \
+                         {backing}): {text}"
+                    ),
+                    None => format!(
+                        "The desk settled on #{topic} after {turns} {plural} (backed by \
+                         {backing})."
+                    ),
+                }
             }
+            // **A deadlock is escalated, not merely reported.**
+            //
+            // `Deadlocked` is returned only when `has_free_dissenter` is false
+            // — every member has taken a side by construction. So the room
+            // cannot break this itself, and nobody in it can even choose who to
+            // ask: any member picking an outside desk would be one side of a
+            // split choosing its own referee. Every member also had the chance
+            // to name an outsider on any of its own turns, since referral is
+            // considered on every committed marked line; none did.
+            //
+            // That leaves exactly one party who can decide, and the sentence
+            // now says so. Reported flatly, this read as an outcome rather than
+            // as a question, and an operator watching a desk had to know the
+            // mechanism to realise a decision was owed.
             EpisodeEnding::Deadlocked { topics } => format!(
-                "The desk deadlocked after {turns} {plural}: {} carried together and nobody broke the tie.",
+                "The desk deadlocked after {turns} {plural}: {} carried together and everyone had \
+                 taken a side, so nobody was left to break the tie. It needs your call — say which \
+                 to take, or what would settle it.",
                 topics
                     .iter()
                     .map(|topic| format!("#{topic}"))

--- a/src/hivemind/types.rs
+++ b/src/hivemind/types.rs
@@ -143,6 +143,13 @@ pub struct HiveConfig {
 }
 
 impl HiveConfig {
+    /// Whether this block says nothing at all, so a record that predates the
+    /// field keeps omitting it exactly as it did before.
+    #[must_use]
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
     /// Whether a desk of `members` effective members deliberates under this
     /// config.
     ///
@@ -534,6 +541,39 @@ impl EpisodeOutcome {
     }
 }
 
+/// The hive block in force for `desk_id`, overlay first and manifest behind it.
+///
+/// Both surfaces can declare one and they are merged the same way
+/// `effective_desk_members` merges membership: an operator-created desk keeps
+/// its own settings, a manifest desk keeps the blueprint's, and a desk that
+/// declares nothing takes the defaults.
+///
+/// Reading only the manifest — which is what this did — meant a console-created
+/// desk could not answer either question the block decides. It deliberated
+/// because the default says so and had no way to opt out, and it could never
+/// opt IN to referral, because there was no `[[group_chat]]` entry to hang the
+/// block on. A company that builds its desks in the console therefore had
+/// cross-desk referral permanently unavailable, with nothing to change to get
+/// it.
+#[must_use]
+pub fn effective_hive_config(record: &CompanyRecord, desk_id: &str) -> HiveConfig {
+    record
+        .overlay_desks
+        .iter()
+        .find(|desk| desk.id == desk_id)
+        .filter(|desk| !desk.hive.is_default())
+        .map(|desk| desk.hive.clone())
+        .or_else(|| {
+            record
+                .manifest
+                .group_chats
+                .iter()
+                .find(|group| group.id == desk_id)
+                .map(|group| group.hive.clone())
+        })
+        .unwrap_or_default()
+}
+
 /// The desk a hive episode should answer `chat` on, or `None` to keep today's
 /// single-responder path.
 ///
@@ -563,12 +603,7 @@ pub fn desk_episode(record: &CompanyRecord, chat: Option<&str>) -> Option<HiveDe
         return None;
     }
     let desk_id = record.resolve_desk_id(chat)?;
-    let declared = record
-        .manifest
-        .group_chats
-        .iter()
-        .find(|group| group.id == desk_id);
-    let config = declared.map(|group| group.hive.clone()).unwrap_or_default();
+    let config = effective_hive_config(record, &desk_id);
     let members: Vec<HiveMember> = record
         .effective_desk_members(&desk_id)
         .into_iter()
@@ -613,9 +648,24 @@ pub fn desk_episode(record: &CompanyRecord, chat: Option<&str>) -> Option<HiveDe
         );
         return None;
     }
+    // Name and description come from whichever surface declared the desk, the
+    // same order the config does. Reading the manifest alone left an operator
+    // -created desk carrying its raw id as its name in every episode prompt and
+    // closing report, because the manifest has no entry for it.
+    let overlay = record.overlay_desks.iter().find(|desk| desk.id == desk_id);
+    let declared = record
+        .manifest
+        .group_chats
+        .iter()
+        .find(|group| group.id == desk_id);
     Some(HiveDesk {
-        name: declared.map_or_else(|| desk_id.clone(), |group| group.name.clone()),
-        description: declared.and_then(|group| group.description.clone()),
+        name: overlay
+            .map(|desk| desk.name.clone())
+            .or_else(|| declared.map(|group| group.name.clone()))
+            .unwrap_or_else(|| desk_id.clone()),
+        description: overlay
+            .and_then(|desk| desk.description.clone())
+            .or_else(|| declared.and_then(|group| group.description.clone())),
         id: desk_id,
         members,
         config,

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -624,6 +624,56 @@ impl StartedBy {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum CompanyEvent {
+    /// A crossing referral's child turn was durably created (tinyhivemind P15).
+    ///
+    /// The idempotency marker, and the only reason this is journaled at all: a
+    /// referral is triggered by a COMMITTED reply, so anything that reprocesses
+    /// that reply — a restart, a redelivered frame, a retry — would decide the
+    /// same referral again and ask the target desk twice. The queue writes this
+    /// under the trigger's identity and refuses a second enqueue that finds it.
+    ///
+    /// Not a conversational line: `chat_history::owns` does not admit it and no
+    /// transcript renders it.
+    ReferralEnqueued {
+        /// The desk the triggering reply was committed on.
+        from_desk: String,
+        /// Sequence of that reply — with `from_desk`, the idempotency key.
+        trigger_sequence: u64,
+        /// The asking desk's display name, captured now.
+        ///
+        /// The console renders this on the referred message, and a desk renamed
+        /// later must not rewrite what the transcript said at the time — the
+        /// same rule `SessionAuthor` follows for its own labels.
+        ///
+        /// **Defaulted, because the journal is append-only.** Markers written
+        /// before this field existed must still deserialize: a required field
+        /// here made every older marker unreadable, and because the history
+        /// projection reads the journal, that took the whole transcript with
+        /// it. Any field added to a journaled event has to default.
+        #[serde(default)]
+        from_desk_name: String,
+        /// Whether this marker is a RETURN — the answer coming home — rather
+        /// than the outbound ask. Defaulted for the reason above.
+        ///
+        /// The console draws a different word for each ("Asked by Design" vs
+        /// "Answered by Design"), and it cannot work this out for itself: both
+        /// legs are agent-authored lines on a desk, so every signal the console
+        /// holds says the same thing about each. `tinyhivemind` decided it
+        /// already — `ReferralKind` — and this carries that decision rather
+        /// than letting the render side infer a second, disagreeing answer.
+        #[serde(default)]
+        returning: bool,
+        /// The agent that asked. Defaulted for the reason above.
+        #[serde(default)]
+        asker: String,
+        /// That agent's display label, captured now, for the same reason.
+        #[serde(default)]
+        asker_label: String,
+        /// The desk the child turn runs on.
+        to_desk: String,
+        /// The agent the child turn runs as.
+        target: String,
+    },
     /// A human sent a chat message.
     OperatorMessage {
         /// The message text.
@@ -2025,6 +2075,7 @@ impl CompanyEvent {
     pub fn kind(&self) -> &'static str {
         match self {
             Self::OperatorMessage { .. } => "OperatorMessage",
+            Self::ReferralEnqueued { .. } => "ReferralEnqueued",
             Self::TurnStarted { .. } => "TurnStarted",
             Self::TurnFailed { .. } => "TurnFailed",
             Self::RunStatusChanged { .. } => "RunStatusChanged",
@@ -2100,6 +2151,16 @@ impl CompanyEvent {
     pub fn retention_class(&self) -> crate::ports::events::RetentionClass {
         use crate::ports::events::RetentionClass::{Permanent, Prunable};
         match self {
+            // **Permanent, and this one is load-bearing** (tinyhivemind P15).
+            //
+            // It is the idempotency marker for a crossing referral: the queue
+            // refuses a second enqueue that finds it. Prune it and a replayed
+            // trigger stops finding it, so the target desk is asked twice —
+            // silently, and only for triggers old enough to have been swept.
+            // It passes the doc's three questions the other way round from its
+            // neighbours: nothing points at it, but something very much reads
+            // it back, and that read is the whole reason it exists.
+            Self::ReferralEnqueued { .. } => Permanent,
             Self::WorkflowRunStarted { .. }
             | Self::WorkflowRunFinished { .. }
             | Self::WorkflowNodeStarted { .. }
@@ -4192,8 +4253,8 @@ impl OverlayBlob {
 /// [`CONFINED_AGENT_ID`](crate::ports::CONFINED_AGENT_ID), unmintable by
 /// construction because slugs never emit a hyphen.
 ///
-/// [`MAIN_THREAD_ID`](crate::server::chat_history::MAIN_THREAD_ID) and
-/// [`DEFAULT_DESK`](crate::server::ops::language::DEFAULT_DESK) join them for
+/// [`MAIN_THREAD_ID`](tinyhivemind_core::chat::MAIN_THREAD_ID) and
+/// [`GENERAL_DESK`](tinyhivemind_core::chat::GENERAL_DESK) join them for
 /// issue #1743, and both are ordinary slugs — a teammate named "Main" or
 /// "General" mints straight onto one. That id is a chat address: `responder_for`
 /// checks roster ids before it falls back to the orchestrator, so the teammate
@@ -4201,13 +4262,22 @@ impl OverlayBlob {
 /// console would render the line's transcript as that teammate's DM. Desk ids
 /// and names are already excluded a few lines below; these are the two keys
 /// that route like a desk without being one.
+///
+/// The General entry is the **identity** constant, not
+/// `server::ops::language::DEFAULT_DESK`, the operator-facing glossary word
+/// that happens to be the same literal. What is reserved here is a chat
+/// address, and this is the port layer: a port naming a server constant is the
+/// upward reach the shared crate exists to remove. The two cannot drift — a
+/// `const` assertion in [`crate::server::chat_history`] pins them together at
+/// compile time — so the reservation still covers a teammate named "General"
+/// however the host chooses to spell that word.
 pub const RESERVED_AGENT_IDS: [&str; 6] = [
     crate::runtime::OPERATOR_CHANNEL,
     crate::company::workspace_scaffold::AGENTS_ROOT,
     crate::company::workspace_scaffold::DESKS_ROOT,
     crate::ports::SYSTEM_AUTHOR,
-    crate::server::chat_history::MAIN_THREAD_ID,
-    crate::server::ops::language::DEFAULT_DESK,
+    tinyhivemind_core::chat::MAIN_THREAD_ID,
+    tinyhivemind_core::chat::GENERAL_DESK,
 ];
 
 /// A durable company record: charter/roster (manifest) plus ledger and
@@ -4624,11 +4694,11 @@ impl CompanyRecord {
         if let Some(exact) = self.manifest.group_chats.iter().find(|c| c.id == key) {
             return Some(exact.id.clone());
         }
-        if !crate::server::chat_history::is_general_chat(Some(key))
+        if !tinyhivemind_core::chat::is_general_chat(Some(key))
             && let Some(exact) = self
                 .overlay_desks
                 .iter()
-                .filter(|d| !crate::server::chat_history::is_general_chat(Some(&d.id)))
+                .filter(|d| !tinyhivemind_core::chat::is_general_chat(Some(&d.id)))
                 .find(|d| d.id == key)
         {
             return Some(exact.id.clone());
@@ -4640,7 +4710,7 @@ impl CompanyRecord {
             .find(|c| c.id == key || c.name.eq_ignore_ascii_case(key))
             .map(|c| c.id.clone())
             .or_else(|| {
-                if crate::server::chat_history::is_general_chat(Some(key)) {
+                if tinyhivemind_core::chat::is_general_chat(Some(key)) {
                     return None;
                 }
                 self.overlay_desks
@@ -4653,7 +4723,7 @@ impl CompanyRecord {
                     // that every desk mutation refuses. Its lead would answer,
                     // and the reply would be journaled under a thread the
                     // console renders no channel for.
-                    .filter(|d| !crate::server::chat_history::is_general_chat(Some(&d.id)))
+                    .filter(|d| !tinyhivemind_core::chat::is_general_chat(Some(&d.id)))
                     .find(|d| d.id == key || d.name.eq_ignore_ascii_case(key))
                     .map(|d| d.id.clone())
             })
@@ -4680,10 +4750,11 @@ impl CompanyRecord {
     /// overlay tier only when the manifest has no match at all.
     pub fn desk_alias_is_ambiguous(&self, key: &str) -> bool {
         if self.manifest.group_chats.iter().any(|c| c.id == key)
-            || (!crate::server::chat_history::is_general_chat(Some(key))
-                && self.overlay_desks.iter().any(|d| {
-                    d.id == key && !crate::server::chat_history::is_general_chat(Some(&d.id))
-                }))
+            || (!tinyhivemind_core::chat::is_general_chat(Some(key))
+                && self
+                    .overlay_desks
+                    .iter()
+                    .any(|d| d.id == key && !tinyhivemind_core::chat::is_general_chat(Some(&d.id))))
         {
             return false;
         }
@@ -4696,12 +4767,12 @@ impl CompanyRecord {
         if manifest_matches > 0 {
             return manifest_matches > 1;
         }
-        if crate::server::chat_history::is_general_chat(Some(key)) {
+        if tinyhivemind_core::chat::is_general_chat(Some(key)) {
             return false;
         }
         self.overlay_desks
             .iter()
-            .filter(|d| !crate::server::chat_history::is_general_chat(Some(&d.id)))
+            .filter(|d| !tinyhivemind_core::chat::is_general_chat(Some(&d.id)))
             .filter(|d| d.name.eq_ignore_ascii_case(key))
             .count()
             > 1

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -617,6 +617,29 @@ impl StartedBy {
     }
 }
 
+/// Separates the other desk's actual answer from the note addressed to the
+/// asker, in a returning relay.
+///
+/// # Why the two have to be separable
+///
+/// The relay is normally dropped from the projection, so the note is private to
+/// the asker and can say things only the asker should read. But the drop is
+/// conditional: if the asker's report never lands — a failed turn, an empty
+/// model response — the relay renders instead, because a line in the wrong
+/// voice is a smaller failure than an answer nobody can see.
+///
+/// That fallback used to publish the note along with it. An operator watching
+/// #engineering was told "you are the only one who has seen it" by an agent
+/// that is not on their desk. So the answer goes FIRST and everything the host
+/// added goes after this marker, and the projection renders only what precedes
+/// it — which is exactly the other desk's own words, the thing the fallback
+/// exists to preserve.
+///
+/// Written to be unmistakable rather than pretty: a bare `---` is a markdown
+/// rule an answer may legitimately contain, and truncating on one would eat
+/// half of it.
+pub const RELAY_NOTE_MARKER: &str = "\n\n[referral-note]\n";
+
 /// An external stimulus fed into a company's cycle loop.
 ///
 /// Serialized internally-tagged under `kind` so each JSONL line is
@@ -3528,6 +3551,26 @@ pub struct OverlayDesk {
     /// no such field.
     #[serde(default, skip_serializing_if = "ResponderMode::is_lead")]
     pub responder: ResponderMode,
+    /// How this desk deliberates and whether it may refer across desks — the
+    /// overlay analogue of `[[group_chat]].hive`.
+    ///
+    /// Without it a console-created desk could not answer either question. The
+    /// hive config was read from the manifest only, and the responder mode from
+    /// the overlay only, so the two surfaces each carried half the settings and
+    /// a desk could never hold both: an overlay desk deliberated because the
+    /// default says so and could not opt out, and could never opt IN to
+    /// referral, because there was no `[[group_chat]]` entry to hang the block
+    /// on. A company whose desks are all operator-created — which is every
+    /// company that builds its desks in the console — therefore had cross-desk
+    /// referral permanently unavailable.
+    ///
+    /// Defaulted and skipped when empty, so every record written before this
+    /// field existed deserializes and re-serializes unchanged.
+    #[serde(
+        default,
+        skip_serializing_if = "crate::hivemind::HiveConfig::is_default"
+    )]
+    pub hive: crate::hivemind::HiveConfig,
 }
 
 /// A workflow graph body authored at runtime (the console's create dialog or
@@ -7477,6 +7520,7 @@ mod test {
             description: None,
             members: Vec::new(),
             responder: crate::ports::types::ResponderMode::default(),
+            hive: Default::default(),
         });
         record.overlay_desks.push(OverlayDesk {
             id: "sales".into(),
@@ -7484,6 +7528,7 @@ mod test {
             description: None,
             members: Vec::new(),
             responder: crate::ports::types::ResponderMode::default(),
+            hive: Default::default(),
         });
 
         assert_eq!(
@@ -7512,6 +7557,7 @@ mod test {
             description: None,
             members: Vec::new(),
             responder: crate::ports::types::ResponderMode::default(),
+            hive: Default::default(),
         });
 
         assert_eq!(record.resolve_desk_id("growth").as_deref(), Some("growth"));
@@ -7541,6 +7587,7 @@ mod test {
             description: None,
             members: Vec::new(),
             responder: crate::ports::types::ResponderMode::default(),
+            hive: Default::default(),
         });
         assert_eq!(record.mint_agent_id("Design Studio"), "design_studio");
         // …while the overlay desk's id is reserved exactly like a manifest one.
@@ -8591,6 +8638,7 @@ mod test {
             description: None,
             members: vec!["eng".into()],
             responder: crate::ports::types::ResponderMode::default(),
+            hive: Default::default(),
         });
         // Resolves by id and by case-insensitive name.
         assert_eq!(record.resolve_desk_id("growth").as_deref(), Some("growth"));
@@ -8637,6 +8685,7 @@ mod test {
             description: None,
             responder: Default::default(),
             members: vec!["eng".into()],
+            hive: Default::default(),
         });
         record.overlay_desks.push(OverlayDesk {
             id: "ops".into(),
@@ -8644,6 +8693,7 @@ mod test {
             description: None,
             responder: Default::default(),
             members: vec!["ceo".into()],
+            hive: Default::default(),
         });
 
         for spelling in ["", "main", "Main", "MAIN", "general", "General"] {
@@ -8688,6 +8738,7 @@ mod test {
             description: None,
             responder: Default::default(),
             members: vec!["eng".into()],
+            hive: Default::default(),
         });
         assert_eq!(
             record.resolve_desk_id("Front office"),
@@ -8712,6 +8763,7 @@ mod test {
             description: None,
             responder: Default::default(),
             members: vec!["eng".into()],
+            hive: Default::default(),
         });
         assert_eq!(
             ordinary.resolve_desk_id("Front office").as_deref(),

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -381,6 +381,7 @@ members = []
             description: None,
             members: vec!["engineer".into(), "ceo".into()],
             responder: crate::ports::types::ResponderMode::Auto,
+            hive: Default::default(),
         });
         assert_eq!(
             resolve(&record, "launch"),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -8758,6 +8758,7 @@ needs_reason = true
                     description: None,
                     members: vec!["ceo".to_string()],
                     responder: crate::ports::types::ResponderMode::default(),
+                    hive: Default::default(),
                 }],
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
@@ -9111,6 +9112,7 @@ needs_reason = true
                     description: None,
                     members: vec!["ceo".to_string()],
                     responder: crate::ports::types::ResponderMode::default(),
+                    hive: Default::default(),
                 }],
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
@@ -9681,6 +9683,7 @@ needs_reason = true
             description: None,
             members: Vec::new(),
             responder: crate::ports::types::ResponderMode::default(),
+            hive: Default::default(),
         });
         record.overlay_desk_members.push(OverlayDeskMember {
             desk_id: "design".to_string(),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -10083,6 +10083,7 @@ members = ["writer"]
             description: None,
             members: vec!["eng1".to_string()],
             responder: crate::ports::types::ResponderMode::Auto,
+            hive: Default::default(),
         });
         rt.store().save(&record).await.unwrap();
 

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2884,6 +2884,9 @@ fn cycle_task_id(
     let mut found: Option<String> = None;
     for event in events {
         let candidate = match event {
+            // Never a trigger: the marker records that a child turn was created,
+            // it does not ask for one.
+            CompanyEvent::ReferralEnqueued { .. } => None,
             CompanyEvent::TaskDispatched { task_id, .. } => Some(task_id.clone()),
             CompanyEvent::ApprovalResolved { approval_id, .. } => {
                 match approval_task(approval_id) {
@@ -3087,6 +3090,9 @@ fn cycle_conversation(
     let mut found: Option<(String, Option<EventSeq>)> = None;
     for (index, event) in events.iter().enumerate() {
         let candidate = match event {
+            // Names no conversation to answer in: it records that a child
+            // turn was created elsewhere, and that turn carries its own.
+            CompanyEvent::ReferralEnqueued { .. } => None,
             // The one event that names a thread outright. An unaddressed message
             // (`chat: None`) went to the orchestrator with no conversation of its
             // own — a rival, not a neutral pass-through, for the same reason a

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -740,6 +740,15 @@ pub(crate) struct TaskHandoff {
     /// it, the same way `direct_card` and this hand-off's own card already
     /// do.
     pub(crate) budget_paused: Option<crate::harness::BudgetPause>,
+    /// SPIKE (async hand-off): the delegate owns the card but has NOT run yet.
+    ///
+    /// The synchronous model awaits the delegate inside the delegator's
+    /// attempt, which is why `TaskRunEnd::Delegated` was documented as
+    /// "unreachable as a run settle today". Handing over without running makes
+    /// it reachable: the delegator settles `Delegated`, and the delegate is
+    /// dispatched as its own attempt with its own cost and its own lock
+    /// acquisition.
+    pub(crate) pending: bool,
 }
 
 /// Drives the brain-agnostic delegation orchestration over a [`RunTurn`]: run the
@@ -1132,6 +1141,16 @@ impl<'a> DelegationRunner<'a> {
     pub(crate) fn for_task(mut self, task_id: &str) -> Self {
         self.task = Some(task_id.to_string());
         self
+    }
+
+    /// [`for_task`](Self::for_task) for a caller that may or may not have one —
+    /// a chat turn scopes itself to the card its THREAD already opened, and to
+    /// nothing when the thread has none.
+    pub(crate) fn maybe_for_task(self, task_id: Option<&str>) -> Self {
+        match task_id {
+            Some(id) => self.for_task(id),
+            None => self,
+        }
     }
 
     /// Scopes this runner to the card's **attempt** (issue #242), so a delegated
@@ -2207,10 +2226,77 @@ impl<'a> DelegationRunner<'a> {
             // card marked cancelled. So an empty hand-off is *provisional* and a
             // later one that answers takes the card over from it (issue #213
             // review finding 3).
-            let owns_card = handoff.as_ref().is_none_or(|prior| prior.reply.is_none());
+            // Once a hand-off owns the card, no LATER one in this turn runs.
+            //
+            // The synchronous model could let a second hand-off run and take the
+            // card from an empty first (issue #213 finding 3). Asynchronously it
+            // cannot: the first hand-off's delegate is already dispatched, so a
+            // second that ran here would produce work under a card whose owner
+            // is somebody else — and if that owner is then cancelled, the card
+            // settles `todo` carrying output that really did run. That is the
+            // exact "work filed under a card marked cancelled" #213 fixed,
+            // reached the other way round.
+            //
+            // So it is recorded and not started. One card, one owner, one
+            // dispatch — and the operator can see what else was asked for.
+            if handoff.as_ref().is_some_and(|prior| prior.pending) {
+                if let Some(target) = hand_off_target_of(&delegation) {
+                    card.note = Some(append_note(
+                        card.note.as_deref(),
+                        delegator,
+                        &format!(
+                            "also asked {target}: {} — not started, this card is already with \
+                             its new owner",
+                            instruction_of(&delegation)
+                        ),
+                    ));
+                }
+                continue;
+            }
+            // A hand-off that produced nothing is PROVISIONAL and a later one
+            // that answers takes the card from it (issue #213 finding 3) — but
+            // a PENDING hand-off is not "produced nothing", it is "has not run
+            // yet". It already owns the card and the delegate is about to be
+            // dispatched for it, so a second hand-off in the same turn must not
+            // move the card again; its instruction is recorded on the note
+            // instead, exactly as a non-owning hand-off's answer is.
+            let owns_card = handoff
+                .as_ref()
+                .is_none_or(|prior| prior.reply.is_none() && !prior.pending);
             if owns_card {
-                self.hand_card_over(card, delegator, &member, instruction_of(&delegation))
-                    .await?;
+                // The target as the model named it, reduced to its canonical
+                // id: a desk stays a desk, a teammate stays a teammate.
+                let owner = hand_off_target_of(&delegation)
+                    .and_then(|target| {
+                        crate::runtime::assignee::resolve(self.record, target)
+                            .canonical()
+                            .map(str::to_string)
+                    })
+                    .unwrap_or_else(|| member.clone());
+                self.hand_card_over(
+                    card,
+                    delegator,
+                    &member,
+                    &owner,
+                    instruction_of(&delegation),
+                )
+                .await?;
+                // SPIKE: hand over and STOP. The delegate is not run inside this
+                // attempt — the card now names them, the delegator settles
+                // `Delegated`, and the dispatch edge re-fires for the new owner.
+                //
+                // What that buys, and why the synchronous version could not:
+                // one attempt row per agent (so cost is attributable), the
+                // per-company cycle lock released between hops, and a card
+                // whose `assignee` is a real reassignment rather than a
+                // mid-turn display concession.
+                handoff = Some(TaskHandoff {
+                    delegate: member,
+                    reply: None,
+                    budget_paused: None,
+                    pending: true,
+                });
+                continue;
             }
             let outcome = self
                 .run_delegation(delegation, None, MessageContext::default())
@@ -2223,6 +2309,7 @@ impl<'a> DelegationRunner<'a> {
                         delegate: member,
                         reply: Some(desk.reply),
                         budget_paused: desk.budget_paused,
+                        pending: false,
                     });
                 }
                 // An operator cancelled their run mid-flight, so it produced
@@ -2233,6 +2320,7 @@ impl<'a> DelegationRunner<'a> {
                         delegate: member,
                         reply: None,
                         budget_paused: None,
+                        pending: false,
                     });
                 }
                 // Nothing produced and NOT a cancellation. `run_delegation`'s
@@ -2986,9 +3074,24 @@ impl<'a> DelegationRunner<'a> {
         card: &mut TaskRecord,
         delegator: &str,
         member: &str,
+        owner: &str,
         instruction: &str,
     ) -> Result<()> {
-        card.assignee = member.to_string();
+        // **Ownership at the granularity it was handed over.**
+        //
+        // `member` is the agent that will RUN the card; `owner` is who now owns
+        // it. For a teammate hand-off they are the same. For a DESK hand-off
+        // they are not: the desk owns it and dispatch picks the lead, which is
+        // the invariant `AssigneeResolution::canonical` documents — "a desk
+        // assignment is ownership, and stays a desk assignment". Writing
+        // `member` here erased the desk from the board on the first hand-off,
+        // and `run_task`'s own write guards that exact case with
+        // `links_working_agent()` while this one did not.
+        //
+        // It matters more now than it did: `assignee` is the ownership record
+        // the thread's overseer is read from, so clobbering it does not just
+        // mislabel a card — it redirects the conversation.
+        card.assignee = owner.to_string();
         card.note = Some(append_note(
             card.note.as_deref(),
             delegator,
@@ -9052,6 +9155,24 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
     /// On the DISPATCHED-card path the card stays owned by the level-1 member
     /// the orchestrator handed it to — nested delegation is visible in the note
     /// and the steps, not by the card changing hands again.
+    ///
+    /// # This test changed with the async hand-off, and the change is the point
+    ///
+    /// It used to additionally assert that `handed.reply` carried the level-1
+    /// member's answer, with the nested researcher's reply folded into it. That
+    /// was a true statement about a SYNCHRONOUS hand-off: the delegate ran
+    /// inside the delegator's attempt, so its answer came back up the stack.
+    ///
+    /// It cannot be true of an asynchronous one. The delegator now hands over
+    /// and settles `Delegated`; the delegate is dispatched as its OWN attempt,
+    /// which is what buys one attempt row per agent (so spend is attributable)
+    /// and releases the per-company serial lock between hops. The answer still
+    /// reaches the operator — through the delegate's own settle and relay —
+    /// just not on the delegator's reply.
+    ///
+    /// What the test was *named* for is unchanged and still asserted: the card
+    /// belongs to the member the orchestrator handed it to, and nested
+    /// delegation does not move it a second time.
     #[tokio::test]
     async fn a_dispatched_card_stays_with_the_level_one_member() {
         let fx = Fixture::nested();
@@ -9105,14 +9226,30 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             handed.delegate, "engineer",
             "the card belongs to the member the ORCHESTRATOR handed it to"
         );
-        let reply = handed.reply.expect("the level-1 member answered");
         assert!(
-            reply.contains("researcher (delegated by engineer) replied"),
-            "the nested answer rides on the level-1 member's reply: {reply}"
+            handed.pending,
+            "the hand-off is pending: the delegate has NOT run inside this attempt"
         );
+        assert!(
+            handed.reply.is_none(),
+            "a pending hand-off carries no reply — the delegate answers from its own \
+             attempt, which is what makes the spend attributable to them: {:?}",
+            handed.reply
+        );
+        // The DESK owns it, the lead works it. `AssigneeResolution::canonical`
+        // states the rule — "a desk assignment is ownership, and stays a desk
+        // assignment — dispatch is what picks the lead" — and `run_task`'s own
+        // write has always honoured it via `links_working_agent()`. This path
+        // did not: it wrote the resolved lead, erasing the desk from the board
+        // on the first hand-off, and this assertion pinned that contradiction.
+        //
+        // `handed.delegate` is still `engineer` just above: owner and worker
+        // are different questions, which is the whole reason a desk assignment
+        // exists.
         assert_eq!(
-            card.assignee, "engineer",
-            "nested delegation must not move the card a second time"
+            card.assignee, "eng_desk",
+            "a desk hand-off keeps DESK ownership; nested delegation must not \
+             move the card a second time"
         );
     }
 

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -2264,23 +2264,8 @@ impl<'a> DelegationRunner<'a> {
                 .as_ref()
                 .is_none_or(|prior| prior.reply.is_none() && !prior.pending);
             if owns_card {
-                // The target as the model named it, reduced to its canonical
-                // id: a desk stays a desk, a teammate stays a teammate.
-                let owner = hand_off_target_of(&delegation)
-                    .and_then(|target| {
-                        crate::runtime::assignee::resolve(self.record, target)
-                            .canonical()
-                            .map(str::to_string)
-                    })
-                    .unwrap_or_else(|| member.clone());
-                self.hand_card_over(
-                    card,
-                    delegator,
-                    &member,
-                    &owner,
-                    instruction_of(&delegation),
-                )
-                .await?;
+                self.hand_card_over(card, delegator, &member, instruction_of(&delegation))
+                    .await?;
                 // SPIKE: hand over and STOP. The delegate is not run inside this
                 // attempt — the card now names them, the delegator settles
                 // `Delegated`, and the dispatch edge re-fires for the new owner.
@@ -3074,24 +3059,23 @@ impl<'a> DelegationRunner<'a> {
         card: &mut TaskRecord,
         delegator: &str,
         member: &str,
-        owner: &str,
         instruction: &str,
     ) -> Result<()> {
-        // **Ownership at the granularity it was handed over.**
+        // **An owner is an agent. A desk is a channel, not an owner.**
         //
-        // `member` is the agent that will RUN the card; `owner` is who now owns
-        // it. For a teammate hand-off they are the same. For a DESK hand-off
-        // they are not: the desk owns it and dispatch picks the lead, which is
-        // the invariant `AssigneeResolution::canonical` documents — "a desk
-        // assignment is ownership, and stays a desk assignment". Writing
-        // `member` here erased the desk from the board on the first hand-off,
-        // and `run_task`'s own write guards that exact case with
-        // `links_working_agent()` while this one did not.
+        // `member` is the agent that will run the card, and that is exactly who
+        // now owns it — for a teammate hand-off the teammate, for a desk
+        // hand-off that desk's lead.
         //
-        // It matters more now than it did: `assignee` is the ownership record
-        // the thread's overseer is read from, so clobbering it does not just
-        // mislabel a card — it redirects the conversation.
-        card.assignee = owner.to_string();
+        // This briefly wrote the hand-off target reduced by
+        // `AssigneeResolution::canonical` instead, on the reading that a desk
+        // hand-off should leave the DESK on the card. That put a channel id in
+        // an ownership field: `assignee` is also what the thread's overseer is
+        // read from, so a card handed to a desk named nobody who could answer
+        // for it. `canonical` maps a desk to its own id because it is the
+        // stored-key helper for whatever a card happens to say — not a claim
+        // that a desk is a thing which owns work.
+        card.assignee = member.to_string();
         card.note = Some(append_note(
             card.note.as_deref(),
             delegator,
@@ -9236,20 +9220,20 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
              attempt, which is what makes the spend attributable to them: {:?}",
             handed.reply
         );
-        // The DESK owns it, the lead works it. `AssigneeResolution::canonical`
-        // states the rule — "a desk assignment is ownership, and stays a desk
-        // assignment — dispatch is what picks the lead" — and `run_task`'s own
-        // write has always honoured it via `links_working_agent()`. This path
-        // did not: it wrote the resolved lead, erasing the desk from the board
-        // on the first hand-off, and this assertion pinned that contradiction.
+        // **An owner is an agent; a desk is a channel.** Handing to a desk hands
+        // the work to that desk's lead, and it is the lead the card names.
         //
-        // `handed.delegate` is still `engineer` just above: owner and worker
-        // are different questions, which is the whole reason a desk assignment
-        // exists.
+        // This assertion previously demanded `eng_desk`, on the reading that a
+        // desk hand-off leaves the DESK owning the card. That put a channel id
+        // in an ownership field — and `assignee` is what the thread's overseer
+        // is read from, so a card handed to a desk named nobody who could
+        // answer for it. `AssigneeResolution::canonical` maps a desk to its own
+        // id because it is the stored-key helper for whatever a card happens to
+        // say, not a claim that a desk owns work.
         assert_eq!(
-            card.assignee, "eng_desk",
-            "a desk hand-off keeps DESK ownership; nested delegation must not \
-             move the card a second time"
+            card.assignee, "engineer",
+            "the desk's lead owns the card; nested delegation must not move it \
+             a second time"
         );
     }
 

--- a/src/runtime/delegation_tools.rs
+++ b/src/runtime/delegation_tools.rs
@@ -1152,6 +1152,7 @@ members = ["counsel"]
             description: None,
             responder: Default::default(),
             members: vec!["writer".to_string()],
+            hive: Default::default(),
         });
         assert_eq!(chat_responder(&record, "main"), None);
 
@@ -1292,6 +1293,7 @@ members = ["counsel"]
             description: None,
             responder: Default::default(),
             members: vec!["ceo".to_string()],
+            hive: Default::default(),
         });
         // Named `General`, but addressable under its own id — it stays.
         record.overlay_desks.push(crate::ports::types::OverlayDesk {
@@ -1300,6 +1302,7 @@ members = ["counsel"]
             description: None,
             responder: Default::default(),
             members: vec!["writer".to_string()],
+            hive: Default::default(),
         });
 
         assert_eq!(
@@ -1808,6 +1811,7 @@ members = ["analyst"]
             description: None,
             members: vec!["ceo".to_string(), "writer".to_string()],
             responder: crate::ports::types::ResponderMode::Auto,
+            hive: Default::default(),
         });
         assert_eq!(
             desk_lead(&record, "launch"),
@@ -1832,6 +1836,7 @@ members = ["analyst"]
             description: None,
             members: vec!["writer".to_string()],
             responder: crate::ports::types::ResponderMode::default(),
+            hive: Default::default(),
         });
         assert_eq!(desk_lead(&record, "growth").as_deref(), Some("writer"));
     }
@@ -1849,6 +1854,7 @@ members = ["analyst"]
             description: None,
             members: vec!["ceo".to_string(), "writer".to_string()],
             responder: crate::ports::types::ResponderMode::Auto,
+            hive: Default::default(),
         });
         let message = reject_desk_target(&record, "launch").expect("refused");
         assert!(message.contains("picked per message"), "{message}");

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -714,6 +714,151 @@ mod test {
         }
     }
 
+    /// **The asker is told it may ask again — that is what makes it able to.**
+    ///
+    /// The returning answer never reaches the channel, so this frame is the
+    /// only thing the asker ever reads about it. Raw, it offered one ending;
+    /// framed, it offers both and gives the spelling that reaches back.
+    #[test]
+    fn a_returning_answer_offers_both_endings_and_a_forward_is_untouched() {
+        let record = software_company();
+        let members = roster_members(&record);
+        let people: Vec<tinyhivemind_core::roster::Person> = Vec::new();
+        let retired: Vec<String> = Vec::new();
+        let roster = tinyhivemind_core::roster::Roster::new(&members, &people, &retired);
+        let desks = desk_snapshots(&record);
+
+        let body = "@product_designer can you take the login screen?";
+        let mentions = tinyhivemind_core::mention::resolve(
+            body,
+            None,
+            &tinyhivemind_core::mention::MentionAuthor::Agent {
+                id: "software_engineer".to_string(),
+            },
+            &roster,
+            &desks.set(),
+        );
+        let tinyhivemind_core::referral::ReferralDecision::One { mut referral } =
+            tinyhivemind_core::referral::referral(
+                tinyhivemind_core::referral::ReferralPolicy {
+                    enabled: true,
+                    max_hops: 4,
+                    reach: tinyhivemind_core::referral::ReferralReach::Channels,
+                    returns: true,
+                },
+                &referral_input(body, mentions),
+                &roster,
+                &desks.set(),
+            )
+            .expect("decides")
+        else {
+            panic!("a crossing referral was available");
+        };
+
+        assert_eq!(
+            returned_answer(&record, &referral),
+            body,
+            "a forward carries the asker's own words into a room people read"
+        );
+
+        // A real return has the mirrored geometry: it was committed on the desk
+        // that answered, and travels to the one that asked. Flipping `kind`
+        // alone would leave a forward's desks in place and let this pass while
+        // naming the wrong room to go back to.
+        referral.kind = tinyhivemind_core::referral::ReferralKind::Return;
+        referral.from = referral.to.clone();
+        referral.source_id = "product_designer".to_string();
+        referral.content = "use a skeleton, not a spinner".to_string();
+        let framed = returned_answer(&record, &referral);
+        assert!(
+            framed.contains("use a skeleton, not a spinner"),
+            "the answer survives the framing: {framed}"
+        );
+        assert!(
+            framed.contains("@#product_design"),
+            "and names the exact spelling that reaches back: {framed}"
+        );
+        assert!(
+            framed.contains("report back") && framed.contains("ask them again"),
+            "both endings are stated, so choosing is the asker's: {framed}"
+        );
+    }
+
+    /// **The chain deepens, and therefore ends.**
+    ///
+    /// Each generation must sit one hop below the one that caused it, or the
+    /// bound is decorative. The host used to hand every referred turn a
+    /// hardcoded depth of `1`, which is true of the first one and of no other:
+    /// a follow-up claimed the same depth as the answer it followed, so
+    /// `max_hops` was never approached however long two desks went on. Nothing
+    /// drove such a loop then — the asker could not ask again — so the defect
+    /// was invisible until the moment it mattered.
+    ///
+    /// Walked here as the policy sees it: the depth a turn reports is the depth
+    /// its own replies are offered at, so the walk is `child_hop` feeding the
+    /// next `hop`. Four hops is ask, answer, ask again, answer again — and the
+    /// fifth is refused.
+    #[test]
+    fn a_follow_up_is_one_hop_deeper_and_the_budget_ends_it() {
+        let record = software_company();
+        let members = roster_members(&record);
+        let people: Vec<tinyhivemind_core::roster::Person> = Vec::new();
+        let retired: Vec<String> = Vec::new();
+        let roster = tinyhivemind_core::roster::Roster::new(&members, &people, &retired);
+        let desks = desk_snapshots(&record);
+        let policy = tinyhivemind_core::referral::ReferralPolicy {
+            enabled: true,
+            max_hops: 4,
+            reach: tinyhivemind_core::referral::ReferralReach::Channels,
+            returns: true,
+        };
+
+        let body = "@product_designer can you take the login screen?";
+        let mut depths: Vec<u32> = Vec::new();
+        let mut hop = 0;
+        loop {
+            let mentions = tinyhivemind_core::mention::resolve(
+                body,
+                None,
+                &tinyhivemind_core::mention::MentionAuthor::Agent {
+                    id: "software_engineer".to_string(),
+                },
+                &roster,
+                &desks.set(),
+            );
+            let mut input = referral_input(body, mentions);
+            input.hop = hop;
+            match tinyhivemind_core::referral::referral(policy, &input, &roster, &desks.set())
+                .expect("decides")
+            {
+                tinyhivemind_core::referral::ReferralDecision::One { referral } => {
+                    assert_eq!(
+                        referral.child_hop,
+                        hop + 1,
+                        "a child sits exactly one below its cause"
+                    );
+                    depths.push(referral.child_hop);
+                    hop = referral.child_hop;
+                }
+                tinyhivemind_core::referral::ReferralDecision::None { reason } => {
+                    assert_eq!(
+                        reason,
+                        tinyhivemind_core::referral::NoReferralReason::HopLimitReached,
+                        "the chain ends because the budget ran out, not for some other reason"
+                    );
+                    break;
+                }
+            }
+            assert!(hop <= 8, "the walk must terminate; it did not");
+        }
+
+        assert_eq!(
+            depths,
+            vec![1, 2, 3, 4],
+            "four hops: ask, answer, ask again, answer again"
+        );
+    }
+
     /// **Journey 1** — a named teammate who is not on this desk runs on THEIR
     /// desk, rather than being pulled into this conversation.
     #[test]
@@ -1166,14 +1311,55 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
             // 4. The child turn, on the TARGET's conversation.
             self.runtime.clone().spawn_referred_turn(
                 referral.to.desk_id.clone(),
-                referral.content.clone(),
+                returned_answer(&record, &referral),
                 referral.source_id.clone(),
                 referral.origin.clone(),
+                // The depth THIS child sits at, so the chain it may start is
+                // measured from here. Passing a constant made every generation
+                // claim the same depth, and a bound that never advances bounds
+                // nothing — see `spawn_referred_turn`.
+                referral.child_hop,
             );
 
             Ok(EnqueueOutcome::Enqueued)
         })
     }
+}
+
+/// What the asker is handed when an answer comes home.
+///
+/// # Why the answer is framed rather than passed through
+///
+/// A returning answer is not a message in the channel — it is dropped from the
+/// projection (see `attach_referral_origins`) precisely so the asker's own
+/// report is the only thing a reader sees. That makes this text private to the
+/// asker, and the only place it can be told what its options are.
+///
+/// Passed through raw, they were exactly one: the answer arrived as bare prose
+/// with no indication of where it came from or what to do with it, and the
+/// asker did the obvious thing — summarise it and move on. That is right when
+/// the answer lands, and wrong when it misses. "You covered layout, but what
+/// about the error state?" was unreachable, not because the machinery could not
+/// carry it, but because nothing ever told the asker it could ask.
+///
+/// So the frame states both endings and the exact spelling that reaches the
+/// other desk. Deciding WHICH ending is the asker's judgement and stays the
+/// asker's — this only makes the second one expressible.
+///
+/// A forward is passed through untouched: that content is the asker's own words,
+/// and it RENDERS on the desk it lands on. Framing it would put the host's
+/// scaffolding in a room where a person is reading.
+fn returned_answer(record: &CompanyRecord, referral: &tinyhivemind::referral::Referral) -> String {
+    if !matches!(referral.kind, tinyhivemind::referral::ReferralKind::Return) {
+        return referral.content.clone();
+    }
+    let who = agent_label(record, &referral.source_id);
+    let desk = desk_label(record, &referral.from.desk_id);
+    let back = &referral.from.desk_id;
+    format!(
+        "{who} on #{desk} answered what you asked them:\n\n{}\n\n         ---\n         This did not appear in your channel — you are the only one who has seen it.          Decide which of these the answer deserves:\n         - It covers the question: report back in your channel, in your own words,          what they said. Do not paste it back verbatim.\n         - Something important is still missing: ask them again. Begin your reply          with @#{back} and put the ONE thing still open in a single short line.\n         Ask again only for a real gap, not for more detail on what they already covered.",
+        referral.content
+    )
 }
 
 /// A desk's operator-facing name, or its id when it has none to show.

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -785,7 +785,7 @@ mod test {
         };
 
         assert_eq!(
-            returned_answer(&record, &referral),
+            returned_answer(&record, &referral, REFERRAL_MAX_HOPS),
             body,
             "a forward carries the asker's own words into a room people read"
         );
@@ -798,7 +798,7 @@ mod test {
         referral.from = referral.to.clone();
         referral.source_id = "product_designer".to_string();
         referral.content = "use a skeleton, not a spinner".to_string();
-        let framed = returned_answer(&record, &referral);
+        let framed = returned_answer(&record, &referral, REFERRAL_MAX_HOPS);
         assert!(
             framed.contains("use a skeleton, not a spinner"),
             "the answer survives the framing: {framed}"
@@ -821,7 +821,7 @@ mod test {
         // the question gets journaled in the channel and never delivered, so it
         // reads as though the other desk had ignored it.
         referral.child_hop = REFERRAL_MAX_HOPS;
-        let last = returned_answer(&record, &referral);
+        let last = returned_answer(&record, &referral, REFERRAL_MAX_HOPS);
         assert!(
             last.contains("exchange 2 of 2") && last.contains("last exchange"),
             "the asker is told this is the end: {last}"
@@ -1176,6 +1176,10 @@ pub struct JournalReferralQueue {
     /// turn that produced several replies gets several chances, and nothing
     /// counted them.
     peer_cap: u32,
+    /// The effective `max_hops` for this desk, carried so the returning frame
+    /// can tell the asker how much of the chain is left. It must be the SAME
+    /// number the policy enforces — see `returned_answer`.
+    max_hops: u32,
     /// Crossing forwards already spent under this queue. Returns are exempt:
     /// a return spends no turn of its own, and refusing one would strand an
     /// answer that has already been paid for.
@@ -1196,11 +1200,13 @@ impl JournalReferralQueue {
         runtime: std::sync::Arc<crate::company::runtime::CompanyRuntime>,
         gate: std::sync::Arc<tokio::sync::Mutex<()>>,
         peer_cap: u32,
+        max_hops: u32,
     ) -> Self {
         Self {
             runtime,
             gate,
             peer_cap,
+            max_hops,
             asked: std::sync::Arc::new(tokio::sync::Mutex::new(0)),
         }
     }
@@ -1410,7 +1416,7 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
             // 5. The child turn, on the TARGET's conversation.
             self.runtime.clone().spawn_referred_turn(
                 referral.to.desk_id.clone(),
-                returned_answer(&record, &referral),
+                returned_answer(&record, &referral, self.max_hops),
                 referral.source_id.clone(),
                 referral.origin.clone(),
                 // The depth THIS child sits at, so the chain it may start is
@@ -1439,12 +1445,17 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
 /// that cannot converge in two exchanges is not going to converge in six, and
 /// every hop is a model call somebody pays for.
 ///
-/// **One constant, two readers.** The policy bounds the chain and
-/// [`returned_answer`] tells the asker how much of it is left. Those must
-/// agree: an asker invited to ask again by a frame the policy then refuses is
-/// worse off than one never invited, because the question it writes is
-/// journaled in its channel and never delivered — so it reads to everyone as
-/// though the other desk had been asked and had not bothered to answer.
+/// **Not the policy.** The bound in force comes from the desk's
+/// `[[group_chat]].hive.referral` block and is carried to
+/// [`returned_answer`] on the queue, so the frame and the policy cannot
+/// disagree. They briefly did: this constant said 4 while a desk that opted in
+/// without naming `max_hops` got 2, and the frame invited a follow-up the
+/// policy would then refuse — a question journaled in its own channel and never
+/// delivered, reading to everyone as though the other desk had ignored it.
+///
+/// Kept only as the value a test asserts against, and deliberately not read by
+/// production code.
+#[cfg(test)]
 pub(crate) const REFERRAL_MAX_HOPS: u32 = 4;
 
 /// Separates the other desk's actual answer from the note addressed to the
@@ -1493,7 +1504,11 @@ pub(crate) const RELAY_NOTE_MARKER: &str = "\n\n[referral-note]\n";
 /// A forward is passed through untouched: that content is the asker's own words,
 /// and it RENDERS on the desk it lands on. Framing it would put the host's
 /// scaffolding in a room where a person is reading.
-fn returned_answer(record: &CompanyRecord, referral: &tinyhivemind::referral::Referral) -> String {
+fn returned_answer(
+    record: &CompanyRecord,
+    referral: &tinyhivemind::referral::Referral,
+    max_hops: u32,
+) -> String {
     if !matches!(referral.kind, tinyhivemind::referral::ReferralKind::Return) {
         return referral.content.clone();
     }
@@ -1509,8 +1524,8 @@ fn returned_answer(record: &CompanyRecord, referral: &tinyhivemind::referral::Re
     // A turn offers its own replies at the depth it was created at, so this one
     // may ask again exactly when that depth is still under the bound.
     let round = referral.child_hop.div_ceil(2);
-    let rounds = REFERRAL_MAX_HOPS.div_ceil(2);
-    let ending = if referral.child_hop < REFERRAL_MAX_HOPS {
+    let rounds = max_hops.div_ceil(2);
+    let ending = if referral.child_hop < max_hops {
         [
             "Decide which of these the answer deserves:",
             "- It covers the question: report back in your channel, in your own words, what they said. Do not paste it back verbatim.",

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -1,0 +1,1205 @@
+//! The `tinyhivemind` session adapter — off by default (`hivemind`).
+//!
+//! [`tinyhivemind::session::project_session`] answers the question this host
+//! answers today in [`crate::server::chat_history`]: what does one participant
+//! see of a transcript several of them share? It answers it **attributed** —
+//! every projected line keeps the author that wrote it. This host's own
+//! projection does not: an agent's turn history is a `(role, content)` ladder
+//! in which every prior reply is folded into the *reader's* own voice, so on a
+//! shared desk agent B reads agent A's replies as B's own earlier turns, and a
+//! system notice, a workflow report and a real teammate are indistinguishable.
+//! That is the first of the two defects `vendor/tinyhivemind` was extracted to
+//! fix (its `ROADMAP.md`, P4).
+//!
+//! What lands here is the port that fix needs and nothing more:
+//! [`JournalSessionLog`] reads this company's journal as
+//! [`tinyhivemind::session::SessionLog`] wants to read it — newest-first, by an
+//! exclusive cursor, from the tail. **No turn calls it yet.** The adapter is
+//! built, gated and tested before it is wired, because the wiring is where the
+//! behavior change lives and it deserves its own diff; see the roadmap's
+//! "paired OpenCompany adapter integration", which lands disabled.
+//!
+//! # Why the journal is already the right shape
+//!
+//! [`EventLog::read_before`](crate::ports::events::EventLog::read_before) is
+//! this port's primitive under another name — the same exclusive `before`, the
+//! same newest-first order, the same tail seek. That is not a coincidence: the
+//! trait's own cost note cites this host's measurement (72.8ms against 0.4ms at
+//! 100k events) as the reason it is specified that way. So the adapter is a
+//! mapping, not a reimplementation, and the only real work it does is deciding
+//! which stored events are *messages*.
+//!
+//! # Which events are messages
+//!
+//! Exactly the three [`owns`](crate::server::chat_history::owns) admits into a
+//! desk history, mapped to the author each one preserves. Everything else in
+//! the journal — runs, budgets, lifecycle — is not a line anybody said, and is
+//! skipped. Skipping is what makes the cursor contract load-bearing below.
+//!
+//! # What this module does not decide
+//!
+//! Which desk a row belongs to. The projection folds the four spellings of
+//! General itself (`tinyhivemind_core::chat::same_conversation`, the same rule
+//! [`owns`](crate::server::chat_history::owns) applies), so the adapter hands
+//! over every chat row and lets the library filter. An adapter that pre-filtered
+//! by desk would be a second answer to a question the library exists to answer
+//! once.
+
+use std::collections::HashMap;
+
+use tinyhivemind::session::{
+    LogMessage, Sequence, SessionAuthor, SessionFuture, SessionLog, SessionPage,
+};
+
+use crate::ports::events::EventLog;
+use crate::ports::types::{
+    ActorKind, CompanyEvent, CompanyId, CompanyRecord, EventSeq, StoredEvent,
+};
+
+/// This company's journal, read as a [`SessionLog`].
+///
+/// Borrows rather than owns: one is built for the duration of a single
+/// projection, from the log, record and label map a caller already holds.
+pub struct JournalSessionLog<'a> {
+    events: &'a dyn EventLog,
+    company: &'a CompanyId,
+    record: &'a CompanyRecord,
+    people: &'a HashMap<String, String>,
+}
+
+// Hand-written because `&dyn EventLog` has no `Debug`, and the port is not this
+// module's to change for the sake of a derive.
+impl std::fmt::Debug for JournalSessionLog<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("JournalSessionLog")
+            .field("company", &self.company)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> JournalSessionLog<'a> {
+    /// Borrow everything one projection needs.
+    ///
+    /// `people` is user id → display label, exactly as
+    /// [`author_labels`](crate::server::chat_history::author_labels) builds it:
+    /// the ladder that prefers a display name over an email local part is one
+    /// this adapter must not fork, because a transcript read by every member
+    /// should not hand each of them everyone else's address.
+    #[must_use]
+    pub const fn new(
+        events: &'a dyn EventLog,
+        company: &'a CompanyId,
+        record: &'a CompanyRecord,
+        people: &'a HashMap<String, String>,
+    ) -> Self {
+        Self {
+            events,
+            company,
+            record,
+            people,
+        }
+    }
+}
+
+impl SessionLog for JournalSessionLog<'_> {
+    /// One page of chat rows older than `before`, newest first.
+    ///
+    /// # The cursor, and why this loops
+    ///
+    /// Most journal rows are not messages, so a raw read of `limit` rows can
+    /// yield none. An empty page is only legal with **no** cursor
+    /// (`Error::EmptyPageCursor`), and returning no cursor means "the log ends
+    /// here" — which would silently truncate a transcript whose older half sits
+    /// behind a run of workflow events. So a page that filtered down to nothing
+    /// keeps reading rather than reporting an end that is not there.
+    ///
+    /// It terminates: each pass starts strictly older than the last row it saw,
+    /// and a short raw read is the log's own end.
+    fn read_before(&self, before: Option<Sequence>, limit: usize) -> SessionFuture<'_> {
+        Box::pin(async move {
+            let mut cursor = before.map(|sequence| EventSeq::new(sequence.0));
+            loop {
+                let raw = self
+                    .events
+                    .read_before(self.company, cursor, limit)
+                    .await
+                    .map_err(|error| Box::new(error) as tinyhivemind::session::SourceError)?;
+                let Some(oldest) = raw.last().map(|stored| stored.seq) else {
+                    return Ok(SessionPage::default());
+                };
+                // A short read is the only end-of-log signal the port has: the
+                // store returns what it has, so fewer rows than asked for means
+                // there are no older ones.
+                let exhausted = raw.len() < limit;
+                let messages: Vec<LogMessage> = raw
+                    .iter()
+                    .filter_map(|stored| self.log_message(stored))
+                    .collect();
+                if !messages.is_empty() || exhausted {
+                    return Ok(SessionPage {
+                        messages,
+                        // The oldest row *scanned*, not the oldest returned: the
+                        // rows in between were skipped, and a cursor that
+                        // re-offered them would make the next page repeat work
+                        // this one already did. Never newer than the oldest
+                        // returned row, which is the contract.
+                        next_before: (!exhausted).then(|| Sequence(oldest.value())),
+                    });
+                }
+                cursor = Some(oldest);
+            }
+        })
+    }
+}
+
+impl JournalSessionLog<'_> {
+    /// One stored event as a log row, or `None` if it is not a message.
+    fn log_message(&self, stored: &StoredEvent) -> Option<LogMessage> {
+        let sequence = Sequence(stored.seq.value());
+        match &stored.event {
+            CompanyEvent::AgentReply {
+                chat_id,
+                agent_id,
+                text,
+                parent,
+                ..
+            } => Some(LogMessage {
+                sequence,
+                chat_id: Some(chat_id.clone()),
+                parent: parent.map(|seq| Sequence(seq.value())),
+                author: self.agent_author(agent_id),
+                content: text.clone(),
+            }),
+            CompanyEvent::OperatorMessage {
+                text,
+                by,
+                chat,
+                parent,
+                ..
+            } => Some(LogMessage {
+                sequence,
+                chat_id: chat.clone(),
+                parent: parent.map(|seq| Sequence(seq.value())),
+                author: self.authored_by(by.as_ref()),
+                content: text.clone(),
+            }),
+            CompanyEvent::DeskTaskCompleted {
+                column,
+                origin_chat_id,
+                origin_parent,
+                ..
+            } => Some(LogMessage {
+                sequence,
+                chat_id: origin_chat_id.clone(),
+                parent: origin_parent.map(|seq| Sequence(seq.value())),
+                author: SessionAuthor::System {
+                    kind: "task_settled".to_string(),
+                    label: crate::ports::SYSTEM_AUTHOR.to_string(),
+                },
+                // Through the one function that owns this sentence, rather than
+                // a second spelling of it: `dispatch_marker_text`'s own doc
+                // names the console copy as "the one remaining exception", and
+                // a third would make a marker reword itself depending on which
+                // reader rendered it.
+                content: crate::server::chat_history::dispatch_marker_text(column),
+            }),
+            _ => None,
+        }
+    }
+
+    /// An agent id as an attributed author.
+    ///
+    /// The label ladder is the operator-given display name, then the manifest
+    /// role, then the id — the order the console shows a teammate in, so a
+    /// transcript names it the way its reader's interface does.
+    fn agent_author(&self, agent_id: &str) -> SessionAuthor {
+        // Manifest before overlay, the order `resolve_roster_agent_id` reads
+        // them in — and a manifest `[[agent]]` carries no display name at all,
+        // which is why the two tiers cannot share one pass.
+        let declared = self
+            .record
+            .manifest
+            .agents
+            .iter()
+            .find(|agent| agent.id.eq_ignore_ascii_case(agent_id))
+            .map(|agent| {
+                agent
+                    .name
+                    .clone()
+                    .filter(|name| !name.trim().is_empty())
+                    .unwrap_or_else(|| agent.role.clone())
+            });
+        let label = declared
+            .or_else(|| {
+                self.record
+                    .overlay_agents
+                    .iter()
+                    .find(|agent| agent.id.eq_ignore_ascii_case(agent_id))
+                    .map(|agent| {
+                        if agent.name.trim().is_empty() {
+                            agent.role.clone()
+                        } else {
+                            agent.name.clone()
+                        }
+                    })
+            })
+            .filter(|label| !label.trim().is_empty())
+            .unwrap_or_else(|| agent_id.to_string());
+        SessionAuthor::Agent {
+            id: agent_id.to_string(),
+            label,
+        }
+    }
+
+    /// An operator message's stored actor as an attributed author.
+    ///
+    /// `None` is the operator: an event journaled before per-user auth existed,
+    /// or a send made with a platform credential, has no person behind it —
+    /// the same reading [`crate::server::chat_history`] gives it.
+    fn authored_by(&self, actor: Option<&crate::ports::types::Actor>) -> SessionAuthor {
+        let Some(actor) = actor else {
+            return SessionAuthor::Operator;
+        };
+        match actor.kind {
+            ActorKind::Operator => SessionAuthor::Operator,
+            ActorKind::User => SessionAuthor::Person {
+                id: actor.id.clone(),
+                label: self
+                    .people
+                    .get(&actor.id)
+                    .cloned()
+                    .unwrap_or_else(|| "someone".to_string()),
+            },
+            ActorKind::Agent => self.agent_author(&actor.id),
+            ActorKind::System => SessionAuthor::System {
+                kind: "runtime".to_string(),
+                label: crate::ports::SYSTEM_AUTHOR.to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::error::OpenCompanyError;
+    use crate::ports::types::{Actor, CompanyEvent, EventSeq, StoredEvent};
+    use async_trait::async_trait;
+    use futures::stream::BoxStream;
+    use tinyhivemind::session::{Conversation, SESSION_WINDOW, SessionQuery, project_session};
+
+    /// A journal that answers `read_before` the way a production store does —
+    /// from the tail, by an exclusive cursor. The default fallback on the trait
+    /// would pass these tests too, and would hide a page-contract mistake that
+    /// only a real tail read makes: this port is specified newest-first, so the
+    /// double it is tested against has to be newest-first for real.
+    struct Journal(Vec<StoredEvent>);
+
+    #[async_trait]
+    impl EventLog for Journal {
+        async fn append(
+            &self,
+            _id: &CompanyId,
+            _event: CompanyEvent,
+        ) -> Result<EventSeq, OpenCompanyError> {
+            unreachable!("the adapter never appends")
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            seq: EventSeq,
+            limit: usize,
+        ) -> Result<Vec<StoredEvent>, OpenCompanyError> {
+            Ok(self
+                .0
+                .iter()
+                .filter(|stored| stored.seq >= seq)
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+        async fn read_before(
+            &self,
+            _id: &CompanyId,
+            before: Option<EventSeq>,
+            limit: usize,
+        ) -> Result<Vec<StoredEvent>, OpenCompanyError> {
+            let mut rows: Vec<StoredEvent> = self
+                .0
+                .iter()
+                .filter(|stored| before.is_none_or(|cursor| stored.seq < cursor))
+                .cloned()
+                .collect();
+            rows.reverse();
+            rows.truncate(limit);
+            Ok(rows)
+        }
+        fn subscribe(
+            &self,
+            _id: &CompanyId,
+        ) -> BoxStream<'static, crate::ports::events::EventStreamItem> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    fn company() -> CompanyId {
+        CompanyId::new("acme")
+    }
+
+    fn record() -> CompanyRecord {
+        let src = "[company]\nname = \"Acme\"\n\n[policy]\nmode = \"full\"\n\
+                   \n[[agent]]\nid = \"engineer\"\nrole = \"Engineer\"\ntier = \"orchestrator\"\n\
+                   \n[[agent]]\nid = \"designer\"\nrole = \"Designer\"\ntier = \"orchestrator\"\n";
+        let manifest: crate::company::CompanyManifest =
+            toml::from_str(src).expect("manifest parses");
+        CompanyRecord {
+            id: company(),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_retired_agents: Vec::new(),
+            overlay_agent_edits: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_tool_grants: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+            name_confirmed: true,
+            created_at_millis: None,
+            activation_completed_at: None,
+        }
+    }
+
+    fn stored(seq: u64, event: CompanyEvent) -> StoredEvent {
+        StoredEvent {
+            seq: EventSeq::new(seq),
+            company: company(),
+            event,
+            at_millis: 1_000 + seq,
+        }
+    }
+
+    fn reply(agent_id: &str, chat: &str, text: &str) -> CompanyEvent {
+        CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
+            parent: None,
+            task_id: None,
+            chat_id: chat.to_string(),
+            agent_id: agent_id.to_string(),
+            text: text.to_string(),
+            steps: Vec::new(),
+        }
+    }
+
+    fn message(by: Option<Actor>, chat: Option<&str>, text: &str) -> CompanyEvent {
+        CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
+            parent: None,
+            text: text.to_string(),
+            by,
+            chat: chat.map(str::to_string),
+            deliverable: None,
+            attachments: Vec::new(),
+        }
+    }
+
+    /// An event that is emphatically not a line anybody said.
+    fn noise(seq: u64) -> StoredEvent {
+        stored(
+            seq,
+            CompanyEvent::WorkflowRunStarted {
+                workflow_id: "wf".into(),
+                run_id: format!("run-{seq}"),
+                scheduled: false,
+                started_by: None,
+                resume_semantic: None,
+            },
+        )
+    }
+
+    async fn read(journal: &Journal, before: Option<u64>, limit: usize) -> SessionPage {
+        let record = record();
+        let people = HashMap::new();
+        let company = company();
+        let log = JournalSessionLog::new(journal, &company, &record, &people);
+        log.read_before(before.map(Sequence), limit)
+            .await
+            .expect("the journal reads")
+    }
+
+    /// The defect this adapter exists to remove: a shared desk's transcript
+    /// keeps the author of every line, so one agent reads its colleague as its
+    /// colleague and not as itself.
+    #[tokio::test]
+    async fn a_shared_desk_reads_back_attributed() {
+        let journal = Journal(vec![
+            stored(
+                1,
+                message(None, Some("engineering"), "who owns the migration?"),
+            ),
+            stored(2, reply("engineer", "engineering", "I do.")),
+            stored(
+                3,
+                reply("designer", "engineering", "I will take the console half."),
+            ),
+        ]);
+        let record = record();
+        let people = HashMap::new();
+        let company = company();
+        let log = JournalSessionLog::new(&journal, &company, &record, &people);
+
+        let projected = project_session(
+            &log,
+            &SessionQuery {
+                conversation: Conversation {
+                    desk_id: "engineering".to_string(),
+                    desk_name: "Engineering".to_string(),
+                    thread_root: None,
+                },
+                before: None,
+                window: SESSION_WINDOW,
+            },
+        )
+        .await
+        .expect("the projection folds");
+
+        let authors: Vec<&SessionAuthor> = projected.iter().map(|m| &m.author).collect();
+        assert_eq!(
+            authors,
+            vec![
+                &SessionAuthor::Operator,
+                &SessionAuthor::Agent {
+                    id: "engineer".to_string(),
+                    label: "Engineer".to_string(),
+                },
+                &SessionAuthor::Agent {
+                    id: "designer".to_string(),
+                    label: "Designer".to_string(),
+                },
+            ],
+            "three lines, three authors — none of them collapsed into the reader"
+        );
+        assert!(
+            projected.iter().all(|m| !m.content.is_empty()),
+            "content travels with the author"
+        );
+    }
+
+    /// The four spellings of General are the library's business, not the
+    /// adapter's: an unaddressed post stores `None` and still belongs to the
+    /// General desk.
+    #[tokio::test]
+    async fn an_unaddressed_post_projects_under_general() {
+        let journal = Journal(vec![
+            stored(1, message(None, None, "morning")),
+            stored(2, reply("engineer", "main", "morning")),
+            stored(3, reply("designer", "strategy", "not this desk")),
+        ]);
+        let record = record();
+        let people = HashMap::new();
+        let company = company();
+        let log = JournalSessionLog::new(&journal, &company, &record, &people);
+
+        let projected = project_session(
+            &log,
+            &SessionQuery {
+                conversation: Conversation {
+                    desk_id: "General".to_string(),
+                    desk_name: "General".to_string(),
+                    thread_root: None,
+                },
+                before: None,
+                window: SESSION_WINDOW,
+            },
+        )
+        .await
+        .expect("the projection folds");
+
+        assert_eq!(projected.len(), 2, "`None` and `main` are one conversation");
+        assert!(
+            projected.iter().all(|m| m.content != "not this desk"),
+            "a named desk's traffic stays out of General"
+        );
+    }
+
+    /// A user's message is that person, and an unattributed one is the
+    /// operator — the reading `chat_history` already gives a stored `by`.
+    #[tokio::test]
+    async fn an_operator_message_keeps_who_sent_it() {
+        let journal = Journal(vec![
+            stored(1, message(None, Some("engineering"), "legacy send")),
+            stored(
+                2,
+                message(
+                    Some(Actor {
+                        kind: ActorKind::User,
+                        id: "u1".to_string(),
+                    }),
+                    Some("engineering"),
+                    "mine",
+                ),
+            ),
+        ]);
+        let record = record();
+        let people = HashMap::from([("u1".to_string(), "Ada".to_string())]);
+        let company = company();
+        let log = JournalSessionLog::new(&journal, &company, &record, &people);
+        let page = log.read_before(None, 8).await.expect("the journal reads");
+
+        assert_eq!(
+            page.messages[1].author,
+            SessionAuthor::Operator,
+            "an event journaled before per-user auth is the operator"
+        );
+        assert_eq!(
+            page.messages[0].author,
+            SessionAuthor::Person {
+                id: "u1".to_string(),
+                label: "Ada".to_string(),
+            },
+            "and a user's send is that person, labelled the way the console labels them"
+        );
+    }
+
+    /// The page contract, asserted rather than assumed: newest-first, never
+    /// larger than asked for, and a cursor no newer than the oldest row.
+    #[tokio::test]
+    async fn a_page_is_newest_first_and_bounded() {
+        let journal = Journal(
+            (1..=10)
+                .map(|seq| stored(seq, reply("engineer", "engineering", "hi")))
+                .collect(),
+        );
+        let page = read(&journal, None, 4).await;
+
+        let sequences: Vec<u64> = page.messages.iter().map(|m| m.sequence.0).collect();
+        assert_eq!(
+            sequences,
+            vec![10, 9, 8, 7],
+            "newest first, at most `limit`"
+        );
+        assert_eq!(
+            page.next_before,
+            Some(Sequence(7)),
+            "the cursor is exclusive, so the next page starts at 6"
+        );
+
+        let older = read(&journal, Some(7), 4).await;
+        let sequences: Vec<u64> = older.messages.iter().map(|m| m.sequence.0).collect();
+        assert_eq!(
+            sequences,
+            vec![6, 5, 4, 3],
+            "and it neither repeats nor skips"
+        );
+    }
+
+    /// The reason [`JournalSessionLog::read_before`] loops. A run of non-message
+    /// events longer than one page must not read as the end of the log: an empty
+    /// page may only carry `None`, and `None` means "no older rows".
+    #[tokio::test]
+    async fn a_run_of_non_messages_does_not_end_the_transcript() {
+        let mut events = vec![stored(
+            1,
+            reply("engineer", "engineering", "the oldest line"),
+        )];
+        events.extend((2..=20).map(noise));
+        events.push(stored(
+            21,
+            reply("designer", "engineering", "the newest line"),
+        ));
+        let journal = Journal(events);
+
+        // Page size 4, so the walk crosses five straight pages of pure noise.
+        let newest = read(&journal, None, 4).await;
+        assert_eq!(newest.messages.len(), 1, "the newest page holds one line");
+
+        let older = read(&journal, newest.next_before.map(|cursor| cursor.0), 4).await;
+        assert_eq!(
+            older.messages.len(),
+            1,
+            "and the next page reaches past the noise to the oldest line"
+        );
+        assert_eq!(older.messages[0].sequence, Sequence(1));
+        assert_eq!(
+            older.next_before, None,
+            "a short read is the end of the log, and only then is the cursor absent"
+        );
+    }
+
+    /// A settle marker is a line on the desk, said by the runtime.
+    #[tokio::test]
+    async fn a_settled_card_is_a_system_line() {
+        let journal = Journal(vec![stored(
+            1,
+            CompanyEvent::DeskTaskCompleted {
+                task_id: "t1".into(),
+                desk: "engineering".into(),
+                output: "done".into(),
+                column: "done".into(),
+                artifact_ids: Vec::new(),
+                origin_chat_id: Some("engineering".into()),
+                origin_parent: None,
+            },
+        )]);
+        let page = read(&journal, None, 8).await;
+
+        assert_eq!(
+            page.messages[0].author,
+            SessionAuthor::System {
+                kind: "task_settled".to_string(),
+                label: crate::ports::SYSTEM_AUTHOR.to_string(),
+            },
+        );
+        assert_eq!(
+            page.messages[0].content,
+            crate::server::chat_history::dispatch_marker_text("done"),
+            "through the one function that owns the sentence"
+        );
+    }
+    // -----------------------------------------------------------------------
+    // SPIKE: the two cross-desk referral journeys, decided against a real
+    // `agentic_software_company`-shaped topology.
+    //
+    // These exercise the PURE decision only — `referral()` performs no I/O and
+    // enqueues nothing. What a host still owes before either journey can run is
+    // the `ReferralQueue` transaction (idempotency, dual-conversation
+    // authorization, the back edge); this proves the decision half fits this
+    // host's desks, which is the question that comes first.
+    // -----------------------------------------------------------------------
+
+    /// The shipped software company's shape: three desks, no overlap.
+    fn software_company() -> CompanyRecord {
+        let src = "[company]\nname = \"Acme\"\n\n[policy]\nmode = \"full\"\n\
+                   \n[[agent]]\nid = \"software_engineer\"\nrole = \"Engineer\"\n\
+                   \n[[agent]]\nid = \"qa_engineer\"\nrole = \"QA\"\n\
+                   \n[[agent]]\nid = \"product_designer\"\nrole = \"Designer\"\n\
+                   \n[[group_chat]]\nid = \"engineering\"\nname = \"Engineering\"\n\
+                   members = [\"software_engineer\", \"qa_engineer\"]\n\
+                   \n[[group_chat]]\nid = \"product_design\"\nname = \"Product & Design\"\n\
+                   members = [\"product_designer\"]\n";
+        let manifest: crate::company::CompanyManifest =
+            toml::from_str(src).expect("manifest parses");
+        CompanyRecord {
+            manifest,
+            ..record()
+        }
+    }
+
+    fn referral_input(
+        content: &str,
+        mentions: Vec<tinyhivemind_core::mention::Mention>,
+    ) -> tinyhivemind_core::referral::ReferralInput {
+        tinyhivemind_core::referral::ReferralInput {
+            key: tinyhivemind_core::dispatch::DispatchKey {
+                trigger_sequence: 42,
+            },
+            conversation: tinyhivemind_core::dispatch::DispatchConversation {
+                desk_id: "engineering".to_string(),
+                thread_root: None,
+            },
+            author_id: "software_engineer".to_string(),
+            content: content.to_string(),
+            mentions,
+            hop: 0,
+            origin: None,
+        }
+    }
+
+    /// **Journey 1** — a named teammate who is not on this desk runs on THEIR
+    /// desk, rather than being pulled into this conversation.
+    #[test]
+    fn a_named_outsider_is_referred_to_their_own_desk() {
+        let record = software_company();
+        let members = roster_members(&record);
+        let people: Vec<tinyhivemind_core::roster::Person> = Vec::new();
+        let retired: Vec<String> = Vec::new();
+        let roster = tinyhivemind_core::roster::Roster::new(&members, &people, &retired);
+        let desks = desk_snapshots(&record);
+
+        let body = "@product_designer can you take the login screen?";
+        let mentions = tinyhivemind_core::mention::resolve(
+            body,
+            None,
+            &tinyhivemind_core::mention::MentionAuthor::Agent {
+                id: "software_engineer".to_string(),
+            },
+            &roster,
+            &desks.set(),
+        );
+        let decision = tinyhivemind_core::referral::referral(
+            tinyhivemind_core::referral::ReferralPolicy {
+                enabled: true,
+                max_hops: 2,
+                reach: tinyhivemind_core::referral::ReferralReach::Channels,
+                returns: true,
+            },
+            &referral_input(body, mentions),
+            &roster,
+            &desks.set(),
+        )
+        .expect("decides");
+
+        match decision {
+            tinyhivemind_core::referral::ReferralDecision::One { referral } => {
+                assert_eq!(referral.target_id, "product_designer");
+                assert_eq!(referral.from.desk_id, "engineering");
+                assert_eq!(
+                    referral.to.desk_id, "product_design",
+                    "the outsider runs on their OWN desk, not as a guest here"
+                );
+                assert!(
+                    referral.origin.is_some(),
+                    "a crossing forward carries the way home"
+                );
+            }
+            other => panic!("expected a referral, got {other:?}"),
+        }
+    }
+
+    /// **Journey 2** — the asker names a DESK, not a person, and the library
+    /// picks that desk's responder.
+    ///
+    /// This is the one that answers "I can't help with this and I don't know
+    /// who can": addressing is at desk granularity, so the engineering agent
+    /// needs to know that design exists, not who is on it.
+    #[test]
+    fn a_desk_mention_selects_that_desks_responder() {
+        let record = software_company();
+        let members = roster_members(&record);
+        let people: Vec<tinyhivemind_core::roster::Person> = Vec::new();
+        let retired: Vec<String> = Vec::new();
+        let roster = tinyhivemind_core::roster::Roster::new(&members, &people, &retired);
+        let desks = desk_snapshots(&record);
+
+        let body = "@#product_design who owns the login screen?";
+        let mentions = tinyhivemind_core::mention::resolve(
+            body,
+            None,
+            &tinyhivemind_core::mention::MentionAuthor::Agent {
+                id: "software_engineer".to_string(),
+            },
+            &roster,
+            &desks.set(),
+        );
+        let decision = tinyhivemind_core::referral::referral(
+            tinyhivemind_core::referral::ReferralPolicy {
+                enabled: true,
+                max_hops: 2,
+                // `Desks` is what makes an `@#desk` mention selectable at all;
+                // under `Channels` it decides nothing.
+                reach: tinyhivemind_core::referral::ReferralReach::Desks,
+                returns: true,
+            },
+            &referral_input(body, mentions),
+            &roster,
+            &desks.set(),
+        )
+        .expect("decides");
+
+        match decision {
+            tinyhivemind_core::referral::ReferralDecision::One { referral } => {
+                assert_eq!(
+                    referral.to.desk_id, "product_design",
+                    "the desk mention chose the desk"
+                );
+                assert_eq!(
+                    referral.target_id, "product_designer",
+                    "and the library picked its responder — the asker never named a person"
+                );
+            }
+            other => panic!("expected a desk referral, got {other:?}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SPIKE: the snapshots the referral / dispatch decisions borrow (P7, P15)
+// ---------------------------------------------------------------------------
+
+/// This company's agents as `tinyhivemind` names them.
+///
+/// The library takes borrowed slices, so a caller owns these for the length of
+/// one decision. Retired agents are excluded here rather than filtered later:
+/// `referral` answers `TargetInactive` off the roster it is given, and a
+/// retired teammate is not somebody work may be handed to.
+#[must_use]
+pub fn roster_members(record: &CompanyRecord) -> Vec<tinyhivemind_core::roster::RosterMember> {
+    record
+        .effective_agents()
+        .into_iter()
+        .filter(|agent| !record.is_retired(&agent.id))
+        .map(|agent| tinyhivemind_core::roster::RosterMember {
+            id: agent.id,
+            name: agent.name,
+        })
+        .collect()
+}
+
+/// The five desk snapshots [`DeskSet`](tinyhivemind_core::desk::DeskSet) borrows,
+/// owned together so one decision can borrow them all.
+///
+/// The split mirrors this host's own overlay model exactly — declared desks from
+/// the manifest, operator-added desks, appended members, explicit orderings, and
+/// the retired set — which is why this is a mapping and not a merge. Folding
+/// them here would be a second answer to the membership question `DeskSet`
+/// exists to answer.
+pub struct DeskSnapshots {
+    declared: Vec<tinyhivemind_core::desk::Desk>,
+    added: Vec<tinyhivemind_core::desk::Desk>,
+    member_additions: Vec<tinyhivemind_core::desk::DeskMember>,
+    orders: Vec<tinyhivemind_core::desk::DeskOrder>,
+    retired: Vec<String>,
+}
+
+impl DeskSnapshots {
+    /// Borrow them as the library's view.
+    #[must_use]
+    pub fn set(&self) -> tinyhivemind_core::desk::DeskSet<'_> {
+        tinyhivemind_core::desk::DeskSet::new(
+            &self.declared,
+            &self.added,
+            &self.member_additions,
+            &self.orders,
+            &self.retired,
+        )
+    }
+}
+
+/// Project this company's desks into [`DeskSnapshots`].
+#[must_use]
+pub fn desk_snapshots(record: &CompanyRecord) -> DeskSnapshots {
+    use tinyhivemind_core::desk::{Desk, DeskMember, DeskOrder, ResponderMode as HiveMode};
+    let mode = |mode: crate::ports::types::ResponderMode| match mode {
+        crate::ports::types::ResponderMode::Auto => HiveMode::Auto,
+        crate::ports::types::ResponderMode::Lead => HiveMode::Lead,
+    };
+    DeskSnapshots {
+        declared: record
+            .manifest
+            .group_chats
+            .iter()
+            .map(|chat| Desk {
+                id: chat.id.clone(),
+                name: chat.name.clone(),
+                description: chat.description.clone(),
+                members: chat.members.clone(),
+                // A manifest desk has no responder field — `desk_responder_mode`
+                // only consults the overlay — so it is lead-routed by
+                // definition, which is the library's default too.
+                responder_mode: HiveMode::Lead,
+            })
+            .collect(),
+        added: record
+            .overlay_desks
+            .iter()
+            .map(|desk| Desk {
+                id: desk.id.clone(),
+                name: desk.name.clone(),
+                description: desk.description.clone(),
+                members: desk.members.clone(),
+                responder_mode: mode(desk.responder),
+            })
+            .collect(),
+        member_additions: record
+            .overlay_desk_members
+            .iter()
+            .map(|added| DeskMember {
+                desk_id: added.desk_id.clone(),
+                agent_id: added.agent_id.clone(),
+            })
+            .collect(),
+        orders: record
+            .overlay_desk_order
+            .iter()
+            .map(|order| DeskOrder {
+                desk_id: order.desk_id.clone(),
+                ordered: order.ordered.clone(),
+            })
+            .collect(),
+        retired: record.overlay_retired_agents.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SPIKE: the host side of a crossing referral (tinyhivemind P15)
+// ---------------------------------------------------------------------------
+
+/// This company's [`ReferralQueue`]: the transaction that turns one decided
+/// referral into at most one durable child turn.
+///
+/// # Why this is a transaction and not a spawn
+///
+/// `referral()` is pure — it decides and does nothing. The trigger is a
+/// COMMITTED reply, so anything that reprocesses that reply (a restart, a
+/// redelivered frame, a retry) decides the same referral again. Without a
+/// durable marker the target desk is asked twice: two turns, two answers, twice
+/// the spend, and an operator looking at one question answered twice.
+///
+/// So the marker is the point, and it is journaled — `ReferralEnqueued`, keyed
+/// by `(from_desk, trigger_sequence)`, and `Permanent` because a pruned marker
+/// silently reopens the duplicate.
+///
+/// # What makes it atomic here
+///
+/// A `tokio::Mutex` held across the check-and-write, plus the host's own
+/// single-instance guarantee (the `.lock` in the instance home). That is
+/// honest about its scope: it serialises this process, and this process is the
+/// only writer of this company's journal. It is NOT a distributed lock, and a
+/// second host pointed at the same home would defeat it — which the home lock
+/// already refuses.
+///
+/// # The gap it does not close
+///
+/// The marker is written BEFORE the child turn is spawned. A crash in that
+/// window leaves a marker with no turn — the referral is silently dropped
+/// rather than duplicated. That is the safer of the two failures and it is the
+/// same exposure `dispatch_task` has between minting a run and spawning its
+/// cycle, but it is a gap and it is written down rather than implied.
+pub struct JournalReferralQueue {
+    runtime: std::sync::Arc<crate::company::runtime::CompanyRuntime>,
+    /// Serialises check-then-write. One referral decision at a time.
+    gate: std::sync::Arc<tokio::sync::Mutex<()>>,
+}
+
+impl std::fmt::Debug for JournalReferralQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JournalReferralQueue")
+            .finish_non_exhaustive()
+    }
+}
+
+impl JournalReferralQueue {
+    /// Bind the queue to a runtime and the gate it shares with its siblings.
+    #[must_use]
+    pub fn new(
+        runtime: std::sync::Arc<crate::company::runtime::CompanyRuntime>,
+        gate: std::sync::Arc<tokio::sync::Mutex<()>>,
+    ) -> Self {
+        Self { runtime, gate }
+    }
+
+    /// Has this exact trigger already created its child turn?
+    ///
+    /// Backwards from the tail and bounded: a trigger is by construction a
+    /// recent sequence, so a marker for it is near the tail or is not there.
+    /// `read_before` is the primitive that makes this cheap — the same argument
+    /// [`JournalSessionLog`] makes for reading a transcript.
+    async fn already(&self, from_desk: &str, trigger: u64) -> bool {
+        /// Far enough back to cover a busy company between trigger and replay.
+        const LOOKBACK: usize = 2048;
+        let Ok(page) = self
+            .runtime
+            .events()
+            .read_before(self.runtime.id(), None, LOOKBACK)
+            .await
+        else {
+            // Fail CLOSED: an unreadable journal cannot prove this is the
+            // first attempt, and asking a desk twice is worse than not asking.
+            return true;
+        };
+        page.into_iter().any(|stored| {
+            matches!(
+                &stored.event,
+                CompanyEvent::ReferralEnqueued {
+                    from_desk: desk,
+                    trigger_sequence,
+                    ..
+                } if desk == from_desk && *trigger_sequence == trigger
+            )
+        })
+    }
+
+    /// Is this return answering a forward this journal actually recorded?
+    ///
+    /// The mirror of the marker written for the forward: it went `to.desk_id →
+    /// from.desk_id` and named this agent as its target, so a return travelling
+    /// the other way is the answer it asked for. Anything else claiming to be a
+    /// return has no forward behind it and is refused.
+    async fn answering_a_forward(&self, referral: &tinyhivemind::referral::Referral) -> bool {
+        const LOOKBACK: usize = 2048;
+        let Ok(page) = self
+            .runtime
+            .events()
+            .read_before(self.runtime.id(), None, LOOKBACK)
+            .await
+        else {
+            return false;
+        };
+        page.into_iter().any(|stored| {
+            matches!(
+                &stored.event,
+                CompanyEvent::ReferralEnqueued { from_desk, to_desk, target, .. }
+                    if *from_desk == referral.to.desk_id
+                        && *to_desk == referral.from.desk_id
+                        && *target == referral.source_id
+            )
+        })
+    }
+
+    /// May `source` cause a turn on `to_desk`?
+    ///
+    /// Reuses `delegates_to` rather than inventing a second authorization key.
+    /// "Which desks may this agent send work to" is ONE fact about an agent,
+    /// and expressing it twice would let the tool path and the referral path
+    /// disagree about the same question. It fails closed: the shipped companies
+    /// all declare `delegates_to = []`.
+    ///
+    /// This is checked INSIDE the gate, against the record as it stands now —
+    /// the decision was made from a snapshot, and a roster can move underneath
+    /// it.
+    async fn authorized(&self, source: &str, to_desk: &str) -> bool {
+        let Ok(Some(record)) = self.runtime.store().load(self.runtime.id()).await else {
+            // Fail closed: an unreadable roster authorizes nothing.
+            return false;
+        };
+        record
+            .manifest
+            .agents
+            .iter()
+            .find(|agent| agent.id == source)
+            .is_some_and(|agent| {
+                agent
+                    .delegates_to
+                    .iter()
+                    .any(|allowed| allowed == "*" || allowed == to_desk)
+            })
+    }
+}
+
+impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
+    fn enqueue_once(
+        &self,
+        referral: tinyhivemind::referral::Referral,
+    ) -> tinyhivemind::referral::ReferralFuture<'_> {
+        Box::pin(async move {
+            use tinyhivemind::dispatch::{EnqueueOutcome, EnqueueRefusal};
+
+            let _serialised = self.gate.lock().await;
+
+            // 1. Already done? The whole reason this type exists.
+            if self
+                .already(&referral.from.desk_id, referral.key.trigger_sequence)
+                .await
+            {
+                return Ok(EnqueueOutcome::Already);
+            }
+
+            // 2. Revalidate, now, inside the gate. A crossing referral writes
+            //    into a channel the author is not a member of, so authorizing
+            //    the source desk alone authorizes nothing — the check is on the
+            //    source AGENT against the TARGET desk.
+            // A RETURN is not a new referral and must not be judged as one.
+            //
+            // It carries an answer back to a conversation that ASKED for it, so
+            // permission was settled when the forward was allowed — requiring
+            // the answering agent to hold `delegates_to` for the asking desk
+            // refuses every answer unless both desks happen to be able to refer
+            // to each other, which is not what either operator agreed to.
+            //
+            // It is still checked, just against the right fact: a forward from
+            // that conversation to this one, addressed to this agent, must
+            // actually be on the journal. The marker that makes the forward
+            // idempotent is the same marker that authorizes its answer home.
+            let permitted = match referral.kind {
+                tinyhivemind::referral::ReferralKind::Return => {
+                    self.answering_a_forward(&referral).await
+                }
+                tinyhivemind::referral::ReferralKind::Forward => {
+                    self.authorized(&referral.source_id, &referral.to.desk_id)
+                        .await
+                }
+            };
+            if !permitted {
+                return Ok(EnqueueOutcome::Refused {
+                    reason: EnqueueRefusal::Unauthorized,
+                });
+            }
+            let Ok(Some(record)) = self.runtime.store().load(self.runtime.id()).await else {
+                return Ok(EnqueueOutcome::Refused {
+                    reason: EnqueueRefusal::TargetUnavailable,
+                });
+            };
+            if !record.is_roster_agent(&referral.target_id)
+                || record.is_retired(&referral.target_id)
+            {
+                return Ok(EnqueueOutcome::Refused {
+                    reason: EnqueueRefusal::TargetUnavailable,
+                });
+            }
+
+            // 3. The marker, durably, BEFORE the turn — see the type's doc for
+            //    which way this window fails.
+            self.runtime
+                .events()
+                .append(
+                    self.runtime.id(),
+                    CompanyEvent::ReferralEnqueued {
+                        from_desk: referral.from.desk_id.clone(),
+                        from_desk_name: desk_label(&record, &referral.from.desk_id),
+                        asker: referral.source_id.clone(),
+                        asker_label: agent_label(&record, &referral.source_id),
+                        // The same discriminant the authorization arm above
+                        // switched on, recorded rather than re-derived: the
+                        // console needs it to say "Asked by" or "Answered by",
+                        // and nothing downstream can tell the two legs apart.
+                        returning: matches!(
+                            referral.kind,
+                            tinyhivemind::referral::ReferralKind::Return
+                        ),
+                        trigger_sequence: referral.key.trigger_sequence,
+                        to_desk: referral.to.desk_id.clone(),
+                        target: referral.target_id.clone(),
+                    },
+                )
+                .await
+                .map_err(|err| Box::new(err) as tinyhivemind::responder::BoxError)?;
+
+            // 4. The child turn, on the TARGET's conversation.
+            self.runtime.clone().spawn_referred_turn(
+                referral.to.desk_id.clone(),
+                referral.content.clone(),
+                referral.source_id.clone(),
+                referral.origin.clone(),
+            );
+
+            Ok(EnqueueOutcome::Enqueued)
+        })
+    }
+}
+
+/// A desk's operator-facing name, or its id when it has none to show.
+fn desk_label(record: &CompanyRecord, desk_id: &str) -> String {
+    record
+        .manifest
+        .group_chats
+        .iter()
+        .find(|chat| chat.id == desk_id)
+        .map(|chat| chat.name.clone())
+        .or_else(|| {
+            record
+                .overlay_desks
+                .iter()
+                .find(|desk| desk.id == desk_id)
+                .map(|desk| desk.name.clone())
+        })
+        .unwrap_or_else(|| desk_id.to_string())
+}
+
+/// An agent's display name, or its id when it has none.
+fn agent_label(record: &CompanyRecord, agent_id: &str) -> String {
+    record
+        .effective_agents()
+        .into_iter()
+        .find(|agent| agent.id == agent_id)
+        .and_then(|agent| agent.name)
+        .unwrap_or_else(|| agent_id.to_string())
+}

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -1502,29 +1502,6 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
 #[cfg(test)]
 pub(crate) const REFERRAL_MAX_HOPS: u32 = 4;
 
-/// Separates the other desk's actual answer from the note addressed to the
-/// asker, in a returning relay.
-///
-/// # Why the two have to be separable
-///
-/// The relay is normally dropped from the projection, so the note is private to
-/// the asker and can say things only the asker should read. But the drop is
-/// conditional: if the asker's report never lands — a failed turn, an empty
-/// model response — the relay renders instead, because a line in the wrong
-/// voice is a smaller failure than an answer nobody can see.
-///
-/// That fallback used to publish the note along with it. An operator watching
-/// #engineering was told "you are the only one who has seen it" by an agent
-/// that is not on their desk. So the answer goes FIRST and everything the host
-/// added goes after this marker, and the projection renders only what precedes
-/// it — which is exactly the other desk's own words, the thing the fallback
-/// exists to preserve.
-///
-/// Written to be unmistakable rather than pretty: a bare `---` is a markdown
-/// rule an answer may legitimately contain, and truncating on one would eat
-/// half of it.
-pub(crate) const RELAY_NOTE_MARKER: &str = "\n\n[referral-note]\n";
-
 /// What the asker is handed when an answer comes home.
 ///
 /// # Why the answer is framed rather than passed through
@@ -1593,10 +1570,12 @@ fn returned_answer(
         .join("\n")
     };
 
-    // Answer first, host note after the marker — see `RELAY_NOTE_MARKER`. The
-    // order is load-bearing, not stylistic: the projection keeps the prefix.
+    // Answer first, host note after the marker — see `RELAY_NOTE_MARKER` in
+    // `ports::types`. The order is load-bearing, not stylistic: the projection
+    // keeps the prefix and drops everything after it.
+    let marker = crate::ports::types::RELAY_NOTE_MARKER;
     format!(
-        "{answer}{RELAY_NOTE_MARKER}\
+        "{answer}{marker}\
          {who} on the {desk} desk answered what you asked them. This is exchange \
          {round} of {rounds} with them.\n\
          This did not appear in your channel — you are the only one who has seen it.\n\

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -163,6 +163,7 @@ impl JournalSessionLog<'_> {
                 agent_id,
                 text,
                 parent,
+                audience,
                 ..
             } => Some(LogMessage {
                 sequence,
@@ -170,6 +171,20 @@ impl JournalSessionLog<'_> {
                 parent: parent.map(|seq| Sequence(seq.value())),
                 author: self.agent_author(agent_id),
                 content: text.clone(),
+                // Read from the row, never assumed. An empty list is
+                // desk-visible — what every row written before asides existed
+                // means, and what an ordinary turn means now — and a non-empty
+                // one is an aside whose members are its addressees. Defaulting
+                // to `Desk` here would publish a private exchange into a seed
+                // its reader is not party to, which is the exact failure the
+                // library made this field required to prevent.
+                audience: if audience.is_empty() {
+                    tinyhivemind_hive::aside::Audience::Desk
+                } else {
+                    tinyhivemind_hive::aside::Audience::Aside {
+                        members: audience.clone(),
+                    }
+                },
             }),
             CompanyEvent::OperatorMessage {
                 text,
@@ -183,6 +198,9 @@ impl JournalSessionLog<'_> {
                 parent: parent.map(|seq| Sequence(seq.value())),
                 author: self.authored_by(by.as_ref()),
                 content: text.clone(),
+                // An operator message is addressed to the desk; there is no
+                // narrower audience for it to carry.
+                audience: tinyhivemind_hive::aside::Audience::Desk,
             }),
             CompanyEvent::DeskTaskCompleted {
                 column,
@@ -203,6 +221,9 @@ impl JournalSessionLog<'_> {
                 // a third would make a marker reword itself depending on which
                 // reader rendered it.
                 content: crate::server::chat_history::dispatch_marker_text(column),
+                // A settle marker is the room's own line: everyone on the desk
+                // is meant to see that the card moved.
+                audience: tinyhivemind_hive::aside::Audience::Desk,
             }),
             _ => None,
         }
@@ -397,6 +418,8 @@ mod test {
             agent_id: agent_id.to_string(),
             text: text.to_string(),
             steps: Vec::new(),
+            // Desk-visible: these fixtures exercise the desk fold, not asides.
+            audience: Vec::new(),
         }
     }
 
@@ -460,6 +483,9 @@ mod test {
         let projected = project_session(
             &log,
             &SessionQuery {
+                // These fold the whole desk — attribution and desk scoping —
+                // and carry no asides, so they read as the room does.
+                viewer: tinyhivemind_hive::aside::Viewer::Operator,
                 conversation: Conversation {
                     desk_id: "engineering".to_string(),
                     desk_name: "Engineering".to_string(),
@@ -512,6 +538,9 @@ mod test {
         let projected = project_session(
             &log,
             &SessionQuery {
+                // These fold the whole desk — attribution and desk scoping —
+                // and carry no asides, so they read as the room does.
+                viewer: tinyhivemind_hive::aside::Viewer::Operator,
                 conversation: Conversation {
                     desk_id: "General".to_string(),
                     desk_name: "General".to_string(),

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -782,6 +782,29 @@ mod test {
             framed.contains("report back") && framed.contains("ask them again"),
             "both endings are stated, so choosing is the asker's: {framed}"
         );
+        assert!(
+            framed.contains("exchange 1 of 2"),
+            "and the asker is told how much room is left: {framed}"
+        );
+
+        // **The last exchange offers one ending, not two.** Inviting a
+        // follow-up the policy will refuse is worse than never inviting one:
+        // the question gets journaled in the channel and never delivered, so it
+        // reads as though the other desk had ignored it.
+        referral.child_hop = REFERRAL_MAX_HOPS;
+        let last = returned_answer(&record, &referral);
+        assert!(
+            last.contains("exchange 2 of 2") && last.contains("last exchange"),
+            "the asker is told this is the end: {last}"
+        );
+        assert!(
+            !last.contains("@#product_design"),
+            "and is not invited to write a question that cannot be delivered: {last}"
+        );
+        assert!(
+            last.contains("could not get it"),
+            "an unmet need is escalated to a person instead of vanishing: {last}"
+        );
     }
 
     /// **The chain deepens, and therefore ends.**
@@ -1326,6 +1349,51 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
     }
 }
 
+/// How many child turns one referral chain may produce.
+///
+/// **Two round trips.** A crossing question and the answer coming home are two
+/// hops, not one — a return carries no origin, so the library counts it as its
+/// own step. `2` was therefore exactly one exchange, and the asker's report,
+/// being one deeper, could never start a second: an answer that missed the
+/// point was the end of the conversation.
+///
+/// `4` buys the asker one follow-up: ask, answer, ask again, answer again. That
+/// is the shape of an actual clarification — "you covered layout, but what
+/// about the error state?" — and stopping there is deliberate. A pair of desks
+/// that cannot converge in two exchanges is not going to converge in six, and
+/// every hop is a model call somebody pays for.
+///
+/// **One constant, two readers.** The policy bounds the chain and
+/// [`returned_answer`] tells the asker how much of it is left. Those must
+/// agree: an asker invited to ask again by a frame the policy then refuses is
+/// worse off than one never invited, because the question it writes is
+/// journaled in its channel and never delivered — so it reads to everyone as
+/// though the other desk had been asked and had not bothered to answer.
+pub(crate) const REFERRAL_MAX_HOPS: u32 = 4;
+
+/// Separates the other desk's actual answer from the note addressed to the
+/// asker, in a returning relay.
+///
+/// # Why the two have to be separable
+///
+/// The relay is normally dropped from the projection, so the note is private to
+/// the asker and can say things only the asker should read. But the drop is
+/// conditional: if the asker's report never lands — a failed turn, an empty
+/// model response — the relay renders instead, because a line in the wrong
+/// voice is a smaller failure than an answer nobody can see.
+///
+/// That fallback used to publish the note along with it. An operator watching
+/// #engineering was told "you are the only one who has seen it" by an agent
+/// that is not on their desk. So the answer goes FIRST and everything the host
+/// added goes after this marker, and the projection renders only what precedes
+/// it — which is exactly the other desk's own words, the thing the fallback
+/// exists to preserve.
+///
+/// Written to be unmistakable rather than pretty: a bare `---` is a markdown
+/// rule an answer may legitimately contain, and truncating on one would eat
+/// half of it.
+pub(crate) const RELAY_NOTE_MARKER: &str = "\n\n[referral-note]\n";
+
 /// What the asker is handed when an answer comes home.
 ///
 /// # Why the answer is framed rather than passed through
@@ -1356,9 +1424,49 @@ fn returned_answer(record: &CompanyRecord, referral: &tinyhivemind::referral::Re
     let who = agent_label(record, &referral.source_id);
     let desk = desk_label(record, &referral.from.desk_id);
     let back = &referral.from.desk_id;
+
+    // Where this sits in the exchange, stated rather than implied. The asker's
+    // own asks are in its channel and the earlier answers are in its context,
+    // so it can already see WHAT happened; what it cannot see is how much room
+    // is left, and that is the one fact that changes what it should do next.
+    //
+    // A turn offers its own replies at the depth it was created at, so this one
+    // may ask again exactly when that depth is still under the bound.
+    let round = referral.child_hop.div_ceil(2);
+    let rounds = REFERRAL_MAX_HOPS.div_ceil(2);
+    let ending = if referral.child_hop < REFERRAL_MAX_HOPS {
+        [
+            "Decide which of these the answer deserves:",
+            "- It covers the question: report back in your channel, in your own words, what they said. Do not paste it back verbatim.",
+            &format!(
+                "- Something important is still missing: ask them again. Begin your reply with @#{back} and put the ONE thing still open in a single short line."
+            ),
+            "Ask again only for a real gap, not for more detail on what they already covered.",
+        ]
+        .join("\n")
+    } else {
+        // Do not offer what the policy will refuse. A question written here is
+        // journaled in the channel and never delivered, so it reads to everyone
+        // as though that desk had been asked and had not bothered to reply.
+        [
+            &format!(
+                "This was the last exchange available with {desk} — asking again will not reach them, so do not try."
+            ),
+            "Report back in your channel, in your own words, what they said.",
+            "If something you needed is still missing, say plainly what it is and that you could not get it, so a person can decide what to do.",
+        ]
+        .join("\n")
+    };
+
+    // Answer first, host note after the marker — see `RELAY_NOTE_MARKER`. The
+    // order is load-bearing, not stylistic: the projection keeps the prefix.
     format!(
-        "{who} on #{desk} answered what you asked them:\n\n{}\n\n         ---\n         This did not appear in your channel — you are the only one who has seen it.          Decide which of these the answer deserves:\n         - It covers the question: report back in your channel, in your own words,          what they said. Do not paste it back verbatim.\n         - Something important is still missing: ask them again. Begin your reply          with @#{back} and put the ONE thing still open in a single short line.\n         Ask again only for a real gap, not for more detail on what they already covered.",
-        referral.content
+        "{answer}{RELAY_NOTE_MARKER}\
+         {who} on the {desk} desk answered what you asked them. This is exchange \
+         {round} of {rounds} with them.\n\
+         This did not appear in your channel — you are the only one who has seen it.\n\
+         {ending}",
+        answer = referral.content,
     )
 }
 

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -1165,6 +1165,21 @@ pub struct JournalReferralQueue {
     runtime: std::sync::Arc<crate::company::runtime::CompanyRuntime>,
     /// Serialises check-then-write. One referral decision at a time.
     gate: std::sync::Arc<tokio::sync::Mutex<()>>,
+    /// How many crossing questions this pass may ask in total — the WIDTH
+    /// bound, which the library deliberately leaves to the host because only a
+    /// host knows what a question costs it. Here it costs a full model turn on
+    /// another desk.
+    ///
+    /// `max_hops` bounds how DEEP one chain runs and says nothing about how
+    /// many chains a single report may start. One committed reply can only ever
+    /// name one target — the library takes the first candidate mention — but a
+    /// turn that produced several replies gets several chances, and nothing
+    /// counted them.
+    peer_cap: u32,
+    /// Crossing forwards already spent under this queue. Returns are exempt:
+    /// a return spends no turn of its own, and refusing one would strand an
+    /// answer that has already been paid for.
+    asked: std::sync::Arc<tokio::sync::Mutex<u32>>,
 }
 
 impl std::fmt::Debug for JournalReferralQueue {
@@ -1180,8 +1195,14 @@ impl JournalReferralQueue {
     pub fn new(
         runtime: std::sync::Arc<crate::company::runtime::CompanyRuntime>,
         gate: std::sync::Arc<tokio::sync::Mutex<()>>,
+        peer_cap: u32,
     ) -> Self {
-        Self { runtime, gate }
+        Self {
+            runtime,
+            gate,
+            peer_cap,
+            asked: std::sync::Arc::new(tokio::sync::Mutex::new(0)),
+        }
     }
 
     /// Has this exact trigger already created its child turn?
@@ -1320,6 +1341,32 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
                     reason: EnqueueRefusal::Unauthorized,
                 });
             }
+
+            // 3. The WIDTH bound, counted only for forwards that will actually
+            //    run.
+            //
+            //    `max_hops` bounds how DEEP one chain goes and says nothing
+            //    about how many chains a report may start; one reply names one
+            //    target, but a turn that produced several replies gets several
+            //    chances and nothing counted them.
+            //
+            //    A return is exempt: it spends no turn of its own, and refusing
+            //    one strands an answer another desk has already produced.
+            //
+            //    Counted AFTER authorization, not before. The budget exists to
+            //    bound what a company spends on other desks' turns, and a
+            //    refused forward spends nothing — charging it would let an
+            //    unauthorized mention exhaust the allowance for the authorized
+            //    question that follows it.
+            if matches!(referral.kind, tinyhivemind::referral::ReferralKind::Forward) {
+                let mut asked = self.asked.lock().await;
+                if *asked >= self.peer_cap {
+                    return Ok(EnqueueOutcome::Refused {
+                        reason: EnqueueRefusal::FeatureDisabled,
+                    });
+                }
+                *asked = asked.saturating_add(1);
+            }
             let Ok(Some(record)) = self.runtime.store().load(self.runtime.id()).await else {
                 return Ok(EnqueueOutcome::Refused {
                     reason: EnqueueRefusal::TargetUnavailable,
@@ -1333,7 +1380,7 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
                 });
             }
 
-            // 3. The marker, durably, BEFORE the turn — see the type's doc for
+            // 4. The marker, durably, BEFORE the turn — see the type's doc for
             //    which way this window fails.
             self.runtime
                 .events()
@@ -1360,7 +1407,7 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
                 .await
                 .map_err(|err| Box::new(err) as tinyhivemind::responder::BoxError)?;
 
-            // 4. The child turn, on the TARGET's conversation.
+            // 5. The child turn, on the TARGET's conversation.
             self.runtime.clone().spawn_referred_turn(
                 referral.to.desk_id.clone(),
                 returned_answer(&record, &referral),
@@ -1497,6 +1544,28 @@ fn returned_answer(record: &CompanyRecord, referral: &tinyhivemind::referral::Re
          {ending}",
         answer = referral.content,
     )
+}
+
+/// The `[[group_chat]].hive.referral` block for one desk, or the default —
+/// which refers nothing.
+///
+/// A desk the manifest does not declare (an overlay desk, a DM, the built-in
+/// General channel) has no block to read and therefore does not refer. That is
+/// the same conservative direction the block's own default takes: referral is
+/// opt-in per desk, because crossing costs a full model turn on somebody else's
+/// desk and only pays where desks have blind spots of their own.
+#[must_use]
+pub(crate) fn referral_config(
+    record: &CompanyRecord,
+    desk_id: &str,
+) -> crate::hivemind::ReferralConfig {
+    record
+        .manifest
+        .group_chats
+        .iter()
+        .find(|chat| chat.id == desk_id)
+        .map(|chat| chat.hive.referral.clone())
+        .unwrap_or_default()
 }
 
 /// A desk's operator-facing name, or its id when it has none to show.

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -706,6 +706,50 @@ mod test {
     // -----------------------------------------------------------------------
 
     /// The shipped software company's shape: three desks, no overlap.
+    /// **A console-created desk can opt into referral.**
+    ///
+    /// The rig that exercised all of this has `group_chat = []` — every desk is
+    /// an overlay desk. Reading the block from the manifest alone therefore
+    /// left referral permanently off for it, with nothing an operator could
+    /// write to turn it on: there was no `[[group_chat]]` entry to hang
+    /// `hive.referral` on, and `OverlayDesk` had no field for it.
+    #[test]
+    fn an_overlay_desk_carries_its_own_referral_block() {
+        let mut record = software_company();
+        record.manifest.group_chats.clear();
+        record.overlay_desks.push(crate::ports::types::OverlayDesk {
+            id: "engineering".to_string(),
+            name: "Engineering".to_string(),
+            description: None,
+            members: vec!["software_engineer".to_string()],
+            responder: crate::ports::types::ResponderMode::default(),
+            hive: crate::hivemind::HiveConfig {
+                referral: crate::hivemind::ReferralConfig {
+                    enabled: Some(true),
+                    max_hops: Some(4),
+                    peer_cap: Some(3),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        });
+
+        let config = referral_config(&record, "engineering");
+        assert!(
+            config.policy().enabled,
+            "an overlay desk that opted in refers: {config:?}"
+        );
+        assert_eq!(config.policy().max_hops, 4);
+        assert_eq!(config.peer_cap(), 3);
+
+        // And a desk that declared nothing still refers nothing — the
+        // conservative default is what the manifest-only read got right.
+        assert!(
+            !referral_config(&record, "design").policy().enabled,
+            "a desk with no block anywhere stays off"
+        );
+    }
+
     fn software_company() -> CompanyRecord {
         let src = "[company]\nname = \"Acme\"\n\n[policy]\nmode = \"full\"\n\
                    \n[[agent]]\nid = \"software_engineer\"\nrole = \"Engineer\"\n\
@@ -1574,13 +1618,7 @@ pub(crate) fn referral_config(
     record: &CompanyRecord,
     desk_id: &str,
 ) -> crate::hivemind::ReferralConfig {
-    record
-        .manifest
-        .group_chats
-        .iter()
-        .find(|chat| chat.id == desk_id)
-        .map(|chat| chat.hive.referral.clone())
-        .unwrap_or_default()
+    crate::hivemind::effective_hive_config(record, desk_id).referral
 }
 
 /// A desk's operator-facing name, or its id when it has none to show.

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -238,6 +238,23 @@ impl JournalSessionLog<'_> {
         // Manifest before overlay, the order `resolve_roster_agent_id` reads
         // them in — and a manifest `[[agent]]` carries no display name at all,
         // which is why the two tiers cannot share one pass.
+        // **An operator rename outranks both tiers.** `overlay_agent_edits` is
+        // what the console writes when a teammate is renamed, and it is what
+        // the Team page and every byline read. Consulting only the manifest and
+        // the overlay roster made the transcript call a teammate by the name it
+        // was declared with while the channel called it by the name it has —
+        // "Software Engineer" in the room, "10x engineer" everywhere else.
+        let edited = self
+            .record
+            .overlay_agent_edits
+            .iter()
+            .find(|edit| edit.agent_id.eq_ignore_ascii_case(agent_id))
+            .and_then(|edit| {
+                edit.name
+                    .clone()
+                    .or_else(|| edit.role.clone())
+                    .filter(|label| !label.trim().is_empty())
+            });
         let declared = self
             .record
             .manifest
@@ -251,7 +268,8 @@ impl JournalSessionLog<'_> {
                     .filter(|name| !name.trim().is_empty())
                     .unwrap_or_else(|| agent.role.clone())
             });
-        let label = declared
+        let label = edited
+            .or(declared)
             .or_else(|| {
                 self.record
                     .overlay_agents
@@ -1403,20 +1421,13 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
             //    A return is exempt: it spends no turn of its own, and refusing
             //    one strands an answer another desk has already produced.
             //
-            //    Counted AFTER authorization, not before. The budget exists to
-            //    bound what a company spends on other desks' turns, and a
-            //    refused forward spends nothing — charging it would let an
-            //    unauthorized mention exhaust the allowance for the authorized
-            //    question that follows it.
-            if matches!(referral.kind, tinyhivemind::referral::ReferralKind::Forward) {
-                let mut asked = self.asked.lock().await;
-                if *asked >= self.peer_cap {
-                    return Ok(EnqueueOutcome::Refused {
-                        reason: EnqueueRefusal::FeatureDisabled,
-                    });
-                }
-                *asked = asked.saturating_add(1);
-            }
+            //    Counted last, after authorization AND after the target is
+            //    known to be reachable. The budget bounds what a company spends
+            //    on other desks' turns, and a forward that is refused — for
+            //    permission, or because the teammate it names has left the
+            //    roster — spends nothing. Charging either would let a mention
+            //    that could never run exhaust the allowance for the question
+            //    behind it.
             let Ok(Some(record)) = self.runtime.store().load(self.runtime.id()).await else {
                 return Ok(EnqueueOutcome::Refused {
                     reason: EnqueueRefusal::TargetUnavailable,
@@ -1428,6 +1439,16 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
                 return Ok(EnqueueOutcome::Refused {
                     reason: EnqueueRefusal::TargetUnavailable,
                 });
+            }
+
+            if matches!(referral.kind, tinyhivemind::referral::ReferralKind::Forward) {
+                let mut asked = self.asked.lock().await;
+                if *asked >= self.peer_cap {
+                    return Ok(EnqueueOutcome::Refused {
+                        reason: EnqueueRefusal::FeatureDisabled,
+                    });
+                }
+                *asked = asked.saturating_add(1);
             }
 
             // 4. The marker, durably, BEFORE the turn — see the type's doc for

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -863,12 +863,45 @@ pub fn resolve(
 /// second, competing notion of "who is this for".
 ///
 /// Resolving nothing returns `None`, which leaves dispatch exactly as it was.
-pub fn mention_responder(record: &CompanyRecord, mentions: &[Mention]) -> Option<String> {
+///
+/// # Naming an outsider does not summon them into the room
+///
+/// The candidate must be a member of `desk`. Roster membership alone was the
+/// old test, and it let `@product_designer` typed in `#engineering` make the
+/// designer answer *in #engineering* — a desk they are not on, in front of a
+/// room they are not part of, while engineering's own lead stayed silent about
+/// a question addressed to their channel.
+///
+/// That is the same defect the cross-desk referral exists to fix one level up,
+/// and `tinyhivemind` already states the rule: an outsider "runs on their OWN
+/// desk, not as a guest here". A mention that names one therefore resolves to
+/// nobody and the ladder continues to the desk's own answerer, who can carry
+/// the question across on the referral path — one agent speaking in both rooms,
+/// and it is the one that belongs to this one.
+///
+/// **A channel with no membership is unrestricted**, which is not a loophole
+/// but the same rule: the built-in `#general` is not a desk and has no members
+/// to be outside of (issue #1743), and neither has a DM. `resolve_desk_id`
+/// returning `None` is how both say so, and there the old behaviour is the
+/// correct one.
+pub fn mention_responder(
+    record: &CompanyRecord,
+    desk: Option<&str>,
+    mentions: &[Mention],
+) -> Option<String> {
+    let members = desk
+        .and_then(|desk| record.resolve_desk_id(desk))
+        .map(|desk_id| record.effective_desk_members(&desk_id));
     mentions
         .iter()
         .filter(|m| !m.quiet)
         .filter_map(|m| m.target.agent_id())
-        .find(|id| record.is_roster_agent(id))
+        .find(|id| {
+            record.is_roster_agent(id)
+                && members
+                    .as_ref()
+                    .is_none_or(|members| members.iter().any(|member| member == id))
+        })
         .map(str::to_string)
 }
 
@@ -1575,11 +1608,90 @@ members = ["engineer", "ceo"]
     // Routing
     // -----------------------------------------------------------------------
 
+    /// Two desks with no overlap, so "not on this desk" is expressible.
+    const TWO_DESKS: &str = r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "engineer"
+role = "Backend Engineer"
+
+[[agent]]
+id = "designer"
+role = "Product Designer"
+
+[[group_chat]]
+id = "engineering"
+name = "Engineering"
+members = ["engineer"]
+
+[[group_chat]]
+id = "design"
+name = "Design"
+members = ["designer"]
+"#;
+
+    /// **Naming an outsider does not summon them into the room.**
+    ///
+    /// `@designer` typed in `#engineering` used to make the designer answer
+    /// there — a desk they are not on. The mention now resolves to nobody, and
+    /// the ladder falls through to the desk's own answerer, who can carry the
+    /// question across on the referral path.
+    #[test]
+    fn a_teammate_from_another_desk_is_not_summoned_into_this_one() {
+        let record = record(TWO_DESKS);
+        let found = resolve(
+            "@designer what would you change about the login screen",
+            None,
+            None,
+            &record,
+            &people(),
+        );
+        assert!(
+            !found.is_empty(),
+            "the mention must resolve, or this test passes for the wrong reason"
+        );
+        assert_eq!(
+            mention_responder(&record, Some("engineering"), &found),
+            None,
+            "the designer answers on their own desk, not as a guest here"
+        );
+        assert_eq!(
+            mention_responder(&record, Some("design"), &found),
+            Some("designer".to_string()),
+            "and is still the responder in the room they belong to"
+        );
+    }
+
+    /// The rule needs a membership to check against. `#general` is not a desk
+    /// and has none (issue #1743), and neither has a DM — `resolve_desk_id`
+    /// says so by returning `None`, and there every roster agent stays
+    /// nameable, exactly as before.
+    #[test]
+    fn a_channel_with_no_membership_still_names_anybody() {
+        let record = record(TWO_DESKS);
+        let found = resolve(
+            "@designer can you look at this",
+            None,
+            None,
+            &record,
+            &people(),
+        );
+        for channel in [None, Some("general"), Some("dm:u1:designer")] {
+            assert_eq!(
+                mention_responder(&record, channel, &found),
+                Some("designer".to_string()),
+                "{channel:?} has no membership to be outside of"
+            );
+        }
+    }
+
     #[test]
     fn a_mentioned_teammate_becomes_the_responder() {
         let found = resolve_text("@engineer what is the build status");
         assert_eq!(
-            mention_responder(&acme(), &found),
+            mention_responder(&acme(), None, &found),
             Some("engineer".to_string())
         );
     }
@@ -1587,7 +1699,10 @@ members = ["engineer", "ceo"]
     #[test]
     fn the_first_mentioned_teammate_answers() {
         let found = resolve_text("@ceo can you check with @engineer");
-        assert_eq!(mention_responder(&acme(), &found), Some("ceo".to_string()));
+        assert_eq!(
+            mention_responder(&acme(), None, &found),
+            Some("ceo".to_string())
+        );
     }
 
     #[test]
@@ -1598,7 +1713,7 @@ members = ["engineer", "ceo"]
             offset: 0,
             quiet: true,
         }];
-        assert_eq!(mention_responder(&acme(), &mentions), None);
+        assert_eq!(mention_responder(&acme(), None, &mentions), None);
     }
 
     #[test]
@@ -1610,7 +1725,7 @@ members = ["engineer", "ceo"]
             quiet: false,
         }];
         assert_eq!(
-            mention_responder(&acme(), &mentions),
+            mention_responder(&acme(), None, &mentions),
             None,
             "so the caller uses the desk lead, exactly as before"
         );
@@ -1619,7 +1734,7 @@ members = ["engineer", "ceo"]
     #[test]
     fn mentioning_only_people_does_not_change_the_responder() {
         let found = resolve_text("@Jane Doe thoughts?");
-        assert_eq!(mention_responder(&acme(), &found), None);
+        assert_eq!(mention_responder(&acme(), None, &found), None);
     }
 
     // -----------------------------------------------------------------------

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -1796,6 +1796,7 @@ members = ["designer"]
             description: None,
             responder: Default::default(),
             members: vec!["ceo".to_string()],
+            hive: Default::default(),
         });
         let found = resolve_text("@everyone standup in five");
         for spelling in ["general", "General", "main", ""] {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -80,6 +80,13 @@ pub mod grants;
 /// harness pool, the MCP runtime, and the two serialising mutexes). See
 /// [`handover`].
 pub mod handover;
+/// The `tinyhivemind` session adapter: this company's journal read as the
+/// vendored library's [`SessionLog`](tinyhivemind::session::SessionLog) port,
+/// so a turn's transcript can be projected **attributed** rather than collapsed
+/// into the reader's own voice. Off by default and wired to nothing yet; see
+/// [`hivemind`].
+#[cfg(feature = "hivemind")]
+pub mod hivemind;
 pub mod journal;
 /// Issue #1845: [`LifecycleScheduler`] — the process-wide daily tick that
 /// nudges a signup who hit their day-7 boundary without saving a workflow,

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -1117,6 +1117,13 @@ pub async fn history_for_desk(
     // memory note keeps the long form, and the chat POST still returns it to
     // its caller. This is a rendering decision about one channel, on the same
     // terms the referral relay is dropped below.
+    //
+    // **Only the closing row.** A failed turn's notice is journaled under its
+    // own reserved id for exactly this reason: the turn it describes does not
+    // exist, so there is no gap for a reader to notice, and dropping it would
+    // leave "a transcript with a hole in it that nothing accounts for". The
+    // report restates a tally whose inputs are the visible turns; a failure
+    // notice is the only record that a seat was asked and could not answer.
     messages.retain(|message| message.channel != crate::hivemind::HIVE_REPORT_AUTHOR);
 
     drop_dead_cards(runtime, &mut messages).await?;
@@ -3168,6 +3175,69 @@ mod referral_origin_test {
         assert!(
             !voices.contains(&crate::hivemind::HIVE_REPORT_AUTHOR),
             "and the room's own bookkeeping is not a participant in it: {voices:?}"
+        );
+    }
+
+    /// **A failed turn still shows.** The report restates a tally whose inputs
+    /// are the visible turns, so hiding it costs nothing. A failure notice
+    /// describes a turn that does not exist — there is no gap for a reader to
+    /// notice — so hiding it would leave a transcript with an unaccounted hole.
+    #[tokio::test]
+    async fn a_failed_turn_is_still_reported_to_the_room() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let runtime = runtime(home.path()).await;
+        let id = CompanyId::new("acme");
+
+        for (agent, text) in [
+            (
+                crate::hivemind::HIVE_FAILURE_AUTHOR,
+                "qa_engineer was asked and could not answer.",
+            ),
+            (
+                crate::hivemind::HIVE_REPORT_AUTHOR,
+                "The desk settled after 2 turns.",
+            ),
+        ] {
+            runtime
+                .events()
+                .append(
+                    &id,
+                    CompanyEvent::AgentReply {
+                        chat_id: "engineering".to_string(),
+                        agent_id: agent.to_string(),
+                        text: text.to_string(),
+                        steps: Vec::new(),
+                        task_id: None,
+                        parent: None,
+                        mentions: Vec::new(),
+                        mention_depth: 0,
+                        audience: Vec::new(),
+                    },
+                )
+                .await
+                .expect("journal");
+        }
+
+        let history = history_for_desk(
+            &runtime,
+            "engineering",
+            "engineering",
+            &Viewer::Operator,
+            None,
+            50,
+            true,
+        )
+        .await
+        .expect("history");
+        let voices: Vec<&str> = history.iter().map(|m| m.channel.as_str()).collect();
+
+        assert!(
+            voices.contains(&crate::hivemind::HIVE_FAILURE_AUTHOR),
+            "a seat that could not answer is accounted for: {voices:?}"
+        );
+        assert!(
+            !voices.contains(&crate::hivemind::HIVE_REPORT_AUTHOR),
+            "while the closing summary stays out of the room: {voices:?}"
         );
     }
 

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -20,15 +20,29 @@ use crate::ports::types::{
     Actor, ActorKind, Attachment, CompanyEvent, CompanyId, CompanyRecord, EventSeq, Mention,
     MentionTarget, StoredEvent, TurnStep,
 };
-use crate::server::ops::language::DEFAULT_DESK as GENERAL_DESK;
+use crate::server::ops::language::DEFAULT_DESK;
 
-/// The console's default/orchestrator thread id
-/// (`frontend/src/lib/threads.ts` `mainThread()`). The console addresses every
-/// send on that thread with `chat: "main"`, so `AgentReply`s answering it are
-/// journaled with `chat_id == "main"` rather than [`GENERAL_DESK`]. `owns`
-/// admits both spellings for the General desk so a transcript is never split
-/// across the two ids depending on which one happened to write it (issue #65).
-pub const MAIN_THREAD_ID: &str = "main";
+// Conversation identity now lives in `tinyhivemind_core::chat`, and these are
+// re-exported so every existing caller keeps its path (issue #65, #435).
+//
+// The move is what lets `ports::types` stop reaching *upward* into
+// `crate::server::` to fold a General spelling: `resolve_desk_id` and
+// `desk_alias_is_ambiguous` call this rule, and a port calling a server module
+// was a layering violation that only a shared crate could remove.
+pub use tinyhivemind_core::chat::{
+    GENERAL_DESK, MAIN_THREAD_ID, is_general_chat, same_conversation,
+};
+
+// `DEFAULT_DESK` is the prosumer glossary string mirroring
+// `frontend/src/lib/language.ts`; `GENERAL_DESK` is the desk's identity. They
+// are different concerns that happen to be the same literal, so neither imports
+// the other — but they must never drift, because a message journaled under the
+// glossary word has to fold into the identity. Pinned here rather than
+// duplicated, and it costs nothing at runtime.
+const _: () = assert!(
+    matches!(DEFAULT_DESK.as_bytes(), b"General") && matches!(GENERAL_DESK.as_bytes(), b"General"),
+    "the operator-facing default desk name and the General desk id must agree",
+);
 
 /// The largest message page either history surface may materialize. Keeping
 /// the limit beside the shared reader prevents a new caller from turning its
@@ -144,48 +158,6 @@ fn trivially_resolved(chat_id: Option<&str>) -> Option<(String, String)> {
     }
 }
 
-/// Does this stored chat id mean the General desk?
-///
-/// **Four spellings, one desk.** The console addresses its default thread as
-/// `"main"`, the chat route stores an unaddressed message as `None`, older
-/// events carry `""`, and the desk's own id/name is `"General"`. [`owns`] has
-/// admitted all four since issue #65, which is what stops a transcript from
-/// splitting across whichever id happened to write each message.
-///
-/// Exposed because that equivalence is **not** local to history rendering.
-/// `CompanyRuntime::resolvable_parent` compares a remembered thread root's chat
-/// id against the channel being answered into, and comparing the raw strings
-/// there made a root stored as `None` fail to match the `"General"` it is
-/// rendered under — so a threaded approval rooted in an unaddressed message
-/// silently resumed in the channel, which is the exact symptom issue #435 set
-/// out to remove. Two places deciding "same conversation?" by different rules
-/// is the drift; one function is the fix. See [`same_conversation`].
-pub fn is_general_chat(chat: Option<&str>) -> bool {
-    match chat {
-        None => true,
-        Some(chat) => {
-            chat.is_empty()
-                || chat.eq_ignore_ascii_case(MAIN_THREAD_ID)
-                || chat.eq_ignore_ascii_case(GENERAL_DESK)
-        }
-    }
-}
-
-/// Do two stored chat ids name the same conversation (issue #435)?
-///
-/// Every spelling of the General desk is one conversation — see
-/// [`is_general_chat`] — and everything else compares verbatim, because a desk
-/// id is an opaque identifier and two desks differing only in case are two
-/// desks. Deliberately **not** a general-purpose case-insensitive compare: the
-/// folding is a fact about one desk's history, not a licence to loosen the
-/// others.
-pub fn same_conversation(a: Option<&str>, b: Option<&str>) -> bool {
-    if is_general_chat(a) || is_general_chat(b) {
-        return is_general_chat(a) && is_general_chat(b);
-    }
-    a == b
-}
-
 /// Whether a stored event belongs to the desk identified by `desk_id` /
 /// `desk_name`.
 ///
@@ -278,6 +250,24 @@ pub fn dispatch_marker_text(column: &str) -> String {
     format!("finished → {}", crate::ports::tasks::column_label(column))
 }
 
+/// Where a crossing referral came from, folded onto the message it caused.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferredFrom {
+    /// The asking desk, by id — for the link.
+    pub desk_id: String,
+    /// Its display name as captured when the referral was made.
+    pub desk_name: String,
+    /// The agent that asked.
+    pub asker_id: String,
+    /// Its display label as captured when the referral was made.
+    pub asker_label: String,
+    /// The asking message, so the console can link to it.
+    pub sequence: u64,
+    /// Whether this is the answer coming home rather than the outbound ask.
+    /// Carried from the marker; see `CompanyEvent::ReferralEnqueued`.
+    pub returning: bool,
+}
+
 /// Who is reading a desk history. `mine` is relative to this.
 ///
 /// There is no `From<StoredEvent> for MessageView`, and there cannot be:
@@ -330,6 +320,12 @@ pub struct MessageView {
     /// dispatch marker and an agent reply are both `false`: neither was typed by
     /// a person.
     pub by_person: bool,
+    /// Set when a crossing referral caused this message (tinyhivemind P15).
+    ///
+    /// Folded from the `ReferralEnqueued` marker rather than stored on the
+    /// message: the marker is written inside the enqueue transaction, before
+    /// the child turn exists, so the message cannot carry it at write time.
+    pub referred_from: Option<ReferredFrom>,
     /// Whether this row may reach only administrators (issue #1781 review,
     /// Codex P1).
     ///
@@ -578,6 +574,8 @@ impl MessageView {
                 mine: false,
                 // The runtime wrote this, whichever brain produced it.
                 by_person: false,
+                // Set by the referral fold in `history_for_desk`, never here.
+                referred_from: None,
                 steps,
                 task_id,
                 parent_id: parent.map(|seq| seq.value().to_string()),
@@ -595,30 +593,73 @@ impl MessageView {
                 attachments,
                 ..
             } => {
-                let (author, mine) = match &by {
+                // `voice` is what the console draws the byline from: `senderOf`
+                // reads `channel`, not `author`, and treats the values in its
+                // COMPANY_VOICE set ("operator", "console", …) as "no distinct
+                // speaker — use the room's own name".
+                //
+                // That is right for a message a person sent. It is wrong for a
+                // referral, which arrives authored by a TEAMMATE: falling into
+                // that set made design's channel name the speaker, so an
+                // engineer asking design read as design talking to itself. An
+                // agent-authored line names the agent, exactly as an
+                // `AgentReply` already does one arm below.
+                let (author, mine, by_person, voice) = match &by {
                     // Sent by a signed-in human.
                     Some(actor) if actor.kind == ActorKind::User => {
                         let label = authors
                             .get(&actor.id)
                             .cloned()
                             .unwrap_or_else(|| "someone".to_string());
-                        (label, *viewer == Viewer::User(actor.id.clone()))
+                        (
+                            label,
+                            *viewer == Viewer::User(actor.id.clone()),
+                            true,
+                            "operator".to_string(),
+                        )
+                    }
+                    // A TEAMMATE sent it — a crossing referral arrives on the
+                    // target's desk as a message authored by the agent that
+                    // asked (tinyhivemind P15).
+                    //
+                    // Without this arm it fell to the machine-credential
+                    // fallback below and was projected as `operator`, with
+                    // `mine: true` for the operator's own view — so a question
+                    // engineering asked read as one the person at the console
+                    // had asked. That is the same shape as the `agent: None`
+                    // → `agent_id: "operator"` defect (#885): a fallback that
+                    // means "no person to name" rendered as a specific, wrong
+                    // person. `mine` is emphatically false: nobody typed it.
+                    Some(actor) if actor.kind == ActorKind::Agent => {
+                        (actor.id.clone(), false, false, actor.id.clone())
                     }
                     // Sent with a machine credential, or journaled before
                     // attribution existed. Either way there is no person to
                     // name, and it belongs to whoever holds that credential.
-                    _ => ("operator".to_string(), matches!(viewer, Viewer::Operator)),
+                    _ => (
+                        "operator".to_string(),
+                        matches!(viewer, Viewer::Operator),
+                        true,
+                        "operator".to_string(),
+                    ),
                 };
                 MessageView {
+                    // Set by the referral fold in `history_for_desk`, never here.
+                    referred_from: None,
                     id,
-                    channel: "operator".to_string(),
+                    channel: voice,
                     admin_only: false,
                     author,
                     text,
                     at_millis,
                     mine,
-                    // A person typed this — the one arm where that is true.
-                    by_person: true,
+                    // Decided with the author above, not assumed: this arm used
+                    // to be "the one arm where a person typed it", which stopped
+                    // being true when a referral began arriving here authored by
+                    // a teammate. `byPerson` gates real behaviour downstream —
+                    // the console's inline-reply promotion reads it — so a
+                    // teammate's line claiming to be a person's is not cosmetic.
+                    by_person,
                     steps: Vec::new(),
                     task_id: None,
                     parent_id: parent.map(|seq| seq.value().to_string()),
@@ -672,6 +713,8 @@ impl MessageView {
                 at_millis,
                 mine: false,
                 by_person: false,
+                // Set by the referral fold in `history_for_desk`, never here.
+                referred_from: None,
                 steps: Vec::new(),
                 task_id: Some(task_id),
                 // Rendered the same way an `OperatorMessage`'s parent is, a few
@@ -692,6 +735,8 @@ impl MessageView {
                 at_millis,
                 mine: false,
                 by_person: false,
+                // Set by the referral fold in `history_for_desk`, never here.
+                referred_from: None,
                 steps: Vec::new(),
                 task_id: None,
                 parent_id: None,
@@ -1054,7 +1099,138 @@ pub async fn history_for_desk(
     }
 
     drop_dead_cards(runtime, &mut messages).await?;
+    attach_referral_origins(runtime, desk_id, &mut messages).await?;
     Ok(messages)
+}
+
+/// Fold each `ReferralEnqueued` marker onto the message it caused
+/// (tinyhivemind P15).
+///
+/// # Why a fold and not a field on the message
+///
+/// The marker is written INSIDE the enqueue transaction, which is necessarily
+/// before the child turn exists — that ordering is what makes it an idempotency
+/// marker at all. So the message it causes cannot carry the provenance at write
+/// time, and the projection is the only place the two can meet.
+///
+/// # How they are matched
+///
+/// A marker names the desk the child runs on and the agent that asked. The
+/// child is the first message on that desk, after the marker, authored by that
+/// agent. Both are written by one task with nothing in between, so "first
+/// after" is exact rather than probabilistic — and the match still requires the
+/// author to agree, so an unrelated line landing between them is not adopted.
+///
+/// # The return leg is an INPUT, not a line in the channel
+///
+/// One agent speaks in both rooms, and it is the ASKER. It goes to the other
+/// desk and asks there under its own name; the desk that answers, answers on
+/// its OWN desk and never appears in the room it was asked from. When the asker
+/// judges the answer sufficient, it comes home and reports — in its own words,
+/// under its own name.
+///
+/// So the child of a RETURN marker is not a message anyone should read. It is
+/// the answer being handed back to the asker so the asker can run a turn on it,
+/// and rendering it produced exactly the double the single-accountable-voice
+/// rule exists to prevent: the other desk's agent posting its answer verbatim
+/// into a room it is not part of, immediately followed by the asker summarising
+/// that same answer. The reader saw the same content twice, in two voices, one
+/// of which does not belong there.
+///
+/// The relay is therefore dropped from the projection and its provenance moves
+/// onto the asker's report — which is the line a reader wants the chip on
+/// anyway, because that is the message whose origin is not otherwise visible.
+///
+/// **Only when the report actually exists.** If the asker's turn has not landed
+/// yet, or failed, the relay renders as it did before. A rendered line in the
+/// wrong voice is a cosmetic defect; a dropped one is a lost answer, and this
+/// projection already refuses that trade once (see the orphan arm below).
+async fn attach_referral_origins(
+    runtime: &CompanyRuntime,
+    desk_id: &str,
+    messages: &mut Vec<MessageView>,
+) -> Result<(), OpenCompanyError> {
+    let Some(oldest) = messages
+        .iter()
+        .filter_map(|m| m.id.parse::<u64>().ok())
+        .min()
+    else {
+        return Ok(());
+    };
+    let page = runtime
+        .events()
+        .read_from(runtime.id(), EventSeq::new(oldest.saturating_sub(2)), 4096)
+        .await?;
+    // Relays that a report has superseded, dropped once the scan is done —
+    // removing inside the loop would invalidate the positions it is still using.
+    let mut relayed: Vec<String> = Vec::new();
+    for (index, stored) in page.iter().enumerate() {
+        let CompanyEvent::ReferralEnqueued {
+            from_desk,
+            from_desk_name,
+            asker,
+            asker_label,
+            trigger_sequence,
+            to_desk,
+            target,
+            returning,
+        } = &stored.event
+        else {
+            continue;
+        };
+        if to_desk != desk_id {
+            continue;
+        }
+        let Some(child) = page[index + 1..].iter().find(|later| {
+            matches!(
+                &later.event,
+                CompanyEvent::OperatorMessage { chat, by, .. }
+                    if chat.as_deref() == Some(to_desk.as_str())
+                        && by.as_ref().is_some_and(|actor| actor.id == *asker)
+            )
+        }) else {
+            continue;
+        };
+        let child_id = child.seq.value().to_string();
+        let origin = ReferredFrom {
+            desk_id: from_desk.clone(),
+            desk_name: from_desk_name.clone(),
+            asker_id: asker.clone(),
+            asker_label: asker_label.clone(),
+            sequence: *trigger_sequence,
+            returning: *returning,
+        };
+
+        // On a return, the chip belongs on the ASKER's report — the first thing
+        // they say on this desk after the answer reached them. `target` is who
+        // the referral was routed to, which on a return is the agent that asked
+        // in the first place, so this needs no second notion of "the asker".
+        let report = returning
+            .then(|| {
+                messages
+                    .iter()
+                    .filter(|m| m.id.parse::<u64>().is_ok_and(|seq| seq > child.seq.value()))
+                    .find(|m| m.channel == *target && !m.by_person)
+                    .map(|m| m.id.clone())
+            })
+            .flatten();
+
+        match report {
+            Some(id) => {
+                relayed.push(child_id);
+                if let Some(view) = messages.iter_mut().find(|m| m.id == id) {
+                    view.referred_from = Some(origin);
+                }
+            }
+            None => {
+                if let Some(view) = messages.iter_mut().find(|m| m.id == child_id) {
+                    view.referred_from = Some(origin);
+                }
+            }
+        }
+    }
+    messages.retain(|m| !relayed.contains(&m.id));
+    Ok(())
 }
 
 /// Blanks `task_id` on any row naming a card the board no longer has
@@ -2826,6 +3002,262 @@ mod dead_card_test {
             .await
             .expect("audit");
         assert_eq!(as_admin.replies, 2, "an admin's count must count both rows");
+    }
+}
+
+/// Where a referred line says it came from, and who it says is speaking.
+#[cfg(test)]
+mod referral_origin_test {
+    use super::*;
+    use crate::company::CompanyManifest;
+    use crate::ports::types::CompanyId;
+    use crate::runtime::RuntimeBuilder;
+
+    fn manifest() -> CompanyManifest {
+        toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n")
+            .expect("parse manifest")
+    }
+
+    async fn runtime(home: &std::path::Path) -> Arc<CompanyRuntime> {
+        Arc::new(
+            RuntimeBuilder::new(home.to_path_buf(), manifest())
+                .with_id(CompanyId::new("acme"))
+                .build()
+                .await
+                .expect("build a runtime"),
+        )
+    }
+
+    /// Helper: the marker and the agent-authored line it caused, as one leg.
+    fn referral_leg(
+        from_desk: &str,
+        from_desk_name: &str,
+        asker: &str,
+        to_desk: &str,
+        target: &str,
+        returning: bool,
+        text: &str,
+    ) -> [CompanyEvent; 2] {
+        [
+            CompanyEvent::ReferralEnqueued {
+                from_desk: from_desk.to_string(),
+                from_desk_name: from_desk_name.to_string(),
+                asker: asker.to_string(),
+                asker_label: asker.to_string(),
+                trigger_sequence: 1,
+                to_desk: to_desk.to_string(),
+                target: target.to_string(),
+                returning,
+            },
+            CompanyEvent::OperatorMessage {
+                text: text.to_string(),
+                by: Some(Actor {
+                    kind: ActorKind::Agent,
+                    id: asker.to_string(),
+                }),
+                chat: Some(to_desk.to_string()),
+                parent: None,
+                deliverable: None,
+                mentions: Vec::new(),
+                attachments: Vec::new(),
+            },
+        ]
+    }
+
+    /// **A referred line is the ASKING AGENT speaking, not the desk.**
+    ///
+    /// `senderOf` in the console draws the byline off `channel`, and treats
+    /// "operator" as "no distinct speaker — use the room's own name". That is
+    /// right for a message a person sent and wrong for a referral, which
+    /// arrives authored by a teammate: hardcoding "operator" made design's own
+    /// name the speaker, so an engineer asking design read as design talking to
+    /// itself. An `AgentReply` already names its agent here; this makes the two
+    /// paths agree rather than teaching the console a second rule.
+    #[tokio::test]
+    async fn a_referred_message_is_voiced_by_the_agent_that_asked() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let runtime = runtime(home.path()).await;
+        let id = CompanyId::new("acme");
+
+        for event in referral_leg(
+            "engineering",
+            "Engineering",
+            "software_engineer",
+            "design",
+            "product_designer",
+            false,
+            "what would you change about the error messages?",
+        ) {
+            runtime.events().append(&id, event).await.expect("journal");
+        }
+
+        let history = history_for_desk(
+            &runtime,
+            "design",
+            "design",
+            &Viewer::Operator,
+            None,
+            50,
+            true,
+        )
+        .await
+        .expect("history");
+        let referred = history
+            .iter()
+            .find(|m| m.referred_from.is_some())
+            .expect("the referred line");
+
+        assert_eq!(
+            referred.channel, "software_engineer",
+            "the byline names the agent, not the desk it landed on: {referred:?}"
+        );
+        assert!(
+            !referred.by_person,
+            "an agent is not a person, whatever the event it rides on"
+        );
+    }
+
+    /// **One agent speaks in both rooms, and it is the asker.**
+    ///
+    /// The asker asks on the other desk under its own name; that desk answers
+    /// on its own desk; the asker comes home and reports. The relay that
+    /// carried the answer back is an input to the asker, not a line anyone
+    /// reads — rendering it put the other desk's agent in a room it is not part
+    /// of, saying the same thing the asker was about to say.
+    #[tokio::test]
+    async fn the_asker_brings_the_answer_home_and_the_other_desk_stays_out_of_the_room() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let runtime = runtime(home.path()).await;
+        let id = CompanyId::new("acme");
+
+        let mut events: Vec<CompanyEvent> = referral_leg(
+            "engineering",
+            "Engineering",
+            "software_engineer",
+            "design",
+            "product_designer",
+            false,
+            "what would you change about the error messages?",
+        )
+        .into_iter()
+        .chain(referral_leg(
+            "design",
+            "Design",
+            "product_designer",
+            "engineering",
+            "software_engineer",
+            true,
+            "error messages look like a copy task and are not one",
+        ))
+        .collect();
+        // The asker's report — the only thing #engineering should show.
+        events.push(CompanyEvent::AgentReply {
+            chat_id: "engineering".to_string(),
+            agent_id: "software_engineer".to_string(),
+            text: "design came back: error messages are a design-system problem".to_string(),
+            steps: Vec::new(),
+            task_id: None,
+            parent: None,
+            mentions: Vec::new(),
+            mention_depth: 0,
+        });
+        for event in events {
+            runtime.events().append(&id, event).await.expect("journal");
+        }
+
+        let history = history_for_desk(
+            &runtime,
+            "engineering",
+            "engineering",
+            &Viewer::Operator,
+            None,
+            50,
+            true,
+        )
+        .await
+        .expect("history");
+
+        assert!(
+            history.iter().all(|m| m.channel != "product_designer"),
+            "the answering desk never speaks in the room it was asked from: {history:?}"
+        );
+        let referred = history
+            .iter()
+            .find(|m| m.referred_from.is_some())
+            .expect("something carries the provenance");
+        assert_eq!(
+            referred.channel, "software_engineer",
+            "the chip rides the asker's own report: {referred:?}"
+        );
+        let origin = referred.referred_from.as_ref().expect("origin");
+        assert!(origin.returning, "and it reads as an answer, not an ask");
+        assert_eq!(origin.desk_name, "Design");
+    }
+
+    /// **The fail-safe half: a relay renders while the report is still missing.**
+    ///
+    /// The test below drops the relay once the asker has reported. Until then
+    /// there is nothing else carrying design's answer, and dropping it would
+    /// lose the answer outright — so it renders, in the wrong voice, saying
+    /// truthfully that it is an answer rather than an ask.
+    ///
+    /// **Which leg this is, is the host's to say (the "Answered by" chip).**
+    ///
+    /// Both legs are agent-authored lines on a desk, so every signal the
+    /// console holds reads identically on each — it guessed from `from` and
+    /// called every returning answer an ask. `tinyhivemind` decided it already
+    /// (`ReferralKind`), and the marker carries that decision.
+    #[tokio::test]
+    async fn a_relay_with_no_report_yet_still_renders_and_says_it_is_an_answer() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let runtime = runtime(home.path()).await;
+        let id = CompanyId::new("acme");
+
+        for event in referral_leg(
+            "engineering",
+            "Engineering",
+            "software_engineer",
+            "design",
+            "product_designer",
+            false,
+            "what would you change about the error messages?",
+        )
+        .into_iter()
+        .chain(referral_leg(
+            "design",
+            "Design",
+            "product_designer",
+            "engineering",
+            "software_engineer",
+            true,
+            "error messages look like a copy task and are not one",
+        )) {
+            runtime.events().append(&id, event).await.expect("journal");
+        }
+
+        for (desk, desk_name, returning) in [
+            ("design", "Engineering", false),
+            ("engineering", "Design", true),
+        ] {
+            let history = history_for_desk(&runtime, desk, desk, &Viewer::Operator, None, 50, true)
+                .await
+                .expect("history");
+            let origin = history
+                .iter()
+                .find_map(|m| m.referred_from.as_ref())
+                .unwrap_or_else(|| panic!("#{desk} carries a referral origin"));
+            assert_eq!(origin.desk_name, desk_name, "on #{desk}");
+            assert_eq!(
+                origin.returning,
+                returning,
+                "#{desk} draws the {} chip",
+                if returning {
+                    "\"Answered by\""
+                } else {
+                    "\"Asked by\""
+                }
+            );
+        }
     }
 }
 

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -1286,7 +1286,7 @@ async fn attach_referral_origins(
 /// **The journal keeps the original.** The fold reads markers off the stored
 /// line, so this rewrite lives here and nowhere earlier — a room whose own
 /// transcript had been cleaned could not count itself.
-fn readable_moves(text: String) -> String {
+pub(crate) fn readable_moves(text: String) -> String {
     if !text
         .lines()
         .any(|line| crate::hivemind::line_kind(line).is_some())

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -569,7 +569,7 @@ impl MessageView {
                 channel: agent_id.clone(),
                 admin_only: agent_id == crate::runtime::OWNER_FALLBACK_REPORT_AUTHOR,
                 author: agent_id,
-                text,
+                text: readable_moves(text),
                 at_millis,
                 mine: false,
                 // The runtime wrote this, whichever brain produced it.
@@ -1270,6 +1270,33 @@ async fn attach_referral_origins(
     }
     messages.retain(|m| !relayed.contains(&m.id));
     Ok(())
+}
+
+/// Renders a deliberation turn for a person, leaving every other reply alone.
+///
+/// A room's grammar — `!move`, `#topic`, `^N`, `>N` — is addressed to the fold
+/// and was reaching the operator verbatim: `!support #lazy-load ^3 agreed`
+/// rendered as-is in a chat window. Each line that carries a move is rewritten
+/// to a plain-English lead; a line that carries none passes through untouched,
+/// which is every reply on every desk that does not deliberate.
+///
+/// Line by line, because a turn may pair prose with its move, and only the
+/// marked line is grammar.
+///
+/// **The journal keeps the original.** The fold reads markers off the stored
+/// line, so this rewrite lives here and nowhere earlier — a room whose own
+/// transcript had been cleaned could not count itself.
+fn readable_moves(text: String) -> String {
+    if !text
+        .lines()
+        .any(|line| crate::hivemind::line_kind(line).is_some())
+    {
+        return text;
+    }
+    text.lines()
+        .map(|line| crate::hivemind::readable(line).unwrap_or_else(|| line.to_string()))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Blanks `task_id` on any row naming a card the board no longer has

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -3434,6 +3434,7 @@ name = "{name}"
             description: None,
             members: Vec::new(),
             responder: crate::ports::types::ResponderMode::default(),
+            hive: Default::default(),
         });
         for spelling in ["ops_desk", "Operations"] {
             assert_eq!(

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -3171,6 +3171,7 @@ mod referral_origin_test {
             parent: None,
             mentions: Vec::new(),
             mention_depth: 0,
+            audience: Vec::new(),
         });
         for event in events {
             runtime.events().append(&id, event).await.expect("journal");

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -1257,9 +1257,8 @@ async fn attach_referral_origins(
                     // FOR the asker — "you are the only one who has seen it" —
                     // in a channel, over the name of an agent that is not even
                     // on this desk. Only the other desk's own words survive.
-                    if let Some((answer, _)) = view
-                        .text
-                        .split_once(crate::runtime::hivemind::RELAY_NOTE_MARKER)
+                    if let Some((answer, _)) =
+                        view.text.split_once(crate::ports::types::RELAY_NOTE_MARKER)
                     {
                         view.text = answer.to_string();
                     }
@@ -3416,7 +3415,7 @@ mod referral_origin_test {
         let note = format!(
             "{}product_designer on the Design desk answered what you asked them. \
              This did not appear in your channel — you are the only one who has seen it.",
-            crate::runtime::hivemind::RELAY_NOTE_MARKER
+            crate::ports::types::RELAY_NOTE_MARKER
         );
         // No reply follows, so the fallback renders this relay.
         for event in referral_leg(

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -1224,6 +1224,17 @@ async fn attach_referral_origins(
             }
             None => {
                 if let Some(view) = messages.iter_mut().find(|m| m.id == child_id) {
+                    // Rendering a relay at all is the fallback; rendering the
+                    // note the host appended to it would publish text written
+                    // FOR the asker — "you are the only one who has seen it" —
+                    // in a channel, over the name of an agent that is not even
+                    // on this desk. Only the other desk's own words survive.
+                    if let Some((answer, _)) = view
+                        .text
+                        .split_once(crate::runtime::hivemind::RELAY_NOTE_MARKER)
+                    {
+                        view.text = answer.to_string();
+                    }
                     view.referred_from = Some(origin);
                 }
             }
@@ -3192,6 +3203,64 @@ mod referral_origin_test {
         let origin = referred.referred_from.as_ref().expect("origin");
         assert!(origin.returning, "and it reads as an answer, not an ask");
         assert_eq!(origin.desk_name, "Design");
+    }
+
+    /// **A rendered relay shows the answer and none of the host's note.**
+    ///
+    /// Seen in the console, not reasoned about: the asker's turn died on an
+    /// empty model response, the fallback rendered the relay, and #engineering
+    /// was told "you are the only one who has seen it" by the design desk's
+    /// agent. The note is written FOR the asker and is private to it; the
+    /// fallback exists to preserve the ANSWER, so that is all it may publish.
+    #[tokio::test]
+    async fn a_rendered_relay_keeps_the_answer_and_drops_the_note() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let runtime = runtime(home.path()).await;
+        let id = CompanyId::new("acme");
+
+        let answer = "use a skeleton, not a spinner";
+        let note = format!(
+            "{}product_designer on the Design desk answered what you asked them. \
+             This did not appear in your channel — you are the only one who has seen it.",
+            crate::runtime::hivemind::RELAY_NOTE_MARKER
+        );
+        // No reply follows, so the fallback renders this relay.
+        for event in referral_leg(
+            "design",
+            "Design",
+            "product_designer",
+            "engineering",
+            "software_engineer",
+            true,
+            &format!("{answer}{note}"),
+        ) {
+            runtime.events().append(&id, event).await.expect("journal");
+        }
+
+        let history = history_for_desk(
+            &runtime,
+            "engineering",
+            "engineering",
+            &Viewer::Operator,
+            None,
+            50,
+            true,
+        )
+        .await
+        .expect("history");
+        let relayed = history
+            .iter()
+            .find(|m| m.referred_from.is_some())
+            .expect("the relay renders, because nothing else carries the answer");
+
+        assert_eq!(
+            relayed.text, answer,
+            "the other desk's own words, and only those"
+        );
+        assert!(
+            !relayed.text.contains("only one who has seen it"),
+            "a note addressed to the asker is not published to the channel"
+        );
     }
 
     /// **The fail-safe half: a relay renders while the report is still missing.**

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -1098,6 +1098,27 @@ pub async fn history_for_desk(
         }
     }
 
+    // **The room's own bookkeeping does not draw in the room.**
+    //
+    // An episode journals every turn as an ordinary reply by the teammate that
+    // took it, and then one closing row under `HIVE_REPORT_AUTHOR`. The turns
+    // are the conversation and belong on screen. The closing row is the host's
+    // summary of a tally it just computed — and rendered here it appeared as a
+    // *teammate* called `hive-report`, a participant in a channel where no such
+    // teammate exists and none can: the id is hyphenated precisely so no roster
+    // id can equal it.
+    //
+    // The fold already reads it as `SessionAuthor::System` rather than as an
+    // agent, so dropping it here makes the console agree with the fold instead
+    // of disagreeing with it in a way an operator can see.
+    //
+    // **Dropped from the projection, never from the journal.** The row stays
+    // durable and stays readable: the next episode folds it as context, the
+    // memory note keeps the long form, and the chat POST still returns it to
+    // its caller. This is a rendering decision about one channel, on the same
+    // terms the referral relay is dropped below.
+    messages.retain(|message| message.channel != crate::hivemind::HIVE_REPORT_AUTHOR);
+
     drop_dead_cards(runtime, &mut messages).await?;
     attach_referral_origins(runtime, desk_id, &mut messages).await?;
     Ok(messages)
@@ -3073,6 +3094,81 @@ mod referral_origin_test {
                 attachments: Vec::new(),
             },
         ]
+    }
+
+    /// **An episode's turns are the conversation; its closing row is not.**
+    ///
+    /// The room journals every turn as an ordinary reply by the teammate that
+    /// took it, then one summary under `hive-report`. Rendered, that summary
+    /// appeared as a *teammate* — a participant in a channel where no such
+    /// teammate exists and none can, since the id is hyphenated exactly so no
+    /// roster id can equal it. The fold already reads it as `System`; this
+    /// makes the console agree.
+    ///
+    /// The turns must survive: dropping the room and keeping only its summary
+    /// would hide the reasoning, the losing options and every objection — the
+    /// one thing a room produces that a single answer cannot.
+    #[tokio::test]
+    async fn an_episodes_turns_render_but_its_closing_row_does_not() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let runtime = runtime(home.path()).await;
+        let id = CompanyId::new("acme");
+
+        for (agent, text) in [
+            (
+                "software_engineer",
+                "!propose #lazy-load defer each section",
+            ),
+            (
+                "junior_engineer",
+                "!object >1 ^1 users bounce between sections",
+            ),
+            (
+                crate::hivemind::HIVE_REPORT_AUTHOR,
+                "The desk settled after 2 turns (#lazy-load, backed by software_engineer): defer each section",
+            ),
+        ] {
+            runtime
+                .events()
+                .append(
+                    &id,
+                    CompanyEvent::AgentReply {
+                        chat_id: "engineering".to_string(),
+                        agent_id: agent.to_string(),
+                        text: text.to_string(),
+                        steps: Vec::new(),
+                        task_id: None,
+                        parent: None,
+                        mentions: Vec::new(),
+                        mention_depth: 0,
+                        audience: Vec::new(),
+                    },
+                )
+                .await
+                .expect("journal");
+        }
+
+        let history = history_for_desk(
+            &runtime,
+            "engineering",
+            "engineering",
+            &Viewer::Operator,
+            None,
+            50,
+            true,
+        )
+        .await
+        .expect("history");
+
+        let voices: Vec<&str> = history.iter().map(|m| m.channel.as_str()).collect();
+        assert!(
+            voices.contains(&"software_engineer") && voices.contains(&"junior_engineer"),
+            "every teammate's turn is on screen, the objection included: {voices:?}"
+        );
+        assert!(
+            !voices.contains(&crate::hivemind::HIVE_REPORT_AUTHOR),
+            "and the room's own bookkeeping is not a participant in it: {voices:?}"
+        );
     }
 
     /// **A referred line is the ASKING AGENT speaking, not the desk.**

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -1046,6 +1046,30 @@ pub async fn history_for_desk(
                 if message.admin_only && !is_admin {
                     continue;
                 }
+                // The room's own bookkeeping, excluded on the same terms and
+                // in the same place, for the same reason: filtered after the
+                // page was built, an episode's closing row silently shortened
+                // every page it appeared on.
+                //
+                // An episode journals every turn as an ordinary reply by the
+                // teammate that took it, and then one closing row under
+                // `HIVE_REPORT_AUTHOR`. The turns are the conversation and
+                // belong on screen. The closing row is the host summarising a
+                // tally whose inputs are those turns — and rendered here it
+                // appeared as a *teammate* in a channel where no such teammate
+                // exists and none can, the id being hyphenated precisely so no
+                // roster id can equal it. The fold already reads it as
+                // `SessionAuthor::System`; this makes the console agree.
+                //
+                // Dropped from the projection, never from the journal: the next
+                // episode folds it as context, the memory note keeps the long
+                // form, and the chat POST still returns it to its caller. A
+                // FAILED turn's notice carries its own reserved id and is not
+                // dropped — the turn it describes does not exist, so there is
+                // no gap for a reader to notice.
+                if message.channel == crate::hivemind::HIVE_REPORT_AUTHOR {
+                    continue;
+                }
                 messages.push(message);
                 if messages.len() == first {
                     break;
@@ -1097,34 +1121,6 @@ pub async fn history_for_desk(
             message.reactions = reactions.remove(&message.id).unwrap_or_default();
         }
     }
-
-    // **The room's own bookkeeping does not draw in the room.**
-    //
-    // An episode journals every turn as an ordinary reply by the teammate that
-    // took it, and then one closing row under `HIVE_REPORT_AUTHOR`. The turns
-    // are the conversation and belong on screen. The closing row is the host's
-    // summary of a tally it just computed — and rendered here it appeared as a
-    // *teammate* called `hive-report`, a participant in a channel where no such
-    // teammate exists and none can: the id is hyphenated precisely so no roster
-    // id can equal it.
-    //
-    // The fold already reads it as `SessionAuthor::System` rather than as an
-    // agent, so dropping it here makes the console agree with the fold instead
-    // of disagreeing with it in a way an operator can see.
-    //
-    // **Dropped from the projection, never from the journal.** The row stays
-    // durable and stays readable: the next episode folds it as context, the
-    // memory note keeps the long form, and the chat POST still returns it to
-    // its caller. This is a rendering decision about one channel, on the same
-    // terms the referral relay is dropped below.
-    //
-    // **Only the closing row.** A failed turn's notice is journaled under its
-    // own reserved id for exactly this reason: the turn it describes does not
-    // exist, so there is no gap for a reader to notice, and dropping it would
-    // leave "a transcript with a hole in it that nothing accounts for". The
-    // report restates a tally whose inputs are the visible turns; a failure
-    // notice is the only record that a seat was asked and could not answer.
-    messages.retain(|message| message.channel != crate::hivemind::HIVE_REPORT_AUTHOR);
 
     drop_dead_cards(runtime, &mut messages).await?;
     attach_referral_origins(runtime, desk_id, &mut messages).await?;
@@ -3201,6 +3197,71 @@ mod referral_origin_test {
         assert!(
             !voices.contains(&crate::hivemind::HIVE_REPORT_AUTHOR),
             "and the room's own bookkeeping is not a participant in it: {voices:?}"
+        );
+    }
+
+    /// **A suppressed row must not shorten the page.**
+    ///
+    /// Filtered after the page was assembled, an episode's closing row silently
+    /// cost the reader a message: a page asked for `n` came back with `n - 1`,
+    /// and the row that should have taken its place stayed unfetched. The
+    /// admission point already excludes an admin-only row for exactly this
+    /// reason, and says so.
+    #[tokio::test]
+    async fn a_suppressed_report_does_not_shorten_the_page() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let runtime = runtime(home.path()).await;
+        let id = CompanyId::new("acme");
+
+        // Four teammate turns with the room's closing row in the middle.
+        for (agent, text) in [
+            ("software_engineer", "first"),
+            ("junior_engineer", "second"),
+            (crate::hivemind::HIVE_REPORT_AUTHOR, "The desk settled."),
+            ("qa_engineer", "third"),
+            ("software_engineer", "fourth"),
+        ] {
+            runtime
+                .events()
+                .append(
+                    &id,
+                    CompanyEvent::AgentReply {
+                        chat_id: "engineering".to_string(),
+                        agent_id: agent.to_string(),
+                        text: text.to_string(),
+                        steps: Vec::new(),
+                        task_id: None,
+                        parent: None,
+                        mentions: Vec::new(),
+                        mention_depth: 0,
+                        audience: Vec::new(),
+                    },
+                )
+                .await
+                .expect("journal");
+        }
+
+        let page = history_for_desk(
+            &runtime,
+            "engineering",
+            "engineering",
+            &Viewer::Operator,
+            None,
+            4,
+            true,
+        )
+        .await
+        .expect("history");
+
+        assert_eq!(
+            page.len(),
+            4,
+            "a page of four is four teammate turns, not three and a hole: {page:?}"
+        );
+        assert!(
+            page.iter()
+                .all(|m| m.channel != crate::hivemind::HIVE_REPORT_AUTHOR),
+            "and none of them is the room's bookkeeping: {page:?}"
         );
     }
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -824,6 +824,9 @@ async fn create_desk(
         description: description.clone(),
         members: members.clone(),
         responder: body.responder,
+        // A desk created here starts with no hive block of its own and takes
+        // the defaults, exactly as a manifest desk that declares none does.
+        hive: crate::hivemind::HiveConfig::default(),
     };
     record.overlay_desks.push(desk);
     scope.runtime.store().save(&record).await?;
@@ -6651,6 +6654,7 @@ mode = "full"
             description: None,
             members: vec!["ceo".to_string()],
             responder: ResponderMode::Lead,
+            hive: Default::default(),
         });
         record.overlay_desks.push(OverlayDesk {
             id: "main".to_string(),
@@ -6658,6 +6662,7 @@ mode = "full"
             description: None,
             members: vec!["eng".to_string()],
             responder: ResponderMode::Lead,
+            hive: Default::default(),
         });
         runtime.store().save(&record).await.unwrap();
 
@@ -6785,6 +6790,7 @@ mode = "full"
             description: None,
             members: vec!["ceo".to_string()],
             responder: ResponderMode::Lead,
+            hive: Default::default(),
         });
         runtime.store().save(&record).await.unwrap();
 
@@ -7654,6 +7660,7 @@ mode = "full"
             description: None,
             members: vec![],
             responder: ResponderMode::Lead,
+            hive: Default::default(),
         });
         runtime.store().save(&record).await.unwrap();
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3514,9 +3514,15 @@ pub(crate) async fn refer_committed_replies(
     // back in the next `ReferralInput`, or the answer has no way home. Nothing
     // in the library remembers it."
     origin: Option<tinyhivemind_core::referral::ReferralOrigin>,
-    // Depth of the reply being offered. A first-level reply is 0; a reply
-    // produced BY a referred turn is 1, which is what lets `max_hops` bound
-    // the chain instead of being inert.
+    // Depth of the reply being offered — NOT of the child it might spawn.
+    //
+    // A reply to an operator message is 0, so every operator message starts a
+    // fresh chain. Otherwise it is the depth of the turn that produced this
+    // reply, which is what makes the count accumulate: the policy compares it
+    // against `max_hops` and hands the child `hop + 1`, and that child's own
+    // replies come back here at that number. Passing a constant here — as this
+    // did — makes every generation claim the same depth, and a bound that never
+    // advances bounds nothing.
     hop: u32,
 ) {
     use tinyhivemind::referral::{ReferralPolicy, ReferralReach, dispatch_referral};
@@ -3568,20 +3574,9 @@ pub(crate) async fn refer_committed_replies(
             &queue,
             ReferralPolicy {
                 enabled: true,
-                // **Two round trips.** A crossing question and the answer
-                // coming home are two hops, not one — a return carries no
-                // origin, so the library counts it as its own step. `2` was
-                // therefore exactly one exchange, and the asker's report, being
-                // one deeper, could never start a second: an answer that missed
-                // the point was the end of the conversation.
-                //
-                // `4` buys the asker one follow-up: ask, answer, ask again,
-                // answer again. That is the shape of an actual clarification —
-                // "you covered layout, but what about the error state?" — and
-                // stopping there is deliberate. A pair of desks that cannot
-                // converge in two exchanges is not going to converge in six,
-                // and every hop is a model call somebody pays for.
-                max_hops: 4,
+                // One constant, shared with the frame that tells the asker how
+                // much of the chain is left — see `REFERRAL_MAX_HOPS`.
+                max_hops: crate::runtime::hivemind::REFERRAL_MAX_HOPS,
                 reach: ReferralReach::Desks,
                 returns: true,
             },

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3482,9 +3482,112 @@ fn spawn_chat_turn(turn: ChatTurn) -> JoinHandle<Result<(CycleReport, Option<Str
         };
         let reply_parent = reply_thread(parent, accepted.message_seq);
         journal_chat_replies(&runtime, &company, &desk, reply_parent, &mut report).await;
+        // SPIKE (tinyhivemind P15): a committed reply may refer work to another
+        // desk. AFTER journaling, never before — the referral is keyed on the
+        // reply's own sequence, so it has to exist first.
+        #[cfg(feature = "hivemind")]
+        refer_committed_replies(&runtime, &company, &desk, &report, None, 0).await;
         settle_chat_turn(&runtime, &company, turn_id.as_deref(), None).await;
         Ok((report, feedback_note))
     })
+}
+
+/// Offer each committed agent reply to the referral decision (tinyhivemind P15).
+///
+/// The decision is pure and the queue is the only thing that acts, so this is
+/// safe to run over every reply: a message that refers nobody costs one
+/// in-memory decision and calls the queue zero times.
+///
+/// Policy is deliberately hard-coded here for the spike. In production it is an
+/// operator setting — `ReferralPolicy::DEFAULT` has every knob off, and that is
+// the shipping default the library intends.
+#[cfg(feature = "hivemind")]
+pub(crate) async fn refer_committed_replies(
+    runtime: &Arc<CompanyRuntime>,
+    company: &CompanyId,
+    desk: &str,
+    report: &CycleReport,
+    // The referral these replies are ANSWERING, when they are answering one.
+    //
+    // This is the back edge, and it is the host's to carry: "when a host runs
+    // a child turn that carried a `ReferralOrigin`, it must pass that origin
+    // back in the next `ReferralInput`, or the answer has no way home. Nothing
+    // in the library remembers it."
+    origin: Option<tinyhivemind_core::referral::ReferralOrigin>,
+    // Depth of the reply being offered. A first-level reply is 0; a reply
+    // produced BY a referred turn is 1, which is what lets `max_hops` bound
+    // the chain instead of being inert.
+    hop: u32,
+) {
+    use tinyhivemind::referral::{ReferralPolicy, ReferralReach, dispatch_referral};
+
+    let Ok(Some(record)) = runtime.store().load(company).await else {
+        return;
+    };
+    let members = crate::runtime::hivemind::roster_members(&record);
+    let people: Vec<tinyhivemind_core::roster::Person> = Vec::new();
+    let retired: Vec<String> = Vec::new();
+    let roster = tinyhivemind_core::roster::Roster::new(&members, &people, &retired);
+    let desks = crate::runtime::hivemind::desk_snapshots(&record);
+    let gate = runtime.referral_gate();
+
+    for response in &report.responses {
+        let (Some(agent), Some(id)) = (response.agent.as_deref(), response.message_id.as_deref())
+        else {
+            continue;
+        };
+        let Ok(sequence) = id.parse::<u64>() else {
+            continue;
+        };
+        let mentions = tinyhivemind_core::mention::resolve(
+            &response.text,
+            None,
+            &tinyhivemind_core::mention::MentionAuthor::Agent {
+                id: agent.to_string(),
+            },
+            &roster,
+            &desks.set(),
+        );
+        let input = tinyhivemind_core::referral::ReferralInput {
+            key: tinyhivemind_core::dispatch::DispatchKey {
+                trigger_sequence: sequence,
+            },
+            conversation: tinyhivemind_core::dispatch::DispatchConversation {
+                desk_id: desk.to_string(),
+                thread_root: None,
+            },
+            author_id: agent.to_string(),
+            content: response.text.clone(),
+            mentions,
+            hop,
+            origin: origin.clone(),
+        };
+        let queue =
+            crate::runtime::hivemind::JournalReferralQueue::new(runtime.clone(), gate.clone());
+        match dispatch_referral(
+            &queue,
+            ReferralPolicy {
+                enabled: true,
+                max_hops: 2,
+                reach: ReferralReach::Desks,
+                returns: true,
+            },
+            &input,
+            &roster,
+            &desks.set(),
+        )
+        .await
+        {
+            Ok(outcome) => tracing::info!(
+                company = %company,
+                desk = %desk,
+                author = %agent,
+                ?outcome,
+                "[referral] decided"
+            ),
+            Err(err) => tracing::warn!(error = %err, "[referral] decision failed"),
+        }
+    }
 }
 
 /// Awaits a spawned chat turn, turning a task that never finished into an error.
@@ -3754,6 +3857,39 @@ struct ChatHistoryQuery {
 
 /// One desk-history message, as the console renders it. Mirrors `ChatMessage`
 /// in `frontend/src/lib/chat.ts`.
+/// Where a crossing referral came from, when another desk caused this message
+/// (tinyhivemind P15).
+///
+/// Mirrors `ReferredFromDto` in `frontend/src/api/types.ts`.
+///
+/// The labels are **captured with the row** rather than resolved when the
+/// transcript is read, for the reason [`SessionAuthor`] captures its own: a
+/// desk renamed later must not rewrite what the conversation said at the time.
+///
+/// [`SessionAuthor`]: tinyhivemind::session::SessionAuthor
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ReferredFromDto {
+    /// The desk that asked, by id — for the link, never for display.
+    desk_id: String,
+    /// The desk's display name as it stood when the referral was made.
+    desk_name: String,
+    /// The agent that asked, by id.
+    asker_id: String,
+    /// That agent's display label as it stood when the referral was made.
+    asker_label: String,
+    /// The asking message, so the chip links straight to it.
+    sequence: u64,
+    /// Which word the chip uses. `"asked"` on the outbound leg, `"answered"`
+    /// when the answer has come home.
+    ///
+    /// Sent as the word rather than a bool because the console renders it and
+    /// nothing else: a `returning: true` would have the render side translating
+    /// a host decision back into English, which is how it came to guess in the
+    /// first place.
+    direction: &'static str,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ChatHistoryMessageDto {
@@ -3765,6 +3901,10 @@ struct ChatHistoryMessageDto {
     author: String,
     /// The message text.
     text: String,
+    /// Set only when another desk's referral caused this line. Absent on every
+    /// ordinary message, so the wire shape is unchanged for them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    referred_from: Option<ReferredFromDto>,
     /// When it was journaled, epoch millis.
     at_millis: f64,
     /// Whether it is the operator's own message.
@@ -3903,6 +4043,18 @@ impl From<ReactionView> for ChatReactionDto {
 impl From<MessageView> for ChatHistoryMessageDto {
     fn from(view: MessageView) -> Self {
         Self {
+            referred_from: view.referred_from.map(|origin| ReferredFromDto {
+                desk_id: origin.desk_id,
+                desk_name: origin.desk_name,
+                asker_id: origin.asker_id,
+                asker_label: origin.asker_label,
+                sequence: origin.sequence,
+                direction: if origin.returning {
+                    "answered"
+                } else {
+                    "asked"
+                },
+            }),
             id: view.id,
             channel: view.channel,
             author: view.author,

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3525,7 +3525,7 @@ pub(crate) async fn refer_committed_replies(
     // advances bounds nothing.
     hop: u32,
 ) {
-    use tinyhivemind::referral::{ReferralPolicy, ReferralReach, dispatch_referral};
+    use tinyhivemind::referral::dispatch_referral;
 
     let Ok(Some(record)) = runtime.store().load(company).await else {
         return;
@@ -3536,6 +3536,32 @@ pub(crate) async fn refer_committed_replies(
     let roster = tinyhivemind_core::roster::Roster::new(&members, &people, &retired);
     let desks = crate::runtime::hivemind::desk_snapshots(&record);
     let gate = runtime.referral_gate();
+
+    // **The desk's own `[[group_chat]].hive.referral` block, not a constant.**
+    //
+    // Referral is opt-in per desk and off by default: crossing costs a full
+    // model turn on somebody else's desk, and tinyhivemind's own benchmark
+    // measured it changing no answer and costing twice the turns on desks that
+    // are individually unbiased. A company that says nothing therefore behaves
+    // exactly as it did before this existed, which is the direction a mechanism
+    // that spends other people's turns should fail in.
+    //
+    // This replaces a hardcoded `enabled: true` with `max_hops` fixed in the
+    // source — a policy no operator could see, let alone change.
+    let config = crate::runtime::hivemind::referral_config(&record, desk);
+    let policy = config.policy();
+    if !policy.enabled {
+        return;
+    }
+
+    // ONE queue for the whole report, which is what makes `peer_cap` mean
+    // anything: the cap counts crossing questions across every reply this turn
+    // produced, and a queue rebuilt per reply would start each count at zero.
+    let queue = crate::runtime::hivemind::JournalReferralQueue::new(
+        runtime.clone(),
+        gate.clone(),
+        config.peer_cap(),
+    );
 
     for response in &report.responses {
         let (Some(agent), Some(id)) = (response.agent.as_deref(), response.message_id.as_deref())
@@ -3568,24 +3594,7 @@ pub(crate) async fn refer_committed_replies(
             hop,
             origin: origin.clone(),
         };
-        let queue =
-            crate::runtime::hivemind::JournalReferralQueue::new(runtime.clone(), gate.clone());
-        match dispatch_referral(
-            &queue,
-            ReferralPolicy {
-                enabled: true,
-                // One constant, shared with the frame that tells the asker how
-                // much of the chain is left — see `REFERRAL_MAX_HOPS`.
-                max_hops: crate::runtime::hivemind::REFERRAL_MAX_HOPS,
-                reach: ReferralReach::Desks,
-                returns: true,
-            },
-            &input,
-            &roster,
-            &desks.set(),
-        )
-        .await
-        {
+        match dispatch_referral(&queue, policy, &input, &roster, &desks.set()).await {
             Ok(outcome) => tracing::info!(
                 company = %company,
                 desk = %desk,

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3561,6 +3561,7 @@ pub(crate) async fn refer_committed_replies(
         runtime.clone(),
         gate.clone(),
         config.peer_cap(),
+        policy.max_hops,
     );
 
     for response in &report.responses {

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3568,7 +3568,20 @@ pub(crate) async fn refer_committed_replies(
             &queue,
             ReferralPolicy {
                 enabled: true,
-                max_hops: 2,
+                // **Two round trips.** A crossing question and the answer
+                // coming home are two hops, not one — a return carries no
+                // origin, so the library counts it as its own step. `2` was
+                // therefore exactly one exchange, and the asker's report, being
+                // one deeper, could never start a second: an answer that missed
+                // the point was the end of the conversation.
+                //
+                // `4` buys the asker one follow-up: ask, answer, ask again,
+                // answer again. That is the shape of an actual clarification —
+                // "you covered layout, but what about the error state?" — and
+                // stopping there is deliberate. A pair of desks that cannot
+                // converge in two exchanges is not going to converge in six,
+                // and every hop is a model call somebody pays for.
+                max_hops: 4,
                 reach: ReferralReach::Desks,
                 returns: true,
             },

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3142,7 +3142,7 @@ async fn chat_and_emit(
     }
 
     let (report, feedback_note) = join_chat_turn(turn).await?;
-    let responses = report.responses.clone();
+    let responses = readable_responses(report.responses.clone());
     emit_cycle_webhooks(state, id, &report).await;
     if let Some(note) = feedback_note {
         emit_feedback_webhook(state, id, &note).await;
@@ -3609,6 +3609,69 @@ pub(crate) async fn refer_committed_replies(
             Err(err) => tracing::warn!(error = %err, "[referral] decision failed"),
         }
     }
+}
+
+#[cfg(test)]
+mod readable_responses_test {
+    use super::readable_responses;
+    use crate::ports::types::OutboundMessage;
+
+    fn reply(text: &str) -> OutboundMessage {
+        OutboundMessage {
+            channel: "engineering".to_string(),
+            agent: Some("software_engineer".to_string()),
+            text: text.to_string(),
+            steps: Vec::new(),
+            reply_to: None,
+            task_id: None,
+            message_id: None,
+            mentions: Vec::new(),
+        }
+    }
+
+    /// **A row must read the same live as it does after a reload.**
+    ///
+    /// The history projection cleaned deliberation grammar; the POST did not.
+    /// So a turn arriving live showed `!support #lazy-load ^3 agreed` and the
+    /// same turn after a refresh showed `agreed` — one message, two renderings,
+    /// separated by a page reload.
+    #[test]
+    fn a_live_reply_reads_as_the_reloaded_one_will() {
+        let cleaned = readable_responses(vec![
+            reply("!support #lazy-load ^3 agreed, and it is reversible"),
+            reply("here is the summary you asked for"),
+        ]);
+
+        assert_eq!(
+            cleaned[0].text, "agreed, and it is reversible",
+            "the grammar is gone on the live path too"
+        );
+        assert_eq!(
+            cleaned[1].text, "here is the summary you asked for",
+            "and an ordinary reply is untouched"
+        );
+    }
+}
+
+/// The same rendering `chat_history` applies, for replies going out on the POST
+/// rather than being read back.
+///
+/// A deliberation turn is journaled with its grammar and cleaned when the
+/// history is projected — but a reply returned to the caller never passes
+/// through that projection, so the console showed `!support #lazy-load ^3` on
+/// a row that arrived live and plain prose on the same row after a reload.
+/// Two readers of one message, disagreeing, with a page refresh between them.
+///
+/// The stored row keeps its markers either way; the fold reads them off the
+/// journal, not off this.
+fn readable_responses(
+    mut responses: Vec<crate::ports::types::OutboundMessage>,
+) -> Vec<crate::ports::types::OutboundMessage> {
+    for response in &mut responses {
+        response.text =
+            crate::server::chat_history::readable_moves(std::mem::take(&mut response.text));
+    }
+    responses
 }
 
 /// Awaits a spawned chat turn, turning a task that never finished into an error.
@@ -5110,7 +5173,7 @@ async fn run_resolve(
     emit_cycle_webhooks(state, company, &report).await;
     Ok(Json(ChatResponse {
         message_id: None,
-        responses: report.responses,
+        responses: readable_responses(report.responses),
         still_awaiting: Some(still_awaiting),
         outcome: Some(outcome),
         review_feedback_applied: None,

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -1189,6 +1189,7 @@ role = "Chief Executive"
             description: None,
             members: vec!["jamie".to_string()],
             responder: crate::ports::types::ResponderMode::default(),
+            hive: Default::default(),
         });
         scoped
             .overlay_desk_tools

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -2577,6 +2577,7 @@ agent = "claude"
             description: None,
             members: vec!["ceo".to_string(), "writer".to_string()],
             responder: crate::ports::types::ResponderMode::Auto,
+            hive: Default::default(),
         });
         record.overlay_desks.push(crate::ports::types::OverlayDesk {
             id: "growth".to_string(),
@@ -2584,6 +2585,7 @@ agent = "claude"
             description: None,
             members: vec!["ceo".to_string(), "writer".to_string()],
             responder: crate::ports::types::ResponderMode::Lead,
+            hive: Default::default(),
         });
         store.save(&record).await.unwrap();
 

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -245,6 +245,7 @@ fn sample_overlay_desks() -> Vec<crate::ports::types::OverlayDesk> {
             description: Some("Customer mail triage.".to_string()),
             members: vec!["ceo".to_string(), "aria_stone".to_string()],
             responder: ResponderMode::default(),
+            hive: Default::default(),
         },
         OverlayDesk {
             id: "launch".to_string(),
@@ -252,6 +253,7 @@ fn sample_overlay_desks() -> Vec<crate::ports::types::OverlayDesk> {
             description: None,
             members: vec!["ceo".to_string(), "aria_stone".to_string()],
             responder: ResponderMode::Auto,
+            hive: Default::default(),
         },
     ]
 }

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -1892,6 +1892,7 @@ mod test {
                 description: Some("Marketing pod".into()),
                 members: vec!["ceo".into()],
                 responder: crate::ports::types::ResponderMode::default(),
+                hive: Default::default(),
             },
             OverlayDesk {
                 id: "launch".into(),
@@ -1899,6 +1900,7 @@ mod test {
                 description: None,
                 members: vec!["ceo".into(), "cto".into()],
                 responder: crate::ports::types::ResponderMode::Auto,
+                hive: Default::default(),
             },
         ];
         // A workflow graph authored at runtime (issue #168). On a hosted tenant

--- a/tests/hivemind_e2e.rs
+++ b/tests/hivemind_e2e.rs
@@ -211,6 +211,11 @@ fn parse_transcript_line(line: &str) -> Option<(u64, String, String)> {
     let rest = line.strip_prefix('[')?;
     let (seq, rest) = rest.split_once("] ")?;
     let (author, content) = rest.split_once(": ")?;
+    // The reader's own rows are attributed `<id> (you)` so a member can tell
+    // its own turns from a colleague's without losing the id colleagues cite
+    // it by. The id is what every assertion here matches on, so the marker is
+    // stripped back off.
+    let author = author.strip_suffix(" (you)").unwrap_or(author);
     Some((
         seq.parse().ok()?,
         author.to_owned(),
@@ -644,7 +649,14 @@ async fn a_desk_deliberates_and_converges_through_the_fold() {
     assert_eq!(reports.len(), 1, "exactly one closing row: {rows:?}");
     let report = &reports[0];
     assert!(report.contains(&format!("#{TOPIC}")), "{report}");
-    assert!(report.contains("settled on"), "{report}");
+    assert!(report.contains("settled"), "{report}");
+    // The decision itself, not only the label the room filed it under: the
+    // report leads with what `!propose` actually said, so an operator reading
+    // it learns the answer without going back to the transcript for it.
+    assert!(
+        report.contains("The closed form of the recurrence is 42."),
+        "the report names the label but not the decision: {report}"
+    );
     for member in [THEORIST, PROGRAMMER, VERIFIER] {
         assert!(
             report.contains(member),
@@ -1064,8 +1076,16 @@ async fn two_carrying_topics_and_no_objection_deadlock() {
     assert!(report.contains(&format!("#{ALPHA}")), "{report}");
     assert!(report.contains(&format!("#{BETA}")), "{report}");
     assert!(
-        report.contains("nobody broke the tie"),
+        report.contains("nobody was left to break the tie"),
         "a deadlock is reported as a deadlock, not as a decision: {report}"
+    );
+    // And escalated rather than merely stated. `Deadlocked` is returned only
+    // when every member has taken a side, so the room cannot break this itself
+    // and cannot even pick who to ask — one side would be choosing its own
+    // referee. That leaves the operator, and the report has to say so.
+    assert!(
+        report.contains("It needs your call"),
+        "a deadlock the room cannot break is put to the operator: {report}"
     );
 }
 


### PR DESCRIPTION
## What this is

Cross-desk referral on the chat path, and a set of fixes to the deliberation
room found by running it against real models rather than only unit tests.
Several of the changes below exist *because* of that run.

**This is a spike branch and wants splitting before review.** It is one
coherent line of work, but it is 14 commits over two surfaces; each commit
stands alone and the history is written to be read in order.

## Cross-desk referral, on the durable chat path

`src/hivemind/referral.rs` adapts the library's `ReferralQueue` for a
deliberation *episode*: idempotency in memory, the child turn inline. Neither
holds for a chat turn, which is durable, resumable, and has a real turn queue —
so this adds a second adapter rather than reusing that one.

- **One agent speaks in both rooms, and it is the asker.** It asks on the far
  desk under its own name; that desk answers on its own desk and never appears
  in the room it was asked from; the asker comes home and reports in its own
  words. The returning answer is an *input* to the asker, dropped from the
  projection — rendering it produced the same content twice, in two voices, one
  of which did not belong there.
- **The asker can go back** when an answer is not enough. This needed a real
  bug fixed first: every referred turn reported a hardcoded depth of `1`, so a
  follow-up claimed the same depth as the answer it followed and `max_hops`
  bounded nothing. Two desks could have passed a question back and forth
  forever; nothing drove that loop only because the asker could not ask again.
- **Policy comes from `[[group_chat]].hive.referral`**, not a constant, and
  `peer_cap` bounds the width the library deliberately leaves to the host.

## Ownership

`hand_card_over` briefly wrote the hand-off target reduced by
`AssigneeResolution::canonical`, which maps a desk to its own id — so
`delegate_to_desk` left a *channel* in `assignee`. An owner is an agent. Since
`assignee` is also what the thread's overseer is read from, such a card named
nobody who could answer for it.

## Deliberation fixes, all from live runs

- **A member could not tell itself apart from its colleagues.** Every transcript
  row was labelled with its author's name, the reader's own included, so a
  member copied the third person it was shown: `software_engineer` closed a room
  with "carried with support from software_engineer and junior_engineer". The
  reader's own rows now read "You" — the same fix `Speaker::Viewer` is for the
  chat seed (#1956), which the episode's renderer never had.
- **A topic goes on the floor once.** Two members filed *opposite* answers under
  one id named after the question, and since the fold counts `Propose` and
  `Support` alike as backing, it read that as a quorum of two for a decision the
  room was split 1-1 on. A re-proposed topic now earns one corrective turn.
- **The report says what was decided**, not just which label carried. A room
  that argued well and filed it under `#need-decide` reported "settled on
  #need-decide", which tells an operator nothing.
- **The grammar stays out of the channel.** `!`, `#`, `^N` and `>N` are
  addressed to the fold and were rendering verbatim where a person reads. Only
  head tokens are stripped — the same characters inside a sentence are the
  member's own words.
- **`hive-report` is not a teammate** and no longer draws in the room. A failed
  turn's notice moved to its own reserved id so it still does: the turn it
  describes does not exist, so there is no gap for a reader to notice.

## Other

- **A console-created desk can carry a `hive` block.** Hive config was read from
  the manifest only and responder mode from the overlay only, so no desk could
  hold both — a company whose desks are all operator-created had cross-desk
  referral permanently unavailable with nothing to write to enable it.
- **Routing reads capability.** `SelectorCandidate` carried what a teammate is
  *for* and never what it can reach, so "fetch the latest issues" routed to a
  product manager holding no `composio` grant, which could not have succeeded
  however well it reasoned.

## Verification

`cargo test --features openhuman,hivemind,composio --lib` — 7282 passed, 0
failed. `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check`
clean. Frontend `vitest` 4822 passed across 514 files, `tsc -b` clean.

Driven live against models on the ladder router throughout: the referral round
trip, the follow-up ask reaching `HopLimitReached`, capability routing, and
several deliberation rooms.

## Known gaps

- The suppressed report also carried the deadlock escalation, so a split room
  now ends with competing proposals and silence. Narrow fix: keep the report
  when the ending is not `Converged`.
- `require_evidential` constrains `!support` and not a self-backing `!propose`,
  so a vote can still carry with no evidence anywhere.
- A room converges on a decision that nobody then owns — no card, no assignee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-desk referrals with origin details and links to source conversations.
  * Added optional Hive-powered attributed transcripts, deliberation summaries, and referral handling.
  * Added available-tool information to agent selection.
  * Added asynchronous task hand-offs with bounded routing and clearer failure handling.
  * Added failed-send notices with optional retry actions.

* **Bug Fixes**
  * Improved thread rendering for multi-party exchanges.
  * Restricted mention-based responses to members of the addressed desk when applicable.
  * Improved history and relay presentation, including readable deliberation entries and referral attribution.
  * Clarified deadlock and settled-topic summaries.
  * Ensured live responses match reloaded chat formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->