### PR TITLE
fix(memory): require host authority to repoint the host's memory engine

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -238,6 +238,15 @@ pub enum OpenCompanyError {
     #[error("company is {0}")]
     LifecycleConflict(String),
 
+    /// The caller is authenticated but does not hold the authority the
+    /// operation needs.
+    ///
+    /// Distinct from a missing grant, which is about a tool: this is about the
+    /// scope of the change itself — an operation that reaches past the company
+    /// in the path and so needs authority over more than that company.
+    #[error("{0}")]
+    Forbidden(String),
+
     /// A side-effecting effect was refused because the company's emergency stop
     /// is engaged (issue #86).
     ///
@@ -473,6 +482,7 @@ impl OpenCompanyError {
             // branch on differently.
             Self::WorkflowRunFailed { source, .. } => source.code(),
             Self::LifecycleConflict(_) => "lifecycle_conflict".to_string(),
+            Self::Forbidden(_) => "forbidden".to_string(),
             Self::EmergencyStop(_) => "emergency_stop".to_string(),
             Self::Conflict(_) => "conflict".to_string(),
             Self::NotInBuild(_) => "not_in_build".to_string(),

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -95,7 +95,9 @@ impl ApiError {
             // A runtime swap is in progress and clears itself within a turn, so
             // this is a retry-me, not a refusal (issue #290).
             OpenCompanyError::Quiescing(_) => StatusCode::SERVICE_UNAVAILABLE,
-            OpenCompanyError::ToolNotGranted(_) => StatusCode::FORBIDDEN,
+            OpenCompanyError::ToolNotGranted(_) | OpenCompanyError::Forbidden(_) => {
+                StatusCode::FORBIDDEN
+            }
             OpenCompanyError::BudgetExceeded(_) => StatusCode::PAYMENT_REQUIRED,
             // 413 — for both ways an upload can be too big. The store's per-file
             // cap raises this variant with the file and the limit named; the

--- a/src/server/ops/memory_engine.rs
+++ b/src/server/ops/memory_engine.rs
@@ -680,9 +680,32 @@ fn family_refusal(engine: &str, unreachable: Option<&[String]>) -> Option<String
 async fn apply(
     company: AdminScopedCompany,
     axum::extract::State(state): axum::extract::State<AppState>,
+    headers: axum::http::HeaderMap,
     Query(query): Query<ApplyQuery>,
     Json(request): Json<EngineRequest>,
 ) -> Result<Json<AppliedDto>, ApiError> {
+    // This route writes the host's `config.toml` and rebuilds every company on
+    // it, so the authority it needs is over the instance, not over one company.
+    // `AdminScopedCompany` proves the caller administers the company in the
+    // path and nothing more: on a shared host it would let one tenant's admin
+    // repoint the memory engine for every other tenant and force them all to
+    // rebuild.
+    //
+    // A single-company host is the case where the two authorities coincide —
+    // the admin there IS the operator, and a self-hosted deployment holds no
+    // platform credential at all, so demanding one would leave the engine
+    // unreachable from its own console.
+    let companies = state.registry().list().len();
+    let platform = matches!(
+        crate::server::graphql::auth::resolve_claims(&headers, &state),
+        Ok(crate::server::graphql::auth::GqlAuth::Platform(claims)) if claims.has_platform_scope()
+    );
+    if companies > 1 && !platform {
+        return Err(ApiError(OpenCompanyError::Forbidden(format!(
+            "the memory engine is configured for this whole host, not for one company, and \
+             this host runs {companies} of them. Changing it needs platform authority."
+        ))));
+    }
     let _ = company.id();
     let (stored, layer) = saved_selection(&state)?;
     if layer == "env" {

--- a/src/server/ops/memory_engine/test.rs
+++ b/src/server/ops/memory_engine/test.rs
@@ -497,6 +497,56 @@ async fn applying_an_engine_persists_it_to_config_toml() {
     assert_eq!(body["layer"], "config.toml");
 }
 
+/// The engine is a property of the host, so changing it needs authority over
+/// the host.
+///
+/// A company admin holds authority over one company. On a host running more
+/// than one, this route would let that admin repoint the engine every other
+/// company on the box reads from, and rebuild all of them. The single-company
+/// case stays open, because there the two authorities are the same authority
+/// and a self-hosted deployment has no platform credential to present.
+#[tokio::test]
+async fn a_company_admin_may_not_repoint_the_engine_a_second_company_also_reads() {
+    let dir = tempfile::tempdir().unwrap();
+    let guard = EnvVarGuard::capture(&MEMORY_ENV);
+    guard.remove("OPENCOMPANY_MEMORY");
+    guard.set("OPENCOMPANY_DATA_DIR", dir.path().to_str().unwrap());
+    let state = state_at(dir.path()).await;
+
+    let (status, body) = call(
+        &state,
+        "PUT",
+        "/api/v1/company/memory/engine",
+        Some(json!({ "engine": "store" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "one company on the host: {body}");
+
+    let second: CompanyManifest =
+        toml::from_str("[company]\nname = \"Beta\"\n[policy]\nmode = \"full\"\n").unwrap();
+    let beta = CompanyId::new("beta");
+    let runtime = RuntimeBuilder::new(dir.path().to_path_buf(), second)
+        .with_id(beta.clone())
+        .build()
+        .await
+        .unwrap();
+    state.registry().insert(beta, Arc::new(runtime));
+
+    let (status, body) = call(
+        &state,
+        "PUT",
+        "/api/v1/companies/acme/memory/engine",
+        Some(json!({ "engine": "store" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "two companies on the host: {body}"
+    );
+    assert_eq!(body["code"], "forbidden", "{body}");
+}
+
 /// An engine id nothing in the catalog carries is a bad request, and the
 /// message lists what may be picked instead.
 #[tokio::test]


### PR DESCRIPTION
## Summary

`PUT {scope}/memory/engine` takes an `AdminScopedCompany` — an admin of the company named in the path — and then discards that id outright:

```rust
let _ = company.id();
```

What it does next is not scoped to that company at all. It writes the host's `config.toml`, sets the process-wide memory overlay, and then walks the registry rebuilding **every** company on the host:

```rust
for id in state.registry().list() {
    match crate::runtime::rebuild_company(&state, &id).await { … }
}
```

So on a host running more than one company, an admin of any one of them repoints the memory engine that all the others read from, and forces all of them to rebuild. The extractor proves authority over one company; the write reaches the whole instance.

## The rule this uses instead

Not "require platform scope". A self-hosted deployment holds no platform credential by design — `platform_auth` is unconfigured there, so nobody holds the scope — and demanding one would leave the engine unreachable from its own console, which is the deployment where an operator most obviously should be able to change it.

The honest rule is that **the authority has to match what the write reaches**. On a host running exactly one company, the two authorities are the same authority: the admin *is* the operator, and "this company" and "this host" name the same thing. Past one, they come apart, and it takes platform scope.

## API Or Behavior Changes

A company admin on a host running two or more companies now gets `403` from `PUT {scope}/memory/engine`, with a message naming why and how many companies the host runs. Single-company hosts — self-hosted, desktop, and every current test fixture — are unchanged. `GET` and the `…/test` probe are untouched: neither writes.

One supporting change: `403` was previously reachable only through `ToolNotGranted`, which is a claim about a tool. A route refusing because the caller's authority does not reach far enough had nothing truthful to raise, so this adds a `Forbidden` variant mapping to `403` with code `forbidden`.

## Tests

`a_company_admin_may_not_repoint_the_engine_a_second_company_also_reads` drives the whole router twice against one state: once with a single company registered, asserting `200` so the case cannot pass by refusing everything, then again with a second company inserted, asserting `403` and the `forbidden` code.

Red-proved. With the gate disabled the second call returns `200` and the write lands — the admin of `acme` reconfigures a host that also runs `beta`.

The two-company call addresses by id rather than through the `/api/v1/company` alias, because that alias resolves the *sole* company and `404`s once a host has more than one — which is itself worth knowing when reading the case.

- [x] `cargo fmt --all -- --check` — rc=0
- [x] `cargo clippy --locked --features openhuman --all-targets --no-deps -- -D warnings` — rc=0
- [x] `cargo test --locked --features openhuman` — rc=0, 7353 passed, 0 failed
- [x] `scripts/ci/assert-auth-matrix.sh` — 9 passed

## Documentation

The module header already says the engine is host-level (`what is bound, what is saved, what can be picked`); the new refusal states the same thing back to a caller who tried to change it from a company scope. No separate doc change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Memory engine changes are now restricted on hosts with multiple companies unless the caller has platform-level authorization.
  - Unauthorized requests receive a clear `403 Forbidden` response with the stable `forbidden` error code.
  - Single-company hosts and authorized callers continue to work as before.
- **Tests**
  - Added coverage verifying that company administrators can apply the engine on single-company hosts but are blocked after another company is registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->