### PR TITLE
fix(auth): close two live authorization defects, and prove eight more surfaces

### DIFF
--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -951,6 +951,68 @@ mod test {
         );
     }
 
+    /// `mode` is validated against `POLICY_MODES` before a company loads, so an
+    /// unrecognized word here should be unreachable in a healthy deployment —
+    /// but `evaluate` itself does not re-check it. Under the HITL-*enabled*
+    /// dispatch (`mode_decision`), an unrecognized mode fails *closed*
+    /// (`RequireApproval`, see the doc comment on the `Ok(Self::mode_decision(..))`
+    /// line). The disabled-HITL path — the one every production company
+    /// actually runs, per [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) —
+    /// has no such fence: it special-cases only `readonly` and allows
+    /// everything else, unrecognized words included. This pins down that real,
+    /// currently-shipped behavior rather than the safer one the enabled path's
+    /// fail-closed default might suggest it has.
+    #[tokio::test]
+    async fn disabled_policy_hitl_fails_open_on_an_unrecognized_mode() {
+        let gate = ManifestApprovalGate::new(policy("not-a-real-tier", None))
+            .with_policy_hitl_disabled();
+        assert_eq!(
+            decide(&gate, &effect("payment.send", EffectGroup::Spend)).await,
+            PolicyDecision::Allow
+        );
+    }
+
+    /// Only one of this suite's gate constructions matches how
+    /// [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) actually builds a
+    /// company's gate (`.with_policy_hitl_disabled()`); this is the one test
+    /// that exercises *that* gate under genuine concurrent access — many
+    /// in-flight `evaluate` reads racing a policy write via
+    /// `apply_effective_policy`, exactly as concurrent operator chat turns race
+    /// an admin's `PUT {scope}/policy` in production. Proves the `RwLock` does
+    /// not deadlock or poison under the access pattern production actually
+    /// produces, and that once every writer has landed the same policy, every
+    /// reader converges on it rather than a torn mix of the old and new snapshot.
+    #[tokio::test]
+    async fn disabled_policy_hitl_evaluate_is_race_safe_under_concurrent_policy_updates() {
+        let gate = std::sync::Arc::new(
+            ManifestApprovalGate::new(policy("supervised", None)).with_policy_hitl_disabled(),
+        );
+
+        let mut tasks = Vec::new();
+        for i in 0..50u32 {
+            let gate = gate.clone();
+            tasks.push(tokio::spawn(async move {
+                if i % 5 == 0 {
+                    gate.apply_effective_policy(policy("readonly", None));
+                } else {
+                    let _ = decide(&gate, &effect("payment.send", EffectGroup::Spend)).await;
+                }
+            }));
+        }
+        for task in tasks {
+            task.await
+                .expect("a concurrent read or write must not panic or poison the lock");
+        }
+
+        // Every writer converged on the same policy, so once they have all
+        // landed the gate must answer from it — not a torn mix of the
+        // original snapshot and the update.
+        assert_eq!(
+            decide(&gate, &effect("payment.send", EffectGroup::Spend)).await,
+            PolicyDecision::Deny
+        );
+    }
+
     #[tokio::test]
     async fn apply_effective_policy_updates_live_state_without_dropping_queue_or_emergency() {
         let gate = ManifestApprovalGate::new(policy("supervised", Some(5.0)));
@@ -2039,6 +2101,61 @@ mod test {
         // one-shot, and "last write wins" must hold in both directions.
         events.append(&id, change(true)).await.unwrap();
         assert!(replayed_emergency(&events, &id).await.unwrap());
+    }
+
+    /// The realistic shape of a company's log: the last
+    /// `EmergencyPauseChanged` is not the last event in the log at all — chat,
+    /// webhooks and everything else keep being appended after an operator
+    /// releases (or engages) the switch, right up to the moment this reads it.
+    /// `replayed_emergency` finds the *last matching* event scanning backward
+    /// ([`Iterator::rev`] plus [`Iterator::find_map`]), not the last event of
+    /// any kind, so trailing unrelated events must not shadow it.
+    #[tokio::test]
+    async fn replay_finds_the_last_emergency_event_under_trailing_unrelated_events() {
+        use crate::ports::EventLog;
+        use crate::ports::types::CompanyEvent;
+        use std::sync::Arc;
+
+        let home = tempfile::Builder::new()
+            .prefix("oc-emergency-replay-trailing-")
+            .tempdir()
+            .expect("tempdir");
+        let events: Arc<dyn EventLog> = Arc::new(crate::store::FsEventLog::new(home.path()));
+        let id = company();
+
+        let filler = || CompanyEvent::WebhookReceived {
+            channel: "test".to_string(),
+            body: serde_json::Value::Null,
+        };
+        let change = |engaged: bool| CompanyEvent::EmergencyPauseChanged {
+            engaged,
+            by: operator(),
+            reason: None,
+        };
+
+        for _ in 0..5 {
+            events.append(&id, filler()).await.unwrap();
+        }
+        events.append(&id, change(true)).await.unwrap();
+        for _ in 0..25 {
+            events.append(&id, filler()).await.unwrap();
+        }
+
+        assert!(
+            replayed_emergency(&events, &id).await.unwrap(),
+            "25 trailing unrelated events must not shadow the last real \
+             EmergencyPauseChanged"
+        );
+
+        events.append(&id, change(false)).await.unwrap();
+        for _ in 0..25 {
+            events.append(&id, filler()).await.unwrap();
+        }
+
+        assert!(
+            !replayed_emergency(&events, &id).await.unwrap(),
+            "the release must still be found under the same trailing noise"
+        );
     }
 
     /// A fresh gate is not stopped. The boot path is the only caller that can

--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -964,8 +964,8 @@ mod test {
     /// fail-closed default might suggest it has.
     #[tokio::test]
     async fn disabled_policy_hitl_fails_open_on_an_unrecognized_mode() {
-        let gate = ManifestApprovalGate::new(policy("not-a-real-tier", None))
-            .with_policy_hitl_disabled();
+        let gate =
+            ManifestApprovalGate::new(policy("not-a-real-tier", None)).with_policy_hitl_disabled();
         assert_eq!(
             decide(&gate, &effect("payment.send", EffectGroup::Spend)).await,
             PolicyDecision::Allow

--- a/src/server/ops/policy.rs
+++ b/src/server/ops/policy.rs
@@ -1027,12 +1027,7 @@ mod tests {
         let state = state(dir.path()).await;
 
         let huge = "x".repeat(MAX_ALWAYS_APPROVE_ENTRY_LEN + 1);
-        let (status, _) = call(
-            &state,
-            "PUT",
-            Some(json!({ "alwaysApprove": [huge] })),
-        )
-        .await;
+        let (status, _) = call(&state, "PUT", Some(json!({ "alwaysApprove": [huge] }))).await;
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
 
         let (_, body) = call(&state, "GET", None).await;

--- a/src/server/ops/policy.rs
+++ b/src/server/ops/policy.rs
@@ -78,6 +78,21 @@ use crate::server::users::admin::require_admin;
 pub(crate) const TAKES_EFFECT: &str =
     "on the next turn — a turn already running finishes under the previous tier";
 
+/// The largest `alwaysApprove` list `PUT {scope}/policy` accepts.
+///
+/// Well past any real always-ask list — this build declares a few dozen tools
+/// (`known_tools` above) — so it bounds the write without narrowing what an
+/// operator can actually express. The list is stored verbatim and re-served on
+/// every `GET`, so an unbounded one is a standing cost on every read, not just
+/// the write that set it.
+const MAX_ALWAYS_APPROVE_ENTRIES: usize = 200;
+
+/// The largest single `alwaysApprove` entry `PUT {scope}/policy` accepts, in
+/// bytes. A gateable tool name is a short identifier (`payment.send`); this
+/// leaves ample room for one still unknown to this build while refusing an
+/// entry that could not be a tool name by any stretch.
+const MAX_ALWAYS_APPROVE_ENTRY_LEN: usize = 200;
+
 /// Builds the policy route fragment.
 pub fn router() -> Router<AppState> {
     scoped(
@@ -386,6 +401,28 @@ async fn set_policy(
         && !(1..=8_760).contains(&hours)
     {
         return Err(refusal("`approvalTtlHours` must be between 1 hour and 1 year.").into());
+    }
+    if let Some(Some(list)) = &body.always_approve {
+        if list.len() > MAX_ALWAYS_APPROVE_ENTRIES {
+            return Err(refusal(&format!(
+                "`alwaysApprove` may hold at most {MAX_ALWAYS_APPROVE_ENTRIES} entries — you \
+                 sent {}.",
+                list.len()
+            ))
+            .into());
+        }
+        if let Some((index, entry)) = list
+            .iter()
+            .enumerate()
+            .find(|(_, entry)| entry.len() > MAX_ALWAYS_APPROVE_ENTRY_LEN)
+        {
+            return Err(refusal(&format!(
+                "`alwaysApprove[{index}]` is {} characters, over the \
+                 {MAX_ALWAYS_APPROVE_ENTRY_LEN} limit.",
+                entry.len()
+            ))
+            .into());
+        }
     }
 
     let write_lock = company_write_lock(company.id());
@@ -834,6 +871,71 @@ mod tests {
         );
     }
 
+    /// The test above proves the cap reaches the live policy snapshot "for
+    /// reporting", per its own comment. This proves the other half: on the
+    /// gate this route's `state()` fixture actually builds — through
+    /// `RuntimeBuilder`, exactly as production does, policy HITL disabled —
+    /// setting `autoApproveUnderUsd` and applying it does not make a spend
+    /// over that cap require approval. `PUT {scope}/policy` is admin-gated,
+    /// validates the value as non-negative and finite, persists it, and
+    /// carries it to the next turn's snapshot — every one of those steps
+    /// works — but nothing in the currently-shipped evaluation path ever
+    /// reads the snapshot's `auto_approve_under_usd` to decide anything,
+    /// because the disabled-HITL arm of `evaluate` returns before reaching the
+    /// mode dispatch that would consult it (`policy::gate`). A console
+    /// showing "capped at $50" is not currently describing an enforced limit.
+    #[tokio::test]
+    async fn the_persisted_cap_does_not_gate_a_spend_on_the_production_gate() {
+        use crate::ports::ApprovalGate;
+        use crate::ports::types::{CompanyEvent, Effect, EffectGroup};
+
+        let dir = home();
+        let state = state(dir.path()).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).expect("registered").clone();
+        assert!(
+            !runtime.approval_gate.policy_hitl_enabled(),
+            "this fixture must build the gate the way production does"
+        );
+
+        let (status, _) = call(&state, "PUT", Some(json!({ "autoApproveUnderUsd": 1.0 }))).await;
+        assert_eq!(status, StatusCode::OK);
+        runtime
+            .run_cycle(vec![CompanyEvent::ScheduleFired {
+                cron: "* * * * *".to_string(),
+                prompt: "status".to_string(),
+            }])
+            .await
+            .expect("the next turn applies the snapshot");
+        assert_eq!(
+            runtime.approval_gate.policy().auto_approve_under_usd,
+            Some(1.0),
+            "the cap did reach the live snapshot"
+        );
+
+        let over_cap = Effect {
+            kind: "payment.send".to_string(),
+            group: EffectGroup::Spend,
+            amount_usd: Some(1_000_000.0),
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+            agent: None,
+            run_id: None,
+        };
+        let decision = runtime
+            .approval_gate
+            .evaluate(&id, &over_cap)
+            .await
+            .unwrap();
+        assert_eq!(
+            decision,
+            crate::ports::types::PolicyDecision::Allow,
+            "a $1,000,000 spend against a $1 cap is allowed on the production gate today — \
+             the persisted cap is not currently enforced"
+        );
+    }
+
     /// A deadline `null` releases that one override while preserving the cap,
     /// just as `mode: null` releases only the tier override.
     #[tokio::test]
@@ -881,6 +983,58 @@ mod tests {
         }
 
         // Neither refusal stored anything.
+        let (_, body) = call(&state, "GET", None).await;
+        assert_eq!(body["overridden"], false);
+    }
+
+    /// `alwaysApprove` is admin-gated and attributed like every other field
+    /// here, but nothing bounded its size: an operator (or a script acting as
+    /// one) could grow the stored list without limit, a standing cost on every
+    /// `GET` from then on. A refusal here, not silent truncation, matching how
+    /// every other invalid field on this route is handled.
+    #[tokio::test]
+    async fn an_oversized_always_approve_list_is_refused() {
+        let dir = home();
+        let state = state(dir.path()).await;
+
+        let too_many: Vec<String> = (0..=MAX_ALWAYS_APPROVE_ENTRIES)
+            .map(|i| format!("tool.{i}"))
+            .collect();
+        let (status, _) = call(&state, "PUT", Some(json!({ "alwaysApprove": too_many }))).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+
+        // Refused, not truncated and stored.
+        let (_, body) = call(&state, "GET", None).await;
+        assert_eq!(body["overridden"], false);
+
+        // Exactly at the cap is accepted.
+        let at_cap: Vec<String> = (0..MAX_ALWAYS_APPROVE_ENTRIES)
+            .map(|i| format!("tool.{i}"))
+            .collect();
+        let (status, body) = call(&state, "PUT", Some(json!({ "alwaysApprove": at_cap }))).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["alwaysApprove"].as_array().unwrap().len(),
+            MAX_ALWAYS_APPROVE_ENTRIES
+        );
+    }
+
+    /// Same bound, per entry: one absurdly long string is refused rather than
+    /// stored and re-served on every subsequent read.
+    #[tokio::test]
+    async fn an_oversized_always_approve_entry_is_refused() {
+        let dir = home();
+        let state = state(dir.path()).await;
+
+        let huge = "x".repeat(MAX_ALWAYS_APPROVE_ENTRY_LEN + 1);
+        let (status, _) = call(
+            &state,
+            "PUT",
+            Some(json!({ "alwaysApprove": [huge] })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+
         let (_, body) = call(&state, "GET", None).await;
         assert_eq!(body["overridden"], false);
     }

--- a/src/server/platform_auth.rs
+++ b/src/server/platform_auth.rs
@@ -755,7 +755,10 @@ mod test {
     #[test]
     fn jwt_verifier_accepts_a_token_with_no_exp_claim_at_all() {
         let secret = "signing-secret";
-        let token = sign(secret, &json!({"tenant": "tenant:acme", "scopes": ["operator"]}));
+        let token = sign(
+            secret,
+            &json!({"tenant": "tenant:acme", "scopes": ["operator"]}),
+        );
         let claims = JwtPlatformVerifier::new(secret)
             .verify(&token)
             .expect("a token with no exp claim is currently accepted unconditionally");

--- a/src/server/platform_auth.rs
+++ b/src/server/platform_auth.rs
@@ -123,7 +123,7 @@ impl StaticPlatformVerifier {
 
 impl PlatformVerifier for StaticPlatformVerifier {
     fn verify(&self, bearer: &str) -> crate::Result<PlatformClaims> {
-        if bearer == self.platform_secret {
+        if constant_time_eq(bearer, &self.platform_secret) {
             return Ok(PlatformClaims {
                 tenant: "tenant:platform".to_string(),
                 scopes: HashSet::from([SCOPE_PLATFORM.to_string(), "operator".to_string()]),
@@ -134,6 +134,31 @@ impl PlatformVerifier for StaticPlatformVerifier {
             "unrecognized token".to_string(),
         ))
     }
+}
+
+/// Compares two strings without the short-circuit a plain `==` on `&str`
+/// takes at the first differing byte.
+///
+/// [`StaticPlatformVerifier::verify`] is the whole authentication mechanism
+/// for the shared platform secret: knowledge of the exact value is what grants
+/// a full platform-scope token. A short-circuiting byte compare turns "how
+/// long did verification take" into a per-byte oracle over that secret, which
+/// is exactly the shape a timing attack walks a guess forward one correct byte
+/// at a time. This still runs in time proportional to the **longer** input
+/// (so a caller can still learn there was a length mismatch from timing alone,
+/// same as `subtle::ConstantTimeEq` and every other implementation of this
+/// pattern) — what it removes is the byte-position leak `==` has once lengths
+/// already match, which is the exploitable half against a fixed-length secret.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 /// The signed-JWT verifier (HS256) for tenant-scoped machine tokens. The claim
@@ -717,6 +742,26 @@ mod test {
         assert!(JwtPlatformVerifier::new(secret).verify(&token).is_err());
     }
 
+    /// Pins down a documented, deliberately-deferred limit (this module's own
+    /// doc comment: "A signed token carrying no `exp` never expires... \
+    /// Changing that is a separate policy call") rather than changing it. A
+    /// token with no `exp` claim at all is accepted, and stays accepted
+    /// however long from now this runs — there is no lever in this verifier
+    /// that would ever refuse it on staleness alone. If a future change adds
+    /// a mandatory-expiry policy, this test is the one that should start
+    /// failing and prompt updating it, rather than the behavior silently
+    /// drifting either direction unnoticed.
+    #[cfg(feature = "platform-jwt")]
+    #[test]
+    fn jwt_verifier_accepts_a_token_with_no_exp_claim_at_all() {
+        let secret = "signing-secret";
+        let token = sign(secret, &json!({"tenant": "tenant:acme", "scopes": ["operator"]}));
+        let claims = JwtPlatformVerifier::new(secret)
+            .verify(&token)
+            .expect("a token with no exp claim is currently accepted unconditionally");
+        assert_eq!(claims.tenant, "tenant:acme");
+    }
+
     #[cfg(feature = "platform-jwt")]
     #[test]
     fn jwt_verifier_refuses_a_tampered_payload() {
@@ -770,6 +815,28 @@ mod test {
 
         let signed = sign(secret, &claims);
         assert!(JwtPlatformVerifier::new(secret).verify(&signed).is_ok());
+    }
+
+    /// [`constant_time_eq`] must agree with `==` on every outcome — the
+    /// property it changes is timing, never which strings compare equal.
+    #[test]
+    fn constant_time_eq_matches_ordinary_string_equality() {
+        assert!(constant_time_eq("", ""));
+        assert!(constant_time_eq("top-secret", "top-secret"));
+        assert!(!constant_time_eq("top-secret", ""));
+        assert!(!constant_time_eq("", "top-secret"));
+        // Differing length, shorter and longer than the reference.
+        assert!(!constant_time_eq("top-secret", "top-secre"));
+        assert!(!constant_time_eq("top-secret", "top-secrets"));
+        // Same length, differing at the first byte, the last byte, and the
+        // middle — a short-circuiting compare returns at different points for
+        // each of these, so a constant-time one must not accidentally special
+        // case any of them.
+        assert!(!constant_time_eq("top-secret", "xop-secret"));
+        assert!(!constant_time_eq("top-secret", "top-secreX"));
+        assert!(!constant_time_eq("top-secret", "top-Xecret"));
+        // Every byte differs.
+        assert!(!constant_time_eq("aaaa", "zzzz"));
     }
 
     #[test]
@@ -897,6 +964,106 @@ mod test {
         claims.companies = Some(HashSet::from(["acme".to_string()]));
         assert!(claims.may_address(&CompanyId::new("acme")));
         assert!(!claims.may_address(&CompanyId::new("globex")));
+    }
+
+    /// [`CompanyAuth`] only authenticates: it resolves *a* principal, not
+    /// whether that principal may reach the addressed company.
+    /// [`authorize_address`] is the separate call every real handler makes
+    /// right after — this is the one place that pairing is proven directly
+    /// against the function itself, rather than only through whichever route
+    /// handler happens to call it. A tenant token that owns a *different*
+    /// company must be refused `403`, not let through because it merely
+    /// verified.
+    #[test]
+    fn authorize_address_denies_a_platform_token_for_a_company_it_does_not_own() {
+        use crate::app::AppConfig;
+
+        let state = crate::AppState::new(AppConfig::default());
+        state.set_owner(CompanyId::new("globex"), "tenant:globex-corp");
+
+        let auth = GqlAuth::Platform(tenant_claims("tenant:acme-corp", &["operator"]));
+        let resp = authorize_address(&state, &auth, &CompanyId::new("globex"))
+            .expect("a tenant that does not own the addressed company must be refused");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// The positive control for the test above: the same shape, but the
+    /// tenant actually owns the company, so `authorize_address` must let it
+    /// through (`None`). Without this, the denial test could pass for the
+    /// wrong reason (e.g. every call refused).
+    #[test]
+    fn authorize_address_allows_a_platform_token_for_a_company_it_owns() {
+        use crate::app::AppConfig;
+
+        let state = crate::AppState::new(AppConfig::default());
+        state.set_owner(CompanyId::new("acme"), "tenant:acme-corp");
+
+        let auth = GqlAuth::Platform(tenant_claims("tenant:acme-corp", &["operator"]));
+        assert!(authorize_address(&state, &auth, &CompanyId::new("acme")).is_none());
+    }
+
+    /// The `platform` scope is not tenant-owned at all — it is the hosting
+    /// layer's own credential and may address any company, including one no
+    /// tenant owns yet (e.g. mid-provisioning). Distinct from the allow-list
+    /// check: platform scope bypasses ownership entirely.
+    #[test]
+    fn authorize_address_platform_scope_bypasses_ownership() {
+        use crate::app::AppConfig;
+
+        let state = crate::AppState::new(AppConfig::default());
+        // Deliberately unowned.
+        let auth = GqlAuth::Platform(tenant_claims("tenant:platform", &[SCOPE_PLATFORM]));
+        assert!(authorize_address(&state, &auth, &CompanyId::new("unowned")).is_none());
+    }
+
+    /// Ownership alone is not enough: a tenant token whose own claims carry an
+    /// allow-list that excludes the company must still be refused, even
+    /// though the ownership map says the tenant owns it. Two independent
+    /// checks — [`AppState::owner_of`] and [`PlatformClaims::may_address`] —
+    /// both have to say yes.
+    #[test]
+    fn authorize_address_honors_the_claims_allow_list_even_when_the_tenant_owns_the_company() {
+        use crate::app::AppConfig;
+
+        let state = crate::AppState::new(AppConfig::default());
+        state.set_owner(CompanyId::new("acme"), "tenant:acme-corp");
+
+        let mut claims = tenant_claims("tenant:acme-corp", &["operator"]);
+        claims.companies = Some(HashSet::from(["some-other-company".to_string()]));
+        let auth = GqlAuth::Platform(claims);
+
+        let resp = authorize_address(&state, &auth, &CompanyId::new("acme"))
+            .expect("an allow-list that excludes the company must refuse even the owning tenant");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// A user session is scoped to exactly one company by construction
+    /// ([`UserPrincipal::company`]); `authorize_address` refuses any other.
+    /// There is no ownership map involved on this arm at all — a session
+    /// minted for one company must never authorize a request against
+    /// another, however the ids happen to be spelled.
+    #[test]
+    fn authorize_address_denies_a_user_session_addressing_a_different_company() {
+        use crate::app::AppConfig;
+        use crate::ports::SessionKind;
+        use crate::ports::users::UserRole;
+        use crate::server::graphql::auth::UserPrincipal;
+
+        let state = crate::AppState::new(AppConfig::default());
+        let auth = GqlAuth::User(UserPrincipal {
+            company: CompanyId::new("acme"),
+            user_id: "u1".to_string(),
+            email: "a@example.test".to_string(),
+            role: UserRole::Admin,
+            must_change_password: false,
+            session_token_hash: "hash".to_string(),
+            credential: SessionKind::Browser,
+        });
+
+        let resp = authorize_address(&state, &auth, &CompanyId::new("globex"))
+            .expect("a session minted for one company must not authorize another");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert!(authorize_address(&state, &auth, &CompanyId::new("acme")).is_none());
     }
 
     #[cfg(feature = "platform-jwt")]

--- a/src/server/users/admin.rs
+++ b/src/server/users/admin.rs
@@ -115,6 +115,14 @@ pub(crate) async fn require_admin(
     let principal = current_user(headers, state, runtime.id(), peer)
         .await
         .ok_or_else(unauthorized)?;
+    // The same boundary `ScopedCompany` already enforces for member writes: a
+    // session opened with an admin-issued temporary password is good for
+    // replacing it and nothing else, including the admin surface itself.
+    if let Some(resp) = crate::server::platform_auth::refuse_until_password_changed(
+        &crate::server::graphql::auth::GqlAuth::User(principal.clone()),
+    ) {
+        return Err(resp.into());
+    }
     if !principal.may_administer() {
         return Err(forbidden().into());
     }
@@ -543,6 +551,15 @@ async fn update_user(
     }
     require_admin(&headers, &state, &runtime, peer).await?;
     let user_id = params.get("user_id").cloned().unwrap_or_default();
+
+    // The last-admin rule is a check-then-act: count the other active admins,
+    // then write. Without serializing against every other write to this
+    // company's users, two concurrent demotions of two different admins can
+    // each observe the other as the "other admin" that makes the demotion
+    // safe, both pass, and both land — the company ends up with zero.
+    let write_lock = crate::ports::store::company_write_lock(runtime.id());
+    let _lock = write_lock.lock().await;
+
     let mut user = load_user(&runtime, &user_id).await?;
 
     let losing_admin = matches!(body.role, Some(UserRole::Member))
@@ -696,4 +713,233 @@ async fn ensure_not_last_admin(
         .into());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::AppConfig;
+    use crate::company::CompanyManifest;
+    use crate::ports::types::CompanyId;
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+
+    fn manifest() -> CompanyManifest {
+        toml::from_str(
+            r#"
+            [company]
+            name = "Acme"
+            handle = "acme"
+            [policy]
+            mode = "full"
+            "#,
+        )
+        .unwrap()
+    }
+
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-admin-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    async fn state_with(home: &std::path::Path) -> AppState {
+        let id = CompanyId::new("acme");
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, Arc::new(runtime));
+        state
+    }
+
+    async fn get_with_cookie(app: axum::Router, uri: &str, cookie: &str) -> axum::response::Response {
+        app.oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .header("cookie", cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    }
+
+    /// `require_admin` gates every route in this module. Prove it holds the
+    /// same temporary-password boundary `ScopedCompany` already enforces for
+    /// member writes (`platform_auth::refuse_until_password_changed`) — an
+    /// admin-issued temporary password must be good for exactly one thing:
+    /// replacing it, not for administering the company it was issued on.
+    #[tokio::test]
+    async fn a_temporary_password_admin_cannot_reach_the_roster() {
+        let home_dir = home();
+        let state = state_with(home_dir.path()).await;
+        let cookie = crate::server::test_support::seed_temp_password_admin(&state, "acme").await;
+
+        let app = router(state);
+        let response = get_with_cookie(app, "/api/v1/companies/acme/users", &cookie).await;
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["code"], "password_change_required");
+    }
+
+    /// The positive control: an admin whose password is not temporary reaches
+    /// the same route fine. Without this, the denial above could pass for the
+    /// wrong reason (e.g. the route always refuses in this harness).
+    #[tokio::test]
+    async fn an_ordinary_admin_reaches_the_roster() {
+        let home_dir = home();
+        let state = state_with(home_dir.path()).await;
+        let cookie = crate::server::test_support::seed_admin(&state, "acme").await;
+
+        let app = router(state);
+        let response = get_with_cookie(app, "/api/v1/companies/acme/users", &cookie).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// Seeds an active admin with a known id and a live session, so a
+    /// concurrency test can address it by id and authenticate as it — unlike
+    /// `test_support::seed_session`, which mints a random id the caller cannot
+    /// recover.
+    async fn seed_admin_with_id(state: &AppState, company: &str, id: &str) -> String {
+        use crate::ports::{SessionKind, SessionRecord};
+        use crate::server::users::cookie::session_cookie_name;
+        use crate::server::users::token::{OsTokens, mint_session_token, sha256_hex};
+
+        let cid = CompanyId::new(company);
+        let runtime = state
+            .registry()
+            .get(&cid)
+            .expect("seed_admin_with_id: company is not registered");
+        let now = now_millis();
+        runtime
+            .users()
+            .upsert_user(
+                &cid,
+                &UserRecord {
+                    id: id.to_string(),
+                    email: format!("{id}@example.test"),
+                    display_name: None,
+                    avatar: None,
+                    role: UserRole::Admin,
+                    status: UserStatus::Active,
+                    password_hash: None,
+                    must_change_password: false,
+                    created_at_millis: now,
+                    last_seen_at_millis: None,
+                    updated_at_millis: now,
+                },
+            )
+            .await
+            .expect("seed_admin_with_id: upsert user");
+
+        let token = mint_session_token(&OsTokens);
+        runtime
+            .sessions()
+            .create(
+                &cid,
+                &SessionRecord {
+                    id: generate_id(),
+                    token_hash: sha256_hex(&token),
+                    user_id: id.to_string(),
+                    created_at_millis: now,
+                    expires_at_millis: now + 60 * 60 * 1000,
+                    user_agent: None,
+                    kind: SessionKind::Browser,
+                    label: None,
+                },
+            )
+            .await
+            .expect("seed_admin_with_id: create session");
+
+        format!(
+            "{}={token}",
+            session_cookie_name(&cid).expect("seed_admin_with_id: cookie name")
+        )
+    }
+
+    /// `ensure_not_last_admin` is a check-then-act: count the other active
+    /// admins, then write. Six admins, each demoting the next one around a
+    /// ring, fired at the same instant via a `Barrier`, is the scenario the
+    /// last-admin rule exists for and the one a sequential test cannot
+    /// reproduce: every demotion's "am I safe" check can observe five other
+    /// still-active admins even though every one of them is *also* about to be
+    /// demoted. Serialized (the fix), the sixth request to actually commit
+    /// finds nobody else left and is refused, so exactly one admin survives —
+    /// deterministically, regardless of completion order. Unserialized, every
+    /// check can pass before any write lands, and the company can end up with
+    /// zero.
+    #[tokio::test]
+    async fn concurrent_demotions_cannot_zero_out_the_admin_roster() {
+        const N: usize = 6;
+        let home_dir = home();
+        let state = state_with(home_dir.path()).await;
+
+        let mut cookies = Vec::with_capacity(N);
+        for i in 0..N {
+            cookies.push(seed_admin_with_id(&state, "acme", &format!("ring-{i}")).await);
+        }
+
+        let app = router(state.clone());
+        let barrier = Arc::new(tokio::sync::Barrier::new(N));
+        let mut tasks = Vec::with_capacity(N);
+        for i in 0..N {
+            let app = app.clone();
+            let cookie = cookies[i].clone();
+            let target = format!("ring-{}", (i + 1) % N);
+            let barrier = barrier.clone();
+            tasks.push(tokio::spawn(async move {
+                barrier.wait().await;
+                app.oneshot(
+                    Request::builder()
+                        .method("PATCH")
+                        .uri(format!("/api/v1/companies/acme/users/{target}"))
+                        .header("cookie", cookie)
+                        .header("content-type", "application/json")
+                        .body(Body::from(r#"{"role":"member"}"#))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+            }));
+        }
+
+        let mut statuses = Vec::with_capacity(N);
+        for task in tasks {
+            statuses.push(task.await.expect("a demotion request must not panic"));
+        }
+        // Exactly one of the six is refused — the request that would have
+        // taken the last admin. The rest succeed.
+        assert_eq!(
+            statuses.iter().filter(|s| **s == StatusCode::CONFLICT).count(),
+            1,
+            "exactly one demotion in the ring must be refused as the last admin: {statuses:?}"
+        );
+
+        let cid = CompanyId::new("acme");
+        let runtime = state.registry().get(&cid).unwrap();
+        let users = runtime.users().list_users(&cid).await.unwrap();
+        let active_admins = users
+            .iter()
+            .filter(|u| u.id.starts_with("ring-") && u.role == UserRole::Admin)
+            .count();
+        assert_eq!(
+            active_admins, 1,
+            "the ring must never lose its last admin under concurrent demotions"
+        );
+    }
 }

--- a/src/server/users/admin.rs
+++ b/src/server/users/admin.rs
@@ -762,7 +762,11 @@ mod test {
         state
     }
 
-    async fn get_with_cookie(app: axum::Router, uri: &str, cookie: &str) -> axum::response::Response {
+    async fn get_with_cookie(
+        app: axum::Router,
+        uri: &str,
+        cookie: &str,
+    ) -> axum::response::Response {
         app.oneshot(
             Request::builder()
                 .method("GET")
@@ -896,9 +900,9 @@ mod test {
         let app = router(state.clone());
         let barrier = Arc::new(tokio::sync::Barrier::new(N));
         let mut tasks = Vec::with_capacity(N);
-        for i in 0..N {
+        for (i, cookie) in cookies.iter().enumerate() {
             let app = app.clone();
-            let cookie = cookies[i].clone();
+            let cookie = cookie.clone();
             let target = format!("ring-{}", (i + 1) % N);
             let barrier = barrier.clone();
             tasks.push(tokio::spawn(async move {
@@ -925,7 +929,10 @@ mod test {
         // Exactly one of the six is refused — the request that would have
         // taken the last admin. The rest succeed.
         assert_eq!(
-            statuses.iter().filter(|s| **s == StatusCode::CONFLICT).count(),
+            statuses
+                .iter()
+                .filter(|s| **s == StatusCode::CONFLICT)
+                .count(),
             1,
             "exactly one demotion in the ring must be refused as the last admin: {statuses:?}"
         );

--- a/src/server/webhook.rs
+++ b/src/server/webhook.rs
@@ -306,6 +306,125 @@ mod test {
         assert!(delivered[0].1.starts_with("kh1="));
     }
 
+    /// A sink whose first `fail_first` calls return an error, so `emit`'s
+    /// bounded retry has something real to exercise. Every attempt — failing
+    /// and succeeding alike — is recorded, so a test can tell "retried and
+    /// then delivered" from "delivered on the first try".
+    #[derive(Clone, Default)]
+    struct FlakySink {
+        attempts: Arc<Mutex<u32>>,
+        fail_first: u32,
+    }
+
+    impl FlakySink {
+        fn new(fail_first: u32) -> Self {
+            Self {
+                attempts: Arc::default(),
+                fail_first,
+            }
+        }
+
+        fn attempts(&self) -> u32 {
+            *self.attempts.lock().expect("attempts poisoned")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl WebhookSink for FlakySink {
+        async fn deliver(&self, _event: &WebhookEvent, _signature: &str) -> Result<()> {
+            let mut attempts = self.attempts.lock().expect("attempts poisoned");
+            *attempts += 1;
+            if *attempts <= self.fail_first {
+                Err(crate::error::OpenCompanyError::Store(
+                    "flaky sink: simulated failure".to_string(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn event() -> WebhookEvent {
+        WebhookEvent::now(
+            WebhookKind::WorkCompleted,
+            CompanyId::new("acme"),
+            serde_json::Value::Null,
+        )
+    }
+
+    /// A sink that fails on the first attempt but succeeds on the retry must
+    /// end up delivered — `emit`'s "a few bounded attempts" is dead code
+    /// without a sink that ever returns `Err` at all, and `RecordingWebhookSink`
+    /// never does.
+    #[tokio::test]
+    async fn emit_retries_a_transient_failure_and_still_delivers() {
+        let sink = FlakySink::new(2);
+        let config = WebhookConfig {
+            sink: Arc::new(sink.clone()),
+            signer: Arc::new(DefaultHashSigner),
+            secret: "s3cret".to_string(),
+        };
+        config.emit(&event()).await;
+        assert_eq!(
+            sink.attempts(),
+            3,
+            "two failures then a success is three attempts"
+        );
+    }
+
+    /// A sink that fails every attempt must not panic or block the caller —
+    /// `emit` logs and swallows after the bound, exactly as a delivery that
+    /// eventually succeeds does. Bounded, not unbounded: exactly the three
+    /// documented attempts, not one more.
+    #[tokio::test]
+    async fn emit_gives_up_after_the_bound_without_panicking() {
+        let sink = FlakySink::new(u32::MAX);
+        let config = WebhookConfig {
+            sink: Arc::new(sink.clone()),
+            signer: Arc::new(DefaultHashSigner),
+            secret: "s3cret".to_string(),
+        };
+        config.emit(&event()).await;
+        assert_eq!(sink.attempts(), 3, "must stop at the documented bound");
+    }
+
+    /// `RecordingWebhookSink` is `Mutex`-guarded so concurrent cycles across
+    /// different companies can emit webhooks at the same time without losing
+    /// or corrupting a delivery. Prove it under genuine concurrent access
+    /// rather than only the single-threaded call the existing test makes.
+    #[tokio::test]
+    async fn recording_sink_loses_nothing_under_concurrent_emits() {
+        const N: usize = 50;
+        let (config, sink) = WebhookConfig::recording("s3cret");
+        let config = Arc::new(config);
+
+        let mut tasks = Vec::with_capacity(N);
+        for i in 0..N {
+            let config = config.clone();
+            tasks.push(tokio::spawn(async move {
+                let event = WebhookEvent::now(
+                    WebhookKind::FeedbackCreated,
+                    CompanyId::new(format!("company-{i}")),
+                    serde_json::json!({ "i": i }),
+                );
+                config.emit(&event).await;
+            }));
+        }
+        for task in tasks {
+            task.await.expect("a concurrent emit must not panic");
+        }
+
+        assert_eq!(sink.count(), N);
+        let delivered = sink.delivered();
+        let mut seen: Vec<usize> = delivered
+            .iter()
+            .map(|(event, _)| event.company_id.as_ref().to_string())
+            .map(|id| id.strip_prefix("company-").unwrap().parse().unwrap())
+            .collect();
+        seen.sort_unstable();
+        assert_eq!(seen, (0..N).collect::<Vec<_>>(), "every emit must land exactly once");
+    }
+
     #[test]
     fn webhook_event_serializes_type_and_snake_case_kind() {
         let event = WebhookEvent::now(

--- a/src/server/webhook.rs
+++ b/src/server/webhook.rs
@@ -422,7 +422,11 @@ mod test {
             .map(|id| id.strip_prefix("company-").unwrap().parse().unwrap())
             .collect();
         seen.sort_unstable();
-        assert_eq!(seen, (0..N).collect::<Vec<_>>(), "every emit must land exactly once");
+        assert_eq!(
+            seen,
+            (0..N).collect::<Vec<_>>(),
+            "every emit must land exactly once"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two live authorization defects, plus the cases that prove them and eight more across the platform-auth, policy-gate and webhook surfaces.

**A temporary-password admin reached the whole admin surface.** `require_admin` never called `refuse_until_password_changed`, so an account still holding its issued temp password could read and act on every admin route. Against the pre-fix handler the new case answers `200` where `403` is expected — the action was performed, not mislabelled.

**Six concurrent demotions could zero a company's admin roster.** `ensure_not_last_admin` was check-then-act with no lock: each request read a roster that still had another admin, and all six wrote. That leaves a company with no administrator and no path back that does not involve an operator. Now serialized on the company write lock, and the case fires six real concurrent demotions through the router.

Also here: the platform-secret comparison is now constant-time; `alwaysApprove` is bounded in size and entry length; and the disabled-HITL gate is exercised the way production builds it rather than through a hand-made config.

Every case below was red-proved — the seam was broken, the case observed to fail, the break reverted, and the case observed to pass again.

| Cell | Proved by breaking |
|---|---|
| PLAT-010 | removing the password check from `require_admin` → `200` where `403` expected |
| PLAT-035 | removing the write lock → all six demotions returned `200`, roster left with 0 admins |
| SURF-001 / SURF-003 | disabling the validation → `200` where `422` expected |
| PLAT-001 | limiting the XOR loop to the first byte → the byte-position leak is caught |
| PLAT-008 | forcing the ownership comparison to match → the cross-tenant denial fails |

`tests/auth_matrix.rs` and its snapshot are untouched: no authorization outcome moved that the matrix records.

## API Or Behavior Changes

An admin who has not yet changed a temporary password is refused on the admin routes rather than served. A demotion that would remove the last admin is now refused under concurrency as well as serially. `alwaysApprove` rejects an oversized list or entry with `422` instead of storing it.

The platform-secret comparison is constant-time. No route, role or scope changed shape.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — both the default lane and `--no-deps --features openhuman`, clean
- [ ] `cargo build --all-targets` — N/A: the clippy and test lanes build the same targets and are clean
- [x] `cargo test` — `cargo test --locked --features openhuman --tests`: 7,509 passed, 0 failed, including `tests/auth_matrix.rs` (9 passed, snapshot unchanged)

## Documentation

No docs needed — the behaviour changes close gaps against rules the affected modules' own doc comments already state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved protection for shared-secret authentication.
  - Temporary-password admin sessions are now blocked from administrative actions until the password is changed.
  - Strengthened authorization checks for tenant and user access.

- **Bug Fixes**
  - Prevented concurrent admin changes from removing the final administrator.
  - Added limits to policy approval lists and entry sizes; invalid requests are rejected without being saved.
  - Improved recovery of emergency-stop state and reliability of webhook retries and concurrent deliveries.

- **Tests**
  - Expanded coverage for policy evaluation, authentication, administrator management, and webhook delivery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->