### PR TITLE
docs(policy): say what still stops a call, and document the consequence floor

### DIFF
--- a/docs/modules/policy/README.md
+++ b/docs/modules/policy/README.md
@@ -70,6 +70,15 @@ decide, in this order, and all of them sit **above** the
 | Paid media | `RequireApproval` — these tools stage their own card |
 | Explicit `request_approval` | `RequireApproval` — the agent asked |
 
+The emergency-stop row is enforced directly inside `ApprovalPolicy::check`
+itself, not delegated to the gate: a harness tool call never reaches
+`ManifestApprovalGate::evaluate`/`park`, so `check` re-reads the same
+`AtomicBool` (via `emergency_gate`) before it can return any of the `Allow`s
+below it. `evaluate`/`park` enforce the identical veto on their own path — an
+effect that does reach the durable approval queue — so the effect gate and the
+harness call policy agree independently rather than one delegating to the
+other; see [Emergency stop](#emergency-stop) below for that path.
+
 Below the bypass sit the tier dispatch, `always_approve`, the daily cap and
 `crate::policy::judge`. Those are the arms #1925 turned off: an arm added there
 today compiles, tests green, and never runs in production. Enforcement has to

--- a/docs/modules/policy/README.md
+++ b/docs/modules/policy/README.md
@@ -62,13 +62,21 @@ decide, in this order, and all of them sit **above** the
 
 | Arm | Answer |
 |---|---|
+| Explicit `request_approval` | `Allow` — asking is not itself an effect to decide |
 | Emergency stop | `Deny` for every effect outside `EffectGroup::Other` |
 | Web deflection | `Deny` for a raw web call at a connected Composio provider's host |
 | `readonly` brake | `Deny` for anything that mutates or reaches outside |
 | Single-use grant | `Allow` — the operator approved exactly this call |
 | Standing deny / standing grant | Refuse or admit, per the operator's period decision |
 | Paid media | `RequireApproval` — these tools stage their own card |
-| Explicit `request_approval` | `RequireApproval` — the agent asked |
+
+`request_approval` is first, and its answer is `Allow` rather than
+`RequireApproval`, because the call being judged *is* the question: `check`
+returns `Allow` and `RequestApprovalTool::execute` then queues the card itself.
+A second ask inside one turn is refused by the boundary above this row, so the
+early `Allow` cannot be used to spin cards. Reading it as `RequireApproval`
+suggests policy stages the card, which is the wrong place to look when an
+approval surface misbehaves.
 
 The emergency-stop row is enforced directly inside `ApprovalPolicy::check`
 itself, not delegated to the gate: a harness tool call never reaches

--- a/docs/modules/policy/README.md
+++ b/docs/modules/policy/README.md
@@ -53,6 +53,67 @@ draining the queue is the `MaintenanceTicker`'s job (issue #971). The operator m
 a parked effect's payload and approve the amended version; the follow-up cycle
 shows the brain both the original and the edit.
 
+## What still stops a call
+
+"Policy-generated HITL is disabled" is easy to read as "nothing gates
+anything", which is wrong and leads to the wrong fix. The arms below still
+decide, in this order, and all of them sit **above** the
+`policy_hitl_enabled` bypass in `ApprovalPolicy::check`:
+
+| Arm | Answer |
+|---|---|
+| Emergency stop | `Deny` for every effect outside `EffectGroup::Other` |
+| Web deflection | `Deny` for a raw web call at a connected Composio provider's host |
+| `readonly` brake | `Deny` for anything that mutates or reaches outside |
+| Single-use grant | `Allow` — the operator approved exactly this call |
+| Standing deny / standing grant | Refuse or admit, per the operator's period decision |
+| Paid media | `RequireApproval` — these tools stage their own card |
+| Explicit `request_approval` | `RequireApproval` — the agent asked |
+
+Below the bypass sit the tier dispatch, `always_approve`, the daily cap and
+`crate::policy::judge`. Those are the arms #1925 turned off: an arm added there
+today compiles, tests green, and never runs in production. Enforcement has to
+go above the bypass, and the paid-media arms are the precedent for how.
+
+The console reads this state rather than assuming it — the policy DTO carries
+`policyHitlEnabled` off the live gate, so the always-ask list is not presented
+as an active gate while it creates no approvals (issue #2149).
+
+## The consequence floor, and its shadow measurement
+
+`crate::policy::floor` owns the consequence rule: which calls commit the
+company — a declared irreversible `EffectGroup` whose reach is
+`Reach::Consequence`, or a call carrying money at or above the cap in force.
+It has two readers and one implementation, because a single approval rule read
+from two places has already drifted into two answers once (issue #684).
+
+The first reader is `judge`, which passes no cap. The second is a **shadow**
+reader immediately above the `policy_hitl_enabled` bypass: it records what a
+floor would have stopped and changes no decision (issue #2147). Epic #1817 asks
+for that stop to be enforced; whether it should be is a product question, and
+the input to it is how often such a stop would fire on live traffic — a
+taxonomically narrow floor can still be practically wide, and a floor that
+parks constantly becomes a stream of TTL default-denials rather than oversight.
+
+The floor deliberately excludes `judge`'s other two arms, which stop on
+*mechanism* — an undeclared tool, or one whose reach cannot be bounded, so
+`shell` stops even for `ls`. That is the interruption #1925 removed.
+`the_floor_is_silent_on_mechanism_alone` pins the distinction so it is
+executable rather than argued.
+
+`publish_artifact` stays deferred per the #658 ruling and is counted on its own
+axis, so that ruling can be revisited with a number instead of two opinions.
+
+Measurement output goes to the `policy::shadow_floor` tracing target, named
+explicitly in `DEFAULT_LOG_FILTER` — the binary's default filter is a bare
+`error` and nothing sets `RUST_LOG` in a tenant, so an unnamed target would
+record nothing and the empty result would read as a finding. To aggregate a
+window of it:
+
+```sh
+kubectl logs -n <ns> <tenant-pod> --since=168h | scripts/aggregate-shadow-floor.sh
+```
+
 ## Emergency stop
 
 `ManifestApprovalGate` carries an `AtomicBool` kill switch, checked by

--- a/scripts/aggregate-shadow-floor.sh
+++ b/scripts/aggregate-shadow-floor.sh
@@ -36,7 +36,7 @@ total=$(wc -l <<<"$lines" | tr -d ' ')
 stops=$(grep -c 'would_stop=' <<<"$lines" || true)
 deferred=$(grep -c 'deferred_group=' <<<"$lines" || true)
 
-field() { grep -oE "$1=[^ ]+" <<<"$lines" | cut -d= -f2- | sort | uniq -c | sort -rn; }
+field() { { grep -oE "$1=[^ ]+" <<<"$lines" || true; } | cut -d= -f2- | sort | uniq -c | sort -rn; }
 
 echo "shadow-floor measurement"
 echo "  lines:            $total"
@@ -49,7 +49,7 @@ field 'would_stop' | sed 's/^/  /'
 echo
 
 echo "by tool"
-grep -oE "tool='[^']+'" <<<"$lines" | cut -d"'" -f2 | sort | uniq -c | sort -rn | sed 's/^/  /'
+{ grep -oE "tool='[^']+'" <<<"$lines" || true; } | cut -d"'" -f2 | sort | uniq -c | sort -rn | sed 's/^/  /'
 echo
 
 echo "by desk"

--- a/scripts/aggregate-shadow-floor.sh
+++ b/scripts/aggregate-shadow-floor.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Aggregate the consequence-floor shadow measurement (issue #2147).
+#
+# Reads tenant logs on stdin or from files and counts what an enforced
+# consequence floor would have stopped, per reason, tool and desk.
+#
+#   kubectl logs -n <ns> <tenant-pod> --since=168h | scripts/aggregate-shadow-floor.sh
+#   scripts/aggregate-shadow-floor.sh tenant-week.log
+#
+# The reader emits one line per call it would have stopped and nothing for the
+# rest, so the counts below are the numerator. The denominator — total tool
+# calls over the same window — is not in this stream; take it from the run step
+# trace, and do not present a percentage without it.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+fi
+
+input=$(cat "$@")
+lines=$(grep -F '[policy:shadow-floor]' <<<"$input" || true)
+
+if [[ -z "$lines" ]]; then
+    echo "No [policy:shadow-floor] lines found." >&2
+    echo >&2
+    echo "Before concluding the floor would fire rarely, check the build actually carries" >&2
+    echo "the reader and that the log filter passes it: DEFAULT_LOG_FILTER must name" >&2
+    echo "policy::shadow_floor=info, and RUST_LOG (if set) replaces that string wholesale." >&2
+    echo "An empty result reads as a finding, which is the one way this measurement lies." >&2
+    exit 1
+fi
+
+total=$(wc -l <<<"$lines" | tr -d ' ')
+stops=$(grep -c 'would_stop=' <<<"$lines" || true)
+deferred=$(grep -c 'deferred_group=' <<<"$lines" || true)
+
+field() { grep -oE "$1=[^ ]+" <<<"$lines" | cut -d= -f2- | sort | uniq -c | sort -rn; }
+
+echo "shadow-floor measurement"
+echo "  lines:            $total"
+echo "  would-stop:       $stops"
+echo "  deferred publish: $deferred   (#658 carve-out, counted separately and never folded in)"
+echo
+
+echo "by reason"
+field 'would_stop' | sed 's/^/  /'
+echo
+
+echo "by tool"
+grep -oE "tool='[^']+'" <<<"$lines" | cut -d"'" -f2 | sort | uniq -c | sort -rn | sed 's/^/  /'
+echo
+
+echo "by desk"
+field 'agent' | sed 's/^/  /'
+echo
+
+echo "by tier"
+field 'mode' | sed 's/^/  /'
+echo
+
+hitl_on=$(grep -c 'hitl=true' <<<"$lines" || true)
+if [[ "$hitl_on" != "0" ]]; then
+    echo "note: $hitl_on line(s) came from a build with policy HITL ENABLED, where the"
+    echo "      tier already parks. Those are not the population a floor would newly stop —"
+    echo "      separate them before quoting a number."
+    echo
+fi
+
+echo "reading this: irreversible_send is the number that decides the design. If Composio"
+echo "sends dominate, a taxonomically narrow floor is still practically wide, and Send"
+echo "belongs behind the per-company-type axis rather than in the floor itself."

--- a/scripts/aggregate-shadow-floor.sh
+++ b/scripts/aggregate-shadow-floor.sh
@@ -19,11 +19,16 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     exit 0
 fi
 
+# Match either half of the line the reader emits: the message prefix
+# `[policy:shadow-floor]`, or the tracing target `policy::shadow_floor` that
+# `DEFAULT_LOG_FILTER` names. A real line carries both, but which one a
+# formatter prints is the formatter's choice, and this measurement must not
+# silently find nothing because someone switched to a JSON subscriber.
 input=$(cat "$@")
-lines=$(grep -F '[policy:shadow-floor]' <<<"$input" || true)
+lines=$(grep -E 'policy:shadow-floor|policy::shadow_floor' <<<"$input" || true)
 
 if [[ -z "$lines" ]]; then
-    echo "No [policy:shadow-floor] lines found." >&2
+    echo "No shadow-floor lines found (looked for policy:shadow-floor and policy::shadow_floor)." >&2
     echo >&2
     echo "Before concluding the floor would fire rarely, check the build actually carries" >&2
     echo "the reader and that the log filter passes it: DEFAULT_LOG_FILTER must name" >&2

--- a/scripts/test-aggregate-shadow-floor.sh
+++ b/scripts/test-aggregate-shadow-floor.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Focused tests for scripts/aggregate-shadow-floor.sh.
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+TARGET="${SCRIPT_DIR}/aggregate-shadow-floor.sh"
+
+# A window with only deferred_group= lines (e.g. only publish_artifact calls)
+# must not abort before the tool/desk/tier breakdowns run — a no-match grep
+# inside field() used to exit 1 under set -euo pipefail and kill the script
+# right after "by reason".
+deferred_only_output=$(printf '%s\n%s\n' \
+    "[policy:shadow-floor] deferred_group=publish_artifact tool='publish_artifact' agent='desk-1' mode='full' hitl=false" \
+    "[policy:shadow-floor] deferred_group=publish_artifact tool='publish_artifact' agent='desk-2' mode='supervised' hitl=false" \
+    | "$TARGET")
+
+printf '%s\n' "$deferred_only_output" | grep -F "would-stop:       0" >/dev/null
+printf '%s\n' "$deferred_only_output" | grep -F "deferred publish: 2" >/dev/null
+printf '%s\n' "$deferred_only_output" | grep -F "by tool" >/dev/null
+printf '%s\n' "$deferred_only_output" | grep -F "publish_artifact" >/dev/null
+printf '%s\n' "$deferred_only_output" | grep -F "by desk" >/dev/null
+printf '%s\n' "$deferred_only_output" | grep -F "by tier" >/dev/null
+
+# A mixed window (would_stop present alongside deferred) must still count and
+# break down normally — the fix must not change behavior when a match exists.
+mixed_output=$(printf '%s\n%s\n' \
+    "[policy:shadow-floor] would_stop=irreversible_send tool='composio_execute' agent='desk-1' mode='full' hitl=false" \
+    "[policy:shadow-floor] deferred_group=publish_artifact tool='publish_artifact' agent='desk-2' mode='supervised' hitl=false" \
+    | "$TARGET")
+
+printf '%s\n' "$mixed_output" | grep -F "would-stop:       1" >/dev/null
+printf '%s\n' "$mixed_output" | grep -F "irreversible_send" >/dev/null
+printf '%s\n' "$mixed_output" | grep -F "composio_execute" >/dev/null
+
+echo "aggregate-shadow-floor tests passed"


### PR DESCRIPTION
## Summary

Part of #1817. Docs and one script; no library code.

The policy module docs correctly say policy-generated HITL is disabled, but that sentence reads as "nothing gates anything" — which is wrong, and leads to the wrong fix. Twice this week that misreading was the thing to correct before any work could start.

Adds two sections:

**What still stops a call** — a table of the arms that decide today, all of which sit *above* the `policy_hitl_enabled` bypass: emergency stop, web deflection, the `readonly` brake, single-use and standing grants, paid media, and an agent's explicit `request_approval`. Then the arms below it — the tier dispatch, `always_approve`, the daily cap, `judge` — with the consequence spelled out: **an arm added there today compiles, tests green, and never runs in production.** The paid-media arms are the precedent for where enforcement has to go instead.

**The consequence floor and its shadow measurement** — what `crate::policy::floor` covers, that it has one implementation and two readers (because #684 already showed what happens when an approval rule is read from two places), what it deliberately excludes and why (`judge`'s mechanism arms stop `shell` even for `ls`, which is the interruption #1925 removed), and that `publish_artifact` stays deferred per #658 and is counted on its own axis so that ruling can be revisited with a number.

Also `scripts/aggregate-shadow-floor.sh`, which turns a window of tenant logs into counts per reason, tool, desk and tier. It exists so #2147's data is read the same way twice rather than eyeballed — and so the counts arrive with the caveats attached rather than as a bare number.

The script **refuses to print zeros silently**: with no matching lines it exits non-zero and names the two ways the stream can be empty for reasons that are not "the floor would rarely fire" — a build without the reader, or a log filter that drops it. That failure already happened once in this epic (the reader shipped on `log::info!`, which the bare `error` default filter drops), and an empty measurement reads as a finding, so it is the one way this instrument lies.

## API Or Behavior Changes

None. Documentation and a standalone script.

## Tests

- `bash scripts/ci/assert-md-line-cap.sh` — clean (policy README now 133 lines, cap is 500)
- `shellcheck scripts/aggregate-shadow-floor.sh` — clean
- Script exercised both ways: against a synthetic log (correct per-reason, per-tool, per-desk, per-tier counts, deferred publish reported apart from the stop count) and against input with no matching lines (non-zero exit, and the diagnostic naming the two silent-empty causes)

## Documentation

This PR is the documentation. `docs/modules/policy/README.md` gains the two sections above; the existing overlay, queue and emergency-stop sections are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded policy guidance covering approval behavior, consequence floors, deferred publishing, and shadow measurements.
  - Added instructions for interpreting and aggregating shadow-floor logs.

- **Tools**
  - Added a command-line utility to summarize shadow-floor results by outcome, reason, tool, desk, and tier.
  - Added support for multiple log formats and clearer no-match handling.
  - Added validation for deferred-only and mixed shadow-floor log scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->