### PR TITLE
test: close a handful of unhappy-path coverage gaps

### DIFF
--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -2309,6 +2309,31 @@ mod tests {
         assert!(problems.iter().any(|p| p.contains("5 fields")));
     }
 
+    /// `parse_usd` rejects negative amounts by construction (`amount >= 0.0`),
+    /// but the only existing skill-price test exercises the non-numeric edge
+    /// (`"free"`). A negative decimal string parses fine as an `f64` and would
+    /// slip through a check that only asked "is this a number".
+    #[test]
+    fn rejects_a_negative_skill_price() {
+        let manifest = parse(
+            r#"
+            [company]
+            name = "X"
+            handle = "x"
+            [place]
+            discoverable = true
+            skills = [{ id = "seo.audit", price_usd = "-5.00" }]
+            "#,
+        );
+        let problems = manifest.validate();
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("price_usd") && p.contains("-5.00")),
+            "{problems:?}"
+        );
+    }
+
     #[test]
     fn rejects_a_duplicate_skill_id() {
         let manifest = parse(

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -12858,6 +12858,126 @@ mod tests {
         }
     }
 
+    /// `notify_mentions`'s own comment calls a notification-store failure
+    /// "deliberately not fatal": the mention still renders as a chip and the
+    /// message still lands, only the badge is missing. Nothing forced that
+    /// store to fail and checked which half of the promise actually held.
+    mod notify_mentions_best_effort {
+        use crate::company::runtime::CompanyRuntime;
+        use crate::ports::notifications::{Notification, NotificationStore};
+        use crate::ports::types::{Actor, ActorKind, CompanyId, EventSeq, Mention, MentionTarget};
+        use crate::ports::users::{UserRecord, UserRole, UserStatus};
+        use std::sync::Arc;
+        use tempfile::TempDir;
+
+        /// A notification store whose `append` always refuses — the store is
+        /// down, not merely empty.
+        struct FailingNotifications;
+
+        #[async_trait::async_trait]
+        impl NotificationStore for FailingNotifications {
+            async fn append(
+                &self,
+                _company: &CompanyId,
+                _notification: &Notification,
+            ) -> crate::Result<()> {
+                Err(crate::error::OpenCompanyError::Store(
+                    "notification append always fails in this test".to_string(),
+                ))
+            }
+            async fn list(
+                &self,
+                _company: &CompanyId,
+                _user: &str,
+            ) -> crate::Result<Vec<crate::ports::notifications::NotificationView>> {
+                Ok(Vec::new())
+            }
+            async fn mark_read(
+                &self,
+                _company: &CompanyId,
+                _user: &str,
+                _ids: Option<&[String]>,
+            ) -> crate::Result<u64> {
+                Ok(0)
+            }
+        }
+
+        /// A one-agent company with one active human collaborator, and a
+        /// notification store that refuses every write.
+        async fn runtime_with_failing_notifications() -> (Arc<CompanyRuntime>, TempDir, String) {
+            let home = tempfile::Builder::new()
+                .prefix("opencompany-mention-notify-fail-")
+                .tempdir()
+                .expect("tempdir");
+            let manifest: crate::company::CompanyManifest = toml::from_str(
+                "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+                 [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n",
+            )
+            .expect("manifest");
+            let runtime = Arc::new(
+                crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+                    .with_id(CompanyId::new("acme"))
+                    .with_notifications(Arc::new(FailingNotifications))
+                    .build()
+                    .await
+                    .expect("runtime"),
+            );
+            let user_id = crate::ports::generate_id();
+            let now = crate::ports::now_millis();
+            runtime
+                .users()
+                .upsert_user(
+                    runtime.id(),
+                    &UserRecord {
+                        id: user_id.clone(),
+                        email: "mentioned@example.test".to_string(),
+                        display_name: None,
+                        avatar: None,
+                        role: UserRole::Member,
+                        status: UserStatus::Active,
+                        password_hash: None,
+                        must_change_password: false,
+                        created_at_millis: now,
+                        last_seen_at_millis: None,
+                        updated_at_millis: now,
+                    },
+                )
+                .await
+                .expect("seed user");
+            (runtime, home, user_id)
+        }
+
+        /// The exact promise `notify_mentions`'s own comment makes: a
+        /// notification store that will not answer must not fail somebody's
+        /// message. Called directly rather than through the chat route, so the
+        /// assertion lands on the one function the promise is about.
+        #[tokio::test]
+        async fn a_failing_notification_store_does_not_panic_or_propagate() {
+            let (runtime, _home, user_id) = runtime_with_failing_notifications().await;
+            let mention = Mention {
+                target: MentionTarget::User { id: user_id },
+                text: "@mentioned".to_string(),
+                offset: 0,
+                quiet: false,
+            };
+            // The whole assertion: `notify_mentions` returns `()`, not a
+            // `Result`, and this completes without panicking even though the
+            // store behind it always errors.
+            runtime
+                .notify_mentions(
+                    runtime.id(),
+                    std::slice::from_ref(&mention),
+                    &EventSeq::new(1),
+                    Some(&Actor {
+                        kind: ActorKind::User,
+                        id: "someone-else".to_string(),
+                    }),
+                    "main",
+                )
+                .await;
+        }
+    }
+
     /// Blocker DMs + reply attribution (issue #1862): a parked blocker surfaces
     /// in the responsible teammate's DM, groups by root cause, and an operator's
     /// reply routes back as a verdict.

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -2163,6 +2163,36 @@ mod test {
         );
     }
 
+    /// A line naming neither `agent` nor `workflow` is not one either format
+    /// wrote on purpose — both fields default on deserialize, so it still
+    /// replays rather than refusing to load. `subject` resolves it the same
+    /// way a pre-#1098 line resolves: no `workflow` key means agent, and an
+    /// empty agent string is still a value, so it replays as a permission held
+    /// by the empty-string agent. Nothing mints a line shaped like this today;
+    /// this pins that a malformed one does not panic or silently vanish, and
+    /// that it cannot be mistaken for a workflow permission.
+    #[test]
+    fn a_line_naming_neither_agent_nor_workflow_replays_as_the_empty_string_agent() {
+        let line = r#"{
+            "id": "g-malformed",
+            "tool": "web_fetch",
+            "granted_by": { "kind": "user", "id": "user-1" },
+            "approval_id": "approval-malformed",
+            "at_millis": 1000,
+            "expires_at_millis": 9999
+        }"#;
+        let replayed: StandingGrant =
+            serde_json::from_str(line).expect("agent and workflow both default on load");
+        assert_eq!(replayed.agent, "");
+        assert_eq!(replayed.workflow, None);
+        assert_eq!(replayed.subject(), GrantSubject::agent(""));
+        assert_ne!(
+            replayed.subject(),
+            GrantSubject::workflow(""),
+            "an empty agent must never resolve to a workflow subject"
+        );
+    }
+
     /// The two subjects are separate namespaces. A workflow named like a teammate
     /// must not spend that teammate's permission, in either direction.
     #[test]

--- a/src/server/ops/company_key/test.rs
+++ b/src/server/ops/company_key/test.rs
@@ -6,6 +6,7 @@ use serde_json::{Value, json};
 use tower::ServiceExt;
 
 use crate::company::CompanyManifest;
+use crate::ports::events::EventLog;
 use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::runtime::RuntimeBuilder;
 use crate::server::router;
@@ -424,6 +425,173 @@ async fn setting_and_clearing_are_journaled_with_an_actor() {
             .iter()
             .any(|(change, _)| change == "credential_set" || change == "credential_cleared"),
         "no Composio write happened here, so no Composio audit word may appear: {changes:?}"
+    );
+}
+
+/// An [`EventLog`](crate::ports::events::EventLog) decorator whose `append`
+/// can be switched to fail after setup, so a test can build a real company
+/// through a working log and then drive a route through the journal-refusal
+/// arm. Reads always delegate to a real
+/// [`FsEventLog`](crate::store::fs::FsEventLog), so `build()`'s own boot reads
+/// are never touched by the failure.
+struct FailingAppendLog {
+    inner: crate::store::fs::FsEventLog,
+    fail_appends: std::sync::atomic::AtomicBool,
+}
+
+impl FailingAppendLog {
+    fn new(inner: crate::store::fs::FsEventLog) -> Self {
+        Self {
+            inner,
+            fail_appends: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    fn fail_appends_from_now_on(&self) {
+        self.fail_appends
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::ports::events::EventLog for FailingAppendLog {
+    async fn append(
+        &self,
+        id: &CompanyId,
+        event: crate::ports::types::CompanyEvent,
+    ) -> crate::Result<crate::ports::types::EventSeq> {
+        if self.fail_appends.load(std::sync::atomic::Ordering::SeqCst) {
+            return Err(crate::error::OpenCompanyError::Config(
+                "the event journal is unwritable".to_string(),
+            ));
+        }
+        self.inner.append(id, event).await
+    }
+
+    async fn read_from(
+        &self,
+        id: &CompanyId,
+        seq: crate::ports::types::EventSeq,
+        limit: usize,
+    ) -> crate::Result<Vec<crate::ports::types::StoredEvent>> {
+        self.inner.read_from(id, seq, limit).await
+    }
+
+    fn subscribe(
+        &self,
+        id: &CompanyId,
+    ) -> futures::stream::BoxStream<'static, crate::ports::events::EventStreamItem> {
+        self.inner.subscribe(id)
+    }
+}
+
+/// [`state_with_manifest`], with the company's journal swapped for
+/// [`FailingAppendLog`] — armed only after the company finishes booting, so
+/// `RuntimeBuilder::build`'s own event reads/writes see a working log and the
+/// test controls exactly when the journal starts refusing.
+async fn state_with_failing_journal(
+    home: &std::path::Path,
+    company: &str,
+    manifest_toml: &str,
+) -> (AppState, std::sync::Arc<FailingAppendLog>) {
+    use crate::ports::CompanyStore;
+    let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+    let store = FsCompanyStore::new(home.to_path_buf());
+    let id = CompanyId::new(company);
+    store
+        .save(&CompanyRecord {
+            overlay_desk_hive: Vec::new(),
+            overlay_retired_agents: Vec::new(),
+            overlay_agent_edits: Vec::new(),
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_tool_grants: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+            name_confirmed: false,
+            activation_completed_at: None,
+            created_at_millis: None,
+        })
+        .await
+        .unwrap();
+    let journal = std::sync::Arc::new(FailingAppendLog::new(crate::store::fs::FsEventLog::new(
+        home.to_path_buf(),
+    )));
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+        .with_id(id.clone())
+        .with_events(journal.clone())
+        .build()
+        .await
+        .unwrap();
+    let state = AppState::new(AppConfig::default());
+    state.registry().insert(id, std::sync::Arc::new(runtime));
+    crate::server::test_support::seed_fixed_admin(&state, company).await;
+    (state, journal)
+}
+
+/// Issue #403's discipline, the unhappy half: `set_key`'s own doc comment
+/// says the journal write is propagated rather than swallowed "so a change to
+/// what the company's agents act through is never invisible" — but a
+/// propagated error is not the same as an undone one. `store_key` has already
+/// landed by the time `journal` runs, so a refused audit line leaves the
+/// credential rotated with the caller holding nothing but a 500.
+///
+/// This is the documented trade, not a bug this test is trying to catch —
+/// but until now nothing forced the journal to refuse and checked which side
+/// of "propagates rather than swallows" actually happened.
+#[tokio::test]
+async fn a_journal_failure_after_the_key_is_stored_still_leaves_the_key_stored() {
+    let home_dir = home();
+    let (state, journal) =
+        state_with_failing_journal(home_dir.path(), "acme", GRANTED).await;
+    let app = router(state.clone());
+    let cookie = crate::server::test_support::fixed_cookie("acme");
+
+    journal.fail_appends_from_now_on();
+
+    let (status, _, raw) = send_as(
+        &state,
+        "PUT",
+        "/api/v1/company/credential",
+        Some(json!({ "key": KEY })),
+        cookie.clone(),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "a refused journal write must not be swallowed into a 200: {raw}"
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/company/credential")
+                .header("cookie", &cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let status_body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(
+        status_body["configured"], true,
+        "the key was stored before the journal ever ran, so it stays stored even though the \
+         caller was told the request failed: {status_body}"
     );
 }
 

--- a/src/server/ops/company_key/test.rs
+++ b/src/server/ops/company_key/test.rs
@@ -552,8 +552,7 @@ async fn state_with_failing_journal(
 #[tokio::test]
 async fn a_journal_failure_after_the_key_is_stored_still_leaves_the_key_stored() {
     let home_dir = home();
-    let (state, journal) =
-        state_with_failing_journal(home_dir.path(), "acme", GRANTED).await;
+    let (state, journal) = state_with_failing_journal(home_dir.path(), "acme", GRANTED).await;
     let app = router(state.clone());
     let cookie = crate::server::test_support::fixed_cookie("acme");
 

--- a/src/server/ops/company_key/test.rs
+++ b/src/server/ops/company_key/test.rs
@@ -6,7 +6,6 @@ use serde_json::{Value, json};
 use tower::ServiceExt;
 
 use crate::company::CompanyManifest;
-use crate::ports::events::EventLog;
 use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::runtime::RuntimeBuilder;
 use crate::server::router;

--- a/src/server/ops/memory_ingest.rs
+++ b/src/server/ops/memory_ingest.rs
@@ -282,10 +282,13 @@ struct ForgottenDto {
 }
 
 /// Classifies a multipart failure the way the workspace upload does: a body
-/// that overran the limit is a 413, anything else a malformed request.
+/// that overran the limit is a 413, anything else a malformed request. The
+/// 413 is raised as [`OpenCompanyError::WorkspaceQuota`] on purpose — the
+/// shared "too big" vocabulary `server::ops::workspace`'s own
+/// `multipart_error` documents, rather than a second one for this route.
 fn multipart_error(error: MultipartError, context: &str) -> ApiError {
     if error.status() == StatusCode::PAYLOAD_TOO_LARGE {
-        return ApiError(OpenCompanyError::InvalidRequest(format!(
+        return ApiError(OpenCompanyError::WorkspaceQuota(format!(
             "this drop is larger than the {} MiB one request may carry, so it was cut off before \
              anything could be read. Nothing was stored — drop it in smaller batches.",
             INGEST_BODY_LIMIT / (1024 * 1024)

--- a/src/server/ops/memory_ingest/test.rs
+++ b/src/server/ops/memory_ingest/test.rs
@@ -310,6 +310,11 @@ async fn a_request_over_the_body_limit_is_refused_as_413_not_malformed() {
     let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
 
     assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{body}");
+    assert_eq!(
+        body["code"], "workspace_quota_exceeded",
+        "the body-limit refusal shares the platform's one \"too big\" code, not the generic \
+         invalid_request one: {body}"
+    );
     let message = body["error"].as_str().expect("an error message");
     assert!(
         message.contains("smaller batches"),

--- a/src/server/ops/memory_ingest/test.rs
+++ b/src/server/ops/memory_ingest/test.rs
@@ -239,6 +239,89 @@ async fn a_drop_with_no_files_is_refused() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
+/// A body of `prefix` + `payload` zero bytes + `suffix`, streamed in 1 MiB
+/// frames with a yield before each — so the *test* never holds the whole
+/// payload in memory even when it is well past the route's limit. Modeled on
+/// `server::ops::write_test`'s `streamed_multipart`, which exists for the same
+/// reason: a contiguous body would make proving a body-limit rejection cost as
+/// much memory as the rejection is supposed to save.
+fn streamed_multipart(prefix: Vec<u8>, payload: usize, suffix: Vec<u8>) -> Body {
+    const FRAME: usize = 1024 * 1024;
+    let prefix = Arc::new(prefix);
+    let suffix = Arc::new(suffix);
+    let filler = bytes::Bytes::from(vec![0u8; FRAME]);
+    let frames = payload.div_ceil(FRAME);
+
+    let stream = futures::stream::unfold(0usize, move |step| {
+        let prefix = prefix.clone();
+        let suffix = suffix.clone();
+        let filler = filler.clone();
+        async move {
+            tokio::task::yield_now().await;
+            let frame = if step == 0 {
+                bytes::Bytes::from(prefix.as_ref().clone())
+            } else if step <= frames {
+                filler.slice(..(payload - (step - 1) * FRAME).min(FRAME))
+            } else if step == frames + 1 {
+                bytes::Bytes::from(suffix.as_ref().clone())
+            } else {
+                return None;
+            };
+            Some((Ok::<_, std::io::Error>(frame), step + 1))
+        }
+    });
+    Body::from_stream(stream)
+}
+
+/// A whole request over [`INGEST_BODY_LIMIT`](super::INGEST_BODY_LIMIT) is cut
+/// off before anything is read: `multipart_error` names this specifically as a
+/// 413 with a "drop it in smaller batches" remedy, distinct from the plain
+/// malformed-request 400 every other multipart failure gets. Only the per-file
+/// cap (`an_unreadable_file_is_reported_without_failing_the_batch`'s sibling
+/// tests) and the empty-drop 400 were covered before this; the whole-request
+/// ceiling itself never had a request built to trip it.
+#[tokio::test]
+async fn a_request_over_the_body_limit_is_refused_as_413_not_malformed() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = state_at(dir.path()).await;
+
+    let prefix = format!(
+        "--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"file\"; \
+         filename=\"huge.bin\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+    )
+    .into_bytes();
+    let suffix = format!("\r\n--{BOUNDARY}--\r\n").into_bytes();
+    // One byte past the 200 MiB ceiling (8 * MAX_DOCUMENT_BYTES).
+    let oversize = 8 * 25 * 1024 * 1024 + 1;
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/company/memory/ingest")
+        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={BOUNDARY}"),
+        )
+        .body(streamed_multipart(prefix, oversize, suffix))
+        .unwrap();
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{body}");
+    let message = body["error"].as_str().expect("an error message");
+    assert!(
+        message.contains("smaller batches"),
+        "the body-limit refusal must name its own remedy, not the generic \
+         malformed-request message: {message}"
+    );
+    assert!(
+        !message.contains("Error parsing"),
+        "an overrun body must not be reported as malformed: {message}"
+    );
+}
+
 /// The server-side request forgery guard: this route makes the *host* fetch a
 /// URL, so the deployment's own network is off limits.
 ///

--- a/src/server/ops/search.rs
+++ b/src/server/ops/search.rs
@@ -412,8 +412,7 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "{body}");
         assert_eq!(body["granted"], true);
 
-        let toml_path =
-            crate::store::Bundle::new(home, &CompanyId::new("acme")).company_toml();
+        let toml_path = crate::store::Bundle::new(home, &CompanyId::new("acme")).company_toml();
         tokio::fs::write(&toml_path, b"not valid toml [[[")
             .await
             .expect("corrupt company.toml");

--- a/src/server/ops/search.rs
+++ b/src/server/ops/search.rs
@@ -391,6 +391,47 @@ mod tests {
         );
     }
 
+    /// `status_of`'s own comment says a company record that cannot be loaded
+    /// reports `granted: false` rather than failing the whole status — "the
+    /// operator still needs to see what IS configured, and a settings page
+    /// that 500s tells them nothing." That fallback only runs when
+    /// `store().load()` actually errors, which an absent record does not do
+    /// (`Ok(None)`, not `Err`) — so this corrupts the on-disk manifest after
+    /// the company has already booted, forcing a real `FsCompanyStore::load`
+    /// failure on the route's own re-read rather than mocking the store.
+    #[tokio::test]
+    async fn a_company_that_fails_to_load_reports_ungranted_instead_of_500() {
+        let home_dir = ::tempfile::tempdir().expect("tempdir");
+        let home = home_dir.path();
+        let state = state_with_company(home, true).await;
+        let admin = crate::server::test_support::seed_admin(&state, "acme").await;
+
+        // Baseline: the manifest grants `search`, so the route reports it.
+        let (status, body) =
+            call(&state, "GET", "/api/v1/companies/acme/search", &admin, None).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["granted"], true);
+
+        let toml_path =
+            crate::store::Bundle::new(home, &CompanyId::new("acme")).company_toml();
+        tokio::fs::write(&toml_path, b"not valid toml [[[")
+            .await
+            .expect("corrupt company.toml");
+
+        let (status, body) =
+            call(&state, "GET", "/api/v1/companies/acme/search", &admin, None).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a store-load failure must still answer with a status, not a 500: {body}"
+        );
+        assert_eq!(
+            body["granted"], false,
+            "an unreadable record must fall back to ungranted rather than keep reporting the \
+             last-known grant: {body}"
+        );
+    }
+
     #[tokio::test]
     async fn a_saved_key_is_reported_as_configured_and_never_returned() {
         let home = ::tempfile::tempdir().expect("tempdir");

--- a/src/turn_stream.rs
+++ b/src/turn_stream.rs
@@ -613,6 +613,36 @@ mod tests {
         publish(&company, frame("tool_call", 0)); // must not panic
     }
 
+    /// A subscriber that lags past [`CAPACITY`] must skip the gap and keep
+    /// reading — never block, and never end the stream. `subscribe`'s `loop`
+    /// treats `RecvError::Lagged` as a reason to keep polling; only `Closed`
+    /// ends the stream, and `REGISTRY` holds a sender for the process
+    /// lifetime, so that never fires here.
+    #[tokio::test]
+    async fn a_lagging_subscriber_skips_dropped_frames_instead_of_ending() {
+        let company = CompanyId::new("turn-stream-overflow");
+        let mut stream = subscribe(&company);
+
+        // Publish well past the ring's capacity with nobody draining it, so
+        // the receiver's cursor falls behind the oldest frame still buffered.
+        let overflow = CAPACITY as u64 + 50;
+        for seq in 0..overflow {
+            publish(&company, frame("tool_call", seq));
+        }
+
+        let got = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+            .await
+            .expect("a lagging subscriber must not block forever")
+            .expect("the stream must not end on a lag");
+        let got = turn(got);
+        assert!(
+            got.seq >= overflow - CAPACITY as u64,
+            "a lagging read must resume at the oldest frame still in the ring, not replay one \
+             that was already dropped: got seq {}",
+            got.seq
+        );
+    }
+
     /// The wire shape carries a `type` discriminant (so the console switches on
     /// it alongside the durable projections), camelCases its keys, and omits
     /// empty optionals.


### PR DESCRIPTION
## Summary

Adds targeted tests for seven unhappy-path behaviors that were implemented but untested, found while auditing edge-case coverage across the manifest validator, standing-grant replay, the live turn-progress bus, the company credential route, the search-status route, the memory-ingest route, and mention notifications. While writing one of them, found and fixed a real defect (see below). Also fixes one unrelated pre-existing compile break in a GraphQL test fixture that was blocking `cargo test --lib` for the whole crate.

- **Manifest**: `parse_usd` rejects a negative `price_usd` by construction, but the only existing skill-price test exercised the non-numeric edge (`"free"`). Added a case for an actual negative decimal string.
- **Grants**: a standing-grant journal line naming neither `agent` nor `workflow` deserializes (both fields default) and resolves to an agent permission held by the empty string, never a workflow one. Nothing minted a line shaped like this before, but nothing rejected one either — pinned the replay behavior directly.
- **Turn stream**: the live per-turn progress bus drops frames for a subscriber that falls more than `CAPACITY` (256) behind, rather than blocking the publisher. Drove a subscriber past that ceiling and confirmed the stream skips the gap and keeps delivering instead of stalling or ending.
- **Company credential route**: setting the company's TinyHumans key stores it first and journals the change second, propagating a journal failure instead of swallowing it. Forced the journal to refuse after a real boot and confirmed the credential stays stored even though the caller is told the request failed — the documented trade, now proven rather than assumed.
- **Search status route**: the route's own comment says a company record that fails to load reports `granted: false` instead of a 500. That branch only fires on a real load error, not an absent record, so the test corrupts the on-disk manifest after boot to force a genuine `FsCompanyStore::load` failure rather than mocking the store.
- **Memory ingest route**: a drop over the whole-request body limit is meant to come back as a 413 naming its own remedy ("drop it in smaller batches"), distinct from the generic malformed-multipart 400. Writing this test caught the route not actually doing that — see the defect below.
- **Mention notifications**: `notify_mentions`'s own comment calls a notification-store failure "deliberately not fatal" — the mention still renders as a chip and the message still lands, only the badge is missing. Nothing forced that store to fail and checked which half of the promise actually held.

### Defect found and fixed: memory-ingest's over-limit drop answered 400, not 413

`memory_ingest.rs`'s `multipart_error` had a doc comment promising "a body that overran the limit is a 413, anything else a malformed request" — the same classifier `server::ops::workspace`'s upload route uses. But both of its branches actually constructed `OpenCompanyError::InvalidRequest`, which always maps to 400. Confirmed this live: the new test failed on the very first run against unmodified code, with `left: 400, right: 413` and body `{"error":"...this drop is larger than...","code":"invalid_request"}` — the message text said "too large" but the status and code said "bad request." Fixed by routing the over-limit branch through `OpenCompanyError::WorkspaceQuota` instead, the same variant `server::ops::workspace`'s own `multipart_error` uses for its over-limit case, so both upload surfaces share one status (413) and one code (`workspace_quota_exceeded`) for "too big."

**Caller-visible behavior change**: an ingest request (`POST …/memory/ingest`) over the body limit now answers `413` with code `workspace_quota_exceeded`, where it previously answered `400` with code `invalid_request`. The error message text is unchanged. This is a bug fix that brings the route in line with its own documented intent and with the sibling workspace-upload route, not a new design decision — but any caller keying on the old `invalid_request` code for this specific case would see it change.

## API Or Behavior Changes

- `POST …/memory/ingest`: an over-body-limit request now returns `413 Payload Too Large` with code `workspace_quota_exceeded` (previously `400 Bad Request` with code `invalid_request`). See "Defect found and fixed" above.
- Everything else in this PR is test-only, plus a one-line `graphql/mod.rs` test-fixture fix (adds the `overlay_desk_hive` field `CompanyRecord` already requires everywhere else — a compile fix, not a behavior change).

## Tests

Full command and result for every new test, run individually against a from-scratch `cargo test --offline --lib` build (this base's `Cargo.lock` disagrees with the `vendor/openhuman` submodule pin — 0.63.24 vs 0.63.23 checked out — so `--locked` cannot resolve; ran `--offline` instead and reverted `Cargo.lock` before every commit, so none of that drift is in this diff):

```
cargo test --offline --lib company::manifest::tests::rejects_a_negative_skill_price
test company::manifest::tests::rejects_a_negative_skill_price ... ok
1 passed; 0 failed

cargo test --offline --lib runtime::grants::test::a_line_naming_neither_agent_nor_workflow_replays_as_the_empty_string_agent
test ... ok
1 passed; 0 failed

cargo test --offline --lib turn_stream::tests::a_lagging_subscriber_skips_dropped_frames_instead_of_ending
test ... ok
1 passed; 0 failed

cargo test --offline --lib server::ops::company_key::test::a_journal_failure_after_the_key_is_stored_still_leaves_the_key_stored
test ... ok
1 passed; 0 failed

cargo test --offline --lib server::ops::search::tests::a_company_that_fails_to_load_reports_ungranted_instead_of_500
test ... ok
1 passed; 0 failed

cargo test --offline --lib server::ops::memory_ingest::test::a_request_over_the_body_limit_is_refused_as_413_not_malformed
test ... ok
1 passed; 0 failed

cargo test --offline --lib company::runtime::tests::notify_mentions_best_effort::a_failing_notification_store_does_not_panic_or_propagate
test ... ok
1 passed; 0 failed
```

Red proof for every test — broke the production behavior, confirmed the test failed for its own reason (not a compile error or unrelated panic), restored, confirmed it passed again:

| Test | Break | Failure message | 
|---|---|---|
| `rejects_a_negative_skill_price` | `parse_usd` dropped its `amount >= 0.0` guard | `panicked ... []` — asserted problem never appeared |
| `a_line_naming_neither_agent_nor_workflow_replays_...` | `StandingGrant::subject()`'s `None` arm returned `GrantSubject::Workflow` instead of `Agent` | `left: Workflow(""), right: Agent("")` |
| `a_lagging_subscriber_skips_dropped_frames_instead_of_ending` | `subscribe`'s `Lagged` arm changed from `continue` to `return None` | `the stream must not end on a lag` |
| `a_journal_failure_after_the_key_is_stored_still_leaves_the_key_stored` | `set_key` changed `journal(...).await?` to `let _ = journal(...).await` (swallowed) | `left: 200, right: 500` — "a refused journal write must not be swallowed into a 200" |
| `a_company_that_fails_to_load_reports_ungranted_instead_of_500` | `status_of`'s load-failure fallback changed from `unwrap_or(false)` to `unwrap_or(true)` | `left: Bool(true), right: false` |
| `a_request_over_the_body_limit_is_refused_as_413_not_malformed` | this is the defect above — the unmodified code itself was the red proof | `left: 400, right: 413`, body carried `code: "invalid_request"` |
| `a_failing_notification_store_does_not_panic_or_propagate` | `notify_mentions`'s swallow-and-warn block changed to `.expect(...)` | panicked: `TEMP BREAK ...: Store("notification append always fails in this test")` |

Every break was restored before committing; `git diff | grep -E "^-" | grep -vE "^---" | grep -vE "^-\s*(//|///)"` on the final branch shows only the two intentional non-test deletions (the `graphql/mod.rs` field-order line and the `InvalidRequest`→`WorkspaceQuota` line in the defect fix) — no leftover break.

Not run locally, given how long a full build takes on this shared machine — please confirm in CI:
- [x] `cargo fmt --all -- --check` — clean on the final commit
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo build --all-targets`
- [ ] `cargo test` (full suite — only the seven new tests above were run individually)

## Documentation

None needed — no public API or documented behavior changed beyond the one status-code fix called out above, which brings the route's actual behavior in line with what its own doc comment already promised.
