### PR TITLE
test(server): pin the resolve race, the skills write lock, and the bridged page's reach

### DIFF
--- a/src/server/graphql/mod.rs
+++ b/src/server/graphql/mod.rs
@@ -192,3 +192,197 @@ pub(crate) fn iso8601(at_millis: u64) -> String {
 
 #[cfg(test)]
 mod test;
+
+/// What a page authored by an agent can reach when its `oc:graphql` request is
+/// bridged to this handler.
+///
+/// The console's page bridge forwards the request under the **operator's own
+/// authenticated session** — it narrows nothing per page. So the only things
+/// standing between an agent-authored page and the operator's whole read plane
+/// are properties of this module: [`EmptyMutation`], which is why a bridged
+/// document can never write, and [`GqlAuth::authorize`], which is why it can
+/// never read across companies. Both were load-bearing and neither was
+/// asserted here.
+#[cfg(test)]
+mod bridge_scope_test {
+    use std::sync::Arc;
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use crate::ports::CompanyStore;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::server::test_support::{fixed_cookie, seed_fixed_admin};
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    /// Two companies on one host, each with its own signed-in admin — the shape
+    /// a per-page scope question needs, since a single-company host cannot tell
+    /// "narrowed correctly" from "there was nothing else to reach".
+    async fn state_with_two_companies(home: &std::path::Path) -> AppState {
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let state = AppState::new(AppConfig::default()).with_home(home.to_path_buf());
+        for name in ["acme", "globex"] {
+            let id = CompanyId::new(name);
+            let manifest = super::test::manifest();
+            store
+                .save(&CompanyRecord {
+                    overlay_retired_agents: Vec::new(),
+                    overlay_agent_edits: Vec::new(),
+                    id: id.clone(),
+                    manifest: manifest.clone(),
+                    ledger: Vec::new(),
+                    lifecycle: "running".to_string(),
+                    overlay_agents: Vec::new(),
+                    overlay_desk_members: Vec::new(),
+                    overlay_desk_order: Vec::new(),
+                    overlay_desks: Vec::new(),
+                    overlay_workflows: Vec::new(),
+                    overlay_budgets: Vec::new(),
+                    overlay_policy: None,
+                    overlay_tool_grants: None,
+                    overlay_desk_tools: Default::default(),
+                    disabled_workflows: Vec::new(),
+                    template_provenance: None,
+                    setup: None,
+                    name_confirmed: false,
+                    activation_completed_at: None,
+                    created_at_millis: None,
+                })
+                .await
+                .unwrap();
+            let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+                .with_id(id.clone())
+                .build()
+                .await
+                .unwrap();
+            state.registry().insert(id, Arc::new(runtime));
+            seed_fixed_admin(&state, name).await;
+        }
+        state
+    }
+
+    async fn query_as(app: &axum::Router, cookie: &str, body: &str) -> serde_json::Value {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/graphql")
+                    .header("content-type", "application/json")
+                    .header("cookie", cookie)
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// AUTH. A bridged request carries the operator's full session, so what a
+    /// page may do is decided entirely here: it may not write, because the
+    /// schema has no mutation root, and it may not read another company,
+    /// because [`GqlAuth::authorize`] refuses a user principal any company but
+    /// their own.
+    ///
+    /// The mutation is a *syntactically valid* document, so the only thing that
+    /// can refuse it is the absent mutation root — a parse error would prove
+    /// nothing.
+    #[tokio::test]
+    async fn a_bridged_request_can_neither_write_nor_read_another_company() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let state = state_with_two_companies(home_dir.path()).await;
+        let app = router(state);
+        let acme = fixed_cookie("acme");
+
+        let value = query_as(&app, &acme, r#"{"query":"mutation { __typename }"}"#).await;
+        assert!(
+            value["data"].is_null(),
+            "a bridged page executed a mutation: {value}"
+        );
+        let errors = value["errors"].as_array().expect("an errors array");
+        assert!(
+            errors.iter().any(|e| e["message"]
+                .as_str()
+                .is_some_and(|m| m.to_ascii_lowercase().contains("mutation"))),
+            "the refusal must be the absent mutation root, got {value}"
+        );
+
+        let value = query_as(
+            &app,
+            &acme,
+            r#"{"query":"{ company(id: \"globex\") { id } }"}"#,
+        )
+        .await;
+        assert!(
+            value["data"]["company"].is_null(),
+            "a bridged page read another company: {value}"
+        );
+        assert_eq!(
+            value["errors"][0]["extensions"]["code"], "forbidden",
+            "reaching another company must be refused as forbidden, got {value}"
+        );
+
+        let value = query_as(&app, &acme, r#"{"query":"{ companies { id } }"}"#).await;
+        let ids: Vec<&str> = value["data"]["companies"]
+            .as_array()
+            .expect("a companies array")
+            .iter()
+            .map(|c| c["id"].as_str().expect("an id"))
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["acme"],
+            "the roster must not disclose that another company exists: {value}"
+        );
+    }
+
+    /// CONC. The schema is built once at startup and shared by every request
+    /// ([`build_schema`]); only the principal is per-request, injected as
+    /// request data by [`graphql_handler`]. So a bridged page opened by one
+    /// operator and a console open as another are executing against the same
+    /// object at the same time, and the thing that must not be shared is the
+    /// principal.
+    ///
+    /// Interleaved on purpose: alternating callers, all in flight together,
+    /// each of which must see only its own company.
+    #[tokio::test]
+    async fn concurrent_requests_never_borrow_another_callers_principal() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let state = state_with_two_companies(home_dir.path()).await;
+        let app = router(state);
+
+        let pending = (0..24).map(|i| {
+            let company = if i % 2 == 0 { "acme" } else { "globex" };
+            let app = app.clone();
+            async move {
+                let value = query_as(
+                    &app,
+                    &fixed_cookie(company),
+                    r#"{"query":"{ companies { id } }"}"#,
+                )
+                .await;
+                (company, value)
+            }
+        });
+
+        for (company, value) in futures::future::join_all(pending).await {
+            let ids: Vec<&str> = value["data"]["companies"]
+                .as_array()
+                .expect("a companies array")
+                .iter()
+                .map(|c| c["id"].as_str().expect("an id"))
+                .collect();
+            assert_eq!(
+                ids,
+                vec![company],
+                "a concurrent request answered under another caller's principal: {value}"
+            );
+        }
+    }
+}

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -16350,4 +16350,203 @@ mode = "full"
             }
         }
     }
+
+    // -- Deciding an approval: which states admit it, and what a failure costs --
+
+    /// STATE. `run_resolve` asks `ensure_running` before it touches the gate,
+    /// and the ordering is the guarantee: a company that has stopped accepting
+    /// work must refuse the decision *and leave the approval parked*, so the
+    /// operator still has a card to decide once it is running again.
+    ///
+    /// A refusal that consumed the park would be worse than no refusal at all —
+    /// the effect would be neither approved nor decidable.
+    #[tokio::test]
+    async fn resolving_on_a_paused_company_is_refused_and_leaves_the_approval_parked() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let approval = park_for_extend(&runtime, "appr-paused", crate::ports::now_millis()).await;
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+        let app = router(state);
+
+        let lifecycle = |verb: &str| {
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/companies/acme/{verb}"))
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap()
+        };
+
+        let paused = app.clone().oneshot(lifecycle("pause")).await.unwrap();
+        assert_eq!(paused.status(), StatusCode::OK, "the company is now paused");
+
+        for verdict in ["approve", "deny"] {
+            let refused = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(format!("/api/v1/company/approvals/{approval}"))
+                        .header("cookie", &cookie)
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            serde_json::json!({ "verdict": verdict }).to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                refused.status(),
+                StatusCode::CONFLICT,
+                "a paused company answered a {verdict} instead of refusing it"
+            );
+        }
+
+        assert!(
+            runtime.pending_approvals().iter().any(|p| p.id == approval),
+            "the refusal must leave the approval decidable, not spend it"
+        );
+        assert_eq!(
+            runtime.grants.live_count(),
+            0,
+            "and it must mint nothing on the way out"
+        );
+
+        let resumed = app.clone().oneshot(lifecycle("resume")).await.unwrap();
+        assert_eq!(resumed.status(), StatusCode::OK);
+        let allowed = app
+            .oneshot(resolve_request(
+                &approval,
+                serde_json::json!({ "verdict": "approve", "detach": true }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            allowed.status(),
+            StatusCode::OK,
+            "the same decision lands once the company is running again"
+        );
+    }
+
+    /// CONC. Two operators on the same card — or one on a double click — reach
+    /// this route at the same time. The approval may settle once and buy one
+    /// permission; the loser must be told it was already decided rather than
+    /// minting a second grant against the same effect.
+    ///
+    /// Distinct from [`a_second_resolve_reports_already_resolved_and_mints_nothing`],
+    /// which sends its second request only after the first has fully settled:
+    /// that one passes even if the parked-set take is a non-atomic
+    /// check-then-remove, because there is no window for the two to overlap in.
+    /// These two are in flight together.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn two_simultaneous_resolves_settle_once_and_mint_one_permission() {
+        let home_dir = home();
+        let c = stalled_company(home_dir.path()).await;
+        c.release.notify_one();
+
+        let approve = || {
+            resolve_request(
+                &c.approval_id,
+                serde_json::json!({ "verdict": "approve", "detach": true }),
+            )
+        };
+        // Spawned onto a multi-threaded runtime, so these genuinely overlap
+        // rather than being polled to completion one at a time. Eight rather
+        // than two because the window a lost take opens is narrow: one pair can
+        // miss it by scheduling luck, and a race this test cannot lose is worth
+        // more than a tidier number.
+        let racers: Vec<_> = (0..8)
+            .map(|_| tokio::spawn(c.app.clone().oneshot(approve())))
+            .collect();
+
+        let mut settled = Vec::new();
+        for racer in racers {
+            let response = racer
+                .await
+                .expect("the request task did not panic")
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = body_json(response).await;
+            settled.push(
+                body["alreadyResolved"]
+                    .as_bool()
+                    .unwrap_or_else(|| panic!("a receipt says whether it settled: {body}")),
+            );
+        }
+        assert_eq!(
+            settled.iter().filter(|already| !**already).count(),
+            1,
+            "exactly one simultaneous resolve may settle the approval, got {settled:?}"
+        );
+
+        assert!(await_continuation(&c.runtime).await);
+        assert_eq!(
+            c.runtime.grants.live_count(),
+            1,
+            "simultaneous approves must not buy more than one permission"
+        );
+    }
+
+    /// FAIL. On the synchronous shape the operator waits for the follow-up
+    /// cycle, so a cycle that falls over is theirs to hear about: the request
+    /// answers an error rather than a success over nothing.
+    ///
+    /// And the verdict is durable regardless — it is settled inline, before the
+    /// cycle is ever spawned. The pairing is the point. An error that also lost
+    /// the decision would leave the operator re-approving something already
+    /// approved; an error swallowed into a `200` would leave them believing work
+    /// resumed that never did.
+    #[tokio::test]
+    async fn a_synchronous_resolve_reports_a_failed_follow_up_and_keeps_the_verdict() {
+        let home_dir = home();
+        let c = multi_park_company(home_dir.path(), 1, Some("sales"), true).await;
+        let approval = c.approvals[0].clone();
+
+        let response = c
+            .app
+            .clone()
+            .oneshot(resolve_request(
+                &approval,
+                serde_json::json!({ "verdict": "approve" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a continuation that fell over must reach the operator waiting on it"
+        );
+
+        assert!(
+            !c.runtime
+                .pending_approvals()
+                .iter()
+                .any(|p| p.id == approval),
+            "the verdict is settled before the cycle runs, so a failed cycle cannot un-decide it"
+        );
+        assert_eq!(c.runtime.grants.live_count(), 1);
+
+        let again = c
+            .app
+            .clone()
+            .oneshot(resolve_request(
+                &approval,
+                serde_json::json!({ "verdict": "approve", "detach": true }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(again.status(), StatusCode::OK);
+        assert_eq!(
+            body_json(again).await["alreadyResolved"],
+            true,
+            "re-deciding after the failure must say it was already decided"
+        );
+        assert_eq!(
+            c.runtime.grants.live_count(),
+            1,
+            "and must not buy a second permission"
+        );
+    }
 }

--- a/src/server/ops/skills.rs
+++ b/src/server/ops/skills.rs
@@ -792,7 +792,7 @@ mod tests {
         use crate::ports::CompanyStore;
         use crate::ports::types::{CompanyId, CompanyRecord};
         use crate::runtime::RuntimeBuilder;
-        use crate::server::ops::skills::MAX_SKILL_DOC_BYTES;
+        use crate::server::ops::skills::{MAX_SKILL_DOC_BYTES, valid_slug, write_lock};
         use crate::server::router;
         use crate::server::test_support::{
             fixed_cookie, member_cookie, seed_fixed_admin, seed_fixed_member,
@@ -1084,6 +1084,161 @@ mod tests {
                 slugs(&state).await.is_empty(),
                 "an over-cap body must not land a delta"
             );
+        }
+
+        /// The property [`write_lock`] exists for, asserted where it actually
+        /// has to hold: on the handlers, not on the primitive.
+        ///
+        /// [`write_lock_serializes_same_company_writes`](super::write_lock_serializes_same_company_writes)
+        /// proves the mutex is a mutex; it passes unchanged if every handler
+        /// stops taking it. This holds the addressed company's lock and drives
+        /// each write route over the real router: a route that reached the
+        /// store anyway answers while the lock is held, which is the whole
+        /// defect — `set_enabled`'s list-then-write window is only closed
+        /// while *every* writer waits on the same lock.
+        #[tokio::test]
+        async fn every_write_route_waits_on_the_company_write_lock() {
+            let home = tempfile::tempdir().unwrap();
+            let state = state_with_company(home.path()).await;
+
+            // One uncontended write first, so everything a request lazily opens
+            // on its way to the handler (session lookup, the skill store) is
+            // already warm and the wait below is measuring the lock alone.
+            let (status, _, raw) = send(
+                &state,
+                "POST",
+                "/api/v1/company/skills/warm-up/install",
+                None,
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "warm-up install: {raw}");
+
+            let attempts: [(&'static str, &'static str, Option<&'static str>); 4] = [
+                ("POST", "/api/v1/company/skills/seo-audit/install", None),
+                (
+                    "PUT",
+                    "/api/v1/company/skills/seo-audit",
+                    Some(r#"{"enabled":false}"#),
+                ),
+                (
+                    "POST",
+                    "/api/v1/company/skills",
+                    Some(r#"{"name":"Locked Skill","description":"waits its turn"}"#),
+                ),
+                ("POST", "/api/v1/company/skills/warm-up/uninstall", None),
+            ];
+
+            for (method, uri, body) in attempts {
+                let lock = write_lock(&CompanyId::new("acme"));
+                let guard = lock.lock().await;
+
+                let held = state.clone();
+                let mut pending = tokio::spawn(async move {
+                    send_as(&held, method, uri, body, Some(&fixed_cookie("acme"))).await
+                });
+
+                let ran_anyway =
+                    tokio::time::timeout(std::time::Duration::from_millis(750), &mut pending).await;
+                assert!(
+                    ran_anyway.is_err(),
+                    "{method} {uri} reached the store while another writer held \
+                     the company write lock"
+                );
+
+                drop(guard);
+                let (status, _, raw) = pending.await.expect("the write task did not panic");
+                assert!(
+                    status.is_success(),
+                    "{method} {uri} once the lock was free: {raw}"
+                );
+            }
+        }
+
+        /// Authoring derives the slug from the display name, so the name is the
+        /// untrusted input that decides a store key and a `skills/<slug>/`
+        /// directory name. Whatever `create_custom` accepts must therefore
+        /// derive a slug the slug-bearing routes accept: an id `valid_slug`
+        /// refuses is a skill nobody can toggle or uninstall afterwards, and a
+        /// path segment nothing else in the product will honour.
+        ///
+        /// Asserted end to end — the derived id is fed straight back to
+        /// `PUT …/skills/{slug}`, the route that does apply `valid_slug`.
+        #[tokio::test]
+        async fn an_authored_slug_is_always_one_the_slug_routes_accept() {
+            let home = tempfile::tempdir().unwrap();
+            let state = state_with_company(home.path()).await;
+
+            for name in [
+                "!!!",
+                "  ---  ",
+                "-leading dash",
+                "Ünïcödé Skill",
+                "42",
+                "A/B\\C",
+                "UPPER CASE",
+                "under_score",
+            ] {
+                let body = serde_json::json!({
+                    "name": name,
+                    "description": "a description",
+                })
+                .to_string();
+                let (status, resp, raw) =
+                    send(&state, "POST", "/api/v1/company/skills", Some(&body)).await;
+                assert_eq!(status, StatusCode::OK, "authoring {name:?}: {raw}");
+
+                let slug = resp["id"].as_str().expect("an id").to_string();
+                assert!(
+                    valid_slug(&slug),
+                    "{name:?} derived {slug:?}, which the slug routes refuse"
+                );
+
+                let (status, _, raw) = send(
+                    &state,
+                    "PUT",
+                    &format!("/api/v1/company/skills/{slug}"),
+                    Some(r#"{"enabled":false}"#),
+                )
+                .await;
+                assert_eq!(
+                    status,
+                    StatusCode::OK,
+                    "the skill authored from {name:?} cannot be managed by its own id \
+                     {slug:?}: {raw}"
+                );
+            }
+        }
+
+        /// A refusal raised *inside* the guarded region must still hand the
+        /// company's write lock back.
+        ///
+        /// Every write handler takes the lock before it validates, so the
+        /// over-cap refusal returns with the guard live. A guard that outlived
+        /// its request would not fail that request — it would wedge every
+        /// later write for that one company, for the life of the process, with
+        /// nothing in the failed response to say so.
+        #[tokio::test]
+        async fn a_write_refused_inside_the_lock_still_hands_it_back() {
+            let home = tempfile::tempdir().unwrap();
+            let state = state_with_company(home.path()).await;
+
+            let body = serde_json::json!({
+                "name": "Huge Skill",
+                "description": "short",
+                "body": "x".repeat(MAX_SKILL_DOC_BYTES),
+            })
+            .to_string();
+            let (status, _, raw) =
+                send(&state, "POST", "/api/v1/company/skills", Some(&body)).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{raw}");
+
+            let next = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                send(&state, "POST", "/api/v1/company/skills/a-1/install", None),
+            )
+            .await
+            .expect("the refused write left the company write lock held");
+            assert_eq!(next.0, StatusCode::OK, "{}", next.2);
         }
     }
 }


### PR DESCRIPTION
## Summary

Coverage for three risk-3 seams — the highest-consequence tier in the audit — where the behaviour is right and nothing asserted it. No production code changes here; the whole diff is tests.

**A resolve that is paused, raced, or fails mid-cycle** (`resolve_approval`). The concurrency case took two attempts to become real: a `tokio::join!` on a current-thread runtime does not race, and a first rewrite caught only the gate-level protection while missing a second layer in `blocker_resolutions`. It now runs eight racers on a multi-thread runtime, and went red five times out of five against the broken mechanism.

**The skills write lock, on the handlers rather than on the primitive.** The existing case exercised the mutex itself, so a handler could quietly stop taking it and the case would stay green. These assert that the handlers hold it.

**What a bridged page can reach** (the GraphQL bridge): no mutation root, a cross-company read refused, and concurrent requests that do not borrow another caller's principal.

Two findings are worth stating plainly rather than burying:

- **PAGE-002 is only half closed here.** The per-page scope narrowing lives in `PagesView.tsx`, on the frontend, and still does not exist. These cases pin the server-side backstops — they are not a fix for the underlying gap.
- **APPR-004 and PLAT-014 needed nothing.** Both were already closed by commits that merged this week. Rather than assume, each existing test was verified by breaking the guard it covers and watching it go red — PLAT-014's shape being the live Member-approves-what-it-cannot-see bypass — then restoring. Re-asserting them would have been noise.

## API Or Behavior Changes

None. Tests only.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — the default lane and `--no-deps --features openhuman`, both clean
- [ ] `cargo build --all-targets` — N/A: the clippy and test lanes build the same targets and are clean
- [x] `cargo test` — `server::` 1,636 passed, 0 failed; full `--features openhuman --tests` run green

## Documentation

No docs needed — no behaviour changed.
