### PR TITLE
test: pin idempotency and parent-guard edge cases across deep-trace, memory, ledgers, domain, workspace

### DIFF
--- a/src/company/ledgers_test.rs
+++ b/src/company/ledgers_test.rs
@@ -330,6 +330,42 @@ async fn only_a_person_may_delete_a_row() {
     );
 }
 
+/// A second delete of the same id must stay the quiet `Ok(false)`
+/// `purge_entry` already reports for "nothing there" — never an error, and
+/// never a second entry in the log. Nothing before this called `delete_entry`
+/// twice on one id.
+#[tokio::test]
+async fn deleting_an_already_deleted_row_reports_false_not_an_error() {
+    let (ctx, runtime, _home) = ledgers().await;
+    let spec = define(&ctx, &hazards()).await.expect("declared");
+    record(&ctx, &spec, &agent(), "r1", fields(&[("risk", "a")]))
+        .await
+        .expect("recorded");
+
+    assert!(
+        delete_entry(&ctx, &spec, &person(), "r1")
+            .await
+            .expect("the first delete removes the row")
+    );
+    assert!(
+        !delete_entry(&ctx, &spec, &person(), "r1")
+            .await
+            .expect("deleting an already-deleted row is not an error"),
+        "a second delete of the same id must report false, not recreate anything"
+    );
+
+    let events = runtime
+        .ledgers()
+        .events(runtime.id(), "hazards")
+        .await
+        .expect("events");
+    assert!(
+        events.is_empty(),
+        "the row's event was purged by the first delete; a no-op second \
+         delete must not resurrect it: {events:?}"
+    );
+}
+
 /// The runtime is not exempt either: a sweep that could delete rows is the same
 /// loss with nobody to ask about it.
 #[tokio::test]
@@ -370,6 +406,46 @@ async fn only_a_person_may_retire_a_ledger_and_the_rows_survive_it() {
         .await
         .expect("events");
     assert_eq!(events.len(), 1, "the log survives the retirement");
+}
+
+/// A second `retire` of the same slug must stay a clean [`NotFound`], not
+/// panic, not silently succeed, and not touch the rows the first retirement
+/// already left alone.
+///
+/// [`NotFound`]: crate::error::OpenCompanyError::NotFound
+#[tokio::test]
+async fn retiring_an_already_retired_ledger_is_refused_not_silently_repeated() {
+    let (ctx, runtime, _home) = ledgers().await;
+    let spec = define(&ctx, &hazards()).await.expect("declared");
+    record(&ctx, &spec, &agent(), "r1", fields(&[("risk", "a")]))
+        .await
+        .expect("recorded");
+
+    retire(&ctx, &person(), "hazards", false)
+        .await
+        .expect("the first retirement succeeds");
+
+    let error = retire(&ctx, &person(), "hazards", false)
+        .await
+        .expect_err("a second retirement of the same slug must be refused");
+    assert!(
+        matches!(error, OpenCompanyError::NotFound(_)),
+        "a repeat retirement must be reported as not-found, not any other \
+         error shape: {error:?}"
+    );
+
+    // The rows the first retirement left in place are still there — the
+    // refused second call did not fall through to a purge.
+    let events = runtime
+        .ledgers()
+        .events(runtime.id(), "hazards")
+        .await
+        .expect("events");
+    assert_eq!(
+        events.len(),
+        1,
+        "the refused repeat retirement must not have purged anything"
+    );
 }
 
 #[tokio::test]

--- a/src/server/ops/deep_trace.rs
+++ b/src/server/ops/deep_trace.rs
@@ -56,3 +56,185 @@ async fn purge_run(
         .map_err(ApiError)?;
     Ok(StatusCode::NO_CONTENT)
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::deep_trace::{RunStepDetailRecord, TurnStepDetail};
+    use crate::ports::types::CompanyId;
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::{AppConfig, AppState};
+
+    const MANIFEST: &str = "[company]\nname = \"Provisional Co\"\n\
+         [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n";
+
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-deep-trace-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    async fn state(home: &std::path::Path) -> AppState {
+        let manifest: CompanyManifest = toml::from_str(MANIFEST).unwrap();
+        let id = CompanyId::new("acme");
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn delete_request(state: &AppState, path: &str) -> StatusCode {
+        let request = Request::builder()
+            .method("DELETE")
+            .uri(path)
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .body(Body::empty())
+            .unwrap();
+        router(state.clone())
+            .oneshot(request)
+            .await
+            .unwrap()
+            .status()
+    }
+
+    /// The store layer already proves `purge_deep_trace` is idempotent
+    /// (`store/conformance.rs`: purging a run twice returns `1` then `0`,
+    /// never an error). What that leaves open is whether the real HTTP
+    /// handler — auth extraction, path parsing, the route itself — actually
+    /// reaches that behaviour, or whether something in the handler (an
+    /// unwrap, a not-found mapped to an error status) turns a second purge
+    /// into something other than a quiet no-op. Drives `DELETE
+    /// …/deep-trace/{run_id}` through the real router twice.
+    #[tokio::test]
+    async fn purge_run_through_the_route_is_idempotent() {
+        let dir = home();
+        let state = state(dir.path()).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+
+        runtime
+            .deep_trace()
+            .append_step_detail(
+                &id,
+                &RunStepDetailRecord {
+                    run_id: "r1".to_string(),
+                    step_seq: 0,
+                    at_millis: 1,
+                    detail: TurnStepDetail {
+                        reasoning: Some("why".to_string()),
+                        ..Default::default()
+                    },
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            runtime.deep_trace().list_step_details(&id, "r1").await.unwrap().len(),
+            1,
+            "fixture did not seed the record the test purges"
+        );
+
+        let first = delete_request(&state, "/api/v1/company/deep-trace/r1").await;
+        assert_eq!(first, StatusCode::NO_CONTENT, "first purge destroys the row");
+        assert!(
+            runtime
+                .deep_trace()
+                .list_step_details(&id, "r1")
+                .await
+                .unwrap()
+                .is_empty(),
+            "the route did not actually purge the record"
+        );
+
+        let second = delete_request(&state, "/api/v1/company/deep-trace/r1").await;
+        assert_eq!(
+            second,
+            StatusCode::NO_CONTENT,
+            "purging an already-purged run through the route must stay a quiet \
+             no-op, not surface an error status"
+        );
+    }
+
+    /// Same shape for the whole-company purge: through the real route, twice
+    /// in a row, on a company with nothing left to destroy the second time.
+    #[tokio::test]
+    async fn purge_all_through_the_route_is_idempotent() {
+        let dir = home();
+        let state = state(dir.path()).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+
+        for (run_id, step_seq) in [("r1", 0u32), ("r2", 0u32)] {
+            runtime
+                .deep_trace()
+                .append_step_detail(
+                    &id,
+                    &RunStepDetailRecord {
+                        run_id: run_id.to_string(),
+                        step_seq,
+                        at_millis: 1,
+                        detail: TurnStepDetail {
+                            output: Some("out".to_string()),
+                            ..Default::default()
+                        },
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        let first = delete_request(&state, "/api/v1/company/deep-trace").await;
+        assert_eq!(first, StatusCode::NO_CONTENT);
+        assert!(
+            runtime.deep_trace().list_step_details(&id, "r1").await.unwrap().is_empty()
+        );
+        assert!(
+            runtime.deep_trace().list_step_details(&id, "r2").await.unwrap().is_empty()
+        );
+
+        let second = delete_request(&state, "/api/v1/company/deep-trace").await;
+        assert_eq!(
+            second,
+            StatusCode::NO_CONTENT,
+            "purging an already-empty deep-trace store through the route must \
+             stay a quiet no-op"
+        );
+    }
+
+    /// The extractor guards this surface: a plain member (not an admin) must
+    /// not reach the purge at all. Pins `AdminScopedCompany` actually being
+    /// wired on this route rather than the ordinary member-scope extractor.
+    #[tokio::test]
+    async fn a_member_may_not_purge_deep_trace() {
+        let dir = home();
+        let state = state(dir.path()).await;
+        crate::server::test_support::seed_fixed_member(&state, "acme").await;
+
+        let request = Request::builder()
+            .method("DELETE")
+            .uri("/api/v1/company/deep-trace")
+            .header(
+                "cookie",
+                crate::server::test_support::member_cookie("acme"),
+            )
+            .body(Body::empty())
+            .unwrap();
+        let status = router(state.clone()).oneshot(request).await.unwrap().status();
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "a member cookie must not be able to purge unredacted deep-trace bodies"
+        );
+    }
+}

--- a/src/server/ops/deep_trace.rs
+++ b/src/server/ops/deep_trace.rs
@@ -140,13 +140,22 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            runtime.deep_trace().list_step_details(&id, "r1").await.unwrap().len(),
+            runtime
+                .deep_trace()
+                .list_step_details(&id, "r1")
+                .await
+                .unwrap()
+                .len(),
             1,
             "fixture did not seed the record the test purges"
         );
 
         let first = delete_request(&state, "/api/v1/company/deep-trace/r1").await;
-        assert_eq!(first, StatusCode::NO_CONTENT, "first purge destroys the row");
+        assert_eq!(
+            first,
+            StatusCode::NO_CONTENT,
+            "first purge destroys the row"
+        );
         assert!(
             runtime
                 .deep_trace()
@@ -197,10 +206,20 @@ mod tests {
         let first = delete_request(&state, "/api/v1/company/deep-trace").await;
         assert_eq!(first, StatusCode::NO_CONTENT);
         assert!(
-            runtime.deep_trace().list_step_details(&id, "r1").await.unwrap().is_empty()
+            runtime
+                .deep_trace()
+                .list_step_details(&id, "r1")
+                .await
+                .unwrap()
+                .is_empty()
         );
         assert!(
-            runtime.deep_trace().list_step_details(&id, "r2").await.unwrap().is_empty()
+            runtime
+                .deep_trace()
+                .list_step_details(&id, "r2")
+                .await
+                .unwrap()
+                .is_empty()
         );
 
         let second = delete_request(&state, "/api/v1/company/deep-trace").await;
@@ -224,13 +243,14 @@ mod tests {
         let request = Request::builder()
             .method("DELETE")
             .uri("/api/v1/company/deep-trace")
-            .header(
-                "cookie",
-                crate::server::test_support::member_cookie("acme"),
-            )
+            .header("cookie", crate::server::test_support::member_cookie("acme"))
             .body(Body::empty())
             .unwrap();
-        let status = router(state.clone()).oneshot(request).await.unwrap().status();
+        let status = router(state.clone())
+            .oneshot(request)
+            .await
+            .unwrap()
+            .status();
         assert_eq!(
             status,
             StatusCode::FORBIDDEN,

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -160,6 +160,36 @@ async fn verify_without_resolver_is_404_not_wired() {
     assert_eq!(value["code"], "not_wired");
 }
 
+/// The other refusal on this route, and the one nothing here had driven yet:
+/// a resolver *is* wired, but no domain was ever `PUT`. `verify_without_resolver_is_404_not_wired`
+/// covers the missing-dependency branch and `verify_with_resolver_marks_verified`
+/// covers the happy path; this is `run_verify`'s own `stored.is_none()` guard,
+/// which is neither of those.
+#[tokio::test]
+async fn verify_with_no_domain_configured_is_400() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let resolver = Arc::new(StaticDnsResolver::fully_verifying("acme.com"));
+    let state = state_with(&home, ConnectionsRuntime::new().with_dns(resolver)).await;
+    let app = router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/company/domain/verify")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let value = body_json(response).await;
+    assert_eq!(value["code"], "invalid_request");
+    assert_eq!(value["error"], "invalid request: no domain configured");
+}
+
 #[tokio::test]
 async fn verify_with_resolver_marks_verified() {
     let home_dir = home();

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -5251,7 +5251,9 @@ pub async fn assert_workspace_folder_claims(ws: Arc<dyn WorkspaceStore>) {
 /// this one.
 ///
 /// [`adopt_or_create_folder`]: WorkspaceStore::adopt_or_create_folder
-pub async fn assert_workspace_create_rejects_an_absent_or_foreign_parent(ws: Arc<dyn WorkspaceStore>) {
+pub async fn assert_workspace_create_rejects_an_absent_or_foreign_parent(
+    ws: Arc<dyn WorkspaceStore>,
+) {
     let alpha = CompanyId::new("parent-guard-alpha");
     let beta = CompanyId::new("parent-guard-beta");
 

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -5238,6 +5238,84 @@ pub async fn assert_workspace_folder_claims(ws: Arc<dyn WorkspaceStore>) {
     assert_eq!(&after.node().id, &ids[0]);
 }
 
+/// [`WorkspaceStore::create`]'s own contract, not [`adopt_or_create_folder`]'s:
+/// "the `parent_id`, when set, must name an existing folder" (the trait doc on
+/// `create`) is asserted directly against `create` on all three backends, for
+/// both a `parent_id` that names nothing and one that names a real folder in a
+/// *different* company.
+///
+/// [`assert_workspace_folder_claims`] already proves the analogous refusal for
+/// the folder-claim primitive; `create` is a separate code path on every
+/// backend (a plain `INSERT`/`insert_one`/file write, not the claim's
+/// transaction-guarded read-or-adopt), so passing there says nothing about
+/// this one.
+///
+/// [`adopt_or_create_folder`]: WorkspaceStore::adopt_or_create_folder
+pub async fn assert_workspace_create_rejects_an_absent_or_foreign_parent(ws: Arc<dyn WorkspaceStore>) {
+    let alpha = CompanyId::new("parent-guard-alpha");
+    let beta = CompanyId::new("parent-guard-beta");
+
+    let child_of_nothing = WorkspaceNode {
+        id: "orphan".to_string(),
+        name: "orphan.md".to_string(),
+        kind: NodeKind::File,
+        parent_id: Some("no-such-folder".to_string()),
+        updated_at_millis: now_millis(),
+        created_by: WorkspaceOrigin::Operator,
+        updated_by: WorkspaceOrigin::Operator,
+        mime: None,
+        size: None,
+        sha256: None,
+        adopted: false,
+    };
+    assert!(
+        ws.create(&alpha, &child_of_nothing, Some("body"))
+            .await
+            .is_err(),
+        "a parent_id naming no node anywhere must be refused"
+    );
+    assert!(
+        ws.tree(&alpha).await.unwrap().is_empty(),
+        "a refused create must not leave the orphan behind"
+    );
+
+    // beta's real folder — reachable, just not from alpha.
+    let beta_root = folder_node("beta-root", "Beta Root");
+    ws.create(&beta, &beta_root, None)
+        .await
+        .expect("a root folder in beta");
+
+    let cross_company_child = WorkspaceNode {
+        id: "cross-company-child".to_string(),
+        name: "cross.md".to_string(),
+        kind: NodeKind::File,
+        parent_id: Some(beta_root.id.clone()),
+        updated_at_millis: now_millis(),
+        created_by: WorkspaceOrigin::Operator,
+        updated_by: WorkspaceOrigin::Operator,
+        mime: None,
+        size: None,
+        sha256: None,
+        adopted: false,
+    };
+    assert!(
+        ws.create(&alpha, &cross_company_child, Some("body"))
+            .await
+            .is_err(),
+        "alpha must not be able to parent a node under beta's folder id, \
+         even though that id is real"
+    );
+    assert!(
+        ws.tree(&alpha).await.unwrap().is_empty(),
+        "the cross-company create must not have landed in alpha either"
+    );
+    assert_eq!(
+        ws.tree(&beta).await.unwrap().len(),
+        1,
+        "beta's own tree is unaffected by alpha's rejected attempt"
+    );
+}
+
 /// The adoption lease every backend must honour (issue #1839).
 ///
 /// #1801 gave the tree an empty-folder rollback: a folder one caller minted, then

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -2915,6 +2915,16 @@ mod test {
     }
 
     #[tokio::test]
+    async fn conformance_workspace_create_rejects_an_absent_or_foreign_parent() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_workspace_create_rejects_an_absent_or_foreign_parent(Arc::new(
+            FsOps::new(&root),
+        ))
+        .await;
+    }
+
+    #[tokio::test]
     async fn conformance_workspace_sibling_names() {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();

--- a/src/store/memory/test.rs
+++ b/src/store/memory/test.rs
@@ -461,6 +461,63 @@ async fn agent_partitions_do_not_leak_into_each_other() {
     );
 }
 
+/// The sibling of [`agent_partitions_do_not_leak_into_each_other`]: two
+/// desks, not two agents. `desk_context` had never been driven through an
+/// isolation assertion — only through the cache-bound tests, which never put
+/// anything into the stores they open.
+#[tokio::test]
+async fn desk_partitions_do_not_leak_into_each_other() {
+    let mem = engine();
+    let id = acme_id();
+    mem.desk_context("engineering")
+        .put(
+            &id,
+            ContextChunk {
+                label: "l".into(),
+                body: "engineering private note".into(),
+            },
+        )
+        .await
+        .unwrap();
+    assert!(
+        mem.desk_context("sales")
+            .list(&id, "")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+/// `agent_context` and `desk_context` key their cache off `format!("agent:{id}")`
+/// / `format!("desk:{id}")` — a prefix, not a separate map. An agent and a
+/// desk that happen to share the same raw id string must still land in
+/// different stores; a regression that dropped the prefix (or collapsed both
+/// into one key space) would pass every existing test here, since none of
+/// them use the same id for both an agent and a desk.
+#[tokio::test]
+async fn an_agent_and_a_desk_sharing_the_same_raw_id_do_not_share_a_partition() {
+    let mem = engine();
+    let id = acme_id();
+    mem.agent_context("ops")
+        .put(
+            &id,
+            ContextChunk {
+                label: "l".into(),
+                body: "the ops agent's note".into(),
+            },
+        )
+        .await
+        .unwrap();
+    assert!(
+        mem.desk_context("ops")
+            .list(&id, "")
+            .await
+            .unwrap()
+            .is_empty(),
+        "the ops desk must not see the ops agent's partition"
+    );
+}
+
 #[tokio::test]
 async fn inbound_writes_are_stamped_external_and_internal_writes_are_not() {
     // Laundering external content into internal-trust content is the failure

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -6288,6 +6288,13 @@ mod test {
         drop_db(&s).await;
     }
 
+    #[tokio::test]
+    async fn conformance_workspace_create_rejects_an_absent_or_foreign_parent() {
+        let Some(s) = store().await else { return };
+        conformance::assert_workspace_create_rejects_an_absent_or_foreign_parent(s.clone()).await;
+        drop_db(&s).await;
+    }
+
     /// Issue #1839: the adoption lease, on the backend that can only *narrow*
     /// Race 1 — the `$set` an adoption writes is what a later `delete_if_empty`
     /// reads, so the sequential contract (mark, then refuse) still holds even

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -4822,6 +4822,11 @@ mod test {
     }
 
     #[tokio::test]
+    async fn conformance_workspace_create_rejects_an_absent_or_foreign_parent() {
+        conformance::assert_workspace_create_rejects_an_absent_or_foreign_parent(store()).await;
+    }
+
+    #[tokio::test]
     async fn conformance_workspace_sibling_names() {
         conformance::assert_workspace_sibling_names(store()).await;
     }


### PR DESCRIPTION
## Summary

Adds targeted regression tests for six edge cases that had real code handling but no test pinning it, plus one small fix needed to get `cargo test --lib` compiling at all on top of current `main`:

- **Deep-trace purge route** (`DELETE …/deep-trace` and `…/deep-trace/{run_id}`): the store layer's idempotent-purge behavior (`purge_deep_trace` returning a quiet `0` on a second call) was only proven at the store-conformance layer, never through the actual HTTP handler. Added two tests driving both routes through the real router twice, plus one confirming a member (non-admin) session is refused.
- **Memory scope isolation** (`agent_context` / `desk_context`): agent-to-agent isolation already had a test; desk-to-desk isolation and an agent id colliding with a desk id of the same raw string did not. Added both.
- **Ledger delete/retire idempotency**: a second `delete_entry` on an already-deleted row, and a second `retire` on an already-retired ledger, had no test proving they stay clean no-ops rather than erroring in a new shape or resurrecting something.
- **Domain verify's third branch**: `run_verify` has three outcomes — no resolver wired (tested), happy path (tested), and no domain ever configured (untested). Added the missing case at the HTTP layer.
- **Workspace `create()`'s own parent guard**: every existing test of "parent must exist" drives `adopt_or_create_folder`, a different code path. `create()` itself — the one the console's "new file/folder" actually calls — had no direct test, on any of the three backends, for either an absent `parent_id` or one that names a real folder in a *different* company. Added one conformance assertion, wired into all three backend suites (fs, sqlite, mongodb).
- **Compile fix**: `CompanyRecord` gained an `overlay_desk_hive` field recently; one manual test-fixture struct literal in `src/server/graphql/mod.rs` was never updated, so `cargo test --lib` fails to compile on current `main` before any test in the crate can run. One-line fix, committed separately from the test additions.

## API Or Behavior Changes

None. Test-only, except the one-field addition to a test fixture literal noted above (test code, not a production behavior change).

## Tests

**Gates not run locally.** The base commit this branch is built on does not resolve under `cargo … --locked`: `vendor/openhuman`'s pinned commit declares `version = "0.63.23"` in its own `Cargo.toml`, but the committed root `Cargo.lock` expects `0.63.24` — this is a pre-existing break on `main`, not something introduced here (upstream CI is currently red on the tip this branch is based on, failing at the same `cargo metadata --locked` step, in every Rust job). Working around it locally means letting `cargo` silently rewrite `Cargo.lock` down to `0.63.23`, which is not something this branch should carry, so the lock file was reverted before every commit here (compare `git log --stat` — no `Cargo.lock` diff in any commit).

On top of that, this machine had several other lanes compiling the same crate concurrently for an extended period and no local run reached a `test result:` line before this branch needed to be pushed rather than risk losing the work.

So, honestly:
- `cargo fmt --all -- --check` — not run locally.
- `cargo clippy --all-targets -- -D warnings` — not run locally.
- `cargo build --all-targets` — not run locally.
- `cargo test --locked` — not run locally; the base does not resolve under `--locked` (see above).
- `cargo test --offline --lib` (targeted, non-`--locked`) — attempted; every attempt exceeded the available compile time on a contended machine before producing a `test result:` line. No compile error was observed in the output before each attempt was interrupted, but this is not the same as a green run and should not be read as one.

**This branch needs a rebase once the `vendor/openhuman` pin / `Cargo.lock` mismatch is fixed on `main`**, after which the gates above should be run for real before merge. CI will also hit the same `--locked` failure on this PR until that lands.

Each test's intent, for review:
- `purge_run_through_the_route_is_idempotent` / `purge_all_through_the_route_is_idempotent` (`src/server/ops/deep_trace.rs`): seed a real deep-trace record, purge through the router, assert `204`, purge again, assert `204` again (not an error) and that the record stayed gone.
- `a_member_may_not_purge_deep_trace` (same file): a member-cookie request to `DELETE …/deep-trace` is `403`.
- `desk_partitions_do_not_leak_into_each_other` / `an_agent_and_a_desk_sharing_the_same_raw_id_do_not_share_a_partition` (`src/store/memory/test.rs`): write into one desk's context, assert a sibling desk (or an agent of the same raw id) reads nothing back.
- `deleting_an_already_deleted_row_reports_false_not_an_error` (`src/company/ledgers_test.rs`): delete a row, delete it again, assert `Ok(false)` and an empty event log (the first delete already purged the one event; the second is a genuine no-op).
- `retiring_an_already_retired_ledger_is_refused_not_silently_repeated` (same file): retire a ledger, retire it again, assert a `NotFound` error and that the surviving row from the first retirement is untouched.
- `verify_with_no_domain_configured_is_400` (`src/server/ops/test.rs`): POST `/domain/verify` with a DNS resolver wired but no domain ever `PUT`, assert `400` with the `invalid_request` code and message.
- `conformance_workspace_create_rejects_an_absent_or_foreign_parent` (`src/store/conformance.rs`, wired into `fs_ops.rs`/`sqlite.rs`/`mongodb.rs`): `create()` with a `parent_id` naming nothing is refused and leaves the tree empty; `create()` in company A with a `parent_id` naming a real folder that exists only in company B is refused identically, and B's tree is unaffected.

## Documentation

None needed — no public API or documented behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming repeated deletion and ledger retirement requests are handled safely and consistently.
  - Added verification that deep-trace purge requests are idempotent and restricted to administrators.
  - Added coverage for clear errors when domain verification lacks configuration.
  - Added safeguards ensuring workspaces cannot reference missing or foreign parents.
  - Added isolation checks preventing data from leaking between desks, agents, or companies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->