### PR TITLE
test: close six edge-case coverage gaps (connections, workflows, composio, chargebee, setup)

### DIFF
--- a/frontend/test/unit/setup-wizard-company-identity.test.ts
+++ b/frontend/test/unit/setup-wizard-company-identity.test.ts
@@ -375,6 +375,15 @@ describe("whether a finished wizard seeds a template or a designed company", () 
   it("seeds nothing onto a host that already has a company", () => {
     expect(shouldSeedTemplate({ ...picked, hasCompany: true })).toBe(false);
   });
+
+  it("designs instead when no template id is actually carried", () => {
+    // `source: "preset"` names the picker's answer, not proof a template id
+    // rode along with it — an empty or whitespace-only `template` has nothing
+    // for the host to seed from, so this must fall to the designed path the
+    // same as any other incomplete pick.
+    expect(shouldSeedTemplate({ ...picked, template: "" })).toBe(false);
+    expect(shouldSeedTemplate({ ...picked, template: "   " })).toBe(false);
+  });
 });
 
 describe("the sign-in modes a first run may offer", () => {

--- a/src/chargebee/api.rs
+++ b/src/chargebee/api.rs
@@ -1221,4 +1221,30 @@ mod tests {
         assert!(err.to_string().contains("at least 1"), "got: {err}");
         assert!(seen.is_empty(), "rejected before any request: {seen:?}");
     }
+
+    #[tokio::test]
+    async fn an_empty_or_blank_invoice_id_is_rejected_before_any_request() {
+        for id in ["", "   "] {
+            let (result, seen) = stub(vec![], |client| async move {
+                get_invoice(
+                    &client,
+                    GetInvoiceArgs {
+                        invoice_id: id.to_string(),
+                    },
+                )
+                .await
+            })
+            .await;
+
+            let err = result.expect_err("a blank invoice_id must be refused locally");
+            assert!(
+                err.to_string().contains("invoice_id"),
+                "got: {err} for input {id:?}"
+            );
+            assert!(
+                seen.is_empty(),
+                "rejected before any request: {seen:?} for input {id:?}"
+            );
+        }
+    }
 }

--- a/src/company/composio.rs
+++ b/src/company/composio.rs
@@ -1076,4 +1076,57 @@ mod tests {
             "https://api.tinyhumans.ai"
         );
     }
+
+    /// Fails every `get` for one chosen key, so a test can prove a read error
+    /// propagates instead of being swallowed into a fallback tier.
+    struct SecretsFailingToRead {
+        inner: MemSecrets,
+        blocked_key: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl SecretStore for SecretsFailingToRead {
+        async fn get(&self, c: &CompanyId, key: &str) -> Result<Option<SecretValue>> {
+            if key == self.blocked_key {
+                return Err(crate::error::OpenCompanyError::Store(
+                    "read refused by test".into(),
+                ));
+            }
+            self.inner.get(c, key).await
+        }
+        async fn set(&self, c: &CompanyId, key: &str, value: SecretValue) -> Result<()> {
+            self.inner.set(c, key, value).await
+        }
+    }
+
+    /// A store read error on the BYO override key must fail the whole
+    /// resolution rather than degrade to the shared brokered tier: an
+    /// unreadable store that silently fell through to
+    /// [`company_key::resolve`] would let a call be attributed to the wrong
+    /// account precisely when the store cannot be trusted to say which
+    /// account was configured.
+    #[tokio::test]
+    async fn a_store_read_error_on_the_byo_token_propagates_rather_than_falling_back() {
+        let company = CompanyId::new("acme");
+        let secrets = SecretsFailingToRead {
+            inner: MemSecrets::default(),
+            blocked_key: TOKEN_KEY,
+        };
+        // A managed-tier credential that *would* answer if resolution fell
+        // through to it — proving the error surfaces rather than that there
+        // was nothing to fall back to.
+        secrets
+            .inner
+            .set(&company, TOKEN_KEY, SecretValue("unreachable".into()))
+            .await
+            .unwrap();
+
+        let err = resolve_credential(&company, &secrets, None)
+            .await
+            .expect_err("an unreadable secret store must not resolve to any credential");
+        assert!(
+            matches!(err, crate::error::OpenCompanyError::Store(_)),
+            "expected the store error to propagate untouched, got {err:?}"
+        );
+    }
 }

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -2536,6 +2536,130 @@ mod tests {
             );
             assert_eq!(out[0].default_connection_id.as_deref(), Some("c1"));
         }
+
+        /// A loopback backend for the `DELETE …/composio/connections/{id}` route
+        /// test: `conn-1` is the only account this company knows about, and the
+        /// backend's own delete either succeeds or fails depending on
+        /// `fail_delete`, so the same mock drives both the 404 and the 502 arm of
+        /// the mapping in [`super::super::disconnect_impl`].
+        async fn spawn_connections_backend(
+            fail_delete: bool,
+        ) -> (String, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
+            use axum::extract::Path;
+            use axum::response::IntoResponse;
+
+            let deletes: std::sync::Arc<std::sync::Mutex<Vec<String>>> = Default::default();
+            let recorded = deletes.clone();
+            let app = Router::new()
+                .route(
+                    "/agent-integrations/composio/connections",
+                    axum::routing::get(|| async {
+                        Json(json!({
+                            "success": true,
+                            "data": { "connections": [
+                                { "id": "conn-1", "toolkit": "gmail", "status": "ACTIVE" }
+                            ] }
+                        }))
+                    }),
+                )
+                .route(
+                    "/agent-integrations/composio/connections/{id}",
+                    axum::routing::delete(move |Path(id): Path<String>| {
+                        let recorded = recorded.clone();
+                        async move {
+                            recorded.lock().unwrap().push(id);
+                            if fail_delete {
+                                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                            } else {
+                                Json(json!({ "success": true, "data": { "deleted": true } }))
+                                    .into_response()
+                            }
+                        }
+                    }),
+                );
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                let _ = axum::serve(listener, app).await;
+            });
+            (format!("http://{addr}"), deletes)
+        }
+
+        /// The documented split in [`super::super::disconnect_impl`]: an id this
+        /// company's own read cannot see is a `404`, never a `502`, because it is a
+        /// claim about the company's accounts rather than about the provider. Route
+        /// tests above only reach the "no client at all" `409` arm; this drives the
+        /// real mapping with a loopback backend standing in for Composio.
+        #[tokio::test]
+        async fn disconnect_maps_an_unknown_id_to_404_not_502() {
+            let (backend, deletes) = spawn_connections_backend(false).await;
+            let env = crate::test_support::EnvVarGuard::capture(&[
+                crate::company::composio::COMPOSIO_BACKEND_URL_ENV,
+            ]);
+            env.set(crate::company::composio::COMPOSIO_BACKEND_URL_ENV, &backend);
+
+            let home_dir = home();
+            let state = state_with_manifest(home_dir.path(), GRANTED).await;
+            send(
+                &state,
+                "PUT",
+                "/api/v1/company/composio/token",
+                Some(json!({ "token": TOKEN })),
+            )
+            .await;
+
+            let (status, body, raw) = send(
+                &state,
+                "DELETE",
+                "/api/v1/company/composio/connections/conn-does-not-exist",
+                None,
+            )
+            .await;
+            assert_eq!(status, StatusCode::NOT_FOUND, "{raw}");
+            assert_eq!(body["code"], "not_found", "{body}");
+            assert!(
+                deletes.lock().unwrap().is_empty(),
+                "an id outside the company's visible connections must never reach a delete call"
+            );
+        }
+
+        /// The other arm of the same split: an id the company DOES hold, but the
+        /// backend refuses to delete, is a `502` naming the provider failure —
+        /// never a `404`, which would tell the operator to stop looking for an
+        /// account that is right there in the list.
+        #[tokio::test]
+        async fn disconnect_maps_a_backend_failure_to_502_not_404() {
+            let (backend, deletes) = spawn_connections_backend(true).await;
+            let env = crate::test_support::EnvVarGuard::capture(&[
+                crate::company::composio::COMPOSIO_BACKEND_URL_ENV,
+            ]);
+            env.set(crate::company::composio::COMPOSIO_BACKEND_URL_ENV, &backend);
+
+            let home_dir = home();
+            let state = state_with_manifest(home_dir.path(), GRANTED).await;
+            send(
+                &state,
+                "PUT",
+                "/api/v1/company/composio/token",
+                Some(json!({ "token": TOKEN })),
+            )
+            .await;
+
+            let (status, body, raw) = send(
+                &state,
+                "DELETE",
+                "/api/v1/company/composio/connections/conn-1",
+                None,
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_GATEWAY, "{raw}");
+            assert_eq!(body["code"], "tinyhumans_composio_disconnect", "{body}");
+            assert_eq!(
+                deletes.lock().unwrap().as_slice(),
+                ["conn-1"],
+                "a known id must actually reach the backend's delete before failing"
+            );
+        }
     }
 
     /// The choice plane is wired on the same terms as the rest of the OAuth

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -547,4 +547,48 @@ mod test {
             .unwrap();
         assert!(is_blanked(&runtime, &provider).await, "secret not blanked");
     }
+
+    /// `disconnect` is declared `AdminScopedCompany` in its signature, but every
+    /// other test above calls [`do_disconnect`]/[`do_disconnect_from`] directly,
+    /// bypassing the extractor entirely. Route through the real router with a
+    /// member session so the scope is the thing under test.
+    #[tokio::test]
+    async fn disconnect_refuses_a_member_session_with_403() {
+        let (runtime, _home) = test_runtime().await;
+        let provider = unique_provider();
+        store_token(&runtime, &provider, "CANARY-member-must-not-disconnect").await;
+
+        let state = AppState::new(AppConfig::default());
+        state
+            .registry()
+            .insert(runtime.id().clone(), runtime.clone());
+        let member = crate::server::test_support::seed_session(
+            &state,
+            runtime.id().as_ref(),
+            crate::ports::users::UserRole::Member,
+        )
+        .await;
+
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!(
+                "/api/v1/companies/{}/connections/{provider}/disconnect",
+                runtime.id().as_ref()
+            ))
+            .header("cookie", member)
+            .body(Body::empty())
+            .unwrap();
+
+        let response = crate::server::router(state).oneshot(request).await.unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "a member reached an admin-scoped disconnect route"
+        );
+        assert!(
+            !is_blanked(&runtime, &provider).await,
+            "a refused member must not blank the stored credential"
+        );
+    }
 }

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -7735,6 +7735,120 @@ to = "ceo"
         assert_eq!(completed, vec!["gate", "shape"]);
     }
 
+    /// A resumed run has no [`CancellationToken`](tinyflows::engine::CancellationToken)
+    /// wired into the engine call (`resume_with_checkpointer_journaled_observed`
+    /// takes none), so `resuming` short-circuits straight to the hard-abort arm
+    /// instead of flipping a token and waiting `CANCEL_HARD_ABORT_GRACE` for a
+    /// clean node-boundary wind-down the way a fresh or checkpointed-initial run
+    /// does. This is the timing half of
+    /// `a_checkpoint_resume_can_be_hard_aborted_keeping_completed_nodes`, which
+    /// only bounds the wait at the grace window itself (5s) and so cannot tell
+    /// "aborted immediately" from "aborted right at the edge of the grace".
+    #[tokio::test]
+    async fn a_checkpoint_resume_cancel_skips_the_grace_window() {
+        const GATED_STALL: &str = r#"
+id = "gated-stall"
+name = "Gated stall"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "gate"
+kind = "transform"
+name = "Gate"
+requires_approval = true
+[[node]]
+id = "shape"
+kind = "transform"
+name = "Shape"
+[[node]]
+id = "ceo"
+kind = "agent"
+name = "CEO"
+agent = "ceo"
+prompt = "Think about it."
+[[edge]]
+from = "start"
+to = "gate"
+[[edge]]
+from = "gate"
+to = "shape"
+[[edge]]
+from = "shape"
+to = "ceo"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let pool = Arc::new(HarnessPool::new());
+        let rec = record();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let (mut deps, _events) = deps_with_events(dir.path());
+        deps.provider = Arc::new(StallingProvider {
+            entered: entered.clone(),
+        });
+        deps.provider_slug = "stalling".to_string();
+        pool.ensure(&rec, &deps).await.expect("roster builds");
+        let turn: Arc<dyn crate::runtime::delegation::RunTurn> = Arc::new(
+            crate::harness::built_in::run_turn::HarnessRunTurn::new(pool, Arc::new(deps.clone())),
+        );
+        let file = parse_workflow(GATED_STALL).expect("workflow parses");
+        let checkpoints = Arc::new(
+            crate::workflows::checkpoint_store::WorkflowCheckpointStore::new(
+                dir.path().join("checkpoints"),
+            ),
+        );
+        let first_ctx = WorkflowRunContext::new(false);
+        let paused = run_workflow_lane_aware_checkpointed(
+            turn.clone(),
+            deps.clone(),
+            &rec,
+            &file,
+            Value::Null,
+            &first_ctx,
+            Some(checkpoints.clone()),
+        )
+        .await
+        .expect("initial run pauses");
+        assert_eq!(paused.pending_approvals, vec!["gate"]);
+
+        let resume_ctx = WorkflowRunContext::new(false).with_checkpoint_resume(
+            first_ctx.run_id,
+            vec!["gate".to_string()],
+            Vec::new(),
+        );
+        let cancel = resume_ctx.cancel.clone();
+        let reached_agent = entered.notified();
+        let mut resumed = Box::pin(run_workflow_lane_aware_checkpointed(
+            turn,
+            deps,
+            &rec,
+            &file,
+            Value::Null,
+            &resume_ctx,
+            Some(checkpoints),
+        ));
+        tokio::select! {
+            _ = &mut resumed => panic!("the resumed agent did not stall"),
+            () = reached_agent => {}
+        }
+
+        let pressed = std::time::Instant::now();
+        cancel.cancel();
+        let run = tokio::time::timeout(CANCEL_HARD_ABORT_GRACE, resumed)
+            .await
+            .expect("checkpoint resume did not hard abort within the grace window")
+            .expect("cancelled checkpoint resume is not a failure");
+        let elapsed = pressed.elapsed();
+
+        assert!(run.cancelled);
+        assert!(
+            elapsed < CANCEL_HARD_ABORT_GRACE,
+            "cancelling a checkpoint resume took {elapsed:?} — at or past the grace window, \
+             meaning the resume path waited for a clean node-boundary wind-down instead of \
+             hard-aborting immediately"
+        );
+    }
+
     /// A checkpointed **initial** run (no `checkpoint_resume`) is not a resume,
     /// but production always attaches a checkpoint store — see
     /// `RuntimeBuilder`, which installs one unconditionally per company and


### PR DESCRIPTION
## Summary

Six focused tests closing edge-case gaps that had solid code behind them but no assertion pinning it:

- A member session is refused (403) at the router for `POST .../connections/{provider}/disconnect`, which is `AdminScopedCompany`-scoped but had only been exercised by calling its inner function directly, bypassing the extractor entirely.
- Cancelling a **resumed** checkpointed workflow run hard-aborts immediately rather than waiting the same grace window a fresh or checkpointed-initial run gets — the resume path has no `CancellationToken` wired into the engine call, so it falls straight to the hard-abort arm. The existing resume-cancel test bounded the wait at the grace window itself, which cannot distinguish "aborted immediately" from "aborted right at the edge of the grace." (This is intended behaviour, not a defect: a resume genuinely has no token to flip, so waiting the grace would only delay the hard abort with no chance of a clean stop.)
- A `SecretStore` read error on a company's BYO Composio token now has a test proving it propagates rather than silently falling back to the shared brokered credential tier.
- `chargebee_get_invoice` rejects an empty or whitespace-only `invoice_id` before any network call — code already did this, nothing named it.
- The `DELETE .../composio/connections/{id}` route's documented 404-vs-502 split (an id outside the company's visible connections is a 404; an id the company holds whose backend delete fails is a 502) is now driven through the real HTTP route with a loopback backend. The underlying classification was already unit-tested one layer down; the route-level mapping itself was not.
- The console's `shouldSeedTemplate` helper had 4 of its 5 conditions tested; the empty/blank-template branch (falling back to the designed path when `source: "preset"` carries no actual template id) did not.

## API Or Behavior Changes

None. Test-only changes.

## Tests

Commands actually run this session, with real results:

- `cargo fmt --all -- --check` — passed (clean).
- `git diff | grep -E "^-" | grep -vE "^---" | grep -vE "^-\s*(//|///)"` against every changed file — empty. Every change is a pure addition; no production line was deleted, so no red-proof break was left unrestored.

**Not completed and not claimed as passing:** `cargo clippy --all-targets --no-deps -- -D warnings` and `cargo test --locked --lib <module>` for the touched modules. This branch is based on `upstream/main`, which is currently broken: its `vendor/openhuman` submodule pin is at `0.63.23` while the committed `Cargo.lock` demands `0.63.24`, so `--locked` cannot resolve at all, and a plain `cargo test`/`clippy` silently rewrites the lock file down to `0.63.23` — which this branch does **not** carry, to avoid reintroducing that regression. That same base breakage is also why an unlocked build surfaces `src/server/graphql/mod.rs`'s `bridge_scope_test::state_with_two_companies` missing the `overlay_desk_hive` field on its `CompanyRecord` literal — already fixed on `fix/vendor-pin-regression` (`8bb058bd2`), just not yet on the `upstream/main` this branch was cut from. Not a separate finding; noted here only so it isn't mistaken for something introduced by this change.

This branch needs a rebase once `fix/vendor-pin-regression` lands on `upstream/main` — until then a from-scratch `--locked` build of this exact branch hits the same pre-existing resolution failure the base has.

Each new test's own red proof (break the behaviour it names, confirm the test fails for that reason, restore, confirm it passes) was done by reasoning through the code path against the mock/fixture rather than a full local `cargo test` run, for the reason above. That is weaker evidence than an actual failing run and should not be taken as equivalent to one.

## Documentation

None needed — no public API or behavior changed, only test coverage.
