### PR TITLE
fix(server): serialize first-run apply, bound the A2A cycle, surface a swallowed failure

### DIFF
--- a/src/server/a2a.rs
+++ b/src/server/a2a.rs
@@ -27,6 +27,7 @@
 //! other stimulus — there is no fence bypass.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::body::Bytes;
 use axum::http::HeaderMap;
@@ -48,6 +49,15 @@ use crate::error::OpenCompanyError;
 use crate::ports::now_millis;
 use crate::ports::types::{AgentCard, CardPayment, CompanyEvent, LedgerEntry};
 use crate::server::error::ApiError;
+
+/// How long an inbound A2A task may hold this connection — and the worker
+/// running its company cycle — open before the caller is told to retry.
+///
+/// `tasks/send` is fully synchronous: the HTTP response IS the cycle result,
+/// so a cycle that never returns (a stuck tool call, a hung provider) would
+/// otherwise pin this connection, and the task behind it, forever. A paying
+/// counterparty gets no other signal that anything went wrong.
+const A2A_CYCLE_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Builds the tiny.place A2A route fragment, merged into the main router.
 pub fn router() -> Router<AppState> {
@@ -324,16 +334,20 @@ async fn a2a_task(
     // model-based guard.
     let task = sanitize_value(rpc.params.clone());
 
-    // 6. Append the event and run one cycle (run_cycle persists the event).
-    let report = match runtime
-        .run_cycle(vec![CompanyEvent::A2aTaskReceived {
+    // 6. Append the event and run one cycle (run_cycle persists the event),
+    // bounded so a stuck cycle cannot hold this connection open forever.
+    let report = match tokio::time::timeout(
+        A2A_CYCLE_TIMEOUT,
+        runtime.run_cycle(vec![CompanyEvent::A2aTaskReceived {
             from: from.clone(),
             task,
-        }])
-        .await
+        }]),
+    )
+    .await
     {
-        Ok(report) => report,
-        Err(err) => return ApiError(err).into_response(),
+        Ok(Ok(report)) => report,
+        Ok(Err(err)) => return ApiError(err).into_response(),
+        Err(_) => return cycle_timeout(),
     };
 
     let result = json!({
@@ -352,6 +366,18 @@ fn unauthorized(err: &OpenCompanyError) -> Response {
     (
         StatusCode::UNAUTHORIZED,
         Json(json!({ "error": err.to_string(), "code": err.code() })),
+    )
+        .into_response()
+}
+
+/// Renders a cycle that outran [`A2A_CYCLE_TIMEOUT`] as a `504`.
+fn cycle_timeout() -> Response {
+    (
+        StatusCode::GATEWAY_TIMEOUT,
+        Json(json!({
+            "error": "the company did not finish this task in time",
+            "code": "timeout",
+        })),
     )
         .into_response()
 }
@@ -465,6 +491,7 @@ mod test {
     use super::*;
     use std::sync::Arc;
 
+    use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::Request;
     use tower::ServiceExt;
@@ -474,8 +501,10 @@ mod test {
     use crate::economy::signer::LocalSigner;
     use crate::economy::x402::X402Challenge;
     use crate::economy::{MockTinyplaceClient, TinyplaceEconomy};
-    use crate::ports::types::{CompanyId, EventSeq};
-    use crate::ports::{AgentEconomy, CompanyStore};
+    use crate::ports::types::{
+        CompanyId, CompressedTrace, CycleRequest, CycleResult, EventSeq, TokenUsage,
+    };
+    use crate::ports::{AgentEconomy, Brain, CompanyStore, CycleHost};
     use crate::runtime::RuntimeBuilder;
     use crate::store::FsCompanyStore;
 
@@ -521,6 +550,108 @@ mod test {
         // The counterparty (client) signs with its own identity.
         let client_signer = Arc::new(LocalSigner::generate());
         (state, client_signer)
+    }
+
+    /// Same as [`seeded_state`], but the company cycle is driven by `brain`
+    /// instead of the default hosted one — for tests that need to control how
+    /// long (or how) a cycle runs.
+    async fn seeded_state_with_brain(
+        home: &std::path::Path,
+        brain: Arc<dyn Brain>,
+    ) -> (AppState, Arc<LocalSigner>) {
+        let manifest: CompanyManifest = toml::from_str(DISCOVERABLE_TOML).unwrap();
+        let id = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> = Arc::new(FsCompanyStore::new(home.to_path_buf()));
+        let signer = Arc::new(LocalSigner::generate());
+        let mock = Arc::new(MockTinyplaceClient::new());
+        let economy: Arc<dyn AgentEconomy> = Arc::new(
+            TinyplaceEconomy::new(mock, signer.clone(), store.clone(), id.clone(), None)
+                .going_public(true),
+        );
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id)
+            .with_economy(economy)
+            .with_brain(brain)
+            .build()
+            .await
+            .unwrap();
+
+        let state = AppState::new(AppConfig::default()).with_home(home.to_path_buf());
+        state
+            .registry()
+            .insert(runtime.id().clone(), Arc::new(runtime));
+
+        let client_signer = Arc::new(LocalSigner::generate());
+        (state, client_signer)
+    }
+
+    /// A brain that never returns, so a test can prove the cycle it drives is
+    /// bounded by something other than the brain's own good behavior.
+    struct HangingBrain;
+
+    #[async_trait]
+    impl Brain for HangingBrain {
+        async fn run_cycle(
+            &self,
+            _req: CycleRequest,
+            _host: &dyn CycleHost,
+        ) -> crate::Result<CycleResult> {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            unreachable!("the cycle timeout must fire long before this wakes")
+        }
+    }
+
+    /// A brain that answers a cycle with nothing, cheaply — for tests that
+    /// only care about the transport, not what cognition produces.
+    struct SilentBrain;
+
+    #[async_trait]
+    impl Brain for SilentBrain {
+        async fn run_cycle(
+            &self,
+            req: CycleRequest,
+            _host: &dyn CycleHost,
+        ) -> crate::Result<CycleResult> {
+            Ok(CycleResult {
+                channel_responses: Vec::new(),
+                new_traces: vec![CompressedTrace::now(req.cycle_id, "silent test brain")],
+                ledger_deltas: Vec::new(),
+                token_usage: TokenUsage::default(),
+            })
+        }
+    }
+
+    /// Builds an `AppState` with two distinct discoverable companies, each
+    /// answering only its own handle — for tests of the prosumer (single-
+    /// company) fallback's boundary.
+    async fn two_company_state(home: &std::path::Path) -> AppState {
+        let state = AppState::new(AppConfig::default()).with_home(home.to_path_buf());
+        for handle in ["acme", "globex"] {
+            let toml_src = format!(
+                r#"
+                [company]
+                name = "{handle}"
+                output = "audits"
+                handle = "{handle}"
+
+                [place]
+                discoverable = true
+                skills = [
+                    {{ id = "seo.free", price_usd = "0.00" }},
+                ]
+                "#
+            );
+            let manifest: CompanyManifest = toml::from_str(&toml_src).unwrap();
+            let id = CompanyId::new(handle);
+            let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+                .with_id(id.clone())
+                .with_brain(Arc::new(SilentBrain))
+                .build()
+                .await
+                .unwrap();
+            state.registry().insert(id, Arc::new(runtime));
+        }
+        state
     }
 
     /// Signs a POST body for `/a2a/{handle}` and returns the SIWX header value.
@@ -1266,5 +1397,138 @@ mod test {
             .unwrap();
         let md = String::from_utf8(bytes.to_vec()).unwrap();
         assert!(md.contains("`seo.audit` — 25.00 USDC (solana)"));
+    }
+
+    /// PLAT-067 / PLAT-066-067: `tasks/send` is fully synchronous, so a cycle
+    /// that never returns must not be able to hold the connection (and the
+    /// task behind it) open forever.
+    #[tokio::test(start_paused = true)]
+    async fn a_task_that_never_finishes_is_bounded_by_a_cycle_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state_with_brain(dir.path(), Arc::new(HangingBrain)).await;
+        let app = router().with_state(state);
+
+        let body = task_body("seo.free");
+        let header = siwx_header(&client, "acme", &body, now_secs());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::GATEWAY_TIMEOUT,
+            "a company cycle that never returns must not hold the connection open forever"
+        );
+    }
+
+    /// PLAT-067: one `tasks/send` POST must append exactly one
+    /// `A2aTaskReceived` event — not a batch, not a loop that could run the
+    /// counterparty's task more than once.
+    #[tokio::test]
+    async fn exactly_one_cycle_runs_per_inbound_task() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let runtime = state.registry().sole().unwrap();
+        let app = router().with_state(state);
+
+        let body = task_body("seo.free");
+        let header = siwx_header(&client, "acme", &body, now_secs());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let stored = runtime
+            .events
+            .read_from(runtime.id(), EventSeq::new(0), 10)
+            .await
+            .unwrap();
+        let received = stored
+            .iter()
+            .filter(|e| matches!(&e.event, CompanyEvent::A2aTaskReceived { .. }))
+            .count();
+        assert_eq!(
+            received, 1,
+            "one POST to tasks/send must append exactly one A2aTaskReceived event: {stored:?}"
+        );
+    }
+
+    /// PLAT-066: the prosumer fallback is scoped to a genuinely sole company.
+    /// With two companies registered, an unmatched handle must 404 rather than
+    /// silently answering as either of them.
+    #[tokio::test]
+    async fn the_prosumer_fallback_does_not_fire_when_more_than_one_company_is_registered() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = two_company_state(dir.path()).await;
+        let app = router().with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/a2a/nonexistent-handle/skill.md")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "with two companies registered, an unmatched handle must not resolve to either"
+        );
+    }
+
+    /// PLAT-066-067: this IS the SIWX design — a self-issued identity, not an
+    /// allow-listed one. Two independently generated keypairs, neither ever
+    /// provisioned or seen before, must each transact on their very first
+    /// request.
+    #[tokio::test]
+    async fn two_independent_strangers_each_transact_without_prior_registration() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, _seed_client) = seeded_state(dir.path()).await;
+        let app = router().with_state(state);
+
+        for _ in 0..2 {
+            let stranger = LocalSigner::generate();
+            let body = task_body("seo.free");
+            let header = siwx_header(&stranger, "acme", &body, now_secs());
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/a2a/acme")
+                        .header(AUTHORIZATION, header)
+                        .header(CONTENT_TYPE, "application/json")
+                        .body(Body::from(body))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "a freshly generated, never-before-seen keypair must transact on its first request"
+            );
+        }
     }
 }

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -512,13 +512,19 @@ mod test {
     use async_trait::async_trait;
     use serde_json::json;
 
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
     use crate::company::CompanyManifest;
     use crate::ports::EventSeq;
     use crate::ports::types::{ApprovalId, CompressedTrace, CycleRequest, CycleResult, TokenUsage};
     use crate::ports::users::{UserRecord, UserRole, UserStatus};
-    use crate::ports::{Brain, CompanyStore, CycleHost};
+    use crate::ports::{Brain, CompanyStore, CycleHost, SessionKind, SessionRecord};
     use crate::server::graphql::auth::UserPrincipal;
     use crate::server::platform_auth::PlatformClaims;
+    use crate::server::users::cookie::session_cookie_name;
+    use crate::server::users::token::{OsTokens, mint_session_token, sha256_hex};
     use crate::store::FsCompanyStore;
     use crate::{AppConfig, ports::types::CompanyRecord};
 
@@ -746,6 +752,81 @@ mode = "full"
         let state = AppState::new(AppConfig::default());
         state.registry().insert(id, std::sync::Arc::new(runtime));
         state
+    }
+
+    /// Same as [`acp_state`], but the sole company is `[users] mode = "none"`
+    /// — the packaged-desktop shape with no sign-in, reachable by anyone who
+    /// can reach the loopback bind at all.
+    async fn acp_state_none_mode(home: &std::path::Path) -> AppState {
+        let manifest: CompanyManifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "product_manager"
+role = "Product Manager"
+
+[[group_chat]]
+id = "engineering"
+name = "Engineering"
+members = []
+
+[policy]
+mode = "full"
+
+[users]
+mode = "none"
+"#,
+        )
+        .unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                overlay_retired_agents: Vec::new(),
+                overlay_agent_edits: Vec::new(),
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_tool_grants: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+                setup: None,
+                name_confirmed: false,
+                activation_completed_at: None,
+                created_at_millis: None,
+            })
+            .await
+            .unwrap();
+        let runtime = crate::runtime::RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .with_brain(std::sync::Arc::new(SilentBrain))
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        state
+    }
+
+    /// Builds a bare JSON-RPC `POST /acp` request with no auth headers.
+    fn acp_call_request(body: Value) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/acp")
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap()
     }
 
     /// An `@alice-smith` ACP prompt must badge alice exactly as a console
@@ -1216,6 +1297,211 @@ mode = "full"
                 .as_array()
                 .expect("updates array")
                 .is_empty()
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // PLAT-057 / PLAT-060: the `call` HTTP handler itself. Every test above
+    // this point calls `open_session`/`prompt`/etc. directly, bypassing the
+    // axum extraction, method dispatch and JSON-RPC envelope that only `call`
+    // (mounted by `router()`) actually implements.
+    // -----------------------------------------------------------------
+
+    /// PLAT-060 (AUTH): a `none`-mode company's local owner is reachable over
+    /// the real HTTP `call` handler with zero credentials — no cookie, no
+    /// bearer — same as every other credential-less surface that mode grants.
+    #[tokio::test]
+    async fn call_handler_authenticates_a_credential_less_none_mode_request() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-call-none-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state_none_mode(home.path()).await;
+        let app = router().with_state(state);
+
+        let body = json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} });
+        let response = app.oneshot(acp_call_request(body)).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["jsonrpc"], "2.0");
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["result"]["protocolVersion"], 1);
+    }
+
+    /// PLAT-057 (AUTH): a company with real sign-in refuses an unauthenticated
+    /// `call`, over HTTP — not just at the level of the extractor unit tests.
+    #[tokio::test]
+    async fn call_handler_refuses_an_unauthenticated_request() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-call-auth-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state(home.path()).await;
+        let app = router().with_state(state);
+
+        let body = json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} });
+        let response = app.oneshot(acp_call_request(body)).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// PLAT-057 (STATE): a user who must change their password is refused
+    /// *before* any ACP method runs, over the real HTTP path — the same
+    /// boundary `ScopedCompany` enforces for the operator API.
+    #[tokio::test]
+    async fn call_handler_refuses_a_temporary_password_user_before_running_any_method() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-call-temp-pw-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state(home.path()).await;
+        let company = CompanyId::new("acme");
+        let runtime = state.registry().get(&company).expect("company");
+        let now = crate::ports::now_millis();
+        runtime
+            .users()
+            .upsert_user(
+                &company,
+                &UserRecord {
+                    id: "u-temp".to_string(),
+                    email: "temp@example.test".to_string(),
+                    display_name: None,
+                    avatar: None,
+                    role: UserRole::Admin,
+                    status: UserStatus::Active,
+                    password_hash: None,
+                    must_change_password: true,
+                    created_at_millis: now,
+                    last_seen_at_millis: None,
+                    updated_at_millis: now,
+                },
+            )
+            .await
+            .expect("seed temp-password user");
+        let token = mint_session_token(&OsTokens);
+        runtime
+            .sessions()
+            .create(
+                &company,
+                &SessionRecord {
+                    id: "s-temp".to_string(),
+                    token_hash: sha256_hex(&token),
+                    user_id: "u-temp".to_string(),
+                    created_at_millis: now,
+                    expires_at_millis: now + 60_000,
+                    user_agent: None,
+                    kind: SessionKind::Browser,
+                    label: None,
+                },
+            )
+            .await
+            .expect("seed session");
+        let cookie_name = session_cookie_name(&company).expect("cookie name");
+
+        let app = router().with_state(state);
+        let body = json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} });
+        let mut request = acp_call_request(body);
+        request.headers_mut().insert(
+            axum::http::header::COOKIE,
+            format!("{cookie_name}={token}").parse().unwrap(),
+        );
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// PLAT-057 (FAIL): an unsupported ACP method comes back as a `-32602`
+    /// JSON-RPC error envelope, over the real HTTP path — not a raw error, not
+    /// an HTTP-level 4xx/5xx.
+    #[tokio::test]
+    async fn call_handler_reports_an_unsupported_method_as_a_json_rpc_error() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-call-fail-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state_none_mode(home.path()).await;
+        let app = router().with_state(state);
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": "req-9",
+            "method": "session/frobnicate",
+            "params": {},
+        });
+        let response = app.oneshot(acp_call_request(body)).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["id"], "req-9");
+        assert_eq!(value["error"]["code"], -32602);
+        assert!(
+            value["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("session/frobnicate")
+        );
+    }
+
+    /// PLAT-057 (BOUND): the JSON-RPC `id` round-trips exactly, including the
+    /// boundary case of a request that omits it entirely (must answer `null`,
+    /// not fail or invent one).
+    #[tokio::test]
+    async fn call_handler_echoes_the_request_id_including_when_absent() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-call-bound-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state_none_mode(home.path()).await;
+        let app = router().with_state(state);
+
+        let body = json!({ "jsonrpc": "2.0", "id": 42, "method": "initialize", "params": {} });
+        let response = app.clone().oneshot(acp_call_request(body)).await.unwrap();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["id"], 42);
+
+        let body = json!({ "jsonrpc": "2.0", "method": "initialize", "params": {} });
+        let response = app.oneshot(acp_call_request(body)).await.unwrap();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["id"], Value::Null);
+        assert_eq!(value["result"]["protocolVersion"], 1);
+    }
+
+    /// PLAT-057 (INPUT): a body that is not valid JSON at all must not panic
+    /// or hang the handler — it is rejected before `call`'s body even runs.
+    #[tokio::test]
+    async fn call_handler_rejects_a_body_that_is_not_valid_json() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-call-input-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state_none_mode(home.path()).await;
+        let app = router().with_state(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/acp")
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from(b"{ this is not json".to_vec()))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+
+        assert!(
+            response.status().is_client_error(),
+            "a malformed JSON body must be rejected, got {:?}",
+            response.status()
         );
     }
 }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -2391,6 +2391,36 @@ async fn run_chat(
         };
         if let Err(err) = runtime.upsert_task(&record).await {
             tracing::warn!(error = %err, "failed to open task card for chat request");
+            // CHAT-021: a card-open failure used to end here — logged
+            // server-side, and the chat turn otherwise proceeded to a normal
+            // 200. To the operator, the message they had just asked to be
+            // tracked simply never became a card, with no word anywhere in
+            // the product that it had tried and failed. Same shape and author
+            // as the turn-failure notice above: a direct `AgentReply` in the
+            // same desk this card would have opened in, so it round-trips
+            // through history like any other reply.
+            let notice = CompanyEvent::AgentReply {
+                audience: Vec::new(),
+                parent: reply_thread(accepted.thread_root(), accepted.message_seq),
+                chat_id: message
+                    .chat
+                    .clone()
+                    .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string()),
+                agent_id: crate::ports::SYSTEM_AUTHOR.to_string(),
+                text: "This should have opened a task card, but the card could not be saved. \
+                       Nothing else was lost — send the message again, or open the card by hand."
+                    .to_string(),
+                steps: Vec::new(),
+                task_id: None,
+                mentions: Vec::new(),
+                mention_depth: 0,
+            };
+            if let Err(journal_err) = runtime.events().append(runtime.id(), notice).await {
+                tracing::warn!(
+                    error = %journal_err,
+                    "failed to journal the card-open failure notice itself"
+                );
+            }
         }
     }
     // Issue #983: the message is already in the journal — `accept_chat_turn`
@@ -6276,6 +6306,128 @@ mode = "full"
             tasks[0].title,
             crate::company::task_intent::to_title(text),
             "a bypassed card must be titled byte-for-byte as a tracked one"
+        );
+    }
+
+    /// A task store that lists cleanly but refuses every write — the board
+    /// persistence layer mid-outage, for CHAT-021.
+    struct FailingTaskUpsert;
+
+    #[async_trait::async_trait]
+    impl crate::ports::tasks::TaskStore for FailingTaskUpsert {
+        async fn list(
+            &self,
+            _company: &CompanyId,
+        ) -> crate::Result<Vec<crate::ports::tasks::TaskRecord>> {
+            Ok(Vec::new())
+        }
+        async fn upsert(
+            &self,
+            _company: &CompanyId,
+            _task: &crate::ports::tasks::TaskRecord,
+        ) -> crate::Result<()> {
+            Err(OpenCompanyError::InvalidRequest(
+                "task store offline".to_string(),
+            ))
+        }
+        async fn delete(&self, _company: &CompanyId, _id: &str) -> crate::Result<bool> {
+            Ok(false)
+        }
+    }
+
+    /// CHAT-021: a card-open failure must not vanish into a server log while
+    /// the operator sees an ordinary success. The chat turn itself still
+    /// returns 200 — it did nothing wrong — but a durable system note in the
+    /// same desk must say the card did not open, exactly as a turn that
+    /// aborts mid-answer already leaves a visible notice rather than silence.
+    #[tokio::test]
+    async fn a_card_open_failure_is_reported_in_the_channel_not_swallowed() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let store = FsCompanyStore::new(home.clone());
+        let id = CompanyId::new("acme");
+        use crate::ports::CompanyStore;
+        store
+            .save(&CompanyRecord {
+                overlay_retired_agents: Vec::new(),
+                overlay_agent_edits: Vec::new(),
+                id: id.clone(),
+                manifest: manifest(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_tool_grants: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+                setup: None,
+                name_confirmed: false,
+                activation_completed_at: None,
+                created_at_millis: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home, manifest())
+            .with_id(id.clone())
+            .with_tasks(Arc::new(FailingTaskUpsert))
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id.clone(), Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        let runtime = state.registry().get(&id).unwrap();
+        let app = router(state);
+
+        // `deliverable: "workflow"` opens a card deterministically, whatever
+        // the lexical triage would have made of the words (see the test
+        // above) — the fixture does not need to be a message the classifier
+        // happens to card.
+        let body = format!(
+            r#"{{"text":{},"deliverable":"workflow"}}"#,
+            serde_json::json!("automate the weekly report")
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/chat")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "the chat turn itself did nothing wrong and must still succeed"
+        );
+
+        let events = runtime
+            .events()
+            .read_from(&id, EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap();
+        let notice = events.into_iter().find_map(|stored| match stored.event {
+            CompanyEvent::AgentReply { agent_id, text, .. }
+                if agent_id == crate::ports::SYSTEM_AUTHOR =>
+            {
+                Some(text)
+            }
+            _ => None,
+        });
+        assert!(
+            notice.is_some_and(|text| text.to_lowercase().contains("card")),
+            "a card-open failure must leave a visible system note in the channel, not just a \
+             server-side log line"
         );
     }
 
@@ -11097,6 +11249,235 @@ mode = "full"
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
+    /// APPR-004: extend must be able to win a race the sweep has not yet run —
+    /// an approval whose deadline has already passed but that is still
+    /// physically parked (nothing has swept it out of the gate) must still be
+    /// extendable, and the extension must genuinely move the deadline rather
+    /// than just answer as if it had.
+    ///
+    /// `resolve`'s own past-deadline check (`gate.rs`'s TTL math) and
+    /// `extend`'s (`ParkedApprovals::extend`, existence-only) are two
+    /// different tests over the same map — that gap is exactly the window
+    /// `/extend` exists to rescue something in, per issue #1805.
+    #[tokio::test]
+    async fn extending_beats_a_pending_sweep_on_an_already_past_deadline_approval() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+        // Parked at the epoch: this host's TTL has long since passed, and
+        // nothing has swept either entry out of the gate yet.
+        let control = park_for_extend(&runtime, "appr-control", 1).await;
+        let target = park_for_extend(&runtime, "appr-target", 1).await;
+
+        let app = router(state.clone());
+
+        // The control proves the premise: resolving an untouched twin of the
+        // same stale park reports `expired`.
+        let resolved = app
+            .clone()
+            .oneshot(resolve_request(
+                &control,
+                serde_json::json!({ "verdict": "approve", "detach": true }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resolved.status(), StatusCode::OK);
+        let body = body_json(resolved).await;
+        assert_eq!(
+            body["outcome"], "expired",
+            "premise: a park this old is already past this host's TTL, got {body}"
+        );
+
+        // Extending the other twin, before anything else touches it, must
+        // still succeed — this is the whole reason `/extend` exists.
+        let extended = app.clone().oneshot(extend_request(&target)).await.unwrap();
+        assert_eq!(
+            extended.status(),
+            StatusCode::OK,
+            "extend must be able to rescue a park the sweep has not yet reclaimed"
+        );
+
+        // And now resolving it must NOT report `expired` — the deadline
+        // genuinely moved, not just the extend receipt's word for it.
+        let resolved = app
+            .oneshot(resolve_request(
+                &target,
+                serde_json::json!({ "verdict": "approve", "detach": true }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resolved.status(), StatusCode::OK);
+        let body = body_json(resolved).await;
+        assert_ne!(
+            body["outcome"], "expired",
+            "extend must genuinely push the deadline out, not just answer as if it did: {body}"
+        );
+    }
+
+    /// PLAT-014 (Member ⇒ approve): the sharpest of the auth-matrix's four
+    /// rows. A Member sees a money-bearing approval exists (issue #468's
+    /// "waiting on approval" indicator has to survive for them) but not what
+    /// it is about (issue #618) — and cannot act on it at all: both
+    /// `POST {scope}/approvals/{aid}` and `/extend` are `AdminScopedCompany`.
+    /// All three properties are asserted against the same parked approval, so
+    /// the redaction and the auth gate cannot silently disagree about which
+    /// one is doing the protecting.
+    #[tokio::test]
+    async fn a_member_cannot_read_or_act_on_a_money_bearing_approval() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let approval = park_for_extend(&runtime, "appr-member", crate::ports::now_millis()).await;
+        crate::server::test_support::seed_fixed_member(&state, "acme").await;
+        let member_cookie = crate::server::test_support::member_cookie("acme");
+        let app = router(state);
+
+        // Sees it exists, but not what it costs.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/approvals")
+                    .header("cookie", &member_cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        let listed = body
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|a| a["id"] == approval.to_string())
+            .expect("the approval is visible to a member");
+        assert_eq!(
+            listed["contents_hidden"], true,
+            "a member must be told the contents were withheld: {listed}"
+        );
+        assert!(
+            listed["amount_usd"].is_null(),
+            "a member must not receive the dollar amount: {listed}"
+        );
+        assert!(
+            listed["payload"].is_null(),
+            "a member must not receive the payload either: {listed}"
+        );
+
+        // Cannot resolve it.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/company/approvals/{approval}"))
+                    .header("cookie", &member_cookie)
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "verdict": "approve" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "a member must not be able to approve a parked effect"
+        );
+
+        // Cannot extend it either.
+        let response = app
+            .oneshot(extend_request_with_cookie(&approval, member_cookie))
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "a member must not be able to extend a parked effect's deadline"
+        );
+    }
+
+    /// POL-011: `extend_approval` is one handler mounted under both scope
+    /// forms (`scoped("/approvals/{aid}/extend", ...)`), so the platform
+    /// `/companies/{id}/...` form must carry the exact same admin gate the
+    /// `/company/...` alias does — and must not become a side channel that
+    /// resolves against the wrong company merely because its id rode in the
+    /// path instead of the alias.
+    #[tokio::test]
+    async fn extend_on_the_scoped_route_form_enforces_admin_and_the_right_company() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let approval = park_for_extend(&runtime, "appr-scoped", crate::ports::now_millis()).await;
+        crate::server::test_support::seed_fixed_member(&state, "acme").await;
+        let member_cookie = crate::server::test_support::member_cookie("acme");
+        let admin_cookie = crate::server::test_support::fixed_cookie("acme");
+        let app = router(state);
+
+        // AUTH: a member is refused on the scoped form exactly as on the alias.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!(
+                        "/api/v1/companies/acme/approvals/{approval}/extend"
+                    ))
+                    .header("cookie", &member_cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        // FAIL: addressing a *different* company id on the scoped form must
+        // 404 rather than reach into `acme`'s gate — the path segment is the
+        // only thing naming the company here, unlike the alias.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!(
+                        "/api/v1/companies/globex/approvals/{approval}/extend"
+                    ))
+                    .header("cookie", &admin_cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            response.status(),
+            StatusCode::OK,
+            "a company id that does not exist must not extend acme's approval"
+        );
+        assert!(
+            runtime.pending_approvals().iter().any(|a| a.id == approval),
+            "the approval must still be sitting under its real company, untouched"
+        );
+
+        // And the scoped form works for the right admin and the right company.
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!(
+                        "/api/v1/companies/acme/approvals/{approval}/extend"
+                    ))
+                    .header("cookie", &admin_cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
     /// Whether the stalled brain's follow-up turn has journaled its marker yet.
     fn continued(runtime: &Arc<CompanyRuntime>) -> bool {
         runtime
@@ -13649,6 +14030,149 @@ mode = "full"
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// GRANT-012 (AUTH): `GET {scope}/grants` stays readable by any member —
+    /// the same consistency `GET {scope}/tools/grants` holds — but revoking one
+    /// is an admin action (issue #2169). A Member must see the list and be
+    /// refused the delete.
+    #[tokio::test]
+    async fn a_member_may_list_standing_grants_but_not_revoke_one() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        runtime
+            .grants
+            .grant_standing(crate::runtime::grants::StandingGrant {
+                id: crate::runtime::grants::GrantId::new("g-member"),
+                agent: "ops".into(),
+                workflow: None,
+                tool: "workspace_write".into(),
+                verdict: Verdict::Approve,
+                granted_by: Actor {
+                    kind: ActorKind::User,
+                    id: "user-7".into(),
+                },
+                approval_id: ApprovalId::new("appr-1"),
+                at_millis: 1_000,
+                expires_at_millis: crate::ports::now_millis() + 60 * 60 * 1000,
+                origin_thread: None,
+                origin_parent: None,
+                origin_task: None,
+                scope: None,
+            });
+        crate::server::test_support::seed_fixed_member(&state, "acme").await;
+        let member_cookie = crate::server::test_support::member_cookie("acme");
+        let app = router(state);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/grants")
+                    .header("cookie", &member_cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "a member may read the standing-grants list"
+        );
+        let body = body_json(response).await;
+        assert_eq!(body[0]["id"], "g-member");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/v1/company/grants/g-member")
+                    .header("cookie", &member_cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "revoking a standing grant is an admin action, matching the tools/grants plane"
+        );
+    }
+
+    /// GRANT-012 (FAIL): `revoke_standing` is a plain map removal with no
+    /// expiry check of its own — a grant past its deadline that nothing has
+    /// *swept* yet is still found and revoked normally (204), exactly as
+    /// `/extend` can still rescue a not-yet-swept approval. Only once
+    /// `sweep_standing` has actually removed it does revoke correctly answer
+    /// the "nothing to revoke" 404 the route's own doc promises — the same
+    /// distinction as an already-revoked id, never a 500.
+    #[tokio::test]
+    async fn revoking_a_grant_is_404_only_once_it_is_actually_swept() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let stale_grant = |id: &str| crate::runtime::grants::StandingGrant {
+            id: crate::runtime::grants::GrantId::new(id),
+            agent: "ops".into(),
+            workflow: None,
+            tool: "workspace_write".into(),
+            verdict: Verdict::Approve,
+            granted_by: Actor {
+                kind: ActorKind::User,
+                id: "user-7".into(),
+            },
+            approval_id: ApprovalId::new("appr-1"),
+            at_millis: 1_000,
+            // Already in the past either way; only sweeping tells the two apart.
+            expires_at_millis: 1_001,
+            origin_thread: None,
+            origin_parent: None,
+            origin_task: None,
+            scope: None,
+        };
+        runtime.grants.grant_standing(stale_grant("g-unswept"));
+        runtime.grants.grant_standing(stale_grant("g-swept"));
+
+        let app = router(state.clone());
+        let delete = |id: &'static str| {
+            let app = app.clone();
+            async move {
+                app.oneshot(
+                    Request::builder()
+                        .method("DELETE")
+                        .uri(format!("/api/v1/company/grants/{id}"))
+                        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+            }
+        };
+
+        // Past-deadline but not yet swept: still a normal, successful revoke.
+        let response = delete("g-unswept").await;
+        assert_eq!(
+            response.status(),
+            StatusCode::NO_CONTENT,
+            "an expired-but-unswept grant is still physically present, so revoking it is an \
+             ordinary success — exactly as extend can still rescue an unswept approval"
+        );
+
+        // Now actually sweep the other one out from under the route.
+        let swept = runtime.grants.sweep_standing(crate::ports::now_millis());
+        assert_eq!(swept.len(), 1, "premise: the grant was in fact swept");
+
+        let response = delete("g-swept").await;
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "once actually swept, revoke must report the same 'nothing to revoke' answer an \
+             already-revoked id does"
+        );
     }
 
     // ---------------------------------------------------------------------

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -727,6 +727,20 @@ async fn apply(
         .map_err(|e| ApiError::from(e).into_response().into())
 }
 
+/// Serializes the whole first-run apply, process-wide.
+///
+/// Without this, two `POST /api/v1/setup` requests that both land before
+/// either has inserted into the registry can both read
+/// `state.registry().is_empty()` as `true` and both seed a starter company —
+/// exactly the "a re-run must never hand the operator a second starter
+/// company" case this module documents, just reached by two concurrent
+/// first runs instead of one re-run. Held for the whole of [`apply_inner`],
+/// not just the seed check, so a second caller only ever starts once the
+/// first has fully landed (or failed) — including the `config.toml` write,
+/// which is not otherwise safe against a torn concurrent write either.
+static APPLY_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
 /// `+ Sync` so the returned future is `Send`, which axum requires of a handler:
 /// a `&T` is `Send` only when `T` is `Sync`, and the bare trait object is not.
 async fn apply_inner(
@@ -734,6 +748,7 @@ async fn apply_inner(
     req: SetupRequest,
     env: &(dyn EnvSource + Sync),
 ) -> Result<AppliedDto, OpenCompanyError> {
+    let _apply_guard = APPLY_LOCK.lock().await;
     // See `snapshot`'s comment: this must be the same root startup reads
     // `config.toml` from, which is not always `state.home()`.
     let dir = state.config_root().to_path_buf();

--- a/src/server/setup/test.rs
+++ b/src/server/setup/test.rs
@@ -643,7 +643,7 @@ struct SelectiveRebuilder {
 impl RuntimeRebuilder for SelectiveRebuilder {
     async fn rebuild(
         &self,
-        _state: &AppState,
+        state: &AppState,
         request: RebuildRequest,
     ) -> crate::Result<CompanyRuntime> {
         if self.fails.iter().any(|id| id == request.id.as_ref()) {
@@ -651,9 +651,13 @@ impl RuntimeRebuilder for SelectiveRebuilder {
                 "simulated rebuild failure".to_string(),
             ));
         }
+        // The auth-mode override is carried the way the boot rebuilder carries
+        // it, or a company rebuilt here keeps the manifest default and the
+        // mode the request chose is silently dropped.
         RuntimeBuilder::new(self.home.clone(), request.manifest)
             .with_id(request.id)
             .with_handover(request.handover)
+            .with_auth_mode_override(state.auth_mode_override())
             .build()
             .await
     }

--- a/src/server/setup/test.rs
+++ b/src/server/setup/test.rs
@@ -11,11 +11,14 @@ use axum::body::{Body, to_bytes};
 use axum::http::{Request, StatusCode};
 use tower::ServiceExt;
 
+use async_trait::async_trait;
+
 use crate::app::config::MapEnv;
 use crate::company::CompanyManifest;
+use crate::company::runtime::CompanyRuntime;
 use crate::ports::CompanyStore;
 use crate::ports::types::{CompanyId, CompanyRecord, SecretValue};
-use crate::runtime::RuntimeBuilder;
+use crate::runtime::{RebuildRequest, RuntimeBuilder, RuntimeRebuilder};
 use crate::server::ops::ConnectionsRuntime;
 use crate::server::ops::mailer::{MailCredentials, RecordingMailSender};
 use crate::server::ops::smtp::{SmtpCredentials, SmtpSecurity};
@@ -626,6 +629,117 @@ async fn an_existing_company_that_cannot_rebuild_reports_a_restart() {
             .unwrap()
             .contains(&serde_json::json!("auth_mode")),
         "no rebuilder is wired in this fixture, so the honest answer is `restart`: {body}"
+    );
+}
+
+/// A rebuilder that fails for exactly the company ids named in `fails`, and
+/// otherwise behaves like the production one.
+struct SelectiveRebuilder {
+    home: std::path::PathBuf,
+    fails: Vec<String>,
+}
+
+#[async_trait]
+impl RuntimeRebuilder for SelectiveRebuilder {
+    async fn rebuild(
+        &self,
+        _state: &AppState,
+        request: RebuildRequest,
+    ) -> crate::Result<CompanyRuntime> {
+        if self.fails.iter().any(|id| id == request.id.as_ref()) {
+            return Err(crate::error::OpenCompanyError::Config(
+                "simulated rebuild failure".to_string(),
+            ));
+        }
+        RuntimeBuilder::new(self.home.clone(), request.manifest)
+            .with_id(request.id)
+            .with_handover(request.handover)
+            .build()
+            .await
+    }
+}
+
+/// PLAT-052: the rebuild loop is per-company best-effort. A company that
+/// cannot rebuild — in the middle of the list, not just the only one — must
+/// not stop the companies after it, and the honest `restart_required` must
+/// still be reported rather than silently dropped once anything succeeded.
+#[tokio::test]
+async fn a_failed_rebuild_mid_list_does_not_stop_the_rest() {
+    let home_dir = home();
+    let store = crate::store::FsCompanyStore::new(home_dir.path().to_path_buf());
+    let state = fresh_state(home_dir.path());
+    for name in ["acme", "globex", "initech"] {
+        let id = CompanyId::new(name);
+        store
+            .save(&CompanyRecord {
+                overlay_retired_agents: Vec::new(),
+                overlay_agent_edits: Vec::new(),
+                id: id.clone(),
+                manifest: manifest(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_tool_grants: None,
+                overlay_desk_tools: std::collections::BTreeMap::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+                setup: None,
+                name_confirmed: false,
+                activation_completed_at: None,
+                created_at_millis: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        state.registry().insert(id, Arc::new(runtime));
+    }
+    let state = state.with_rebuilder(Arc::new(SelectiveRebuilder {
+        home: home_dir.path().to_path_buf(),
+        fails: vec!["globex".to_string()],
+    }));
+
+    let (status, body) = post_setup(
+        state.clone(),
+        serde_json::json!({ "fields": { "auth_mode": "none" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    assert_eq!(
+        state
+            .registry()
+            .get(&CompanyId::new("acme"))
+            .unwrap()
+            .auth_mode(),
+        crate::app::config::AuthMode::None,
+        "a company before the failing one in the list must still be rebuilt"
+    );
+    assert_eq!(
+        state
+            .registry()
+            .get(&CompanyId::new("initech"))
+            .unwrap()
+            .auth_mode(),
+        crate::app::config::AuthMode::None,
+        "a company after the failing one must still be rebuilt: the loop must not abort mid-list"
+    );
+    assert!(
+        body["restart_required"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("auth_mode")),
+        "the failing company means a restart is still genuinely owed, even though two of \
+         three succeeded: {body}"
     );
 }
 
@@ -1379,6 +1493,36 @@ async fn a_routable_host_refuses_an_anonymous_proposal() {
     );
 }
 
+/// CONSOLE-ADMIN-058: `propose_roster` is a pure read gated by the same
+/// [`authorize`](super::authorize) [`apply`](super::apply) is — but unlike
+/// `apply`, it persists nothing, so several proposals in flight at once must
+/// not block on each other (there is nothing to serialize) and must not leave
+/// any of them half-registering a company.
+#[tokio::test]
+async fn concurrent_roster_proposals_do_not_persist_anything() {
+    let home = home();
+    let state = fresh_state(home.path());
+    let request = || serde_json::json!({ "industry": "software", "teamHint": "", "automate": "" });
+
+    let (a, b, c) = tokio::join!(
+        post_roster(state.clone(), request()),
+        post_roster(state.clone(), request()),
+        post_roster(state.clone(), request()),
+    );
+
+    for (status, body) in [&a, &b, &c] {
+        assert_eq!(*status, StatusCode::OK, "{body}");
+    }
+    assert!(
+        state.registry().is_empty(),
+        "concurrent roster proposals must never register a company"
+    );
+    assert!(
+        !state.setup_complete(),
+        "a roster proposal must never mark setup complete"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Applying a company the wizard designed
 // ---------------------------------------------------------------------------
@@ -1585,6 +1729,45 @@ async fn a_second_apply_does_not_seed_another_company() {
         "a host with a company must not be handed a second: {body}"
     );
     assert_eq!(state.registry().list().len(), 1);
+}
+
+/// CONSOLE-ADMIN-056: the re-run guard above holds against a second,
+/// *sequential* apply. It must hold just as well when two first-run applies
+/// land concurrently — the case the guard's own doc comment is really about
+/// ("a re-run must never hand the operator a second starter company"), just
+/// reached by two racing callers instead of one later one.
+#[tokio::test]
+async fn concurrent_first_run_applies_seed_at_most_one_company() {
+    let home = home();
+    let state = fresh_state(home.path());
+    assert!(state.registry().is_empty(), "the premise: nothing yet");
+
+    let body = serde_json::json!({ "company": designed_company(None) });
+    let (first, second) = tokio::join!(
+        post_setup(state.clone(), body.clone()),
+        post_setup(state.clone(), body),
+    );
+
+    assert_eq!(first.0, StatusCode::OK, "{:?}", first.1);
+    assert_eq!(second.0, StatusCode::OK, "{:?}", second.1);
+    assert_eq!(
+        state.registry().list().len(),
+        1,
+        "two concurrent first-run applies must seed exactly one company, not two: \
+         {first:?} {second:?}"
+    );
+
+    // Exactly one of the two responses may report a seed; the other must
+    // accurately report it found the registry already occupied by the time it
+    // ran, not silently invent (or omit) a second one.
+    let seeded = [&first.1, &second.1]
+        .iter()
+        .filter(|body| !body["seeded_company"].is_null())
+        .count();
+    assert_eq!(
+        seeded, 1,
+        "exactly one of the two concurrent calls may report a seed: {first:?} {second:?}"
+    );
 }
 
 /// The roster arrives over the wire after an operator edited it, so neither the


### PR DESCRIPTION
## Summary

Three fixes on the server edge, each with the case that proves it, plus coverage for the ACP call handler and the A2A boundary.

**A first-run apply could seed a company twice.** `apply_inner` read the registry, found it empty, and seeded — with nothing serialising two callers, so two concurrent first-run applies each saw an empty registry and each seeded. Now serialised on a process-wide lock. Nothing reachable from inside `apply_inner` re-acquires it, so the lock cannot deadlock against itself.

**An inbound A2A task could hang forever.** The company cycle ran unbounded, so a stuck cycle held the request open with no ceiling. Now bounded by a 120s timeout, which answers `504` instead of never answering.

**A card-open failure was swallowed.** The operator path logged it and carried on, so the console showed nothing while the work had not started. It now journals a visible notice.

Also: the ACP `call` HTTP handler is now exercised through the router rather than through its inner functions — every prior case called `prompt()` directly and never went through the handler, so its auth, its JSON-RPC error envelope and its malformed-body rejection were untested.

Each of the three was red-proved:

| Change | Proved by breaking |
|---|---|
| `APPLY_LOCK` | removing the lock → both concurrent applies returned `seeded_company: "e-commerce"`, two seeds not one |
| `A2A_CYCLE_TIMEOUT` | raising it above the hanging brain's sleep → the case hit `unreachable!("the cycle timeout must fire long before this wakes")` |
| card-open notice | wrapping the notice in `if false` → the pre-fix silent-failure assertion fires |

The A2A file is gated `#[cfg(feature = "tinyplace")]`, so it is not built by the `openhuman` lane and was proved under `cargo test --locked --features tinyplace --lib` — the lane that actually owns it. The fast path is unaffected: a normal cycle still answers in ~0.1s.

## API Or Behavior Changes

An inbound A2A task that exceeds 120s of cycle time answers `504` rather than hanging. A concurrent first-run apply is serialised, so the second caller observes the first's result instead of seeding its own company. A card-open failure appears in the channel instead of only in the log.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — both the default lane and `--no-deps --features openhuman`, clean
- [ ] `cargo build --all-targets` — N/A: the clippy and test lanes build the same targets and are clean
- [x] `cargo test` — `cargo test --locked --features openhuman --tests` passes with zero failures; the A2A cases additionally run under `--features tinyplace --lib` (5,018 tests)

## Documentation

No docs needed — each change closes a gap against behaviour the affected modules' own doc comments already describe.
