### PR TITLE
fix(delegation): report an unknown-card write instead of a false success, and close four runtime cells

### DIFF
--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -9969,4 +9969,32 @@ needs_reason = true
             "the injected readonly gate must keep its own policy, not the carried override"
         );
     }
+
+    /// Issue #1925: approvals are explicit-only in production — the
+    /// manifest-`[policy]` HITL gate is deliberately dead weight, disabled at
+    /// the one construction site nothing else reaches
+    /// (`RuntimeBuilder::build`'s default, uninjected gate). Nothing else in
+    /// the type system pins that wiring: `with_policy_hitl_disabled` is a
+    /// plain builder call on `ManifestApprovalGate`, so deleting it would
+    /// compile clean and silently resurrect policy-driven parking in every
+    /// company that never explicitly injects a gate. Pinned here so that
+    /// deletion instead breaks this test.
+    #[tokio::test]
+    async fn the_default_uninjected_gate_ships_with_policy_hitl_disabled() {
+        let dir = tmp_home("oc-policy-hitl-default-");
+        let manifest = parse(
+            "[company]\nname = \"Acme\"\n\
+             [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n\
+             [policy]\nmode = \"supervised\"\n",
+        );
+        let runtime = RuntimeBuilder::new(dir.path().to_path_buf(), manifest)
+            .build()
+            .await
+            .unwrap();
+        assert!(
+            !runtime.approval_gate.policy_hitl_enabled(),
+            "the production default build must disable the manifest-policy HITL gate; a \
+             company that injects no gate of its own must never fall back to it"
+        );
+    }
 }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -10892,6 +10892,101 @@ members = ["writer"]
         );
     }
 
+    /// A [`JournalStore`](crate::ports::journal::JournalStore) that fails
+    /// every `ApprovalGranted` append, passing every other line straight
+    /// through to an in-memory backend.
+    struct FailGrantedMintStore {
+        inner: crate::ports::journal::MemoryJournalStore,
+    }
+
+    impl FailGrantedMintStore {
+        fn new() -> Self {
+            Self {
+                inner: crate::ports::journal::MemoryJournalStore::default(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ports::journal::JournalStore for FailGrantedMintStore {
+        async fn append_journal(
+            &self,
+            id: &CompanyId,
+            line: &str,
+            durability: crate::ports::journal::Durability,
+        ) -> Result<()> {
+            if line.contains("ApprovalGranted") {
+                return Err(crate::error::OpenCompanyError::Store(
+                    "FailGrantedMintStore: forced failure on the single-use grant mint"
+                        .to_string(),
+                ));
+            }
+            self.inner.append_journal(id, line, durability).await
+        }
+
+        async fn read_journal(&self, id: &CompanyId) -> Result<Vec<String>> {
+            self.inner.read_journal(id).await
+        }
+
+        async fn journal_imported(&self, id: &CompanyId) -> Result<bool> {
+            self.inner.journal_imported(id).await
+        }
+
+        async fn complete_import(&self, id: &CompanyId, lines: Vec<String>) -> Result<()> {
+            self.inner.complete_import(id, lines).await
+        }
+    }
+
+    /// Issue #243's ordering claim, pinned rather than left to reading the code:
+    /// `mint_grant` journals `ApprovalGranted` *before* arming the single-use
+    /// grant in the live set (`settle_approved_effect` → `mint_grant`), so a
+    /// failure on that append must leave the grant un-armed rather than live
+    /// with no durable record. A crash between the two is meant to replay as
+    /// "granted", never to lose the write; forcing the write itself to fail
+    /// proves the arm genuinely comes after it in the code, not just in the
+    /// comment describing it.
+    #[tokio::test]
+    async fn a_failed_grant_mint_never_arms_the_live_grant() {
+        let home_dir = tmp_home();
+        let effect = harness_effect("finance", "composio_execute", serde_json::json!({}));
+        let rt = Arc::new(
+            RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("supervised"))
+                .with_brain(Arc::new(ParkingBrain {
+                    effect: effect.clone(),
+                }))
+                .with_journal_store(Arc::new(FailGrantedMintStore::new()))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
+                parent: None,
+                text: "do it".into(),
+                by: None,
+                chat: None,
+                deliverable: None,
+                attachments: Vec::new(),
+            }])
+            .await
+            .unwrap();
+        let id = report.parked[0].clone();
+
+        let result = rt.resolve_approval(&id, Verdict::Approve, operator()).await;
+        assert!(
+            result.is_err(),
+            "the forced failure on the journal append must surface, not be swallowed"
+        );
+        assert_eq!(
+            rt.grants.live_count(),
+            0,
+            "the grant must not be armed when the journal write that was supposed to \
+             precede it failed"
+        );
+        assert!(rt.grants.peek(&id).is_none());
+    }
+
     /// Issue #1458 under concurrency: two opposite-polarity resolutions of the
     /// **same** scope settled while both are in flight — the approve and the
     /// deny each half-finished before either mints — must still leave a single

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -10917,8 +10917,7 @@ members = ["writer"]
         ) -> Result<()> {
             if line.contains("ApprovalGranted") {
                 return Err(crate::error::OpenCompanyError::Store(
-                    "FailGrantedMintStore: forced failure on the single-use grant mint"
-                        .to_string(),
+                    "FailGrantedMintStore: forced failure on the single-use grant mint".to_string(),
                 ));
             }
             self.inner.append_journal(id, line, durability).await

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -3312,21 +3312,23 @@ impl<'a> DelegationRunner<'a> {
                 note,
             } => {
                 let Some((tasks, mut card)) = self.load_card(&task_id).await? else {
-                    // Issue #453: the residual case. The tool told the model the
-                    // assignment takes effect as the turn completes, the drain
-                    // ran, and there was no card to write to — so the receipt
-                    // promised something no store hiccup or missing wiring
-                    // explains. Silent no-op is right for the *card* (there is
-                    // nothing to do), and wrong for the operator, who is the
-                    // only one who can tell a mistyped id from a deleted card.
+                    if self.tasks.is_none() {
+                        tracing::warn!(
+                            company = %self.company,
+                            task_id = %task_id,
+                            "[delegation] assign_task could not run: no task store is wired"
+                        );
+                        return Ok(DelegationOutcome::default());
+                    }
                     tracing::warn!(
                         company = %self.company,
                         task_id = %task_id,
-                        "[delegation] assign_task named a card that is not on the board (or no \
-                         task store is wired); nothing was assigned, and the turn was told it \
-                         would be"
+                        "[delegation] assign_task named a card that is not on the board; \
+                         nothing was assigned"
                     );
-                    return Ok(DelegationOutcome::default());
+                    return Err(crate::error::OpenCompanyError::NotFound(format!(
+                        "assign_task: no card with id {task_id:?} on the board"
+                    )));
                 };
                 // Issue #205: the orchestrator writes this `assignee` out of an
                 // LLM tool call, so it is exactly as capable of naming somebody
@@ -3408,21 +3410,25 @@ impl<'a> DelegationRunner<'a> {
                 note,
             } => {
                 let Some((tasks, mut card)) = self.load_card(&task_id).await? else {
-                    // Issue #453, the same residual case one arm up and the more
-                    // consequential of the two: the model has just been told the
-                    // card "moves to done as this turn completes", and this is
-                    // the drain completing with nothing to move. The claim
-                    // guarantees the drain ran; it cannot guarantee the id names
-                    // a real card.
+                    if self.tasks.is_none() {
+                        tracing::warn!(
+                            company = %self.company,
+                            task_id = %task_id,
+                            ?decision,
+                            "[delegation] review_task could not run: no task store is wired"
+                        );
+                        return Ok(DelegationOutcome::default());
+                    }
                     tracing::warn!(
                         company = %self.company,
                         task_id = %task_id,
                         ?decision,
-                        "[delegation] review_task named a card that is not on the board (or no \
-                         task store is wired); the verdict was recorded nowhere, and the turn was \
-                         told the card had moved"
+                        "[delegation] review_task named a card that is not on the board; the \
+                         verdict was recorded nowhere"
                     );
-                    return Ok(DelegationOutcome::default());
+                    return Err(crate::error::OpenCompanyError::NotFound(format!(
+                        "review_task: no card with id {task_id:?} on the board"
+                    )));
                 };
                 card.note = Some(append_note(
                     card.note.as_deref(),
@@ -3441,8 +3447,10 @@ impl<'a> DelegationRunner<'a> {
     }
 
     /// Loads one board card by id, with the store handle. `None` when there is
-    /// no task store wired, or the card has since been deleted — both a silent
-    /// no-op rather than an error (issue #186).
+    /// no task store wired, or the card has since been deleted (issue #186). The
+    /// two callers no longer treat these alike: no store wired stays a silent
+    /// no-op, and a deleted/mistyped card now errors instead of reporting a
+    /// false success (issue #453 residual).
     async fn load_card(
         &self,
         task_id: &str,
@@ -9255,7 +9263,6 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
     /// is told, which is not. A mistyped id and a deleted card are the same
     /// silence, and the turn has already been told it worked.
     #[tokio::test]
-    #[ignore = "assign_task on an unknown task_id is a silent drain-time no-op after a success receipt"]
     async fn assigning_a_card_that_is_not_on_the_board_does_not_report_success() {
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(
@@ -9297,7 +9304,6 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
     /// verdict nowhere, and returns the same empty outcome a real approval
     /// returns.
     #[tokio::test]
-    #[ignore = "review_task on an unknown task_id records the verdict nowhere after a 'moves to done' receipt"]
     async fn approving_a_card_that_is_not_on_the_board_does_not_report_success() {
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -416,6 +416,33 @@ pub(crate) struct DelegationOutcome {
     /// `false` for every other delegation kind, so the chat and task paths — which
     /// never read it — are unaffected.
     pub(crate) assigned: bool,
+    /// An `assign_task`/`review_task` whose id named no card on the board
+    /// (issue #453 residual, HT-077/HT-078).
+    ///
+    /// Carried as a fact rather than an `Err`, for the same reason
+    /// [`assigned`](Self::assigned) is a fact rather than a boolean the caller
+    /// has to infer: `run_delegation` is driven from loops that drain a whole
+    /// turn's queued delegations one at a time
+    /// ([`drain_and_execute`](DelegationRunner::drain_and_execute),
+    /// [`handle_task_delegations`](DelegationRunner::handle_task_delegations)),
+    /// and every one of them propagates an `Err` with `?` — which is correct
+    /// for a genuine failure (a store write that errored), but a hallucinated
+    /// or stale `task_id` from the model is a routine path, not an exotic one.
+    /// Erroring here would abort the whole drain and silently discard every
+    /// delegation queued behind this one in the same turn, trading a false
+    /// success for lost work — the same defect family one layer over. `None`
+    /// on every other path, including a genuine store failure, which still
+    /// propagates as an `Err`.
+    pub(crate) unknown_card: Option<UnknownCardWrite>,
+}
+
+/// One `assign_task`/`review_task` that named a card not on the board — see
+/// [`DelegationOutcome::unknown_card`].
+#[derive(Clone, Debug)]
+pub(crate) struct UnknownCardWrite {
+    /// `"assign_task"` or `"review_task"`, for the operator-facing note.
+    pub(crate) tool: &'static str,
+    pub(crate) task_id: String,
 }
 
 /// Which workflow run a board write belongs to (issue #661 / M5).
@@ -654,6 +681,13 @@ pub(crate) struct Drained {
     /// The **first** board card this drain opened, matching
     /// [`OperatorTurn::spawned_task`]'s first-wins rule.
     pub(crate) spawned_task: Option<String>,
+    /// Every `assign_task`/`review_task` this drain could not perform because
+    /// its id named no card on the board (issue #453 residual, HT-077/HT-078).
+    ///
+    /// Mirrors [`cancelled_desks`](Self::cancelled_desks): a fact carried out
+    /// of the loop rather than an `Err` that would abort it, so one bad id
+    /// does not discard every delegation queued behind it in the same turn.
+    pub(crate) unknown_cards: Vec<UnknownCardWrite>,
 }
 
 /// The operator-facing result of one operator message after delegation: the
@@ -1642,6 +1676,12 @@ impl<'a> DelegationRunner<'a> {
         // bubble lands in `bubbles`.
         let mut bubbles = Vec::new();
         let mut desk_replies: Vec<(String, String)> = Vec::new();
+        // Issue #453 residual (HT-077/HT-078): sticky like `hit_iteration_cap`
+        // and the other facts below — folded into `operator_reply` at the very
+        // end, after the CEO-relay branch has had its chance to replace that
+        // string wholesale, so an unknown-card note from either drain survives
+        // the relay rather than being overwritten by it.
+        let mut unknown_cards: Vec<UnknownCardWrite> = Vec::new();
         // Issue #1846 review (Codex #3870516681): whether a DESK paused, kept
         // apart from the sticky `budget_paused` above. That one is already
         // carrying the responder's OWN pause, and a responder that paused on
@@ -1670,6 +1710,7 @@ impl<'a> DelegationRunner<'a> {
             spawned_task.get_or_insert(id);
         }
         bubbles.extend(drained.bubbles);
+        unknown_cards.extend(drained.unknown_cards);
         for desk in drained.desk_replies {
             // Fold the teammate's activity onto the operator timeline, then
             // remember the answer to relay.
@@ -1753,6 +1794,7 @@ impl<'a> DelegationRunner<'a> {
                 spawned_task.get_or_insert(id);
             }
             bubbles.extend(drained.bubbles);
+            unknown_cards.extend(drained.unknown_cards);
             // A hand-off the relay turn's tool refused is dropped with the
             // hand-offs themselves — there is no card in scope to record it on,
             // and the drain would otherwise leak it into the next turn.
@@ -1858,6 +1900,17 @@ impl<'a> DelegationRunner<'a> {
                      for a budget pause, so they are recorded nowhere but here"
                 );
             }
+        }
+        // Issue #453 residual (HT-077/HT-078): folded in last, after both
+        // drains and the relay branch that can replace `operator_reply`
+        // wholesale, so an id the model hallucinated or a card deleted out
+        // from under it is a fact the operator reads rather than a silent
+        // no-op behind a receipt that said it worked.
+        for unknown in unknown_cards {
+            operator_reply.push_str(&format!(
+                "\n\n(tried to {} card {:?}, but no such card is on the board)",
+                unknown.tool, unknown.task_id
+            ));
         }
         // Drained after the relay, not before it: a relay turn carries the same
         // inline `create_workflow` tool, so draining at the responder's turn
@@ -2079,6 +2132,9 @@ impl<'a> DelegationRunner<'a> {
             }
             if let Some(desk) = out.desk_reply {
                 drained.desk_replies.push(desk);
+            }
+            if let Some(unknown) = out.unknown_card {
+                drained.unknown_cards.push(unknown);
             }
         }
         Ok(drained)
@@ -2626,6 +2682,16 @@ impl<'a> DelegationRunner<'a> {
                  hand-off was refused and did not happen)"
             ));
         }
+        // Issue #453 residual (HT-077/HT-078): the same fold, one level down —
+        // a deeper delegate's own `assign_task`/`review_task` naming no card is
+        // folded into THIS member's reply exactly as their cancellations and
+        // refused hand-offs are, rather than vanishing into the log.
+        for unknown in nested.unknown_cards {
+            reply.push_str(&format!(
+                "\n\n({member} tried to {} card {:?}, but no such card is on the board)",
+                unknown.tool, unknown.task_id
+            ));
+        }
         // Issue #1846 review (Codex #3865395868): this hand-off's own card
         // (opened above by `open_hand_off_work_card`, distinct from any
         // dispatched-card the delegation is nested inside) must settle
@@ -2669,6 +2735,10 @@ impl<'a> DelegationRunner<'a> {
             // level down, so it stays the reported one; a card the member
             // opened is reported only when this hand-off opened none.
             spawned_task: card.map(|c| c.id).or(nested.spawned_task),
+            // Not a board write; see `DelegationOutcome::unknown_card`. A
+            // deeper delegate's own unknown-card write was already folded
+            // into `reply` above, not carried on this outcome.
+            unknown_card: None,
         })
     }
 
@@ -3324,11 +3394,16 @@ impl<'a> DelegationRunner<'a> {
                         company = %self.company,
                         task_id = %task_id,
                         "[delegation] assign_task named a card that is not on the board; \
-                         nothing was assigned"
+                         nothing was assigned, and the failure is carried out with the drain \
+                         rather than aborting it"
                     );
-                    return Err(crate::error::OpenCompanyError::NotFound(format!(
-                        "assign_task: no card with id {task_id:?} on the board"
-                    )));
+                    return Ok(DelegationOutcome {
+                        unknown_card: Some(UnknownCardWrite {
+                            tool: "assign_task",
+                            task_id,
+                        }),
+                        ..DelegationOutcome::default()
+                    });
                 };
                 // Issue #205: the orchestrator writes this `assignee` out of an
                 // LLM tool call, so it is exactly as capable of naming somebody
@@ -3424,11 +3499,16 @@ impl<'a> DelegationRunner<'a> {
                         task_id = %task_id,
                         ?decision,
                         "[delegation] review_task named a card that is not on the board; the \
-                         verdict was recorded nowhere"
+                         verdict was recorded nowhere, and the failure is carried out with the \
+                         drain rather than aborting it"
                     );
-                    return Err(crate::error::OpenCompanyError::NotFound(format!(
-                        "review_task: no card with id {task_id:?} on the board"
-                    )));
+                    return Ok(DelegationOutcome {
+                        unknown_card: Some(UnknownCardWrite {
+                            tool: "review_task",
+                            task_id,
+                        }),
+                        ..DelegationOutcome::default()
+                    });
                 };
                 card.note = Some(append_note(
                     card.note.as_deref(),
@@ -3449,8 +3529,11 @@ impl<'a> DelegationRunner<'a> {
     /// Loads one board card by id, with the store handle. `None` when there is
     /// no task store wired, or the card has since been deleted (issue #186). The
     /// two callers no longer treat these alike: no store wired stays a silent
-    /// no-op, and a deleted/mistyped card now errors instead of reporting a
-    /// false success (issue #453 residual).
+    /// no-op, and a deleted/mistyped card now reports
+    /// [`DelegationOutcome::unknown_card`] instead of a false success — as a
+    /// fact carried out of the drain, not an `Err`, so one bad id does not
+    /// abort every delegation queued behind it (issue #453 residual, HT-077/
+    /// HT-078).
     async fn load_card(
         &self,
         task_id: &str,
@@ -9257,11 +9340,14 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
     // ── Issue #453 residual: an id that names no card ───────────────────────
 
     /// `assign_task`'s receipt tells the model the assignment "takes effect as
-    /// this turn completes". The drain is what completes it, and an id naming
-    /// no card reaches a `tracing::warn!` and `DelegationOutcome::default()` —
-    /// the board is untouched, which is right, and nobody who could act on it
-    /// is told, which is not. A mistyped id and a deleted card are the same
-    /// silence, and the turn has already been told it worked.
+    /// this turn completes". An id naming no card must not make the drain
+    /// silently agree with that receipt: the write does not happen, and the
+    /// operator reads a note saying so, carried as a fact on the outcome
+    /// (`DelegationOutcome::unknown_card`) rather than an `Err` — an `Err`
+    /// here would abort `drain_and_execute`'s loop via its `?` and discard
+    /// every delegation queued behind this one in the same turn, which is
+    /// the sibling defect `a_valid_delegation_after_an_unknown_card_still_lands`
+    /// below pins.
     #[tokio::test]
     async fn assigning_a_card_that_is_not_on_the_board_does_not_report_success() {
         let fx = Fixture::new();
@@ -9284,25 +9370,25 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 "put the launch plan on engineering",
                 Some("general"),
             )
-            .await;
+            .await
+            .expect("an unknown card is a reported fact, not a turn failure");
 
         assert!(
             fx.cards().await.iter().all(|card| card.assignee.is_empty()),
             "nothing may be assigned on the strength of an id that names no card"
         );
-        let error = outcome.err().map(|e| e.to_string()).unwrap_or_default();
         assert!(
-            error.contains("card-that-never-existed"),
-            "the drain must name the card it could not assign rather than warn into the log and \
-             let the receipt stand: {error:?}"
+            outcome.reply.contains("card-that-never-existed"),
+            "the operator's reply must name the card the assignment could not reach rather than \
+             warn into the log and let the receipt stand silently: {:?}",
+            outcome.reply
         );
     }
 
     /// The same residual on the arm the code's own comment calls the more
     /// consequential one: `review_task`'s receipt says the card "moves to done
-    /// as this turn completes". An unknown id moves nothing, records the
-    /// verdict nowhere, and returns the same empty outcome a real approval
-    /// returns.
+    /// as this turn completes". An unknown id moves nothing and records the
+    /// verdict nowhere, surfaced the same way `assign_task`'s is.
     #[tokio::test]
     async fn approving_a_card_that_is_not_on_the_board_does_not_report_success() {
         let fx = Fixture::new();
@@ -9321,17 +9407,104 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let outcome = fx
             .runner(&turns)
             .handle_operator_message("chief", "approve the launch plan card", Some("general"))
-            .await;
+            .await
+            .expect("an unknown card is a reported fact, not a turn failure");
 
         assert!(
             fx.cards().await.is_empty(),
             "a verdict on an id that names no card may not mint one"
         );
-        let error = outcome.err().map(|e| e.to_string()).unwrap_or_default();
         assert!(
-            error.contains("card-that-never-existed"),
-            "the drain must name the card whose approval landed nowhere rather than warn into the \
-             log while the turn is told it moved: {error:?}"
+            outcome.reply.contains("card-that-never-existed"),
+            "the operator's reply must name the card whose approval landed nowhere rather than \
+             warn into the log while the turn is told it moved: {:?}",
+            outcome.reply
+        );
+    }
+
+    /// The defect one layer over the false-success receipt: `run_delegation`
+    /// is driven from `drain_and_execute`'s loop with `?`, so an `Err` on one
+    /// delegation would abort the whole drain and discard every delegation
+    /// queued behind it in the SAME turn — including ones the model queued
+    /// validly. A hallucinated `task_id` is a routine model mistake, not an
+    /// exotic one, so a batch of two — an `assign_task` naming no card,
+    /// followed by one naming a real card — must still land the second write
+    /// AND still report the first's failure. The two tests above alone cannot
+    /// catch a regression to `Err`: they each queue exactly one delegation, so
+    /// an abort and a reported fact look identical from their vantage point.
+    #[tokio::test]
+    async fn a_valid_delegation_after_an_unknown_card_still_lands() {
+        let fx = Fixture::new();
+        let card = TaskRecord {
+            id: "card-real".to_string(),
+            title: TaskTitle::authored("Draft the launch plan"),
+            note: None,
+            column: COLUMN_TODO.to_string(),
+            priority: "medium".to_string(),
+            assignee: String::new(),
+            updated_at_millis: now_millis(),
+            origin: None,
+            parent_task_id: None,
+            output: None,
+            plan: None,
+            planning_attempts: Vec::new(),
+            deliverable: crate::ports::tasks::TaskDeliverable::Once,
+            workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
+            origin_message_seq: None,
+            bounced: None,
+        };
+        fx.tasks
+            .upsert(&fx.record.id, &card)
+            .await
+            .expect("seed the real card");
+
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![Turn::queueing(
+                "assigning both",
+                vec![
+                    Delegation::AssignTask {
+                        task_id: "card-that-never-existed".to_string(),
+                        assignee: "engineer".to_string(),
+                        note: None,
+                    },
+                    Delegation::AssignTask {
+                        task_id: "card-real".to_string(),
+                        assignee: "engineer".to_string(),
+                        note: None,
+                    },
+                ],
+            )],
+        );
+
+        let outcome = fx
+            .runner(&turns)
+            .handle_operator_message(
+                "chief",
+                "put the launch plan and the real card on engineering",
+                Some("general"),
+            )
+            .await
+            .expect("one unknown card must not fail the turn");
+
+        let cards = fx.cards().await;
+        let real = cards
+            .iter()
+            .find(|c| c.id == "card-real")
+            .expect("the real card is still on the board");
+        assert_eq!(
+            real.assignee, "engineer",
+            "the valid delegation queued AFTER the unknown-card one must still land — a false \
+             success traded for silently discarding queued work is the same defect family, one \
+             layer over"
+        );
+        assert!(
+            outcome.reply.contains("card-that-never-existed"),
+            "the unknown card's failure must still be reported even though the drain kept \
+             going: {:?}",
+            outcome.reply
         );
     }
 

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -1859,6 +1859,82 @@ mod test {
         assert!(set.peek(&ApprovalId::new("a2")).is_some());
     }
 
+    /// `rehydrate` seeds a `HashMap` keyed by approval id, so two journal
+    /// lines that name the same id (a replay quirk, or a caller that passes
+    /// the same call twice) do not double-count the grant — the later entry
+    /// in the iterator simply overwrites the earlier one, same as inserting
+    /// the same key twice into any map.
+    #[test]
+    fn rehydrate_with_a_duplicate_approval_id_keeps_only_the_last_entry() {
+        let set = GrantSet::default();
+        set.rehydrate([
+            call("a1", "finance", "old_tool", serde_json::json!({"n": 1})),
+            call("a1", "finance", "new_tool", serde_json::json!({"n": 2})),
+        ]);
+        assert_eq!(
+            set.live_count(),
+            1,
+            "one approval id must seed exactly one live grant, not two"
+        );
+        let seeded = set
+            .peek(&ApprovalId::new("a1"))
+            .expect("the id is live");
+        assert_eq!(
+            seeded.tool, "new_tool",
+            "the later entry in the replay order wins"
+        );
+    }
+
+    /// `rehydrate` enforces no ceiling of its own on how many grants a single
+    /// replay can seed — the boot-time journal is the only source of a cap
+    /// (if any), and this queue must not silently drop entries past some
+    /// count. Mirrors the standing-list no-ceiling pin for the live side.
+    #[test]
+    fn rehydrate_seeds_every_grant_in_a_large_replay_batch_with_no_cap() {
+        let set = GrantSet::default();
+        let calls: Vec<_> = (0..500)
+            .map(|i| call(&format!("a{i}"), "finance", "t", serde_json::json!({ "i": i })))
+            .collect();
+        set.rehydrate(calls);
+        assert_eq!(
+            set.live_count(),
+            500,
+            "every grant in the replay batch must be seeded; none held back"
+        );
+        assert!(set.peek(&ApprovalId::new("a499")).is_some());
+    }
+
+    /// A boot-time `rehydrate` must not clobber grants a concurrent `consume`
+    /// is already working with: it seeds only the ids it was handed, under
+    /// the same lock as every other `GrantSet` operation, so a batch replay
+    /// can never wipe a grant that was live before the batch arrived.
+    #[test]
+    fn rehydrate_only_adds_its_own_batch_and_leaves_other_live_grants_alone() {
+        let set = GrantSet::default();
+        let pre_existing_args = serde_json::json!({ "amount_usd": 12.0 });
+        set.grant(call(
+            "pre-existing",
+            "finance",
+            "pay_invoice",
+            pre_existing_args,
+        ));
+
+        let batch: Vec<_> = (0..50)
+            .map(|i| call(&format!("new{i}"), "ops", "t", serde_json::json!({ "i": i })))
+            .collect();
+        set.rehydrate(batch);
+
+        assert!(
+            set.peek(&ApprovalId::new("pre-existing")).is_some(),
+            "a grant already live before the batch must survive the rehydrate"
+        );
+        assert_eq!(
+            set.live_count(),
+            51,
+            "the pre-existing grant plus every grant in the batch must all be live"
+        );
+    }
+
     /// Concurrent redemption of one grant: exactly one caller wins.
     ///
     /// The match and the removal are one critical section precisely so this

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -1876,9 +1876,7 @@ mod test {
             1,
             "one approval id must seed exactly one live grant, not two"
         );
-        let seeded = set
-            .peek(&ApprovalId::new("a1"))
-            .expect("the id is live");
+        let seeded = set.peek(&ApprovalId::new("a1")).expect("the id is live");
         assert_eq!(
             seeded.tool, "new_tool",
             "the later entry in the replay order wins"
@@ -1893,7 +1891,14 @@ mod test {
     fn rehydrate_seeds_every_grant_in_a_large_replay_batch_with_no_cap() {
         let set = GrantSet::default();
         let calls: Vec<_> = (0..500)
-            .map(|i| call(&format!("a{i}"), "finance", "t", serde_json::json!({ "i": i })))
+            .map(|i| {
+                call(
+                    &format!("a{i}"),
+                    "finance",
+                    "t",
+                    serde_json::json!({ "i": i }),
+                )
+            })
             .collect();
         set.rehydrate(calls);
         assert_eq!(
@@ -1920,7 +1925,14 @@ mod test {
         ));
 
         let batch: Vec<_> = (0..50)
-            .map(|i| call(&format!("new{i}"), "ops", "t", serde_json::json!({ "i": i })))
+            .map(|i| {
+                call(
+                    &format!("new{i}"),
+                    "ops",
+                    "t",
+                    serde_json::json!({ "i": i }),
+                )
+            })
             .collect();
         set.rehydrate(batch);
 


### PR DESCRIPTION
## Summary

One defect fixed, four cells closed with tests, across the runtime.

**The defect: a lifecycle write reported success it had not performed.** `assign_task` and `review_task` told the caller the write took effect while the drain silently no-op'd on a `task_id` naming no card — a `warn!` into the log and nothing else. The model writes those ids out of an LLM tool call, so a hallucinated id is a routine path, and the turn was told its assignment landed either way. Two tests already pinned this on `main`; both shipped `#[ignore]`d with the defect written into the ignore reason.

Fixing it needed two passes, and the second is the one that matters. Returning `Err` on an unknown card surfaces the failure, but `drain_and_execute` propagates with `?` — so one bad id aborted the whole drain and discarded every delegation queued behind it, valid ones included. That trades a false success for silently lost work. The same bare-`?` shape was in `handle_task_delegations` too, so it was not confined to the operator path.

So the unknown-card write is now carried as a **fact** rather than raised as an error: `DelegationOutcome` gained `unknown_card`, `Drained` accumulates them across the loop without aborting, and the fact is folded into the operator's reply — the mechanism `assigned` already established for exactly this "three distinct paths, do not call them all success" reasoning. `execute_board_writes` needed no change; it was already matching per-delegation rather than propagating.

**The cells**, each red-proved by breaking what it covers and confirming the case goes red:

| Cell | What it now asserts | Break used to prove it |
|---|---|---|
| GRANT-004 | `rehydrate` keeps the last of duplicate ids, seeds a 500-grant batch uncapped, and does not clobber a live grant | `state.live.clear()` before insert, and `.take(10)` on the iterator |
| GRANT-003 | a failed single-use grant mint never arms the live grant | armed the grant before the journal write |
| POL-002 | the default uninjected-gate build disables manifest-policy HITL | removed `.with_policy_hitl_disabled()` |
| HT-077 / HT-078 | an unknown card is reported, and a valid delegation queued behind it still lands | checked out the pre-fix commit; the new case panicked with `NotFound(...)`, proving the second delegation never ran |

Six further cells were investigated and found **already covered on `main`** (APPR-009, MET-004, GRANT-002, GRANT-009, GRANT-010, GRANT-011) — the covering tests exist and no new work was warranted.

## API Or Behavior Changes

`assign_task` / `review_task` on a `task_id` that names no card now report the failure in the operator's reply instead of reporting success. A build with no task store wired stays a silent no-op — there is genuinely no board to write to, which is a different fact from an id that names nothing.

`DelegationOutcome` gains `unknown_card`; `Drained` gains `unknown_cards`. Both are internal (`pub(crate)`).

Not extended here: `handle_task_delegations` no longer aborts, but an unknown-card write on that path stays a silent no-op rather than gaining a surfaced note, alongside the other already-silent outcomes there. Flagged rather than assumed in scope.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — run as `--locked --no-deps --features openhuman --all-targets`, clean
- [ ] `cargo build --all-targets` — N/A: `cargo check --locked --features openhuman --tests` covers the same targets and is clean
- [x] `cargo test` — `runtime::delegation::tests::` 116 passed, 0 failed, including the two previously-`#[ignore]`d cases now running

## Documentation

No docs needed — the behaviour change is internal to the delegation drain and is described in the affected functions' own doc comments.
