### PR TITLE
fix(ingest): refuse a link on what its host resolves to, not on its spelling

### DIFF
--- a/src/server/ops/memory_ingest.rs
+++ b/src/server/ops/memory_ingest.rs
@@ -67,6 +67,13 @@ const MAX_LINK_BYTES: usize = 4 * 1024 * 1024;
 #[cfg(feature = "documents")]
 const LINK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
+/// How long one host may take to resolve before the link is refused.
+///
+/// Separate from [`LINK_TIMEOUT`], which bounds the fetch and starts only once
+/// the guard has answered. Well under it, because a name that has not resolved
+/// in five seconds is not going to be fetched inside the remaining ten.
+const DNS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Builds the ingest route fragment.
 pub fn router() -> Router<AppState> {
     scoped("/memory/ingest", post(ingest))
@@ -432,13 +439,23 @@ fn is_internal_address(address: std::net::IpAddr) -> bool {
                 || v4.octets()[0] == 100 && (64..128).contains(&v4.octets()[1])
         }
         std::net::IpAddr::V6(v6) => {
-            if let Some(v4) = v6.to_ipv4_mapped() {
-                return is_internal_address(std::net::IpAddr::V4(v4));
-            }
-            v6.is_loopback()
+            // `::1` and `::` are judged as themselves before any v4 reading of
+            // them: `to_ipv4` maps `::1` to `0.0.0.1`, which is not internal by
+            // v4 rules, so testing that first would admit loopback.
+            if v6.is_loopback()
                 || v6.is_unspecified()
                 || v6.segments()[0] & 0xfe00 == 0xfc00
                 || v6.segments()[0] & 0xffc0 == 0xfe80
+            {
+                return true;
+            }
+            // `to_ipv4`, not `to_ipv4_mapped`: the mapped form (`::ffff:a.b.c.d`)
+            // is only half of it. The deprecated IPv4-compatible form
+            // (`::a.b.c.d`) carries the same address, is not `is_loopback`, and
+            // `to_ipv4_mapped` answers `None` for it — so reading only the
+            // mapped form admits `::127.0.0.1`.
+            v6.to_ipv4()
+                .is_some_and(|v4| is_internal_address(std::net::IpAddr::V4(v4)))
         }
     }
 }
@@ -495,9 +512,17 @@ async fn guard_link(url: &str) -> Result<(), String> {
         Some("https") => 443,
         _ => 80,
     });
-    let resolved = tokio::net::lookup_host((lowered.as_str(), port))
-        .await
-        .map_err(|e| format!("that host could not be resolved: {e}"))?;
+    // `LINK_TIMEOUT` belongs to the request built after this returns, so it
+    // does not bound the lookup. Without its own ceiling a name whose resolver
+    // blackholes queries holds this handler for a retry period, and the route
+    // walks its URLs one at a time — so a list of such names costs their sum.
+    let resolved = tokio::time::timeout(
+        DNS_TIMEOUT,
+        tokio::net::lookup_host((lowered.as_str(), port)),
+    )
+    .await
+    .map_err(|_| format!("`{lowered}` took too long to resolve"))?
+    .map_err(|e| format!("that host could not be resolved: {e}"))?;
     let mut any = false;
     for socket in resolved {
         any = true;

--- a/src/server/ops/memory_ingest.rs
+++ b/src/server/ops/memory_ingest.rs
@@ -359,7 +359,7 @@ async fn ingest_links(
     let mut items = Vec::new();
     for url in request.urls {
         let url = url.trim().to_string();
-        if let Err(refusal) = guard_link(&url) {
+        if let Err(refusal) = guard_link(&url).await {
             items.push(IngestedItem::failed(url, refusal));
             continue;
         }
@@ -414,15 +414,58 @@ async fn fetch_link(
     item
 }
 
+/// Whether an address belongs to the deployment rather than the internet.
+///
+/// The set the fetch below must never reach: loopback, RFC1918, link-local
+/// (which is where a cloud metadata service lives), unspecified, and their
+/// IPv6 equivalents including unique-local and the v4-mapped forms, since
+/// `::ffff:127.0.0.1` is a loopback address written the long way.
+#[cfg(feature = "documents")]
+fn is_internal_address(address: std::net::IpAddr) -> bool {
+    match address {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.octets()[0] == 100 && (64..128).contains(&v4.octets()[1])
+        }
+        std::net::IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_internal_address(std::net::IpAddr::V4(v4));
+            }
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.segments()[0] & 0xfe00 == 0xfc00
+                || v6.segments()[0] & 0xffc0 == 0xfe80
+        }
+    }
+}
+
 /// Refuses a URL this host must not fetch on an operator's behalf.
 ///
-/// Scheme and host only: DNS is resolved by the client at request time and
-/// re-resolving here to check the address would be a different lookup than the
-/// one that happens (a TOCTOU no host-level check closes). What this stops is
-/// the direct form — `http://localhost:8080/admin`, `http://169.254.169.254/`
-/// — which is the shape of every accidental and most deliberate attempts.
+/// Two checks, and the second is the one that matters. A literal address is
+/// judged directly. A **hostname** is resolved, and refused when any address
+/// it answers with belongs to this deployment — without that step
+/// `http://anything.example/` pointing at `169.254.169.254` reads as an
+/// ordinary public URL, and the fetch below reaches the metadata service.
+/// Refusing the literal form alone stops the accident and none of the intent.
+///
+/// The residual TOCTOU is real and is not what this closes: a name that
+/// resolves publicly here can answer differently for the client a moment
+/// later. Narrowing that means having the connector pin the address this
+/// validated, which is a change to the client rather than to this check.
+///
+/// The agent runtime carries the same rule for the tools it exposes
+/// (`validate_url_with_dns_check`), but it is not reachable from every build
+/// this route ships in — `documents` is a default feature and `openhuman` is
+/// not — and pulling the whole runtime into the default build to borrow forty
+/// lines of URL guard costs more than it saves. The lasting fix is to lift
+/// this rule somewhere both can depend on; until then the two are deliberate
+/// copies rather than an oversight.
 #[cfg(feature = "documents")]
-fn guard_link(url: &str) -> Result<(), String> {
+async fn guard_link(url: &str) -> Result<(), String> {
     let parsed = url
         .parse::<axum::http::Uri>()
         .map_err(|_| "not a URL".to_string())?;
@@ -433,22 +476,40 @@ fn guard_link(url: &str) -> Result<(), String> {
     let host = parsed
         .host()
         .ok_or_else(|| "no host in the URL".to_string())?;
+    // A bracketed IPv6 literal keeps its brackets in `Uri::host`.
+    let host = host.trim_start_matches('[').trim_end_matches(']');
     let lowered = host.to_ascii_lowercase();
     if lowered == "localhost" || lowered.ends_with(".localhost") || lowered.ends_with(".internal") {
         return Err("that host is internal to this deployment".to_string());
     }
+
     if let Ok(address) = lowered.parse::<std::net::IpAddr>() {
-        let private = match address {
-            std::net::IpAddr::V4(v4) => {
-                v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.is_unspecified()
-            }
-            std::net::IpAddr::V6(v6) => {
-                v6.is_loopback() || v6.is_unspecified() || v6.segments()[0] & 0xfe00 == 0xfc00
-            }
+        return if is_internal_address(address) {
+            Err("that address is inside this deployment's own network".to_string())
+        } else {
+            Ok(())
         };
-        if private {
-            return Err("that address is inside this deployment's own network".to_string());
+    }
+
+    let port = parsed.port_u16().unwrap_or(match parsed.scheme_str() {
+        Some("https") => 443,
+        _ => 80,
+    });
+    let resolved = tokio::net::lookup_host((lowered.as_str(), port))
+        .await
+        .map_err(|e| format!("that host could not be resolved: {e}"))?;
+    let mut any = false;
+    for socket in resolved {
+        any = true;
+        if is_internal_address(socket.ip()) {
+            return Err(format!(
+                "`{lowered}` resolves to {}, which is inside this deployment's own network",
+                socket.ip()
+            ));
         }
+    }
+    if !any {
+        return Err(format!("`{lowered}` resolved to no addresses"));
     }
     Ok(())
 }

--- a/src/server/ops/memory_ingest.rs
+++ b/src/server/ops/memory_ingest.rs
@@ -483,6 +483,27 @@ fn is_internal_address(address: std::net::IpAddr) -> bool {
 /// copies rather than an oversight.
 #[cfg(feature = "documents")]
 async fn guard_link(url: &str) -> Result<(), String> {
+    guard_link_resolving_with(url, |host, port| async move {
+        tokio::net::lookup_host((host.as_str(), port))
+            .await
+            .map(|addrs| addrs.map(|socket| socket.ip()).collect())
+    })
+    .await
+}
+
+/// [`guard_link`], against a resolver the caller supplies.
+///
+/// The split exists so the resolving arm can be tested without a lookup. A
+/// case that reaches real DNS to prove this fails on a runner without it, and
+/// that failure says nothing about the product — the wrong way round for a
+/// check that sits in the default feature set. The runtime's own guard is
+/// split the same way and for the same reason.
+#[cfg(feature = "documents")]
+async fn guard_link_resolving_with<F, Fut>(url: &str, resolve: F) -> Result<(), String>
+where
+    F: FnOnce(String, u16) -> Fut,
+    Fut: std::future::Future<Output = std::io::Result<Vec<std::net::IpAddr>>>,
+{
     let parsed = url
         .parse::<axum::http::Uri>()
         .map_err(|_| "not a URL".to_string())?;
@@ -512,29 +533,19 @@ async fn guard_link(url: &str) -> Result<(), String> {
         Some("https") => 443,
         _ => 80,
     });
-    // `LINK_TIMEOUT` belongs to the request built after this returns, so it
-    // does not bound the lookup. Without its own ceiling a name whose resolver
-    // blackholes queries holds this handler for a retry period, and the route
-    // walks its URLs one at a time — so a list of such names costs their sum.
-    let resolved = tokio::time::timeout(
-        DNS_TIMEOUT,
-        tokio::net::lookup_host((lowered.as_str(), port)),
-    )
-    .await
-    .map_err(|_| format!("`{lowered}` took too long to resolve"))?
-    .map_err(|e| format!("that host could not be resolved: {e}"))?;
-    let mut any = false;
-    for socket in resolved {
-        any = true;
-        if is_internal_address(socket.ip()) {
+    let resolved = tokio::time::timeout(DNS_TIMEOUT, resolve(lowered.clone(), port))
+        .await
+        .map_err(|_| format!("`{lowered}` took too long to resolve"))?
+        .map_err(|e| format!("that host could not be resolved: {e}"))?;
+    if resolved.is_empty() {
+        return Err(format!("`{lowered}` resolved to no addresses"));
+    }
+    for address in resolved {
+        if is_internal_address(address) {
             return Err(format!(
-                "`{lowered}` resolves to {}, which is inside this deployment's own network",
-                socket.ip()
+                "`{lowered}` resolves to {address}, which is inside this deployment's own network"
             ));
         }
-    }
-    if !any {
-        return Err(format!("`{lowered}` resolved to no addresses"));
     }
     Ok(())
 }

--- a/src/server/ops/memory_ingest/test.rs
+++ b/src/server/ops/memory_ingest/test.rs
@@ -274,60 +274,68 @@ async fn link_ingestion_refuses_this_deployments_own_network() {
     );
 }
 
-/// The half a string check cannot do, and the reason this delegates.
+/// The half a string check cannot do.
 ///
 /// A host that is not a literal was admitted on its spelling alone, so
 /// `http://anything.example/` answering `169.254.169.254` read as an ordinary
-/// public URL and the fetch reached the metadata service. The guard now
-/// resolves the name and refuses it on what it answers with.
+/// public URL and the fetch reached the metadata service. The guard resolves
+/// the name and refuses it on what it answers with.
 ///
-/// This case needs working DNS, which the rest of the guard's cases
-/// deliberately do not: `localtest.me` is a long-standing public name that
-/// answers `127.0.0.1`, and using a real one is the only way to exercise the
-/// resolving arm from outside the runtime crate, whose own
-/// resolver-injected tests are not reachable from here. A runner without DNS
-/// fails this loudly rather than passing it quietly, which is the right way
-/// round.
+/// Through an injected resolver rather than real DNS: a case that reaches the
+/// network to prove this fails on a runner without it, and that failure says
+/// nothing about the product — the wrong way round for a check in the default
+/// feature set.
 #[cfg(feature = "documents")]
 #[tokio::test]
 async fn a_host_that_resolves_into_this_network_is_refused_on_what_it_resolves_to() {
-    let refusal = super::guard_link("http://localtest.me/admin")
-        .await
-        .expect_err("a name resolving to loopback must be refused");
-    // Which loopback it answers with is the resolver's business — v4 on some
-    // hosts, `::1` on others. What must hold is that the refusal names the
-    // address it resolved to, so the operator can see why their link was
-    // turned down rather than guessing.
-    assert!(
-        refusal.contains("resolves to") && refusal.contains("own network"),
-        "the refusal must name the address it resolved to: {refusal}"
-    );
-}
-
-/// The same address written the long way is the same address.
-///
-/// `::ffff:127.0.0.1` and `::127.0.0.1` both carry 127.0.0.1 — the first the
-/// mapped form, the second the deprecated IPv4-compatible one. Neither answers
-/// `is_loopback`, and `to_ipv4_mapped` answers `None` for the second, so a
-/// guard reading only the mapped form admits it.
-#[cfg(feature = "documents")]
-#[tokio::test]
-async fn an_internal_address_written_as_ipv6_is_still_refused() {
-    for refused in [
-        "http://[::ffff:127.0.0.1]/admin",
-        "http://[::127.0.0.1]/admin",
-        "http://[::ffff:169.254.169.254]/latest/meta-data/",
-        "http://[::ffff:10.0.0.5]/",
-        "http://[fd00::1]/",
-        "http://[fe80::1]/",
+    for (answer, label) in [
+        ("127.0.0.1", "loopback"),
+        ("169.254.169.254", "the metadata service"),
+        ("10.0.0.5", "an RFC1918 address"),
+        ("::1", "v6 loopback"),
     ] {
+        let address: std::net::IpAddr = answer.parse().expect("a literal");
+        let refusal =
+            super::guard_link_resolving_with("http://anything.example/x", |_, _| async move {
+                Ok(vec![address])
+            })
+            .await
+            .unwrap_err();
         assert!(
-            super::guard_link(refused).await.is_err(),
-            "{refused} must be refused"
+            refusal.contains("resolves to") && refusal.contains("own network"),
+            "a name answering {label} must be refused, naming the address: {refusal}"
         );
     }
-    // A public v6 literal still passes, so the check is not refusing all of v6.
-    assert!(super::guard_link("https://[2606:4700::1]/").await.is_ok());
+}
+
+/// One internal answer among several is still internal.
+///
+/// A resolver may hand back a list. Refusing only when *every* address is
+/// internal would admit a name that answers one public address and one
+/// loopback, which is the shape a rebinding setup produces.
+#[cfg(feature = "documents")]
+#[tokio::test]
+async fn a_host_answering_one_internal_address_among_public_ones_is_refused() {
+    let refusal = super::guard_link_resolving_with("http://anything.example/x", |_, _| async {
+        Ok(vec![
+            "93.184.216.34".parse().unwrap(),
+            "127.0.0.1".parse().unwrap(),
+        ])
+    })
+    .await
+    .unwrap_err();
+    assert!(refusal.contains("127.0.0.1"), "{refusal}");
+}
+
+/// A wholly public answer is admitted, so the guard is not refusing every name.
+#[cfg(feature = "documents")]
+#[tokio::test]
+async fn a_host_answering_only_public_addresses_is_admitted() {
+    super::guard_link_resolving_with("http://anything.example/x", |_, _| async {
+        Ok(vec!["93.184.216.34".parse().unwrap()])
+    })
+    .await
+    .expect("a public answer is fetchable");
 }
 
 /// A name that will not resolve does not hold the request open.
@@ -337,21 +345,30 @@ async fn an_internal_address_written_as_ipv6_is_still_refused() {
 /// at a time, and a list of names whose resolver blackholes queries would
 /// otherwise cost their sum.
 #[cfg(feature = "documents")]
+#[tokio::test(start_paused = true)]
+async fn a_resolver_that_never_answers_is_bounded_rather_than_waited_on() {
+    let refusal = super::guard_link_resolving_with("http://anything.example/x", |_, _| async {
+        std::future::pending::<()>().await;
+        unreachable!("the lookup timeout must fire long before this wakes")
+    })
+    .await
+    .unwrap_err();
+    assert!(
+        refusal.contains("too long to resolve"),
+        "the refusal must say the lookup was cut short: {refusal}"
+    );
+}
+
+/// A resolver that answers nothing is refused rather than admitted.
+#[cfg(feature = "documents")]
 #[tokio::test]
-async fn a_host_that_will_not_resolve_is_refused_rather_than_waited_on() {
-    let started = std::time::Instant::now();
-    let refusal = super::guard_link("http://this-name-does-not-exist.invalid/x")
-        .await
-        .expect_err("an unresolvable host must be refused");
-    assert!(
-        refusal.contains("could not be resolved") || refusal.contains("too long to resolve"),
-        "the refusal must say the name did not resolve: {refusal}"
-    );
-    assert!(
-        started.elapsed() < std::time::Duration::from_secs(10),
-        "the lookup must be bounded, took {:?}",
-        started.elapsed()
-    );
+async fn a_host_that_resolves_to_no_addresses_is_refused() {
+    let refusal = super::guard_link_resolving_with("http://anything.example/x", |_, _| async {
+        Ok(Vec::new())
+    })
+    .await
+    .unwrap_err();
+    assert!(refusal.contains("no addresses"), "{refusal}");
 }
 
 /// Dropping the wrong folder is a mistake an operator makes once; without a

--- a/src/server/ops/memory_ingest/test.rs
+++ b/src/server/ops/memory_ingest/test.rs
@@ -304,6 +304,56 @@ async fn a_host_that_resolves_into_this_network_is_refused_on_what_it_resolves_t
     );
 }
 
+/// The same address written the long way is the same address.
+///
+/// `::ffff:127.0.0.1` and `::127.0.0.1` both carry 127.0.0.1 — the first the
+/// mapped form, the second the deprecated IPv4-compatible one. Neither answers
+/// `is_loopback`, and `to_ipv4_mapped` answers `None` for the second, so a
+/// guard reading only the mapped form admits it.
+#[cfg(feature = "documents")]
+#[tokio::test]
+async fn an_internal_address_written_as_ipv6_is_still_refused() {
+    for refused in [
+        "http://[::ffff:127.0.0.1]/admin",
+        "http://[::127.0.0.1]/admin",
+        "http://[::ffff:169.254.169.254]/latest/meta-data/",
+        "http://[::ffff:10.0.0.5]/",
+        "http://[fd00::1]/",
+        "http://[fe80::1]/",
+    ] {
+        assert!(
+            super::guard_link(refused).await.is_err(),
+            "{refused} must be refused"
+        );
+    }
+    // A public v6 literal still passes, so the check is not refusing all of v6.
+    assert!(super::guard_link("https://[2606:4700::1]/").await.is_ok());
+}
+
+/// A name that will not resolve does not hold the request open.
+///
+/// `LINK_TIMEOUT` bounds the fetch, which starts only once this guard has
+/// answered, so the lookup needs its own ceiling: the route walks its URLs one
+/// at a time, and a list of names whose resolver blackholes queries would
+/// otherwise cost their sum.
+#[cfg(feature = "documents")]
+#[tokio::test]
+async fn a_host_that_will_not_resolve_is_refused_rather_than_waited_on() {
+    let started = std::time::Instant::now();
+    let refusal = super::guard_link("http://this-name-does-not-exist.invalid/x")
+        .await
+        .expect_err("an unresolvable host must be refused");
+    assert!(
+        refusal.contains("could not be resolved") || refusal.contains("too long to resolve"),
+        "the refusal must say the name did not resolve: {refusal}"
+    );
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(10),
+        "the lookup must be bounded, took {:?}",
+        started.elapsed()
+    );
+}
+
 /// Dropping the wrong folder is a mistake an operator makes once; without a
 /// forget, the only remedy would be the company's whole memory.
 #[tokio::test]

--- a/src/server/ops/memory_ingest/test.rs
+++ b/src/server/ops/memory_ingest/test.rs
@@ -240,24 +240,68 @@ async fn a_drop_with_no_files_is_refused() {
 
 /// The server-side request forgery guard: this route makes the *host* fetch a
 /// URL, so the deployment's own network is off limits.
+///
+/// Every case here is decided without a lookup — a literal address, or a
+/// scheme refused before any host is considered — so the test does not depend
+/// on the runner having DNS. The arm that does resolve is the one this now
+/// delegates: a hostname answering with a private address is refused by
+/// `dns_check_with_empty_allowlist_blocks_private_resolved_ip` and
+/// `dns_check_blocks_localhost_resolution` in the runtime's own
+/// `url_guard_tests.rs`, both against the empty allow-list this passes.
 #[cfg(feature = "documents")]
-#[test]
-fn link_ingestion_refuses_this_deployments_own_network() {
+#[tokio::test]
+async fn link_ingestion_refuses_this_deployments_own_network() {
     for refused in [
         "http://localhost:8080/admin",
         "http://127.0.0.1/",
         "http://169.254.169.254/latest/meta-data/",
         "http://10.0.0.5/",
         "http://192.168.1.1/",
+        "http://[::1]/",
         "file:///etc/passwd",
         "ftp://example.com/x",
     ] {
         assert!(
-            super::guard_link(refused).is_err(),
+            super::guard_link(refused).await.is_err(),
             "{refused} must be refused"
         );
     }
-    assert!(super::guard_link("https://example.com/pricing").is_ok());
+    // A public literal, so the answer is the guard's and not a resolver's.
+    assert!(
+        super::guard_link("https://93.184.216.34/pricing")
+            .await
+            .is_ok()
+    );
+}
+
+/// The half a string check cannot do, and the reason this delegates.
+///
+/// A host that is not a literal was admitted on its spelling alone, so
+/// `http://anything.example/` answering `169.254.169.254` read as an ordinary
+/// public URL and the fetch reached the metadata service. The guard now
+/// resolves the name and refuses it on what it answers with.
+///
+/// This case needs working DNS, which the rest of the guard's cases
+/// deliberately do not: `localtest.me` is a long-standing public name that
+/// answers `127.0.0.1`, and using a real one is the only way to exercise the
+/// resolving arm from outside the runtime crate, whose own
+/// resolver-injected tests are not reachable from here. A runner without DNS
+/// fails this loudly rather than passing it quietly, which is the right way
+/// round.
+#[cfg(feature = "documents")]
+#[tokio::test]
+async fn a_host_that_resolves_into_this_network_is_refused_on_what_it_resolves_to() {
+    let refusal = super::guard_link("http://localtest.me/admin")
+        .await
+        .expect_err("a name resolving to loopback must be refused");
+    // Which loopback it answers with is the resolver's business — v4 on some
+    // hosts, `::1` on others. What must hold is that the refusal names the
+    // address it resolved to, so the operator can see why their link was
+    // turned down rather than guessing.
+    assert!(
+        refusal.contains("resolves to") && refusal.contains("own network"),
+        "the refusal must name the address it resolved to: {refusal}"
+    );
 }
 
 /// Dropping the wrong folder is a mistake an operator makes once; without a


### PR DESCRIPTION
## Summary

The link-ingest route makes the **host** fetch a URL an operator supplies, so the deployment's own network has to be off limits. The guard judged that on the host as a string: a literal private address was refused, anything else was admitted.

A hostname was therefore admitted on its spelling alone. `http://anything.example/` answering `169.254.169.254` reads as an ordinary public URL, and the fetch that follows reaches the metadata service. Refusing only the literal form stops the accident and none of the intent — and the function's own doc comment said as much, arguing the resolving check was unavoidable TOCTOU and leaving it out.

That argument covers a smaller gap than it appeared to. A hostname is now resolved, and refused when **any** address it answers with belongs to this deployment. The internal set also gains the IPv4-mapped IPv6 forms and the carrier-grade NAT range, since `::ffff:127.0.0.1` is a loopback address written the long way.

The residual TOCTOU is real and unchanged: a name that resolves publicly here can answer differently for the client a moment later. Narrowing that means having the connector pin the address this validated, which is a change to the client rather than to this check. Worth doing, and separate from this.

**Red proof:** dropping the resolution step admits `http://localtest.me/admin` — a long-standing public name that answers loopback — which is exactly the shape the old guard let through.

### On the duplication, which is deliberate

The agent runtime already carries this rule as `validate_url_with_dns_check`, and it was exported so a host outside that crate could reuse it. It is not reachable from every build this route ships in: `documents` is a default feature and `openhuman` is not, so the default build compiles this route without that crate. Pulling the whole runtime into the default build to borrow forty lines of URL guard costs more than it saves.

So these are two copies on purpose rather than by oversight, and the comment in the source says so. The lasting fix is to lift the rule somewhere both can depend on.

## API Or Behavior Changes

A link whose host resolves into the deployment's own network is refused with a message naming the address it resolved to, where it was previously fetched. A host that cannot be resolved is refused rather than attempted. Literal addresses and non-http schemes behave as before.

`guard_link` is now `async`, since it resolves.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — the default lane and `--no-deps --features openhuman`, both clean
- [ ] `cargo build --all-targets` — N/A: the clippy and test lanes build the same targets and are clean
- [x] `cargo test` — `server::ops::memory_ingest` passes under the default features and under `--features openhuman`, 8 cases each

Note one case resolves a real name. Every other case in that test is decided without a lookup — a literal address, or a scheme refused before any host is considered — but the arm this PR adds cannot be exercised without resolving something, and the runtime's resolver-injected tests are not reachable from here. A runner without DNS fails it loudly rather than passing it quietly, which is the right way round.

## Documentation

No separate docs — the rule, its residual TOCTOU, and the reason for the duplication are stated in the guard's own doc comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Link ingestion now validates resolved host addresses before fetching, blocking private, local, loopback, link-local, and other internal network destinations.
  * URL handling now covers IPv4 and IPv6 literals, explicit or default ports, unresolved hostnames, and hosts without address records.
  * Domain lookups are bounded by a timeout, preventing ingestion from hanging when a hostname cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->