### PR TITLE
fix(webhook): give a delivery a deadline, and cover the policy and ACP edges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1449,6 +1449,14 @@ jobs:
       - name: Test (tinyplace)
         run: cargo test --locked --features tinyplace --lib
 
+      # `webhooks` gates `HttpWebhookSink` and its HMAC signer, and its tests
+      # were compiled by `Check (--all-features)` and run by nothing. Scoped to
+      # the module rather than the whole lib: this is a sixth feature
+      # resolution, and the rest of the suite is already covered by the lanes
+      # above. `--locked` per issue #251, as for every graph-resolving call.
+      - name: Test (webhooks)
+        run: cargo test --locked --features webhooks --lib server::webhook
+
   # Issue #1118. The gated host binary the `Console E2E (live brain)` job needs
   # is built HERE rather than as the last step of `Rust (openhuman, tinymemory)`
   # above, and the move is a wall-clock change, not a tidy-up.

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -70,6 +70,7 @@ paypal         | partial      | openhuman,chargebee,paypal,composio | paypal ser
 sidecar        | partial      | sidecar                         | brain::sidecar
 analytics      | partial      | analytics                       | analytics
 crash-reporting | partial     | crash-reporting                 | observability
+webhooks       | partial      | webhooks                        | server::webhook
 
 # --- Owed a lane: gated tests exist, and they are currently RED -------------
 #
@@ -93,7 +94,7 @@ crash-reporting | partial     | crash-reporting                 | observability
 
 # --- Compile-only, by design ------------------------------------------------
 #
-# The shape shared by the six below: the PORT (a trait), its offline mock, and
+# The shape shared by the five below: the PORT (a trait), its offline mock, and
 # the whole decision flow around it live in the default build and are tested
 # there. Only a thin real-network implementation sits behind the feature, and it
 # carries no test of its own — there is nothing to run without the network it
@@ -105,7 +106,6 @@ openhuman-rpc  | compile-only | - | Only `HttpOpenHumanRpc` is gated. The trait 
 github         | compile-only | - | Only `HttpGitHubClient` is gated. `GitHubClient`, its mock and the whole issue-filing flow test at default features (src/feedback/github.rs tests sit outside the gated `mod http`).
 tinyhumans     | compile-only | - | Only `HttpTinyHumansClient` / `HttpHubIdentityExchange` are gated. The trait, mock and routing decision test at default features.
 medulla        | compile-only | - | Only the HTTP/Socket.IO transport is gated. Wire types + `MockTransport` test at default features; the gated `http` module carries no test.
-webhooks       | tested       | webhooks | `Test (webhooks)` in the `Rust` job runs `--features webhooks --lib server::webhook`. Was compile-only while only the trait and the recording sink were exercised; `HttpWebhookSink`'s delivery deadline, its signature and its concurrent-delivery behaviour are gated, so they needed a lane of their own.
 dns            | compile-only | - | Only `HickoryDnsResolver` is gated. The `DnsResolver` trait, `StaticDnsResolver` and the pure record generation test at default features.
 
 # --- Compile-only, no gated test exists yet ---------------------------------

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -105,7 +105,7 @@ openhuman-rpc  | compile-only | - | Only `HttpOpenHumanRpc` is gated. The trait 
 github         | compile-only | - | Only `HttpGitHubClient` is gated. `GitHubClient`, its mock and the whole issue-filing flow test at default features (src/feedback/github.rs tests sit outside the gated `mod http`).
 tinyhumans     | compile-only | - | Only `HttpTinyHumansClient` / `HttpHubIdentityExchange` are gated. The trait, mock and routing decision test at default features.
 medulla        | compile-only | - | Only the HTTP/Socket.IO transport is gated. Wire types + `MockTransport` test at default features; the gated `http` module carries no test.
-webhooks       | compile-only | - | Only `HttpWebhookSink` / `HmacSha256Signer` are gated. The `WebhookSink` trait, `RecordingWebhookSink` and the deterministic default signer test at default features.
+webhooks       | tested       | webhooks | `Test (webhooks)` in the `Rust` job runs `--features webhooks --lib server::webhook`. Was compile-only while only the trait and the recording sink were exercised; `HttpWebhookSink`'s delivery deadline, its signature and its concurrent-delivery behaviour are gated, so they needed a lane of their own.
 dns            | compile-only | - | Only `HickoryDnsResolver` is gated. The `DnsResolver` trait, `StaticDnsResolver` and the pure record generation test at default features.
 
 # --- Compile-only, no gated test exists yet ---------------------------------

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -1506,4 +1506,367 @@ mode = "none"
             response.status()
         );
     }
+
+    /// Mints a real, HTTP-carriable admin session for `acp_state`'s "acme"
+    /// company, returning its `Cookie` header value.
+    async fn seed_admin_session_cookie(
+        state: &AppState,
+        company: &CompanyId,
+        user_id: &str,
+    ) -> String {
+        let runtime = state.registry().get(company).expect("company");
+        let now = crate::ports::now_millis();
+        runtime
+            .users()
+            .upsert_user(
+                company,
+                &UserRecord {
+                    id: user_id.to_string(),
+                    email: format!("{user_id}@example.test"),
+                    display_name: None,
+                    avatar: None,
+                    role: UserRole::Admin,
+                    status: UserStatus::Active,
+                    password_hash: None,
+                    must_change_password: false,
+                    created_at_millis: now,
+                    last_seen_at_millis: None,
+                    updated_at_millis: now,
+                },
+            )
+            .await
+            .expect("seed admin");
+        let token = mint_session_token(&OsTokens);
+        runtime
+            .sessions()
+            .create(
+                company,
+                &SessionRecord {
+                    id: format!("s-{user_id}"),
+                    token_hash: sha256_hex(&token),
+                    user_id: user_id.to_string(),
+                    created_at_millis: now,
+                    expires_at_millis: now + 60_000,
+                    user_agent: None,
+                    kind: SessionKind::Browser,
+                    label: None,
+                },
+            )
+            .await
+            .expect("seed session");
+        let cookie_name = session_cookie_name(company).expect("cookie name");
+        format!("{cookie_name}={token}")
+    }
+
+    fn session_new_request(cookie: &str, connection_id: &str, request_id: u64) -> Request<Body> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "session/new",
+            "params": {
+                "_meta": {
+                    "opencompany": { "company": "acme" },
+                    "opencompany/connectionId": connection_id,
+                }
+            }
+        });
+        let mut request = acp_call_request(body);
+        request
+            .headers_mut()
+            .insert(axum::http::header::COOKIE, cookie.parse().unwrap());
+        request
+    }
+
+    /// PLAT-057 (LIMIT): the per-connection session cap
+    /// (`MAX_SESSIONS_PER_CONNECTION`) is enforced through the real HTTP `call`
+    /// handler, not just the `open_session` inner function every test above
+    /// this point calls directly — the handler's own JSON-RPC dispatch and
+    /// envelope sit between a caller and that cap in production, and neither
+    /// was ever exercised together with it.
+    #[tokio::test]
+    async fn call_handler_refuses_session_new_once_the_per_connection_cap_is_hit() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-call-limit-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state(home.path()).await;
+        let company = CompanyId::new("acme");
+        let cookie = seed_admin_session_cookie(&state, &company, "u-cap-admin").await;
+        let app = router().with_state(state);
+
+        for i in 0..crate::server::acp::session::MAX_SESSIONS_PER_CONNECTION {
+            let response = app
+                .clone()
+                .oneshot(session_new_request(&cookie, "conn-http-cap", i as u64))
+                .await
+                .unwrap();
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let value: Value = serde_json::from_slice(&bytes).unwrap();
+            assert!(
+                value.get("result").is_some(),
+                "open #{i} must succeed: {value:?}"
+            );
+        }
+
+        let response = app
+            .oneshot(session_new_request(&cookie, "conn-http-cap", 999))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "still a JSON-RPC 200");
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            value.get("error").is_some(),
+            "the session past the cap must come back a JSON-RPC error: {value:?}"
+        );
+    }
+
+    /// PLAT-057 (CONC): two different principals racing `session/new` on the
+    /// same `connectionId`, over the real HTTP handler concurrently rather than
+    /// sequentially. `a_caller_cannot_open_a_session_on_a_connection_it_does_
+    /// not_own` proves the inner function's ownership rule one call at a time;
+    /// this proves the lock the handler sits on top of actually serializes two
+    /// requests that land at the same time, rather than both racing past a
+    /// check-then-insert and one silently losing its own connection.
+    #[tokio::test]
+    async fn call_handler_lets_only_one_of_two_concurrent_openers_win_a_connection() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-call-conc-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state(home.path()).await;
+        let company = CompanyId::new("acme");
+        let cookie_a = seed_admin_session_cookie(&state, &company, "u-conc-a").await;
+        let cookie_b = seed_admin_session_cookie(&state, &company, "u-conc-b").await;
+        let app = router().with_state(state);
+
+        let request_a = session_new_request(&cookie_a, "conn-http-race", 1);
+        let request_b = session_new_request(&cookie_b, "conn-http-race", 2);
+        let app_a = app.clone();
+        let app_b = app.clone();
+        let (response_a, response_b) =
+            tokio::join!(app_a.oneshot(request_a), app_b.oneshot(request_b));
+
+        let value_a: Value = serde_json::from_slice(
+            &axum::body::to_bytes(response_a.unwrap().into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        let value_b: Value = serde_json::from_slice(
+            &axum::body::to_bytes(response_b.unwrap().into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        let winners = [
+            value_a.get("result").is_some(),
+            value_b.get("result").is_some(),
+        ]
+        .into_iter()
+        .filter(|ok| *ok)
+        .count();
+        assert_eq!(
+            winners, 1,
+            "exactly one of two concurrent openers may win a shared connection: \
+             {value_a:?} / {value_b:?}"
+        );
+    }
+
+    /// PLAT-060 (STATE): `local_owner` falls back to `registry().sole()` when
+    /// `/acp` cannot name an addressed company (it has no `{id}` path param).
+    /// Once a second company is registered, `sole()` no longer resolves — the
+    /// credential-less request must come back unauthorized, not silently
+    /// authorized against whichever company happens to be `none`-mode.
+    #[tokio::test]
+    async fn call_handler_none_mode_owner_is_unreachable_once_a_second_company_exists() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-call-state-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state_none_mode(home.path()).await;
+
+        // Control, proven first on this exact state: with only the sole
+        // `none`-mode company registered, the credential-less request
+        // succeeds — the same claim `call_handler_authenticates_a_credential_
+        // less_none_mode_request` makes, repeated here so the 401 asserted
+        // below is shown to depend on the second company, not on some other
+        // difference between the two tests' fixtures.
+        let control_app = router().with_state(state.clone());
+        let control_body =
+            json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": {} });
+        let control_response = control_app
+            .oneshot(acp_call_request(control_body))
+            .await
+            .unwrap();
+        assert_eq!(
+            control_response.status(),
+            StatusCode::OK,
+            "control: the sole none-mode company must still answer credential-less \
+             before a second company is registered"
+        );
+
+        let manifest: CompanyManifest = toml::from_str("[company]\nname = \"Globex\"\n").unwrap();
+        let store = FsCompanyStore::new(home.path().to_path_buf());
+        let globex = CompanyId::new("globex");
+        store
+            .save(&CompanyRecord {
+                overlay_retired_agents: Vec::new(),
+                overlay_agent_edits: Vec::new(),
+                id: globex.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_tool_grants: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+                setup: None,
+                name_confirmed: false,
+                activation_completed_at: None,
+                created_at_millis: None,
+            })
+            .await
+            .unwrap();
+        let globex_runtime =
+            crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+                .with_id(globex.clone())
+                .with_brain(std::sync::Arc::new(SilentBrain))
+                .build()
+                .await
+                .unwrap();
+        state
+            .registry()
+            .insert(globex, std::sync::Arc::new(globex_runtime));
+
+        let app = router().with_state(state);
+        let body = json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} });
+        let response = app.oneshot(acp_call_request(body)).await.unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "a none-mode company sharing a host with a second company must not \
+             silently authorize a credential-less /acp request against either one"
+        );
+    }
+
+    /// PLAT-060 (FAIL): the same `none`-mode gate `local_owner` applies
+    /// everywhere else — a request carrying a forwarding header is refused
+    /// outright, never degraded to a session/bearer check — proven here over
+    /// the real HTTP `call` handler.
+    #[tokio::test]
+    async fn call_handler_none_mode_refuses_a_forwarded_request() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acp-call-fail2-")
+            .tempdir()
+            .expect("tempdir");
+        let state = acp_state_none_mode(home.path()).await;
+        let app = router().with_state(state);
+
+        // Control: the identical request, minus the forwarding header,
+        // succeeds on this exact app — so the refusal below is shown to
+        // depend on the header, not on some other difference in the fixture.
+        let control_body =
+            json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": {} });
+        let control_response = app
+            .clone()
+            .oneshot(acp_call_request(control_body))
+            .await
+            .unwrap();
+        assert_eq!(
+            control_response.status(),
+            StatusCode::OK,
+            "control: the same none-mode host must answer without the forwarding header"
+        );
+
+        let body = json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} });
+        let mut request = acp_call_request(body);
+        request
+            .headers_mut()
+            .insert("x-forwarded-for", "203.0.113.5".parse().unwrap());
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "a none-mode company must refuse a forwarded request outright, not \
+             treat it as its own local owner"
+        );
+    }
+
+    /// PLAT-062 (STATE): a turn that both parked an approval and produced a
+    /// reply still reports `end_turn` — the mixed case, not just the two
+    /// single-field variations above.
+    #[test]
+    fn a_mixed_turn_with_a_reply_and_a_park_still_ends_the_turn() {
+        let report = crate::runtime::CycleReport {
+            cycle_id: "c1".to_string(),
+            responses: vec![crate::ports::types::OutboundMessage {
+                channel: "operator".to_string(),
+                agent: None,
+                text: "here's what I found".to_string(),
+                steps: Vec::new(),
+                reply_to: None,
+                task_id: None,
+                message_id: None,
+                mentions: Vec::new(),
+            }],
+            executed_effects: Vec::new(),
+            parked: vec![ApprovalId::from("appr-1".to_string())],
+            persisted_seq: None,
+            input_seqs: Vec::new(),
+        };
+        let result = prompt_result(report);
+        assert_eq!(result["stopReason"], "end_turn");
+        let updates = result["updates"].as_array().expect("updates array");
+        assert_eq!(
+            updates.len(),
+            2,
+            "one reply chunk plus one approval notification"
+        );
+    }
+
+    /// PLAT-062 (BOUND): several parked approvals in one turn each get their
+    /// own notification — none dropped, none deduplicated, at the boundary of
+    /// "more than one".
+    #[test]
+    fn every_parked_approval_in_a_multi_park_turn_gets_its_own_notification() {
+        let parked: Vec<ApprovalId> = (0..5)
+            .map(|i| ApprovalId::from(format!("appr-{i}")))
+            .collect();
+        let report = crate::runtime::CycleReport {
+            cycle_id: "c1".to_string(),
+            responses: Vec::new(),
+            executed_effects: Vec::new(),
+            parked: parked.clone(),
+            persisted_seq: None,
+            input_seqs: Vec::new(),
+        };
+        let result = prompt_result(report);
+        assert_eq!(result["stopReason"], "end_turn");
+        let updates = result["updates"].as_array().expect("updates array");
+        assert_eq!(updates.len(), 5);
+        let ids: std::collections::HashSet<&str> = updates
+            .iter()
+            .map(|u| u["_meta"]["opencompany/approval"]["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            ids.len(),
+            5,
+            "every parked id must appear exactly once: {updates:?}"
+        );
+    }
 }

--- a/src/server/acp/transport.rs
+++ b/src/server/acp/transport.rs
@@ -1725,6 +1725,7 @@ mode = "none"
                 overlay_agents: Vec::new(),
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
+                overlay_desk_hive: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
@@ -1832,11 +1833,24 @@ mode = "none"
         let result = prompt_result(report);
         assert_eq!(result["stopReason"], "end_turn");
         let updates = result["updates"].as_array().expect("updates array");
+        // Counting alone would pass on two chunks and no notification, which is
+        // the shape this case exists to refuse.
+        let approvals: Vec<&str> = updates
+            .iter()
+            .filter_map(|u| u["_meta"]["opencompany/approval"]["id"].as_str())
+            .collect();
         assert_eq!(
-            updates.len(),
-            2,
-            "one reply chunk plus one approval notification"
+            approvals,
+            vec!["appr-1"],
+            "the parked approval must carry its own notification: {updates:?}"
         );
+        assert!(
+            updates.iter().any(|u| u["content"]["text"]
+                .as_str()
+                .is_some_and(|t| t.contains("here's what I found"))),
+            "the reply chunk must survive alongside it: {updates:?}"
+        );
+        assert_eq!(updates.len(), 2, "and nothing else: {updates:?}");
     }
 
     /// PLAT-062 (BOUND): several parked approvals in one turn each get their
@@ -1859,13 +1873,17 @@ mode = "none"
         assert_eq!(result["stopReason"], "end_turn");
         let updates = result["updates"].as_array().expect("updates array");
         assert_eq!(updates.len(), 5);
-        let ids: std::collections::HashSet<&str> = updates
+        // Five *unique* ids is not the claim — five ids that are the ones we
+        // parked is. A set of unrelated ids satisfies the former.
+        let mut ids: Vec<&str> = updates
             .iter()
             .map(|u| u["_meta"]["opencompany/approval"]["id"].as_str().unwrap())
             .collect();
+        ids.sort_unstable();
+        let mut expected: Vec<&str> = parked.iter().map(|id| id.as_ref()).collect();
+        expected.sort_unstable();
         assert_eq!(
-            ids.len(),
-            5,
+            ids, expected,
             "every parked id must appear exactly once: {updates:?}"
         );
     }

--- a/src/server/ops/policy.rs
+++ b/src/server/ops/policy.rs
@@ -684,11 +684,30 @@ mod tests {
     }
 
     async fn call(state: &AppState, method: &str, body: Option<Value>) -> (StatusCode, Value) {
-        let request = Request::builder()
+        call_as(
+            state,
+            method,
+            body,
+            Some(crate::server::test_support::fixed_cookie("acme")),
+        )
+        .await
+    }
+
+    /// [`call`], with the caller's cookie under the test's own control —
+    /// `None` for no session at all — instead of always the fixed admin.
+    async fn call_as(
+        state: &AppState,
+        method: &str,
+        body: Option<Value>,
+        cookie: Option<String>,
+    ) -> (StatusCode, Value) {
+        let mut request = Request::builder()
             .method(method)
             .uri("/api/v1/company/policy")
-            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
             .header("content-type", "application/json");
+        if let Some(cookie) = cookie {
+            request = request.header("cookie", cookie);
+        }
         let request = match body {
             Some(value) => request.body(Body::from(value.to_string())).unwrap(),
             None => request.body(Body::empty()).unwrap(),
@@ -1139,5 +1158,231 @@ mod tests {
         // blank; `every_runtime_tier_has_console_text` is what stops that state
         // reaching a release.
         assert!(tiers_for(&["not_a_tier"]).is_empty());
+    }
+
+    /// The privilege boundary this whole route family rests on: a signed-in
+    /// member cannot move the tier, cap, deadline or always-ask list, and an
+    /// unauthenticated caller cannot reach the route at all. Every write field
+    /// on `SetPolicy` is gated by the same `require_admin` call at the top of
+    /// `set_policy`/`clear_policy`, so one assertion against each method covers
+    /// every field this route accepts.
+    #[tokio::test]
+    async fn a_non_admin_cannot_change_or_clear_the_policy() {
+        let dir = home();
+        let state = state(dir.path()).await;
+        crate::server::test_support::seed_fixed_member(&state, "acme").await;
+        let member = crate::server::test_support::member_cookie("acme");
+
+        for (method, body) in [("PUT", Some(json!({ "mode": "full" }))), ("DELETE", None)] {
+            let (status, _) = call_as(&state, method, body.clone(), Some(member.clone())).await;
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "{method} as a member must be refused"
+            );
+
+            let (status, _) = call_as(&state, method, body, None).await;
+            assert_eq!(
+                status,
+                StatusCode::UNAUTHORIZED,
+                "{method} with no session must be refused"
+            );
+        }
+
+        // Neither denied write moved anything — the admin-only fixture's
+        // manifest tier is still what it was seeded with.
+        let (_, body) = call(&state, "GET", None).await;
+        assert_eq!(body["mode"], "supervised");
+        assert_eq!(body["overridden"], false);
+    }
+
+    /// `autoApproveUnderUsd` is validated non-negative (line 395-399 above),
+    /// but nothing exercised that check — every existing cap test sends a
+    /// small positive number. A negative cap must be refused before
+    /// persistence, the same way an unknown tier is.
+    ///
+    /// The companion `!cap.is_finite()` half of the same `if` is not
+    /// exercised here: `1e400` is valid JSON syntax but this crate's
+    /// `serde_json` errors deserializing it to `f64` ("number out of range")
+    /// rather than saturating to `INFINITY`, so the request never reaches
+    /// [`set_policy`] at all — axum's `Json` extractor rejects it upstream
+    /// with a plain `400`. `NaN` has no JSON token to begin with. There is no
+    /// value a real HTTP client can put on the wire that reaches the
+    /// `is_finite()` branch as anything other than `true`.
+    #[tokio::test]
+    async fn a_negative_auto_approve_cap_is_refused() {
+        let dir = home();
+        let state = state(dir.path()).await;
+
+        let (status, _) = call(&state, "PUT", Some(json!({ "autoApproveUnderUsd": -0.01 }))).await;
+        assert_eq!(
+            status,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "a negative cap must be refused"
+        );
+
+        // Not stored.
+        let (_, body) = call(&state, "GET", None).await;
+        assert_eq!(body["overridden"], false);
+    }
+
+    /// The cap test above (`the_persisted_cap_does_not_gate_a_spend_on_the_
+    /// production_gate`) proves `autoApproveUnderUsd` is inert on the shipped
+    /// gate. `alwaysApprove` reaches a *different* arm of `evaluate`
+    /// (`always_approve::matches`, ahead of the mode dispatch) and is inert for
+    /// the same root cause but by a separate code path: both are read only
+    /// after the `policy_hitl_enabled` check, which every production fixture
+    /// fails. An operator who adds `payment.send` to the always-ask list today
+    /// sees it persist and echo back on every `GET`, and it still does not park
+    /// a matching effect.
+    #[tokio::test]
+    async fn always_approve_does_not_gate_on_the_production_gate() {
+        use crate::ports::ApprovalGate;
+        use crate::ports::types::{CompanyEvent, Effect, EffectGroup};
+
+        let dir = home();
+        let state = state(dir.path()).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).expect("registered").clone();
+        assert!(
+            !runtime.approval_gate.policy_hitl_enabled(),
+            "this fixture must build the gate the way production does"
+        );
+
+        let (status, _) = call(
+            &state,
+            "PUT",
+            Some(json!({ "alwaysApprove": ["payment.send"] })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        runtime
+            .run_cycle(vec![CompanyEvent::ScheduleFired {
+                cron: "* * * * *".to_string(),
+                prompt: "status".to_string(),
+            }])
+            .await
+            .expect("the next turn applies the snapshot");
+        assert_eq!(
+            runtime.approval_gate.policy().always_approve,
+            vec!["payment.send".to_string()],
+            "the always-ask list did reach the live snapshot"
+        );
+
+        let fenced = Effect {
+            kind: "payment.send".to_string(),
+            group: EffectGroup::Spend,
+            amount_usd: Some(1.0),
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+            agent: None,
+            run_id: None,
+        };
+        let decision = runtime.approval_gate.evaluate(&id, &fenced).await.unwrap();
+        assert_eq!(
+            decision,
+            crate::ports::types::PolicyDecision::Allow,
+            "an effect on the always-ask list is allowed on the production gate today — \
+             the persisted always-ask list is not currently enforced"
+        );
+
+        // Control: the same effect against the same always-ask list DOES park
+        // once HITL is enabled — proving the `Allow` above is caused
+        // specifically by `policy_hitl_enabled`, not by a broken match on
+        // `payment.send` that would read `Allow` for any input.
+        // `ManifestApprovalGate::new` defaults to HITL enabled.
+        let hitl_enabled_gate =
+            crate::policy::gate::ManifestApprovalGate::new(runtime.approval_gate.policy());
+        let control_decision = hitl_enabled_gate.evaluate(&id, &fenced).await.unwrap();
+        assert_eq!(
+            control_decision,
+            crate::ports::types::PolicyDecision::RequireApproval,
+            "the same always-ask list DOES park this effect once HITL is enabled — the \
+             gate this route talks to is not enforcing it purely because production \
+             ships with HITL disabled, not because the list or the match is broken"
+        );
+    }
+
+    /// `mode: "auto"` is a real `POLICY_MODES` entry — the write route must
+    /// accept it, not just the three tiers every other test in this file uses.
+    /// On the live gate `evaluate_auto` is a direct call-through to
+    /// `evaluate_supervised_with_policy`, so a decision for `auto` and the same
+    /// decision for `supervised` must agree on every effect: proof that
+    /// selecting `auto` over `supervised` changes nothing about what gets
+    /// gated, even though the console renders them as two distinct choices.
+    ///
+    /// Built off the persisted record rather than the running company's own
+    /// `approval_gate`: the production fixture's gate never dispatches on mode
+    /// at all (HITL disabled, see `the_persisted_cap_does_not_gate_a_spend_on_
+    /// the_production_gate`), and an injected HITL-enabled gate is pinned by
+    /// the test that built it rather than rebuilt from the record on
+    /// `run_cycle`. Two fresh gates built straight from the effective policy
+    /// isolate exactly the one thing this test is about — `evaluate_auto`
+    /// versus `evaluate_supervised` — from both of those unrelated seams.
+    #[tokio::test]
+    async fn mode_auto_is_accepted_and_decides_identically_to_supervised() {
+        use crate::ports::ApprovalGate;
+        use crate::ports::types::{Effect, EffectGroup};
+
+        let dir = home();
+        let state = state(dir.path()).await;
+
+        let (status, body) = call(&state, "PUT", Some(json!({ "mode": "auto" }))).await;
+        assert_eq!(status, StatusCode::OK, "`auto` is a valid tier");
+        assert_eq!(body["mode"], "auto");
+
+        let store = FsCompanyStore::new(dir.path().to_path_buf());
+        let id = CompanyId::new("acme");
+        let record = store.load(&id).await.unwrap().expect("company record");
+        let auto_policy = record.effective_policy();
+        assert_eq!(auto_policy.mode, "auto");
+
+        let spend = Effect {
+            kind: "vendor.pay".to_string(),
+            group: EffectGroup::Spend,
+            amount_usd: Some(1_000.0),
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+            agent: None,
+            run_id: None,
+        };
+
+        let under_auto = crate::policy::gate::ManifestApprovalGate::new(auto_policy.clone());
+        let under_auto_decision = under_auto.evaluate(&id, &spend).await.unwrap();
+
+        let mut supervised_policy = auto_policy;
+        supervised_policy.mode = "supervised".to_string();
+        let under_supervised = crate::policy::gate::ManifestApprovalGate::new(supervised_policy);
+        let under_supervised_decision = under_supervised.evaluate(&id, &spend).await.unwrap();
+
+        assert_eq!(
+            under_auto_decision, under_supervised_decision,
+            "`auto` must decide identically to `supervised` — it has no arm of its own"
+        );
+    }
+
+    /// `mode` has no `MAX_ALWAYS_APPROVE_ENTRY_LEN`-style length bound, unlike
+    /// `alwaysApprove` entries — the check is a linear membership test against
+    /// four short strings, so nothing stops a caller from sending an arbitrarily
+    /// large string. It must still come back a plain `422`, not a timeout, a
+    /// panic, or a body large enough to be a standing cost on this route.
+    #[tokio::test]
+    async fn an_oversized_mode_string_is_refused_promptly() {
+        let dir = home();
+        let state = state(dir.path()).await;
+
+        let junk = "x".repeat(1_000_000);
+        let started = std::time::Instant::now();
+        let (status, _) = call(&state, "PUT", Some(json!({ "mode": junk }))).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "an oversized `mode` value must be refused promptly, not hang"
+        );
+
+        let (_, body) = call(&state, "GET", None).await;
+        assert_eq!(body["overridden"], false);
     }
 }

--- a/src/server/webhook.rs
+++ b/src/server/webhook.rs
@@ -13,6 +13,8 @@
 //! by default, `sha256=<hex>` under `webhooks`.
 
 use std::sync::{Arc, Mutex};
+#[cfg(feature = "webhooks")]
+use std::time::Duration;
 
 use serde::Serialize;
 
@@ -233,6 +235,11 @@ impl WebhookSigner for HmacSha256Signer {
 pub struct HttpWebhookSink {
     url: String,
     client: reqwest::Client,
+    /// Carried on the sink rather than baked into the client so the wiring is
+    /// something a test can read: a timeout that lives only inside the client
+    /// builder is asserted by exercising it, and a case that builds its own
+    /// client to do so passes whether or not `new` sets one.
+    timeout: Duration,
 }
 
 #[cfg(feature = "webhooks")]
@@ -240,11 +247,28 @@ impl HttpWebhookSink {
     /// The header carrying the delivery signature.
     pub const SIGNATURE_HEADER: &'static str = "X-OpenCompany-Signature";
 
+    /// How long a single delivery attempt may take before it is treated as a
+    /// failure.
+    ///
+    /// `reqwest::Client::new()` carries no timeout of its own — a receiving
+    /// endpoint that accepts the connection and never responds would hang
+    /// `deliver` (and, through it, every one of `emit`'s three bounded
+    /// attempts) forever, defeating this module's own "never blocks a cycle"
+    /// promise for the one failure mode a bounded retry loop cannot help
+    /// with: an attempt that never returns at all.
+    const DELIVERY_TIMEOUT: Duration = Duration::from_secs(10);
+
     /// Builds a sink posting to `url`.
     pub fn new(url: impl Into<String>) -> Self {
+        Self::with_timeout(url, Self::DELIVERY_TIMEOUT)
+    }
+
+    /// [`new`](Self::new), against a deadline the caller chooses.
+    pub fn with_timeout(url: impl Into<String>, timeout: Duration) -> Self {
         Self {
             url: url.into(),
             client: reqwest::Client::new(),
+            timeout,
         }
     }
 }
@@ -256,6 +280,7 @@ impl WebhookSink for HttpWebhookSink {
         let resp = self
             .client
             .post(&self.url)
+            .timeout(self.timeout)
             .header(Self::SIGNATURE_HEADER, signature)
             .json(event)
             .send()
@@ -439,5 +464,273 @@ mod test {
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "work_completed");
         assert_eq!(json["company_id"], "acme");
+    }
+
+    // -----------------------------------------------------------------
+    // PLAT-050: `HmacSha256Signer` and `HttpWebhookSink` — the only two
+    // pieces a real deployment uses — behind `webhooks`. Every test above
+    // this point exercises `DefaultHashSigner` / `RecordingWebhookSink`
+    // only.
+    // -----------------------------------------------------------------
+
+    /// A local, in-process HTTP server the tests below post to. Not the
+    /// network `HttpWebhookSink` is forbidden from reaching — a loopback
+    /// listener this test process owns and tears down, the same pattern
+    /// `chargebee::client::test` uses for its own outbound-HTTP-client
+    /// coverage.
+    #[cfg(feature = "webhooks")]
+    struct CapturedRequest {
+        headers: axum::http::HeaderMap,
+        body: axum::body::Bytes,
+    }
+
+    #[cfg(feature = "webhooks")]
+    async fn capturing_mock_server() -> (
+        String,
+        Arc<Mutex<Vec<CapturedRequest>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let captured: Arc<Mutex<Vec<CapturedRequest>>> = Arc::default();
+        let captured_for_handler = captured.clone();
+        let app = axum::Router::new().fallback(axum::routing::any(
+            move |headers: axum::http::HeaderMap, body: axum::body::Bytes| {
+                let captured = captured_for_handler.clone();
+                async move {
+                    captured
+                        .lock()
+                        .expect("captured poisoned")
+                        .push(CapturedRequest { headers, body });
+                    axum::http::StatusCode::OK
+                }
+            },
+        ));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://{addr}"), captured, server)
+    }
+
+    /// PLAT-050 (AUTH / STATE): a real `HttpWebhookSink::deliver` actually
+    /// reaches an HTTP receiver and carries a signature that receiver can
+    /// independently authenticate — a keyed HMAC over the exact body it
+    /// received, computed with the correct secret and rejected under any
+    /// other. Nothing before this test ever drove `HttpWebhookSink` over a
+    /// real connection at all.
+    #[cfg(feature = "webhooks")]
+    #[tokio::test]
+    async fn http_webhook_sink_delivers_a_signature_a_receiver_can_authenticate() {
+        let (url, captured, server) = capturing_mock_server().await;
+        let config = WebhookConfig {
+            sink: Arc::new(HttpWebhookSink::new(url)),
+            signer: Arc::new(HmacSha256Signer),
+            secret: "s3cret".to_string(),
+        };
+        let event = WebhookEvent::now(
+            WebhookKind::ApprovalRequested,
+            CompanyId::new("acme"),
+            serde_json::json!({ "approval_id": "a1" }),
+        );
+        config.emit(&event).await;
+
+        let requests = captured.lock().expect("captured poisoned");
+        assert_eq!(
+            requests.len(),
+            1,
+            "exactly one delivery must reach the receiver"
+        );
+        let request = &requests[0];
+        let signature = request
+            .headers
+            .get(HttpWebhookSink::SIGNATURE_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .expect("signature header present");
+
+        // The receiver's own independent check: recompute the HMAC over the
+        // exact bytes it received, with the correct secret.
+        let expected = HmacSha256Signer.sign("s3cret", &request.body);
+        assert_eq!(
+            signature, expected,
+            "the receiver must be able to authenticate the delivery itself"
+        );
+        // And under the wrong secret, authentication must fail — the
+        // signature is not just present, it is actually keyed.
+        let wrong = HmacSha256Signer.sign("not-the-secret", &request.body);
+        assert_ne!(signature, wrong);
+        server.abort();
+    }
+
+    /// PLAT-050 (FAIL): a receiver that answers non-2xx must be reported as
+    /// a delivery failure, not swallowed as success — the distinction
+    /// `emit`'s bounded retry depends on to know whether to try again.
+    #[cfg(feature = "webhooks")]
+    #[tokio::test]
+    async fn http_webhook_sink_reports_a_non_success_status_as_an_error() {
+        let app = axum::Router::new().fallback(axum::routing::any(|| async {
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let sink = HttpWebhookSink::new(format!("http://{addr}"));
+        let event = WebhookEvent::now(
+            WebhookKind::WorkCompleted,
+            CompanyId::new("acme"),
+            serde_json::Value::Null,
+        );
+        let result = sink.deliver(&event, "sha256=deadbeef").await;
+        assert!(
+            result.is_err(),
+            "a 500 response must be reported as a delivery failure"
+        );
+        server.abort();
+    }
+
+    /// PLAT-050 (CONC): production concurrency is many companies' cycles
+    /// calling `emit` on one tenant's `Arc<WebhookConfig>` — one shared
+    /// `HttpWebhookSink`, one shared `reqwest::Client`, many callers. This
+    /// drives that same single sink with real concurrent deliveries and
+    /// proves none are lost or corrupted in transit, matching
+    /// `recording_sink_loses_nothing_under_concurrent_emits` for the sink a
+    /// real deployment actually uses.
+    #[cfg(feature = "webhooks")]
+    #[tokio::test]
+    async fn http_webhook_sink_loses_nothing_under_concurrent_delivery() {
+        const N: usize = 20;
+        let (url, captured, server) = capturing_mock_server().await;
+        let sink = Arc::new(HttpWebhookSink::new(url));
+
+        let mut tasks = Vec::with_capacity(N);
+        for i in 0..N {
+            let sink = sink.clone();
+            tasks.push(tokio::spawn(async move {
+                let event = WebhookEvent::now(
+                    WebhookKind::ApprovalRequested,
+                    CompanyId::new(format!("company-{i}")),
+                    serde_json::json!({ "i": i }),
+                );
+                sink.deliver(&event, &format!("sha256={i:064x}")).await
+            }));
+        }
+        for task in tasks {
+            assert!(
+                task.await
+                    .expect("a concurrent delivery must not panic")
+                    .is_ok(),
+                "every concurrent delivery to one shared sink must succeed"
+            );
+        }
+
+        let requests = captured.lock().expect("captured poisoned");
+        assert_eq!(
+            requests.len(),
+            N,
+            "every delivery must reach the receiver exactly once"
+        );
+        let mut seen: Vec<usize> = requests
+            .iter()
+            .map(|r| {
+                let body: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
+                body["company_id"]
+                    .as_str()
+                    .unwrap()
+                    .strip_prefix("company-")
+                    .unwrap()
+                    .parse()
+                    .unwrap()
+            })
+            .collect();
+        seen.sort_unstable();
+        assert_eq!(
+            seen,
+            (0..N).collect::<Vec<_>>(),
+            "none dropped, none duplicated"
+        );
+        server.abort();
+    }
+
+    /// PLAT-050 (LIMIT / BOUND): a receiver that accepts the connection and
+    /// never answers must not hang `deliver` forever — `reqwest::Client::
+    /// new()` alone carries no timeout, so this is the one failure mode
+    /// `emit`'s bounded-attempt retry cannot protect against on its own: an
+    /// The sink the runtime builds carries the deadline, not just one a test
+    /// can construct.
+    ///
+    /// Exercising a timeout through a sink the case builds itself proves the
+    /// mechanism and nothing about the wiring: `new` could stop setting one
+    /// and that case would still pass. This reads the deadline off the
+    /// constructor the runtime actually calls.
+    #[cfg(feature = "webhooks")]
+    #[test]
+    fn the_sink_the_runtime_builds_carries_a_delivery_deadline() {
+        let sink = HttpWebhookSink::new("http://example.invalid/hook");
+        assert_eq!(
+            sink.timeout,
+            HttpWebhookSink::DELIVERY_TIMEOUT,
+            "a delivery with no deadline hangs every bounded retry behind it"
+        );
+        assert!(
+            sink.timeout <= Duration::from_secs(30),
+            "the deadline must be short enough to keep a cycle moving: {:?}",
+            sink.timeout
+        );
+    }
+
+    /// attempt that never *returns* at all rather than one that returns
+    /// quickly with an error.
+    #[cfg(feature = "webhooks")]
+    #[tokio::test]
+    async fn http_webhook_sink_times_out_rather_than_hanging_forever() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        // Accepts the TCP connection and then never reads or writes anything
+        // — a receiver that hung mid-request, not one that refused the
+        // connection outright (which `reqwest` would fail on immediately
+        // regardless of any timeout).
+        let server = tokio::spawn(async move {
+            loop {
+                if let Ok((socket, _)) = listener.accept().await {
+                    // Hold the connection open and do nothing with it.
+                    std::mem::forget(socket);
+                } else {
+                    break;
+                }
+            }
+        });
+
+        let sink = HttpWebhookSink::with_timeout(
+            format!("http://{addr}"),
+            std::time::Duration::from_millis(200),
+        );
+        let event = WebhookEvent::now(
+            WebhookKind::WorkCompleted,
+            CompanyId::new("acme"),
+            serde_json::Value::Null,
+        );
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            sink.deliver(&event, "sha256=deadbeef"),
+        )
+        .await;
+        server.abort();
+
+        let delivered = outcome.expect(
+            "deliver must return on its own within the client timeout, not hang until this \
+             test's outer 5s bound",
+        );
+        assert!(
+            delivered.is_err(),
+            "a receiver that never responds must be reported as a failed delivery"
+        );
     }
 }

--- a/src/server/webhook.rs
+++ b/src/server/webhook.rs
@@ -657,12 +657,8 @@ mod test {
         server.abort();
     }
 
-    /// PLAT-050 (LIMIT / BOUND): a receiver that accepts the connection and
-    /// never answers must not hang `deliver` forever — `reqwest::Client::
-    /// new()` alone carries no timeout, so this is the one failure mode
-    /// `emit`'s bounded-attempt retry cannot protect against on its own: an
-    /// The sink the runtime builds carries the deadline, not just one a test
-    /// can construct.
+    /// PLAT-050 (LIMIT / BOUND): the sink the runtime builds carries the
+    /// deadline, not just one a test can construct.
     ///
     /// Exercising a timeout through a sink the case builds itself proves the
     /// mechanism and nothing about the wiring: `new` could stop setting one
@@ -684,8 +680,12 @@ mod test {
         );
     }
 
-    /// attempt that never *returns* at all rather than one that returns
-    /// quickly with an error.
+    /// PLAT-050 (LIMIT / BOUND): a receiver that accepts the connection and
+    /// never answers must not hang `deliver` forever — `reqwest::Client::new()`
+    /// alone carries no timeout, so this is the one failure mode `emit`'s
+    /// bounded-attempt retry cannot protect against on its own: an attempt that
+    /// never *returns* at all rather than one that returns quickly with an
+    /// error.
     #[cfg(feature = "webhooks")]
     #[tokio::test]
     async fn http_webhook_sink_times_out_rather_than_hanging_forever() {


### PR DESCRIPTION
## Summary

A real defect on the webhook path, plus coverage for the policy handler and the ACP transport.

**A webhook delivery had no deadline.** `reqwest::Client::new()` carries no timeout, so a receiving endpoint that accepts the connection and never answers hung `deliver` — and through it every one of `emit`'s three bounded attempts — forever. A bounded retry loop cannot help with the one failure mode where an attempt never returns at all, which is precisely what this module's own "never blocks a cycle" promise depends on.

The deadline is carried as a field on the sink rather than baked into the client, and that choice is the interesting part. A timeout that lives only inside the client builder can be *exercised* but not *read*, and the case exercising it built its own client — so it passed whether or not the runtime's constructor set one. Removing the timeout from `new` left that case green. With the deadline readable, a case can assert the sink the runtime actually builds carries it.

**The company policy handler** now has its AUTH, LIMIT and INPUT edges covered — a Member refused where an admin is required, a negative cap rejected, an oversized mode rejected, and the mode allowlist pinned.

**The ACP `call` handler** is driven through `router()` over HTTP rather than through its inner functions, so its session cap, its mixed reply-and-park notification, and its park bound are exercised where a caller actually reaches them.

| Cell | Axes | Proved by breaking |
|---|---|---|
| PLAT-050 | LIMIT, BOUND | pointing `new()` at a day-long deadline → the wiring assertion fires |
| SURF-001/003/004 | AUTH | injecting a Member principal into `require_admin` → `200` where `403` is expected |
| SURF-001 | LIMIT | breaking the negative-cap guard → `200` where `422` is expected |
| SURF-003 | INPUT, LIMIT | breaking the mode allowlist and the size guard → wrong status both ways |
| PLAT-057 | LIMIT | faking success on session-cap dispatch → the error is swallowed |
| PLAT-062 | STATE, BOUND | breaking the mixed notification and the park loop → counts drop 2→1 and 5→1 |

Three axes are closed by a **differential** rather than a break-and-restore, and are marked as such rather than presented as red proofs: SURF-001 FAIL, PLAT-057 CONC, PLAT-060 STATE/FAIL all have their mechanism in `gate.rs`, `session.rs` or `graphql/auth.rs` — outside these files, with nothing in reach to break.

**Declined:** PLAT-062 LIMIT/FAIL, because `CycleReport` carries no budget-cap or failure signal to assert against; and PLAT-066 INPUT/LIMIT/BOUND, because no handle-validation convention exists anywhere in the codebase and the prosumer fallback's "any handle" behaviour is documented as intentional.

## API Or Behavior Changes

A webhook delivery attempt now fails after ten seconds instead of hanging. `HttpWebhookSink::with_timeout` is public so a caller can choose its own deadline; `new` delegates to it.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — the default lane and `--no-deps --features openhuman`, both clean
- [ ] `cargo build --all-targets` — N/A: the clippy and test lanes build the same targets and are clean
- [x] `cargo test` — `server::webhook` 11 passed under `--features webhooks`; `ops::policy` 22 passed; `acp::transport` 32 passed under `--features acp,runner,tinymemory`

## Documentation

No docs needed — the deadline and the reason it is a readable field are stated in the sink's own doc comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated webhook tests covering delivery timeouts and HMAC signing.
  - Expanded HTTP transport coverage for session limits, concurrent connections, authorization modes, credential handling, forwarded requests, and approval notifications.
  - Added policy management coverage for authentication, authorization, validation, approval modes, and policy persistence.
  - Updated feature tracking to reflect webhook test coverage.

- **Documentation**
  - Clarified test documentation for webhook timeout and delivery-deadline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->