### PR TITLE
fix(runtime): hold the emergency stop at every boundary it was missing

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -882,8 +882,13 @@ impl CompanyRuntime {
     /// (wired by the [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) to the one
     /// the harness deps hold, so the orchestrator's `run_workflow` tool registers
     /// into the map the cancel route reads).
+    ///
+    /// Re-gated on this runtime's emergency flag for
+    /// [`adopt_workflow_gates`](Self::adopt_workflow_gates)' reason: the
+    /// supervisor that reaches a runtime must refuse admission while the stop
+    /// is engaged whether or not the site that built it remembered to say so.
     pub fn set_run_supervisor(&mut self, supervisor: crate::runtime::RunSupervisor) {
-        self.run_supervisor = supervisor;
+        self.run_supervisor = supervisor.with_emergency_gate(self.approval_gate.clone());
     }
 
     /// This company's live set of cancellable workflow runs (issue #383).
@@ -1938,8 +1943,16 @@ impl CompanyRuntime {
     /// alongside it: the two describe one run's decisions from opposite sides,
     /// and a runtime holding a fresh copy of one and an inherited copy of the
     /// other would release a batch it cannot re-dispatch.
+    ///
+    /// The adopted queue is re-gated on this runtime's own emergency flag. A
+    /// queue arrives here from two places that both have reason not to carry
+    /// one — a boot builds a fresh queue to rehydrate parked gates into, and a
+    /// rebuild clones the outgoing runtime's — so requiring each construction
+    /// site to remember the gate makes the stop hold only where someone
+    /// remembered. Re-gating on adoption is the one place that cannot be
+    /// forgotten, because it is the only way a queue reaches a runtime.
     pub fn adopt_workflow_gates(&mut self, gates: WorkflowGateQueue) {
-        self.workflow_gates = gates;
+        self.workflow_gates = gates.with_emergency_gate(self.approval_gate.clone());
     }
 
     /// Installs the blocked-agent-node stash the builder prepared (issue #899,
@@ -14171,6 +14184,63 @@ to = "draft"
                 .await
                 .expect("usage query")
                 .len()
+        }
+
+        /// The stop must survive the runtime being *assembled*, not only the
+        /// runtime being constructed.
+        ///
+        /// `CompanyRuntime::new` gates the workflow gate queue, and then the
+        /// builder replaces that field wholesale with the queue it prepared —
+        /// a fresh one on a boot, the outgoing runtime's on a rebuild. Neither
+        /// has a company to ask, so neither carries a gate, and the queue that
+        /// actually reaches production carried none: a batch whose last sibling
+        /// expired during a stop was released and destroyed, and the approved
+        /// work in it could not be recovered.
+        ///
+        /// Built through the real builder rather than by hand, because
+        /// assembling it by hand is what hid this.
+        #[tokio::test]
+        async fn a_builder_assembled_runtime_still_refuses_to_release_a_batch_while_stopped() {
+            use crate::ports::types::{Effect, EffectGroup, Verdict};
+            use crate::runtime::workflow_resume::{PAYLOAD_NODE_ID, WORKFLOW_APPROVE_KIND};
+
+            let (rt, _brain, _home) = working_company().await;
+
+            let gate = Effect {
+                kind: WORKFLOW_APPROVE_KIND.to_string(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::json!({ PAYLOAD_NODE_ID: "node-a" }),
+                agent: None,
+                run_id: Some("wr-1".to_string()),
+            };
+            let id = crate::ports::types::ApprovalId::new("appr-a");
+            rt.workflow_gates().arm("turn-1", &id, &gate);
+            rt.workflow_gates().decide("turn-1", &id, Verdict::Approve);
+
+            rt.workflow_gates()
+                .release("turn-1")
+                .expect("running, so the batch releases")
+                .expect("a batch was armed");
+
+            rt.workflow_gates().arm("turn-2", &id, &gate);
+            rt.workflow_gates().decide("turn-2", &id, Verdict::Approve);
+            rt.emergency_pause(operator(), None).await.expect("stop");
+
+            rt.workflow_gates()
+                .release("turn-2")
+                .expect_err("a stopped company must not release a decided batch");
+            assert!(
+                rt.workflow_gates().is_armed("turn-2"),
+                "the refused batch keeps every verdict it banked, for a redrive after the stop"
+            );
+            assert_eq!(
+                rt.workflow_gates().ready_for_release(),
+                vec!["turn-2".to_string()],
+                "and it is discoverable, which is what makes the approved work recoverable"
+            );
         }
 
         /// **The defect.** With the stop engaged, a new turn must not run, the

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2594,6 +2594,19 @@ pub(crate) async fn execute_effect_once(
     if rt.journal.is_executed(key) {
         return Ok(());
     }
+    // The commit boundary, and so the last place the stop can still hold.
+    //
+    // Every caller checks the flag before reaching here, and every one of those
+    // checks sits behind at least one `.await` — resolving an approval journals
+    // the verdict before this runs, and a tool-call settlement yields on the
+    // grant lookup. A stop landing in that window would otherwise send the
+    // email or move the money after the company had reported itself stopped.
+    //
+    // Refused before `record_executed`, never after: the at-most-once mark is
+    // what makes the runtime never re-attempt an effect, so recording it and
+    // then refusing would lose the effect permanently rather than defer it.
+    // Unmarked, the key is still executable once an operator releases the stop.
+    rt.ensure_not_emergency_stopped()?;
     // The commit now describes what it is committing (issue #351). Classified
     // here, against the gate in force at execution time, because this is the one
     // place that has both the effect and the policy — and because "was this
@@ -6000,6 +6013,53 @@ members = ["writer"]
             .await
             .unwrap();
         let record = rt2.store.load(rt2.id()).await.unwrap().unwrap();
+        assert_eq!(record.ledger.len(), 1);
+    }
+
+    /// The commit boundary holds the stop, and defers rather than destroys.
+    ///
+    /// Callers check the flag before reaching the executor, and every one of
+    /// those checks sits behind an await — resolving an approval journals the
+    /// verdict first, so a stop landing in that window used to send the money
+    /// anyway. Refusing must also leave the key unexecuted, or the effect is
+    /// lost instead of postponed.
+    #[tokio::test]
+    async fn a_stop_refuses_the_effect_commit_and_leaves_it_executable_after_release() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let rt = RuntimeBuilder::fs_defaults(home.clone(), manifest("full"))
+            .await
+            .unwrap();
+
+        let effect = Effect {
+            kind: "x402.spend".into(),
+            group: EffectGroup::Spend,
+            amount_usd: Some(3.0),
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+            agent: None,
+            run_id: None,
+        };
+
+        rt.approval_gate.set_emergency(true);
+        execute_effect_once(&rt, "k1", &effect, None)
+            .await
+            .expect_err("a stopped company must not commit an effect");
+
+        assert!(
+            !rt.journal.is_executed("k1"),
+            "a refused commit must not carry the at-most-once mark, or the effect is lost \
+             rather than deferred"
+        );
+        let record = rt.store().load(rt.id()).await.unwrap().unwrap();
+        assert!(record.ledger.is_empty(), "and the money must not have moved");
+
+        rt.approval_gate.set_emergency(false);
+        execute_effect_once(&rt, "k1", &effect, None)
+            .await
+            .expect("released, so the deferred effect runs");
+        let record = rt.store().load(rt.id()).await.unwrap().unwrap();
         assert_eq!(record.ledger.len(), 1);
     }
 

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -6053,7 +6053,10 @@ members = ["writer"]
              rather than deferred"
         );
         let record = rt.store().load(rt.id()).await.unwrap().unwrap();
-        assert!(record.ledger.is_empty(), "and the money must not have moved");
+        assert!(
+            record.ledger.is_empty(),
+            "and the money must not have moved"
+        );
 
         rt.approval_gate.set_emergency(false);
         execute_effect_once(&rt, "k1", &effect, None)

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -393,6 +393,12 @@ async fn prompt(state: &AppState, auth: &GqlAuth, params: &Value) -> Result<Valu
         // ACP-sent message never has attachments (issue #1682).
         attachments: vec![],
     };
+    // Asked again, immediately before the durable write, for the reason
+    // `chat_and_emit` asks again: the check above sits behind mention and desk
+    // resolution, and a stop landing in that window would leave a transcript
+    // entry no turn will ever answer — and on this ingress no turn row or
+    // failure event explains it either.
+    runtime.ensure_accepting().map_err(|e| e.to_string())?;
     let message_seq = runtime
         .events()
         .append(&session.company, event.clone())

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -2778,6 +2778,13 @@ async fn accept_chat_turn(
         // claim. Empty on a message with no attachment, which skips the field.
         attachments,
     };
+    // Asked again, immediately before the durable write. The check above sits
+    // two awaits back — attachment and mention resolution both yield — and a
+    // stop landing in that window would leave a message in the transcript that
+    // no turn will ever answer, on a company that has already reported itself
+    // stopped. The first check is still worth keeping: it refuses before the
+    // resolution work rather than after it.
+    runtime.ensure_accepting().map_err(ApiError)?;
     let message_seq = runtime
         .events()
         .append(id, message_event.clone())

--- a/src/workflows/caps/http.rs
+++ b/src/workflows/caps/http.rs
@@ -370,7 +370,10 @@ mod tests {
 
         gate.set_emergency(true);
         let refused = client
-            .request(json!({ "method": "GET", "url": "https://api.test/x" }), None)
+            .request(
+                json!({ "method": "GET", "url": "https://api.test/x" }),
+                None,
+            )
             .await
             .expect_err("a stopped company must make no request");
         assert!(
@@ -380,7 +383,10 @@ mod tests {
 
         gate.set_emergency(false);
         let allowed = client
-            .request(json!({ "method": "GET", "url": "https://api.test/x" }), None)
+            .request(
+                json!({ "method": "GET", "url": "https://api.test/x" }),
+                None,
+            )
             .await;
         assert!(
             !matches!(allowed, Err(EngineError::Capability(ref m)) if m.contains("is stopped")),

--- a/src/workflows/caps/http.rs
+++ b/src/workflows/caps/http.rs
@@ -24,6 +24,10 @@ use openhuman_core::openhuman as oh;
 /// [`HttpRequestTool`].
 pub struct GuardedHttpClient {
     tool: HttpRequestTool,
+    /// The emergency stop, consulted per request, for
+    /// [`WorkflowToolInvoker`](super::tools::WorkflowToolInvoker)'s reason: a
+    /// run admitted before the switch was pulled never re-consults admission.
+    emergency: Option<std::sync::Arc<crate::policy::gate::ManifestApprovalGate>>,
 }
 
 impl GuardedHttpClient {
@@ -39,7 +43,19 @@ impl GuardedHttpClient {
                 defaults.max_response_size,
                 defaults.timeout_secs,
             ),
+            emergency: None,
         }
+    }
+
+    /// Installs the emergency stop [`request`](HttpClient::request) refuses
+    /// against. `None` keeps the client dispatching exactly as before, which is
+    /// what every construction site with no company to ask wants.
+    pub fn with_emergency_gate(
+        mut self,
+        gate: Option<Arc<crate::policy::gate::ManifestApprovalGate>>,
+    ) -> Self {
+        self.emergency = gate;
+        self
     }
 }
 
@@ -50,6 +66,17 @@ impl HttpClient for GuardedHttpClient {
     /// has no per-account HTTP connection registry yet, so a request acts as the
     /// company itself; threading a real credential is a documented follow-on.
     async fn request(&self, request: Value, _conn: Option<&str>) -> TfResult<Value> {
+        if self
+            .emergency
+            .as_ref()
+            .is_some_and(|gate| gate.is_emergency())
+        {
+            return Err(EngineError::Capability(
+                "http_request refused: the company is stopped and will run no work until an \
+                 operator releases it"
+                    .to_string(),
+            ));
+        }
         let args = to_tool_args(&request);
         let result = self
             .tool
@@ -320,6 +347,46 @@ fn is_non_global_v4(v4: std::net::Ipv4Addr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A run admitted before the switch was pulled must not keep making
+    /// requests. Admission is taken once for the whole run, so the request
+    /// itself has to ask.
+    ///
+    /// Refused before the URL is even resolved: the point is that no packet
+    /// leaves, not that a bad one is rejected.
+    #[tokio::test]
+    async fn a_stopped_company_refuses_a_node_http_request() {
+        use tinyflows::caps::HttpClient;
+        let gate = Arc::new(crate::policy::gate::ManifestApprovalGate::new(
+            crate::company::Policy {
+                mode: "full".to_string(),
+                always_approve: Vec::new(),
+                auto_approve_under_usd: None,
+                approval_ttl_hours: None,
+            },
+        ));
+        let client = GuardedHttpClient::new(Arc::new(SecurityPolicy::default()), Vec::new())
+            .with_emergency_gate(Some(gate.clone()));
+
+        gate.set_emergency(true);
+        let refused = client
+            .request(json!({ "method": "GET", "url": "https://api.test/x" }), None)
+            .await
+            .expect_err("a stopped company must make no request");
+        assert!(
+            matches!(refused, EngineError::Capability(ref m) if m.contains("is stopped")),
+            "{refused:?}"
+        );
+
+        gate.set_emergency(false);
+        let allowed = client
+            .request(json!({ "method": "GET", "url": "https://api.test/x" }), None)
+            .await;
+        assert!(
+            !matches!(allowed, Err(EngineError::Capability(ref m)) if m.contains("is stopped")),
+            "released, so the stop no longer refuses it: {allowed:?}"
+        );
+    }
 
     #[test]
     fn to_tool_args_maps_method_url_headers_and_stringifies_body() {

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -374,8 +374,10 @@ pub async fn build_capabilities(
             deps.tenant_search.as_ref(),
             search_metering,
             wiring,
-        );
-        let http = GuardedHttpClient::new(exec_security, web_allowed_domains);
+        )
+        .with_emergency_gate(deps.emergency_gate.clone());
+        let http = GuardedHttpClient::new(exec_security, web_allowed_domains)
+            .with_emergency_gate(deps.emergency_gate.clone());
 
         // Durable run state over the per-company secret store, namespaced by
         // workflow id. `None` (default/tests) keeps the inert no-op with a

--- a/src/workflows/caps/tools.rs
+++ b/src/workflows/caps/tools.rs
@@ -310,6 +310,10 @@ pub struct WorkflowToolInvoker {
     /// The company's `[tools].allow` grant globs — the fail-closed gate.
     grants: Vec<String>,
     wiring: WorkflowToolWiring,
+    /// The emergency stop, consulted per call. A run admitted before the switch
+    /// was pulled holds its admission for the whole run, so admission alone
+    /// cannot stop it; the node's own dispatch has to ask.
+    emergency: Option<Arc<crate::policy::gate::ManifestApprovalGate>>,
 }
 
 impl WorkflowToolInvoker {
@@ -414,7 +418,23 @@ impl WorkflowToolInvoker {
             tools,
             grants,
             wiring,
+            emergency: None,
         }
+    }
+}
+
+impl WorkflowToolInvoker {
+    /// Installs the emergency stop [`invoke`](ToolInvoker::invoke) refuses a
+    /// node's call against.
+    ///
+    /// Without this the invoker dispatches regardless of the flag — the default
+    /// for every construction site with no company to ask.
+    pub fn with_emergency_gate(
+        mut self,
+        gate: Option<Arc<crate::policy::gate::ManifestApprovalGate>>,
+    ) -> Self {
+        self.emergency = gate;
+        self
     }
 }
 
@@ -439,6 +459,16 @@ impl ToolInvoker for WorkflowToolInvoker {
         // nothing.
         if let Some(result) = super::super::replay::replayed_result(slug, &args) {
             return Ok(result);
+        }
+        if self
+            .emergency
+            .as_ref()
+            .is_some_and(|gate| gate.is_emergency())
+        {
+            return Err(EngineError::Capability(format!(
+                "tool_call '{slug}' refused: the company is stopped and will run no work until \
+                 an operator releases it"
+            )));
         }
         // FAIL-CLOSED grant check FIRST, before any lookup or execution.
         if let Some(message) = refusal_for(slug, &self.grants, &self.wiring) {
@@ -584,6 +614,7 @@ mod tests {
             tools: HashMap::new(),
             grants: vec!["web.*".to_string()],
             wiring: WorkflowToolWiring::default(),
+            emergency: None,
         };
         let denied = tokio_test_block_on(invoker.invoke("csv_export", json!({}), None));
         assert!(
@@ -598,6 +629,45 @@ mod tests {
         );
     }
 
+    /// A run admitted before the switch was pulled must not keep calling tools.
+    ///
+    /// Admission is taken once, for the whole run, and the workflow runner
+    /// disables policy gates inside it — so nothing between admission and the
+    /// node's own dispatch asks the flag again. Without this check a `tool_call`
+    /// node could send an email or move money after the stop was acknowledged.
+    #[test]
+    fn a_stopped_company_refuses_a_node_tool_call_even_on_an_admitted_run() {
+        use tinyflows::caps::ToolInvoker;
+        let gate = std::sync::Arc::new(crate::policy::gate::ManifestApprovalGate::new(
+            crate::company::Policy {
+                mode: "full".to_string(),
+                always_approve: Vec::new(),
+                auto_approve_under_usd: None,
+                approval_ttl_hours: None,
+            },
+        ));
+        let invoker = WorkflowToolInvoker {
+            tools: HashMap::new(),
+            grants: vec!["*".to_string()],
+            wiring: WorkflowToolWiring::default(),
+            emergency: None,
+        }
+        .with_emergency_gate(Some(gate.clone()));
+
+        let running = tokio_test_block_on(invoker.invoke("csv_export", json!({}), None));
+        assert!(
+            matches!(running, Err(EngineError::Capability(ref m)) if m.contains("not available")),
+            "not stopped, so the call reaches the tool lookup: {running:?}"
+        );
+
+        gate.set_emergency(true);
+        let stopped = tokio_test_block_on(invoker.invoke("csv_export", json!({}), None));
+        assert!(
+            matches!(stopped, Err(EngineError::Capability(ref m)) if m.contains("is stopped")),
+            "{stopped:?}"
+        );
+    }
+
     #[test]
     fn the_search_namespace_requires_an_explicit_grant_not_a_wildcard() {
         use tinyflows::caps::ToolInvoker;
@@ -607,6 +677,7 @@ mod tests {
             tools: HashMap::new(),
             grants: vec!["*".to_string()],
             wiring: WorkflowToolWiring::default(),
+            emergency: None,
         };
         let denied = tokio_test_block_on(wildcard.invoke("web_search", json!({}), None));
         assert!(
@@ -619,6 +690,7 @@ mod tests {
             tools: HashMap::new(),
             grants: vec!["search".to_string()],
             wiring: WorkflowToolWiring::default(),
+            emergency: None,
         };
         let looked_up = tokio_test_block_on(granted.invoke("web_search", json!({}), None));
         assert!(


### PR DESCRIPTION
## Summary

Four holes in the emergency stop, all the same shape: **the flag is read, and then the thing it was meant to stop happens anyway.** Each was found on the merged emergency-stop work and each is fixed and red-proved here.

These commits were reviewed and gated on the previous branch but were not in the head GitHub merged, so they are re-cut onto current `main`.

**1. The gate never reached production at all.**
`CompanyRuntime::new` builds the workflow gate queue with the company's emergency flag installed, and the builder then replaces that field wholesale — with a fresh queue on a boot, with the outgoing runtime's on a rebuild. Neither has a company to ask, so neither carried a gate. The queue that actually ran in production carried none, which means a decided batch whose last sibling expired during a stop was released and destroyed, and the approved work in it could not be recovered.

Fixed by re-gating on adoption rather than at each construction site. Adoption is the only path a queue takes into a runtime, so it is the one place that cannot be forgotten. `set_run_supervisor` gets the same treatment for the same reason.

**2. Effects committed after the stop.**
Every caller checks the flag before reaching the executor, and every one of those checks sits behind at least one `.await` — resolving an approval journals the verdict before the native arm runs. A stop landing in that window sent the email or moved the money after the company had already reported itself stopped.

Fenced at the commit boundary, and deliberately **before** the at-most-once mark rather than after: that mark is what stops the runtime re-attempting an effect, so recording it and then refusing would lose the effect instead of deferring it. Unmarked, it runs once an operator releases the stop.

**3. Admitted workflows kept running.**
A run takes its admission once and holds it for the whole run, and the runner disables policy gates inside a workflow. Nothing between admission and a node's own dispatch asks the flag again, so a workflow admitted a second before the switch was pulled went on calling tools and making HTTP requests afterwards. Both capabilities now consult the same gate the supervisor does, wired once where they are assembled.

**4. Chat appended after the stop.**
Both ingresses check admission and then resolve attachments, mentions and the desk before appending, so the check sits two awaits back from the durable write. A stop landing there left a message in the transcript that no turn would ever answer — and on the ACP ingress with no turn row or failure event to explain it.

## API Or Behavior Changes

A stopped company now refuses in four places it previously did not: releasing a decided workflow gate batch, committing a native effect, a workflow node's `tool_call` / `http_request`, and appending a chat message. All four were already the documented behaviour; none is a new rule.

No effect is lost by any refusal — each one declines before the step that would make the work unrecoverable, so it resumes when an operator releases the stop.

## Tests

Every fix is red-proved: the fix reverted, the test confirmed failing, the fix restored.

- `a_builder_assembled_runtime_still_refuses_to_release_a_batch_while_stopped` — built through the real builder, not by hand, because assembling it by hand is what hid this. Without the fix the stopped company releases and destroys the batch.
- `a_stop_refuses_the_effect_commit_and_leaves_it_executable_after_release` — asserts both halves: refused while stopped, and still executable after release, so the effect is deferred rather than lost.
- `a_stopped_company_refuses_a_node_tool_call_even_on_an_admitted_run`
- `a_stopped_company_refuses_a_node_http_request`

- [x] `cargo fmt --all -- --check` — rc=0
- [x] `cargo clippy --locked --features openhuman --all-targets --no-deps -- -D warnings` — rc=0
- [x] `cargo test --locked --features openhuman` — rc=0, 7331 passed, 0 failed
- [x] `scripts/ci/assert-auth-matrix.sh` — rc=0

## Documentation

None needed — no new rule, and each fence carries a short note where it sits explaining what it holds and why it is ordered where it is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Safety Improvements**
  * Emergency stops now consistently block workflow admissions, tool calls, HTTP requests, effect execution, and new operator messages.
  * Blocked workflow batches remain available for recovery after the emergency stop is released.

* **Bug Fixes**
  * Prevented durable journal entries and execution markers from being written when an emergency stop engages during processing.
  * Pending effects can resume safely after the stop is lifted without being lost or executed prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->