### PR TITLE
fix(config): let a hosted tenant default the tiny.place URL

### DIFF
--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -112,7 +112,7 @@ that does and does not imply.
 | --- | --- | --- |
 | `TINYHUMANS_TOKEN_FILE` | — | Platform-projected, audience-bound token file; rotates in place and outranks `TINYHUMANS_API_KEY` |
 | `TINYHUMANS_API_KEY` | — (required for cycles when no token file) | Static TinyHumans credential (JWT or API key) |
-| `TINYHUMANS_API_URL` | `https://api.tinyhumans.ai` | Backend base URL |
+| `TINYHUMANS_API_URL` | `https://api.tinyhumans.ai` | Backend base URL. A **hosted tenant refuses to boot** when neither this nor `config.toml` states it: the platform hands a tenant its whole environment, so a silent production default is a destination nobody chose |
 | `OPENCOMPANY_BIND` | `127.0.0.1:8080` | HTTP bind address. Outranked by `serve --bind`, outranks `config.toml`'s `bind` — see [the bind address](#the-bind-address) |
 | `OPENCOMPANY_DATA_DIR` | `~/.opencompany` (workspace and bundle home alike; bundles at `companies/<slug>`) | The instance data root: both the workspace layout and the company-bundle home. `--home` outranks it for the bundle home **only** — the workspace (`memory/`, `store/`, `files/`, `logs/`, `tmp/`) still resolves under this variable, so `--home` alone does not move a whole instance. The only knob that isolates two hosts from each other — see [the workspace layout](workspace-layout.md#choosing-the-root-srcstorepathsrs) |
 | `OPENCOMPANY_BRAIN_MODE` | `hosted` | `hosted` \| `sidecar` (overrides `[brain].mode`) |
@@ -122,7 +122,7 @@ that does and does not imply.
 | `OPENCOMPANY_INFERENCE_URL` | `https://api.tinyhumans.ai/openai/v1` | Harness-brain OpenAI-compatible endpoint (`openhuman` feature) |
 | `OPENCOMPANY_INFERENCE_MODEL` | `chat-v1` | Roster-wide default model/tier for the harness brain (`openhuman` feature) |
 | `OPENCOMPANY_CONTEXT_WINDOW` | `240000` | Context window the managed inference profile advertises, in tokens (`openhuman` feature). Compression and deterministic trimming engage at 90% of it; set it to a smaller model's advertised window (with an estimation margin) or `off`/`0` to restore unbounded intra-turn history — see [harness history protection](providers.md#history-protection) |
-| `TINYPLACE_API_URL` | `https://api.tiny.place` | tiny.place base (staging/local override) |
+| `TINYPLACE_API_URL` | `https://api.tiny.place` | tiny.place base (staging/local override). Defaults on every deployment kind, hosted tenants included: the economy is read only when a company sets `place.discoverable` and names a handle, and takes this same default when unset |
 | `GITHUB_TOKEN` | — | Only for the feedback→issue flow; without it, feedback is stored locally and a prefilled "file it yourself" link is shown |
 | `OPENCOMPANY_MAIL_PROVIDER` | `smtp` when any `OPENCOMPANY_MAIL_*` is set | Host-level outbound mail transport. Supported: `smtp` |
 | `OPENCOMPANY_MAIL_HOST` | — | SMTP submission host. Setting it opts the host into platform mail |

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -809,9 +809,12 @@ pub fn resolve(
         "api_url",
         "TINYHUMANS_API_URL",
         deployment,
-        env.get("TINYHUMANS_API_URL"),
-        config_toml.and_then(|c| c.api_url.clone()),
-        DEFAULT_API_URL.to_string(),
+        HostedDefault::Refuse,
+        BaseUrlSources {
+            env: env.get("TINYHUMANS_API_URL"),
+            toml: config_toml.and_then(|c| c.api_url.clone()),
+            default: DEFAULT_API_URL.to_string(),
+        },
     )?;
 
     let tinyplace_api_url = resolve_base_url(
@@ -819,9 +822,16 @@ pub fn resolve(
         "tinyplace_api_url",
         "TINYPLACE_API_URL",
         deployment,
-        env.get("TINYPLACE_API_URL"),
-        config_toml.and_then(|c| c.tinyplace_api_url.clone()),
-        DEFAULT_TINYPLACE_API_URL.to_string(),
+        // Opt-in: `maybe_build_economy` returns before reading this unless the
+        // manifest sets `place.discoverable` AND names a handle, and takes the
+        // same default this does when it gets `None`. Refusing here stopped
+        // every tenant over a value almost none of them reach.
+        HostedDefault::Allow,
+        BaseUrlSources {
+            env: env.get("TINYPLACE_API_URL"),
+            toml: config_toml.and_then(|c| c.tinyplace_api_url.clone()),
+            default: DEFAULT_TINYPLACE_API_URL.to_string(),
+        },
     )?;
 
     // brain_mode: env <- config.toml <- manifest (always present) <- default.
@@ -997,6 +1007,20 @@ fn resolve_str(
     }
 }
 
+/// Whether a [`Deployment::HostedTenant`] must state a base URL rather than
+/// inherit the built-in default.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum HostedDefault {
+    /// Refuse to boot when nothing states it. For a backend the tenant talks
+    /// to unconditionally, a silent production default is a destination
+    /// nobody chose.
+    Refuse,
+    /// Fall back to the default like any other deployment. For a backend
+    /// reached only when the company opts in, where the consumer carries its
+    /// own fallback anyway.
+    Allow,
+}
+
 /// Resolves a base-URL field that names which real backend this process talks
 /// to (`api_url`, `tinyplace_api_url`).
 ///
@@ -1005,24 +1029,44 @@ fn resolve_str(
 /// default — the operator running either owns the choice, and the default
 /// (production) *is* that choice when they name nothing.
 ///
-/// For [`Deployment::HostedTenant`] the default is refused instead: a tenant
-/// container is handed its entire environment by the platform that
-/// provisions it, so nobody ever chose the destination that a silent default
-/// would apply. The caller gets a config error naming `var_name` rather than
-/// a container that boots and quietly talks to production.
+/// For [`Deployment::HostedTenant`] the default is refused when `hosted` is
+/// [`HostedDefault::Refuse`]: a tenant container is handed its entire
+/// environment by the platform that provisions it, so nobody ever chose the
+/// destination that a silent default would apply. The caller gets a config
+/// error naming `var_name` rather than a container that boots and quietly
+/// talks to production.
+///
+/// That argument holds only for a backend every tenant reaches. It does not
+/// hold for one gated behind an opt-in the tenant has not taken: refusing
+/// there stops a container over a URL it would never have built a client for.
+/// Such a field passes [`HostedDefault::Allow`] and keeps defaulting.
 ///
 /// An env or `config.toml` value that is empty (after trimming) counts as
 /// unset in both branches — a launcher that exported the variable with
 /// nothing in it has said nothing.
+/// Where a base URL may come from, in precedence order.
+struct BaseUrlSources {
+    /// The process environment.
+    env: Option<String>,
+    /// `config.toml`.
+    toml: Option<String>,
+    /// The built-in default, which for every field here is production.
+    default: String,
+}
+
 fn resolve_base_url(
     prov: &mut ConfigProvenance,
     field: &'static str,
     var_name: &str,
     deployment: Deployment,
-    env_val: Option<String>,
-    toml_val: Option<String>,
-    default_val: String,
+    hosted: HostedDefault,
+    sources: BaseUrlSources,
 ) -> Result<String> {
+    let BaseUrlSources {
+        env: env_val,
+        toml: toml_val,
+        default: default_val,
+    } = sources;
     if let Some(value) = env_val.filter(|v| !v.trim().is_empty()) {
         prov.set(field, ConfigLayer::Env);
         return Ok(value);
@@ -1031,7 +1075,7 @@ fn resolve_base_url(
         prov.set(field, ConfigLayer::ConfigToml);
         return Ok(value);
     }
-    if deployment == Deployment::HostedTenant {
+    if deployment == Deployment::HostedTenant && hosted == HostedDefault::Refuse {
         return Err(OpenCompanyError::Config(format!(
             "{var_name} is not set. This is a hosted-tenant deployment, which is handed its \
              whole environment by the platform that provisions it — so this refuses to boot \
@@ -1629,15 +1673,42 @@ mod test {
         assert!(message.contains("TINYHUMANS_API_URL"), "{message}");
     }
 
+    /// **The tiny.place hub is opt-in, so an unset URL is not a
+    /// misconfiguration.**
+    ///
+    /// `maybe_build_economy` returns `None` before reading this unless the
+    /// manifest sets `place.discoverable` and names a handle — `discoverable`
+    /// defaults to false and no shipped company turns it on — and on the path
+    /// that does read it, it takes this same default when handed `None`.
+    ///
+    /// Refusing here stopped every hosted tenant from booting over a URL it
+    /// would never have built a client for. `api_url` keeps its refusal: that
+    /// backend is reached unconditionally, so a silent production default
+    /// there is a destination nobody chose.
     #[test]
-    fn hosted_tenant_refuses_to_boot_with_no_tinyplace_api_url() {
-        // api_url set so the failure under test is unambiguously about
-        // tinyplace_api_url, not the sibling field checked above.
+    fn hosted_tenant_defaults_tinyplace_api_url_rather_than_refusing() {
+        // api_url set so the resolve under test turns on tinyplace_api_url
+        // alone, not the sibling field checked above.
         let env = hosted_tenant_env([("TINYHUMANS_API_URL", "https://api.tinyhumans.ai")]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest())
+            .expect("an unset tiny.place URL is not a boot failure");
+        assert_eq!(cfg.tinyplace_api_url, DEFAULT_TINYPLACE_API_URL);
+        assert_eq!(
+            prov.layer("tinyplace_api_url"),
+            Some(ConfigLayer::Default),
+            "and it is recorded as the default it is"
+        );
+    }
+
+    /// The sibling still refuses, so this change narrowed the rule rather
+    /// than removing it.
+    #[test]
+    fn hosted_tenant_still_refuses_a_missing_api_url_with_tinyplace_set() {
+        let env = hosted_tenant_env([("TINYPLACE_API_URL", "https://staging-api.tiny.place")]);
         let err = resolve(&env, None, &default_manifest()).unwrap_err();
         assert_eq!(err.code(), "config_error");
         let message = err.to_string();
-        assert!(message.contains("TINYPLACE_API_URL"), "{message}");
+        assert!(message.contains("TINYHUMANS_API_URL"), "{message}");
     }
 
     #[test]

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::{Parser, Subcommand, ValueEnum};
+use opencompany::app::config::HostedDefault;
 use opencompany::company::Schedule;
 use opencompany::runtime::lifecycle_scheduler::load_or_create_cutoff_millis;
 use opencompany::runtime::{
@@ -1893,9 +1894,14 @@ fn log_filter(rust_log: Option<&str>) -> tracing_subscriber::EnvFilter {
 /// both callers is a production base URL. Every other deployment kind keeps
 /// the default: the operator running it owns the choice, and no-override *is*
 /// that choice.
+///
+/// `hosted` carries the same distinction its twin makes: that argument holds
+/// for a backend every tenant reaches, and not for one behind an opt-in the
+/// tenant has not taken. See [`HostedDefault`].
 fn resolve_serve_base_url(
     var_name: &str,
     deployment: opencompany::app::deployment::Deployment,
+    hosted: HostedDefault,
     toml_val: Option<String>,
     default_val: String,
 ) -> Result<String> {
@@ -1908,7 +1914,9 @@ fn resolve_serve_base_url(
     if let Some(value) = toml_val.filter(|value| !value.trim().is_empty()) {
         return Ok(value);
     }
-    if deployment == opencompany::app::deployment::Deployment::HostedTenant {
+    if deployment == opencompany::app::deployment::Deployment::HostedTenant
+        && hosted == HostedDefault::Refuse
+    {
         return Err(opencompany::error::OpenCompanyError::Config(format!(
             "{var_name} is not set. This is a hosted-tenant deployment, which is handed its \
              whole environment by the platform that provisions it — so this refuses to boot \
@@ -2090,6 +2098,10 @@ async fn async_main() -> Result<()> {
             let tinyplace_api_url = resolve_serve_base_url(
                 "TINYPLACE_API_URL",
                 deployment,
+                // Opt-in: `maybe_build_economy` returns before reading this
+                // unless the manifest sets `place.discoverable` AND names a
+                // handle, and takes this same default when given `None`.
+                HostedDefault::Allow,
                 config_file
                     .as_ref()
                     .and_then(|c| c.tinyplace_api_url.clone()),
@@ -2146,6 +2158,7 @@ async fn async_main() -> Result<()> {
             let api_url = resolve_serve_base_url(
                 "TINYHUMANS_API_URL",
                 deployment,
+                HostedDefault::Refuse,
                 config_file.as_ref().and_then(|c| c.api_url.clone()),
                 AppConfig::default().api_url,
             )?;
@@ -3305,6 +3318,7 @@ mod test {
         let resolved = resolve_serve_base_url(
             UNSET_VAR,
             opencompany::app::deployment::Deployment::HostedTenant,
+            HostedDefault::Refuse,
             Some("https://toml.example".to_string()),
             "https://default.example".to_string(),
         )
@@ -3318,6 +3332,7 @@ mod test {
         let err = resolve_serve_base_url(
             UNSET_VAR,
             opencompany::app::deployment::Deployment::HostedTenant,
+            HostedDefault::Refuse,
             None,
             "https://default.example".to_string(),
         )
@@ -3334,6 +3349,7 @@ mod test {
         let err = resolve_serve_base_url(
             UNSET_VAR,
             opencompany::app::deployment::Deployment::HostedTenant,
+            HostedDefault::Refuse,
             Some("   ".to_string()),
             "https://default.example".to_string(),
         )
@@ -3345,11 +3361,34 @@ mod test {
         ));
     }
 
+    /// **The boot path the tenant container actually takes.**
+    ///
+    /// `serve` builds `AppConfig` field-by-field through this twin, so a rule
+    /// relaxed only in `app::config::resolve_base_url` would leave every
+    /// hosted tenant still refusing to start. Observed on staging: a tenant
+    /// rolled onto an image carrying PR #2141 crash-looped with
+    /// `TINYPLACE_API_URL is not set`, for a company whose manifest has no
+    /// `[place]` block at all.
+    #[test]
+    fn serve_base_url_lets_a_hosted_tenant_default_an_opt_in_backend() {
+        let resolved = resolve_serve_base_url(
+            UNSET_VAR,
+            opencompany::app::deployment::Deployment::HostedTenant,
+            HostedDefault::Allow,
+            None,
+            "https://default.example".to_string(),
+        )
+        .expect("an opt-in backend must not stop a tenant from booting");
+
+        assert_eq!(resolved, "https://default.example");
+    }
+
     #[test]
     fn serve_base_url_self_hosted_still_defaults_when_neither_env_nor_toml() {
         let resolved = resolve_serve_base_url(
             UNSET_VAR,
             opencompany::app::deployment::Deployment::SelfHosted,
+            HostedDefault::Refuse,
             None,
             "https://default.example".to_string(),
         )


### PR DESCRIPTION
## Summary

PR #2141 made a hosted tenant refuse to boot when neither the environment nor `config.toml` states a base URL, so a tenant missing its injection could not silently talk to production. That reasoning is right for `api_url`. It does not hold for `tinyplace_api_url`, and applying it there stops tenants over a value they never read.

`maybe_build_economy` returns before touching the URL unless the manifest opts in:

```rust
if !(manifest.place.discoverable && manifest.company.handle.is_some()) {
    return None;
}
```

`place.discoverable` defaults to `false`, no shipped company sets it true (the one manifest that mentions it sets it false), and on the path that *does* read the URL it is an `Option<String>` resolved with `.unwrap_or_else(|| DEFAULT_TINYPLACE_API_URL)`. The field is optional at its only use site.

## How it showed up

Rolling a staging tenant onto an image carrying #2141 crash-looped, 7 restarts, never ready:

```
Error: Config("TINYPLACE_API_URL is not set. This is a hosted-tenant deployment, ...")
```

That tenant runs `agentic_software_company`, whose manifest has no `[place]` block at all. `TINYPLACE_API_URL` is injected nowhere on the cluster — not on any tenant StatefulSet, not on the manager — so every tenant rolled forward would have hit the same wall. A tenant idled to zero replicas would have failed on its next wake rather than visibly at deploy time.

## Change

`resolve_base_url` and `serve`'s local twin take a `HostedDefault` saying whether a hosted tenant must state the field:

- `api_url` → `HostedDefault::Refuse` (unchanged behaviour)
- `tinyplace_api_url` → `HostedDefault::Allow` (defaults, as it did before #2141)

Both twins change together. `serve` builds `AppConfig` field-by-field through its own copy, and that is the path a tenant container boots through — relaxing only the library one would have left the crash loop exactly where it was.

The value sources moved into a `BaseUrlSources` struct so the added parameter does not trip `clippy::too_many_arguments`.

## Tests

- `hosted_tenant_defaults_tinyplace_api_url_rather_than_refusing` — replaces the test that asserted the old refusal, and pins the provenance as `Default`.
- `hosted_tenant_still_refuses_a_missing_api_url_with_tinyplace_set` — the sibling still refuses, so this narrows the rule rather than removing it.
- `serve_base_url_lets_a_hosted_tenant_default_an_opt_in_backend` — covers the boot path the container actually takes.

## Follow-up, not in this PR

The stricter version of the safety property is to require the URL exactly when it is reachable — `place.discoverable && handle.is_some()` — so a tenant that *does* go public still cannot silently reach the production hub from staging. That needs the manifest at config-resolution time and is worth doing separately.

## Commands run

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings`
- `cargo test --locked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hosted deployments now use the default backend when `TINYPLACE_API_URL` and its configuration setting are unset.
  - Hosted deployments still refuse to start when `TINYHUMANS_API_URL` and its configuration setting do not specify a backend URL.

- **Documentation**
  - Clarified the default behavior and hosted-deployment requirements for both backend URL environment variables.
  - Documented when the economy is read based on company discoverability and handle settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->