### PR TITLE
test: close five edge-case coverage gaps (runs, workflows, policy, login codes, workspace search)

### DIFF
--- a/src/company/workspace_search/test.rs
+++ b/src/company/workspace_search/test.rs
@@ -338,6 +338,68 @@ async fn a_search_never_crosses_the_company_boundary() {
     );
 }
 
+// -- agent visibility --------------------------------------------------------
+
+/// [`search_workspace_for_agent`]'s whole reason to exist: the operator-only
+/// `secrets/` subtree must not surface a hit — neither by name nor by body —
+/// while the same query through the operator's own [`search_workspace`] still
+/// finds it. Matching both ways (like
+/// `a_query_matches_both_names_and_bodies` above) so the exclusion is proven
+/// against the same content an operator search would report by either route,
+/// not just the one the fixture happens to hit.
+#[tokio::test]
+async fn agent_search_never_surfaces_the_secrets_subtree() {
+    let (dir, ops, id) = seeded().await;
+    ops.create(&id, &folder("f-secrets", "secrets", None), None)
+        .await
+        .unwrap();
+    ops.create(
+        &id,
+        &file("n-cred", "vendor-credential.md", Some("f-secrets"), 4_000),
+        Some("The rotation password is hunter2."),
+    )
+    .await
+    .unwrap();
+
+    // The operator's own search reaches it, by name and by body.
+    let by_name = search(&ops, &id, "vendor-credential").await;
+    assert_eq!(paths(&by_name), vec!["secrets/vendor-credential.md"]);
+    let by_body = search(&ops, &id, "hunter2").await;
+    assert_eq!(paths(&by_body), vec!["secrets/vendor-credential.md"]);
+
+    // An agent's search must not, by either route.
+    let agent_by_name =
+        search_workspace_for_agent(ops.as_ref(), &id, "vendor-credential", None, limit(20))
+            .await
+            .expect("search");
+    assert!(
+        paths(&agent_by_name).is_empty(),
+        "a name match inside secrets/ must not reach an agent: {:?}",
+        paths(&agent_by_name)
+    );
+    let agent_by_body = search_workspace_for_agent(ops.as_ref(), &id, "hunter2", None, limit(20))
+        .await
+        .expect("search");
+    assert!(
+        paths(&agent_by_body).is_empty(),
+        "a body match inside secrets/ must not reach an agent: {:?}",
+        paths(&agent_by_body)
+    );
+
+    // Control: an agent search still finds ordinary content the fixture seeds,
+    // so the empty results above are the exclusion working, not a broken query.
+    let agent_ordinary =
+        search_workspace_for_agent(ops.as_ref(), &id, "Engineering", None, limit(20))
+            .await
+            .expect("search");
+    assert_eq!(
+        paths(&agent_ordinary),
+        vec!["standards/Engineering standards.md"]
+    );
+
+    drop(dir);
+}
+
 // -- ordering, limits and totals --------------------------------------------
 
 /// Name before content, freshest first inside each group, path as the tie-break.

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -2401,6 +2401,46 @@ mod tests {
         );
     }
 
+    /// FAIL-axis: the mapping above is a value the test above already pins,
+    /// but nothing proved what that value does at the one place it is
+    /// actually consumed — `build.rs` feeds `policy.toolbelt_mode()` straight
+    /// into [`crate::harness::built_in::toolbelt::exec_security`], whose
+    /// `require_approval_for_medium_risk` is the last independent brake on a
+    /// shell/code/web call below this policy. This drives that real
+    /// composition, through the production constructor, rather than a
+    /// literal `PolicyMode::Full` — proving the brake really does go dark for
+    /// every non-readonly company once policy HITL is disabled, not just that
+    /// `toolbelt_mode()` returns a value that would imply it.
+    #[test]
+    fn disabled_hitl_also_disarms_the_shell_medium_risk_brake() {
+        use crate::harness::built_in::toolbelt::exec_security;
+
+        let ws = std::path::Path::new("/tmp/oc-policy-toolbelt-wiring");
+        for mode in ["auto", "supervised", "full"] {
+            let p = policy(mode, &[], None).with_policy_hitl_disabled();
+            let security = exec_security(ws, p.toolbelt_mode());
+            assert!(
+                !security.require_approval_for_medium_risk,
+                "{mode} with policy HITL disabled must leave OpenHuman's own medium-risk \
+                 shell gate unarmed, matching the mode this desk actually dispatches with"
+            );
+        }
+
+        // The control: policy HITL enabled (a non-production shape) keeps the
+        // brake exactly as `exec_security_shape_is_workspace_scoped_and_hardened`
+        // and `auto_borrows_supervised_exec_security_rather_than_full` already
+        // pin it — armed for `supervised` and `auto`.
+        for mode in ["auto", "supervised"] {
+            let p = policy(mode, &[], None);
+            let security = exec_security(ws, p.toolbelt_mode());
+            assert!(
+                security.require_approval_for_medium_risk,
+                "{mode} with policy HITL enabled must still arm the brake — the disarming \
+                 above must be the HITL-disabled path's effect, not `exec_security`'s"
+            );
+        }
+    }
+
     /// The brake's other half: it denies now, but it does not consume the
     /// grant. `readonly` is a mode a company sits in temporarily, so the same
     /// approval must still be redeemable once the brake releases — inside its

--- a/src/server/ops/runs.rs
+++ b/src/server/ops/runs.rs
@@ -876,6 +876,88 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
+    /// Registers a second company, `beta`, in `state`'s existing registry.
+    async fn add_second_company(state: &AppState, home: &std::path::Path) -> CompanyId {
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("beta");
+        store
+            .save(&CompanyRecord {
+                overlay_desk_hive: Vec::new(),
+                overlay_retired_agents: Vec::new(),
+                overlay_agent_edits: Vec::new(),
+                id: id.clone(),
+                manifest: manifest(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_tool_grants: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                overlay_workflows: Vec::new(),
+                template_provenance: None,
+                setup: None,
+                name_confirmed: false,
+                activation_completed_at: None,
+                created_at_millis: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        state
+            .registry()
+            .insert(id.clone(), std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(state, "beta").await;
+        id
+    }
+
+    /// AUTH-axis: the doc comment right above (`an_unknown_run_is_not_found`)
+    /// claims a run id minted in another company is what the company-scoped
+    /// store read keeps out, but that test only ever tries an id nobody
+    /// minted anywhere. This is the case it describes but never drove: a run
+    /// that genuinely exists, in a genuinely different company, must be
+    /// invisible from both the list and the detail route.
+    #[tokio::test]
+    async fn a_run_minted_in_another_company_is_invisible_from_this_one() {
+        let dir = home();
+        let (state, _acme) = state_with_company(dir.path()).await;
+        let beta = add_second_company(&state, dir.path()).await;
+
+        let beta_runs = runs_of(&state, &beta);
+        mint(&beta_runs, &beta, "beta-run-1", "beta-card").await;
+
+        let list = json_body(
+            router(state.clone())
+                .oneshot(request("/api/v1/companies/acme/runs"))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(
+            list.as_array().expect("array").len(),
+            0,
+            "a run minted in another company must not appear on this one's list: {list}"
+        );
+
+        let response = router(state)
+            .oneshot(request("/api/v1/companies/acme/runs/beta-run-1"))
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "a run id that resolves in another company must 404 here, not leak the record"
+        );
+    }
+
     /// `stepCount` is a high-water ordinal, capped — so the wire says when the
     /// number has stopped meaning "how many steps the agent took".
     #[tokio::test]

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -4970,6 +4970,95 @@ mod tests {
         assert_eq!(ids, vec!["demo"]);
     }
 
+    /// FAIL-axis: unlike the list route above (which skips a broken graph and
+    /// carries on), addressing the broken one directly is a single-resource
+    /// read on a body that cannot be used, and `OpenCompanyError::DataParse`
+    /// is centrally mapped to `400` (`server/error.rs`). This is the
+    /// single-workflow `GET` driven all the way through the router, not just
+    /// the loader function, so the mapping is proven at the seam the console
+    /// actually calls.
+    #[tokio::test]
+    async fn getting_a_malformed_workflow_by_id_answers_400_data_parse() {
+        use axum::body::{Body, to_bytes};
+        use axum::http::{Request, StatusCode};
+        use tower::ServiceExt;
+
+        use crate::company::CompanyManifest;
+        use crate::ports::CompanyStore;
+        use crate::ports::types::{CompanyId, CompanyRecord};
+        use crate::runtime::RuntimeBuilder;
+        use crate::server::router;
+        use crate::store::FsCompanyStore;
+        use crate::{AppConfig, AppState};
+
+        let dir = seed_demo();
+        std::fs::write(
+            dir.path().join("workflows").join("broken.toml"),
+            "id = \"broken\"\nname = \n[[node]] oops",
+        )
+        .unwrap();
+
+        let manifest: CompanyManifest =
+            toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap();
+        let store = FsCompanyStore::new(dir.path().to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                overlay_desk_hive: Vec::new(),
+                overlay_retired_agents: Vec::new(),
+                overlay_agent_edits: Vec::new(),
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_tool_grants: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+                setup: None,
+                name_confirmed: false,
+                activation_completed_at: None,
+                created_at_millis: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(dir.path().to_path_buf(), manifest)
+            .with_id(id.clone())
+            .with_seed_dir(dir.path().to_path_buf())
+            .build()
+            .await
+            .unwrap();
+        assert!(
+            runtime.source_dir().is_some(),
+            "test setup must give the company a real source tree to read `broken.toml` from"
+        );
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/v1/company/workflows/broken")
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .body(Body::empty())
+            .unwrap();
+        let response = router(state).oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            body["code"], "data_parse",
+            "the stable error code must name a parse failure, not a generic 500: {body}"
+        );
+    }
+
     // HTTP-level: a hosted tenant has no source directory to scan, so these
     // exercise the manifest-enabled union path end to end via the router.
     mod hosted_mode {
@@ -10039,6 +10128,81 @@ mod tests {
                 .unwrap();
             let graph = json_body(response).await;
             assert_eq!(graph["description"], "Say hi, every morning.");
+        }
+
+        /// CONC-axis: restore inherits `PUT`'s optimistic-concurrency check —
+        /// the doc on [`restore_workflow_revision`] says so — but only `PUT`'s
+        /// own stale-token 409 was ever driven end to end. This drives
+        /// restore's own conflict path: two consoles racing a restore of the
+        /// same revision with the token each read, the second losing.
+        #[tokio::test]
+        async fn a_stale_expected_version_is_a_conflict_on_restore() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            let stale = create_then_edit_greeter(&state).await;
+
+            let list = json_body(
+                router(state.clone())
+                    .oneshot(request(
+                        "GET",
+                        "/api/v1/company/workflows/greeter/revisions",
+                        None,
+                    ))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            let rev_id = list["revisions"][0]["id"].as_str().unwrap().to_string();
+            let before = list["revisions"].as_array().unwrap().len();
+
+            // Console A restores first, carrying the token it read.
+            let first = router(state.clone())
+                .oneshot(request(
+                    "POST",
+                    &format!("/api/v1/company/workflows/greeter/revisions/{rev_id}/restore"),
+                    Some(serde_json::json!({ "expectedVersion": stale })),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(first.status(), StatusCode::OK);
+
+            // Console B restores the SAME revision with the SAME token A already
+            // spent — it named the graph before A's write, not after it.
+            let second = router(state.clone())
+                .oneshot(request(
+                    "POST",
+                    &format!("/api/v1/company/workflows/greeter/revisions/{rev_id}/restore"),
+                    Some(serde_json::json!({ "expectedVersion": stale })),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(second.status(), StatusCode::CONFLICT);
+            let body = json_body(second).await;
+            let message = body["error"].as_str().unwrap_or_default().to_lowercase();
+            assert!(message.contains("reload"), "unhelpful 409: {body}");
+
+            // The refused restore must not have captured a second snapshot —
+            // restoring the same revision twice would otherwise look identical
+            // on the live graph (it is the same snapshot both times), so the
+            // history length is what actually distinguishes "refused" from
+            // "silently ran again".
+            let list = json_body(
+                router(state)
+                    .oneshot(request(
+                        "GET",
+                        "/api/v1/company/workflows/greeter/revisions",
+                        None,
+                    ))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(
+                list["revisions"].as_array().unwrap().len(),
+                before + 1,
+                "only the first restore may have run: {list}"
+            );
         }
 
         /// **The silent-clobber guard, at the front door (issue #1013).** Omitting

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2189,6 +2189,34 @@ pub async fn assert_login_code_store(codes: Arc<dyn LoginCodeStore>) {
     // An unknown hash is indistinguishable from a spent one.
     assert!(codes.consume(&alpha, "nope", 10).await.unwrap().is_none());
 
+    // CONC: the SINGLE USE assertion above is sequential — it cannot tell an
+    // atomic check-and-mark from a check-then-mark race, because nothing makes
+    // the two redemptions overlap. This drives two requests genuinely racing
+    // the same code, the way two tabs opening the same magic link would.
+    //
+    // Expiry is set well past every `purge_expired` cutoff this function later
+    // asserts against (the highest is 100), so this fixture cannot silently
+    // change an unrelated purge count.
+    codes
+        .create(
+            &alpha,
+            &code("racer", "hash-race", "racer@example.com", 100_000),
+        )
+        .await
+        .unwrap();
+    let (first, second) = tokio::join!(
+        codes.consume(&alpha, "hash-race", 10),
+        codes.consume(&alpha, "hash-race", 10)
+    );
+    let winners = [first.unwrap(), second.unwrap()]
+        .into_iter()
+        .filter(Option::is_some)
+        .count();
+    assert_eq!(
+        winners, 1,
+        "exactly one of two concurrent redemptions of the same code may mint a session"
+    );
+
     // --- latest_for_email: what the resend throttle asks ---
     // Isolation holds here too.
     assert!(


### PR DESCRIPTION
## Summary

Adds regression tests for five behaviours that were either correct-but-untested or only exercised as an intermediate value, not through the seam they actually protect:

- **Cross-company run isolation.** A run minted in one company must not appear in another company's run list, and its id must not resolve there either. The existing 404 test's own comment claimed this was covered, but it only ever tried an id nobody had minted anywhere.
- **A malformed workflow's `GET` answers `400`, not `500`.** A stored workflow whose TOML can no longer be parsed is centrally mapped to a `400 data_parse` response, but that mapping had no test driving it through the actual single-workflow route (only the *list* route's more forgiving skip-and-continue behaviour was covered).
- **Restoring a workflow revision has its own stale-token conflict.** Restore inherits the same optimistic-concurrency check a `PUT` edit uses, but only the `PUT` route's stale-token `409` was ever driven end to end. Two consoles racing a restore of the same revision now proves the second loses, with no extra history entry recorded.
- **The shell medium-risk brake goes dark when policy HITL is disabled.** In production every non-readonly company hands OpenHuman `Full` autonomy once policy HITL is off, which means OpenHuman's own `require_approval_for_medium_risk` check — the last independent brake below our own approval policy — never arms. That mapping was pinned as an isolated value; nothing proved what it does once composed through the real constructor into the security policy shell/code/web tools actually run under.
- **Login-code redemption is genuinely atomic under a race, not just sequentially single-use.** The existing single-use assertion redeemed the same code twice in sequence, which cannot distinguish an atomic check-and-mark from a check-then-mark race. Two redemptions are now driven concurrently with `tokio::join!`, and exactly one is asserted to win. This runs through the shared store-conformance suite, so it exercises every registered `LoginCodeStore` backend.
- **Agent workspace search never surfaces the operator-only `secrets/` subtree.** `search_workspace_for_agent`'s entire reason to exist — excluding `secrets/` — had no direct test; only the unrestricted operator search path was covered. A file seeded there is now asserted invisible to an agent search by both name and body match, with a control proving ordinary content still surfaces normally.

Also includes a small, separate fix: two `CompanyRecord` test fixtures (`src/server/graphql/mod.rs`, `src/runtime/hivemind.rs`) were missing the `overlay_desk_hive` field a recent merge added, which meant `cargo test --lib` did not compile at all on `upstream/main`. That fix is its own commit and touches no other behavior.

## API Or Behavior Changes

None. Every change in this PR is test-only, aside from the two-line fixture fix noted above (which restores a struct literal to match its already-existing field, with no behavior change).

## Tests

Base note: `upstream/main`'s `Cargo.lock` currently pins `openhuman` at `0.63.24`, but the `vendor/openhuman` submodule is checked out at `0.63.23`, so `cargo … --locked` cannot resolve and any non-`--locked` cargo invocation silently downgrades the lockfile. This is a pre-existing base issue unrelated to this PR; every command below was run without `--locked` for that reason, and `Cargo.lock` is left untouched in this branch.

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets --no-deps -- -D warnings` — clean, no warnings.
- `cargo test --lib` (default features) — **5022 passed, 1 failed, 6 ignored**. The one failure, `runtime::channel::test::the_consoles_pre_flight_says_the_same_thing`, is a frontend/backend string-drift check between `frontend/src/views/WorkflowCreateDialog.tsx` and `src/runtime/channel.rs` — neither file is touched by this PR, and the failure reproduces identically on a clean `upstream/main` checkout before any of these changes.
- `cargo test --features openhuman --lib harness::built_in::policy::tests::disabled_hitl_also_disarms_the_shell_medium_risk_brake` — 1 passed (this test needs the `openhuman` feature lane; it is not reachable under default features).

Each new test's red proof — the production line broken, the exact failure, then restored and reconfirmed green:

1. `server::ops::runs::tests::a_run_minted_in_another_company_is_invisible_from_this_one` — broke `FsOps::get_run`/`list_runs` to read from a fixed company bundle regardless of the `company` argument. Failed with `left: 1, right: 0` (the other company's run leaked into the list) and a 200 instead of 404 on direct fetch. Restored, passes.
2. `server::ops::workflows::tests::getting_a_malformed_workflow_by_id_answers_400_data_parse` — changed the central `DataParse -> StatusCode` mapping to `500`. Failed with `left: 500, right: 400`. Restored, passes.
3. `server::ops::workflows::tests::hosted_mode::a_stale_expected_version_is_a_conflict_on_restore` — dropped `expected_version` on the way into `update_company_workflow` inside `rollback_company_workflow`. Failed with `left: 200, right: 409` (the second, stale restore silently ran). Restored, passes.
4. `harness::built_in::policy::tests::disabled_hitl_also_disarms_the_shell_medium_risk_brake` — collapsed `toolbelt_mode()` to always return `self.mode` (dropping the HITL-disabled `-> Full` mapping). Failed with `auto with policy HITL disabled must leave OpenHuman's own medium-risk shell gate unarmed...`. Restored, passes.
5. `store::fs_ops::test::conformance_login_code_store` — removed the per-path lock around `FsOps::consume`'s check-and-mark. Failed reliably across 5 consecutive runs with `left: 2, right: 1` (both concurrent redemptions won). Restored, passes reliably across 3 consecutive runs.
6. `company::workspace_search::test::agent_search_never_surfaces_the_secrets_subtree` — changed `search_workspace_for_agent`'s visibility predicate to `|_| true`. Failed with the `secrets/vendor-credential.md` hit reaching the agent search. Restored, passes.

## Documentation

None needed — no public API or documented behavior changed; these tests pin existing, intended behavior.

