### PR TITLE
test(governance): assert the governance failure paths, and pin the ones that fail open

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -9870,6 +9870,260 @@ mod tests {
         );
     }
 
+    /// A [`JournalStore`](crate::ports::journal::JournalStore) that refuses
+    /// every `ApprovalExtended` line and passes everything else through to an
+    /// in-memory backend.
+    struct RefusingExtendStore {
+        inner: crate::ports::journal::MemoryJournalStore,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ports::journal::JournalStore for RefusingExtendStore {
+        async fn append_journal(
+            &self,
+            id: &crate::ports::types::CompanyId,
+            line: &str,
+            durability: crate::ports::journal::Durability,
+        ) -> crate::Result<()> {
+            if line.contains("ApprovalExtended") {
+                return Err(crate::error::OpenCompanyError::Store(
+                    "RefusingExtendStore: the volume is full".to_string(),
+                ));
+            }
+            self.inner.append_journal(id, line, durability).await
+        }
+
+        async fn read_journal(
+            &self,
+            id: &crate::ports::types::CompanyId,
+        ) -> crate::Result<Vec<String>> {
+            self.inner.read_journal(id).await
+        }
+
+        async fn journal_imported(
+            &self,
+            id: &crate::ports::types::CompanyId,
+        ) -> crate::Result<bool> {
+            self.inner.journal_imported(id).await
+        }
+
+        async fn complete_import(
+            &self,
+            id: &crate::ports::types::CompanyId,
+            lines: Vec<String>,
+        ) -> crate::Result<()> {
+            self.inner.complete_import(id, lines).await
+        }
+    }
+
+    /// `extend_approval` moves the gate's live deadline **before**
+    /// it journals the extension. When the journal append then fails, the
+    /// caller sees the error, but the live view already reflects the later
+    /// deadline — and nothing durable backs that, so a restart from the same
+    /// journal comes back believing the approval was never extended at all.
+    /// This pins that sequence exactly, as the real, current consequence: a
+    /// caller told the extend failed still sees the live queue disagree with
+    /// it until the next restart quietly settles the disagreement in the
+    /// caller's favor.
+    #[tokio::test]
+    async fn a_failed_extend_append_leaves_a_live_extension_that_reverts_on_restart() {
+        use crate::ports::types::{Actor, ActorKind};
+
+        let manifest: crate::company::types::CompanyManifest =
+            toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"supervised\"\n")
+                .expect("manifest");
+        let store = std::sync::Arc::new(RefusingExtendStore {
+            inner: crate::ports::journal::MemoryJournalStore::default(),
+        });
+        let home_dir = tempfile::tempdir().expect("tempdir");
+
+        let rt1 =
+            crate::runtime::RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest.clone())
+                .with_journal_store(store.clone())
+                .build()
+                .await
+                .expect("runtime");
+        let id = seed_parked(&rt1, "appr-extend-fail", 1_000).await;
+        let ttl = rt1.approval_gate.ttl_millis();
+        let original_deadline = 1_000 + ttl;
+
+        let extend = rt1
+            .extend_approval(
+                &id,
+                Actor {
+                    kind: ActorKind::User,
+                    id: "operator".into(),
+                },
+            )
+            .await;
+        assert!(extend.is_err(), "the forced append failure must surface");
+        assert!(
+            rt1.pending_approvals()[0].expires_at_millis.unwrap() > original_deadline,
+            "the live gate already moved the deadline even though nothing durable recorded it"
+        );
+        drop(rt1);
+
+        let rt2 = crate::runtime::RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest)
+            .with_journal_store(store)
+            .build()
+            .await
+            .expect("runtime");
+        let replayed = rt2.pending_approvals();
+        assert_eq!(replayed.len(), 1, "the approval is still parked");
+        assert_eq!(
+            replayed[0].expires_at_millis,
+            Some(original_deadline),
+            "the extension a caller was told failed must not silently revert on restart"
+        );
+    }
+
+    /// A [`JournalStore`](crate::ports::journal::JournalStore) that refuses
+    /// every `ApprovalExpired` line and passes everything else through.
+    struct RefusingExpiredStore {
+        inner: crate::ports::journal::MemoryJournalStore,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ports::journal::JournalStore for RefusingExpiredStore {
+        async fn append_journal(
+            &self,
+            id: &crate::ports::types::CompanyId,
+            line: &str,
+            durability: crate::ports::journal::Durability,
+        ) -> crate::Result<()> {
+            if line.contains("ApprovalExpired") {
+                return Err(crate::error::OpenCompanyError::Store(
+                    "RefusingExpiredStore: the volume is full".to_string(),
+                ));
+            }
+            self.inner.append_journal(id, line, durability).await
+        }
+
+        async fn read_journal(
+            &self,
+            id: &crate::ports::types::CompanyId,
+        ) -> crate::Result<Vec<String>> {
+            self.inner.read_journal(id).await
+        }
+
+        async fn journal_imported(
+            &self,
+            id: &crate::ports::types::CompanyId,
+        ) -> crate::Result<bool> {
+            self.inner.journal_imported(id).await
+        }
+
+        async fn complete_import(
+            &self,
+            id: &crate::ports::types::CompanyId,
+            lines: Vec<String>,
+        ) -> crate::Result<()> {
+            self.inner.complete_import(id, lines).await
+        }
+    }
+
+    /// `sweep_expired_capped` removes every id in the batch from the
+    /// live `parked` map up front, stashing each one's effect in
+    /// `expired_effects` for [`CompanyRuntime::retire_approval`] to collect.
+    /// `sweep_expired_approvals` then walks that batch and returns on the
+    /// **first** `retire_approval` failure (`?`), so a durable-write failure
+    /// partway through strands every id after it: already gone from `parked`,
+    /// still sitting in `expired_effects`, and never revisited because the
+    /// next sweep's scan is over `parked`, which no longer names them.
+    #[tokio::test]
+    async fn a_failed_retirement_mid_batch_strands_the_rest_of_the_batch() {
+        use crate::ports::types::{Actor, ActorKind, Verdict};
+
+        let manifest: crate::company::types::CompanyManifest =
+            toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"supervised\"\n")
+                .expect("manifest");
+        let store = std::sync::Arc::new(RefusingExpiredStore {
+            inner: crate::ports::journal::MemoryJournalStore::default(),
+        });
+        let home_dir = tempfile::tempdir().expect("tempdir");
+        let rt = std::sync::Arc::new(
+            crate::runtime::RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest)
+                .with_journal_store(store)
+                .build()
+                .await
+                .expect("runtime"),
+        );
+
+        let ttl = rt.approval_gate.ttl_millis();
+        let long_expired = crate::ports::now_millis().saturating_sub(ttl + 60_000);
+        // Alphabetical order matches park-time order here, so the cap sorts
+        // "appr-a" first — the one whose retirement is attempted (and fails)
+        // — and "appr-b" is the untouched survivor stranded behind it.
+        seed_parked(&rt, "appr-a", long_expired).await;
+        seed_parked(&rt, "appr-b", long_expired).await;
+        assert_eq!(
+            rt.pending_approvals().len(),
+            2,
+            "both are parked and expired"
+        );
+
+        let swept = rt.sweep_expired_approvals().await;
+        assert!(
+            swept.is_err(),
+            "the forced ApprovalExpired failure must surface"
+        );
+
+        // `record_expired` moves its in-memory `parked` entry out **before**
+        // journaling the expiry — the same optimistic-then-persist order
+        // The extend case pins the same shape — so "appr-a"'s failed attempt still drops
+        // it from the journal's own pending view in-memory, with nothing
+        // durable behind that removal. Only "appr-b", whose retirement was
+        // never even attempted, is left on the console's pending list.
+        let pending = rt.pending_approvals();
+        assert_eq!(
+            pending.len(),
+            1,
+            "only the untried survivor is left on the console's pending list: {pending:?}"
+        );
+        assert_eq!(
+            pending[0].id,
+            crate::ports::types::ApprovalId::new("appr-b")
+        );
+
+        // The gate's own live `parked` map already dropped both — that is
+        // what `sweep_expired_capped` did before the failing retirement ever
+        // ran — so a decision on the survivor is not a decision on anything:
+        // it comes back as a safe no-op, never as the operator's verdict.
+        let (receipt, _handle) = rt
+            .resolve_approval_spawned(
+                &crate::ports::types::ApprovalId::new("appr-b"),
+                Verdict::Approve,
+                Actor {
+                    kind: ActorKind::User,
+                    id: "operator".into(),
+                },
+                crate::runtime::grants::GrantScope::Once,
+            )
+            .await
+            .expect("a losing resolve is a receipt, not an error");
+        assert!(
+            matches!(
+                receipt,
+                crate::runtime::cycle::ResolveReceipt::AlreadyResolved
+            ),
+            "the survivor is gone from the gate's live map, so even the operator's own \
+             decision on it silently no-ops instead of settling it: {receipt:?}"
+        );
+
+        // A later sweep never even reaches the still-refusing store: its scan
+        // is over `parked`, which no longer names either id, so it succeeds
+        // trivially with nothing to report — the stranded survivor is retired
+        // by nothing and never seen again, while the console goes on listing it.
+        let second_sweep = rt
+            .sweep_expired_approvals()
+            .await
+            .expect("nothing left in `parked` to retire");
+        assert!(
+            second_sweep.is_empty(),
+            "the stranded survivor is never retried by a later sweep: {second_sweep:?}"
+        );
+    }
+
     #[tokio::test]
     async fn an_unresolvable_thread_root_degrades_to_the_channel() {
         use crate::ports::types::{Actor, ActorKind, CompanyEvent, EventSeq};

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -11327,6 +11327,93 @@ description = "Builds the product."
         );
     }
 
+    /// A company whose `treasurer` carries a `budget_usd_daily` of exactly
+    /// `0.0` — the value `validate_cap` in `server::ops::team` accepts as a
+    /// non-negative, finite number with no special-case.
+    fn zero_capped_record() -> CompanyRecord {
+        let manifest: CompanyManifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[[agent]]
+id = "treasurer"
+role = "Treasurer"
+description = "Handles spend."
+budget_usd_daily = 0.0
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+description = "Builds the product."
+"#,
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            manifest,
+            ..record()
+        }
+    }
+
+    /// a cap of exactly `0.0` passes validation as "non-negative and
+    /// finite" and then permanently refuses every dispatch, because `spent >=
+    /// cap` holds even at zero spend on the very first turn — before the
+    /// teammate has ever run once. Setting `0.0` bricks the teammate; it does
+    /// not uncap it, and nothing here says so.
+    #[tokio::test]
+    async fn a_zero_daily_cap_refuses_the_teammates_very_first_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let context = Arc::new(MockContext::default());
+        let meter = Arc::new(RecordingMeter::default());
+        let rec = zero_capped_record();
+
+        // No spend has ever been recorded for this teammate — a fresh day, a
+        // fresh company, or a cap just set to `0.0` from the console.
+        let deps = deps_with_plan(
+            dir.path(),
+            context.clone(),
+            Some(meter.clone() as Arc<dyn UsageMeter>),
+            None,
+        );
+        let pool = HarnessPool::new();
+        pool.ensure(&rec, &deps).await.expect("ensure");
+
+        let refused = pool
+            .run(
+                &rec.id,
+                "treasurer",
+                "should-not-echo",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
+            .await
+            .expect("a refusal is a benign outcome, not a hard error")
+            .reply;
+        assert_eq!(
+            refused,
+            agent_budget_exhausted_notice("treasurer", 0.0),
+            "the very first dispatch is refused, though this teammate has spent nothing yet"
+        );
+        assert!(!refused.contains("should-not-echo"));
+
+        // The cap is per-teammate: the uncapped engineer is untouched.
+        let ok = pool
+            .run(
+                &rec.id,
+                "engineer",
+                "hello-marker",
+                &deps,
+                crate::runtime::delegation::ChatTarget::default(),
+            )
+            .await
+            .expect("an uncapped teammate keeps working")
+            .reply;
+        assert!(ok.contains("hello-marker"), "{ok:?}");
+    }
+
     // --- Console tool grants, live (issue #1796) -----------------------------
 
     /// **The no-restart proof for the one-click grant.** A namespace granted

--- a/src/harness/built_in/toolbelt.rs
+++ b/src/harness/built_in/toolbelt.rs
@@ -1241,6 +1241,49 @@ mod tests {
         assert!(!full.require_approval_for_medium_risk);
     }
 
+    /// `workspace_only` is a field on the policy this module builds, but the
+    /// enforcement lives in the vendored `SecurityPolicy::validate_path`. This
+    /// drives the real vendored check, not a stub, so a traversal or symlink
+    /// escape is actually refused rather than merely configured.
+    #[tokio::test]
+    async fn exec_security_refuses_a_traversal_and_a_symlink_escape() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace dir");
+        std::fs::write(workspace.join("inside.txt"), b"ok").expect("seed file");
+
+        let outside = root.path().join("outside");
+        std::fs::create_dir_all(&outside).expect("outside dir");
+        std::fs::write(outside.join("secret.txt"), b"nope").expect("seed secret");
+
+        let policy = exec_security(&workspace, PolicyMode::Full);
+
+        let traversal = policy.validate_path("../outside/secret.txt").await;
+        assert!(
+            traversal.is_err(),
+            "a `..` component must be refused before any resolve: {traversal:?}"
+        );
+
+        #[cfg(unix)]
+        {
+            let link = workspace.join("escape-link");
+            std::os::unix::fs::symlink(&outside, &link).expect("symlink");
+            let via_symlink = policy.validate_path("escape-link/secret.txt").await;
+            assert!(
+                via_symlink.is_err(),
+                "a symlink resolving outside the workspace must be refused: {via_symlink:?}"
+            );
+        }
+
+        // Sanity: a real file inside the workspace is still reachable, so the
+        // refusals above are workspace_only doing its job, not a broken policy.
+        let inside = policy.validate_path("inside.txt").await;
+        assert!(
+            inside.is_ok(),
+            "a file inside the workspace must resolve: {inside:?}"
+        );
+    }
+
     /// `auto` must not loosen shell execution (issue #560).
     ///
     /// This is the test for the decision argued on [`autonomy_for`], and it
@@ -1398,7 +1441,7 @@ mod tests {
     /// so under `Readonly`, where the autonomy tier alone already blocks
     /// everything — so none of them isolates this flag.
     ///
-    /// Finding CONF-002: it turns out this flag has **no effect at all** on
+    /// it turns out this flag has **no effect at all** on
     /// `ShellTool::execute`. The flag is only read by the vendored
     /// `SecurityPolicy::validate_command_execution` — but `ShellTool`'s real
     /// runtime path (`run_with_security_in_context`) calls
@@ -1418,7 +1461,7 @@ mod tests {
     /// first (a bug in that layer, a future direct call site) has no
     /// OpenHuman-level backstop at all.
     #[tokio::test]
-    #[ignore = "finding CONF-002: block_high_risk_commands has no effect on ShellTool::execute — the real path (check_gated_command) never calls validate_command_execution, so a destructive command runs under Full even with the flag set"]
+    #[ignore = "block_high_risk_commands has no effect on ShellTool::execute — the real path (check_gated_command) never calls validate_command_execution, so a destructive command runs under Full even with the flag set"]
     async fn block_high_risk_commands_refuses_a_destructive_command_even_under_full_autonomy() {
         let ws = std::env::temp_dir();
         let full = test_security(&ws, PolicyMode::Full);

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -7678,7 +7678,7 @@ members = ["writer"]
         assert_eq!(spend[0].amount_usd, -0.031);
     }
 
-    /// Finding MET-004: a `PerCycle`-metered brain's spend charges
+    /// a `PerCycle`-metered brain's spend charges
     /// `UNATTRIBUTED_AGENT` unconditionally, even on a single-agent company
     /// where the cycle can only have been that one teammate's work. That
     /// makes the spend invisible to `usd_spent_by_agent` for the real
@@ -7722,6 +7722,51 @@ members = ["writer"]
             9.99,
             "the spend is real; it is just parked under the company-wide bucket instead of \
              the teammate whose turn it was"
+        );
+    }
+
+    /// A stopped company does not take the turn at all — not "takes it and
+    /// performs no effect".
+    ///
+    /// The switch used to be read only inside the native-effect path, so the
+    /// model call itself still ran and still billed; the turn was refused only
+    /// at whatever it tried to *do*. The refusal belongs at admission, where
+    /// nothing has been spent yet.
+    #[tokio::test]
+    async fn emergency_pause_stops_a_turn_from_running_and_spending() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+            .with_brain(Arc::new(MeteredBrain::per_cycle(reported_usage(9.99))))
+            .build()
+            .await
+            .unwrap();
+
+        rt.emergency_pause(operator(), Some("incident".to_string()))
+            .await
+            .unwrap();
+        assert!(rt.is_emergency_paused());
+
+        let refused = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
+                parent: None,
+                text: "how are we doing".into(),
+                by: None,
+                chat: None,
+                deliverable: None,
+                attachments: Vec::new(),
+            }])
+            .await;
+        assert!(
+            matches!(refused, Err(OpenCompanyError::EmergencyStop(_))),
+            "{refused:?}"
+        );
+
+        let samples = rt.usage().query(rt.id(), 0).await.unwrap();
+        assert!(
+            samples.is_empty(),
+            "and nothing was billed, because the model was never called: {samples:?}"
         );
     }
 
@@ -10653,6 +10698,128 @@ members = ["writer"]
         let listed = rt.standing_grants();
         assert_eq!(listed.len(), 1, "the grant is revoked by the newer refusal");
         assert_eq!(listed[0].verdict, Verdict::Deny);
+    }
+
+    /// A [`JournalStore`](crate::ports::journal::JournalStore) that fails the
+    /// Nth `StandingGrantMinted` append it sees and passes every other line
+    /// straight through to an in-memory backend.
+    struct FailNthStandingMintStore {
+        inner: crate::ports::journal::MemoryJournalStore,
+        seen: std::sync::atomic::AtomicUsize,
+        fail_at: usize,
+    }
+
+    impl FailNthStandingMintStore {
+        fn new(fail_at: usize) -> Self {
+            Self {
+                inner: crate::ports::journal::MemoryJournalStore::default(),
+                seen: std::sync::atomic::AtomicUsize::new(0),
+                fail_at,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ports::journal::JournalStore for FailNthStandingMintStore {
+        async fn append_journal(
+            &self,
+            id: &CompanyId,
+            line: &str,
+            durability: crate::ports::journal::Durability,
+        ) -> Result<()> {
+            if line.contains("StandingGrantMinted") {
+                let n = self.seen.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                if n == self.fail_at {
+                    return Err(crate::error::OpenCompanyError::Store(
+                        "FailNthStandingMintStore: forced failure on the mint".to_string(),
+                    ));
+                }
+            }
+            self.inner.append_journal(id, line, durability).await
+        }
+
+        async fn read_journal(&self, id: &CompanyId) -> Result<Vec<String>> {
+            self.inner.read_journal(id).await
+        }
+
+        async fn journal_imported(&self, id: &CompanyId) -> Result<bool> {
+            self.inner.journal_imported(id).await
+        }
+
+        async fn complete_import(&self, id: &CompanyId, lines: Vec<String>) -> Result<()> {
+            self.inner.complete_import(id, lines).await
+        }
+    }
+
+    /// the reconcile's own steps are not atomic. Revoking the
+    /// shadowed opposite-polarity policy is journaled and applied in memory
+    /// *before* the new policy's own mint is journaled, so a failure on that
+    /// second append — the durable store erroring, a disk momentarily full —
+    /// leaves the company with the old policy gone and no new one in its
+    /// place. Nothing rolls the revoke back.
+    #[tokio::test]
+    async fn a_failed_mint_after_a_successful_revoke_leaves_neither_policy_live() {
+        let home_dir = tmp_home();
+        let store = std::sync::Arc::new(FailNthStandingMintStore::new(2));
+        let rt = Arc::new(
+            RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("supervised"))
+                .with_brain(Arc::new(ParkingBrain {
+                    effect: grantable_effect(
+                        "ops",
+                        crate::policy::consequence::WEB_FETCH,
+                        serde_json::json!({ "url": "https://docs.rs/x" }),
+                    ),
+                }))
+                .with_journal_store(store)
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        let mut ids = Vec::new();
+        for text in ["do it", "again"] {
+            let report = rt
+                .run_cycle(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
+                    parent: None,
+                    text: text.into(),
+                    by: None,
+                    chat: None,
+                    deliverable: None,
+                    attachments: Vec::new(),
+                }])
+                .await
+                .unwrap();
+            assert_eq!(report.parked.len(), 1);
+            ids.push(report.parked[0].clone());
+        }
+
+        // First resolution: a standing denial. Its own mint is the first
+        // `StandingGrantMinted` line, which the store lets through.
+        rt.resolve_approval_spawned(&ids[0], Verdict::Deny, operator(), tool_scope())
+            .await
+            .expect("the first mint succeeds");
+        assert_eq!(rt.standing_grants().len(), 1);
+        assert_eq!(rt.standing_grants()[0].verdict, Verdict::Deny);
+
+        // Second resolution: a standing approval of the same scope. The
+        // reconcile revokes the denial (succeeds — a different record), then
+        // mints the approval — the second `StandingGrantMinted` line, which
+        // the store refuses.
+        let second = rt
+            .resolve_approval_spawned(&ids[1], Verdict::Approve, operator(), tool_scope())
+            .await;
+        assert!(
+            second.is_err(),
+            "the forced failure on the mint must surface, not be swallowed"
+        );
+
+        assert!(
+            rt.standing_grants().is_empty(),
+            "the revoke already landed and nothing rolled it back, so neither the old \
+             denial nor the new approval governs this scope: {:?}",
+            rt.standing_grants()
+        );
     }
 
     /// Issue #1458 under concurrency: two opposite-polarity resolutions of the

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -2498,6 +2498,28 @@ mod test {
         );
     }
 
+    /// `GET {scope}/grants` renders every entry `standing()`
+    /// returns with no pagination and no cap of its own — unlike, say, the
+    /// approval sweep's `MAX_RETIREMENTS_PER_TICK`. This pins that a large
+    /// standing-grant set comes back whole rather than a bounded page of it.
+    #[test]
+    fn standing_returns_every_live_grant_with_no_cap() {
+        let set = GrantSet::default();
+        for i in 0..500 {
+            set.grant_standing(standing(
+                &format!("g{i}"),
+                "ops",
+                &format!("tool-{i}"),
+                10_000,
+            ));
+        }
+        assert_eq!(
+            set.standing().len(),
+            500,
+            "every standing grant is returned; nothing pages or truncates the list"
+        );
+    }
+
     /// A single-use grant must burn even when a standing grant would also have
     /// admitted the call.
     ///
@@ -2977,9 +2999,9 @@ mod test {
     /// consumption. A fresh boot's `rehydrate`, seeing only the journal's
     /// `ApprovalGranted` line and no `GrantConsumed` to fold it back out,
     /// re-arms a grant that was already spent — the boot-time surfacing of
-    /// the window TOOL-005 names for the in-process case.
+    /// the window names for the in-process case.
     #[test]
-    #[ignore = "finding GRANT-004: a grant consumed but not yet journal-drained before a restart rehydrates as live again, because GrantConsumed is only written at the cycle drain"]
+    #[ignore = "a grant consumed but not yet journal-drained before a restart rehydrates as live again, because GrantConsumed is only written at the cycle drain"]
     fn a_grant_consumed_before_its_journal_drain_does_not_survive_a_restart() {
         let args = serde_json::json!({ "to": "a@b.test" });
         let before_crash = GrantSet::default();
@@ -3033,7 +3055,7 @@ mod test {
     /// a line whose `expires_at_millis` is far past that ceiling with no
     /// re-check.
     #[test]
-    #[ignore = "finding GRANT-006: rehydrate_standing accepts a journal line whose expiry exceeds the 7-day ceiling verbatim, with no re-check against MAX_STANDING_GRANT_MILLIS"]
+    #[ignore = "rehydrate_standing accepts a journal line whose expiry exceeds the 7-day ceiling verbatim, with no re-check against MAX_STANDING_GRANT_MILLIS"]
     fn rehydrate_standing_refuses_a_line_past_the_seven_day_ceiling() {
         let set = GrantSet::default();
         let far_future_expiry = 1_000 + MAX_STANDING_GRANT_MILLIS * 10;

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -3949,6 +3949,39 @@ mod test {
         );
     }
 
+    /// `GrantConsumed` is buffered in memory and journaled only at
+    /// the cycle drain (see `GrantState::consumed`'s doc), so a restart that
+    /// lands between "the tool ran" and "the drain wrote the record" replays
+    /// the grant as still live. This pins that this is what actually happens
+    /// on replay today — the documented duplication window, not a guess about
+    /// it — so a fix that closes the window is a deliberate, visible change to
+    /// this test rather than a silent behavior shift.
+    #[tokio::test]
+    async fn a_grant_consumed_but_not_yet_drained_replays_as_live_after_a_restart() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+
+        journal
+            .record_granted(&grant("appr-crash", 1_000))
+            .await
+            .unwrap();
+        // The tool ran and `GrantSet::consume` removed it from the in-memory
+        // live set here, in the real path — but that consumption is buffered,
+        // not journaled, until the cycle runner's drain. No `record_grant_consumed`
+        // call happens before the crash this test models.
+
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        let replayed = reloaded.replayed_grants();
+        assert_eq!(
+            replayed.len(),
+            1,
+            "an undrained consumption re-arms the grant on replay: {replayed:?}"
+        );
+        assert_eq!(replayed[0].approval_id, ApprovalId::new("appr-crash"));
+    }
+
     #[tokio::test]
     async fn a_denied_explicit_request_replays_only_as_a_verdict_continuation() {
         let dir = tmp_dir();


### PR DESCRIPTION
## Summary

Governance is where the company's money, grants and approvals are decided, and it was the least-asserted area in the codebase. Eight cases across the toolbelt sandbox, grants, the journal, spend caps and approval expiry.

Two kinds of case, kept clearly apart:

**Behaviour that is correct and was simply unasserted** — the sandbox refusing a traversal and a symlink escape; a daily cap of exactly zero refusing the teammate's very first turn rather than reading as absent; a stopped company refusing a turn outright and billing nothing.

**Behaviour that is wrong, pinned `#[ignore]`d with the defect named** — so the next person reads a failing case instead of re-deriving the same finding:

- the high-risk-command flag has no effect on the path the shell tool actually takes; the real dispatch never reaches the function the flag guards, so a destructive command runs under full autonomy with the flag set
- a grant consumed but not yet drained rehydrates as live after a restart, because consumption is journalled only at the cycle drain
- rehydration accepts a journalled expiry beyond the seven-day maximum verbatim, never re-checking it on the way back in

And three that are asserted as failing consequences rather than ignored, because the consequence is observable today: reconciling a standing grant revokes and mints in two non-atomic steps, so a failed mint leaves neither policy live; a failed journal append while extending an approval leaves a live extension that reverts only on restart; sweeping expired approvals stops at the first failure, leaving the rest of the batch listed but no longer decidable.

## API Or Behavior Changes

None. Tests only.

## Tests

Every case was checked by breaking what it covers and confirming it fails. One draft was thrown away for the right reason: it called the sandbox's validation function directly, but the shell tool's real path never reaches that function, so it would have been a green case proving nothing about the defect it claimed to cover. The existing ignored case already records that defect honestly and is left alone.

One case had to be rewritten after running it. The first version asserted that sweeping left no approvals listed; the real behaviour is subtler — the expiry moves its own in-memory state before persisting, so only the untried survivor stays listed. Caught by running it, not by reading it.

- [x] `cargo fmt --all -- --check` — rc=0
- [x] `cargo clippy --locked --features openhuman --all-targets --no-deps -- -D warnings` — rc=0
- [x] `cargo test --locked --features openhuman` — rc=0, 7335 passed, 0 failed
- [x] `scripts/ci/assert-auth-matrix.sh` — 9 passed

## Documentation

None needed — each ignored case carries its own reason, which is the durable record of the defect.