### PR TITLE
test(console): read a refused send off the row that now carries it

### DIFF
--- a/frontend/test/unit/cov-chat-composer-send-fail.test.ts
+++ b/frontend/test/unit/cov-chat-composer-send-fail.test.ts
@@ -139,8 +139,9 @@ describe("a chat send the host refuses", () => {
     // The draft is cleared optimistically (`MessageComposer.send`) — the
     // refusal must not leave the operator's words looking lost.
     expect(composerInput().value).toBe("");
+    expect(container.textContent).toContain("a message the host will refuse");
     expect(container.textContent).toContain(
-      "Couldn't send — That message is too long to send.",
+      "Not sent — That message is too long to send.",
     );
   });
 
@@ -151,6 +152,7 @@ describe("a chat send the host refuses", () => {
     type(composerInput(), "hello");
     await send();
 
-    expect(container.textContent).toContain("Couldn't send — something went wrong");
+    expect(container.textContent).toContain("hello");
+    expect(container.textContent).toContain("Not sent — something went wrong");
   });
 });


### PR DESCRIPTION
## Summary

`main` is red on the console unit suite: two cases in
`cov-chat-composer-send-fail.test.ts` fail.

Neither side did anything wrong on its own. One change added the cases,
asserting the refusal read `Couldn't send — <reason>`. A later change moved a
failed send onto its own transcript row, where the lead is `Not sent —`. Each
was green when it merged; the union is red.

This reads the reason off the row that carries it now, and adds an assertion
the older cases were missing: the operator's own words survive beside the
refusal. That is what the case exists to protect — a refusal must not leave
what someone typed looking lost — and until now nothing checked it.

## API Or Behavior Changes

None. Test-only.

## Tests

- [x] `npx vitest run` — 586 files, 5077 passed, 1 skipped, 0 failed
- [x] `npm run typecheck` — clean
- [x] Confirmed red first: both cases fail on `main` at f0a5a1e8a before this change
- [ ] `cargo fmt --all -- --check` — N/A: no Rust in this change
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust in this change
- [ ] `cargo build --all-targets` — N/A: no Rust in this change
- [ ] `cargo test` — N/A: no Rust in this change

## Documentation

None needed — no user-facing surface changes.