### PR TITLE
fix(blockers): resume a stepless agent question through its approval's task link (#2008)

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2871,9 +2871,12 @@ impl CompanyRuntime {
     ///
     /// The step rides on the resolution itself — the journal scrubs a parked
     /// effect's payload, so it is captured at resolve time — while the DM thread
-    /// is read off the approval's origin, which is not scrubbed. The answer is
-    /// retired from the re-arm queue once re-entered, so the next boot does not
-    /// resume it a second time.
+    /// is read off the approval's origin, which is not scrubbed. A blocker that
+    /// carried no step of its own falls back to the card its approval is linked
+    /// to, read from that same unscrubbed origin: see
+    /// [`blocker_step_from_task_link`](Self::blocker_step_from_task_link). The
+    /// answer is retired from the re-arm queue once re-entered, so the next boot
+    /// does not resume it a second time.
     #[cfg(feature = "openhuman")]
     async fn resume_blocker(
         self: &Arc<Self>,
@@ -2887,13 +2890,12 @@ impl CompanyRuntime {
         let origin_parent = conversation
             .as_ref()
             .and_then(|conversation| conversation.parent);
+        let step = resolution
+            .step
+            .clone()
+            .or_else(|| self.blocker_step_from_task_link(approval_id));
         let outcome = self
-            .drive_blocker_resume(
-                &resolution,
-                resolution.step.as_ref(),
-                thread.as_deref(),
-                origin_parent,
-            )
+            .drive_blocker_resume(&resolution, step.as_ref(), thread.as_deref(), origin_parent)
             .await;
         // Retire the armed answer whether or not the drive succeeded: a failed
         // resume is reported, not retried forever, and re-arming it would resume
@@ -2914,6 +2916,40 @@ impl CompanyRuntime {
                 .await;
         }
         Ok(CycleRunner::new(self).already_resolved_report())
+    }
+
+    /// The card a blocker stopped, when its own payload never named one.
+    ///
+    /// An agent's question parks with no
+    /// [`BlockerStep`](crate::ports::blockers::BlockerStep): the tool holds
+    /// neither a card nor a node. Where a board card's dispatch cycle raised it,
+    /// the approval records that as its [`TaskLink`], the same key
+    /// [`unanswered_blocker`](Self::unanswered_blocker) returns an expired
+    /// blocker's card by — and for the same reason, that the journal has always
+    /// maintained the link while the payload's step is a field a producer can
+    /// omit.
+    ///
+    /// Read from the retained origins, never the pending set: the settle that
+    /// precedes a resume is what empties that set, so by here the approval is no
+    /// longer parked. An [`Unlinked`](TaskLink::Unlinked) record, a link written
+    /// before the journal kept one, and an id the journal never saw are one
+    /// answer — there is no card to re-enter, and the answer is carried back
+    /// into the conversation instead.
+    ///
+    /// [`TaskLink`]: crate::runtime::journal::TaskLink
+    #[cfg(feature = "openhuman")]
+    fn blocker_step_from_task_link(
+        &self,
+        id: &ApprovalId,
+    ) -> Option<crate::ports::blockers::BlockerStep> {
+        use crate::runtime::journal::TaskLink;
+
+        match self.journal.approval_task(id) {
+            Some(Some(TaskLink::Task { id })) => {
+                Some(crate::ports::blockers::BlockerStep::Task { task_id: id })
+            }
+            Some(Some(TaskLink::Unlinked)) | Some(None) | None => None,
+        }
     }
 
     /// Routes a resolved blocker to the right resume by its
@@ -2941,9 +2977,8 @@ impl CompanyRuntime {
                 self.resume_node_blocker(run_id, node_id, resolution, thread)
                     .await
             }
-            // An agent question with no step behind it — there is nothing to
-            // re-dispatch, so carrying the answer back into its DM is the whole
-            // of the resume.
+            // A question with no card or node behind it — carrying the answer
+            // back into its DM is the whole of the resume.
             None => {
                 self.post_blocker_resume_note(thread, &blocker_resume_note(resolution))
                     .await
@@ -13367,6 +13402,154 @@ mod tests {
                 "a cancel abandons the work rather than re-dispatching it"
             );
             assert!(after.bounced.is_some(), "the card is marked not-fresh");
+        }
+
+        /// What an agent's own `escalate_to_human` parks: a question with no
+        /// step, because the tool holds neither a card nor a node.
+        fn agent_question() -> BlockerPayload {
+            BlockerPayload {
+                kind: BlockerKind::Information,
+                source: BlockerSource::AgentQuestion,
+                step: None,
+                reason: "which of the two briefs is the current one?".to_string(),
+                needed: "an answer from you".to_string(),
+                group_key: None,
+            }
+        }
+
+        /// Parks a blocker the journal records as belonging to **no** card, the
+        /// way a workflow node's does. `park_blocker` always links the card it
+        /// is given, so the unlinked case has to be built here.
+        async fn park_unlinked(
+            runtime: &Arc<CompanyRuntime>,
+            payload: &BlockerPayload,
+        ) -> crate::ports::types::ApprovalId {
+            use crate::ports::now_millis;
+            use crate::ports::types::{Effect, EffectGroup};
+            use crate::runtime::journal::{ApprovalConversation, TaskLink};
+
+            let effect = Effect {
+                kind: payload.effect_kind(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::to_value(payload).expect("payload"),
+                agent: None,
+                run_id: None,
+            };
+            let id = runtime
+                .approvals
+                .park(&runtime.id, effect.clone())
+                .await
+                .expect("parks");
+            runtime
+                .journal
+                .record_parked(
+                    &id,
+                    &effect,
+                    now_millis(),
+                    TaskLink::Unlinked,
+                    ApprovalConversation {
+                        thread: Some("dm:eng".to_string()),
+                        parent: None,
+                    },
+                    None,
+                )
+                .await
+                .expect("records");
+            id
+        }
+
+        /// The defect this tier was missing: a question parked with no step of
+        /// its own still re-enters the card its approval is linked to, and the
+        /// operator's answer rides onto it.
+        #[tokio::test]
+        async fn an_agent_question_re_enters_the_card_its_approval_links() {
+            let (runtime, _home) = runtime().await;
+            seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
+            runtime
+                .park_blocker(&agent_question(), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            let ids: Vec<_> = runtime
+                .pending_approvals()
+                .into_iter()
+                .map(|a| a.id)
+                .collect();
+
+            runtime
+                .apply_blocker_reply(
+                    &ids,
+                    BlockerReplyIntent::Amend,
+                    "the second brief is current",
+                    None,
+                )
+                .await
+                .expect("resumes");
+
+            let after = stored(&runtime, "t-1").await;
+            assert_eq!(
+                after.column, COLUMN_IN_PROGRESS,
+                "a stepless question resumes through its approval's task link"
+            );
+            assert!(
+                after
+                    .note
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("the second brief is current"),
+                "the answer reaches the re-run: {:?}",
+                after.note
+            );
+        }
+
+        /// The same fallback settles rather than re-dispatches when the answer
+        /// is a cancel — the arm that moves a card for the first time.
+        #[tokio::test]
+        async fn an_agent_question_cancelled_settles_the_linked_card() {
+            let (runtime, _home) = runtime().await;
+            seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
+            runtime
+                .park_blocker(&agent_question(), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            let ids: Vec<_> = runtime
+                .pending_approvals()
+                .into_iter()
+                .map(|a| a.id)
+                .collect();
+
+            runtime
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Cancel, "drop it", None)
+                .await
+                .expect("settles");
+
+            let after = stored(&runtime, "t-1").await;
+            assert_eq!(after.column, COLUMN_TODO);
+            assert!(after.bounced.is_some(), "the card is marked not-fresh");
+        }
+
+        /// The negative that keeps the fallback honest: a blocker the journal
+        /// records against no card touches no card, however it is answered. A
+        /// fallback that reached for "whichever card was paused" would resume
+        /// work nobody asked about.
+        #[tokio::test]
+        async fn an_unlinked_question_moves_no_card() {
+            let (runtime, _home) = runtime().await;
+            seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
+            let id = park_unlinked(&runtime, &agent_question()).await;
+
+            runtime
+                .apply_blocker_reply(&[id], BlockerReplyIntent::Retry, "go on", None)
+                .await
+                .expect("resumes");
+
+            assert_eq!(
+                stored(&runtime, "t-1").await.column,
+                COLUMN_PAUSED,
+                "an unlinked question leaves every card where it was"
+            );
         }
 
         /// The guard the whole tier turns on: a blocker's effect is inert, so a

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2892,7 +2892,7 @@ impl CompanyRuntime {
             .and_then(|conversation| conversation.parent);
         let step = match resolution.step.clone() {
             Some(step) => Some(step),
-            None => self.blocker_step_from_task_link(approval_id).await,
+            None => self.blocker_step_from_task_link(approval_id).await?,
         };
         let outcome = self
             .drive_blocker_resume(&resolution, step.as_ref(), thread.as_deref(), origin_parent)
@@ -2937,30 +2937,37 @@ impl CompanyRuntime {
     /// into the conversation instead.
     ///
     /// A link is weaker evidence than a step, so it is only followed to a card
-    /// the board still holds. A declared step names the thing that stopped; a
-    /// link only says a card was in hand when the question was raised. Reading
-    /// a link to a card that is gone as a card resume answers the operator
-    /// with *that card is no longer on the board* — a report about a card,
-    /// where what was asked for was an answer to a question.
+    /// the board still holds and still has paused. A declared step names the
+    /// thing that stopped; a link only says a card was in hand when the
+    /// question was raised. Reading a link to a card that is gone — or to one
+    /// an operator has since moved on, which both card resumes leave alone
+    /// without a word — answers the operator with a report about a card, or
+    /// with nothing at all, where what was asked for was an answer to a
+    /// question.
+    ///
+    /// A board that cannot be read is not a board without the card: the error
+    /// propagates, leaving the answer armed for the next attempt rather than
+    /// retiring it against a resume that never re-entered anything.
     ///
     /// [`TaskLink`]: crate::runtime::journal::TaskLink
     #[cfg(feature = "openhuman")]
     async fn blocker_step_from_task_link(
         &self,
         id: &ApprovalId,
-    ) -> Option<crate::ports::blockers::BlockerStep> {
+    ) -> Result<Option<crate::ports::blockers::BlockerStep>> {
         use crate::runtime::journal::TaskLink;
 
         let Some(Some(TaskLink::Task { id: task_id })) = self.journal.approval_task(id) else {
-            return None;
+            return Ok(None);
         };
-        let on_board = self
+        let paused = self
             .ops
             .tasks
             .list(&self.id)
-            .await
-            .is_ok_and(|tasks| tasks.iter().any(|task| task.id == task_id));
-        on_board.then_some(crate::ports::blockers::BlockerStep::Task { task_id })
+            .await?
+            .into_iter()
+            .any(|task| task.id == task_id && task.column == crate::ports::tasks::COLUMN_PAUSED);
+        Ok(paused.then_some(crate::ports::blockers::BlockerStep::Task { task_id }))
     }
 
     /// Routes a resolved blocker to the right resume by its
@@ -13445,6 +13452,28 @@ mod tests {
 
         /// What an agent's own `escalate_to_human` parks: a question with no
         /// step, because the tool holds neither a card nor a node.
+        async fn dm_notes(runtime: &Arc<CompanyRuntime>) -> Vec<String> {
+            runtime
+                .events
+                .read_from(
+                    runtime.id(),
+                    crate::ports::types::EventSeq::new(0),
+                    usize::MAX,
+                )
+                .await
+                .expect("read events")
+                .into_iter()
+                .filter_map(|stored| match stored.event {
+                    crate::ports::types::CompanyEvent::AgentReply { chat_id, text, .. }
+                        if chat_id == "dm:eng" =>
+                    {
+                        Some(text)
+                    }
+                    _ => None,
+                })
+                .collect()
+        }
+
         fn agent_question() -> BlockerPayload {
             BlockerPayload {
                 kind: BlockerKind::Information,
@@ -13588,6 +13617,52 @@ mod tests {
                 stored(&runtime, "t-1").await.column,
                 COLUMN_PAUSED,
                 "an unlinked question leaves every card where it was"
+            );
+        }
+
+        /// A card an operator moved on from is not the step, so the answer
+        /// goes back into the conversation.
+        ///
+        /// Both card resumes leave a card that is no longer paused exactly
+        /// where it is and return without a word, so following the link to one
+        /// would deliver the answer nowhere at all while the blocker is still
+        /// recorded as resumed.
+        #[tokio::test]
+        async fn an_agent_question_whose_card_moved_on_answers_the_conversation() {
+            let (runtime, _home) = runtime().await;
+            seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
+            runtime
+                .park_blocker(&agent_question(), "t-1", assignee("eng"))
+                .await
+                .expect("parks");
+            let ids: Vec<_> = runtime
+                .pending_approvals()
+                .into_iter()
+                .map(|a| a.id)
+                .collect();
+            seed(&runtime, &card("t-1", COLUMN_IN_PROGRESS)).await;
+
+            runtime
+                .apply_blocker_reply(
+                    &ids,
+                    BlockerReplyIntent::Amend,
+                    "the second brief is current",
+                    None,
+                )
+                .await
+                .expect("resumes");
+
+            let after = stored(&runtime, "t-1").await;
+            assert_eq!(
+                after.column, COLUMN_IN_PROGRESS,
+                "a card an operator moved on is left where they put it"
+            );
+            let notes = dm_notes(&runtime).await;
+            assert!(
+                notes.iter().any(
+                    |note| note == "Thanks — using that and carrying on from where it stopped."
+                ),
+                "the answer must reach the conversation it was asked in; posted: {notes:?}"
             );
         }
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2890,10 +2890,10 @@ impl CompanyRuntime {
         let origin_parent = conversation
             .as_ref()
             .and_then(|conversation| conversation.parent);
-        let step = resolution
-            .step
-            .clone()
-            .or_else(|| self.blocker_step_from_task_link(approval_id));
+        let step = match resolution.step.clone() {
+            Some(step) => Some(step),
+            None => self.blocker_step_from_task_link(approval_id).await,
+        };
         let outcome = self
             .drive_blocker_resume(&resolution, step.as_ref(), thread.as_deref(), origin_parent)
             .await;
@@ -2936,20 +2936,31 @@ impl CompanyRuntime {
     /// answer — there is no card to re-enter, and the answer is carried back
     /// into the conversation instead.
     ///
+    /// A link is weaker evidence than a step, so it is only followed to a card
+    /// the board still holds. A declared step names the thing that stopped; a
+    /// link only says a card was in hand when the question was raised. Reading
+    /// a link to a card that is gone as a card resume answers the operator
+    /// with *that card is no longer on the board* — a report about a card,
+    /// where what was asked for was an answer to a question.
+    ///
     /// [`TaskLink`]: crate::runtime::journal::TaskLink
     #[cfg(feature = "openhuman")]
-    fn blocker_step_from_task_link(
+    async fn blocker_step_from_task_link(
         &self,
         id: &ApprovalId,
     ) -> Option<crate::ports::blockers::BlockerStep> {
         use crate::runtime::journal::TaskLink;
 
-        match self.journal.approval_task(id) {
-            Some(Some(TaskLink::Task { id })) => {
-                Some(crate::ports::blockers::BlockerStep::Task { task_id: id })
-            }
-            Some(Some(TaskLink::Unlinked)) | Some(None) | None => None,
-        }
+        let Some(Some(TaskLink::Task { id: task_id })) = self.journal.approval_task(id) else {
+            return None;
+        };
+        let on_board = self
+            .ops
+            .tasks
+            .list(&self.id)
+            .await
+            .is_ok_and(|tasks| tasks.iter().any(|task| task.id == task_id));
+        on_board.then_some(crate::ports::blockers::BlockerStep::Task { task_id })
     }
 
     /// Routes a resolved blocker to the right resume by its
@@ -12910,12 +12921,42 @@ mod tests {
             );
         }
 
-        /// A bare agent question — `step: None`, so no board card is needed and
-        /// the resume note alone distinguishes one verdict from another.
-        ///
-        /// Deliberately not the module's `blocker()` helper: that one carries a
-        /// Task step, and with no card seeded both retry and cancel resume as
-        /// "card not found", which cannot tell the two verdicts apart.
+        /// The paused card a parked blocker's approval links to.
+        async fn seed_paused_card(runtime: &Arc<CompanyRuntime>, id: &str) {
+            use crate::ports::tasks::{COLUMN_PAUSED, TaskDeliverable, TaskRecord, TaskTitle};
+
+            runtime
+                .ops
+                .tasks
+                .upsert(
+                    &runtime.id,
+                    &TaskRecord {
+                        id: id.to_string(),
+                        title: TaskTitle::authored("Draft the launch note"),
+                        note: None,
+                        column: COLUMN_PAUSED.to_string(),
+                        priority: "medium".to_string(),
+                        assignee: "eng".to_string(),
+                        updated_at_millis: 1,
+                        origin: crate::ports::TaskOrigin::new(Some("dm:eng".to_string()), None),
+                        parent_task_id: None,
+                        output: None,
+                        plan: None,
+                        planning_attempts: Vec::new(),
+                        deliverable: TaskDeliverable::Once,
+                        workflow_proposal: None,
+                        origin_run_id: None,
+                        origin_workflow_id: None,
+                        origin_message_seq: None,
+                        bounced: None,
+                    },
+                )
+                .await
+                .expect("seed card");
+        }
+
+        /// A bare agent question: `step: None`, so the resume has only the
+        /// approval's task link to work from.
         fn question() -> BlockerPayload {
             BlockerPayload {
                 kind: BlockerKind::Information,
@@ -13035,6 +13076,7 @@ mod tests {
 
             let (runtime, home) = runtime().await;
             let payload = question();
+            seed_paused_card(&runtime, "t-1").await;
             let id = runtime
                 .park_blocker(&payload, "t-1", assignee("eng"))
                 .await
@@ -13105,15 +13147,8 @@ mod tests {
                     .expect("follow-up runs");
             }
 
-            // The mechanism under test: for a step-less blocker, the resume
-            // posts a DIFFERENT acknowledgement into the DM depending on which
-            // verdict it reads off the armed side-channel — "Got it — picking
-            // that back up now." for retry, "Okay — cancelled." for cancel
-            // (`blocker_resume_note`). Exactly one resume runs (the loser's
-            // settle is `AlreadyResolved`, which owes no follow-up), so
-            // whichever note landed must match the winner — a
-            // last-write-wins race could instead post the LOSER's note under
-            // the WINNER's durable verdict.
+            // Retry and cancel post different notes into the DM, and exactly
+            // one resume runs, so the note that landed must match the winner.
             let notes: Vec<String> = runtime
                 .events
                 .read_from(
@@ -13135,12 +13170,16 @@ mod tests {
                 .collect();
 
             let (expected, contradicting) = match winner_verdict {
-                BlockerVerdict::Retry => {
-                    ("Got it — picking that back up now.", "Okay — cancelled.")
-                }
-                BlockerVerdict::Cancel => {
-                    ("Okay — cancelled.", "Got it — picking that back up now.")
-                }
+                BlockerVerdict::Retry => (
+                    "Got it — picking that back up now.",
+                    "Okay — I've cancelled that. It's back in To-do if you want to pick it up \
+                     later.",
+                ),
+                BlockerVerdict::Cancel => (
+                    "Okay — I've cancelled that. It's back in To-do if you want to pick it up \
+                     later.",
+                    "Got it — picking that back up now.",
+                ),
                 _ => unreachable!(),
             };
             assert!(

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -10690,24 +10690,18 @@ mode = "full"
         assert!(banked_resolutions(&home, &company).await.is_empty());
     }
 
-    /// **A documented limitation, pinned rather than left incidental.**
-    ///
     /// A blocker raised by `escalate_to_human` carries no
-    /// [`BlockerStep`](crate::ports::blockers::BlockerStep), and every resume
-    /// reads the verdict's step and nothing else — so its card is never
-    /// re-dispatched however it is answered, on this route and on the
-    /// two-value one that predates it. The resume posts a note into the
-    /// blocker's thread and stops there.
+    /// [`BlockerStep`](crate::ports::blockers::BlockerStep) — the tool holds
+    /// neither a card nor a node — so the resume falls back to the card the
+    /// approval is linked to, and answering re-dispatches it.
     ///
-    /// The route lets the verdict through rather than refusing it: the answer
-    /// is banked durably and correctly, so the resume that reads the approval's
-    /// own task link inherits a right answer rather than a discarded one, and
-    /// refusing only `skip`/`amend` would leave `approve` no-opping in exactly
-    /// the same way while looking supported. Tracked as its own defect; when it
-    /// is fixed this test's final assertion is what changes.
+    /// The banked resolution is still stepless, and that assertion is
+    /// load-bearing rather than incidental: the fallback is read at resume
+    /// time, so the durable record keeps saying what the blocker actually
+    /// carried instead of being rewritten to claim a step it never had.
     #[cfg(feature = "openhuman")]
     #[tokio::test]
-    async fn an_agent_question_banks_its_verdict_but_re_dispatches_no_card() {
+    async fn an_agent_question_re_dispatches_the_card_its_approval_is_linked_to() {
         use crate::ports::blockers::{BlockerKind, BlockerPayload, BlockerSource};
         use crate::runtime::journal::{ApprovalConversation, TaskLink};
 
@@ -10806,7 +10800,7 @@ mode = "full"
         );
         assert!(
             banked[0]["resolution"].get("step").is_none(),
-            "an agent question is parked with no step, which is the defect: {}",
+            "the durable record keeps the stepless park the blocker carried: {}",
             banked[0]
         );
         let card = runtime
@@ -10819,8 +10813,8 @@ mode = "full"
             .expect("the card still exists");
         assert_eq!(
             card.column,
-            crate::ports::tasks::COLUMN_PAUSED,
-            "the stepless resume moves no card — the limitation this pins"
+            crate::ports::tasks::COLUMN_IN_PROGRESS,
+            "the answer re-dispatches the linked card"
         );
     }
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -10818,6 +10818,118 @@ mode = "full"
         );
     }
 
+    /// The link is followed only to a card the board still holds.
+    ///
+    /// A stepless question's approval carries a task link because a card was in
+    /// hand when it was asked, not because the card is the thing to re-enter.
+    /// When that card is gone — deleted, or never on this board — reading the
+    /// link as a card resume answers the operator with *that card is no longer
+    /// on the board*, which is a report about a card in place of the answer to
+    /// the question they just gave. The answer goes back into the conversation
+    /// instead, exactly as it does for a question that was never linked.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn an_agent_question_linked_to_a_card_the_board_lost_still_answers_the_question() {
+        use crate::ports::blockers::{BlockerKind, BlockerPayload, BlockerSource};
+        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let company = CompanyId::new("acme");
+        let runtime = state.registry().get(&company).unwrap();
+        let app = router(state);
+
+        let payload = BlockerPayload {
+            kind: BlockerKind::Information,
+            source: BlockerSource::AgentQuestion,
+            step: None,
+            reason: "which of the two briefs is current?".to_string(),
+            needed: "an answer from you".to_string(),
+            group_key: None,
+        };
+        let approval = ApprovalId::new("question-2");
+        let effect = crate::ports::types::Effect {
+            kind: payload.effect_kind(),
+            group: crate::ports::types::EffectGroup::Other,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::to_value(&payload).unwrap(),
+            agent: None,
+            run_id: None,
+        };
+        let at = crate::ports::now_millis();
+        runtime
+            .approval_gate
+            .rehydrate(approval.clone(), effect.clone(), at);
+        // The link names a card that is not on the board, which is the whole
+        // case: nothing is seeded for `t-gone`.
+        runtime
+            .journal
+            .record_parked(
+                &approval,
+                &effect,
+                at,
+                TaskLink::from_task_id(Some("t-gone")),
+                ApprovalConversation {
+                    thread: Some("dm:eng".to_string()),
+                    parent: None,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let (status, answer) = post_resolve(
+            &app,
+            &approval,
+            serde_json::json!({ "verdict": "approve", "blocker_verdict": "retry" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{answer}");
+
+        let banked = banked_resolutions(&home, &company).await;
+        assert_eq!(banked.len(), 1);
+        assert_eq!(
+            banked[0]["resolution"]["verdict"], "retry",
+            "the operator's answer is banked whatever the resume finds: {}",
+            banked[0]
+        );
+        let notes: Vec<String> = runtime
+            .events
+            .read_from(
+                runtime.id(),
+                crate::ports::types::EventSeq::new(0),
+                usize::MAX,
+            )
+            .await
+            .expect("read events")
+            .into_iter()
+            .filter_map(|stored| match stored.event {
+                crate::ports::types::CompanyEvent::AgentReply { chat_id, text, .. }
+                    if chat_id == "dm:eng" =>
+                {
+                    Some(text)
+                }
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !notes
+                .iter()
+                .any(|note| note.contains("no longer on the board")),
+            "answering a question must not report on a card the asker never mentioned; \
+             posted: {notes:?}"
+        );
+        assert!(
+            notes
+                .iter()
+                .any(|note| note == "Got it — picking that back up now."),
+            "the answer must still reach the conversation it was asked in; posted: {notes:?}"
+        );
+    }
+
     /// A build with no blocker resume refuses the field outright. Accepting and
     /// ignoring it would answer `200` to a skip that silently became a retry —
     /// the exact defect, reintroduced by a feature flag.


### PR DESCRIPTION
## Summary

Answering an agent's own question never restarted the work. `escalate_to_human` parks with no `BlockerStep` — the tool holds neither a card nor a node — and every resume routed on that step alone, so a card-backed question re-dispatched nothing on **any** entrypoint: console approve, the four-verdict route, and a DM reply alike. The card sat in `paused` behind a manual Resume button, and the operator was told "picking that back up now" while nothing was picked back up.

The fix reads the card off the approval's own `TaskLink` when the payload names no step. Nothing new is recorded — the link has always been stamped by `record_parked`, `escalate_to_human` already says so where it parks (*"where one does exist the approval's own task link already names it"*), and `unanswered_blocker` already prefers that key over `payload.step` on the expiry path. The resume was the one place still reading only the step.

It goes in `resume_blocker`, the single funnel every entrypoint reaches, rather than at the two resolve-time sites that derive the step: one site instead of two plus an invariant nothing enforces, and answers banked before this change still resume on replay. Reading at resume time also means the durable resolution keeps recording the stepless park the blocker actually carried, instead of being rewritten to claim a step it never had — the journal scrubs a parked payload, but the origins index it reads is never scrubbed or pruned.

A record that names no card still behaves exactly as before: `Unlinked`, a link written before the journal kept one, and an id the journal never saw all stay note-only.

Closes #2008. Part of #1860.

## API Or Behavior Changes

Two, both on blockers that carry no step of their own and are linked to a card:

- **Answering now re-dispatches the card.** Retry and skip re-run it; an answer re-runs it carrying the operator's words on the card note. Previously all three posted a note and stopped.
- **Cancel/deny now settles the card** — back to To-do with the reason and the not-fresh chip, through the plain task-store port so nothing dispatches. Previously it did nothing at all, leaving the card wedged in `paused` after the operator had already decided. This is the sharper half of the change and is called out deliberately.

A genuinely cardless question — a chat-turn escalation with no card behind it — is unchanged.

No API surface changes. The wire contract for the resolve routes is untouched, and the banked resolution's shape is unchanged.

## Tests

Run locally on this branch:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -j 1 --features openhuman,tinymemory --all-targets --no-deps -- -D warnings` — the gated form; the vendored tree needs `--no-deps`
- [x] `cargo check -j 1 --features openhuman,tinymemory --all-targets`
- [x] `cargo test -j 1 --features openhuman,tinymemory --lib company::runtime::tests::blocker_resume` — 17 passed
- [x] `cargo test -j 1 --features openhuman,tinymemory --lib an_agent_question_re_dispatches_the_card_its_approval_is_linked_to` — 1 passed
- [ ] `cargo build --all-targets` — not run in this form; `cargo check --all-targets` and a `--bin opencompany` build were run instead
- [ ] `cargo test` — not run unscoped; the full lib suite exhausts memory on this machine, so the affected modules were run by filter

Nearly all of this code is `#[cfg(feature = "openhuman")]`, so a default-feature run compiles none of it.

**The tests were proven to fail without the fix.** Reverting only the fallback and re-running the same filters turns three red — `an_agent_question_re_enters_the_card_its_approval_links`, `an_agent_question_cancelled_settles_the_linked_card`, and the route-level test — while every pre-existing test in the module stays green, so the change is additive rather than a rewrite of behaviour already covered. `an_unlinked_question_moves_no_card` passes either way by design: it guards against over-reach, and is not evidence the fix works.

The previously pinned limitation, `an_agent_question_banks_its_verdict_but_re_dispatches_no_card`, said in its own doc that its final assertion was what would change when this was fixed. It is renamed and flipped. Its banked-resolution assertion is kept and is now load-bearing: it pins that the durable record is *not* rewritten.

### Verified in the running console

Local host, real agent turns against staging inference, board-dispatched card:

1. A card was dispatched to a teammate that could not proceed without two facts. The agent called `escalate_to_human`; the parked approval carried `source: agent_question`, **no `step`**, and `task: {link: task, …}` — the exact shape of the defect.
2. **Answer** in the console → the card re-entered and the agent's next message opened *"I now have the product name (Northwind) and launch date (14 October 2026)"*, so the operator's words reached the re-run. It then parked a new, different question, which is the loop working.
3. **Cancel run** on that second blocker → approvals queue to zero, card to To-do, `bounced: "cancelled from the blocker chat — the work was stopped, not failed"`.

The console toast is not evidence either way — it renders the same whether or not the step resumed, which is what made the original report hard to confirm. The card moving is the proof.

Not covered live: the cardless case, which needs a chat-turn escalation this board-dispatched fixture cannot produce. It is covered by unit test only.

## Documentation

No doc change. `BlockerPayload::step`'s existing doc already described this behaviour as intended — it named the task link as the path back to the work where the payload carries no step — so this makes the code match the documentation rather than changing what is documented. One line was added there naming the resume as the consumer that now reads it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Linked cards now correctly resume processing after an agent question is resolved through amend or retry.
  - Canceling a linked approval now properly settles the associated card.
  - Step-less agent questions now re-dispatch their linked card when answered.
  - Unlinked approvals continue without moving any card.
  - Approvals linked to cards that no longer exist no longer attempt to resume a card.

- **Tests**
  - Added coverage for linked-card resume, cancellation, missing-card, and unlinked approval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->