### PR TITLE
feat(policy): admit a dispatched run's in-scope calls (Rung 3, ships dormant)

### DIFF
--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1512,6 +1512,13 @@ impl HarnessBrain {
                     scan_partial,
                     &control,
                     sink.clone(),
+                    Some(
+                        crate::harness::built_in::run_origin::RunOrigin::Dispatched {
+                            agent: responder.to_string(),
+                            source: crate::harness::built_in::run_origin::DispatchSource::Task,
+                            scope: None,
+                        },
+                    ),
                 )
                 .await;
         }
@@ -2029,31 +2036,33 @@ impl HarnessBrain {
         scan_partial: bool,
         control: &crate::company::steer::SteerControl,
         sink: Option<Arc<RunTraceSink>>,
+        dispatched: Option<crate::harness::built_in::run_origin::RunOrigin>,
     ) -> Option<String> {
         let instruction = publish::nudge_instruction(brief, reply, unpublished, scan_partial);
-        // Issue #2150: this is still the same dispatched card's run, so the
-        // nudge turn earns the same trust its primary turn did — a fresh claim
-        // naming the same responder and the same `Task` source, not a
-        // privilege re-derived from nothing.
-        let nudge_origin = crate::harness::built_in::run_origin::claim(
-            crate::harness::built_in::run_origin::RunOrigin::Dispatched {
-                agent: responder.to_string(),
-                source: crate::harness::built_in::run_origin::DispatchSource::Task,
-                scope: None,
-            },
-        );
-        let outcome = nudge_origin
-            .scoped(Box::pin(run_turn.run_steered_background(
-                &self.record().id,
-                responder,
-                &instruction,
-                control,
-                // A hand-off inside a dispatched card: the board is the
-                // conversation, not a thread (#1890 I).
-                ChatTarget::default(),
-                sink,
-            )))
-            .await;
+        let company = self.record().id.clone();
+        let turn = Box::pin(run_turn.run_steered_background(
+            &company,
+            responder,
+            &instruction,
+            control,
+            // A hand-off inside a dispatched card: the board is the
+            // conversation, not a thread (#1890 I).
+            ChatTarget::default(),
+            sink,
+        ));
+        // Only the caller knows whether this nudge belongs to a dispatched
+        // card. The cycle runs the operator's own turn, its delegated desk
+        // turns, a dispatched card and a re-dispatch after an approval through
+        // one path, so minting a `Dispatched` origin here would hand a turn
+        // that followed an operator's message the trust a card earned.
+        let outcome = match dispatched {
+            Some(origin) => {
+                crate::harness::built_in::run_origin::claim(origin)
+                    .scoped(turn)
+                    .await
+            }
+            None => turn.await,
+        };
         // A steer that landed during the nudge is consumed here so it cannot
         // leak into a later `control.take()` and be mistaken for a steer of the
         // primary run, which has already ended.
@@ -4075,6 +4084,7 @@ impl HarnessBrain {
                                     changed.partial,
                                     &nudge_control,
                                     None,
+                                    None,
                                 )
                                 .await;
                             let nudge_published = self.deps.pending_publishes.drain();
@@ -4430,6 +4440,7 @@ impl HarnessBrain {
                                     &unpublished,
                                     changed.partial,
                                     &nudge_control,
+                                    None,
                                     None,
                                 )
                                 .await;

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1146,6 +1146,18 @@ impl HarnessBrain {
         let run_turn = self.run_turn();
         // Bound for the runner's whole lifetime (issue #707): one turn, one record.
         let record = self.record();
+        // Issue #2150: this dispatch's trust window. Captured once, against
+        // the responder frozen above — a redirect re-runs the same claim, and
+        // a hand-off inside `handle_task_delegations` below inherits it
+        // unchanged rather than re-deriving one for the delegate (see
+        // `crate::harness::built_in::run_origin`).
+        let dispatch_origin = crate::harness::built_in::run_origin::claim(
+            crate::harness::built_in::run_origin::RunOrigin::Dispatched {
+                agent: responder.clone(),
+                source: crate::harness::built_in::run_origin::DispatchSource::Task,
+                scope: None,
+            },
+        );
         // Issue #242: where this attempt's own approval requests begin. The
         // queue is shared with any chat turn earlier in the same cycle and is
         // append-only until the cycle-end drain, so a position taken here stays
@@ -1176,26 +1188,30 @@ impl HarnessBrain {
             // it, for the same reason — the card's link must name what the turn
             // that actually settled produced, not what a discarded one did.
             self.deps.workflow_refs.clear();
-            let outcome = run_turn
-                // A dispatched task card carries no chat bubble (its steps are
-                // discarded into the note), so its live turn frames must not leak
-                // onto the console timeline — run it un-streamed (#125 review).
-                .run_steered_background(
-                    &self.record().id,
-                    &responder,
-                    &instruction,
-                    &control,
-                    // No conversation to bind to: a dispatched card's turn
-                    // answers the board, not a thread (#1890 I). Unchanged
-                    // behaviour — including that it does not clear history,
-                    // since one task can span several turns.
-                    ChatTarget::default(),
-                    // Issue #242: un-streamed does not mean unrecorded. The
-                    // trace this turn produces is written to the attempt row as
-                    // it happens, which is what a redirect re-run appends to
-                    // rather than restarting.
-                    sink.clone(),
-                )
+            let outcome = dispatch_origin
+                .scoped(Box::pin(
+                    run_turn
+                        // A dispatched task card carries no chat bubble (its steps
+                        // are discarded into the note), so its live turn frames
+                        // must not leak onto the console timeline — run it
+                        // un-streamed (#125 review).
+                        .run_steered_background(
+                            &self.record().id,
+                            &responder,
+                            &instruction,
+                            &control,
+                            // No conversation to bind to: a dispatched card's turn
+                            // answers the board, not a thread (#1890 I). Unchanged
+                            // behaviour — including that it does not clear
+                            // history, since one task can span several turns.
+                            ChatTarget::default(),
+                            // Issue #242: un-streamed does not mean unrecorded. The
+                            // trace this turn produces is written to the attempt
+                            // row as it happens, which is what a redirect re-run
+                            // appends to rather than restarting.
+                            sink.clone(),
+                        ),
+                ))
                 .await;
             // One-shot read of what (if anything) the operator asked for. `None`
             // is the ordinary, unsteered path.
@@ -2015,8 +2031,19 @@ impl HarnessBrain {
         sink: Option<Arc<RunTraceSink>>,
     ) -> Option<String> {
         let instruction = publish::nudge_instruction(brief, reply, unpublished, scan_partial);
-        let outcome = run_turn
-            .run_steered_background(
+        // Issue #2150: this is still the same dispatched card's run, so the
+        // nudge turn earns the same trust its primary turn did — a fresh claim
+        // naming the same responder and the same `Task` source, not a
+        // privilege re-derived from nothing.
+        let nudge_origin = crate::harness::built_in::run_origin::claim(
+            crate::harness::built_in::run_origin::RunOrigin::Dispatched {
+                agent: responder.to_string(),
+                source: crate::harness::built_in::run_origin::DispatchSource::Task,
+                scope: None,
+            },
+        );
+        let outcome = nudge_origin
+            .scoped(Box::pin(run_turn.run_steered_background(
                 &self.record().id,
                 responder,
                 &instruction,
@@ -2025,7 +2052,7 @@ impl HarnessBrain {
                 // conversation, not a thread (#1890 I).
                 ChatTarget::default(),
                 sink,
-            )
+            )))
             .await;
         // A steer that landed during the nudge is consumed here so it cannot
         // leak into a later `control.take()` and be mistaken for a steer of the

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -139,6 +139,7 @@ pub mod publish;
 /// records a decline, and can never fail the run it follows. Test-only.
 #[cfg(test)]
 mod publish_turn_test;
+pub mod run_origin;
 pub mod run_trace;
 pub mod run_turn;
 pub mod search;

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -142,7 +142,7 @@ use oh::agent::tool_policy::{ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
 
 use crate::company::Policy;
 use crate::metering::{usd_spent_by_agent, utc_day_start_millis};
-use crate::policy::{CallPath, McpReadSet};
+use crate::policy::{CallPath, McpReadSet, Standing};
 use crate::ports::UsageMeter;
 use crate::ports::types::{CompanyId, Effect, EffectGroup, Verdict};
 use crate::runtime::grants::{GrantSet, GrantSubject, GrantedCall};
@@ -1580,6 +1580,94 @@ impl ApprovalPolicy {
         }
         consequence
     }
+
+    /// Does the run this call is executing inside already carry an operator's
+    /// consent for it (issue #2150, Rung 3 of epic #1817)?
+    ///
+    /// Consulted only from inside the `auto` / `supervised` mode arms of
+    /// [`check`](ToolPolicy::check), which is what keeps this a narrowing: it
+    /// can turn a park those two tiers would otherwise raise into an allow,
+    /// and it is never reached for `readonly` (denies before the mode
+    /// dispatch) or `full` (never parks here at all). Everything above the
+    /// mode dispatch — the reserved `never_do` slot, the S2 web-deflection
+    /// deny, the `readonly` brake, both grant arms, `always_approve`, the
+    /// daily cap — has already had its say and none of it reads this.
+    ///
+    /// [`crate::harness::built_in::run_origin::current`] is fail-closed by
+    /// construction, so every early `false` below is this predicate refusing
+    /// to admit rather than the origin failing to supply an answer.
+    fn trusted_dispatch_admits(
+        &self,
+        tool: &str,
+        args: &serde_json::Value,
+        consequence: crate::policy::Consequence,
+    ) -> bool {
+        // Issue #674's split, reasserted here rather than merely documented:
+        // `judge` is silent on an authored workflow node, so admitting one
+        // through trust as well would remove the ceiling `always_approve`
+        // still leaves on that path. `for_authored_workflow_nodes` is the only
+        // constructor that sets this, and this arm must never fire for it.
+        if self.call_path != CallPath::Agent {
+            return false;
+        }
+        // `Standing::PerCall` is exactly "every call is its own decision" —
+        // the set an operator could never have handed over ahead of time, so
+        // there is nothing here for a dispatched run to have inherited.
+        if consequence.standing == Standing::PerCall {
+            return false;
+        }
+        // The consequence floor outranks every trust this module hands out.
+        // `None` for the cap matches `judge`'s own reading — any declared
+        // amount stops.
+        //
+        // It cannot change an outcome today, and that is worth saying rather
+        // than discovering. Two reasons, and both could stop being true:
+        // every tool the floor names is `PerCall`, which the arm above already
+        // refused (the one `Grantable` tool with a consequence group,
+        // `publish_artifact`, is deferred by #658 so the floor is silent on
+        // it); and the money arm is caught anyway by `judge` at the tail of
+        // `check`, which re-judges whatever the tier allowed.
+        //
+        // Removing it therefore keeps the suite green — verified, not assumed.
+        // It stays because the second reason is positional: if epic #1817's
+        // floor becomes an enforced arm ABOVE the `policy_hitl_enabled`
+        // bypass, `judge`'s tail placement no longer covers a call this
+        // function admitted, and this line is what keeps trust from outranking
+        // the floor on that day. The first reason is one `DECLARED` edit away
+        // from changing on its own.
+        if crate::policy::floor::evaluate_consequence(tool, consequence, args, None)
+            .requires_human()
+        {
+            return false;
+        }
+        let crate::harness::built_in::run_origin::RunOrigin::Dispatched { agent, scope, .. } =
+            crate::harness::built_in::run_origin::current()
+        else {
+            return false;
+        };
+        // The dispatched agent, not this call's arguments, is what earned the
+        // trust — and the checking policy's own `self.agent` is the identity
+        // actually making this call. A delegate running under an origin its
+        // dispatch never named is exactly the escalation `run_origin`'s own
+        // docs warn against; the mismatch here is what stops it.
+        if self.agent.as_deref() != Some(agent.as_str()) {
+            return false;
+        }
+        match consequence.standing {
+            Standing::Grantable => true,
+            Standing::ScopedGrantable => {
+                // A scope that cannot be derived refuses rather than admits —
+                // the same direction `StandingGrant::admits_scope` takes for a
+                // live call whose scope reads `None` against a scoped grant.
+                let Some(call_scope) = crate::policy::consequence::standing_scope_of(tool, args)
+                else {
+                    return false;
+                };
+                scope.as_deref() == Some(call_scope.as_str())
+            }
+            Standing::PerCall => unreachable!("returned above"),
+        }
+    }
 }
 
 #[async_trait]
@@ -1833,7 +1921,11 @@ impl ToolPolicy for ApprovalPolicy {
             // company-context downgrade, graded by `consequence_for` before the
             // table verdict is taken (issue #877).
             PolicyMode::Auto => {
-                if consequence.parks_under_auto() {
+                if !consequence.parks_under_auto()
+                    || self.trusted_dispatch_admits(tool, &request.arguments, consequence)
+                {
+                    ToolPolicyDecision::Allow
+                } else {
                     self.require_approval(
                         tool,
                         &request.arguments,
@@ -1841,19 +1933,19 @@ impl ToolPolicy for ApprovalPolicy {
                             "'{tool}' leaves the company or spends money, and this desk runs auto"
                         ),
                     )
-                } else {
-                    ToolPolicyDecision::Allow
                 }
             }
             PolicyMode::Supervised => {
-                if reach.parks_under_supervision() {
+                if !reach.parks_under_supervision()
+                    || self.trusted_dispatch_admits(tool, &request.arguments, consequence)
+                {
+                    ToolPolicyDecision::Allow
+                } else {
                     self.require_approval(
                         tool,
                         &request.arguments,
                         format!("'{tool}' has an external effect and this desk runs supervised"),
                     )
-                } else {
-                    ToolPolicyDecision::Allow
                 }
             }
             PolicyMode::Readonly => {
@@ -6488,5 +6580,425 @@ mod tests {
             ),
             "the S2 arm must sit above the grant checks"
         );
+    }
+
+    // Issue #2150 (Rung 3, epic #1817): trusted-dispatch-origin admission.
+    //
+    // These tests exercise `trusted_dispatch_admits` both through `check()`
+    // (real declared tools, real tiers) and directly (the `ScopedGrantable`
+    // scope-matching branch, which no tool in today's declaration table
+    // reaches through `check()` — the same gap
+    // `a_grant_scoped_to_one_provider_does_not_admit_another_providers_read`
+    // above records for the standing-grant scope check this mirrors).
+
+    use crate::harness::built_in::run_origin::{DispatchSource, RunOrigin, claim};
+
+    fn dispatched(agent: &str) -> crate::harness::built_in::run_origin::RunOriginClaim {
+        claim(RunOrigin::Dispatched {
+            agent: agent.to_string(),
+            source: DispatchSource::Task,
+            scope: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn an_unlabelled_turn_decides_exactly_as_before() {
+        let p = policy("supervised", &[], None).with_agent("ops");
+        assert!(
+            matches!(
+                p.check(&request("file_write", serde_json::json!({}))).await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "no origin was scoped, so this must park exactly as it did before #2150"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_operator_origin_decides_the_same_as_unlabelled() {
+        let p = policy("supervised", &[], None).with_agent("ops");
+        let origin = claim(RunOrigin::Operator);
+        assert!(
+            matches!(
+                origin
+                    .scoped(p.check(&request("file_write", serde_json::json!({}))))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "a live operator turn earns no trust from this arm — only `Dispatched` does"
+        );
+    }
+
+    /// The headline case: a call an operator could already have granted
+    /// standing for (`Standing::Grantable`, so no scope to check) parks under
+    /// `supervised` absent a grant — `an_expired_standing_grant_re_parks`
+    /// above pins that baseline — and a dispatched run whose agent matches is
+    /// admitted without ever raising an approval row.
+    #[tokio::test]
+    async fn a_dispatched_run_admits_a_grantable_call_with_no_approval_row() {
+        let queue = ApprovalRequestQueue::default();
+        let p = policy("supervised", &[], None)
+            .with_requests(queue.clone())
+            .with_agent("ops");
+        let origin = dispatched("ops");
+        assert_eq!(
+            origin
+                .scoped(p.check(&request("file_write", serde_json::json!({}))))
+                .await,
+            ToolPolicyDecision::Allow,
+            "a scratch write is exactly what an operator could have granted standing for"
+        );
+        assert_eq!(
+            queue.queued(),
+            0,
+            "an admitted call must never raise an approval row"
+        );
+    }
+
+    /// A dispatched run carrying money still reaches a person.
+    ///
+    /// This pins the **outcome**, not any one arm, and the distinction is
+    /// deliberate. `trusted_dispatch_admits` consults the consequence floor,
+    /// but deleting that consultation leaves this test — and the whole suite —
+    /// green, because `judge` re-judges whatever the tier allowed and stops a
+    /// declared amount at the tail of `check`. The floor consultation is a belt
+    /// whose braces are `judge`; see the note at that line for the two facts
+    /// that make it unreachable today and what would change either.
+    ///
+    /// What this test is worth is the property itself: trust granted for being
+    /// dispatched must not become permission to spend. Whichever arm enforces
+    /// that, an operator sees the call.
+    ///
+    /// `supervised` rather than `auto`, deliberately: under `auto` a
+    /// `Grantable` tool never reaches the trusted arm at all, so the test would
+    /// pass without exercising the admission path.
+    #[tokio::test]
+    async fn the_consequence_floor_outranks_a_trusted_dispatch() {
+        let queue = ApprovalRequestQueue::default();
+        let p = policy("supervised", &[], None)
+            .with_requests(queue.clone())
+            .with_agent("ops");
+        let origin = dispatched("ops");
+        let spend = serde_json::json!({ "amount_usd": 500.0 });
+        assert!(
+            matches!(
+                origin.scoped(p.check(&request("file_write", spend))).await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "a dispatched run carrying money must reach a person, whatever the tool's standing"
+        );
+        assert_eq!(
+            queue.queued(),
+            1,
+            "and it must raise exactly one approval row for them to answer"
+        );
+    }
+
+    /// The same run, calling a `Standing::PerCall` tool, still raises exactly
+    /// one approval row — trust never reaches a call nobody could have handed
+    /// over ahead of time.
+    #[tokio::test]
+    async fn a_dispatched_run_still_parks_a_percall_send() {
+        let queue = ApprovalRequestQueue::default();
+        let p = policy("supervised", &[], None)
+            .with_requests(queue.clone())
+            .with_agent("ops");
+        let origin = dispatched("ops");
+        assert!(
+            matches!(
+                origin
+                    .scoped(p.check(&request("composio_execute", composio_send_args())))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "a send is `Standing::PerCall` — nothing here for a dispatch to have earned"
+        );
+        assert_eq!(queue.queued(), 1, "exactly one approval row for the send");
+    }
+
+    /// Delegation must not be a privilege-escalation primitive: an origin
+    /// dispatched to one agent must not admit a call from a different agent's
+    /// policy instance, even though the task-local is still ambient (the
+    /// same-task inheritance `run_origin`'s own tests cover).
+    #[tokio::test]
+    async fn a_mismatched_agent_does_not_admit() {
+        let p = policy("supervised", &[], None).with_agent("marketing");
+        let origin = dispatched("ops");
+        assert!(
+            matches!(
+                origin
+                    .scoped(p.check(&request("file_write", serde_json::json!({}))))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "the dispatch named `ops`; a different agent's policy must not be trusted by it"
+        );
+    }
+
+    /// Issue #674's split, reasserted at the constructor: `judge` is silent on
+    /// an authored workflow node, so admitting one through trust as well would
+    /// remove the ceiling `always_approve` still leaves on that path.
+    #[tokio::test]
+    async fn the_arm_never_fires_for_an_authored_workflow_node() {
+        let p = policy("supervised", &[], None)
+            .with_agent("ops")
+            .for_authored_workflow_nodes();
+        let origin = dispatched("ops");
+        assert!(
+            matches!(
+                origin
+                    .scoped(p.check(&request("file_write", serde_json::json!({}))))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "an authored node must never be admitted by this arm, whatever the origin says"
+        );
+    }
+
+    /// `shell` is `Standing::PerCall` (arbitrary code, unbounded reach) and an
+    /// undeclared tool defaults to `Standing::PerCall` too (never `Grantable`
+    /// by omission) — both stop for a human whatever this run's origin says.
+    #[tokio::test]
+    async fn shell_and_an_undeclared_tool_still_park_under_a_dispatched_origin() {
+        let p = policy("supervised", &[], None).with_agent("ops");
+        for tool in ["shell", "some_tool_nobody_declared"] {
+            let origin = dispatched("ops");
+            assert!(
+                matches!(
+                    origin
+                        .scoped(p.check(&request(tool, serde_json::json!({}))))
+                        .await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "`{tool}` must still park inside a dispatched run"
+            );
+        }
+    }
+
+    /// The consequence floor (issue #1817's own arm) outranks a trusted
+    /// origin for every tool it declares irreversible — exhaustive over the
+    /// declaration table, the same style `floor`'s own tests use, so a future
+    /// tool added to either table is covered without a second hand-written
+    /// list.
+    #[tokio::test]
+    async fn a_dispatched_origin_still_parks_every_floor_covered_tool() {
+        for tool in crate::policy::consequence::declared_tools() {
+            let args = serde_json::json!({});
+            let consequence = crate::policy::consequence_of(tool, &args);
+            if !crate::policy::floor::evaluate_consequence(tool, consequence, &args, None)
+                .requires_human()
+            {
+                continue;
+            }
+            for mode in ["auto", "supervised"] {
+                let p = policy(mode, &[], None).with_agent("ops");
+                let origin = dispatched("ops");
+                let decision = origin.scoped(p.check(&request(tool, args.clone()))).await;
+                assert!(
+                    !matches!(decision, ToolPolicyDecision::Allow),
+                    "`{tool}` commits the company under `{mode}`; a dispatched origin must \
+                     never admit it, got {decision:?}"
+                );
+            }
+        }
+    }
+
+    /// [`crate::policy::consequence::standing_scope_of`] is the same reader a
+    /// standing grant's mint side uses. Pinned **directly** against
+    /// `trusted_dispatch_admits` rather than through `check()` — no tool in
+    /// today's declaration table reaches `Standing::ScopedGrantable` with a
+    /// reach that parks (`web_fetch` is the only classifier that produces the
+    /// variant, and it pairs the variant exclusively with `Reach::ExternalRead`,
+    /// which parks nowhere — see `a_grant_scoped_to_one_provider_does_not_admit_another_providers_read`
+    /// above for the same gap on the standing-grant path). A synthetic
+    /// `Consequence` is the only way to exercise the branch this codebase's own
+    /// tables cannot reach yet.
+    fn scoped_grantable() -> crate::policy::Consequence {
+        crate::policy::Consequence {
+            group: EffectGroup::Other,
+            reach: crate::policy::Reach::Consequence,
+            standing: Standing::ScopedGrantable,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_scope_matched_call_inside_a_trusted_run_is_admitted() {
+        let p = policy("supervised", &[], None).with_agent("ops");
+        let origin = claim(RunOrigin::Dispatched {
+            agent: "ops".to_string(),
+            source: DispatchSource::Task,
+            scope: Some("gmail".to_string()),
+        });
+        let admitted = origin
+            .scoped(async {
+                p.trusted_dispatch_admits(
+                    "composio_execute",
+                    &composio_send_args(),
+                    scoped_grantable(),
+                )
+            })
+            .await;
+        assert!(
+            admitted,
+            "the call's own scope (gmail, from GMAIL_SEND_EMAIL) matches the run's declared scope"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_out_of_scope_call_inside_a_trusted_run_still_parks() {
+        let p = policy("supervised", &[], None).with_agent("ops");
+        let origin = claim(RunOrigin::Dispatched {
+            agent: "ops".to_string(),
+            source: DispatchSource::Task,
+            scope: Some("github".to_string()),
+        });
+        let admitted = origin
+            .scoped(async {
+                p.trusted_dispatch_admits(
+                    "composio_execute",
+                    &composio_send_args(),
+                    scoped_grantable(),
+                )
+            })
+            .await;
+        assert!(
+            !admitted,
+            "the run is scoped to github; a call whose own scope resolves to gmail must still park"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_underivable_scope_refuses_rather_than_admits() {
+        let p = policy("supervised", &[], None).with_agent("ops");
+        // No scope declared on the run either — the underivable-call-scope
+        // refusal must hold even when it would otherwise be the more
+        // permissive reading (an unscoped run admitting an unscoped call).
+        let origin = dispatched("ops");
+        let admitted = origin
+            .scoped(async {
+                p.trusted_dispatch_admits(
+                    "composio_execute",
+                    &composio_unclassified_args(),
+                    scoped_grantable(),
+                )
+            })
+            .await;
+        assert!(
+            !admitted,
+            "an action the catalogue cannot place resolves no scope; refuse rather than admit"
+        );
+    }
+
+    /// Everything above the mode dispatch keeps deciding first, whatever this
+    /// run's origin says: the `readonly` brake, `always_approve`, the daily
+    /// spend cap, and a standing deny.
+    #[tokio::test]
+    async fn a_dispatched_origin_does_not_bypass_the_arms_above_the_mode_dispatch() {
+        // `readonly` denies an external effect before any grant or origin is
+        // consulted.
+        let p = policy("readonly", &[], None).with_agent("ops");
+        assert!(
+            matches!(
+                dispatched("ops")
+                    .scoped(p.check(&request("file_write", serde_json::json!({}))))
+                    .await,
+                ToolPolicyDecision::Deny { .. }
+            ),
+            "readonly must still deny, dispatched origin or not"
+        );
+
+        // `always_approve` wins over every tier, `full` included.
+        let p = policy("full", &["file_write"], None).with_agent("ops");
+        assert!(
+            matches!(
+                dispatched("ops")
+                    .scoped(p.check(&request("file_write", serde_json::json!({}))))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "always_approve must still park under full, dispatched origin or not"
+        );
+
+        // The per-agent daily cap parks a priced call once the agent is out of
+        // budget, above the tier dispatch entirely.
+        let meter = FixedMeter::with(vec![spend_sample("ops", 5.00, today())]);
+        let (capped, _) = capped_policy("supervised", None, 5.0, "ops", meter);
+        assert!(
+            matches!(
+                dispatched("ops")
+                    .scoped(capped.check(&request(
+                        "web_search",
+                        serde_json::json!({ "query": "acme pricing" })
+                    )))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "the daily cap must still park at cap, dispatched origin or not"
+        );
+
+        // A standing deny is a company saying "not this", which a run's own
+        // origin cannot override.
+        let (denying, grants) = granting_policy("supervised", &[], "ops");
+        grants.grant_standing(standing_verdict(
+            "ops",
+            "file_write",
+            far_future(),
+            Verdict::Deny,
+        ));
+        assert!(
+            matches!(
+                dispatched("ops")
+                    .scoped(denying.check(&request("file_write", serde_json::json!({}))))
+                    .await,
+                ToolPolicyDecision::Deny { .. }
+            ),
+            "a standing deny must still refuse, dispatched origin or not"
+        );
+    }
+
+    /// Structural proof that the arm adds nothing outside `auto`/`supervised`:
+    /// scoping a dispatched origin must never change `full`'s or `readonly`'s
+    /// verdict, because the code for this arm is not reachable from either of
+    /// their match arms.
+    #[tokio::test]
+    async fn the_arm_is_inert_under_full_and_readonly() {
+        for mode in ["full", "readonly"] {
+            let p = policy(mode, &[], None).with_agent("ops");
+            let baseline = p.check(&request("file_write", serde_json::json!({}))).await;
+            let with_origin = dispatched("ops")
+                .scoped(p.check(&request("file_write", serde_json::json!({}))))
+                .await;
+            assert_eq!(
+                with_origin, baseline,
+                "`{mode}` must decide identically whether or not a dispatch origin is scoped"
+            );
+        }
+    }
+
+    /// [`standing`] mints an `Approve` grant; this is its `Deny` twin, needed
+    /// once here to prove a standing deny still outranks a trusted origin.
+    fn standing_verdict(
+        agent: &str,
+        tool: &str,
+        expires_at_millis: u64,
+        verdict: Verdict,
+    ) -> crate::runtime::grants::StandingGrant {
+        crate::runtime::grants::StandingGrant {
+            id: crate::runtime::grants::GrantId::new("deny-standing-1"),
+            agent: agent.to_string(),
+            workflow: None,
+            tool: tool.to_string(),
+            verdict,
+            granted_by: crate::ports::types::Actor {
+                kind: crate::ports::types::ActorKind::User,
+                id: "user-1".into(),
+            },
+            approval_id: crate::ports::types::ApprovalId::new("appr-deny-1"),
+            at_millis: 1_000,
+            expires_at_millis,
+            origin_thread: None,
+            origin_parent: None,
+            origin_task: None,
+            scope: None,
+        }
     }
 }

--- a/src/harness/built_in/run_origin.rs
+++ b/src/harness/built_in/run_origin.rs
@@ -1,0 +1,224 @@
+//! Which run dispatched the current agent turn (issue #2150, Rung 3 of epic
+//! #1817).
+//!
+//! Vendored OpenHuman answers the same question for its own turns with
+//! `AgentTurnOrigin`
+//! (`vendor/openhuman/src/openhuman/agent/turn_origin.rs`), read by its
+//! approval gate at `vendor/openhuman/src/openhuman/security/approval/gate.rs`.
+//! This is the same shape at OpenCompany's own dispatch layer — a company can
+//! run a task card, a workflow node or a scheduled job with nobody watching,
+//! and [`ApprovalPolicy::check`](crate::harness::built_in::policy::ApprovalPolicy::check)
+//! needs to tell that apart from a model improvising inside a live operator
+//! chat.
+//!
+//! An unlabelled turn reads as [`RunOrigin::Unknown`] and stays untrusted —
+//! [`current`]'s `unwrap_or` is that fail-closed default, not a convenience.
+
+use std::future::Future;
+
+/// Who dispatched the current agent turn.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RunOrigin {
+    /// No entry point scoped a real origin.
+    Unknown,
+    /// A live operator chat turn.
+    Operator,
+    /// A turn this company dispatched itself, with no operator watching it
+    /// happen.
+    Dispatched {
+        /// The roster agent this run was dispatched to.
+        ///
+        /// Compared against the checking [`ApprovalPolicy`]'s own agent, so an
+        /// origin carried across a same-turn delegation hand-off cannot admit
+        /// a call the delegate itself was never dispatched to make —
+        /// delegation inherits this origin unchanged rather than re-deriving
+        /// it, so the mismatch is exactly what stops trust from widening at
+        /// the hand-off.
+        ///
+        /// [`ApprovalPolicy`]: crate::harness::built_in::policy::ApprovalPolicy
+        agent: String,
+        /// Which kind of dispatch this was.
+        source: DispatchSource,
+        /// The scope this trust is confined to, when the dispatch declared
+        /// one.
+        ///
+        /// `None` admits only a call whose
+        /// [`Standing`](crate::policy::Standing) needs no scope at all
+        /// (`Standing::Grantable`) — never a
+        /// [`Standing::ScopedGrantable`](crate::policy::Standing::ScopedGrantable)
+        /// call, whatever scope that call itself resolves to. An unscoped
+        /// grant admitting everything is exactly what
+        /// [`crate::runtime::grants`] calls catastrophic; an unscoped origin
+        /// must not reproduce that shape for the trust this module hands out
+        /// instead of a grant.
+        scope: Option<String>,
+    },
+}
+
+/// Which kind of dispatch produced a [`RunOrigin::Dispatched`] turn.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DispatchSource {
+    /// A task card the board dispatched to its assignee.
+    Task,
+    /// A saved workflow's agent node, or the peer consultation a recovery
+    /// rung raises on its behalf.
+    Workflow {
+        /// The workflow this run belongs to.
+        workflow_id: String,
+    },
+    /// A scheduled run with no operator watching.
+    Schedule,
+}
+
+tokio::task_local! {
+    static RUN_ORIGIN: RunOrigin;
+}
+
+/// The ambient origin, or [`RunOrigin::Unknown`] when nothing scoped one.
+///
+/// The `unwrap_or` is the fail-closed requirement this whole module rests on:
+/// a caller that forgot to scope an origin — or one running detached from any
+/// scope at all, such as a `tokio::spawn`ed task nothing re-scoped — reads as
+/// unlabelled rather than as whatever the last scope happened to leave
+/// behind.
+pub fn current() -> RunOrigin {
+    RUN_ORIGIN
+        .try_with(Clone::clone)
+        .unwrap_or(RunOrigin::Unknown)
+}
+
+/// One turn's exclusive hold on a [`RunOrigin`] (issue #2150).
+///
+/// Modelled on [`ApprovalClaim`](crate::harness::built_in::policy::ApprovalClaim):
+/// obtained once via [`claim`] and scoped around the turn with
+/// [`scoped`](Self::scoped). `tokio::task_local`'s own `scope` already
+/// installs and removes its value around each individual poll rather than for
+/// the future's whole lifetime, so an early return, a panic unwinding through
+/// the scoped future, or the future being dropped mid-poll by a cancellation
+/// all leave no origin installed for whatever runs next on this task — a
+/// hand-dropped guard is not what makes that safe. This type exists so the
+/// open/close of a trust window reads as the same claim-and-scope pair as
+/// every other one in this file, and so its `Drop` gives the open/close a
+/// symmetric debug-log trace.
+pub struct RunOriginClaim {
+    origin: RunOrigin,
+}
+
+impl RunOriginClaim {
+    /// The origin this claim carries.
+    pub fn origin(&self) -> &RunOrigin {
+        &self.origin
+    }
+
+    /// Runs `fut` with this claim's origin installed as the ambient one.
+    ///
+    /// Mirrors [`ApprovalClaim::scoped`](crate::harness::built_in::policy::ApprovalClaim::scoped):
+    /// this does not box `fut` itself — the caller does, same as every other
+    /// claim in this file. A dispatch site is typically already nested inside
+    /// an [`ApprovalScope`](crate::harness::built_in::policy::ApprovalScope)
+    /// claim (and, at the workflow agent node, a `DelegationScope` claim
+    /// beneath that too) — three task-local scopes wrapping one very large
+    /// openhuman agent turn future have overflowed the worker thread's stack
+    /// before (`.cargo/config.toml`, issue #895), so a caller nesting this
+    /// scope inside others must box its future before passing it here.
+    pub async fn scoped<F: Future>(&self, fut: F) -> F::Output {
+        RUN_ORIGIN.scope(self.origin.clone(), fut).await
+    }
+}
+
+impl Drop for RunOriginClaim {
+    fn drop(&mut self) {
+        tracing::trace!(origin = ?self.origin, "[run_origin] dispatch origin scope closed");
+    }
+}
+
+/// Claims `origin` for the span of one turn.
+pub fn claim(origin: RunOrigin) -> RunOriginClaim {
+    tracing::trace!(?origin, "[run_origin] dispatch origin scope opened");
+    RunOriginClaim { origin }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn unscoped_reads_as_unknown() {
+        assert_eq!(current(), RunOrigin::Unknown);
+    }
+
+    #[tokio::test]
+    async fn a_dispatched_origin_is_readable_inside_its_scope() {
+        let dispatched = RunOrigin::Dispatched {
+            agent: "researcher".to_string(),
+            source: DispatchSource::Task,
+            scope: None,
+        };
+        let claim = claim(dispatched.clone());
+        let observed = claim.scoped(async { current() }).await;
+        assert_eq!(observed, dispatched);
+    }
+
+    #[tokio::test]
+    async fn an_origin_does_not_escape_its_scope() {
+        let claim = claim(RunOrigin::Dispatched {
+            agent: "researcher".to_string(),
+            source: DispatchSource::Task,
+            scope: None,
+        });
+        claim.scoped(async {}).await;
+        // The claim is still alive (not dropped) but its `scope` future has
+        // ended — the ambient origin outside that future must not carry it.
+        assert_eq!(current(), RunOrigin::Unknown);
+    }
+
+    #[tokio::test]
+    async fn nested_scopes_restore_the_outer_origin_on_the_way_out() {
+        let outer = claim(RunOrigin::Dispatched {
+            agent: "researcher".to_string(),
+            source: DispatchSource::Task,
+            scope: None,
+        });
+        outer
+            .scoped(async {
+                let inner = claim(RunOrigin::Dispatched {
+                    agent: "engineer".to_string(),
+                    source: DispatchSource::Schedule,
+                    scope: None,
+                });
+                inner.scoped(async {}).await;
+                assert_eq!(
+                    current(),
+                    RunOrigin::Dispatched {
+                        agent: "researcher".to_string(),
+                        source: DispatchSource::Task,
+                        scope: None,
+                    }
+                );
+            })
+            .await;
+    }
+
+    /// A delegate that runs on a **new task** (a `tokio::spawn` this module
+    /// never re-scoped) must not inherit the parent's origin — the same
+    /// fail-closed default as never scoping one at all. Same-task delegation
+    /// (the ordinary hand-off path, a direct nested `.await` with no spawn in
+    /// between) is covered by `a_dispatched_origin_is_readable_inside_its_scope`
+    /// above: a plain nested call reads the same ambient origin its caller
+    /// did, with no extra code, which is what "inherit rather than re-derive"
+    /// means at `src/runtime/delegation.rs`.
+    #[tokio::test]
+    async fn a_spawned_task_does_not_inherit_the_parent_origin() {
+        let parent = claim(RunOrigin::Dispatched {
+            agent: "researcher".to_string(),
+            source: DispatchSource::Workflow {
+                workflow_id: "wf-1".to_string(),
+            },
+            scope: None,
+        });
+        let observed = parent
+            .scoped(async { tokio::spawn(async { current() }).await.unwrap() })
+            .await;
+        assert_eq!(observed, RunOrigin::Unknown);
+    }
+}

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1214,6 +1214,7 @@ impl HarnessAgentRunner {
             turn: self.turn.as_ref(),
             record: &self.record,
             exclude_agent: agent_ref,
+            workflow_id: &self.workflow_id,
         };
         let approval_claim = self
             .deps
@@ -2593,6 +2594,17 @@ impl HarnessAgentRunner {
             .deps
             .approval_requests
             .claim(ApprovalScope::Run(self.run_id.clone()));
+        // Issue #2150: this node's trust window, named by the agent it
+        // dispatched to and the workflow it belongs to.
+        let origin_claim = crate::harness::built_in::run_origin::claim(
+            crate::harness::built_in::run_origin::RunOrigin::Dispatched {
+                agent: agent_ref.to_string(),
+                source: crate::harness::built_in::run_origin::DispatchSource::Workflow {
+                    workflow_id: self.workflow_id.clone(),
+                },
+                scope: None,
+            },
+        );
         // Issue #661 (M5): the turn AND its post-turn drains run inside the run's
         // board scope, so a `spawn_task` the model calls files into this run's
         // bucket and the drain below reads that same bucket back. The claim itself
@@ -2601,27 +2613,31 @@ impl HarnessAgentRunner {
         //
         // **Every layer here is `Box::pin`ed, and that is load-bearing.** This
         // nests one task-local scope inside another (`ApprovalScope` inside
-        // `DelegationScope`), and `TaskLocalFuture` stores its inner future
-        // *inline* — so without boxing, an openhuman agent turn (already a very
-        // large future) is held by value inside two nested wrappers and the
-        // composed state blows the thread's stack. Verified: it overflows on the
-        // first spawning run without these.
+        // `DelegationScope`, now also the dispatch-origin scope), and
+        // `TaskLocalFuture` stores its inner future *inline* — so without
+        // boxing, an openhuman agent turn (already a very large future) is held
+        // by value inside these nested wrappers and the composed state blows
+        // the thread's stack. Verified: it overflows on the first spawning run
+        // without these.
         let turn = Box::pin(async {
             let outcome = claim
-                .scoped(Box::pin(self.turn.run_background_workflow(
-                    &self.company,
-                    agent_ref,
-                    &message,
-                    run_sink.clone(),
-                    // The workflow run + node this turn belongs to (issue #1702):
-                    // its live tool-call frames stream tagged with these so the
-                    // console's run-trace sheet appends them under the right run
-                    // while the node is still executing. `lineage_node` is the
-                    // resolved node id (graph node, else the agent ref) — the
-                    // same id the durable trace attributes the node's steps to.
-                    &self.run_id,
-                    &lineage_node,
-                )))
+                .scoped(Box::pin(origin_claim.scoped(Box::pin(
+                    self.turn.run_background_workflow(
+                        &self.company,
+                        agent_ref,
+                        &message,
+                        run_sink.clone(),
+                        // The workflow run + node this turn belongs to (issue
+                        // #1702): its live tool-call frames stream tagged with
+                        // these so the console's run-trace sheet appends them
+                        // under the right run while the node is still
+                        // executing. `lineage_node` is the resolved node id
+                        // (graph node, else the agent ref) — the same id the
+                        // durable trace attributes the node's steps to.
+                        &self.run_id,
+                        &lineage_node,
+                    ),
+                ))))
                 .await;
             // Drained on BOTH arms, deliberately. A turn that errored may still have
             // had a tool call gated before it failed, and that request is just as

--- a/src/workflows/judge.rs
+++ b/src/workflows/judge.rs
@@ -286,6 +286,10 @@ pub struct PeerConsult<'a> {
     pub turn: &'a dyn RunTurn,
     pub record: &'a CompanyRecord,
     pub exclude_agent: &'a str,
+    /// The workflow this recovery rung belongs to (issue #2150), so the
+    /// peer's turn can be scoped with the same `RunOrigin::Dispatched`
+    /// trust a workflow agent node's own turn carries.
+    pub workflow_id: &'a str,
 }
 
 /// How the one peer consultation ended, so `ask_around` can log each outcome
@@ -376,9 +380,24 @@ async fn consult_peer(
         return PeerOutcome::NoRoleMatched;
     };
     let ask = peer_prompt(question);
+    // Issue #2150: the peer's turn is dispatched by this recovery rung, not
+    // asked by an operator — the same trust a workflow agent node's own turn
+    // carries, named for the peer actually chosen rather than the node that
+    // raised the question.
+    let origin = crate::harness::built_in::run_origin::claim(
+        crate::harness::built_in::run_origin::RunOrigin::Dispatched {
+            agent: peer.id.clone(),
+            source: crate::harness::built_in::run_origin::DispatchSource::Workflow {
+                workflow_id: consult.workflow_id.to_string(),
+            },
+            scope: None,
+        },
+    );
     match tokio::time::timeout(
         PEER_TIMEOUT,
-        consult.turn.run_background(company, &peer.id, &ask, None),
+        origin.scoped(Box::pin(
+            consult.turn.run_background(company, &peer.id, &ask, None),
+        )),
     )
     .await
     {
@@ -1224,6 +1243,7 @@ role = "Renewal Team"
                 turn: stub,
                 record,
                 exclude_agent: "researcher",
+                workflow_id: "wf",
             }),
         )
         .await
@@ -1392,6 +1412,7 @@ role = "Renewal Team"
                 turn: &stub,
                 record: &record,
                 exclude_agent: "researcher",
+                workflow_id: "wf",
             }),
         )
         .await;
@@ -1439,6 +1460,7 @@ role = "Renewal Team"
                 turn: &stub,
                 record: &record,
                 exclude_agent: "researcher",
+                workflow_id: "wf",
             }),
         )
         .await;


### PR DESCRIPTION
## Summary

Closes #2150. Part of #1817 (Rung 3 of its precedence chain).

`ApprovalPolicy::check` decides from company configuration and the call's own arguments only — nothing told it *who dispatched this turn*, so a scheduled card, a workflow node and an operator typing in chat were indistinguishable. Epic #1817 asks for a dispatched run to stop deadlocking on calls an operator could have pre-authorised.

`RunOrigin` rides a task-local with an RAII claim, so an early return or a panic cannot leave an origin installed for the next turn. An unlabelled turn reads `Unknown` and stays untrusted — that `unwrap_or` is the fail-closed default. It cannot be a field on the policy: that instance is roster-cached and shared across concurrent turns, which is why `CURRENT_SCOPE` in the same file already exists in this shape. The design mirrors the vendored runtime's `AgentTurnOrigin`, which answers the same question for OpenHuman's own turns.

Trust is narrow by construction, and every narrowing is tested: the call must be one an operator could have granted standing for; the dispatch must name *this* agent; a scoped tool must match the dispatch's scope, and a scope that cannot be derived **refuses** rather than admits (an unscoped grant admits everything — see #2163). Authored workflow nodes are refused outright, because `judge` is silent on that path and the combination would remove the ceiling.

**This ships dormant, and that is worth stating plainly.** With policy HITL disabled (#1925) almost nothing parks, so the arm unblocks a deadlock that currently cannot occur. It becomes load-bearing if #1817's consequence floor lands — and that floor is designed to outrank it.

## API Or Behavior Changes

Under `supervised` and `auto`, a call that would have parked is allowed when a dispatched origin is in scope and the call passes every narrowing above. Nothing else moves: `Full` and `Readonly` are untouched, the arm sits inside the tier dispatch and can only turn a park into an allow, and `judge` still re-judges whatever the tier allowed.

**A finding worth recording**, because it changes what one line in this PR can claim. `trusted_dispatch_admits` consults the consequence floor. I red-proofed that consultation by deleting it: the suite stayed green. Two reasons, both verified — every tool the floor names is `Standing::PerCall`, which the arm above already refuses (the one `Grantable` tool with a consequence group, `publish_artifact`, is deferred by #658), and the reachable money path is caught anyway by `judge` at the tail of `check`.

So it is a belt whose braces are `judge`. It stays, with the reasoning at the line, because the second reason is positional: if #1817's floor becomes an arm above the `policy_hitl_enabled` bypass, `judge`'s tail placement no longer covers a call this function admitted. The first reason is one `DECLARED` edit from changing on its own. I would rather ship an unreachable guard that says it is unreachable than one that reads as load-bearing and is not.

## Tests

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --features openhuman --no-deps -- -D warnings` — clean (fixed an `if_same_then_else` where the tier check and the trusted check were separate branches returning the same value; collapsed to one `||`, which also reads truer)
- `cargo test --features openhuman` — **7318 passed, 0 failed**, 22 ignored, all integration targets green
- `cargo test --locked --features tinyplace --lib` — the other feature set, where the curated Composio catalogue is not compiled in

Coverage: an unlabelled turn decides exactly as before; an operator origin decides as an unlabelled one; a mismatched agent does not admit; an out-of-scope call still parks; an underivable scope refuses; a `PerCall` send still raises exactly one approval row; `shell` and undeclared tools still park; the arm never fires for an authored workflow node; the arm adds nothing under `full` or `readonly`; an origin does not escape its scope; a delegate inherits the ambient origin; a spawned task does not. Plus `the_consequence_floor_outranks_a_trusted_dispatch`, which pins the **outcome** — a dispatched run carrying money reaches a person — rather than claiming a specific arm enforces it, for the reason given above.

## Documentation

Module docs on `run_origin` explain what the origin is for, why the fail-closed default is the design rather than a convenience, and which entry points install it — including why the approval re-issue turn deliberately does not. The gate arm carries its own precedence argument, neighbour by neighbour, and the floor-consultation note records what the red proof found and the condition that would make that line matter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trusted execution handling for agent actions initiated through tasks and workflows.
  * Actions made during an approved dispatched run can proceed without repeated approval when they meet applicable safety and scope requirements.
  * Added workflow-aware context to peer recovery and background execution.

* **Bug Fixes**
  * Preserved dispatch authorization across redirected task runs, follow-up nudges, and peer recovery turns.
  * Prevented dispatch context from leaking beyond its execution scope or into separately spawned tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->