### PR TITLE
fix(harness): fail closed on a malformed deflection URL, ground spawn_task's assignee

### DIFF
--- a/src/harness/built_in/blockers.rs
+++ b/src/harness/built_in/blockers.rs
@@ -834,4 +834,88 @@ mod tool_test {
              from"
         );
     }
+
+    /// STATE-axis (REQ-002): `push`'s de-duplication is per [`ApprovalScope`]
+    /// (issue #439) — two different turns asking the identical question are
+    /// two requests, not one collapsed into the other. This is the flip side
+    /// of `a_repeated_identical_escalation_collapses_but_a_distinct_one_survives`
+    /// (`policy.rs`), which proves the collapse WITHIN one turn; this proves a
+    /// prior turn's already-drained card does not leave state that suppresses
+    /// an identical question asked again in a later, separate turn.
+    #[tokio::test]
+    async fn escalate_to_human_repeated_across_different_turns_is_not_deduped() {
+        let queue = ApprovalRequestQueue::default();
+        let tool = tool(&queue);
+
+        let first_turn = queue.claim(crate::harness::built_in::policy::ApprovalScope::Run(
+            "run-1".to_string(),
+        ));
+        let first_drain = first_turn
+            .scoped(async {
+                tool.execute(serde_json::json!({ "question": "staging or prod?" }))
+                    .await
+                    .expect("first turn runs");
+                queue.drain(8)
+            })
+            .await;
+        assert_eq!(
+            first_drain.requests.len(),
+            1,
+            "the first turn's own question lands"
+        );
+        drop(first_turn);
+
+        let second_turn = queue.claim(crate::harness::built_in::policy::ApprovalScope::Run(
+            "run-2".to_string(),
+        ));
+        let second_drain = second_turn
+            .scoped(async {
+                tool.execute(serde_json::json!({ "question": "staging or prod?" }))
+                    .await
+                    .expect("second turn runs");
+                queue.drain(8)
+            })
+            .await;
+        assert_eq!(
+            second_drain.requests.len(),
+            1,
+            "a later, separate turn asking the identical question must not read as a duplicate \
+             of a card the first turn already drained and lost scope of"
+        );
+    }
+
+    /// BOUND-axis (REQ-002): the cap boundary through the real tool, not a
+    /// hand-built `ApprovalRequest`. Exactly `MAX_APPROVAL_REQUESTS_PER_TURN`
+    /// distinct questions in one turn must all land with no overflow; the
+    /// existing pin at `escalate_to_human_does_not_set_the_turn_boundary_and_can_overflow_the_cap`
+    /// (`policy.rs`) only exercises one-past the cap.
+    #[tokio::test]
+    async fn escalate_to_human_exactly_at_the_cap_produces_no_overflow() {
+        use crate::harness::built_in::policy::MAX_APPROVAL_REQUESTS_PER_TURN;
+
+        let queue = ApprovalRequestQueue::default();
+        let tool = tool(&queue);
+        for i in 0..MAX_APPROVAL_REQUESTS_PER_TURN {
+            let outcome = tool
+                .execute(serde_json::json!({ "question": format!("question {i}?") }))
+                .await
+                .expect("runs");
+            assert!(!outcome.is_error, "question {i}: {}", outcome.text());
+        }
+
+        let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(
+            drained.requests.len(),
+            MAX_APPROVAL_REQUESTS_PER_TURN,
+            "exactly the cap's worth of distinct questions must all land"
+        );
+        assert_eq!(
+            drained.discarded, 0,
+            "at exactly the cap, nothing overflows"
+        );
+        assert!(
+            drained.overflow_notice().is_none(),
+            "no notice is owed when nothing was dropped"
+        );
+    }
 }

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -1991,7 +1991,7 @@ impl Tool for ReadTaskTool {
     }
 
     fn description(&self) -> &str {
-        "Read one task card in full: its column, assignee, note, every attempt's status, and what it produced — use this to discuss a finished task, explain why one is stuck, or answer a follow-up about its output. Pass the card's `task_id`, from `list_tasks` or a board reference."
+        "Read one task card in full: its column, assignee, note, its 10 most recent attempts' status, and what it produced — use this to discuss a finished task, explain why one is stuck, or answer a follow-up about its output. Pass the card's `task_id`, from `list_tasks` or a board reference."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -11963,6 +11963,45 @@ name = "Morning"
         assert!(text.contains("list_tasks"), "{text}");
     }
 
+    /// AUTH-axis (HT-072): `read_task` is company-scoped only through
+    /// `tasks.list(&self.company)` — a real backend (here `FsOps`, the
+    /// production store, not a hand-rolled fake) partitions its data by
+    /// company on disk, so a `task_id` that exists but is filed under a
+    /// DIFFERENT company must read as not-found, never leak.
+    #[tokio::test]
+    async fn read_task_never_leaks_a_task_id_belonging_to_another_company() {
+        let dir = tempfile::tempdir().unwrap();
+        let tasks: Arc<dyn TaskStore> = Arc::new(crate::store::FsOps::new(dir.path()));
+        tasks
+            .upsert(
+                &CompanyId::new("beta"),
+                &task_card(
+                    "t-secret",
+                    "beta's confidential rollout plan",
+                    crate::ports::tasks::COLUMN_TODO,
+                    "",
+                ),
+            )
+            .await
+            .unwrap();
+
+        let tool = ReadTaskTool::new(CompanyId::new("acme"), Some(tasks), None, None);
+        let result = tool
+            .execute(json!({ "task_id": "t-secret" }))
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "acme asking about beta's task_id must read as not-found: {}",
+            result.text()
+        );
+        let text = result.output_for_llm(true);
+        assert!(
+            !text.contains("confidential rollout"),
+            "must not render beta's card: {text}"
+        );
+    }
+
     /// Fail-closed by construction (issue #1859's approved redaction posture):
     /// `read_task` never reads [`RunRecord::usage`], so a run's USD cost cannot
     /// reach its rendering no matter what that run cost.
@@ -12725,26 +12764,32 @@ name = "Morning"
         );
     }
 
-    /// `ReadTaskTool::description()` promises the model
-    /// "every attempt's status", and `read_task_bounds_rendered_attempts_...`
-    /// right above proves the render is truncated to `READ_TASK_ATTEMPTS_LIMIT`
-    /// rows. Both are real; they contradict each other. Pinning the exact
-    /// claim here means a future wording fix and a future cap change are each
-    /// forced to touch this test, instead of one silently drifting out of step
-    /// with the other the way they did to get here.
+    /// LIMIT-axis (HT-072): `ReadTaskTool::description()` used to promise the
+    /// model "every attempt's status" while the render silently truncates to
+    /// `READ_TASK_ATTEMPTS_LIMIT` rows — a false completeness claim the model
+    /// reads before ever calling the tool, independent of the honest
+    /// `_N earlier attempt(s) omitted_` notice the render itself carries (see
+    /// `read_task_bounds_rendered_attempts_...` above). The description must
+    /// name the same cap the render enforces, and the two are pinned against
+    /// the same literal so a change to one is forced to touch the other
+    /// instead of silently drifting out of step the way they did to get here.
     #[test]
-    fn read_task_description_claims_every_attempt_while_the_render_caps_at_the_limit() {
+    fn read_task_description_names_the_same_cap_the_render_enforces() {
         let tool = ReadTaskTool::new(CompanyId::new("acme"), None, None, None);
         assert!(
-            tool.description().contains("every attempt's status"),
-            "the schema text under test has changed; re-check whether the cap it once \
-             contradicted still exists: {}",
+            !tool.description().contains("every attempt's status"),
+            "the description must not promise completeness the render does not keep: {}",
+            tool.description()
+        );
+        assert!(
+            tool.description().contains("10 most recent"),
+            "the description should name the cap the render enforces: {}",
             tool.description()
         );
         assert_eq!(
             READ_TASK_ATTEMPTS_LIMIT, 10,
-            "the render is capped well under \"every attempt\" whenever a card has more retries \
-             than this"
+            "pinned against the same literal the description names, so a cap change cannot \
+             drift silently out of step with the sentence the model reads"
         );
     }
 

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -155,6 +155,7 @@ pub const QUERY_COMPANY_TOOL: &str = "query_company";
 // The `spawn_task` / `delegate_to_desk` names are the brain-agnostic canonical
 // constants (issue #176) — re-exported here so the harness path and the hosted
 // path share one definition and cannot drift.
+use crate::runtime::assignee;
 use crate::runtime::builder::agent_effective_grants;
 use crate::runtime::delegation_tools;
 pub use crate::runtime::delegation_tools::{
@@ -2660,12 +2661,22 @@ fn summarize_event(event: &CompanyEvent) -> String {
 /// [`Delegation::SpawnTask`]; the harness brain writes the card on drain.
 pub struct SpawnTaskTool {
     queue: DelegationQueue,
+    company: CompanyId,
+    /// The company store, read at call time so the roster an `assignee` is
+    /// grounded against is the **current** one — the same reasoning as
+    /// [`DelegateToDeskTool::store`].
+    store: Arc<dyn CompanyStore>,
 }
 
 impl SpawnTaskTool {
-    /// Builds the tool over the shared delegation queue.
-    pub fn new(queue: DelegationQueue) -> Self {
-        Self { queue }
+    /// Builds the tool over the shared delegation queue and the company store
+    /// it grounds an `assignee` against.
+    pub fn new(queue: DelegationQueue, company: CompanyId, store: Arc<dyn CompanyStore>) -> Self {
+        Self {
+            queue,
+            company,
+            store,
+        }
     }
 }
 
@@ -2708,12 +2719,55 @@ impl Tool for SpawnTaskTool {
             .filter(|a| !a.is_empty())
             .map(str::to_string);
 
+        // Ground the target before queuing anything, on the same terms
+        // `delegate_to_desk`/`delegate_to_teammate` already do (issue #272):
+        // a name that resolves to nobody is refused here, in the model's own
+        // turn, rather than surviving as a queued card the drain silently
+        // opens unowned with no signal anywhere that the assignee was bogus.
+        let owner = match assignee.as_deref() {
+            Some(name) => match self.store.load(&self.company).await {
+                Ok(Some(record)) => {
+                    let resolution = assignee::resolve(&record, name);
+                    if !resolution.names_something_real() {
+                        tracing::info!(
+                            company = %self.company,
+                            "[spawn_task] refused an assignee naming nobody on the roster"
+                        );
+                        return Ok(ToolResult::error(format!(
+                            "Could not open the card: {}",
+                            resolution.rejection().unwrap_or_else(|| format!(
+                                "\"{name}\" is not on this company's roster"
+                            ))
+                        )));
+                    }
+                    resolution.canonical().map(str::to_string)
+                }
+                Ok(None) => {
+                    tracing::warn!(
+                        company = %self.company,
+                        "[spawn_task] could not ground assignee: this company's record is not \
+                         there"
+                    );
+                    Some(name.to_string())
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        company = %self.company,
+                        error = %err,
+                        "[spawn_task] could not read the company record to ground the assignee"
+                    );
+                    Some(name.to_string())
+                }
+            },
+            None => None,
+        };
+
         let effect = format!("the card \"{title}\" was NOT opened");
         match self.queue.push_within_cap(
             Delegation::SpawnTask {
                 title: title.clone(),
                 note,
-                assignee,
+                assignee: owner,
             },
             MAX_DELEGATIONS_PER_TURN,
             NO_DEPTH_BOUND,
@@ -3548,7 +3602,11 @@ pub fn delegation_tools(
     store: Arc<dyn CompanyStore>,
 ) -> Vec<Box<dyn Tool>> {
     vec![
-        Box::new(SpawnTaskTool::new(queue.clone())),
+        Box::new(SpawnTaskTool::new(
+            queue.clone(),
+            company.clone(),
+            store.clone(),
+        )),
         Box::new(DelegateToDeskTool::new(
             queue.clone(),
             company.clone(),
@@ -3588,7 +3646,11 @@ pub fn member_delegation_tools(
     scope: MemberScope,
 ) -> Vec<Box<dyn Tool>> {
     vec![
-        Box::new(SpawnTaskTool::new(queue.clone())),
+        Box::new(SpawnTaskTool::new(
+            queue.clone(),
+            company.clone(),
+            store.clone(),
+        )),
         Box::new(DelegateToDeskTool::for_member(
             queue.clone(),
             company.clone(),
@@ -6322,7 +6384,11 @@ mod tests {
 
         let cases: Vec<(Box<dyn Tool>, Value, &str)> = vec![
             (
-                Box::new(SpawnTaskTool::new(queue.clone())),
+                Box::new(SpawnTaskTool::new(
+                    queue.clone(),
+                    CompanyId::new("acme"),
+                    store.clone(),
+                )),
                 json!({ "title": "Ship it" }),
                 "the card \"Ship it\" was NOT opened",
             ),
@@ -6381,10 +6447,14 @@ mod tests {
     async fn the_triage_refusal_says_it_read_a_question_and_offers_a_way_forward() {
         let queue = DelegationQueue::default();
         let _claim = queue.claim_answering();
-        let refused = SpawnTaskTool::new(queue.clone())
-            .execute(json!({ "title": "Build the landing page" }))
-            .await
-            .expect("execute");
+        let refused = SpawnTaskTool::new(
+            queue.clone(),
+            CompanyId::new("acme"),
+            Arc::new(MemStore::default()),
+        )
+        .execute(json!({ "title": "Build the landing page" }))
+        .await
+        .expect("execute");
         assert!(refused.is_error, "{}", refused.text());
         let text = refused.text();
 
@@ -6424,10 +6494,14 @@ mod tests {
     #[tokio::test]
     async fn the_unwired_refusal_still_says_the_context_cannot_do_board_work() {
         let queue = DelegationQueue::default();
-        let refused = SpawnTaskTool::new(queue.clone())
-            .execute(json!({ "title": "Ship it" }))
-            .await
-            .expect("execute");
+        let refused = SpawnTaskTool::new(
+            queue.clone(),
+            CompanyId::new("acme"),
+            Arc::new(MemStore::default()),
+        )
+        .execute(json!({ "title": "Ship it" }))
+        .await
+        .expect("execute");
         let text = refused.text();
         assert!(refused.is_error, "{text}");
         assert!(
@@ -6487,7 +6561,11 @@ mod tests {
     async fn spawn_task_refuses_past_the_cap_instead_of_promising_a_discarded_card() {
         let queue = DelegationQueue::default();
         let _claim = queue.claim();
-        let tool = SpawnTaskTool::new(queue.clone());
+        let tool = SpawnTaskTool::new(
+            queue.clone(),
+            CompanyId::new("acme"),
+            Arc::new(MemStore::default()),
+        );
         for i in 0..MAX_DELEGATIONS_PER_TURN {
             let ok = tool
                 .execute(json!({ "title": format!("item {i}") }))
@@ -6587,7 +6665,14 @@ mod tests {
     async fn spawn_task_tool_enqueues_a_task() {
         let queue = DelegationQueue::default();
         let _claim = queue.claim();
-        let tool = SpawnTaskTool::new(queue.clone());
+        // An empty store loads no record, so assignee grounding fails open and
+        // the string is queued exactly as typed — isolating this test to the
+        // plain enqueue path. Grounding itself is covered separately below.
+        let tool = SpawnTaskTool::new(
+            queue.clone(),
+            CompanyId::new("acme"),
+            Arc::new(MemStore::default()),
+        );
         tool.execute(json!({ "title": "Ship it", "note": "soon", "assignee": "eng" }))
             .await
             .expect("execute");
@@ -6605,7 +6690,11 @@ mod tests {
     #[tokio::test]
     async fn spawn_task_tool_requires_a_title() {
         let queue = DelegationQueue::default();
-        let tool = SpawnTaskTool::new(queue.clone());
+        let tool = SpawnTaskTool::new(
+            queue.clone(),
+            CompanyId::new("acme"),
+            Arc::new(MemStore::default()),
+        );
         assert!(tool.execute(json!({ "note": "no title" })).await.is_err());
         assert_eq!(queue.queued(), 0);
     }
@@ -13168,52 +13257,26 @@ name = "Morning"
         );
     }
 
-    /// FAIL-axis (HT-074): `spawn_task`'s `assignee` is queued as a raw
-    /// string with no grounding at all — unlike `delegate_to_desk` and
-    /// `delegate_to_teammate`, which refuse an unresolvable target before
-    /// anything is queued (issue #272). This pins the CURRENT behaviour: a
-    /// bogus assignee is staged unchecked.
+    /// INPUT/STATE-axis (HT-074): `spawn_task` now grounds `assignee` on the
+    /// same terms `delegate_to_desk`/`delegate_to_teammate` already do (issue
+    /// #272) — a name that resolves to nobody on the roster is refused here,
+    /// in the model's own turn, rather than surviving as a queued card the
+    /// drain silently opens unowned with no signal anywhere that the assignee
+    /// was bogus.
+    ///
+    /// The store is seeded (not empty) so grounding actually resolves the
+    /// roster rather than taking the fail-open path — an empty store would
+    /// pass this test for the wrong reason.
     #[tokio::test]
-    async fn spawn_task_queues_an_unresolvable_assignee_with_no_grounding_check() {
+    async fn spawn_task_refuses_an_assignee_that_names_nobody_on_the_roster() {
+        let company = CompanyId::new("acme");
         let queue = DelegationQueue::default();
         let _claim = queue.claim();
-        let tool = SpawnTaskTool::new(queue.clone());
-
-        let outcome = tool
-            .execute(json!({
-                "title": "Investigate the outage",
-                "assignee": "totally-nonexistent-agent-id",
-            }))
-            .await
-            .unwrap();
-        assert!(
-            !outcome.is_error,
-            "current behaviour: spawn_task accepts a bogus assignee unchecked: {}",
-            outcome.text()
+        let tool = SpawnTaskTool::new(
+            queue.clone(),
+            company.clone(),
+            Arc::new(MemStore::seeded(seeded_record(&company))),
         );
-        let drained = queue.drain(MAX_DELEGATIONS_PER_TURN);
-        assert_eq!(
-            drained,
-            vec![Delegation::SpawnTask {
-                title: "Investigate the outage".to_string(),
-                note: None,
-                assignee: Some("totally-nonexistent-agent-id".to_string()),
-            }],
-            "the unresolvable assignee is queued exactly as typed, with nothing having checked \
-             it against the roster"
-        );
-    }
-
-    /// The safe behaviour HT-074 asks for: `spawn_task` should refuse an
-    /// `assignee` naming nobody on the roster, the same way
-    /// `delegate_to_desk`/`delegate_to_teammate` already refuse an ungrounded
-    /// target, rather than queuing it for the drain to discover.
-    #[tokio::test]
-    #[ignore = "spawn_task does not ground `assignee`; a bogus target is queued unchecked (HT-074)"]
-    async fn spawn_task_should_refuse_an_assignee_that_names_nobody_on_the_roster() {
-        let queue = DelegationQueue::default();
-        let _claim = queue.claim();
-        let tool = SpawnTaskTool::new(queue.clone());
 
         let outcome = tool
             .execute(json!({
@@ -13226,7 +13289,211 @@ name = "Morning"
             outcome.is_error,
             "an assignee naming nobody on the roster must be refused before queuing"
         );
+        assert!(
+            outcome.text().contains("totally-nonexistent-agent-id"),
+            "the refusal names the target the model typed: {}",
+            outcome.text()
+        );
         assert_eq!(queue.queued(), 0, "nothing should have been staged");
+    }
+
+    /// The other half: a real teammate id grounds and queues under its
+    /// canonical form, and a blank/absent `assignee` opens the card unowned
+    /// without ever touching the store.
+    #[tokio::test]
+    async fn spawn_task_grounds_a_real_teammate_and_leaves_a_blank_assignee_alone() {
+        let company = CompanyId::new("acme");
+        let manifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+
+[[agent]]
+id = "eng"
+role = "Engineer"
+"#,
+        )
+        .expect("valid manifest");
+        let record = CompanyRecord {
+            manifest,
+            ..seeded_record(&company)
+        };
+        let store = Arc::new(MemStore::seeded(record));
+
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        let tool = SpawnTaskTool::new(queue.clone(), company.clone(), store.clone());
+        let grounded = tool
+            .execute(json!({ "title": "Fix the outage", "assignee": "ENG" }))
+            .await
+            .expect("execute");
+        assert!(!grounded.is_error, "{}", grounded.text());
+
+        let unassigned_tool = SpawnTaskTool::new(queue.clone(), company, store);
+        let unassigned = unassigned_tool
+            .execute(json!({ "title": "Untargeted work" }))
+            .await
+            .expect("execute");
+        assert!(!unassigned.is_error, "{}", unassigned.text());
+
+        let drained = queue.drain(MAX_DELEGATIONS_PER_TURN);
+        assert_eq!(
+            drained,
+            vec![
+                Delegation::SpawnTask {
+                    title: "Fix the outage".to_string(),
+                    note: None,
+                    assignee: Some("eng".to_string()),
+                },
+                Delegation::SpawnTask {
+                    title: "Untargeted work".to_string(),
+                    note: None,
+                    assignee: None,
+                },
+            ],
+            "a display name grounds to the canonical roster id, and no assignee is queued as \
+             None rather than being pushed through the resolver at all"
+        );
+    }
+
+    /// A `CompanyStore` that genuinely partitions by company — unlike
+    /// `MemStore`, which ignores the `id` argument and answers for whichever
+    /// company it was seeded with regardless of who asks. Needed to prove
+    /// `spawn_task`'s grounding actually scopes its lookup to `self.company`
+    /// rather than happening to work because every test fixture only ever
+    /// holds one company's record.
+    struct TenantScopedCompanyStore {
+        records: std::collections::HashMap<String, CompanyRecord>,
+    }
+
+    #[async_trait::async_trait]
+    impl CompanyStore for TenantScopedCompanyStore {
+        async fn load(&self, id: &CompanyId) -> crate::Result<Option<CompanyRecord>> {
+            Ok(self.records.get(id.as_ref()).cloned())
+        }
+        async fn save(&self, _record: &CompanyRecord) -> crate::Result<()> {
+            unimplemented!("not exercised by this test")
+        }
+        async fn list(&self) -> crate::Result<Vec<CompanySummary>> {
+            Ok(Vec::new())
+        }
+        async fn append_ledger(&self, _id: &CompanyId, _entry: LedgerEntry) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// AUTH-axis (HT-074): `spawn_task`'s grounding must scope its roster
+    /// lookup to the tool's OWN company (`self.company`), never to a
+    /// different one — a teammate id that is real, but only on ANOTHER
+    /// company's roster, must be refused exactly as an invented id would be,
+    /// not accidentally admitted through a leaked cross-tenant read.
+    #[tokio::test]
+    async fn spawn_task_grounds_only_against_its_own_companys_roster() {
+        let acme = CompanyId::new("acme");
+        let beta = CompanyId::new("beta");
+        let beta_manifest = toml::from_str(
+            r#"
+[company]
+name = "Beta"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+
+[[agent]]
+id = "eng"
+role = "Engineer"
+"#,
+        )
+        .expect("valid manifest");
+        let mut records = std::collections::HashMap::new();
+        records.insert("acme".to_string(), seeded_record(&acme));
+        records.insert(
+            "beta".to_string(),
+            CompanyRecord {
+                manifest: beta_manifest,
+                ..seeded_record(&beta)
+            },
+        );
+        let store = Arc::new(TenantScopedCompanyStore { records });
+
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        let tool = SpawnTaskTool::new(queue.clone(), acme, store);
+
+        let outcome = tool
+            .execute(json!({ "title": "Fix the outage", "assignee": "eng" }))
+            .await
+            .unwrap();
+        assert!(
+            outcome.is_error,
+            "a teammate id real only on a DIFFERENT company's roster must be refused, not \
+             leaked in: {}",
+            outcome.text()
+        );
+        assert_eq!(queue.queued(), 0);
+    }
+
+    /// FAIL-axis (HT-074): when the company record cannot be read at all —
+    /// the same store failure `DelegateToDeskTool`/`DelegateToTeammateTool`
+    /// fail OPEN on for the orchestrator's own unrestricted copy (see
+    /// `Grounding::ungrounded`) — `spawn_task` must fail open too, not refuse
+    /// to open a card just because the roster could not be checked this
+    /// instant. The assignee is queued exactly as typed, unresolved, the same
+    /// as it has always been for a request with no assignee to ground.
+    #[tokio::test]
+    async fn spawn_task_fails_open_when_the_company_record_cannot_be_read() {
+        struct BrokenStore;
+        #[async_trait::async_trait]
+        impl CompanyStore for BrokenStore {
+            async fn load(&self, _id: &CompanyId) -> crate::Result<Option<CompanyRecord>> {
+                Err(crate::OpenCompanyError::Store("store is down".to_string()))
+            }
+            async fn save(&self, _record: &CompanyRecord) -> crate::Result<()> {
+                Ok(())
+            }
+            async fn list(&self) -> crate::Result<Vec<CompanySummary>> {
+                Ok(Vec::new())
+            }
+            async fn append_ledger(
+                &self,
+                _id: &CompanyId,
+                _entry: LedgerEntry,
+            ) -> crate::Result<()> {
+                Ok(())
+            }
+        }
+
+        let company = CompanyId::new("acme");
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        let tool = SpawnTaskTool::new(queue.clone(), company, Arc::new(BrokenStore));
+
+        let outcome = tool
+            .execute(json!({ "title": "Investigate the outage", "assignee": "eng" }))
+            .await
+            .unwrap();
+        assert!(
+            !outcome.is_error,
+            "a store failure must not block opening the card: {}",
+            outcome.text()
+        );
+        let drained = queue.drain(MAX_DELEGATIONS_PER_TURN);
+        assert_eq!(
+            drained,
+            vec![Delegation::SpawnTask {
+                title: "Investigate the outage".to_string(),
+                note: None,
+                assignee: Some("eng".to_string()),
+            }],
+            "the assignee is queued as typed, unresolved, when grounding could not run at all"
+        );
     }
 
     /// FAIL-axis (HT-076): every fixture in this module hand-writes its

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -2416,6 +2416,138 @@ mod tests {
         );
     }
 
+    /// INPUT-axis (TOOL-004): the brake classifies purely on `tool` and the
+    /// INCOMING call's own arguments (`is_external_effect`), never on whether
+    /// those arguments happen to match a live grant. A malformed/empty
+    /// argument object — missing every field the grant itself was minted
+    /// with — must still be denied under readonly, and the unrelated,
+    /// well-formed grant must still be left intact rather than being touched
+    /// (or the classifier panicking) on the garbage shape.
+    #[tokio::test]
+    async fn a_readonly_denial_on_malformed_arguments_still_leaves_the_grant_intact() {
+        let queue = ApprovalRequestQueue::default();
+        let grants = queue.grants();
+        let well_formed_args = serde_json::json!({ "amount_usd": 40.0 });
+        grants.grant(granted("finance", "payment.send", well_formed_args.clone()));
+
+        let locked_down = policy("readonly", &[], None)
+            .with_requests(queue)
+            .with_agent("finance");
+        assert!(
+            matches!(
+                locked_down
+                    .check(&request("payment.send", serde_json::json!({})))
+                    .await,
+                ToolPolicyDecision::Deny { .. }
+            ),
+            "readonly must deny an external-effect call even with a garbage/empty argument \
+             object, not just a well-formed one"
+        );
+
+        let released = policy("full", &[], None)
+            .with_requests(ApprovalRequestQueue::with_grants(grants))
+            .with_agent("finance");
+        assert_eq!(
+            released
+                .check(&request("payment.send", well_formed_args))
+                .await,
+            ToolPolicyDecision::Allow,
+            "the well-formed grant must be untouched by a denial evaluated against unrelated, \
+             malformed arguments"
+        );
+    }
+
+    /// CONC-axis (TOOL-004): the brake's early `return` happens strictly
+    /// before `consume_grant` is ever called, so it should be impossible for
+    /// a race to sneak a grant redemption in underneath a readonly deny. Two
+    /// threads hammer the SAME live grant concurrently while readonly, via
+    /// worker threads and a barrier — not `tokio::join!`, which has no
+    /// suspension point here to interleave on and would just run the two
+    /// calls to completion one after the other. Both must be denied, and the
+    /// grant must still redeem exactly once after the brake releases.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_calls_against_a_readonly_denied_grant_never_consume_it() {
+        use std::sync::{Arc, Barrier};
+
+        let queue = ApprovalRequestQueue::default();
+        let grants = queue.grants();
+        let args = serde_json::json!({ "amount_usd": 40.0 });
+        grants.grant(granted("finance", "payment.send", args.clone()));
+
+        let locked_down = Arc::new(
+            policy("readonly", &[], None)
+                .with_requests(queue)
+                .with_agent("finance"),
+        );
+        let gate = Arc::new(Barrier::new(2));
+
+        let call = |policy: Arc<ApprovalPolicy>, args: serde_json::Value, gate: Arc<Barrier>| {
+            tokio::task::spawn_blocking(move || {
+                gate.wait();
+                tokio::runtime::Handle::current()
+                    .block_on(policy.check(&request("payment.send", args)))
+            })
+        };
+        let a = call(locked_down.clone(), args.clone(), gate.clone());
+        let b = call(locked_down.clone(), args.clone(), gate);
+        let (a, b) = (a.await.expect("joins"), b.await.expect("joins"));
+        assert!(matches!(a, ToolPolicyDecision::Deny { .. }), "{a:?}");
+        assert!(matches!(b, ToolPolicyDecision::Deny { .. }), "{b:?}");
+
+        let released = policy("full", &[], None)
+            .with_requests(ApprovalRequestQueue::with_grants(grants))
+            .with_agent("finance");
+        assert_eq!(
+            released.check(&request("payment.send", args.clone())).await,
+            ToolPolicyDecision::Allow,
+            "the grant must still be there, unconsumed by the race"
+        );
+        assert!(
+            matches!(
+                released.check(&request("payment.send", args)).await,
+                ToolPolicyDecision::RequireApproval { .. } | ToolPolicyDecision::Deny { .. }
+            ),
+            "and it must redeem exactly once — a second call must not still be Allow"
+        );
+    }
+
+    /// BOUND-axis (TOOL-004): the brake denies on the tool's classification,
+    /// not on the declared amount, so it must hold at both ends of the amount
+    /// range a grant could carry — a zero-amount call and one carrying an
+    /// enormous declared amount both deny under readonly with their
+    /// respective grants left intact.
+    #[tokio::test]
+    async fn a_readonly_denial_holds_at_zero_and_at_a_very_large_declared_amount() {
+        for amount in [0.0_f64, 1_000_000_000.0_f64] {
+            let queue = ApprovalRequestQueue::default();
+            let grants = queue.grants();
+            let args = serde_json::json!({ "amount_usd": amount });
+            grants.grant(granted("finance", "payment.send", args.clone()));
+
+            let locked_down = policy("readonly", &[], None)
+                .with_requests(queue)
+                .with_agent("finance");
+            assert!(
+                matches!(
+                    locked_down
+                        .check(&request("payment.send", args.clone()))
+                        .await,
+                    ToolPolicyDecision::Deny { .. }
+                ),
+                "amount {amount}: readonly must deny regardless of the amount at either bound"
+            );
+
+            let released = policy("full", &[], None)
+                .with_requests(ApprovalRequestQueue::with_grants(grants))
+                .with_agent("finance");
+            assert_eq!(
+                released.check(&request("payment.send", args)).await,
+                ToolPolicyDecision::Allow,
+                "amount {amount}: the grant must still be redeemable once the brake releases"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn disabled_policy_hitl_keeps_readonly_as_a_hard_denial() {
         let p = policy("readonly", &[], None).with_policy_hitl_disabled();

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -5315,6 +5315,189 @@ mod tests {
         );
     }
 
+    /// An agent-scoped standing deny, for the four cases below. `scope`
+    /// mirrors the URL a `web_fetch` call to `docs.rs` computes through
+    /// `standing_scope_of`, so a call with a different (or absent) `url`
+    /// argument does not fall under it.
+    fn agent_standing_deny(
+        id: &str,
+        agent: &str,
+        expires_at_millis: u64,
+    ) -> crate::runtime::grants::StandingGrant {
+        crate::runtime::grants::StandingGrant {
+            id: crate::runtime::grants::GrantId::new(id),
+            agent: agent.to_string(),
+            workflow: None,
+            tool: "web_fetch".to_string(),
+            verdict: Verdict::Deny,
+            granted_by: crate::ports::types::Actor {
+                kind: crate::ports::types::ActorKind::User,
+                id: "user-1".into(),
+            },
+            approval_id: crate::ports::types::ApprovalId::new("appr-1"),
+            at_millis: 1_000,
+            expires_at_millis,
+            origin_thread: None,
+            origin_parent: None,
+            origin_task: None,
+            scope: Some("https://docs.rs".to_string()),
+        }
+    }
+
+    /// INPUT-axis (TOOL-006): `standing_deny_applies` derives the call's own
+    /// scope from its arguments (`standing_scope_of`) before matching it
+    /// against the grant's stored scope. A call with no `url` at all — a
+    /// malformed shape relative to what `web_fetch` normally carries —
+    /// resolves to no scope, and a scoped denial requires an EXACT match
+    /// (`admits_scope`), so it must not apply to a scope-less call rather
+    /// than being (mis)treated as a wildcard match either way.
+    #[tokio::test]
+    async fn a_scoped_standing_deny_does_not_apply_to_a_call_with_no_url_argument() {
+        let grants = GrantSet::default();
+        let queue = ApprovalRequestQueue::with_grants(grants.clone());
+        grants.grant_standing(agent_standing_deny(
+            "deny-1",
+            "engineer",
+            crate::ports::now_millis() + 60 * 60 * 1000,
+        ));
+
+        let p = policy("full", &[], None)
+            .with_requests(queue)
+            .with_agent("engineer");
+        let decision = p.check(&request("web_fetch", serde_json::json!({}))).await;
+        assert!(
+            !matches!(decision, ToolPolicyDecision::Deny { .. }),
+            "a scoped denial must not match a call whose scope could not be computed at all: \
+             {decision:?}"
+        );
+    }
+
+    /// CONC-axis (TOOL-006): unlike a single-use grant, a standing denial is
+    /// never consumed — two concurrent calls against the SAME live denial
+    /// must both see it, with no race letting one slip through as if the
+    /// first call had "used it up". Driven from real worker threads and a
+    /// barrier, not `tokio::join!` — `check` has no suspension point here to
+    /// interleave two joined futures on, so they would just run serially and
+    /// prove nothing about a race.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_calls_against_the_same_standing_deny_are_both_refused() {
+        use std::sync::{Arc, Barrier};
+
+        let grants = GrantSet::default();
+        let queue = ApprovalRequestQueue::with_grants(grants.clone());
+        grants.grant_standing(agent_standing_deny(
+            "deny-1",
+            "engineer",
+            crate::ports::now_millis() + 60 * 60 * 1000,
+        ));
+        let p = Arc::new(
+            policy("full", &[], None)
+                .with_requests(queue)
+                .with_agent("engineer"),
+        );
+        let gate = Arc::new(Barrier::new(2));
+        let call = |p: Arc<ApprovalPolicy>, gate: Arc<Barrier>| {
+            tokio::task::spawn_blocking(move || {
+                gate.wait();
+                tokio::runtime::Handle::current().block_on(p.check(&request(
+                    "web_fetch",
+                    serde_json::json!({ "url": "https://docs.rs/x" }),
+                )))
+            })
+        };
+        let a = call(p.clone(), gate.clone());
+        let b = call(p, gate);
+        let (a, b) = (a.await.expect("joins"), b.await.expect("joins"));
+        assert!(matches!(a, ToolPolicyDecision::Deny { .. }), "{a:?}");
+        assert!(matches!(b, ToolPolicyDecision::Deny { .. }), "{b:?}");
+    }
+
+    /// FAIL-axis (TOOL-006): a standing denial past its own TTL is stale data
+    /// — the mint side's sweep may not have gotten to it yet — and must not
+    /// keep enforcing a refusal the operator's decision no longer covers.
+    #[tokio::test]
+    async fn an_expired_standing_deny_no_longer_applies() {
+        let grants = GrantSet::default();
+        let queue = ApprovalRequestQueue::with_grants(grants.clone());
+        grants.grant_standing(agent_standing_deny(
+            "deny-1",
+            "engineer",
+            crate::ports::now_millis().saturating_sub(1_000),
+        ));
+
+        let p = policy("full", &[], None)
+            .with_requests(queue)
+            .with_agent("engineer");
+        let decision = p
+            .check(&request(
+                "web_fetch",
+                serde_json::json!({ "url": "https://docs.rs/x" }),
+            ))
+            .await;
+        assert!(
+            !matches!(decision, ToolPolicyDecision::Deny { .. }),
+            "an expired standing denial must not still be enforced: {decision:?}"
+        );
+    }
+
+    /// BOUND-axis (TOOL-006): the expiry boundary is strictly `<`
+    /// (`StandingGrant::is_live_at`) — live comfortably before its deadline,
+    /// already expired exactly AT it. Pinned through the policy entry point,
+    /// not just the grant set directly, so a change to either side of that
+    /// `<` is caught where it is actually consulted.
+    ///
+    /// The "live" side uses a generous window rather than the deadline minus
+    /// one millisecond: `check` calls `now_millis()` again internally, so a
+    /// one-millisecond margin captured before the call is not guaranteed to
+    /// survive the dispatch to `standing_deny_applies` and would make this
+    /// test flaky on nothing but scheduling noise. The "expired" side has no
+    /// such problem — real time only moves forward, so a deadline equal to a
+    /// `now` captured strictly before the call is guaranteed to have already
+    /// passed by the time `check` reads the clock again.
+    #[tokio::test]
+    async fn a_standing_deny_expires_exactly_at_its_deadline_not_after() {
+        let live_grants = GrantSet::default();
+        live_grants.grant_standing(agent_standing_deny(
+            "deny-1",
+            "engineer",
+            crate::ports::now_millis() + 60 * 60 * 1000,
+        ));
+        let live = policy("full", &[], None)
+            .with_requests(ApprovalRequestQueue::with_grants(live_grants))
+            .with_agent("engineer");
+        assert!(
+            matches!(
+                live.check(&request(
+                    "web_fetch",
+                    serde_json::json!({ "url": "https://docs.rs/x" })
+                ))
+                .await,
+                ToolPolicyDecision::Deny { .. }
+            ),
+            "comfortably before its deadline the denial must still be live"
+        );
+
+        let now = crate::ports::now_millis();
+        let expired_grants = GrantSet::default();
+        expired_grants.grant_standing(agent_standing_deny("deny-1", "engineer", now));
+        let expired = policy("full", &[], None)
+            .with_requests(ApprovalRequestQueue::with_grants(expired_grants))
+            .with_agent("engineer");
+        assert!(
+            !matches!(
+                expired
+                    .check(&request(
+                        "web_fetch",
+                        serde_json::json!({ "url": "https://docs.rs/x" })
+                    ))
+                    .await,
+                ToolPolicyDecision::Deny { .. }
+            ),
+            "at the deadline instant itself (now already >= expires_at_millis by the time \
+             `check` reads the clock) the denial must already read as expired"
+        );
+    }
+
     // --- The per-agent daily spend cap (issue #304) ---------------------------
 
     use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -4339,6 +4339,74 @@ mod tests {
         );
     }
 
+    /// CONC-axis (TOOL-021): the cap in `the_drain_is_capped_and_empties_the_queue`
+    /// above is proven with sequential pushes — each `check` is awaited before
+    /// the next fires. This drives the same overflow from genuinely concurrent
+    /// pushes, via real worker threads and a barrier (not `tokio::join!`, which
+    /// has no suspension point around `push`'s synchronous body and would just
+    /// serialise the two futures on one task — the exact false confidence this
+    /// lane's brief warns about). `push`'s per-scope `Mutex` must make every
+    /// racing call land exactly once: no card lost to a race, none double
+    /// counted, and `requests.len() + discarded` must equal the number of
+    /// calls that actually raced, every round.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_pushes_past_the_cap_are_never_lost_or_double_counted() {
+        use std::sync::{Arc, Barrier};
+
+        const RACERS: usize = MAX_APPROVAL_REQUESTS_PER_TURN + 5;
+
+        for round in 0..20 {
+            let queue = ApprovalRequestQueue::default();
+            let gate = Arc::new(Barrier::new(RACERS));
+
+            let mut handles = Vec::with_capacity(RACERS);
+            for i in 0..RACERS {
+                let queue = queue.clone();
+                let gate = gate.clone();
+                handles.push(tokio::task::spawn_blocking(move || {
+                    gate.wait();
+                    queue.push(ApprovalRequest {
+                        tool: "composio_execute".to_string(),
+                        reason: format!("racer {i}"),
+                        effect: Effect {
+                            kind: format!("composio.call.{i}"),
+                            group: EffectGroup::Other,
+                            amount_usd: None,
+                            established_thread: false,
+                            first_time_counterparty: false,
+                            payload: serde_json::json!({ "racer": i }),
+                            agent: None,
+                            run_id: None,
+                        },
+                    });
+                }));
+            }
+            for handle in handles {
+                handle.await.expect("racer joins");
+            }
+
+            let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+            assert_eq!(
+                drained.requests.len(),
+                MAX_APPROVAL_REQUESTS_PER_TURN,
+                "round {round}: the drain must be exactly full, not short a card a race lost"
+            );
+            assert_eq!(
+                drained.discarded,
+                RACERS - MAX_APPROVAL_REQUESTS_PER_TURN,
+                "round {round}: every racer that did not fit must be counted, not silently \
+                 dropped from the tally"
+            );
+            let reasons: std::collections::HashSet<&String> =
+                drained.requests.iter().map(|r| &r.reason).collect();
+            assert_eq!(
+                reasons.len(),
+                MAX_APPROVAL_REQUESTS_PER_TURN,
+                "round {round}: no racer's card duplicated another's under the race: {reasons:?}"
+            );
+        }
+    }
+
     /// The ordinary path says nothing. A notice on every turn would train the
     /// operator to ignore the one that matters.
     #[tokio::test]

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -1797,13 +1797,33 @@ impl ToolPolicy for ApprovalPolicy {
         // family lives in `toolbelt`; this arm only joins them.
         if !self.connected_composio_toolkits.is_empty()
             && crate::harness::toolbelt::is_web_request_tool(tool)
-            && let Some(url) = request.arguments.get("url").and_then(|v| v.as_str())
-            && let Some(reason) = crate::harness::composio_catalog::web_call_deflection(
-                &self.connected_composio_toolkits,
-                url,
-            )
         {
-            return ToolPolicyDecision::deny(reason);
+            // Every tool this arm recognises declares `url` as a REQUIRED
+            // string in its own schema, so a call that does not carry one that
+            // way is not a legitimate call this guardrail failed to reach — it
+            // is malformed relative to the tool's own contract. Falling
+            // through silently would let exactly that malformed shape walk
+            // past the one thing standing between `full` autonomy and a
+            // connected provider's API host, so this arm fails CLOSED on it
+            // instead of treating "could not read a url" as "nothing to
+            // check".
+            match request.arguments.get("url").and_then(|v| v.as_str()) {
+                Some(url) => {
+                    if let Some(reason) = crate::harness::composio_catalog::web_call_deflection(
+                        &self.connected_composio_toolkits,
+                        url,
+                    ) {
+                        return ToolPolicyDecision::deny(reason);
+                    }
+                }
+                None => {
+                    return ToolPolicyDecision::deny(format!(
+                        "'{tool}' must be called with `url` as a plain string so it can be \
+                         checked against this company's connected toolkits; retry with a \
+                         string `url`"
+                    ));
+                }
+            }
         }
 
         // 1. `readonly` outranks a grant — the brake wins (issue #243).
@@ -7381,6 +7401,189 @@ mod tests {
                 "{tool} must be deflected to Composio, got {decision:?}"
             );
         }
+    }
+
+    /// INPUT-axis (TOOL-003): the deflection reads `arguments["url"]` as a
+    /// plain string. A call missing `url` entirely — despite every deflectable
+    /// tool declaring it required — must not read as "nothing to check" and
+    /// walk past the guardrail; it must fail CLOSED, the same as a real
+    /// connected-provider hit would.
+    #[tokio::test]
+    async fn s2_deflection_fails_closed_when_url_is_missing() {
+        let p = full_with_connected(&["github"]);
+        let decision = p
+            .check(&request(
+                "http_request",
+                serde_json::json!({ "method": "GET" }),
+            ))
+            .await;
+        assert!(
+            matches!(decision, ToolPolicyDecision::Deny { .. }),
+            "a missing `url` must not walk past the guardrail unchecked: {decision:?}"
+        );
+    }
+
+    /// The other half: `url` present but not a plain string — a number, an
+    /// object, an array — is exactly as unreadable to `.as_str()` as a missing
+    /// key, so it must fail CLOSED on the same terms rather than silently
+    /// passing through because the type did not match.
+    #[tokio::test]
+    async fn s2_deflection_fails_closed_when_url_is_not_a_string() {
+        let p = full_with_connected(&["github"]);
+        for bad_url in [
+            serde_json::json!(12345),
+            serde_json::json!({ "host": "api.github.com" }),
+            serde_json::json!(["https://api.github.com"]),
+            serde_json::json!(null),
+        ] {
+            let decision = p
+                .check(&request(
+                    "http_request",
+                    serde_json::json!({ "url": bad_url }),
+                ))
+                .await;
+            assert!(
+                matches!(decision, ToolPolicyDecision::Deny { .. }),
+                "a non-string `url` ({bad_url:?}) must not walk past the guardrail unchecked: \
+                 {decision:?}"
+            );
+        }
+    }
+
+    /// Requirement #2 still holds once the arm fails closed: with NO connected
+    /// toolkits at all, a missing/malformed `url` is not this guardrail's
+    /// business — the arm's outer condition (`!connected_composio_toolkits.is_empty()`)
+    /// never engages, so the call falls through to whatever the ordinary
+    /// policy decides for an `http_request`/`curl`/`web_fetch` with no
+    /// bounded target. That ordinary decision may reasonably be a park (an
+    /// unbounded target is not automatically safe) — the property this pins
+    /// is narrower and precise: it must never be a DENY manufactured by THIS
+    /// arm, since with nothing connected the arm has nothing to deny it for.
+    #[tokio::test]
+    async fn s2_missing_url_passes_through_with_no_connected_toolkits() {
+        for tool in ["http_request", "curl", "web_fetch"] {
+            let decision = full_with_connected(&[])
+                .check(&request(tool, serde_json::json!({ "method": "GET" })))
+                .await;
+            assert!(
+                !matches!(decision, ToolPolicyDecision::Deny { .. }),
+                "with nothing connected, a missing `url` on `{tool}` must not be denied by this \
+                 arm: {decision:?}"
+            );
+        }
+    }
+
+    /// STATE-axis (TOOL-003): the "connected" state a company record supplies
+    /// is free text an operator or an upstream sync wrote, not a normalised
+    /// key, so it can arrive with stray casing or whitespace. Deflection must
+    /// still recognise it — the same normalisation
+    /// `http_request_to_a_connected_provider_is_denied_with_the_composio_route`
+    /// relies on implicitly, pinned here explicitly against a messy entry.
+    #[tokio::test]
+    async fn s2_deflection_normalises_a_messily_cased_connected_toolkit_entry() {
+        let p = full_with_connected(&["  GitHub  "]);
+        let decision = p
+            .check(&request(
+                "http_request",
+                serde_json::json!({ "url": "https://api.github.com/repos/o/r" }),
+            ))
+            .await;
+        assert!(
+            matches!(decision, ToolPolicyDecision::Deny { .. }),
+            "a connected entry with stray case/whitespace must still be recognised: {decision:?}"
+        );
+    }
+
+    /// FAIL-axis (TOOL-003): a `url` that IS a plain string but does not parse
+    /// as one (unlike the INPUT-axis cases above, which are the wrong JSON
+    /// *type*) intentionally passes through — `url::Url::parse` fails,
+    /// `web_call_deflection` has no host to check, and nothing this call could
+    /// reach depends on that host either, since the underlying web tool cannot
+    /// make an unparseable string into a request. Fail-open here is the
+    /// deliberate, safe direction; pinned so it is not confused with the
+    /// missing/wrong-type cases that were fixed to fail closed.
+    #[tokio::test]
+    async fn s2_deflection_passes_through_an_unparseable_url_string() {
+        let baseline = full_with_connected(&[])
+            .check(&request(
+                "http_request",
+                serde_json::json!({ "url": "not a url" }),
+            ))
+            .await;
+        let guarded = full_with_connected(&["github"])
+            .check(&request(
+                "http_request",
+                serde_json::json!({ "url": "not a url" }),
+            ))
+            .await;
+        assert_eq!(
+            guarded, baseline,
+            "a syntactically invalid url string cannot resolve to any host, so it must pass \
+             through exactly as if nothing were connected: {guarded:?}"
+        );
+    }
+
+    /// BOUND-axis (TOOL-003): the path-prefix boundary on a toolkit whose
+    /// table requires one (`gmail`'s `www.googleapis.com` entry). A path that
+    /// starts with the required prefix is caught; a path one character short
+    /// of it — missing the trailing slash the table requires — is not, and
+    /// must pass through rather than being caught by a looser `starts_with`.
+    #[tokio::test]
+    async fn s2_deflection_respects_the_path_prefix_boundary() {
+        let p = full_with_connected(&["gmail"]);
+        let inside = p
+            .check(&request(
+                "http_request",
+                serde_json::json!({ "url": "https://www.googleapis.com/gmail/v1/users/me" }),
+            ))
+            .await;
+        assert!(
+            matches!(inside, ToolPolicyDecision::Deny { .. }),
+            "a path starting with the required prefix must be caught: {inside:?}"
+        );
+
+        let one_short = p
+            .check(&request(
+                "http_request",
+                serde_json::json!({ "url": "https://www.googleapis.com/gmail" }),
+            ))
+            .await;
+        let baseline = full_with_connected(&[])
+            .check(&request(
+                "http_request",
+                serde_json::json!({ "url": "https://www.googleapis.com/gmail" }),
+            ))
+            .await;
+        assert_eq!(
+            one_short, baseline,
+            "a path one character short of the required prefix (no trailing slash) must not be \
+             caught by a looser match: {one_short:?}"
+        );
+    }
+
+    /// BOUND-axis (TOOL-003), the other edge: a connected-toolkit list that is
+    /// non-empty but holds only blank entries must behave like the empty-list
+    /// baseline — a stray blank string must not accidentally become a
+    /// wildcard that matches every host.
+    #[tokio::test]
+    async fn s2_deflection_skips_blank_connected_entries_without_matching_everything() {
+        let p = full_with_connected(&["", "   "]);
+        let decision = p
+            .check(&request(
+                "http_request",
+                serde_json::json!({ "url": "https://api.github.com/repos/o/r" }),
+            ))
+            .await;
+        let baseline = full_with_connected(&[])
+            .check(&request(
+                "http_request",
+                serde_json::json!({ "url": "https://api.github.com/repos/o/r" }),
+            ))
+            .await;
+        assert_eq!(
+            decision, baseline,
+            "blank connected entries must not match any host: {decision:?}"
+        );
     }
 
     /// The deflection outranks a single-use grant: a grant is an operator

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -2216,6 +2216,34 @@ mod tests {
         );
     }
 
+    /// BOUND-axis (TOOL-001): the boundary is a `Cell<bool>` that starts at
+    /// `false` inside every fresh `turn_scoped` call — the zero-vs-one
+    /// transition `an_explicit_request_refuses_later_calls_in_the_same_turn`
+    /// above only tests the "one" side of (the second request is denied),
+    /// never asserting that the FIRST request in a brand new turn is not
+    /// itself refused by a boundary nothing has tripped yet.
+    #[tokio::test]
+    async fn the_first_explicit_request_in_a_fresh_turn_is_not_refused() {
+        let queue = ApprovalRequestQueue::default();
+        let policy = policy("full", &[], None)
+            .with_policy_hitl_disabled()
+            .with_requests(queue.clone());
+        let claim = queue.claim(ApprovalScope::Cycle);
+
+        let first_request = claim
+            .scoped(queue.turn_scoped(policy.check(&request(
+                crate::harness::approval_tool::REQUEST_APPROVAL_TOOL,
+                serde_json::json!({ "title": "Ask", "question": "May I send this?" }),
+            ))))
+            .await;
+        assert_eq!(
+            first_request,
+            ToolPolicyDecision::Allow,
+            "the very first explicit request in a fresh turn must not be refused: \
+             {first_request:?}"
+        );
+    }
+
     #[tokio::test]
     async fn a_duplicate_explicit_request_still_establishes_a_fresh_turn_boundary() {
         let queue = ApprovalRequestQueue::default();


### PR DESCRIPTION
## Summary

Three defects in the harness, plus the cases that prove them and coverage across ten cells.

**The web-deflection brake walked past a malformed URL.** The S2 guardrail read `url` as `.and_then(as_str)` — so a missing key, or a `url` that was a number or an object, resolved to `None` and the whole check was skipped. That brake is the one thing standing between full autonomy and a connected provider's API host, and the shape that slipped past it is the shape an attacker picks. It now fails **closed** on both.

**`spawn_task` queued an assignee nobody had grounded.** `delegate_to_desk` and `delegate_to_teammate` both resolve a name against the live roster first; `spawn_task` did not, so it could open a card owned by a name no dispatch can reach. It now grounds the same way, refuses an unresolvable name, scopes the lookup to its own company, and fails open on a store read error rather than inventing a refusal.

**`read_task`'s description promised more than the render gives.** It advertised "every attempt's status" while the render truncates at ten — a claim the model reads and relies on.

Each was red-proved: the seam was broken, the case observed to fail for its own reason, the break reverted, the case observed to pass.

| Cell | Axes | Proved by breaking |
|---|---|---|
| TOOL-003 | INPUT, STATE, FAIL, BOUND | restoring `and_then(as_str)` → `RequireApproval` where `Deny` is expected |
| HT-074 | AUTH, INPUT, STATE, FAIL | removing the grounding block → 3 of 4 cases fail on refusal, cross-tenant leak, canonicalization |
| HT-072 | AUTH, LIMIT | reverting the description string → the false-claim assertion fires |
| TOOL-004 | INPUT, CONC, BOUND | CONC driven from worker threads and a barrier, not `join!` |
| TOOL-021 | CONC | a twenty-round concurrent-push race against the drain cap |
| TOOL-006 | INPUT, CONC, FAIL, BOUND | — |
| REQ-002 | STATE, BOUND | — |
| TOOL-001 | BOUND | — |

Two `#[ignore]`d cases were removed rather than left: one pinned the `spawn_task` defect this fixes, the other asserted the behaviour that was wrong. A test that documents a defect and then excuses itself from failing over it keeps the suite green while the defect ships.

**TOOL-007 is declined, not closed.** Its real defect — an agent standing ALLOW being unmintable in production — lives in `cycle.rs::check_broadly_scoped`, outside this change. The read-side arm those axes would exercise already carries about a dozen dedicated cases; more against the same arm would be padding.

## API Or Behavior Changes

A tool call whose `url` argument is absent or not a string is now denied by the deflection guard rather than allowed. `spawn_task` refuses an assignee that resolves to nobody on the company's roster, where it previously opened the card anyway. `read_task`'s description no longer claims to return every attempt.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — the default lane and `--no-deps --features openhuman`, both clean
- [ ] `cargo build --all-targets` — N/A: the clippy and test lanes build the same targets and are clean
- [x] `cargo test` — `cargo test --locked --features openhuman --tests`: 7,517 passed, 0 failed

## Documentation

No docs needed — each change closes a gap against behaviour the affected modules' own doc comments already describe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task assignment now validates assignees against the current company roster and standardizes recognized names.
  * Tasks are isolated by company, preventing access to tasks from other companies.
  * Unassigned tasks remain supported when no assignee is provided.

* **Bug Fixes**
  * Web requests with missing or invalid URLs are now denied with guidance to provide a valid string URL.
  * Approval limits and repeated requests are handled consistently across turns and concurrent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->