### PR TITLE
test(harness): assert seven unasserted edge behaviours in the agent harness

### DIFF
--- a/src/harness/built_in/blockers.rs
+++ b/src/harness/built_in/blockers.rs
@@ -746,41 +746,48 @@ mod tool_test {
     /// after the other on a single task. That arrangement exercises two serial
     /// inserts and would pass unchanged if simultaneous calls could lose a
     /// card — which is the only thing this test exists to rule out.
+    ///
+    /// Repeated, because the barrier releases both workers before either
+    /// reaches `push` rather than at `push` itself: a single round can
+    /// interleave benignly. Making the window certain would mean a test hook
+    /// inside the queue every caller pays for, so the rounds buy it instead.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn concurrent_questions_from_different_agents_both_park() {
         use std::sync::{Arc, Barrier};
 
-        let queue = ApprovalRequestQueue::default();
-        let finance = EscalateToHumanTool::new(queue.clone(), "finance".to_string());
-        let legal = EscalateToHumanTool::new(queue.clone(), "legal".to_string());
-        let gate = Arc::new(Barrier::new(2));
+        for round in 0..20 {
+            let queue = ApprovalRequestQueue::default();
+            let finance = EscalateToHumanTool::new(queue.clone(), "finance".to_string());
+            let legal = EscalateToHumanTool::new(queue.clone(), "legal".to_string());
+            let gate = Arc::new(Barrier::new(2));
 
-        let ask = |tool: EscalateToHumanTool, question: &'static str, gate: Arc<Barrier>| {
-            tokio::task::spawn_blocking(move || {
-                gate.wait();
-                tokio::runtime::Handle::current()
-                    .block_on(tool.execute(serde_json::json!({ "question": question })))
-            })
-        };
-        let a = ask(finance, "approve the Q3 budget?", gate.clone());
-        let b = ask(legal, "sign the NDA as-is?", gate.clone());
-        assert!(!a.await.expect("joins").expect("runs").is_error);
-        assert!(!b.await.expect("joins").expect("runs").is_error);
+            let ask = |tool: EscalateToHumanTool, question: &'static str, gate: Arc<Barrier>| {
+                tokio::task::spawn_blocking(move || {
+                    gate.wait();
+                    tokio::runtime::Handle::current()
+                        .block_on(tool.execute(serde_json::json!({ "question": question })))
+                })
+            };
+            let a = ask(finance, "approve the Q3 budget?", gate.clone());
+            let b = ask(legal, "sign the NDA as-is?", gate.clone());
+            assert!(!a.await.expect("joins").expect("runs").is_error);
+            assert!(!b.await.expect("joins").expect("runs").is_error);
 
-        let drained = queue.drain(8);
-        let reasons: Vec<&String> = drained.requests.iter().map(|r| &r.reason).collect();
-        assert_eq!(
-            drained.requests.len(),
-            2,
-            "both concurrent questions must reach the queue, not just whichever wins the \
-             race: {reasons:?}"
-        );
-        for question in ["approve the Q3 budget?", "sign the NDA as-is?"] {
-            assert!(
-                reasons.iter().any(|reason| reason.contains(question)),
-                "the queue must hold each agent's own question, not one of them twice: \
-                 {reasons:?}"
+            let drained = queue.drain(8);
+            let reasons: Vec<&String> = drained.requests.iter().map(|r| &r.reason).collect();
+            assert_eq!(
+                drained.requests.len(),
+                2,
+                "round {round}: both concurrent questions must reach the queue, not just \
+                 whichever wins the race: {reasons:?}"
             );
+            for question in ["approve the Q3 budget?", "sign the NDA as-is?"] {
+                assert!(
+                    reasons.iter().any(|reason| reason.contains(question)),
+                    "round {round}: the queue must hold each agent's own question, not one of \
+                     them twice: {reasons:?}"
+                );
+            }
         }
     }
 

--- a/src/harness/built_in/blockers.rs
+++ b/src/harness/built_in/blockers.rs
@@ -739,30 +739,49 @@ mod tool_test {
     /// `execute` concurrently — nothing upstream of this tool serialises the
     /// calls — so both must still land their own card rather than one
     /// silently losing to the other on the shared queue's `Mutex`.
-    #[tokio::test]
+    ///
+    /// Driven from two worker threads through a [`Barrier`], not from
+    /// `tokio::join!`: `execute` has no suspension point around its
+    /// synchronous `push`, so joined futures are polled to completion one
+    /// after the other on a single task. That arrangement exercises two serial
+    /// inserts and would pass unchanged if simultaneous calls could lose a
+    /// card — which is the only thing this test exists to rule out.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn concurrent_questions_from_different_agents_both_park() {
+        use std::sync::{Arc, Barrier};
+
         let queue = ApprovalRequestQueue::default();
         let finance = EscalateToHumanTool::new(queue.clone(), "finance".to_string());
         let legal = EscalateToHumanTool::new(queue.clone(), "legal".to_string());
+        let gate = Arc::new(Barrier::new(2));
 
-        let (a, b) = tokio::join!(
-            finance.execute(serde_json::json!({ "question": "approve the Q3 budget?" })),
-            legal.execute(serde_json::json!({ "question": "sign the NDA as-is?" })),
-        );
-        assert!(!a.expect("runs").is_error);
-        assert!(!b.expect("runs").is_error);
+        let ask = |tool: EscalateToHumanTool, question: &'static str, gate: Arc<Barrier>| {
+            tokio::task::spawn_blocking(move || {
+                gate.wait();
+                tokio::runtime::Handle::current()
+                    .block_on(tool.execute(serde_json::json!({ "question": question })))
+            })
+        };
+        let a = ask(finance, "approve the Q3 budget?", gate.clone());
+        let b = ask(legal, "sign the NDA as-is?", gate.clone());
+        assert!(!a.await.expect("joins").expect("runs").is_error);
+        assert!(!b.await.expect("joins").expect("runs").is_error);
 
         let drained = queue.drain(8);
+        let reasons: Vec<&String> = drained.requests.iter().map(|r| &r.reason).collect();
         assert_eq!(
             drained.requests.len(),
             2,
-            "both concurrent questions must reach the queue, not just whichever wins the race: {:?}",
-            drained
-                .requests
-                .iter()
-                .map(|r| &r.reason)
-                .collect::<Vec<_>>()
+            "both concurrent questions must reach the queue, not just whichever wins the \
+             race: {reasons:?}"
         );
+        for question in ["approve the Q3 budget?", "sign the NDA as-is?"] {
+            assert!(
+                reasons.iter().any(|reason| reason.contains(question)),
+                "the queue must hold each agent's own question, not one of them twice: \
+                 {reasons:?}"
+            );
+        }
     }
 
     /// The other half of `an_escalation_mints_no_grant`, and the half that is

--- a/src/harness/built_in/blockers.rs
+++ b/src/harness/built_in/blockers.rs
@@ -735,6 +735,32 @@ mod tool_test {
         assert!(queue.drain(8).requests[0].effect.agent.is_none());
     }
 
+    /// Two agents asking distinct questions in the same turn race through
+    /// `execute` concurrently — nothing upstream of this tool serialises the
+    /// calls — so both must still land their own card rather than one
+    /// silently losing to the other on the shared queue's `Mutex`.
+    #[tokio::test]
+    async fn concurrent_questions_from_different_agents_both_park() {
+        let queue = ApprovalRequestQueue::default();
+        let finance = EscalateToHumanTool::new(queue.clone(), "finance".to_string());
+        let legal = EscalateToHumanTool::new(queue.clone(), "legal".to_string());
+
+        let (a, b) = tokio::join!(
+            finance.execute(serde_json::json!({ "question": "approve the Q3 budget?" })),
+            legal.execute(serde_json::json!({ "question": "sign the NDA as-is?" })),
+        );
+        assert!(!a.expect("runs").is_error);
+        assert!(!b.expect("runs").is_error);
+
+        let drained = queue.drain(8);
+        assert_eq!(
+            drained.requests.len(),
+            2,
+            "both concurrent questions must reach the queue, not just whichever wins the race: {:?}",
+            drained.requests.iter().map(|r| &r.reason).collect::<Vec<_>>()
+        );
+    }
+
     /// The other half of `an_escalation_mints_no_grant`, and the half that is
     /// load-bearing in the opposite direction.
     ///

--- a/src/harness/built_in/blockers.rs
+++ b/src/harness/built_in/blockers.rs
@@ -757,7 +757,11 @@ mod tool_test {
             drained.requests.len(),
             2,
             "both concurrent questions must reach the queue, not just whichever wins the race: {:?}",
-            drained.requests.iter().map(|r| &r.reason).collect::<Vec<_>>()
+            drained
+                .requests
+                .iter()
+                .map(|r| &r.reason)
+                .collect::<Vec<_>>()
         );
     }
 

--- a/src/harness/built_in/cost.rs
+++ b/src/harness/built_in/cost.rs
@@ -400,16 +400,21 @@ mod tests {
     /// and "not".
     #[test]
     fn the_smallest_representable_positive_cost_still_posts_a_ledger_entry() {
+        // The smallest positive `f64` there is: the least subnormal, which is
+        // smaller than `MIN_POSITIVE` (the smallest *normal*). Nothing positive
+        // can sit closer to the gate than this.
+        let smallest = f64::from_bits(1);
+        assert!(smallest.is_subnormal() && smallest > 0.0);
         let turn = TurnUsage {
             input_tokens: 3,
             output_tokens: 1,
             cached_input_tokens: 0,
-            cost_usd: f64::MIN_POSITIVE,
+            cost_usd: smallest,
         };
         let entry = ledger_entry_for(&turn, "ceo").expect(
             "a nonzero cost, however small, still posts — the gate is exact equality to zero",
         );
-        assert_eq!(entry.amount_usd, -f64::MIN_POSITIVE);
+        assert_eq!(entry.amount_usd, -smallest);
 
         let exactly_zero = TurnUsage {
             cost_usd: 0.0,

--- a/src/harness/built_in/cost.rs
+++ b/src/harness/built_in/cost.rs
@@ -393,6 +393,78 @@ mod tests {
         );
     }
 
+    /// The gate is `cost_usd == 0.0` on a value openhuman derives, not a
+    /// token-count threshold — so the smallest representable positive `f64`
+    /// still posts a ledger entry, however invisible its rendered amount
+    /// would be, and there is no rounding tolerance between "exactly zero"
+    /// and "not".
+    #[test]
+    fn the_smallest_representable_positive_cost_still_posts_a_ledger_entry() {
+        let turn = TurnUsage {
+            input_tokens: 3,
+            output_tokens: 1,
+            cached_input_tokens: 0,
+            cost_usd: f64::MIN_POSITIVE,
+        };
+        let entry = ledger_entry_for(&turn, "ceo").expect(
+            "a nonzero cost, however small, still posts — the gate is exact equality to zero",
+        );
+        assert_eq!(entry.amount_usd, -f64::MIN_POSITIVE);
+
+        let exactly_zero = TurnUsage {
+            cost_usd: 0.0,
+            ..turn
+        };
+        assert!(
+            ledger_entry_for(&exactly_zero, "ceo").is_none(),
+            "and exactly zero is still the one value that does not post"
+        );
+    }
+
+    /// A session that only ever runs managed-passthrough turns has real cost
+    /// (openhuman billed backend-side) this seam can never see — `cost_usd`
+    /// arrives `0.0` on every turn. The acknowledged limit is that Finances
+    /// stays silent about it forever, not just on one turn: repeated turns
+    /// keep producing zero ledger entries while their tokens keep
+    /// accumulating on the Usage surface, so the two surfaces drift apart by
+    /// design rather than by omission.
+    #[tokio::test]
+    async fn a_session_of_only_zero_cost_turns_never_posts_a_ledger_entry() {
+        let store = RecordingStore::default();
+        let meter = RecordingMeter::default();
+        let turn = TurnUsage {
+            input_tokens: 500,
+            output_tokens: 120,
+            cached_input_tokens: 0,
+            cost_usd: 0.0,
+        };
+        for _ in 0..5 {
+            record_turn_cost(
+                &turn,
+                "ceo",
+                "managed",
+                None,
+                &CompanyId::new("acme"),
+                &store,
+                Some(&meter),
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        assert!(
+            store.ledger.lock().unwrap().is_empty(),
+            "five real turns, still zero ledger entries — this seam has no visibility into \
+             managed-passthrough spend at any scale"
+        );
+        assert_eq!(
+            meter.samples.lock().unwrap().len(),
+            5,
+            "but every turn's tokens still land on the Usage surface"
+        );
+    }
+
     #[tokio::test]
     async fn record_turn_cost_is_a_noop_for_zero_usage() {
         let store = RecordingStore::default();

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -4341,26 +4341,27 @@ mod tests {
     /// second `request_approval` would be.
     #[tokio::test]
     async fn escalate_to_human_does_not_refuse_a_sibling_gated_call_in_the_same_turn() {
+        use openhuman_core::openhuman::tools::traits::Tool as _;
+
         let queue = ApprovalRequestQueue::default();
         let policy = policy("supervised", &[], None).with_requests(queue.clone());
         let claim = queue.claim(ApprovalScope::Cycle);
 
+        // Through the tool, not a hand-built `ApprovalRequest`: the boundary is
+        // established by what `execute` does, so a fixture that pushes the
+        // request itself would keep passing if the tool later began setting the
+        // task-local — the one regression this case exists to catch.
+        let tool = crate::harness::built_in::blockers::EscalateToHumanTool::new(
+            queue.clone(),
+            "engineer".to_string(),
+        );
         let later_call = claim
             .scoped(queue.turn_scoped(async {
-                queue.push(ApprovalRequest {
-                    tool: crate::harness::built_in::blockers::ESCALATE_TO_HUMAN_TOOL.to_string(),
-                    reason: "staging or prod?".to_string(),
-                    effect: Effect {
-                        kind: "blocker.information".to_string(),
-                        group: EffectGroup::Other,
-                        amount_usd: None,
-                        established_thread: false,
-                        first_time_counterparty: false,
-                        payload: serde_json::json!({ "reason": "staging or prod?" }),
-                        agent: None,
-                        run_id: None,
-                    },
-                });
+                let asked = tool
+                    .execute(serde_json::json!({ "question": "staging or prod?" }))
+                    .await
+                    .expect("the question runs");
+                assert!(!asked.is_error, "{}", asked.output());
                 policy
                     .check(&request("composio_execute", composio_send_args()))
                     .await

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -2328,6 +2328,66 @@ mod tests {
         assert_eq!(p.toolbelt_mode(), PolicyMode::Full);
     }
 
+    /// `toolbelt_mode` maps EVERY non-readonly tier to `Full` once policy HITL
+    /// is disabled, not just `supervised` — `auto` loses OpenHuman's own
+    /// `require_approval_for_medium_risk` exactly the same way, because
+    /// nothing in the mapping singles either tier out. `readonly` is the one
+    /// mode the guard excludes, so it must survive untouched.
+    #[tokio::test]
+    async fn disabled_hitl_maps_every_non_readonly_tier_to_full_toolbelt_mode() {
+        for mode in ["auto", "supervised", "full"] {
+            let p = policy(mode, &[], None).with_policy_hitl_disabled();
+            assert_eq!(
+                p.toolbelt_mode(),
+                PolicyMode::Full,
+                "{mode} with policy HITL disabled must hand OpenHuman Full, not its own tier"
+            );
+        }
+
+        let readonly = policy("readonly", &[], None).with_policy_hitl_disabled();
+        assert_eq!(
+            readonly.toolbelt_mode(),
+            PolicyMode::Readonly,
+            "readonly is the one tier the mapping excludes — even with policy HITL disabled, \
+             OpenHuman's own toolbelt must still see readonly"
+        );
+    }
+
+    /// The brake's other half: it denies now, but it does not consume the
+    /// grant. `readonly` is a mode a company sits in temporarily, so the same
+    /// approval must still be redeemable once the brake releases — inside its
+    /// TTL — exactly as if the readonly window had never happened.
+    #[tokio::test]
+    async fn a_readonly_denial_leaves_the_grant_redeemable_once_the_brake_releases() {
+        let locked_down_queue = ApprovalRequestQueue::default();
+        let grants = locked_down_queue.grants();
+        let args = serde_json::json!({ "amount_usd": 40.0 });
+        grants.grant(granted("finance", "payment.send", args.clone()));
+
+        let locked_down = policy("readonly", &[], None)
+            .with_requests(locked_down_queue)
+            .with_agent("finance");
+        assert!(
+            matches!(
+                locked_down
+                    .check(&request("payment.send", args.clone()))
+                    .await,
+                ToolPolicyDecision::Deny { .. }
+            ),
+            "readonly denies the call outright"
+        );
+
+        let released = policy("full", &[], None)
+            .with_requests(ApprovalRequestQueue::with_grants(grants))
+            .with_agent("finance");
+        assert_eq!(
+            released.check(&request("payment.send", args)).await,
+            ToolPolicyDecision::Allow,
+            "the same grant is still redeemable once the brake releases — the readonly denial \
+             must not have consumed it"
+        );
+    }
+
     #[tokio::test]
     async fn disabled_policy_hitl_keeps_readonly_as_a_hard_denial() {
         let p = policy("readonly", &[], None).with_policy_hitl_disabled();
@@ -4270,6 +4330,129 @@ mod tests {
             drained.discarded, 1,
             "a ninth question in one turn overflows the cap and is silently dropped — no card \
              is ever raised for it, though the run may still park expecting an answer"
+        );
+    }
+
+    /// `check`'s fail-closed boundary (the block right above `Deny`ing every
+    /// call once `request_approval` has fired) reads the same task-local as
+    /// `explicit_request_pending`. Since `escalate_to_human` never sets it, a
+    /// sibling gated call queued in the same turn right after a question is
+    /// evaluated on its own terms rather than refused outright the way a
+    /// second `request_approval` would be.
+    #[tokio::test]
+    async fn escalate_to_human_does_not_refuse_a_sibling_gated_call_in_the_same_turn() {
+        let queue = ApprovalRequestQueue::default();
+        let policy = policy("supervised", &[], None).with_requests(queue.clone());
+        let claim = queue.claim(ApprovalScope::Cycle);
+
+        let later_call = claim
+            .scoped(queue.turn_scoped(async {
+                queue.push(ApprovalRequest {
+                    tool: crate::harness::built_in::blockers::ESCALATE_TO_HUMAN_TOOL.to_string(),
+                    reason: "staging or prod?".to_string(),
+                    effect: Effect {
+                        kind: "blocker.information".to_string(),
+                        group: EffectGroup::Other,
+                        amount_usd: None,
+                        established_thread: false,
+                        first_time_counterparty: false,
+                        payload: serde_json::json!({ "reason": "staging or prod?" }),
+                        agent: None,
+                        run_id: None,
+                    },
+                });
+                policy
+                    .check(&request("composio_execute", composio_send_args()))
+                    .await
+            }))
+            .await;
+
+        assert!(
+            matches!(later_call, ToolPolicyDecision::RequireApproval { .. }),
+            "escalate_to_human must not trip the request_approval turn boundary — the sibling \
+             call should still be gated on its own terms, not refused outright: {later_call:?}"
+        );
+    }
+
+    /// A repeated identical question in one turn — a model retrying a call it
+    /// is unsure landed — collapses into the card already queued via `push`'s
+    /// per-scope de-duplication (issue #439), same as a duplicate
+    /// `request_approval`. Both calls still report success to the model, so a
+    /// distinct question asked right after must not vanish along with the
+    /// duplicate.
+    #[tokio::test]
+    async fn a_repeated_identical_escalation_collapses_but_a_distinct_one_survives() {
+        use openhuman_core::openhuman::tools::traits::Tool as _;
+
+        let queue = ApprovalRequestQueue::default();
+        let tool =
+            crate::harness::built_in::blockers::EscalateToHumanTool::new(queue.clone(), "engineer".to_string());
+
+        let first = tool
+            .execute(serde_json::json!({ "question": "staging or prod?" }))
+            .await
+            .expect("the tool runs");
+        let second = tool
+            .execute(serde_json::json!({ "question": "staging or prod?" }))
+            .await
+            .expect("the tool runs");
+        assert!(!first.is_error);
+        assert!(!second.is_error, "a duplicate ask is not itself a failure");
+
+        let distinct = tool
+            .execute(serde_json::json!({ "question": "which key rotates first?" }))
+            .await
+            .expect("the tool runs");
+        assert!(!distinct.is_error);
+
+        let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(
+            drained.requests.len(),
+            2,
+            "the repeated question collapses into the card already queued, but the distinct \
+             question still gets its own: {:?}",
+            drained.requests.iter().map(|r| &r.reason).collect::<Vec<_>>()
+        );
+    }
+
+    /// Outside `turn_scoped`, the task-local backing the boundary was never
+    /// installed. `explicit_request_pending` reads that absence through
+    /// `unwrap_or(false)` rather than erroring or denying, so a call site
+    /// that forgot to wrap its turn in `turn_scoped` gets "no request
+    /// pending" — the boundary fails OPEN outside its scope, not closed.
+    #[tokio::test]
+    async fn the_turn_boundary_reads_as_not_pending_outside_any_turn_scope() {
+        let queue = ApprovalRequestQueue::default();
+        let policy = policy("full", &[], None)
+            .with_policy_hitl_disabled()
+            .with_requests(queue.clone());
+
+        // No `turn_scoped` anywhere in this call's ancestry.
+        queue.push(ApprovalRequest {
+            tool: crate::harness::approval_tool::REQUEST_APPROVAL_TOOL.to_string(),
+            reason: "May I send this?".to_string(),
+            effect: Effect {
+                kind: crate::harness::approval_tool::REQUEST_APPROVAL_TOOL.to_string(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::json!({
+                    "title": "Send update",
+                    "question": "May I send it?"
+                }),
+                agent: Some("ceo".to_string()),
+                run_id: None,
+            },
+        });
+
+        let decision = policy
+            .check(&request("composio_execute", composio_send_args()))
+            .await;
+        assert!(
+            !matches!(decision, ToolPolicyDecision::Deny { .. }),
+            "outside any turn_scoped call, the boundary reads as not-pending and does not \
+             refuse a sibling call: {decision:?}"
         );
     }
 

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -4385,8 +4385,10 @@ mod tests {
         use openhuman_core::openhuman::tools::traits::Tool as _;
 
         let queue = ApprovalRequestQueue::default();
-        let tool =
-            crate::harness::built_in::blockers::EscalateToHumanTool::new(queue.clone(), "engineer".to_string());
+        let tool = crate::harness::built_in::blockers::EscalateToHumanTool::new(
+            queue.clone(),
+            "engineer".to_string(),
+        );
 
         let first = tool
             .execute(serde_json::json!({ "question": "staging or prod?" }))
@@ -4411,7 +4413,11 @@ mod tests {
             2,
             "the repeated question collapses into the card already queued, but the distinct \
              question still gets its own: {:?}",
-            drained.requests.iter().map(|r| &r.reason).collect::<Vec<_>>()
+            drained
+                .requests
+                .iter()
+                .map(|r| &r.reason)
+                .collect::<Vec<_>>()
         );
     }
 


### PR DESCRIPTION
## Summary

Seven edge cells in the agent harness had behaviour that works and nothing asserting it. This adds the assertions — no production code changes at all, so the whole diff is tests.

Covered: the cost gate's exact-zero boundary and a zero-cost session at scale; two concurrent `escalate_to_human` calls both reaching the queue; a gated sibling call surviving an escalation in the same turn; a repeated identical escalation collapsing while a distinct one survives; the turn boundary read outside any turn scope; a readonly denial leaving its grant redeemable once the brake releases; and the toolbelt-mode mapping across every non-readonly tier.

Each test was red-proved individually: break the specific behaviour it covers, watch that case fail, restore, confirm the file's whole suite is green again. The proofs are recorded per test below rather than claimed in aggregate, because a test that cannot fail for the reason it exists is not coverage.

| Cell | Test | What was broken to prove it |
|---|---|---|
| MET-003 | `the_smallest_representable_positive_cost_still_posts_a_ledger_entry` | added a `< 1e-9` threshold to `ledger_entry_for` |
| MET-008 | `a_session_of_only_zero_cost_turns_never_posts_a_ledger_entry` | made `record_turn_cost` post unconditionally |
| HT-005 | `concurrent_questions_from_different_agents_both_park` | weakened `push()`'s de-dup to compare `effect.kind` only |
| REQ-002 | `escalate_to_human_does_not_refuse_a_sibling_gated_call_in_the_same_turn` | broadened `push()`'s `explicit` flag to the escalation tool |
| REQ-002 | `a_repeated_identical_escalation_collapses_but_a_distinct_one_survives` | same de-dup break as HT-005 |
| TOOL-001 | `the_turn_boundary_reads_as_not_pending_outside_any_turn_scope` | flipped the `unwrap_or` default |
| TOOL-004 | `a_readonly_denial_leaves_the_grant_redeemable_once_the_brake_releases` | consumed the grant inside the readonly-deny arm |
| TOOL-019 | `disabled_hitl_maps_every_non_readonly_tier_to_full_toolbelt_mode` | narrowed the mapping to `Supervised` only |

One of these is worth reading as a finding rather than a closure. `TOOL-001` pins that the turn boundary reads **not pending** outside a turn scope — it fails *open*. The test records current behaviour so drift becomes a failure; it does not make the behaviour safe, and the cell stays a gap. Whether any production path reaches that check unscoped is the open question.

## API Or Behavior Changes

None. Tests only.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — run as `--locked --no-deps --features openhuman,mcp --all-targets`, clean
- [ ] `cargo build --all-targets` — N/A: covered by the clippy and test runs, which build the same targets
- [x] `cargo test` — `harness::built_in::cost::tests::` 10 passed · `harness::built_in::blockers::` 22 passed · `harness::built_in::policy::tests::` 140 passed

## Documentation

No docs needed — no behaviour changed and no public API moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify concurrent human-escalation requests are preserved and queued correctly.
  * Added cost-accounting tests for the smallest positive costs and sessions containing only zero-cost turns.
  * Expanded policy coverage for HITL-disabled tool access, readonly grants, approval boundaries, escalation deduplication, distinct questions, and turn-scoped behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->