### PR TITLE
fix(delegation): ground a spawned card's owner, and pin two schemas against their own behaviour

### DIFF
--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8889,6 +8889,33 @@ members = ["eng1", "eng2"]
         );
     }
 
+    /// A spawned card is grounded on the same terms an assigned one is: a name
+    /// that resolves to nobody opens the card unowned, rather than stamping an
+    /// owner the board renders and no dispatch can reach.
+    #[tokio::test]
+    async fn spawn_task_refuses_to_stamp_an_off_roster_owner_on_a_new_card() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_desk(dir.path());
+        brain
+            .run_delegation(
+                Delegation::SpawnTask {
+                    title: "Draft the plan".to_string(),
+                    note: None,
+                    assignee: Some("not-a-real-agent-xyz".to_string()),
+                },
+                None,
+            )
+            .await
+            .expect("delegation runs");
+
+        let cards = tasks.list(&CompanyId::new("acme")).await.unwrap();
+        assert_eq!(cards.len(), 1);
+        assert_eq!(
+            cards[0].assignee, "",
+            "an unresolvable name leaves the card unowned"
+        );
+    }
+
     /// Issue #246: a chat turn that opened a card says so on the bubble it
     /// answered from. Before this the card appeared on the board and the reply
     /// carried nothing tying the two together, so an operator had no way to

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -12707,6 +12707,29 @@ name = "Morning"
         );
     }
 
+    /// `ReadTaskTool::description()` promises the model
+    /// "every attempt's status", and `read_task_bounds_rendered_attempts_...`
+    /// right above proves the render is truncated to `READ_TASK_ATTEMPTS_LIMIT`
+    /// rows. Both are real; they contradict each other. Pinning the exact
+    /// claim here means a future wording fix and a future cap change are each
+    /// forced to touch this test, instead of one silently drifting out of step
+    /// with the other the way they did to get here.
+    #[test]
+    fn read_task_description_claims_every_attempt_while_the_render_caps_at_the_limit() {
+        let tool = ReadTaskTool::new(CompanyId::new("acme"), None, None, None);
+        assert!(
+            tool.description().contains("every attempt's status"),
+            "the schema text under test has changed; re-check whether the cap it once \
+             contradicted still exists: {}",
+            tool.description()
+        );
+        assert_eq!(
+            READ_TASK_ATTEMPTS_LIMIT, 10,
+            "the render is capped well under \"every attempt\" whenever a card has more retries \
+             than this"
+        );
+    }
+
     #[tokio::test]
     async fn read_task_bounds_the_rendered_title_so_attempts_and_output_stay_reachable() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/harness/built_in/toolbelt.rs
+++ b/src/harness/built_in/toolbelt.rs
@@ -1435,6 +1435,49 @@ mod tests {
         );
     }
 
+    /// `ShellTool`'s own schema tells the model that an
+    /// omitted or out-of-range `timeout_secs` "falls back to the configured
+    /// tool timeout" — `ToolTimeout::Inherit`, the run's global deadline. What
+    /// `timeout_policy` actually returns for `None`/`0` is
+    /// `ToolTimeout::Unbounded`: no deadline at all. A model that reads only
+    /// the schema has no way to learn that omitting the field removes the
+    /// backstop rather than falling onto one.
+    #[test]
+    fn shell_timeout_policy_contradicts_its_own_schema_fallback_claim() {
+        use oh::tools::traits::ToolTimeout;
+
+        let ws = std::env::temp_dir();
+        let security = test_security(&ws, PolicyMode::Full);
+        let tool = ShellTool::new(security, native_runtime(), AuditLogger::disabled());
+
+        let schema = tool.parameters_schema();
+        let description = schema["properties"]["timeout_secs"]["description"]
+            .as_str()
+            .expect("timeout_secs has a description");
+        assert!(
+            description.contains("falls back to the configured tool timeout"),
+            "pin the exact claim under test so a wording change re-opens this finding: {description}"
+        );
+
+        assert_eq!(
+            tool.timeout_policy(&json!({})),
+            ToolTimeout::Unbounded,
+            "an omitted timeout_secs must run unbounded per issue #4023 — the opposite of what \
+             the schema promises the model"
+        );
+        assert_eq!(
+            tool.timeout_policy(&json!({ "timeout_secs": 0 })),
+            ToolTimeout::Unbounded,
+            "an explicit 0 disables the deadline the same way omitting it does"
+        );
+        assert_ne!(
+            tool.timeout_policy(&json!({})),
+            ToolTimeout::Inherit,
+            "the schema's \"configured tool timeout\" is ToolTimeout::Inherit, which shell never \
+             returns"
+        );
+    }
+
     #[tokio::test]
     async fn web_tools_reject_ssrf_ip_literals() {
         let ws = std::env::temp_dir();

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -3055,6 +3055,15 @@ impl<'a> DelegationRunner<'a> {
                 let Some(tasks) = self.tasks else {
                     return Ok(DelegationOutcome::default());
                 };
+                // Grounded against the roster on the same terms `AssignTask`
+                // grounds its own: a name that resolves to nobody opens the card
+                // unowned rather than stamping a phantom owner the board would
+                // then render and no dispatch could ever reach.
+                let owner = assignee
+                    .as_deref()
+                    .map(|name| assignee::resolve(self.record, name))
+                    .and_then(|resolved| resolved.canonical().map(str::to_string))
+                    .unwrap_or_default();
                 let card = TaskRecord {
                     id: generate_id(),
                     title: crate::ports::tasks::TaskTitle::system(&title),
@@ -3062,7 +3071,7 @@ impl<'a> DelegationRunner<'a> {
                     origin_message_seq: None,
                     column: COLUMN_TODO.to_string(),
                     priority: "medium".to_string(),
-                    assignee: assignee.unwrap_or_default(),
+                    assignee: owner,
                     updated_at_millis: now_millis(),
                     // Issue #151 §3.2: remember which conversation asked for this,
                     // so the completion can answer there instead of only landing in


### PR DESCRIPTION
## Summary

**The fix.** Assigning a card resolves the assignee against the roster and refuses a name that matches nobody, leaving the previous owner in place. Spawning one did not: it wrote whatever string the caller passed straight onto the new card. An orchestrator naming an agent that does not exist therefore produced a card the board renders with an owner, and no dispatch can ever reach that owner.

Grounded on the same terms as assignment. A name that resolves to nobody opens the card unowned, which is at least true, and visible as such on the board. Refusing at the tool boundary instead — so the model is told immediately rather than discovering it at drain time — needs roster access the tool does not have; the case pinned for that stays ignored, unchanged.

**Two schema claims pinned against the behaviour they describe.** Both tools tell the model something their own code contradicts:

- the shell tool's schema promises that an omitted timeout falls back to a configured one; the policy in force is unbounded
- `read_task`'s schema promises every attempt's status; the render truncates at a limit, which a neighbouring case already proves

Both halves are real and they disagree. Pinning the exact claim means a future wording fix and a future behaviour fix each have to touch this, instead of one drifting silently out of step with the other the way they did to get here.

## API Or Behavior Changes

A card spawned with an assignee that names nobody on the roster now opens unowned instead of carrying a phantom owner. No other change.

## Tests

The fix is red-proved: reverted to the raw write, the case fails with `left: "not-a-real-agent-xyz"`, `right: ""`. Restored, it passes.

A case pinning that `add_agent` enforces no roster cap was dropped before this PR — the codebase already pins that defect from both directions, and a third case asserting the gap is still there would have been noise contradicting the ignored case that asks for it to be closed.

- [x] `cargo fmt --all -- --check` — rc=0
- [x] `cargo clippy --locked --features openhuman --all-targets --no-deps -- -D warnings` — rc=0
- [x] `cargo test --locked --features openhuman` — rc=0, 7330 passed, 0 failed
- [x] `scripts/ci/assert-auth-matrix.sh` — 9 passed

## Documentation

None needed.