### PR TITLE
fix: serialize concurrent ledger declarations

### DIFF
--- a/src/company/ledgers.rs
+++ b/src/company/ledgers.rs
@@ -49,20 +49,33 @@ use crate::ledger::{
 use crate::ports::now_millis;
 use crate::ports::types::CompanyId;
 
-/// One company's one ledger, by slug — the key a write lock is scoped to.
-type LedgerKey = (CompanyId, String);
+/// What a write lock covers.
+///
+/// A ledger's rows are its own, so they lock per slug and unrelated ledgers
+/// never queue behind each other. The set of declarations is not any one
+/// ledger's: the cap counts across slugs, and no two ledgers may write the
+/// same derived file. Both are answered by reading every spec, so a
+/// declaration locks the registry rather than the slug it is about.
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum LockScope {
+    Registry,
+    Rows(String),
+}
 
-/// A registry of per-[`LedgerKey`] async locks, one per every distinct ledger
+/// One company's one lock scope — the key a write lock is held under.
+type LedgerKey = (CompanyId, LockScope);
+
+/// A registry of per-[`LedgerKey`] async locks, one per every distinct scope
 /// a write has touched.
 struct LedgerLocks {
     inner: StdMutex<HashMap<LedgerKey, Arc<AsyncMutex<()>>>>,
 }
 
 impl LedgerLocks {
-    fn get(&self, company: &CompanyId, slug: &str) -> Arc<AsyncMutex<()>> {
+    fn get(&self, company: &CompanyId, scope: LockScope) -> Arc<AsyncMutex<()>> {
         let mut locks = self.inner.lock().expect("ledger-write-lock map poisoned");
         locks
-            .entry((company.clone(), slug.to_string()))
+            .entry((company.clone(), scope))
             .or_insert_with(|| Arc::new(AsyncMutex::new(())))
             .clone()
     }
@@ -81,14 +94,27 @@ static LEDGER_WRITE_LOCKS: LazyLock<LedgerLocks> = LazyLock::new(|| LedgerLocks 
     inner: StdMutex::new(HashMap::new()),
 });
 
-/// The write lock for one company's one ledger.
+/// The write lock for one company's one ledger's rows.
 ///
 /// Held across a check-then-append (or a purge) so the two never observe each
-/// other's half-done state. Scoped to `(company, slug)` rather than to the
-/// whole store, so writes to unrelated ledgers — or unrelated companies —
-/// never queue behind each other.
-fn ledger_lock(company: &CompanyId, slug: &str) -> Arc<AsyncMutex<()>> {
-    LEDGER_WRITE_LOCKS.get(company, slug)
+/// other's half-done state. Scoped to one slug rather than to the whole store,
+/// so writes to unrelated ledgers — or unrelated companies — never queue
+/// behind each other.
+fn rows_lock(company: &CompanyId, slug: &str) -> Arc<AsyncMutex<()>> {
+    LEDGER_WRITE_LOCKS.get(company, LockScope::Rows(slug.to_string()))
+}
+
+/// The write lock for one company's set of declarations.
+///
+/// Held across a check-then-write so that what [`Registry::admits`] answered
+/// is still true when the spec lands. Its two rules — the cap on how many a
+/// company declares, and one writer per derived file — range over every
+/// declaration, so two declarations of *different* slugs contend just as two
+/// of the same slug do.
+///
+/// A path that takes both takes this one first.
+fn registry_lock(company: &CompanyId) -> Arc<AsyncMutex<()>> {
+    LEDGER_WRITE_LOCKS.get(company, LockScope::Registry)
 }
 
 /// Everything a ledger operation needs, without a whole [`CompanyRuntime`].
@@ -402,7 +428,7 @@ async fn record_amending(
 ) -> Result<engine::Entry> {
     let id = guard_write(spec, author, id)?;
 
-    let lock = ledger_lock(&ctx.company, &spec.slug);
+    let lock = rows_lock(&ctx.company, &spec.slug);
     let _guard = lock.lock().await;
 
     let fields = normalize_fields(fields);
@@ -568,11 +594,9 @@ pub async fn close(
 /// malformed, collides with an existing ledger, or is past the cap.
 pub async fn define(ctx: &Ledgers, document: &serde_json::Value) -> Result<LedgerSpec> {
     let spec = crate::ledger::parse(document, false)?;
-    registry(ctx).await?.admits(&spec)?;
-    let lock = ledger_lock(&ctx.company, &spec.slug);
+    let lock = registry_lock(&ctx.company);
     let _guard = lock.lock().await;
-    let registry = registry(ctx).await?;
-    registry.admits(&spec)?;
+    registry(ctx).await?.admits(&spec)?;
     ctx.ledgers.put_spec(&ctx.company, &spec).await?;
     // Rendered immediately, empty, so the ledger is visible in `derived/` from
     // the moment it exists rather than from its first row. A folder that gains
@@ -597,6 +621,8 @@ pub async fn define(ctx: &Ledgers, document: &serde_json::Value) -> Result<Ledge
 /// nothing carries that slug.
 pub async fn retire(ctx: &Ledgers, author: &LedgerAuthor, slug: &str, purge: bool) -> Result<()> {
     refuse_non_human(author, "retire a ledger")?;
+    let lock = registry_lock(&ctx.company);
+    let _guard = lock.lock().await;
     let registry = registry(ctx).await?;
     let spec = registry.require(slug)?;
     if spec.builtin {
@@ -608,7 +634,7 @@ pub async fn retire(ctx: &Ledgers, author: &LedgerAuthor, slug: &str, purge: boo
     }
     ctx.ledgers.delete_spec(&ctx.company, &spec.slug).await?;
     if purge {
-        let lock = ledger_lock(&ctx.company, &spec.slug);
+        let lock = rows_lock(&ctx.company, &spec.slug);
         let _guard = lock.lock().await;
         ctx.ledgers.purge_ledger(&ctx.company, &spec.slug).await?;
     }
@@ -638,7 +664,7 @@ pub async fn delete_entry(
             spec.slug, spec.written_by
         )));
     }
-    let lock = ledger_lock(&ctx.company, &spec.slug);
+    let lock = rows_lock(&ctx.company, &spec.slug);
     let _guard = lock.lock().await;
     let removed = ctx
         .ledgers

--- a/src/company/ledgers.rs
+++ b/src/company/ledgers.rs
@@ -568,6 +568,9 @@ pub async fn close(
 /// malformed, collides with an existing ledger, or is past the cap.
 pub async fn define(ctx: &Ledgers, document: &serde_json::Value) -> Result<LedgerSpec> {
     let spec = crate::ledger::parse(document, false)?;
+    registry(ctx).await?.admits(&spec)?;
+    let lock = ledger_lock(&ctx.company, &spec.slug);
+    let _guard = lock.lock().await;
     let registry = registry(ctx).await?;
     registry.admits(&spec)?;
     ctx.ledgers.put_spec(&ctx.company, &spec).await?;

--- a/src/company/ledgers_test.rs
+++ b/src/company/ledgers_test.rs
@@ -1378,25 +1378,24 @@ async fn a_limit_of_zero_or_past_every_bound_clamps_rather_than_emptying_the_pag
     assert_eq!(past.matched, 3);
 }
 
-/// A [`LedgerStore`] that pauses inside `list_specs` exactly once, after the
-/// read has already happened, so a test can hold a declaration mid-collision
-/// -check while another declaration of the same slug runs to completion
-/// underneath it.
-struct PausingSpecStore {
+/// A [`LedgerStore`] that yields inside `list_specs`, after the read and
+/// before the caller can act on it.
+///
+/// The window a declaration races in is between reading the registry and
+/// writing to it. Yielding there hands the runtime to whatever else is ready,
+/// so on the single-threaded test runtime two concurrent declarations
+/// deterministically interleave inside that window rather than doing so only
+/// when thread timing happens to arrange it. A declaration that is properly
+/// serialized never reaches the yield concurrently with another.
+struct YieldingSpecStore {
     inner: Arc<dyn LedgerStore>,
-    armed: Arc<AtomicBool>,
-    paused: Arc<Notify>,
-    resume: Arc<Notify>,
 }
 
 #[async_trait::async_trait]
-impl LedgerStore for PausingSpecStore {
+impl LedgerStore for YieldingSpecStore {
     async fn list_specs(&self, company: &CompanyId) -> Result<Vec<LedgerSpec>> {
         let read = self.inner.list_specs(company).await;
-        if self.armed.swap(false, Ordering::SeqCst) {
-            self.paused.notify_one();
-            self.resume.notified().await;
-        }
+        tokio::task::yield_now().await;
         read
     }
 
@@ -1427,29 +1426,22 @@ impl LedgerStore for PausingSpecStore {
 
 /// A ledger named twice at once must be declared once.
 ///
-/// `record`, `close` and `retire` all take [`ledger_lock`] before they read
-/// the store, so their check and their write are one section. `define` takes
-/// nothing: it lists the specs, asks the registry whether the slug collides,
-/// and only then writes. Two declarations of a slug that does not exist yet
+/// `record`, `close` and `retire` all take their lock before they read the
+/// store, so their check and their write are one section. A declaration that
+/// took none would list the specs, ask the registry whether the slug collides,
+/// and only then write: two declarations of a slug that does not exist yet
 /// both read a registry without it, both pass `admits`, and both write — so
 /// the second silently replaces the first, and the caller that lost is told
 /// its ledger was created.
 ///
-/// [`PausingSpecStore`] holds the first declaration inside exactly that gap so
-/// the window is deterministic rather than a matter of thread timing. Exactly
-/// one of the two must be refused.
+/// [`YieldingSpecStore`] puts both inside that window deterministically.
+/// Exactly one of the two must be refused.
 #[tokio::test]
 async fn two_declarations_of_one_new_slug_cannot_both_be_admitted() {
     let (runtime, _home) = runtime().await;
 
-    let armed = Arc::new(AtomicBool::new(false));
-    let paused = Arc::new(Notify::new());
-    let resume = Arc::new(Notify::new());
-    let store: Arc<dyn LedgerStore> = Arc::new(PausingSpecStore {
+    let store: Arc<dyn LedgerStore> = Arc::new(YieldingSpecStore {
         inner: runtime.ledgers().clone(),
-        armed: armed.clone(),
-        paused: paused.clone(),
-        resume: resume.clone(),
     });
     let ctx = Ledgers::new(runtime.id().clone(), store);
 
@@ -1458,22 +1450,7 @@ async fn two_declarations_of_one_new_slug_cannot_both_be_admitted() {
     let mut second = hazards();
     second["title"] = json!("Hazards, as the second caller named them");
 
-    armed.store(true, Ordering::SeqCst);
-
-    let first_ctx = ctx.clone();
-    let declarer = tokio::spawn(async move { define(&first_ctx, &first).await });
-
-    paused.notified().await;
-
-    // The second declaration runs to completion inside the first's collision
-    // window: its own `list_specs` is no longer armed.
-    let second_result = define(&ctx, &second).await;
-
-    resume.notify_one();
-    let first_result = tokio::time::timeout(std::time::Duration::from_secs(5), declarer)
-        .await
-        .expect("the first declaration did not finish")
-        .expect("the first declaration panicked");
+    let (first_result, second_result) = tokio::join!(define(&ctx, &first), define(&ctx, &second));
 
     assert!(
         first_result.is_err() ^ second_result.is_err(),
@@ -1494,6 +1471,69 @@ async fn two_declarations_of_one_new_slug_cannot_both_be_admitted() {
         survivor.title,
         winner.expect("the admitted declaration").title,
         "the stored ledger must be the one whose caller was told it was created"
+    );
+}
+
+/// How many ledgers this company has declared, built-ins aside.
+async fn declared_count(ctx: &Ledgers) -> usize {
+    registry(ctx)
+        .await
+        .expect("registry")
+        .specs()
+        .iter()
+        .filter(|spec| !spec.builtin)
+        .count()
+}
+
+/// Builds a declaration that collides with nothing but its own slug.
+fn ledger_named(slug: &str) -> serde_json::Value {
+    let mut doc = hazards();
+    doc["slug"] = json!(slug);
+    doc["title"] = json!(slug);
+    doc["derived"] = json!(format!("derived/{slug}.md"));
+    doc
+}
+
+/// The cap counts declarations, so two of *different* slugs contend too.
+///
+/// A lock taken per slug serializes only the callers naming one ledger. Both
+/// of `admits`' rules range over every declaration — how many the company has,
+/// and which derived file each writes — so two declarations of different slugs
+/// read the same registry, both find room under the cap, and both write. The
+/// company ends up past a cap it is the only thing enforcing.
+///
+/// With one slot left, exactly one must win.
+#[tokio::test]
+async fn two_declarations_of_different_slugs_cannot_both_take_the_last_slot() {
+    let (runtime, _home) = runtime().await;
+    let plain = Ledgers::new(runtime.id().clone(), runtime.ledgers().clone());
+
+    let declared = declared_count(&plain).await;
+    for n in declared..crate::ledger::registry::MAX_DECLARED - 1 {
+        define(&plain, &ledger_named(&format!("filler-{n}")))
+            .await
+            .expect("filler declaration");
+    }
+
+    let store: Arc<dyn LedgerStore> = Arc::new(YieldingSpecStore {
+        inner: runtime.ledgers().clone(),
+    });
+    let ctx = Ledgers::new(runtime.id().clone(), store);
+
+    let (first_doc, second_doc) = (
+        ledger_named("first-past-the-post"),
+        ledger_named("second-past-the-post"),
+    );
+    let (first, second) = tokio::join!(define(&ctx, &first_doc), define(&ctx, &second_doc));
+
+    assert!(
+        first.is_ok() ^ second.is_ok(),
+        "exactly one declaration may take the last slot — first: {first:?}, second: {second:?}"
+    );
+    assert_eq!(
+        declared_count(&plain).await,
+        crate::ledger::registry::MAX_DECLARED,
+        "the cap is the only thing bounding declarations, so it must hold under a race"
     );
 }
 

--- a/src/company/ledgers_test.rs
+++ b/src/company/ledgers_test.rs
@@ -1439,7 +1439,6 @@ impl LedgerStore for PausingSpecStore {
 /// the window is deterministic rather than a matter of thread timing. Exactly
 /// one of the two must be refused.
 #[tokio::test]
-#[ignore = "define() takes no ledger lock: two declarations of one new slug both pass admits() and the second overwrites the first"]
 async fn two_declarations_of_one_new_slug_cannot_both_be_admitted() {
     let (runtime, _home) = runtime().await;
 
@@ -1496,6 +1495,27 @@ async fn two_declarations_of_one_new_slug_cannot_both_be_admitted() {
         winner.expect("the admitted declaration").title,
         "the stored ledger must be the one whose caller was told it was created"
     );
+}
+
+#[tokio::test]
+async fn independently_constructed_contexts_share_declaration_admission() {
+    let (runtime, _home) = runtime().await;
+    let first_ctx = Ledgers::new(runtime.id().clone(), runtime.ledgers().clone());
+    let second_ctx = Ledgers::new(runtime.id().clone(), runtime.ledgers().clone());
+    let mut first = hazards();
+    first["title"] = json!("First declaration");
+    let mut second = hazards();
+    second["title"] = json!("Second declaration");
+
+    let (first_result, second_result) =
+        tokio::join!(define(&first_ctx, &first), define(&second_ctx, &second));
+
+    assert!(first_result.is_ok() ^ second_result.is_ok());
+    let winner = first_result
+        .or(second_result)
+        .expect("one declaration wins");
+    let stored = registry(&first_ctx).await.expect("registry");
+    assert_eq!(stored.require("hazards").expect("stored ledger"), &winner);
 }
 
 /// A ledger with a `required` field, but no `Check::RequiredField` in its


### PR DESCRIPTION
## Summary

Serialize declaration admission for one company's one ledger slug with the existing process-wide ledger write lock. Unignore `two_declarations_of_one_new_slug_cannot_both_be_admitted` without changing any of its assertions, and cover independently constructed `Ledgers` contexts sharing the same store.

## API Or Behavior Changes

Concurrent declarations of the same new slug no longer both report success while one silently overwrites the other. A declaration performs an optimistic admission check, then acquires the existing queued lock and reloads/revalidates the registry before writing. The guard remains held through publication.

The optimistic check refuses known-invalid declarations without waiting for another ledger operation; only the revalidation under the lock authorizes the write. Keeping that distinction also preserves the acceptance fixture's deterministic pause before admission: its second declaration can complete before the first paused read resumes. A fail-fast global lock would spuriously reject independent stores sharing a company ID, so this uses the existing queued lock unchanged.

Scope is the existing in-process, per-company/per-slug lock. It does not add cross-process transactions or serialize distinct slugs against registry-wide limits or derived-path collisions.

## Tests

Gates ran unpiped with their own `rc`, with `CARGO_BUILD_JOBS=2`, `CARGO_PROFILE_DEV_DEBUG=0`, `CARGO_PROFILE_TEST_DEBUG=0`, and an isolated worktree target directory. These environment settings disable debug symbols only, not assertions or tests.

An initial symbol-enabled cold build was deliberately interrupted (exit 130; no tests had run) when simultaneous jobs on the shared 24 GiB machine caused heavy swapping. No artifacts or repository configuration were deleted or changed. An initial formatting check exited 1 on wrapping in the new supplemental test; that was corrected before the final exit-0 check.

Observed red proof: copied `src/company/ledgers.rs` to `/tmp/redproof-ledger-define-lock-ledgers.rs`, then temporarily removed the three added lines in `define()` (the optimistic admission check, lock lookup, and awaited guard), leaving the acceptance test unignored and unchanged. Running `cargo test --locked --features openhuman --lib two_declarations_of_one_new_slug_cannot_both_be_admitted` exited **101**, with **0 passed, 1 failed, 0 ignored, 7391 filtered out**. The failure said: `one of two declarations of hazards must be refused; both were admitted`, and printed two `Ok(LedgerSpec)` values with the callers' different titles. Restored all three lines immediately using `apply_patch`; `cmp` against the backup and `git diff --exit-code` each exited **0**, and `git status --short` was empty. The temporary edit was never committed.

- [x] `cargo fmt --check` — exit 0.
- [x] `cargo clippy --locked --features openhuman --all-targets --no-deps -- -D warnings` — exit 0 (7m 02s).
- [x] N/A: separate `cargo build --all-targets`; all targets are checked by the required Clippy gate and the library test binary is compiled by the required focused tests.
- [x] `cargo test --locked --features openhuman --lib two_declarations_of_one_new_slug_cannot_both_be_admitted` — restored fix: exit 0, **1 passed, 0 failed, 0 ignored, 7391 filtered out**, 0.17s.
- [x] `cargo test --locked --features openhuman --lib company::ledgers` — exit 0, **44 passed, 0 failed, 0 ignored, 7348 filtered out**, 7.22s at default test parallelism, including the independent-context regression and existing purge/close lock tests.

## Documentation

No public API or configuration change. The existing declaration contract already promises collision rejection; this enforces it. Concurrency behavior and scope are documented above, without adding narrative comments to source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrent ledger creation so conflicting declarations are handled safely and consistently.
  - Ensured that when multiple contexts declare the same ledger simultaneously, only one declaration is accepted and the stored specification reflects the accepted declaration.
- **Tests**
  - Added and enabled coverage for concurrent declaration conflicts across independently constructed contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->