### PR TITLE
test(tour): ask for the roster until it settles, rather than once

### DIFF
--- a/frontend/test/e2e/tour-overlay-click.spec.ts
+++ b/frontend/test/e2e/tour-overlay-click.spec.ts
@@ -61,8 +61,30 @@ function opener(page: Page) {
 async function goToRoster(page: Page): Promise<void> {
   // By address rather than by clicking the nav: during a tour the nav is under
   // the overlay, which is the very thing under test.
-  await page.goto("/#/company");
-  await expect(opener(page)).toBeVisible({ timeout: 30_000 });
+  //
+  // Re-asserted in a poll rather than set once, because the tour navigates too.
+  // `TourController`'s per-step hook drives the console to the stop's own view,
+  // and stop one is not this page, so a single hand-set address races it: land
+  // before the hook and the tour takes the view straight back. Asking again
+  // until the roster is actually here settles that race in one direction
+  // without waiting on the tour's internals.
+  await expect
+    .poll(
+      async () => {
+        await page.evaluate(() => {
+          window.location.hash = "#/company";
+        });
+        return opener(page)
+          .waitFor({ state: "visible", timeout: 2_000 })
+          .then(() => true)
+          .catch(() => false);
+      },
+      {
+        timeout: 30_000,
+        message: "the Company roster never settled under the tour",
+      },
+    )
+    .toBe(true);
 }
 
 /**
@@ -109,10 +131,13 @@ test("a click on the dimmed page neither moves the tour nor changes the address"
   // Give a navigation the chance to happen before concluding none did.
   await page.waitForTimeout(750);
 
-  await expect(page, "the overlay must not carry the click into the Room").not.toHaveURL(
-    /#\/chat\/main$/,
+  await expect(
+    page,
+    "the overlay must not carry the click into the Room",
+  ).not.toHaveURL(/#\/chat\/main$/);
+  await expect(page, "the address must not move at all").toHaveURL(
+    /#\/company$/,
   );
-  await expect(page, "the address must not move at all").toHaveURL(/#\/company$/);
   await expect(
     tooltip.getByText(`Step 1 of ${TOUR_STOPS}`),
     "and the tour must not have stepped",
@@ -134,7 +159,9 @@ test("the tooltip's own Next still advances the tour", async ({ page }) => {
   ).toBeVisible();
 });
 
-test("with the tour dismissed the same card still opens the teammate", async ({ page }) => {
+test("with the tour dismissed the same card still opens the teammate", async ({
+  page,
+}) => {
   await page.goto("/#/company");
   await page.getByText(WELCOME).waitFor();
   await page.getByRole("button", { name: "Skip for now" }).click();


### PR DESCRIPTION
## Summary

`tour-overlay-click.spec.ts:92` fails on roughly **half of all CI runs**, on `main` and on every open PR. It is the single largest source of red lanes right now and it has cost several PRs a rerun each. It is a flake in the spec, not a defect in the console.

## Problem

The spec navigates to Company **by address** while the tour is running — deliberately, because during a tour the nav sits under the overlay, which is the thing under test.

But the tour navigates too. `TourController`'s per-step hook drives the console to that stop's own view, and stop one is not the Company page. So setting the address once races the hook: land before it fires and the tour takes the view straight back, and the roster the spec is about is never there.

Every failure is the same one, and it is always in the wait, never on the assertions the spec exists for:

```
Error: expect(locator).toBeVisible() failed
Locator: getByTestId('team-card').filter({ hasText: 'Chief Executive' })
           .first().getByTestId('team-card-open')
Timeout: 30000ms — element(s) not found
   at goToRoster (tour-overlay-click.spec.ts:65)
```

Two things confirm it is a race rather than a break. The sibling case at `:137` performs the same navigation and passes every time — it **skips the tour first**, so nothing competes for the view. And the failure rate tracks machine speed: about one run in six locally against roughly one in two on CI runners.

**A wrong theory, recorded because it cost a cycle.** I first read the second `page.goto("/#/company")` — to a URL the page is already on, which reloads — as the cause: a reload mid-tour would restart the console with the tour still running. Replacing it with a hash change did not help, and the failure came back unchanged at the same line on the eighth repeat. The reload was never the mechanism; the tour's own navigation is.

## Solution

Ask for the roster until it is actually there, instead of asking once:

```ts
await expect.poll(async () => {
  await page.evaluate(() => { window.location.hash = "#/company"; });
  return opener(page).waitFor({ state: "visible", timeout: 2_000 })
    .then(() => true).catch(() => false);
}, { timeout: 30_000 }).toBe(true);
```

This settles the race in one direction without reaching into the tour's internals and without a sleep. It tolerates a transient steal and still fails if the tour holds the view for the full timeout — so a real regression that made Company unreachable during a tour would still turn this red.

`expectOverlayCovers` is untouched. That is the precondition stopping this spec passing for the wrong reason — the file's own header records that an earlier version passed against a broken build because the click landed on the page rather than the overlay — so leaving it exactly as it was matters.

## Tests

Measured, not argued.

| | Target case | Whole file |
|---|---|---|
| Before, 6 repeats | 5 / 6 | 17 / 18 |
| After the wrong fix, 8 repeats | 7 / 8 | 23 / 24 |
| **After this change, 10 repeats** | **10 / 10** | **30 / 30** |

- [x] `npx playwright test tour-overlay-click --repeat-each=10` — 30 passed, 0 failed
- [x] `npm run typecheck:e2e` — rc=0
- [x] `npx prettier --check` — clean
- [ ] `cargo fmt --all -- --check` — N/A: no Rust in this change
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust in this change
- [ ] `cargo build --all-targets` — N/A: no Rust in this change
- [ ] `cargo test` — N/A: no Rust in this change

## Impact

One E2E spec. No console or host code changes. Every PR stops paying a coin flip on this lane.

## Related

None.