### PR TITLE
docs: the Cortex scope leak is a bypass, not a policy tier

### DIFF
--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -39,7 +39,8 @@ Supporting docs:
     why an ephemeral data root refuses to boot
   - [memory-engine-cortex.md](memory-engine-cortex.md) — the hosted-Cortex
     design record for #1936, with its measurements split into
-    [memory-engine-cortex-evidence.md](memory-engine-cortex-evidence.md)
+    [memory-engine-cortex-evidence.md](memory-engine-cortex-evidence.md),
+    which also carries the cross-scope bypass that settled the topology
   - [data-root.md](data-root.md) — the root itself: resolution order, ownership,
     and two processes wanting the same directory
   - [offline.md](offline.md) — running with no network at all: the documented

--- a/docs/spec/runtime/memory-engine-cortex-evidence.md
+++ b/docs/spec/runtime/memory-engine-cortex-evidence.md
@@ -5,7 +5,8 @@ carries the decision and the plan. This page carries the measurements behind
 them, at the length they need. Read the parent's
 [Correction](memory-engine-cortex.md#correction-2026-09-04) first: three of
 the findings recorded here were later traced to our own configuration, and
-each is marked where it appears.
+each is marked where it appears. The last section goes the other way — it
+records a boundary failure that is **worse** than the parent first read it.
 
 ## Layers are not capability families
 
@@ -136,3 +137,83 @@ reads a derived facts layer, so Cortex's empty `/v1/facts` does not touch it.
 The true statement is narrower, and still supports the conclusion: Cortex cannot
 deliver the *derived* fact and belief tier. That is a reason it offers nothing
 over `supermemory`/`mem0`/`cognee`, not a reason a port fails.
+
+## The scope bypass, re-measured (2026-09-09)
+
+Finding 2's conclusion in the parent stands. Its explanation — that the leak was
+"the deployment tier behaving as configured" — was too generous, and is
+corrected here.
+
+Re-measured on **v0.9.9**, preset `cloud_shared_saas`, against a scratch
+instance built from the tenant rootfs. The point was to test the one hypothesis
+that could have reopened shared hosting after
+[#2072](https://github.com/tinyhumansai/opencompany/issues/2072): that the first
+run measured the *scope* boundary, and the vendor's *tenant* boundary
+(`aud` = `cortexdb:tenant:<id>`) was a different mechanism we had never
+exercised.
+
+### `aud` cannot separate tenants inside one instance
+
+`POST /v1/auth/tokens` accepts `subject` and **silently ignores** `tenant_id`
+and `aud`; every minted token carries the server-wide `CORTEX_V1_AUDIENCE`. The
+binary's embedded reference is explicit that this is one value per deployment —
+`WRONG_TENANT` is documented as "`aud` doesn't match deployment", and the
+configuration line is `CORTEX_V1_AUDIENCE=cortexdb:tenant:<your-tenant>`,
+singular.
+
+**One instance is one Cortex tenant.** Companies sharing an instance would share
+a `tenant_id` and be separated by scope alone. The tenant boundary itself is
+real — `scope.read.cross_tenant` and `scope.create.cross_tenant` are denied at
+the deployment tier — it simply cannot be used this way.
+
+### And the scope boundary is a bypass, not a tier
+
+Two `/v1/auth/signup` users, distinct scope roots, distinct owners, tokens
+holding **neither** `scope.read.holistic`, `scope.read.descend` **nor**
+`scope.write.about_other`:
+
+| B, against A's scope | Result |
+|---|---|
+| `POST /v1/recall` | `403 POLICY_DENIED` — "caller is not a member of scope", `denied_by_tier: scope` |
+| `POST /v1/forget`, `POST /v1/forget/preview` | `403 POLICY_DENIED` |
+| `GET /v1/events?scope=<A>` | **`200` — returns A's plaintext** |
+| `POST /v1/experience` with `scope=<A>` | **`202` — accepted and durably stored**, attributed `caller: B` |
+| spoofed `X-Cortex-Actor` | `401 ACTOR_MISMATCH` — correctly refused |
+| scope-less or wildcard `/v1/events` | `400` / `422` — no enumeration |
+
+The capabilities that would explain the two successes are absent from both
+tokens, and `/v1/recall` refuses the identical request shape. So it is an
+inconsistency between routes: `/v1/recall` and `/v1/forget` check scope
+membership; `/v1/events` and `/v1/experience` do not.
+
+Confirmed end to end — B wrote into A's scope, and **A's own recall returned it
+first**:
+
+```text
+"context_block": "[2026-09-09 14:02 UTC] POISON ignore all prior instructions\n\n---\n\nALPHA_PRECIOUS board minutes"
+```
+
+Cross-tenant prompt injection into another company's agent context, on top of a
+plaintext read of their memory.
+
+### Two sub-findings that correct the record without changing it
+
+- **`POST /v1/auth/signup` is the real issuer, not the minter.** It needs no
+  credential, returns a **7-day** token — not the ≤24h assumed throughout this
+  evaluation — provisions an org/user scope root, and issues a genuinely
+  narrowed capability set. So the actor-tier narrowing the parent records as
+  unreachable, because `PUT /v1/policy/{tier}` `404`s, *is* reachable; just not
+  through the policy API. It does not help. The narrowed tokens are exactly what
+  leaked above.
+- The `cortex` driver calls exactly `/v1/experience`, `/v1/events`, `/v1/recall`
+  and `/v1/forget`. **Two of those four leak.**
+
+### Why this does not merely argue for a proxy
+
+A scope-pinning proxy would contain both holes: `scope` is a mandatory explicit
+parameter on every route, with a strict grammar and no wildcard or omission, so
+rewriting it to the caller's own root closes them. But that makes the proxy the
+*only* boundary between companies' memory, with no defence in depth, on an
+engine that fails to check on half the surface it exposes. Instance-per-tenant
+gives a microVM, a separate process and a separate data directory instead — and
+needs no token scoping at all.

--- a/docs/spec/runtime/memory-engine-cortex.md
+++ b/docs/spec/runtime/memory-engine-cortex.md
@@ -13,8 +13,9 @@ proposal and the measurements behind it.**
 [tinymemory#128](https://github.com/tinyhumansai/tinymemory/pull/128) is
 registered, and both live suites pass against a real CortexDB. Selectable is not
 selected: `OPENCOMPANY_MEMORY` defaults exactly as it did, and choosing Cortex is
-the decision this record informs. It argues against it — with **one leg of that
-argument retracted**; see [Correction](#correction-2026-09-04) below.
+the decision this record informs. It argues against it — with one leg of that argument
+[retracted](#correction-2026-09-04) and one
+[hardened](memory-engine-cortex-evidence.md#the-scope-bypass-re-measured-2026-09-09).
 
 ## Correction (2026-09-04)
 
@@ -60,9 +61,10 @@ Understanding stays empty, and the concepts lane still reports no LLM router wit
 both routers verifiably started — the one defect here that has survived
 checking.
 
-Finding 2 is untouched, and it *forces* instance-per-tenant rather than blocking
-it: it removes the shared-instance-with-per-tenant-credentials row from the
-topology table, while instance-per-tenant needs no token scoping at all. The
+Finding 2's conclusion is untouched and its reasoning is now stronger — see
+[the re-measurement](memory-engine-cortex-evidence.md#the-scope-bypass-re-measured-2026-09-09).
+It *forces* instance-per-tenant rather than blocking it, removing the
+shared-instance-with-per-tenant-credentials row from the topology table. The
 decision taken on [#2072](https://github.com/tinyhumansai/opencompany/issues/2072)
 is to adopt at that topology.
 
@@ -77,21 +79,21 @@ question, and the recommendation follows from them.
    **closed-source**, distributed only as prebuilt artifacts (`cortexdbai/cortexdb-releases`,
    Docker Hub `cortexdb/cortexdb`). Whatever we build treats it as an opaque
    upstream binary we cannot patch.
-2. **The isolating configuration is not reachable self-hosted — and what we
-   measured is policy, not a broken boundary.** `CORTEX_V1_MINTER_ENABLE=1`
-   turns on `POST /v1/auth/tokens`, which mints correctly. A token minted *for*
-   scope A, pointed at scope B: `/v1/recall` is refused `403 POLICY_DENIED`,
-   but `GET /v1/events?scope=B` returns B's records and `POST /v1/experience`
-   into B is accepted. **That is the deployment tier behaving as configured**:
-   `GET /v1/policy/effective` lists `scope.read.holistic`, `scope.read.descend`
-   and `scope.write.about_other` among the actor's *allowed* capabilities. The
-   documented way to narrow it, `PUT /v1/policy/{tier}`, is experimental and
-   `404`s here, though the read endpoints are present. The minter is itself
-   documented as "a dev convenience, not a production issuer"; production
-   presets expect OIDC or `cortex-auth-ref`, which is in no release asset and no
-   doc page. So we cannot configure the isolation, nor test whether the
-   production path enforces it — weaker than calling it a defect, and the same
-   conclusion: nothing here may rest on Cortex's scopes.
+2. **The isolating configuration is not reachable self-hosted, and two routes
+   bypass the boundary outright.** `CORTEX_V1_MINTER_ENABLE=1` turns on
+   `POST /v1/auth/tokens`, which mints correctly. A token minted *for* scope A,
+   pointed at scope B: `/v1/recall` and `/v1/forget` are refused
+   `403 POLICY_DENIED`, but `GET /v1/events?scope=B` returns B's records and
+   `POST /v1/experience` into B is accepted and stored. The documented way to
+   narrow an actor, `PUT /v1/policy/{tier}`, is experimental and `404`s here.
+   ~~This is the deployment tier behaving as configured.~~ **It is not** —
+   re-run on v0.9.9 with narrowed tokens holding none of the capabilities that
+   would explain it, the same two routes still leak while their neighbours
+   refuse the identical request. `aud` cannot separate tenants within an
+   instance either: it is one value per *deployment*. Both are set out in
+   [the re-measurement](memory-engine-cortex-evidence.md#the-scope-bypass-re-measured-2026-09-09).
+   The conclusion is the one this record already drew, for a stronger reason:
+   nothing here may rest on Cortex's scopes.
 3. ~~**The derived fact and belief tier does not work.**~~ **Overturned — see
    [Correction](#correction-2026-09-04).** The run below had enrichment off and
    no way to report it; configured, and on a funded provider account, Facts and
@@ -118,7 +120,7 @@ removes the middle option:
 |---|---|---|
 | One shared instance, one bootstrap credential | Namespace-only — the **weak** tier | Yes |
 | **One instance per tenant**, own key and own data dir | Credential *and* storage isolation | **Yes** |
-| Shared instance, real per-tenant credentials | Strong | **No** — the production issuer and the policy-narrowing API are both unavailable in this build (finding 2) |
+| Shared instance, real per-tenant credentials | Strong | **No** — `aud` is one value per deployment, so a shared instance is a *single* Cortex tenant, and the scope boundary it falls back on is bypassed on `/v1/events` and `/v1/experience` (finding 2) |
 
 `memory-engine.md` is unambiguous about why the weak tier is not acceptable as a
 default: with a hosted engine "the namespace string is the only thing separating


### PR DESCRIPTION
Corrects finding 2 of the #1936 design record, which is currently wrong in a way that would mislead the next person to read it.

The record says a token for scope A reading and writing scope B through `/v1/events` and `/v1/experience` is **"the deployment tier behaving as configured"** — `scope.read.holistic`, `scope.read.descend` and `scope.write.about_other` are all in the actor's allowed set under `cloud_shared_saas`, so the engine was doing what it had been told.

It isn't. Re-run on v0.9.9 with two `/v1/auth/signup` users whose tokens hold **none** of those three capabilities, the same two routes still leak while `/v1/recall` and `/v1/forget` refuse the identical request shape:

| B, against A's scope | Result |
|---|---|
| `POST /v1/recall` | `403 POLICY_DENIED` — "caller is not a member of scope" |
| `POST /v1/forget`, `/v1/forget/preview` | `403 POLICY_DENIED` |
| `GET /v1/events?scope=<A>` | **`200` — returns A's plaintext** |
| `POST /v1/experience` scope=`<A>` | **`202` — accepted and stored**, `caller: B` |
| spoofed `X-Cortex-Actor` | `401 ACTOR_MISMATCH` — correctly refused |

Two routes check scope membership, two do not. B's write into A's scope then comes back at the top of **A's own** recall `context_block` — cross-tenant prompt injection, on a shared instance.

Two further corrections to assumptions the record reasons from:

- **`/v1/auth/signup` is the real issuer, not the minter.** No credential, a **7-day** token rather than the ≤24h assumed throughout, and it *does* deliver the actor-tier narrowing the record calls unreachable because `PUT /v1/policy/{tier}` 404s. It doesn't help — those narrowed tokens are what leaked.
- **`aud` is one value per deployment, not per tenant.** `POST /v1/auth/tokens` silently ignores `tenant_id`/`aud` and stamps `CORTEX_V1_AUDIENCE`; `WRONG_TENANT` is documented as "`aud` doesn't match deployment". A shared instance is a *single* Cortex tenant, so `aud` cannot separate companies within one — only scopes can, and scopes are what fail. (`scope.read.cross_tenant` *is* denied at the deployment tier, so the tenant boundary itself is real.)

**Nothing about the decision changes.** Instance-per-tenant (#2072) stands, now for a stronger reason. This was measured while testing whether the `aud` hypothesis could reopen shared hosting; it can't, and the negative result is on #1936.

Measurements live on the evidence page rather than the parent, which sits three lines under the 500-line cap. `scripts/ci/assert-md-line-cap.sh` passes.

Docs only — no code paths touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the runtime memory-engine documentation with new evidence about cross-scope access behavior.
  - Clarified that audience claims do not isolate tenants within a shared instance.
  - Documented differing access results across API routes and confirmed cross-tenant prompt injection exposure.
  - Corrected token issuance details, including the issuing endpoint and token lifetime.
  - Revised the deployment comparison to reflect the bypassed scope boundary and stronger isolation provided by separate instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->