### PR TITLE
feat(hive): record every crossing, and make a question to a person a conversation with them

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -305,6 +305,8 @@ export interface ReferralConversationDto {
   otherId: string;
   otherDeskId: string;
   otherDeskName: string;
+  /** Whether a person was asked rather than a desk — `@name` vs `#desk`. */
+  direct: boolean;
   lines: ReferralLineDto[];
 }
 
@@ -315,6 +317,8 @@ export interface ReferredFromDto {
   askerLabel: string;
   /** The asking message, so the chip can link straight to it. */
   sequence: number;
+  /** Whether a person was asked rather than a desk. */
+  direct?: boolean;
   /**
    * Which leg of the referral this message is: the outbound ask, or the answer
    * arriving home.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -282,6 +282,32 @@ export interface CreateDeskInput {
  * reason `SessionAuthor` captures its own: a desk renamed later must not
  * rewrite what the transcript said at the time.
  */
+/** One line of a crossing between a desk and somebody who does not work on it. */
+export interface ReferralLineDto {
+  authorId: string;
+  /** Empty for this desk's own agent, whom the console already names. */
+  authorLabel: string;
+  text: string;
+  /** True for the question going out, false for the answer coming back. */
+  outbound: boolean;
+}
+
+/**
+ * A crossing folded onto the report that brought it home.
+ *
+ * The relayed rows are dropped from the transcript — an agent who does not work
+ * on this desk did not speak on it — so without this the operator could see that
+ * a question crossed and never what was said either way. `lines.length` is the
+ * count the collapsed label shows.
+ */
+export interface ReferralConversationDto {
+  askerId: string;
+  otherId: string;
+  otherDeskId: string;
+  otherDeskName: string;
+  lines: ReferralLineDto[];
+}
+
 export interface ReferredFromDto {
   deskId: string;
   deskName: string;
@@ -311,6 +337,7 @@ export interface ChatHistoryMessageDto {
   author: string;
   text: string;
   referredFrom?: ReferredFromDto;
+  referralConversation?: ReferralConversationDto;
   atMillis: number;
   mine: boolean;
   /**

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -224,6 +224,8 @@ export interface ChatMessage {
    * only link back to the conversation that asked.
    */
   referredFrom?: import("@/api/types").ReferredFromDto;
+  /** The crossing this report brought home, rendered as one collapsed line. */
+  referralConversation?: import("@/api/types").ReferralConversationDto;
   /**
    * Who reacted to this line with what — one row per person per emoji, not a
    * count (issue #364).
@@ -581,6 +583,7 @@ export function fromHistory(entries: ChatHistoryMessageDto[]): ChatMessage[] {
       // Straight through, like `byPerson`: only the host knows another desk
       // caused this line, and nothing here may infer it.
       referredFrom: entry.referredFrom,
+      referralConversation: entry.referralConversation,
       // Reactions come through whoever the host said reacted; nothing is
       // inferred here, `mine` included.
       reactions: entry.reactions?.length ? entry.reactions : undefined,

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -23,7 +23,12 @@ import {
   type TimelineEntry,
 } from "./model";
 import { EchoPlaceholder, echoMarkerFor } from "./EchoPlaceholder";
-import { CardChip, ReferralChip, StepTimeline } from "./StepTimeline";
+import {
+  CardChip,
+  ReferralChip,
+  ReferralConversation,
+  StepTimeline,
+} from "./StepTimeline";
 import { WorkingIndicator } from "./WorkingIndicator";
 
 interface Props {
@@ -389,6 +394,12 @@ export function MessageRow({
             // an ask. Falling back to "asked" matches a host too old to say.
             direction={message.referredFrom.direction ?? "asked"}
           />
+        )}
+        {/* And what actually crossed. The chip says a referral happened; this
+            says what was asked and what came back, collapsed so the desk still
+            reads as its own conversation. */}
+        {message.referralConversation && (
+          <ReferralConversation crossing={message.referralConversation} />
         )}
         {message.taskId && (
           <div className="flex flex-wrap items-center gap-2">

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -388,6 +388,8 @@ export function MessageRow({
           <ReferralChip
             deskId={message.referredFrom.deskId}
             deskName={message.referredFrom.deskName}
+            askerId={message.referredFrom.askerId}
+            direct={message.referredFrom.direct}
             sequence={message.referredFrom.sequence}
             // The host's word, never a guess off `from`: both legs of a
             // referral are `company` lines, so that test called every answer

--- a/frontend/src/views/chat/StepTimeline.tsx
+++ b/frontend/src/views/chat/StepTimeline.tsx
@@ -26,6 +26,8 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 
+import { TeammateAvatar } from "@/components/teammate-avatar";
+
 import type { ReferralConversationDto } from "@/api/types";
 
 import {
@@ -133,17 +135,39 @@ export function ReferralConversation({ crossing }: { crossing: ReferralConversat
         </span>
       </button>
       {open && (
-        <ol className="mt-0.5 flex flex-col gap-1.5 rounded-lg border bg-card/60 px-2.5 py-1.5">
-          {crossing.lines.map((line, i) => (
-            <li key={i} className="flex flex-col gap-0.5 text-2xs leading-relaxed">
-              <span className="font-medium text-muted-foreground">
-                {line.outbound
-                  ? `@${crossing.askerId} asked`
-                  : `@${line.authorLabel || line.authorId} on ${crossing.otherDeskName} answered`}
-              </span>
-              <span className="whitespace-pre-wrap">{line.text}</span>
-            </li>
-          ))}
+        // Rendered as a conversation, because that is what it is. The same
+        // gutter-avatar-then-author-then-body shape a message uses in the
+        // transcript above, one size down: an operator reading this is reading
+        // a chat between two desks, and a label-over-paragraph list made them
+        // translate it back into one.
+        <ol className="mt-0.5 flex flex-col gap-2 rounded-lg border bg-card/60 px-2.5 py-2">
+          {crossing.lines.map((line, i) => {
+            const who = line.outbound
+              ? crossing.askerId
+              : line.authorLabel || line.authorId;
+            // The desk each side is speaking from — the asker's is this one, so
+            // it goes unsaid; the answer comes from somewhere the reader may not
+            // have open.
+            const where = line.outbound ? null : crossing.otherDeskName;
+            return (
+              <li key={i} className="flex gap-2">
+                <TeammateAvatar name={who} className="mt-0.5 size-5 shrink-0" />
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  <span className="text-2xs leading-none font-semibold">
+                    {who}
+                    {where && (
+                      <span className="ml-1 font-normal text-muted-foreground">
+                        on {where}
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-2xs leading-relaxed whitespace-pre-wrap text-muted-foreground">
+                    {line.text}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
         </ol>
       )}
     </div>

--- a/frontend/src/views/chat/StepTimeline.tsx
+++ b/frontend/src/views/chat/StepTimeline.tsx
@@ -130,8 +130,12 @@ export function ReferralConversation({ crossing }: { crossing: ReferralConversat
       >
         {open ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
         <span>
-          asked @{crossing.otherId} on {crossing.otherDeskName} · {count} message
-          {count === 1 ? "" : "s"}
+          {/* Who was asked, in the form they were asked in: `@name` went to a
+              person, `#desk` was put to a room. Naming the answerer's desk
+              alongside their name read as though the desk had been asked, which
+              for a `@name` crossing is the one thing that did not happen. */}
+          asked {crossing.direct ? `@${crossing.otherId}` : `#${crossing.otherDeskId}`} ·{" "}
+          {count} message{count === 1 ? "" : "s"}
         </span>
       </button>
       {open && (
@@ -148,19 +152,15 @@ export function ReferralConversation({ crossing }: { crossing: ReferralConversat
             // The desk each side is speaking from — the asker's is this one, so
             // it goes unsaid; the answer comes from somewhere the reader may not
             // have open.
-            const where = line.outbound ? null : crossing.otherDeskName;
             return (
               <li key={i} className="flex gap-2">
                 <TeammateAvatar name={who} className="mt-0.5 size-5 shrink-0" />
                 <div className="flex min-w-0 flex-col gap-0.5">
-                  <span className="text-2xs leading-none font-semibold">
-                    {who}
-                    {where && (
-                      <span className="ml-1 font-normal text-muted-foreground">
-                        on {where}
-                      </span>
-                    )}
-                  </span>
+                  {/* The name alone. The header already says whether this was
+                      a person or a desk, and repeating the answerer's desk on
+                      their line was what made a `@name` crossing read as though
+                      the desk had been asked. */}
+                  <span className="text-2xs leading-none font-semibold">{who}</span>
                   <span className="text-2xs leading-relaxed whitespace-pre-wrap text-muted-foreground">
                     {line.text}
                   </span>
@@ -299,15 +299,23 @@ function formatElapsed(ms: number | undefined, status: TurnStep["status"]): stri
 export function ReferralChip({
   deskId,
   deskName,
+  askerId,
   sequence,
   direction,
+  direct = false,
 }: {
   deskId: string;
   deskName: string;
+  askerId: string;
   sequence: number;
   direction: "asked" | "answered";
+  direct?: boolean;
 }) {
-  const label = direction === "asked" ? `Asked by ${deskName}` : `Answered by ${deskName}`;
+  // Whoever was actually addressed. A crossing put to a PERSON never reached
+  // their desk — that desk holds none of the exchange and its other members had
+  // no part in it — so naming the desk here credited a room that was never asked.
+  const who = direct ? `@${askerId}` : deskName;
+  const label = direction === "asked" ? `Asked by ${who}` : `Answered by ${who}`;
   return (
     <span className="mt-1.5 flex w-fit items-center rounded-full bg-accent text-accent-foreground">
       <a

--- a/frontend/src/views/chat/StepTimeline.tsx
+++ b/frontend/src/views/chat/StepTimeline.tsx
@@ -316,16 +316,35 @@ export function ReferralChip({
   // no part in it — so naming the desk here credited a room that was never asked.
   const who = direct ? `@${askerId}` : deskName;
   const label = direction === "asked" ? `Asked by ${who}` : `Answered by ${who}`;
+  const body = (
+    <>
+      <CornerUpLeft className="size-3 shrink-0" />
+      {label}
+    </>
+  );
   return (
     <span className="mt-1.5 flex w-fit items-center rounded-full bg-accent text-accent-foreground">
-      <a
-        href={`#/chat?desk=${encodeURIComponent(deskId)}&at=${sequence}`}
-        className="flex items-center gap-1 px-2 py-0.5 text-2xs font-medium transition-opacity hover:opacity-80"
-        title={`Open the conversation that ${direction === "asked" ? "asked" : "answered"}`}
-      >
-        <CornerUpLeft className="size-3 shrink-0" />
-        {label}
-      </a>
+      {/* A DESK crossing ran on that desk, so its transcript is where the
+          question at `sequence` is and the link reaches it.
+
+          A DIRECT one did not: both sides are held in the pair's own thread and
+          the target's desk holds none of it, so this link would open an
+          unrelated conversation and land on a sequence that is not there.
+          Nothing to link to until a pair thread is a surface an operator can
+          open — and the exchange itself is already one click away, on the
+          message this chip sits under. So it reads as a label rather than
+          offering a way somewhere wrong. */}
+      {direct ? (
+        <span className="flex items-center gap-1 px-2 py-0.5 text-2xs font-medium">{body}</span>
+      ) : (
+        <a
+          href={`#/chat?desk=${encodeURIComponent(deskId)}&at=${sequence}`}
+          className="flex items-center gap-1 px-2 py-0.5 text-2xs font-medium transition-opacity hover:opacity-80"
+          title={`Open the conversation that ${direction === "asked" ? "asked" : "answered"}`}
+        >
+          {body}
+        </a>
+      )}
     </span>
   );
 }

--- a/frontend/src/views/chat/StepTimeline.tsx
+++ b/frontend/src/views/chat/StepTimeline.tsx
@@ -26,6 +26,8 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 
+import type { ReferralConversationDto } from "@/api/types";
+
 import {
   AWAITING_APPROVAL_LABEL,
   STEP_FAILURE_LABEL,
@@ -92,6 +94,55 @@ export function StepTimeline({
         <ol className="mt-0.5 flex flex-col gap-1 rounded-lg border bg-card/60 px-2.5 py-1.5">
           {steps.map((step, i) => (
             <StepRow key={i} step={step} />
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A crossing with somebody outside this desk, as one collapsed line.
+ *
+ * Same idiom as {@link StepTimeline} and for the same reason: the exchange is
+ * detail behind a report, not part of the desk's own conversation. The relayed
+ * rows are dropped host-side — an agent who does not work here did not speak
+ * here — so this is the only place an operator can read what was actually asked
+ * and answered rather than the asker's paraphrase of it.
+ *
+ * Closed by default. The count is the whole point of the collapsed state: it
+ * says how much was said without saying it.
+ */
+export function ReferralConversation({ crossing }: { crossing: ReferralConversationDto }) {
+  const [open, setOpen] = useState(false);
+  const count = crossing.lines.length;
+  if (count === 0) return null;
+
+  return (
+    <div className="mt-1 w-full max-w-[85%] sm:max-w-[75%]">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-accent/60"
+      >
+        {open ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        <span>
+          asked @{crossing.otherId} on {crossing.otherDeskName} · {count} message
+          {count === 1 ? "" : "s"}
+        </span>
+      </button>
+      {open && (
+        <ol className="mt-0.5 flex flex-col gap-1.5 rounded-lg border bg-card/60 px-2.5 py-1.5">
+          {crossing.lines.map((line, i) => (
+            <li key={i} className="flex flex-col gap-0.5 text-2xs leading-relaxed">
+              <span className="font-medium text-muted-foreground">
+                {line.outbound
+                  ? `@${crossing.askerId} asked`
+                  : `@${line.authorLabel || line.authorId} on ${crossing.otherDeskName} answered`}
+              </span>
+              <span className="whitespace-pre-wrap">{line.text}</span>
+            </li>
           ))}
         </ol>
       )}

--- a/frontend/src/views/chat/ThreadPanel.tsx
+++ b/frontend/src/views/chat/ThreadPanel.tsx
@@ -518,6 +518,8 @@ function Line({
           <ReferralChip
             deskId={message.referredFrom.deskId}
             deskName={message.referredFrom.deskName}
+            askerId={message.referredFrom.askerId}
+            direct={message.referredFrom.direct}
             sequence={message.referredFrom.sequence}
             direction={message.referredFrom.direction ?? "asked"}
           />

--- a/frontend/src/views/chat/ThreadPanel.tsx
+++ b/frontend/src/views/chat/ThreadPanel.tsx
@@ -12,7 +12,7 @@ import { BudgetPauseNoticeCard } from "./BudgetPauseNoticeCard";
 import { EchoPlaceholder, echoMarkerFor } from "./EchoPlaceholder";
 import { FailedSendNotice } from "./MessageRow";
 import { MessageAttachments } from "./MessageAttachments";
-import { StepTimeline } from "./StepTimeline";
+import { ReferralChip, ReferralConversation, StepTimeline } from "./StepTimeline";
 import { MessageComposer } from "./MessageComposer";
 import { TypingLine } from "./TypingLine";
 import { WorkingIndicator } from "./WorkingIndicator";
@@ -509,6 +509,22 @@ function Line({
             #2069). */}
         {message.steps && message.steps.length > 0 && <StepTimeline steps={message.steps} />}
         {!!liveSteps?.length && <StepTimeline steps={[...liveSteps]} defaultOpen />}
+        {/* And the crossings, for the same reason the steps are here: a room's
+            turns are threaded, so this panel is the only surface a deliberating
+            desk's line has. Rendered only here would be a channel-only feature
+            that a room — the one place crossings actually come from — never
+            shows. */}
+        {message.referredFrom && (
+          <ReferralChip
+            deskId={message.referredFrom.deskId}
+            deskName={message.referredFrom.deskName}
+            sequence={message.referredFrom.sequence}
+            direction={message.referredFrom.direction ?? "asked"}
+          />
+        )}
+        {message.referralConversation && (
+          <ReferralConversation crossing={message.referralConversation} />
+        )}
       </div>
     </div>
   );

--- a/frontend/test/unit/referral-crossing.test.ts
+++ b/frontend/test/unit/referral-crossing.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ReferralConversationDto } from "@/api/types";
+import { ReferralChip, ReferralConversation } from "@/views/chat/StepTimeline";
+
+/**
+ * **What a crossing looks like to the operator reading it.**
+ *
+ * The rows a crossing is made of are dropped from the asking desk — an agent
+ * who does not work there did not speak there — so this component and the chip
+ * beside it are the only account of what was actually asked and answered. The
+ * asker's own report is a paraphrase, and paraphrases drift.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function crossing(over: Partial<ReferralConversationDto> = {}): ReferralConversationDto {
+  return {
+    askerId: "exchanges",
+    otherId: "triage",
+    otherDeskId: "front_desk",
+    otherDeskName: "Front Desk",
+    direct: true,
+    lines: [
+      { authorId: "exchanges", authorLabel: "", text: "what is on order #W2378156?", outbound: true },
+      { authorId: "triage", authorLabel: "triage", text: "five items, keyboard included.", outbound: false },
+    ],
+    ...over,
+  };
+}
+
+describe("a crossing on the message that brought it home", () => {
+  it("counts the exchange and names who was asked, without opening it", () => {
+    act(() => {
+      root.render(createElement(ReferralConversation, { crossing: crossing() }));
+    });
+    // Closed by default: the desk still reads as its own conversation, and how
+    // much was said is visible without saying it.
+    expect(container.textContent).toContain("asked @triage · 2 messages");
+    expect(container.textContent).not.toContain("what is on order");
+  });
+
+  it("shows both sides, in order, once opened", () => {
+    act(() => {
+      root.render(createElement(ReferralConversation, { crossing: crossing() }));
+    });
+    act(() => {
+      container.querySelector("button")?.click();
+    });
+    const text = container.textContent ?? "";
+    expect(text).toContain("what is on order #W2378156?");
+    expect(text).toContain("five items, keyboard included.");
+    expect(text.indexOf("what is on order")).toBeLessThan(text.indexOf("five items"));
+  });
+
+  it("names a DESK with a #, because a room was asked rather than a person", () => {
+    act(() => {
+      root.render(
+        createElement(ReferralConversation, {
+          crossing: crossing({ direct: false, otherDeskId: "order_ops" }),
+        }),
+      );
+    });
+    expect(container.textContent).toContain("asked #order_ops · 2 messages");
+    expect(container.textContent).not.toContain("@triage");
+  });
+
+  it("renders nothing at all when the crossing carried no lines", () => {
+    act(() => {
+      root.render(createElement(ReferralConversation, { crossing: crossing({ lines: [] }) }));
+    });
+    expect(container.textContent).toBe("");
+  });
+});
+
+describe("the chip beside it", () => {
+  const base = {
+    deskId: "front_desk",
+    deskName: "Front Desk",
+    askerId: "triage",
+    sequence: 42,
+    direction: "answered" as const,
+  };
+
+  it("names the person on a direct crossing, and offers no link", () => {
+    act(() => {
+      root.render(createElement(ReferralChip, { ...base, direct: true }));
+    });
+    expect(container.textContent).toContain("Answered by @triage");
+    // Their desk holds none of the exchange, so a link there would open an
+    // unrelated conversation at a sequence that is not in it.
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  it("names the desk on a desk crossing, and links to it", () => {
+    act(() => {
+      root.render(createElement(ReferralChip, { ...base, direct: false }));
+    });
+    expect(container.textContent).toContain("Answered by Front Desk");
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "#/chat?desk=front_desk&at=42",
+    );
+  });
+});

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1311,6 +1311,12 @@ impl CompanyRuntime {
         // Where an answer goes home, on a crossing FORWARD. `None` on a return
         // — an answer that has arrived does not need carrying further.
         origin: Option<tinyhivemind_core::referral::ReferralOrigin>,
+        // The forward this child is answering, by the journal sequence of its
+        // marker — carried so the return can name it exactly. Two crossings
+        // between the same desks to the same agent write geometrically
+        // identical markers, so a return that searched for "the forward that
+        // looks like mine" would pair one question with the other's answer.
+        answers: Option<u64>,
         // How deep in the chain this turn sits. Its own replies are offered to
         // the referral pass at this depth, so a follow-up is one deeper than
         // the answer it follows and `max_hops` finally counts something.
@@ -1368,6 +1374,7 @@ impl CompanyRuntime {
                         &desk_for_replies,
                         &report,
                         origin,
+                        answers,
                         hop,
                     )
                     .await;
@@ -9857,7 +9864,8 @@ mod tests {
         let (rt, _home) = runtime_that_may_refer().await;
         let rt = Arc::new(rt);
         let gate = Arc::new(tokio::sync::Mutex::new(()));
-        let queue = crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate, 1, 4);
+        let queue =
+            crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate, 1, 4, None);
 
         let forward = |trigger: u64| tinyhivemind::referral::Referral {
             key: tinyhivemind::dispatch::DispatchKey {
@@ -9911,7 +9919,8 @@ mod tests {
         let gate = Arc::new(tokio::sync::Mutex::new(()));
         // A cap high enough not to be what this test measures: the second
         // enqueue must be refused as `Already`, by the marker, not by width.
-        let queue = crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate, 8, 4);
+        let queue =
+            crate::runtime::hivemind::JournalReferralQueue::new(rt.clone(), gate, 8, 4, None);
 
         let referral = tinyhivemind::referral::Referral {
             key: tinyhivemind::dispatch::DispatchKey {

--- a/src/hivemind/prompt.rs
+++ b/src/hivemind/prompt.rs
@@ -74,6 +74,21 @@ fn move_line(kind: &str) -> Option<&'static str> {
 }
 
 /// The rules those moves are read under.
+/// **Write about yourself in the first person.**
+///
+/// The transcript attributes every row, the reader's own included — `[20]
+/// refunds (you):` — so a member can see which lines are its own. Seeing them
+/// is not the same as writing that way: rows are labelled by id, and a member
+/// copies the convention it was shown, which produced commits like "both
+/// refunds and exchanges agreed" written BY refunds — a member describing
+/// itself as somebody else in the one line whose job is to say who carried the
+/// decision.
+///
+/// Naming a COLLEAGUE by id stays right: that is how a citation is read back
+/// and how the fold counts them.
+const FIRST_PERSON_RULE: &str = "Lines marked `(you)` in the transcript are your own. Write about \
+yourself in the first person — never by your own id — and name colleagues by their id as usual.";
+
 const DELIBERATE_RULES: &str = "\
 The # on a topic and the ^ on a citation are part of the grammar: `!propose \
 #canary ...` names an option, `!propose canary ...` names nothing and is \
@@ -197,7 +212,7 @@ fn commit_protocol(topic: &str) -> String {
          topic and the ^ on the citation; without them the line records nothing. Angle brackets \
          are not part of the line — write the sentence itself. This is bookkeeping, not a fresh \
          judgement: record the topic the room actually settled on rather than the one you would \
-         have preferred, and do not re-derive the answer. Write nothing before or after the \
+         have preferred, and do not re-derive the answer. {FIRST_PERSON_RULE} Write nothing before or after the \
          single marker line."
     )
 }
@@ -412,6 +427,8 @@ impl<'a> EpisodePrompt<'a> {
         );
         let head = "Reply with ONE line only, beginning with exactly one of these markers:";
         let mut tail = DELIBERATE_RULES.to_owned();
+        tail.push('\n');
+        tail.push_str(FIRST_PERSON_RULE);
         if self.quorum.require_evidential {
             tail.push('\n');
             tail.push_str(EVIDENTIAL_RULE);

--- a/src/hivemind/referral.rs
+++ b/src/hivemind/referral.rs
@@ -54,7 +54,7 @@ use tinyhivemind_hive::{
     EnqueueOutcome, EnqueueRefusal,
     desk::{Desk, DeskSet, ResponderMode},
     dispatch::{DispatchConversation, DispatchKey},
-    mention::{Mention, MentionAuthor, resolve as resolve_mentions},
+    mention::{Mention, MentionAuthor, MentionTarget, resolve as resolve_mentions},
     referral::{
         NoReferralReason, Referral, ReferralFuture, ReferralInput, ReferralKind, ReferralOrigin,
         ReferralOutcome, ReferralPolicy, ReferralQueue, ReferralReach, dispatch_referral,
@@ -327,6 +327,26 @@ marker: this is not a deliberation turn, it is an answer to a colleague."
     )
 }
 
+/// The conversation two teammates hold with each other, by their ids.
+///
+/// **A crossing is a conversation between two people, not a message posted in
+/// somebody's office.** The library places a referred turn on the target's home
+/// desk, which is what "runs on their own desk" means there — but that puts a
+/// question about ANOTHER desk's case into a channel whose transcript is
+/// supposed to be the record of what that desk did, in front of colleagues who
+/// were never asked. The pair get their own conversation instead: the question
+/// goes there, the answer is written there, and neither desk carries somebody
+/// else's exchange.
+///
+/// Sorted, so `a` asking `b` and `b` asking `a` are the same thread rather than
+/// two half-conversations. Prefixed `dm:` so it can never collide with a desk
+/// id — a manifest desk id is a bare slug.
+#[must_use]
+pub fn pair_conversation(one: &str, two: &str) -> String {
+    let (first, second) = if one <= two { (one, two) } else { (two, one) };
+    format!("dm:{first}+{second}")
+}
+
 /// How the far desk's answer reads on the asking desk.
 ///
 /// Attributed in the text and authored by the room, never by the answerer: see
@@ -426,6 +446,16 @@ struct ReferralState {
     /// The answer the last forward produced, if it finished — read by the
     /// driver to decide whether a return hop is worth folding.
     last_answer: Option<(Referral, String)>,
+    /// The agents this episode's lines named DIRECTLY, by their id.
+    ///
+    /// A crossing goes to the pair's own thread only when a person was asked
+    /// for by name. A `@#desk` mention resolves to whoever answers for that
+    /// desk, and that is a question put to the DESK — it belongs on the desk,
+    /// where the room can deliberate it, exactly as it did before pairs had
+    /// their own thread. The two are indistinguishable by the time the library
+    /// hands back a `Referral` — both carry the target's home desk in `to` —
+    /// so the distinction is recorded here, where the mention is still in hand.
+    named: HashSet<String>,
     /// The journal sequence of each forward marker this episode wrote, by the
     /// desk it went to. A return names the forward it answers (`answers`), and
     /// this is where that sequence comes from — the episode knows it, because
@@ -467,6 +497,17 @@ impl<'a> EpisodeReferrals<'a> {
     }
 
     /// What this episode's referrals amounted to.
+    /// Record which agents this line named by name, before the referral for it
+    /// is decided.
+    pub async fn note_named(&self, mentions: &[Mention]) {
+        let mut state = self.state.lock().await;
+        for mention in mentions {
+            if let MentionTarget::Agent { id } = &mention.target {
+                state.named.insert(id.clone());
+            }
+        }
+    }
+
     pub async fn ledger(&self) -> ReferralLedger {
         self.state.lock().await.ledger.clone()
     }
@@ -550,6 +591,19 @@ impl<'a> EpisodeReferrals<'a> {
             None
         };
         let event = CompanyEvent::ReferralEnqueued {
+            // Where this leg ran. A forward runs in the pair's own thread; a
+            // return is carried home to the asking conversation, which the desk
+            // fields already name.
+            conversation: match returning {
+                true => None,
+                false => self
+                    .state
+                    .lock()
+                    .await
+                    .named
+                    .contains(&referral.target_id)
+                    .then(|| pair_conversation(&referral.source_id, &referral.target_id)),
+            },
             from_desk: referral.from.desk_id.clone(),
             from_desk_name: self.desk_name(&referral.from.desk_id),
             asker: referral.source_id.clone(),
@@ -583,9 +637,35 @@ impl<'a> EpisodeReferrals<'a> {
         let asker = self.label(&referral.source_id);
         let asker_desk = self.desk_name(&referral.from.desk_id);
         let prompt = referral_prompt(&asker, &asker_desk, &referral.content);
+        // Where this runs: the pair's own thread when a person was asked for by
+        // name, the target's desk when a desk was. Asking `@#order_ops` is a
+        // question put to that desk — turning it into a private chat with
+        // whoever leads it would skip the deliberation the desk exists for,
+        // which is the whole objection to `delegate_to_desk`.
+        let by_name = self.state.lock().await.named.contains(&referral.target_id);
+        let pair = if by_name {
+            DispatchConversation {
+                desk_id: pair_conversation(&referral.source_id, &referral.target_id),
+                thread_root: None,
+            }
+        } else {
+            referral.to.clone()
+        };
+        // The question, written into the pair's thread — and ONLY there.
+        //
+        // A pair thread is a conversation between two people and has to hold
+        // both sides, or it reads as a monologue. A desk crossing is not: the
+        // far desk is not told it was asked, it is asked, and its transcript
+        // records the turn its own member took. Writing the question there too
+        // would put a question that desk never received into its history.
+        if by_name {
+            let _ = self
+                .journal(&pair, &referral.source_id, referral.content.clone())
+                .await;
+        }
         let answer = match self
             .runner
-            .refer(&referral.to.desk_id, &referral.target_id, &prompt)
+            .refer(&pair.desk_id, &referral.target_id, &prompt)
             .await
         {
             Ok(answer) => answer,
@@ -616,18 +696,21 @@ impl<'a> EpisodeReferrals<'a> {
                 };
             }
         };
-        // Journaled on the desk the turn ran on, under the teammate that took
-        // it, because that is what happened: a real turn by a real member on
-        // its own desk, which its own desk should be able to read back.
+        // Journaled in the conversation the turn ran in — the pair's own thread,
+        // under the teammate that answered, directly beneath the question they
+        // were answering. Their desk does not carry it: the question was not
+        // put to that desk and its colleagues were never asked, so a transcript
+        // that is supposed to record what THAT desk did should not be holding
+        // somebody else's exchange.
         if let Err(error) = self
-            .journal(&referral.to, &referral.target_id, answer.clone())
+            .journal(&pair, &referral.target_id, answer.clone())
             .await
         {
             tracing::warn!(
                 company = %self.company,
-                desk = %referral.to.desk_id,
+                pair = %pair.desk_id,
                 error = %error,
-                "[hive] a referred answer could not be journaled on the far desk"
+                "[hive] a referred answer could not be journaled in the pair's thread"
             );
         }
         let mut state = self.state.lock().await;
@@ -766,6 +849,9 @@ pub async fn consider(
         &roster,
         &desk_set,
     );
+    // Recorded before the decision, because the decision cannot tell a person
+    // from a desk afterwards — see `ReferralState::named`.
+    queue.note_named(&mentions).await;
     if mentions.is_empty() {
         return;
     }

--- a/src/hivemind/referral.rs
+++ b/src/hivemind/referral.rs
@@ -446,7 +446,7 @@ struct ReferralState {
     /// The answer the last forward produced, if it finished — read by the
     /// driver to decide whether a return hop is worth folding.
     last_answer: Option<(Referral, String)>,
-    /// The agents this episode's lines named DIRECTLY, by their id.
+    /// The agents named DIRECTLY, by the line that named them.
     ///
     /// A crossing goes to the pair's own thread only when a person was asked
     /// for by name. A `@#desk` mention resolves to whoever answers for that
@@ -455,7 +455,11 @@ struct ReferralState {
     /// their own thread. The two are indistinguishable by the time the library
     /// hands back a `Referral` — both carry the target's home desk in `to` —
     /// so the distinction is recorded here, where the mention is still in hand.
-    named: HashSet<String>,
+    /// Keyed by the trigger, not accumulated episode-wide: an earlier line
+    /// naming `@sre` must not make a LATER `@#platform` — which resolves to
+    /// that same person — look like it named them. Directness is a fact about
+    /// one line, and a room asks more than once.
+    named: HashMap<u64, HashSet<String>>,
     /// The journal sequence of each forward marker this episode wrote, by the
     /// desk it went to. A return names the forward it answers (`answers`), and
     /// this is where that sequence comes from — the episode knows it, because
@@ -497,15 +501,26 @@ impl<'a> EpisodeReferrals<'a> {
     }
 
     /// What this episode's referrals amounted to.
-    /// Record which agents this line named by name, before the referral for it
-    /// is decided.
-    pub async fn note_named(&self, mentions: &[Mention]) {
+    /// Record which agents THIS line named by name, before its referral is
+    /// decided.
+    pub async fn note_named(&self, trigger: u64, mentions: &[Mention]) {
         let mut state = self.state.lock().await;
+        let named = state.named.entry(trigger).or_default();
         for mention in mentions {
             if let MentionTarget::Agent { id } = &mention.target {
-                state.named.insert(id.clone());
+                named.insert(id.clone());
             }
         }
+    }
+
+    /// Whether `target` was named by the line that raised `trigger`.
+    async fn named_by(&self, trigger: u64, target: &str) -> bool {
+        self.state
+            .lock()
+            .await
+            .named
+            .get(&trigger)
+            .is_some_and(|named| named.contains(target))
     }
 
     pub async fn ledger(&self) -> ReferralLedger {
@@ -597,11 +612,8 @@ impl<'a> EpisodeReferrals<'a> {
             conversation: match returning {
                 true => None,
                 false => self
-                    .state
-                    .lock()
+                    .named_by(referral.key.trigger_sequence, &referral.target_id)
                     .await
-                    .named
-                    .contains(&referral.target_id)
                     .then(|| pair_conversation(&referral.source_id, &referral.target_id)),
             },
             from_desk: referral.from.desk_id.clone(),
@@ -642,7 +654,9 @@ impl<'a> EpisodeReferrals<'a> {
         // question put to that desk — turning it into a private chat with
         // whoever leads it would skip the deliberation the desk exists for,
         // which is the whole objection to `delegate_to_desk`.
-        let by_name = self.state.lock().await.named.contains(&referral.target_id);
+        let by_name = self
+            .named_by(referral.key.trigger_sequence, &referral.target_id)
+            .await;
         let pair = if by_name {
             DispatchConversation {
                 desk_id: pair_conversation(&referral.source_id, &referral.target_id),
@@ -851,7 +865,7 @@ pub async fn consider(
     );
     // Recorded before the decision, because the decision cannot tell a person
     // from a desk afterwards — see `ReferralState::named`.
-    queue.note_named(&mentions).await;
+    queue.note_named(seq.value(), &mentions).await;
     if mentions.is_empty() {
         return;
     }

--- a/src/hivemind/referral.rs
+++ b/src/hivemind/referral.rs
@@ -45,7 +45,7 @@
 //!
 //! See `docs/spec/runtime/hivemind-referral.md`.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -426,6 +426,11 @@ struct ReferralState {
     /// The answer the last forward produced, if it finished — read by the
     /// driver to decide whether a return hop is worth folding.
     last_answer: Option<(Referral, String)>,
+    /// The journal sequence of each forward marker this episode wrote, by the
+    /// desk it went to. A return names the forward it answers (`answers`), and
+    /// this is where that sequence comes from — the episode knows it, because
+    /// it wrote the marker itself a moment earlier.
+    forwards: HashMap<String, u64>,
 }
 
 impl<'a> EpisodeReferrals<'a> {
@@ -523,6 +528,57 @@ impl<'a> EpisodeReferrals<'a> {
 
     /// Run one crossing (or local) question and journal its answer where the
     /// turn actually happened.
+    /// Journal the `ReferralEnqueued` marker for one crossing.
+    ///
+    /// The same row the chat path writes, so one projection reads both: the
+    /// console's chip and its crossing transcript key off this marker, and a
+    /// hand-off that does not write one is a hand-off nobody can audit.
+    ///
+    /// A return names the forward it answers, taken from what this episode
+    /// recorded when it wrote that forward — the pairing is a fact the writer
+    /// holds, never something a reader re-derives by scanning.
+    async fn mark(&self, referral: &Referral) {
+        let returning = matches!(referral.kind, ReferralKind::Return);
+        let answers = if returning {
+            self.state
+                .lock()
+                .await
+                .forwards
+                .get(&referral.from.desk_id)
+                .copied()
+        } else {
+            None
+        };
+        let event = CompanyEvent::ReferralEnqueued {
+            from_desk: referral.from.desk_id.clone(),
+            from_desk_name: self.desk_name(&referral.from.desk_id),
+            asker: referral.source_id.clone(),
+            asker_label: self.label(&referral.source_id),
+            trigger_sequence: referral.key.trigger_sequence,
+            returning,
+            answers,
+            to_desk: referral.to.desk_id.clone(),
+            target: referral.target_id.clone(),
+        };
+        match self.events.append(&self.company, event).await {
+            Ok(seq) if !returning => {
+                // Keyed by the desk being asked, which is the desk a return
+                // comes back FROM — the lookup above.
+                self.state
+                    .lock()
+                    .await
+                    .forwards
+                    .insert(referral.to.desk_id.clone(), seq.value());
+            }
+            Ok(_) => {}
+            Err(err) => tracing::warn!(
+                company = %self.company,
+                desk = %referral.from.desk_id,
+                "[hive] a crossing could not be marked on the journal ({err}); the turn still runs"
+            ),
+        }
+    }
+
     async fn forward(&self, referral: &Referral) -> EnqueueOutcome {
         let asker = self.label(&referral.source_id);
         let asker_desk = self.desk_name(&referral.from.desk_id);
@@ -646,6 +702,22 @@ impl ReferralQueue for EpisodeReferrals<'_> {
                     state.asked = state.asked.saturating_add(1);
                 }
             }
+            // **The marker, before the turn it authorizes.**
+            //
+            // A crossing raised inside a room used to leave no trace on the
+            // journal at all: this adapter kept its idempotency in memory and
+            // dispatched straight to the runner, so the console had nothing to
+            // attach a chip or a transcript to and a room's question was
+            // invisible to the operator it was asked on behalf of. The chat
+            // path has always written one (`JournalReferralQueue`); writing it
+            // here too means every crossing is recorded the same way, whichever
+            // path raised it.
+            //
+            // Best-effort: a marker that cannot be appended is logged and the
+            // turn still runs, for the reason the rest of this module gives —
+            // a question that went unrecorded is a worse episode, not a broken
+            // one.
+            self.mark(&referral).await;
             Ok(match referral.kind {
                 ReferralKind::Forward => self.forward(&referral).await,
                 ReferralKind::Return => self.ret(&referral).await,

--- a/src/hivemind/referral.rs
+++ b/src/hivemind/referral.rs
@@ -672,11 +672,32 @@ impl<'a> EpisodeReferrals<'a> {
         // far desk is not told it was asked, it is asked, and its transcript
         // records the turn its own member took. Writing the question there too
         // would put a question that desk never received into its history.
-        if by_name {
-            let _ = self
+        //
+        // Whether it actually landed decides what may follow it. A pair thread
+        // is read positionally — the first thing said there IS the question —
+        // so an answer written into a thread whose question failed to append
+        // renders as that question: the reader is shown an answer and told it
+        // was the ask. Better to carry nothing than to carry it mislabelled.
+        let asked = if by_name {
+            match self
                 .journal(&pair, &referral.source_id, referral.content.clone())
-                .await;
-        }
+                .await
+            {
+                Ok(_) => true,
+                Err(error) => {
+                    tracing::warn!(
+                        company = %self.company,
+                        pair = %pair.desk_id,
+                        error = %error,
+                        "[hive] a crossing's question could not be journaled; the turn still runs \
+                         and its answer still comes home, but the pair thread keeps neither side"
+                    );
+                    false
+                }
+            }
+        } else {
+            true
+        };
         let answer = match self
             .runner
             .refer(&pair.desk_id, &referral.target_id, &prompt)
@@ -716,9 +737,10 @@ impl<'a> EpisodeReferrals<'a> {
         // put to that desk and its colleagues were never asked, so a transcript
         // that is supposed to record what THAT desk did should not be holding
         // somebody else's exchange.
-        if let Err(error) = self
-            .journal(&pair, &referral.target_id, answer.clone())
-            .await
+        if asked
+            && let Err(error) = self
+                .journal(&pair, &referral.target_id, answer.clone())
+                .await
         {
             tracing::warn!(
                 company = %self.company,

--- a/src/hivemind/referral_test.rs
+++ b/src/hivemind/referral_test.rs
@@ -407,6 +407,66 @@ async fn a_desk_mention_runs_one_turn_on_the_far_desk_and_carries_the_answer_hom
     );
 }
 
+/// **Naming a PERSON puts the exchange in their pair thread, not on a desk.**
+///
+/// A crossing addressed to somebody by name is a conversation between the two
+/// of them. Run on the answerer's desk, it published a question that desk was
+/// never asked, in front of colleagues who had no part in it, in a transcript
+/// whose job is to record what THAT desk did.
+///
+/// The sibling test above pins the other half: `@#platform` is a question put
+/// to the desk, and still runs there so the room can settle it. Both forms are
+/// indistinguishable by the time the library hands back a `Referral` — each
+/// carries the target's home desk — so the two tests together are what keep
+/// the distinction from collapsing back into one.
+#[tokio::test]
+async fn naming_a_person_holds_the_exchange_in_their_pair_thread() {
+    let far = FarDesk::answering("The replica lag budget is 400ms.");
+    let (log, _outcome) = run(
+        REFERRING,
+        &[
+            (
+                "planner",
+                "!question #lag What is the replica lag budget? @sre",
+            ),
+            ("scout", "!propose #stage Stage the rollout behind a flag."),
+            ("critic", "!support #stage ^1 Staging fits the lag budget."),
+            ("planner", "!commit #stage ^3 Recorded."),
+        ],
+        Some(&far),
+    )
+    .await;
+
+    let pair = super::referral::pair_conversation("planner", "sre");
+    assert_eq!(pair, "dm:planner+sre", "sorted, so one thread not two");
+
+    // Both sides are there, in order, so the thread reads as the conversation
+    // it was.
+    let said = log.replies(&pair);
+    assert_eq!(said.len(), 2, "question then answer: {said:?}");
+    assert_eq!(said[0].0, "planner", "the asker speaks first");
+    assert!(said[0].1.contains("replica lag budget"), "{said:?}");
+    assert_eq!(said[1].0, "sre", "and the person asked answers");
+    assert!(said[1].1.contains("400ms"), "{said:?}");
+
+    // And the answerer's desk carries none of it. This is the whole point: the
+    // question was put to a person, so their colleagues are not made to read it.
+    assert!(
+        log.replies("platform").is_empty(),
+        "a desk that was never asked holds nothing: {:?}",
+        log.replies("platform")
+    );
+
+    // The room still gets the conclusion, under the room's own author — the
+    // property this must not break.
+    let home = log.replies("eng");
+    let returned = home
+        .iter()
+        .find(|(_, text)| text.contains("400ms"))
+        .expect("the answer still comes home");
+    assert_eq!(returned.0, HIVE_REFERRAL_AUTHOR, "{home:?}");
+}
+
 #[tokio::test]
 async fn the_answer_comes_home_under_the_room_so_it_can_never_be_counted_as_support() {
     // The property the whole design turns on. A row authored by a roster id

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -686,6 +686,25 @@ pub enum CompanyEvent {
         /// than letting the render side infer a second, disagreeing answer.
         #[serde(default)]
         returning: bool,
+        /// On a RETURN, the journal sequence of the forward marker this answers.
+        /// `None` on a forward leg, and on returns written before this field
+        /// existed.
+        ///
+        /// **The host already knew this and was discarding it.** Authorizing a
+        /// return means finding the forward it answers (`answering_a_forward`),
+        /// which locates the exact marker and then kept only a bool — leaving
+        /// the console to re-derive the same pairing at read time, from a
+        /// different window and a separately-written set of match rules. Two
+        /// readers of one fact, free to disagree, and they did: a crossing whose
+        /// ask fell outside the console's window rendered as though the question
+        /// had never been asked.
+        ///
+        /// Recorded here, the pairing is a fact rather than an inference, and
+        /// the projection reads one event instead of scanning for it. Defaulted
+        /// for the reason above, so older markers still deserialize and fall
+        /// back to the scan.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        answers: Option<u64>,
         /// The agent that asked. Defaulted for the reason above.
         #[serde(default)]
         asker: String,

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -705,6 +705,21 @@ pub enum CompanyEvent {
         /// back to the scan.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         answers: Option<u64>,
+        /// The conversation the exchange actually happened in, when it was not
+        /// a desk — the two teammates' own thread (`dm:a+b`).
+        ///
+        /// The desk fields stay what they are: who asked, from where, and whose
+        /// home desk the answerer keeps. Those name the PEOPLE, and the console
+        /// labels a crossing with them. This names the PLACE, which is what a
+        /// reader needs to find the rows. Keeping them apart is why a crossing
+        /// can move off the answerer's channel without the label following it
+        /// somewhere meaningless.
+        ///
+        /// Absent on a crossing that ran on a desk, and on markers written
+        /// before pairs had their own conversation. Defaulted for the reason
+        /// every other field here is.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        conversation: Option<String>,
         /// The agent that asked. Defaulted for the reason above.
         #[serde(default)]
         asker: String,

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -1246,6 +1246,15 @@ pub struct JournalReferralQueue {
     /// a return spends no turn of its own, and refusing one would strand an
     /// answer that has already been paid for.
     asked: std::sync::Arc<tokio::sync::Mutex<u32>>,
+    /// The forward these replies answer, when they are answering one — the
+    /// journal sequence of its marker, handed down by the turn that spawned
+    /// this one.
+    ///
+    /// Recorded rather than searched for. Two crossings between the same desks
+    /// to the same agent write markers that are identical in every field a
+    /// search could match on, so "the most recent forward that looks like mine"
+    /// pairs one question with the other's answer as soon as two are in flight.
+    answers: Option<u64>,
 }
 
 impl std::fmt::Debug for JournalReferralQueue {
@@ -1263,12 +1272,14 @@ impl JournalReferralQueue {
         gate: std::sync::Arc<tokio::sync::Mutex<()>>,
         peer_cap: u32,
         max_hops: u32,
+        answers: Option<u64>,
     ) -> Self {
         Self {
             runtime,
             gate,
             peer_cap,
             max_hops,
+            answers,
             asked: std::sync::Arc::new(tokio::sync::Mutex::new(0)),
         }
     }
@@ -1406,14 +1417,18 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
             // that conversation to this one, addressed to this agent, must
             // actually be on the journal. The marker that makes the forward
             // idempotent is the same marker that authorizes its answer home.
-            // On a return this is the forward it answers — both the permission
-            // and the pairing the marker records below. On a forward it stays
-            // `None`: there is nothing earlier to point at.
-            let mut answers: Option<u64> = None;
+            // On a return, the forward it answers, as the spawning turn named
+            // it. On a forward, nothing earlier to point at.
+            let answers = match referral.kind {
+                tinyhivemind::referral::ReferralKind::Return => self.answers,
+                tinyhivemind::referral::ReferralKind::Forward => None,
+            };
             let permitted = match referral.kind {
                 tinyhivemind::referral::ReferralKind::Return => {
-                    answers = self.answering_a_forward(&referral).await;
-                    answers.is_some()
+                    // Authorization still asks "is there a forward for this
+                    // return at all"; the PAIRING is the sequence carried down,
+                    // never this search's pick among look-alikes.
+                    self.answering_a_forward(&referral).await.is_some()
                 }
                 tinyhivemind::referral::ReferralKind::Forward => {
                     self.authorized(&referral.source_id, &referral.to.desk_id)
@@ -1468,8 +1483,11 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
             }
 
             // 4. The marker, durably, BEFORE the turn — see the type's doc for
-            //    which way this window fails.
-            self.runtime
+            //    which way this window fails. Its sequence is kept: the child
+            //    is told which forward it answers, rather than searching for a
+            //    marker that looks like the right one.
+            let marker_seq = self
+                .runtime
                 .events()
                 .append(
                     self.runtime.id(),
@@ -1498,12 +1516,24 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
                 .await
                 .map_err(|err| Box::new(err) as tinyhivemind::responder::BoxError)?;
 
-            // 5. The child turn, on the TARGET's conversation.
+            // 5. The child turn, on the TARGET's conversation, told which
+            //    forward it is answering.
+            //
+            //    The sequence just returned by `append`, not a search: two
+            //    referrals between the same desks to the same agent can be in
+            //    flight at once, and every marker they write is geometrically
+            //    identical — same `from_desk`, `to_desk` and `target`. A return
+            //    that picked the newest match would pair one question with the
+            //    other question's answer. The writer knows which marker it wrote;
+            //    carrying that is the only way the reader cannot get it wrong.
+            let answers = (!matches!(referral.kind, tinyhivemind::referral::ReferralKind::Return))
+                .then_some(marker_seq.value());
             self.runtime.clone().spawn_referred_turn(
                 referral.to.desk_id.clone(),
                 returned_answer(&record, &referral, self.max_hops),
                 referral.source_id.clone(),
                 referral.origin.clone(),
+                answers,
                 // The depth THIS child sits at, so the chain it may start is
                 // measured from here. Passing a constant made every generation
                 // claim the same depth, and a bound that never advances bounds

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -1474,6 +1474,9 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
                 .append(
                     self.runtime.id(),
                     CompanyEvent::ReferralEnqueued {
+                        // The chat path still runs a crossing on the target's
+                        // desk; only an episode's crossing moves to the pair.
+                        conversation: None,
                         from_desk: referral.from.desk_id.clone(),
                         from_desk_name: desk_label(&record, &referral.from.desk_id),
                         asker: referral.source_id.clone(),

--- a/src/runtime/hivemind.rs
+++ b/src/runtime/hivemind.rs
@@ -1310,7 +1310,10 @@ impl JournalReferralQueue {
     /// from.desk_id` and named this agent as its target, so a return travelling
     /// the other way is the answer it asked for. Anything else claiming to be a
     /// return has no forward behind it and is refused.
-    async fn answering_a_forward(&self, referral: &tinyhivemind::referral::Referral) -> bool {
+    async fn answering_a_forward(
+        &self,
+        referral: &tinyhivemind::referral::Referral,
+    ) -> Option<u64> {
         const LOOKBACK: usize = 2048;
         let Ok(page) = self
             .runtime
@@ -1318,17 +1321,25 @@ impl JournalReferralQueue {
             .read_before(self.runtime.id(), None, LOOKBACK)
             .await
         else {
-            return false;
+            return None;
         };
-        page.into_iter().any(|stored| {
-            matches!(
-                &stored.event,
-                CompanyEvent::ReferralEnqueued { from_desk, to_desk, target, .. }
-                    if *from_desk == referral.to.desk_id
-                        && *to_desk == referral.from.desk_id
-                        && *target == referral.source_id
-            )
-        })
+        // The SEQUENCE, not just whether one exists. Finding the forward is the
+        // whole of authorizing a return, so this function already had to locate
+        // the exact marker; returning a bool threw that away and left the
+        // console to find the same marker again from a smaller window with its
+        // own copy of the match rules. Handing the sequence back lets the
+        // marker record the pairing, so nothing downstream re-derives it.
+        page.into_iter()
+            .find(|stored| {
+                matches!(
+                    &stored.event,
+                    CompanyEvent::ReferralEnqueued { from_desk, to_desk, target, .. }
+                        if *from_desk == referral.to.desk_id
+                            && *to_desk == referral.from.desk_id
+                            && *target == referral.source_id
+                )
+            })
+            .map(|stored| stored.seq.value())
     }
 
     /// May `source` cause a turn on `to_desk`?
@@ -1395,9 +1406,14 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
             // that conversation to this one, addressed to this agent, must
             // actually be on the journal. The marker that makes the forward
             // idempotent is the same marker that authorizes its answer home.
+            // On a return this is the forward it answers — both the permission
+            // and the pairing the marker records below. On a forward it stays
+            // `None`: there is nothing earlier to point at.
+            let mut answers: Option<u64> = None;
             let permitted = match referral.kind {
                 tinyhivemind::referral::ReferralKind::Return => {
-                    self.answering_a_forward(&referral).await
+                    answers = self.answering_a_forward(&referral).await;
+                    answers.is_some()
                 }
                 tinyhivemind::referral::ReferralKind::Forward => {
                     self.authorized(&referral.source_id, &referral.to.desk_id)
@@ -1471,6 +1487,7 @@ impl tinyhivemind::referral::ReferralQueue for JournalReferralQueue {
                             tinyhivemind::referral::ReferralKind::Return
                         ),
                         trigger_sequence: referral.key.trigger_sequence,
+                        answers,
                         to_desk: referral.to.desk_id.clone(),
                         target: referral.target_id.clone(),
                     },

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -306,6 +306,13 @@ pub struct ReferredFrom {
     /// Whether this is the answer coming home rather than the outbound ask.
     /// Carried from the marker; see `CompanyEvent::ReferralEnqueued`.
     pub returning: bool,
+    /// Whether a PERSON was asked rather than a desk.
+    ///
+    /// The chip names whoever was actually addressed. "Answered by Front Desk"
+    /// for a question put to one person names a room that was never asked — its
+    /// other members had no part in it, and on a direct crossing it holds none
+    /// of the exchange.
+    pub direct: bool,
 }
 
 /// One line of a crossing, in the order it was said.
@@ -340,6 +347,13 @@ pub struct ReferralConversation {
     /// And where that person sits, for the label and the link.
     pub other_desk_id: String,
     pub other_desk_name: String,
+    /// Whether a PERSON was asked, rather than a desk.
+    ///
+    /// The two are different acts and the label says which: `@name` went to
+    /// somebody, `#desk` was put to a room. Taken from whether the crossing
+    /// named its own pair conversation — a desk crossing runs on the desk and
+    /// names none.
+    pub direct: bool,
     /// The exchange, oldest first. Its length is the message count the
     /// collapsed label shows.
     pub lines: Vec<ReferralLine>,
@@ -1294,6 +1308,7 @@ async fn attach_referral_origins(
             target,
             returning,
             answers,
+            conversation,
         } = &stored.event
         else {
             continue;
@@ -1323,6 +1338,23 @@ async fn attach_referral_origins(
             continue;
         };
         let child_id = child.seq.value().to_string();
+        // Whether this crossing went to a person. Read off the FORWARD, which
+        // is the leg that names a pair conversation; a return names none, so it
+        // cannot answer this about itself.
+        let direct = match returning {
+            true => answers
+                .and_then(|seq| page.iter().find(|st| st.seq.value() == seq))
+                .is_some_and(|fwd| {
+                    matches!(
+                        &fwd.event,
+                        CompanyEvent::ReferralEnqueued {
+                            conversation: Some(_),
+                            ..
+                        }
+                    )
+                }),
+            false => conversation.is_some(),
+        };
         let origin = ReferredFrom {
             desk_id: from_desk.clone(),
             desk_name: from_desk_name.clone(),
@@ -1330,6 +1362,7 @@ async fn attach_referral_origins(
             asker_label: asker_label.clone(),
             sequence: *trigger_sequence,
             returning: *returning,
+            direct,
         };
 
         // On a return, the chip belongs on the ASKER's report — the first thing
@@ -1364,6 +1397,33 @@ async fn attach_referral_origins(
                 // rules to drift from the host's.
                 let paired = answers.and_then(|seq| {
                     let forward = page.iter().find(|stored| stored.seq.value() == seq)?;
+                    // A crossing that ran in the pair's own thread keeps BOTH
+                    // sides there, in order, and neither desk carries them. That
+                    // is the whole exchange already — no delivered copy to hunt
+                    // for, no trigger row to fall back to.
+                    if let CompanyEvent::ReferralEnqueued {
+                        conversation: Some(thread),
+                        ..
+                    } = &forward.event
+                    {
+                        let said: Vec<String> = page
+                            .iter()
+                            .filter(|stored| stored.seq > forward.seq)
+                            .filter(|stored| {
+                                matches!(
+                                    &stored.event,
+                                    CompanyEvent::AgentReply { chat_id, .. } if chat_id == thread
+                                )
+                            })
+                            .filter_map(|stored| strip_relay_note(&stored.event))
+                            .collect();
+                        // The question is the first thing said there; anything
+                        // after it is the answer, which may run to several turns.
+                        if let Some(question) = said.first() {
+                            return Some(question.clone());
+                        }
+                        return None;
+                    }
                     // The question, in whichever form this crossing left behind.
                     //
                     // A chat-path crossing delivers a copy onto the far desk —
@@ -1461,6 +1521,7 @@ async fn attach_referral_origins(
                 if let Some(view) = messages.iter_mut().find(|m| m.id == id) {
                     if !lines.is_empty() {
                         view.referral_conversation = Some(ReferralConversation {
+                            direct,
                             asker_id: target.clone(),
                             other_id: asker.clone(),
                             other_desk_id: from_desk.clone(),
@@ -3416,6 +3477,9 @@ mod referral_origin_test {
     ) -> [CompanyEvent; 2] {
         [
             CompanyEvent::ReferralEnqueued {
+                // These fixtures are desk crossings, which run on the target's
+                // own desk and name no pair conversation.
+                conversation: None,
                 answers,
                 from_desk: from_desk.to_string(),
                 from_desk_name: from_desk_name.to_string(),

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -308,6 +308,43 @@ pub struct ReferredFrom {
     pub returning: bool,
 }
 
+/// One line of a crossing, in the order it was said.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralLine {
+    /// The agent that wrote it.
+    pub author_id: String,
+    /// Their display label, captured when the referral was made.
+    pub author_label: String,
+    /// What they said, with any host note to the asker already stripped.
+    pub text: String,
+    /// True when this desk's own agent wrote it — the question going out.
+    pub outbound: bool,
+}
+
+/// The whole exchange between an agent on this desk and somebody who is not,
+/// folded onto the report that brought it home.
+///
+/// The relayed rows themselves are still dropped from the transcript: a desk's
+/// history is the conversation that happened ON it, and an agent who does not
+/// work here did not speak here. But dropping them outright left an operator
+/// able to see that a question crossed and never what was said either way,
+/// with only the asker's paraphrase to go on. This carries the exchange as its
+/// own collapsible line — closed by default, so the desk still reads as its
+/// own conversation and the crossing is one click away rather than gone.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralConversation {
+    /// The agent on this desk that asked.
+    pub asker_id: String,
+    /// Who they asked.
+    pub other_id: String,
+    /// And where that person sits, for the label and the link.
+    pub other_desk_id: String,
+    pub other_desk_name: String,
+    /// The exchange, oldest first. Its length is the message count the
+    /// collapsed label shows.
+    pub lines: Vec<ReferralLine>,
+}
+
 /// Who is reading a desk history. `mine` is relative to this.
 ///
 /// There is no `From<StoredEvent> for MessageView`, and there cannot be:
@@ -366,6 +403,8 @@ pub struct MessageView {
     /// message: the marker is written inside the enqueue transaction, before
     /// the child turn exists, so the message cannot carry it at write time.
     pub referred_from: Option<ReferredFrom>,
+    /// The crossing this report brought home, when it brought one.
+    pub referral_conversation: Option<ReferralConversation>,
     /// Whether this row may reach only administrators (issue #1781 review,
     /// Codex P1).
     ///
@@ -616,6 +655,7 @@ impl MessageView {
                 by_person: false,
                 // Set by the referral fold in `history_for_desk`, never here.
                 referred_from: None,
+                referral_conversation: None,
                 steps,
                 task_id,
                 parent_id: parent.map(|seq| seq.value().to_string()),
@@ -686,6 +726,7 @@ impl MessageView {
                 MessageView {
                     // Set by the referral fold in `history_for_desk`, never here.
                     referred_from: None,
+                    referral_conversation: None,
                     id,
                     channel: voice,
                     admin_only: false,
@@ -755,6 +796,7 @@ impl MessageView {
                 by_person: false,
                 // Set by the referral fold in `history_for_desk`, never here.
                 referred_from: None,
+                referral_conversation: None,
                 steps: Vec::new(),
                 task_id: Some(task_id),
                 // Rendered the same way an `OperatorMessage`'s parent is, a few
@@ -777,6 +819,7 @@ impl MessageView {
                 by_person: false,
                 // Set by the referral fold in `history_for_desk`, never here.
                 referred_from: None,
+                referral_conversation: None,
                 steps: Vec::new(),
                 task_id: None,
                 parent_id: None,
@@ -1221,9 +1264,21 @@ async fn attach_referral_origins(
     else {
         return Ok(());
     };
+    // Two events back was enough while this only needed the marker sitting just
+    // before the first visible row. Reading the crossing itself needs the
+    // OUTBOUND leg too, and that is a round trip earlier — the ask, the far
+    // desk's turn, the answer — with whatever else the company journalled in
+    // between. `LOOKBACK` is a bounded widening, not a guarantee: a crossing
+    // whose ask fell outside it renders with the answer alone, which is what
+    // this showed before the question was captured at all.
+    const LOOKBACK: u64 = 64;
     let page = runtime
         .events()
-        .read_from(runtime.id(), EventSeq::new(oldest.saturating_sub(2)), 4096)
+        .read_from(
+            runtime.id(),
+            EventSeq::new(oldest.saturating_sub(LOOKBACK)),
+            4096,
+        )
         .await?;
     // Relays that a report has superseded, dropped once the scan is done —
     // removing inside the loop would invalidate the positions it is still using.
@@ -1238,6 +1293,7 @@ async fn attach_referral_origins(
             to_desk,
             target,
             returning,
+            answers,
         } = &stored.event
         else {
             continue;
@@ -1281,8 +1337,99 @@ async fn attach_referral_origins(
 
         match report {
             Some(id) => {
+                // The answer's own words, before the row is dropped. The host's
+                // note rides the same text and is addressed to the asker alone
+                // ("you are the only one who has seen it"), so it is stripped
+                // here for the same reason the fallback strips it.
+                let answer = strip_relay_note(&child.event);
+                // The question that opened this crossing: the forward leg that
+                // left THIS desk for the desk now answering, addressed to the
+                // agent now speaking. Matched on the pair rather than on
+                // sequence order, because a room may have more than one
+                // crossing open and their legs interleave.
+                // The forward this answers, named by the marker itself when the
+                // host recorded it (`answers`). One event, fetched by sequence:
+                // no window to fall outside of, and no second copy of the match
+                // rules to drift from the host's.
+                let paired = answers.and_then(|seq| {
+                    let forward = page.iter().find(|stored| stored.seq.value() == seq)?;
+                    page.iter()
+                        .find(|later| {
+                            later.seq > forward.seq
+                                && matches!(
+                                    &later.event,
+                                    CompanyEvent::OperatorMessage { chat, by, .. }
+                                        if chat.as_deref() == Some(from_desk.as_str())
+                                            && by.as_ref().is_some_and(|a| a.id == *target)
+                                )
+                        })
+                        .and_then(|m| strip_relay_note(&m.event))
+                });
+                // Markers written before `answers` existed carry no pointer, so
+                // they still pair by scanning. Same result when the ask is in
+                // range, and the same under-count when it is not — this path is
+                // the old behaviour kept for old rows, not a second opinion.
+                let question = paired.or_else(|| page
+                    .iter()
+                    .take(index)
+                    .rev()
+                    .find_map(|earlier| match &earlier.event {
+                        CompanyEvent::ReferralEnqueued {
+                            from_desk: out_from,
+                            to_desk: out_to,
+                            asker: out_asker,
+                            target: out_target,
+                            returning: false,
+                            ..
+                        } if out_from == desk_id
+                            && out_to == from_desk
+                            && out_asker == target
+                            && out_target == asker =>
+                        {
+                            page[..index]
+                                .iter()
+                                .find(|later| {
+                                    later.seq > earlier.seq
+                                        && matches!(
+                                            &later.event,
+                                            CompanyEvent::OperatorMessage { chat, by, .. }
+                                                if chat.as_deref() == Some(out_to.as_str())
+                                                    && by.as_ref().is_some_and(|a| a.id == *out_asker)
+                                        )
+                                })
+                                .map(|m| strip_relay_note(&m.event))
+                        }
+                        _ => None,
+                    })
+                    .flatten());
+                let mut lines = Vec::new();
+                if let Some(text) = question {
+                    lines.push(ReferralLine {
+                        author_id: target.clone(),
+                        author_label: String::new(),
+                        text,
+                        outbound: true,
+                    });
+                }
+                if let Some(text) = answer {
+                    lines.push(ReferralLine {
+                        author_id: asker.clone(),
+                        author_label: asker_label.clone(),
+                        text,
+                        outbound: false,
+                    });
+                }
                 relayed.push(child_id);
                 if let Some(view) = messages.iter_mut().find(|m| m.id == id) {
+                    if !lines.is_empty() {
+                        view.referral_conversation = Some(ReferralConversation {
+                            asker_id: target.clone(),
+                            other_id: asker.clone(),
+                            other_desk_id: from_desk.clone(),
+                            other_desk_name: from_desk_name.clone(),
+                            lines,
+                        });
+                    }
                     view.referred_from = Some(origin);
                 }
             }
@@ -1305,6 +1452,23 @@ async fn attach_referral_origins(
     }
     messages.retain(|m| !relayed.contains(&m.id));
     Ok(())
+}
+
+/// An agent line's own words, with the host's private note to the asker removed.
+///
+/// The note is appended to the SAME text the other desk wrote and is addressed
+/// to the asker alone, so anything published to a channel — the relay fallback,
+/// or a crossing folded onto a report — has to cut it off at the marker. One
+/// function, so the two readers cannot disagree about where the words end.
+fn strip_relay_note(event: &CompanyEvent) -> Option<String> {
+    let CompanyEvent::OperatorMessage { text, .. } = event else {
+        return None;
+    };
+    let words = text
+        .split_once(crate::ports::types::RELAY_NOTE_MARKER)
+        .map_or(text.as_str(), |(answer, _)| answer)
+        .trim();
+    (!words.is_empty()).then(|| words.to_string())
 }
 
 /// Renders a deliberation turn for a person, leaving every other reply alone.
@@ -3183,8 +3347,34 @@ mod referral_origin_test {
         returning: bool,
         text: &str,
     ) -> [CompanyEvent; 2] {
+        referral_leg_answering(
+            from_desk,
+            from_desk_name,
+            asker,
+            to_desk,
+            target,
+            returning,
+            text,
+            None,
+        )
+    }
+
+    /// The same, with the forward this return answers named explicitly — the
+    /// pointer the host records so the projection need not scan for it.
+    #[expect(clippy::too_many_arguments, reason = "a journal event's own shape")]
+    fn referral_leg_answering(
+        from_desk: &str,
+        from_desk_name: &str,
+        asker: &str,
+        to_desk: &str,
+        target: &str,
+        returning: bool,
+        text: &str,
+        answers: Option<u64>,
+    ) -> [CompanyEvent; 2] {
         [
             CompanyEvent::ReferralEnqueued {
+                answers,
                 from_desk: from_desk.to_string(),
                 from_desk_name: from_desk_name.to_string(),
                 asker: asker.to_string(),
@@ -3541,6 +3731,33 @@ mod referral_origin_test {
         let origin = referred.referred_from.as_ref().expect("origin");
         assert!(origin.returning, "and it reads as an answer, not an ask");
         assert_eq!(origin.desk_name, "Design");
+
+        // **The crossing itself rides the report, both legs of it.**
+        //
+        // The relayed rows still go — that is the assertion above, and the
+        // reason for it — but the exchange they carried is kept here so an
+        // operator can read what was actually asked and answered instead of
+        // only the asker's paraphrase of it. `lines.len()` is the count the
+        // collapsed label shows, which is why the QUESTION has to be captured
+        // too: an answer on its own would always read "1 message".
+        let crossing = referred
+            .referral_conversation
+            .as_ref()
+            .expect("the crossing rides the report that brought it home");
+        assert_eq!(crossing.asker_id, "software_engineer");
+        assert_eq!(crossing.other_id, "product_designer");
+        assert_eq!(crossing.other_desk_name, "Design");
+        assert_eq!(crossing.lines.len(), 2, "{:?}", crossing.lines);
+        assert!(crossing.lines[0].outbound, "the question goes out first");
+        assert_eq!(
+            crossing.lines[0].text,
+            "what would you change about the error messages?"
+        );
+        assert!(!crossing.lines[1].outbound, "then the answer comes back");
+        assert_eq!(
+            crossing.lines[1].text,
+            "error messages look like a copy task and are not one"
+        );
     }
 
     /// **A rendered relay shows the answer and none of the host's note.**

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -1395,8 +1395,24 @@ async fn attach_referral_origins(
                 // host recorded it (`answers`). One event, fetched by sequence:
                 // no window to fall outside of, and no second copy of the match
                 // rules to drift from the host's.
+                // The forward this answers, by the sequence the host recorded.
+                //
+                // Read straight from the journal when the page does not reach
+                // it, which is the whole point of recording a pointer: a
+                // crossing whose ask is older than the window is exactly the
+                // case the scan could not serve. Two events, because a forward
+                // marker is immediately followed by the row it caused.
+                let forward_leg: Vec<StoredEvent> = match answers {
+                    Some(seq) if !page.iter().any(|st| st.seq.value() == *seq) => runtime
+                        .events()
+                        .read_from(runtime.id(), EventSeq::new(*seq), 2)
+                        .await
+                        .unwrap_or_default(),
+                    _ => Vec::new(),
+                };
+                let reachable: Vec<&StoredEvent> = page.iter().chain(forward_leg.iter()).collect();
                 let paired = answers.and_then(|seq| {
-                    let forward = page.iter().find(|stored| stored.seq.value() == seq)?;
+                    let forward = reachable.iter().find(|stored| stored.seq.value() == seq)?;
                     // A crossing that ran in the pair's own thread keeps BOTH
                     // sides there, in order, and neither desk carries them. That
                     // is the whole exchange already — no delivered copy to hunt
@@ -1406,7 +1422,7 @@ async fn attach_referral_origins(
                         ..
                     } = &forward.event
                     {
-                        let said: Vec<String> = page
+                        let said: Vec<String> = reachable
                             .iter()
                             .filter(|stored| stored.seq > forward.seq)
                             .filter(|stored| {
@@ -1429,7 +1445,7 @@ async fn attach_referral_origins(
                     // A chat-path crossing delivers a copy onto the far desk —
                     // the asking agent speaking there — so that copy is the
                     // question, already addressed to its reader.
-                    let delivered = page
+                    let delivered = reachable
                         .iter()
                         .find(|later| {
                             later.seq > forward.seq
@@ -1453,7 +1469,8 @@ async fn attach_referral_origins(
                         else {
                             return None;
                         };
-                        page.iter()
+                        reachable
+                            .iter()
                             .find(|stored| stored.seq.value() == *trigger_sequence)
                             .and_then(|m| strip_relay_note(&m.event))
                     })
@@ -1539,10 +1556,14 @@ async fn attach_referral_origins(
                     // FOR the asker — "you are the only one who has seen it" —
                     // in a channel, over the name of an agent that is not even
                     // on this desk. Only the other desk's own words survive.
-                    if let Some((answer, _)) =
-                        view.text.split_once(crate::ports::types::RELAY_NOTE_MARKER)
-                    {
-                        view.text = answer.to_string();
+                    //
+                    // Through the shared helper, not a second copy of the split:
+                    // two readers of one rule is how a marker change leaves one
+                    // path publishing a private note. It also drops a relay
+                    // whose words are only whitespace, which the hand-rolled
+                    // split kept as an empty line.
+                    if let Some(words) = strip_relay_note(&child.event) {
+                        view.text = words;
                     }
                     view.referred_from = Some(origin);
                 }
@@ -3863,6 +3884,128 @@ mod referral_origin_test {
         assert_eq!(
             crossing.lines[1].text,
             "error messages look like a copy task and are not one"
+        );
+    }
+
+    /// **The marker names its own forward, so the ask is found however far back
+    /// it is.**
+    ///
+    /// The scan this replaces looked back a fixed number of events from the
+    /// oldest visible row, so a crossing whose ask fell outside that window
+    /// rendered with the answer alone and said "1 message" — quietly wrong, and
+    /// wrong in the direction that looks plausible. The host already located
+    /// that marker to authorize the return and was keeping only a bool;
+    /// `answers` records it instead.
+    ///
+    /// Here the two legs are separated by far more than the scan's `LOOKBACK`,
+    /// so the fallback cannot reach the ask and only the pointer can.
+    #[tokio::test]
+    async fn a_marker_that_names_its_forward_pairs_beyond_the_scan_window() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let runtime = runtime(home.path()).await;
+        let id = CompanyId::new("acme");
+
+        // The marker's OWN sequence, not a guess at it: the runtime journals
+        // its own setup rows first, so the first referral event is not
+        // sequence zero. Pointing `answers` at a sequence that happens to hold
+        // something else is the confusion the pointer exists to remove.
+        let mut forward_seq = 0u64;
+        for (i, event) in referral_leg(
+            "engineering",
+            "Engineering",
+            "software_engineer",
+            "design",
+            "product_designer",
+            false,
+            "what would you change about the error messages?",
+        )
+        .into_iter()
+        .enumerate()
+        {
+            let seq = runtime.events().append(&id, event).await.expect("journal");
+            if i == 0 {
+                forward_seq = seq.value();
+            }
+        }
+        // The forward marker is sequence 0, its question 1. Bury them under
+        // enough unrelated traffic that the scan's window cannot reach back.
+        for i in 0..200 {
+            runtime
+                .events()
+                .append(
+                    &id,
+                    CompanyEvent::AgentReply {
+                        chat_id: "engineering".to_string(),
+                        agent_id: "software_engineer".to_string(),
+                        text: format!("unrelated line {i}"),
+                        steps: Vec::new(),
+                        task_id: None,
+                        parent: None,
+                        mentions: Vec::new(),
+                        mention_depth: 0,
+                        audience: Vec::new(),
+                    },
+                )
+                .await
+                .expect("journal");
+        }
+        for event in referral_leg_answering(
+            "design",
+            "Design",
+            "product_designer",
+            "engineering",
+            "software_engineer",
+            true,
+            "error messages look like a copy task and are not one",
+            Some(forward_seq),
+        ) {
+            runtime.events().append(&id, event).await.expect("journal");
+        }
+        runtime
+            .events()
+            .append(
+                &id,
+                CompanyEvent::AgentReply {
+                    chat_id: "engineering".to_string(),
+                    agent_id: "software_engineer".to_string(),
+                    text: "design came back: it is a design-system problem".to_string(),
+                    steps: Vec::new(),
+                    task_id: None,
+                    parent: None,
+                    mentions: Vec::new(),
+                    mention_depth: 0,
+                    audience: Vec::new(),
+                },
+            )
+            .await
+            .expect("journal");
+
+        // Only the tail is on screen, so the ask is far outside the scan.
+        let history = history_for_desk(
+            &runtime,
+            "engineering",
+            "engineering",
+            &Viewer::Operator,
+            None,
+            5,
+            true,
+        )
+        .await
+        .expect("history");
+        let crossing = history
+            .iter()
+            .find_map(|m| m.referral_conversation.as_ref())
+            .expect("the crossing rides the report");
+        assert_eq!(
+            crossing.lines.len(),
+            2,
+            "the pointer reaches an ask the scan cannot: {:?}",
+            crossing.lines
+        );
+        assert!(crossing.lines[0].outbound);
+        assert_eq!(
+            crossing.lines[0].text,
+            "what would you change about the error messages?"
         );
     }
 

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -1301,13 +1301,24 @@ async fn attach_referral_origins(
         if to_desk != desk_id {
             continue;
         }
-        let Some(child) = page[index + 1..].iter().find(|later| {
-            matches!(
-                &later.event,
-                CompanyEvent::OperatorMessage { chat, by, .. }
-                    if chat.as_deref() == Some(to_desk.as_str())
-                        && by.as_ref().is_some_and(|actor| actor.id == *asker)
-            )
+        // The row the marker is about, in either shape the two paths write.
+        //
+        // A chat-path crossing lands as an `OperatorMessage` on the target desk
+        // authored by the agent that asked — it IS that agent speaking there. A
+        // crossing raised inside a room lands as an `AgentReply` under the
+        // reserved `hive-referral` author, because the room folds it into its
+        // own transcript for the next speaker to read. Same event, two shapes,
+        // and a matcher that knew only the first left every room crossing
+        // unattached: marker on the journal, nothing on the message.
+        let Some(child) = page[index + 1..].iter().find(|later| match &later.event {
+            CompanyEvent::OperatorMessage { chat, by, .. } => {
+                chat.as_deref() == Some(to_desk.as_str())
+                    && by.as_ref().is_some_and(|actor| actor.id == *asker)
+            }
+            CompanyEvent::AgentReply {
+                chat_id, agent_id, ..
+            } => chat_id == to_desk && agent_id == crate::hivemind::HIVE_REFERRAL_AUTHOR,
+            _ => false,
         }) else {
             continue;
         };
@@ -1353,7 +1364,13 @@ async fn attach_referral_origins(
                 // rules to drift from the host's.
                 let paired = answers.and_then(|seq| {
                     let forward = page.iter().find(|stored| stored.seq.value() == seq)?;
-                    page.iter()
+                    // The question, in whichever form this crossing left behind.
+                    //
+                    // A chat-path crossing delivers a copy onto the far desk —
+                    // the asking agent speaking there — so that copy is the
+                    // question, already addressed to its reader.
+                    let delivered = page
+                        .iter()
                         .find(|later| {
                             later.seq > forward.seq
                                 && matches!(
@@ -1363,7 +1380,23 @@ async fn attach_referral_origins(
                                             && by.as_ref().is_some_and(|a| a.id == *target)
                                 )
                         })
-                        .and_then(|m| strip_relay_note(&m.event))
+                        .and_then(|m| strip_relay_note(&m.event));
+                    // A room's crossing delivers no copy: the far seat simply
+                    // takes a turn, and only its answer is journalled. What
+                    // asked is the member's own line back home — the committed
+                    // reply the marker was raised from, which `trigger_sequence`
+                    // names exactly.
+                    delivered.or_else(|| {
+                        let CompanyEvent::ReferralEnqueued {
+                            trigger_sequence, ..
+                        } = &forward.event
+                        else {
+                            return None;
+                        };
+                        page.iter()
+                            .find(|stored| stored.seq.value() == *trigger_sequence)
+                            .and_then(|m| strip_relay_note(&m.event))
+                    })
                 });
                 // Markers written before `answers` existed carry no pointer, so
                 // they still pair by scanning. Same result when the ask is in
@@ -1403,11 +1436,16 @@ async fn attach_referral_origins(
                     })
                     .flatten());
                 let mut lines = Vec::new();
+                // A room's question is a committed MOVE — `!question @#triage
+                // …` — because that is how it was said. The move grammar is
+                // addressed to the fold, not to a person reading a transcript,
+                // and it is stripped everywhere else a person sees a room's
+                // words; a crossing is no different.
                 if let Some(text) = question {
                     lines.push(ReferralLine {
                         author_id: target.clone(),
                         author_label: String::new(),
-                        text,
+                        text: readable_moves(text),
                         outbound: true,
                     });
                 }
@@ -1415,7 +1453,7 @@ async fn attach_referral_origins(
                     lines.push(ReferralLine {
                         author_id: asker.clone(),
                         author_label: asker_label.clone(),
-                        text,
+                        text: readable_moves(text),
                         outbound: false,
                     });
                 }
@@ -1461,8 +1499,12 @@ async fn attach_referral_origins(
 /// or a crossing folded onto a report — has to cut it off at the marker. One
 /// function, so the two readers cannot disagree about where the words end.
 fn strip_relay_note(event: &CompanyEvent) -> Option<String> {
-    let CompanyEvent::OperatorMessage { text, .. } = event else {
-        return None;
+    let text = match event {
+        CompanyEvent::OperatorMessage { text, .. } => text,
+        // The shape a room's crossing takes; see the matcher in
+        // `attach_referral_origins`.
+        CompanyEvent::AgentReply { text, .. } => text,
+        _ => return None,
     };
     let words = text
         .split_once(crate::ports::types::RELAY_NOTE_MARKER)

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -4003,6 +4003,39 @@ struct ChatHistoryQuery {
 /// desk renamed later must not rewrite what the conversation said at the time.
 ///
 /// [`SessionAuthor`]: tinyhivemind::session::SessionAuthor
+/// One line of a crossing, as the console renders it.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ReferralLineDto {
+    /// Who wrote it, by id.
+    author_id: String,
+    /// Their display label when the referral was made; empty for this desk's
+    /// own agent, whom the console already names.
+    author_label: String,
+    /// What they said.
+    text: String,
+    /// True for the question leaving this desk, false for the answer coming
+    /// back — which is what lets the console show the two sides differently.
+    outbound: bool,
+}
+
+/// A crossing folded onto the report that brought it home, so the console can
+/// render it as one collapsed line naming both parties and counting the
+/// messages.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ReferralConversationDto {
+    /// The agent on this desk that asked.
+    asker_id: String,
+    /// Who they asked.
+    other_id: String,
+    /// And where that person sits — id for the link, name for the label.
+    other_desk_id: String,
+    other_desk_name: String,
+    /// The exchange, oldest first. Its length is the count in the label.
+    lines: Vec<ReferralLineDto>,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ReferredFromDto {
@@ -4041,6 +4074,10 @@ struct ChatHistoryMessageDto {
     /// ordinary message, so the wire shape is unchanged for them.
     #[serde(skip_serializing_if = "Option::is_none")]
     referred_from: Option<ReferredFromDto>,
+    /// The crossing this report brought home, when it brought one. Absent on
+    /// every ordinary message, so the wire shape is unchanged for them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    referral_conversation: Option<ReferralConversationDto>,
     /// When it was journaled, epoch millis.
     at_millis: f64,
     /// Whether it is the operator's own message.
@@ -4179,6 +4216,24 @@ impl From<ReactionView> for ChatReactionDto {
 impl From<MessageView> for ChatHistoryMessageDto {
     fn from(view: MessageView) -> Self {
         Self {
+            referral_conversation: view.referral_conversation.map(|crossing| {
+                ReferralConversationDto {
+                    asker_id: crossing.asker_id,
+                    other_id: crossing.other_id,
+                    other_desk_id: crossing.other_desk_id,
+                    other_desk_name: crossing.other_desk_name,
+                    lines: crossing
+                        .lines
+                        .into_iter()
+                        .map(|line| ReferralLineDto {
+                            author_id: line.author_id,
+                            author_label: line.author_label,
+                            text: line.text,
+                            outbound: line.outbound,
+                        })
+                        .collect(),
+                }
+            }),
             referred_from: view.referred_from.map(|origin| ReferredFromDto {
                 desk_id: origin.desk_id,
                 desk_name: origin.desk_name,

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -4032,6 +4032,8 @@ pub(crate) struct ReferralConversationDto {
     /// And where that person sits — id for the link, name for the label.
     other_desk_id: String,
     other_desk_name: String,
+    /// Whether a person was asked rather than a desk — `@name` vs `#desk`.
+    direct: bool,
     /// The exchange, oldest first. Its length is the count in the label.
     lines: Vec<ReferralLineDto>,
 }
@@ -4049,6 +4051,9 @@ pub(crate) struct ReferredFromDto {
     asker_label: String,
     /// The asking message, so the chip links straight to it.
     sequence: u64,
+    /// Whether a person was asked rather than a desk, so the chip can name
+    /// whoever was actually addressed.
+    direct: bool,
     /// Which word the chip uses. `"asked"` on the outbound leg, `"answered"`
     /// when the answer has come home.
     ///
@@ -4222,6 +4227,7 @@ impl From<MessageView> for ChatHistoryMessageDto {
                     other_id: crossing.other_id,
                     other_desk_id: crossing.other_desk_id,
                     other_desk_name: crossing.other_desk_name,
+                    direct: crossing.direct,
                     lines: crossing
                         .lines
                         .into_iter()
@@ -4240,6 +4246,7 @@ impl From<MessageView> for ChatHistoryMessageDto {
                 asker_id: origin.asker_id,
                 asker_label: origin.asker_label,
                 sequence: origin.sequence,
+                direct: origin.direct,
                 direction: if origin.returning {
                     "answered"
                 } else {

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3541,7 +3541,7 @@ fn spawn_chat_turn(turn: ChatTurn) -> JoinHandle<Result<(CycleReport, Option<Str
         // desk. AFTER journaling, never before — the referral is keyed on the
         // reply's own sequence, so it has to exist first.
         #[cfg(feature = "hivemind")]
-        refer_committed_replies(&runtime, &company, &desk, &report, None, 0).await;
+        refer_committed_replies(&runtime, &company, &desk, &report, None, None, 0).await;
         settle_chat_turn(&runtime, &company, turn_id.as_deref(), None).await;
         Ok((report, feedback_note))
     })
@@ -3569,6 +3569,12 @@ pub(crate) async fn refer_committed_replies(
     // back in the next `ReferralInput`, or the answer has no way home. Nothing
     // in the library remembers it."
     origin: Option<tinyhivemind_core::referral::ReferralOrigin>,
+    // The forward these replies are answering, by its marker's journal
+    // sequence. Recorded on the return so the console pairs the two legs by
+    // identity rather than by looking for the nearest similar marker — two
+    // crossings between the same desks to the same agent are indistinguishable
+    // by shape.
+    answers: Option<u64>,
     // Depth of the reply being offered — NOT of the child it might spawn.
     //
     // A reply to an operator message is 0, so every operator message starts a
@@ -3617,6 +3623,7 @@ pub(crate) async fn refer_committed_replies(
         gate.clone(),
         config.peer_cap(),
         policy.max_hops,
+        answers,
     );
 
     for response in &report.responses {


### PR DESCRIPTION
## Summary

A crossing raised inside a room left **nothing on the journal**, and a question put to a colleague by name ran on **their desk** rather than between the two of them. Three commits, each one exposed by fixing the one before it.

### 1. A room's crossing is recorded like any other

`EpisodeReferrals` kept its idempotency in memory and dispatched straight to the runner, while the chat path has always written a `ReferralEnqueued`. So the console had nothing to attach to, and a room's question — the one place crossings actually come from — was invisible to the operator it was asked on behalf of.

The episode now writes the same marker, and records the forward's sequence so its return can name it.

That exposed two more places the paths had drifted:

* **The answer row has two shapes.** A chat-path crossing delivers an `OperatorMessage` by the asking agent; a room's lands under the reserved `hive-referral` author. The matcher knew only the first.
* **A room delivers no copy of the question** to the far desk — the seat simply takes a turn — so there is nothing to pair with. What asked is the member's own line back home, which `trigger_sequence` names exactly.

### 2. The crossing is shown, as one collapsed line

The relayed rows are dropped from the asking desk — an agent who does not work there did not speak there — so an operator could see that a question crossed and never what was said either way, with only the asker's paraphrase to go on. The paraphrase is written by an agent, and agents summarise loosely.

The exchange now rides the report that brought it home:

```
↩ Answered by @triage
⌄ asked @triage · 2 messages
   exchanges   what items are on order #W2378156 for yusuf_rossi_9620 …
   triage      here's the full list: order #W2378156 (delivered) …
```

Closed by default, so the desk still reads as its own conversation.

**Pairing the legs is the host's to record, not the console's to re-derive.** `answering_a_forward` already located the exact forward marker to authorize a return and kept only a bool, leaving the projection to find the same marker again from a smaller window with its own copy of the match rules. Two readers of one fact, and they disagreed: a crossing whose ask fell outside that window rendered as though the question was never asked. The marker now carries `answers`.

### 3. A question put to a person is a conversation with them

Asking a colleague by name ran their turn on their own desk, because that is what the library means by *"runs on their own desk"*. A crossing addressed to a **person** now runs in the pair's own thread (`dm:a+b`, sorted so one pair is one thread), holding the question and the answer together. Neither desk carries it. The conclusion still comes home to the asking room under `hive-referral`, so nothing the room reads or counts changes.

A crossing put to a **desk** is untouched: `@#order_ops` is a question for that room to settle, and turning it into a private chat with whoever leads it would skip the deliberation the desk exists for. The two are indistinguishable by the time the library hands back a `Referral` — each carries the target's home desk — so `consider` records which mentions named a person while the mention is still in hand.

The console names whoever was actually addressed: `asked @triage` for a person, `asked #order_ops` for a desk. Naming the answerer's desk on a direct crossing credited a room that was never asked and holds none of the exchange.

And members write about themselves in the first person. The transcript already marks their own rows `(you)`, but rows are labelled by id and a member copies the convention it is shown — which produced commits like *"both refunds and exchanges agreed"* written **by** refunds, in the one line whose job is to say who carried the decision.

## Tests

* `naming_a_person_holds_the_exchange_in_their_pair_thread` — both sides in the pair thread, in order; the answerer's desk holds nothing; the conclusion still comes home under `hive-referral`.
* Its sibling `a_desk_mention_runs_one_turn_on_the_far_desk_and_carries_the_answer_home` pins the other half. Together they are what keeps the distinction from collapsing back into one.
* `a_marker_that_names_its_forward_pairs_beyond_the_scan_window` — two legs separated by 200 unrelated events, where only the pointer can pair them.
* The crossing assertions on `the_asker_brings_the_answer_home_and_the_other_desk_stays_out_of_the_room`.

## Commands run

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings`
- `cargo test --locked --features openhuman,hivemind,composio --lib` — 7563 passed
- `npm test` (console) — 5080 passed; `tsc -b --noEmit` clean

## Not included

The `retail-co` bundle these were developed against — five tau2-bench roles over role-scoped MCP servers — is a separate change: it depends on an external repo for those servers, and it needs `SEARCH_*`/setup postures before `company::content_test` will accept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Referral requests can be directed to an individual or a desk.
  * Chat and thread views show collapsible referral conversations with the original question and response.
  * Referral details are preserved in chat history for easier context and follow-up.

* **Improvements**
  * Referral exchanges are more accurately paired and displayed, including direct-message conversations.
  * Assistant responses refer to the current user as “you” while identifying colleagues by ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->