### PR TITLE
feat(console): add an existing agent to a channel from the Team panel

### DIFF
--- a/frontend/src/views/RoomView.tsx
+++ b/frontend/src/views/RoomView.tsx
@@ -2532,40 +2532,10 @@ export function RoomView({
   }
 
   /**
-   * Drop a teammate from the roster through the host when it has a record of
-   * them. A blueprint teammate is removable too — the host records a tombstone
-   * rather than rewriting `company.toml` — and the only refusal left is the
-   * company's last teammate (409). A starter-roster row has no host record at
-   * all, so it falls back to a local-only removal.
-   */
-  async function removeMember(member: TeamMember) {
-    if (!fromHost) {
-      setMembers((ms) => ms.filter((m) => m.id !== member.id));
-      return;
-    }
-    try {
-      await client.removeTeamMember(member.id, company);
-      setMembers((ms) => ms.filter((m) => m.id !== member.id));
-      // The removed teammate leaves the picker now, not on the next reload.
-      void reloadDirectory();
-    } catch (error) {
-      if (error instanceof ApiError && error.status === 409) {
-        // The only 409 this route still answers: a company must keep at
-        // least one teammate. The host's own message says which teammate and
-        // what to do about it, so it is shown rather than restated.
-        toast.error(
-          error.message || "You can't remove your company's last agent.",
-        );
-      } else {
-        toast.error(error instanceof Error ? error.message : "Couldn't remove agent.");
-      }
-    }
-  }
-
-  /**
    * Put an agent already on the roster onto this channel's desk (issue
-   * #2224) — the counterpart to `removeMember` above, not a variant of
-   * `addMember`, which creates a brand-new teammate. `activeIsDesk` gates
+   * #2224) — not a variant of `addMember`, which creates a brand-new
+   * teammate. Dropping one from the roster entirely is a Team-page action;
+   * `MembersPane` no longer offers it here. `activeIsDesk` gates
    * `MembersPane`'s own "add existing" affordance, so `active.id` is a real
    * desk id by the time this runs; the check here is defensive, not load
    * bearing.
@@ -3117,10 +3087,6 @@ export function RoomView({
                   }
                   loading={loadingTeam}
                   fromHost={fromHost}
-                  onRemove={(id) => {
-                    const member = members.find((m) => m.id === id);
-                    if (member) void removeMember(member);
-                  }}
                   // `activeIsDesk`, not "`channelMembers` is non-null": a DM
                   // has real (non-null) channel membership too — one row,
                   // itself — and is not a desk. `addDeskMember` has no

--- a/frontend/src/views/RoomView.tsx
+++ b/frontend/src/views/RoomView.tsx
@@ -2563,6 +2563,42 @@ export function RoomView({
   }
 
   /**
+   * Put an agent already on the roster onto this channel's desk (issue
+   * #2224) — the counterpart to `removeMember` above, not a variant of
+   * `addMember`, which creates a brand-new teammate. `activeIsDesk` gates
+   * `MembersPane`'s own "add existing" affordance, so `active.id` is a real
+   * desk id by the time this runs; the check here is defensive, not load
+   * bearing.
+   *
+   * `reloadDirectory` alone does not move the added agent into "In this
+   * channel": it only refetches the `@mention` picker's directory.
+   * `channelMembers`/`others` come from `inChannel`/`outsideChannel`, which
+   * are derived from `desks` — so this also calls `loadDesks`, the same
+   * function every desk-membership mutation on the org chart already
+   * refetches through after `addDeskMember`/`removeDeskMember`. Confirmed
+   * safe to call on a plain revisit, not just a scope change: `loadDesks`'s
+   * own comment says it blanks the list only when the client or company
+   * changed, never on a revisit — so this does not flash the pane empty.
+   */
+  async function addExistingMember(agentId: string) {
+    if (!activeIsDesk) return;
+    try {
+      await client.addDeskMember(active.id, agentId, company);
+      void reloadDirectory();
+      void loadDesks();
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 409) {
+        // The one 409 this route answers: already a member. Reached only by
+        // a race with another tab or operator — the row that triggered this
+        // is already gone from "Everyone else" on the next reload.
+        toast.error("Already on this channel.");
+      } else {
+        toast.error(error instanceof Error ? error.message : "Couldn't add agent.");
+      }
+    }
+  }
+
+  /**
    * The rail's create affordance (issue #1835) — or `undefined`, which is the
    * rule this codebase follows for a control that would be refused: absent,
    * not disabled. A starter roster (`!fromHost`) has no saved teammates to
@@ -3086,6 +3122,15 @@ export function RoomView({
                     if (member) void removeMember(member);
                   }}
                   onAdd={() => setAddOpen(true)}
+                  // `activeIsDesk`, not "`channelMembers` is non-null": a DM
+                  // has real (non-null) channel membership too — one row,
+                  // itself — and is not a desk. `addDeskMember` has no
+                  // meaning there, and the affordance must not appear at all
+                  // (absent, never disabled — the rule `onManageDesk` below
+                  // already follows for the same reason).
+                  onAddExisting={
+                    activeIsDesk ? (agentId) => void addExistingMember(agentId) : undefined
+                  }
                   onMessage={(m) => selectChannel(dmChannelId(m))}
                   /**
                    * The way from this channel to the desk it is (issue #485).

--- a/frontend/src/views/RoomView.tsx
+++ b/frontend/src/views/RoomView.tsx
@@ -3121,7 +3121,6 @@ export function RoomView({
                     const member = members.find((m) => m.id === id);
                     if (member) void removeMember(member);
                   }}
-                  onAdd={() => setAddOpen(true)}
                   // `activeIsDesk`, not "`channelMembers` is non-null": a DM
                   // has real (non-null) channel membership too — one row,
                   // itself — and is not a desk. `addDeskMember` has no

--- a/frontend/src/views/RoomView.tsx
+++ b/frontend/src/views/RoomView.tsx
@@ -2552,15 +2552,33 @@ export function RoomView({
    */
   async function addExistingMember(agentId: string) {
     if (!activeIsDesk) return;
+    // Same rule `send` above follows: if the operator switches company or
+    // connection while the POST is in flight, every UI-visible effect of it —
+    // refresh or toast — belongs to a scope nobody is looking at anymore, so
+    // it is dropped rather than landing on whatever they switched to.
+    const scopeAtAdd = { connection: scope.connection, company: scope.company, client };
+    const stale = () => {
+      const latestScope = scopeRef.current;
+      return (
+        latestScope !== null &&
+        (scopeAtAdd.connection !== latestScope.connection ||
+          scopeAtAdd.company !== latestScope.company ||
+          scopeAtAdd.client !== latestScope.client)
+      );
+    };
     try {
       await client.addDeskMember(active.id, agentId, company);
+      if (stale()) return;
       void reloadDirectory();
       void loadDesks();
     } catch (error) {
+      if (stale()) return;
       if (error instanceof ApiError && error.status === 409) {
         // The one 409 this route answers: already a member. Reached only by
-        // a race with another tab or operator — the row that triggered this
-        // is already gone from "Everyone else" on the next reload.
+        // a race with another tab or operator — refresh now so the row
+        // leaves "Everyone else" immediately rather than on an unrelated
+        // reload.
+        void loadDesks();
         toast.error("Already on this channel.");
       } else {
         toast.error(error instanceof Error ? error.message : "Couldn't add agent.");

--- a/frontend/src/views/room/MembersPane.tsx
+++ b/frontend/src/views/room/MembersPane.tsx
@@ -1,16 +1,9 @@
 import type { ReactNode } from "react";
-import { MessageSquare, MoreHorizontal, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
 
 import { AgentAvatarButton } from "@/components/agent-profile-sheet";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { PresenceStatus } from "@/lib/awareness";
 import { roleSubtitle, type TeamMember } from "@/lib/team";
@@ -61,12 +54,6 @@ interface Props {
   /** True when the roster came from the host rather than the starter set. */
   fromHost: boolean;
   /**
-   * Give this teammate an inbox, or take it away. Whether they have one is read
-   * from the roster (`member.inboxEnabled`), never guessed client-side, so this
-   * pane and the Inbox page agree on the same host state (issue #173).
-   */
-  onRemove: (id: string) => void;
-  /**
    * Put an agent already on the roster onto this channel's desk (issue #2224).
    * Only ever offered on an "Everyone else" row. Absent has the same meaning
    * `onManageDesk` gives it: no real desk behind this channel, nothing to add
@@ -102,13 +89,13 @@ interface Props {
  * The right-hand member pane — who is in this channel, and the rest of the
  * company under it.
  *
- * This replaces the standalone Team page: everything that page could do lives
- * on a row here — give an agent an inbox, drop them from the roster, put an
- * existing one onto this desk directly from "Everyone else" (issue #2224) —
- * and a row now also opens that teammate's DM, which the page could not do
- * at all. Hiring a brand-new teammate is a different action and lives
- * elsewhere (the empty-desk "Add an agent" prompt, the Team page's own Add
- * agent) — this pane only ever offers an agent already on the roster.
+ * This replaces the standalone Team page for channel-scoped work: put an
+ * agent already on the roster onto this desk directly from "Everyone else"
+ * (issue #2224), and a row now also opens that teammate's DM, which the page
+ * could not do at all. Hiring a brand-new teammate, and dropping one from the
+ * roster entirely, are different actions and live elsewhere (the empty-desk
+ * "Add an agent" prompt and the Team page, respectively) — this pane only
+ * ever offers an agent already on the roster, and never removes one.
  *
  * The two sections exist because those are two different questions. "Who is in
  * this room" is what a channel header is for, and answering it with the whole
@@ -124,7 +111,6 @@ export function MembersPane({
   presence,
   loading,
   fromHost,
-  onRemove,
   onAddExisting,
   onMessage,
   onManageDesk,
@@ -167,7 +153,6 @@ export function MembersPane({
                     <MemberRow
                       member={m}
                       lead={m.id === leadId}
-                      onRemove={() => onRemove(m.id)}
                       onMessage={() => onMessage(m)}
                       onAddToChannel={
                         withAdd && onAddExisting ? () => onAddExisting(m.id) : undefined
@@ -282,14 +267,12 @@ function SectionLabel({ children, className }: { children: ReactNode; className?
 function MemberRow({
   member,
   lead,
-  onRemove,
   onAddToChannel,
   onMessage,
 }: {
   member: TeamMember;
   /** The desk's lead — badged, since this channel routes to them. */
   lead?: boolean;
-  onRemove: () => void;
   /**
    * Present only on an "Everyone else" row when there is a real desk to add
    * to (issue #2224) — `undefined` renders no button at all, not a disabled
@@ -345,30 +328,6 @@ function MemberRow({
           <Plus className="size-4" />
         </Button>
       )}
-
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 shrink-0 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/member:opacity-100"
-              aria-label={`Actions for ${member.name}`}
-            />
-          }
-        >
-          <MoreHorizontal className="size-4" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={onMessage}>
-            <MessageSquare className="size-4" /> Message
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem variant="destructive" onClick={onRemove}>
-            Remove from roster
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
     </div>
   );
 }

--- a/frontend/src/views/room/MembersPane.tsx
+++ b/frontend/src/views/room/MembersPane.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { MessageSquare, MoreHorizontal, UserPlus } from "lucide-react";
+import { MessageSquare, MoreHorizontal, Plus, UserPlus } from "lucide-react";
 
 import { AgentAvatarButton } from "@/components/agent-profile-sheet";
 import { TeammateAvatar } from "@/components/teammate-avatar";
@@ -67,6 +67,16 @@ interface Props {
    */
   onRemove: (id: string) => void;
   onAdd: () => void;
+  /**
+   * Put an agent already on the roster onto this channel's desk (issue #2224).
+   * Only ever offered on an "Everyone else" row, and only when `channelMembers`
+   * is non-null — there is no desk id to add into otherwise. Deliberately
+   * separate from `onAdd`: that opens the create-a-new-teammate dialog, this
+   * adds an existing one, and the two are not the same action wearing one
+   * button. Absent has the same meaning `onManageDesk` gives it: no desk here,
+   * nothing to add to.
+   */
+  onAddExisting?: (id: string) => void;
   onMessage: (member: TeamMember) => void;
   /**
    * Open this channel's desk on the org chart (issue #485). Absent for a DM and
@@ -97,7 +107,10 @@ interface Props {
  * This replaces the standalone Team page: everything that page could do lives
  * on a row here (give an agent an inbox, drop them from the roster) or on the
  * Add button, and a row now also opens that teammate's DM, which the page
- * could not do at all.
+ * could not do at all. An "Everyone else" row can also put that agent onto
+ * this desk directly (issue #2224) — putting an existing teammate on a
+ * channel and hiring a new one are different actions, so that stays separate
+ * from the Add button, which still opens the create-a-teammate dialog.
  *
  * The two sections exist because those are two different questions. "Who is in
  * this room" is what a channel header is for, and answering it with the whole
@@ -115,6 +128,7 @@ export function MembersPane({
   fromHost,
   onRemove,
   onAdd,
+  onAddExisting,
   onMessage,
   onManageDesk,
 }: Props) {
@@ -155,7 +169,11 @@ export function MembersPane({
           </div>
         ) : (
           (() => {
-            const rows = (list: TeamMember[]) => (
+            // `withAdd` is only ever true for the "Everyone else" list on a
+            // real desk (see below) — never for `channelMembers` (already
+            // here) and never for the plain-roster fallback (no desk id to
+            // add into).
+            const rows = (list: TeamMember[], withAdd?: boolean) => (
               <ul className="flex flex-col gap-px">
                 {list.map((m) => (
                   <li key={m.id}>
@@ -164,6 +182,9 @@ export function MembersPane({
                       lead={m.id === leadId}
                       onRemove={() => onRemove(m.id)}
                       onMessage={() => onMessage(m)}
+                      onAddToChannel={
+                        withAdd && onAddExisting ? () => onAddExisting(m.id) : undefined
+                      }
                     />
                   </li>
                 ))}
@@ -203,7 +224,7 @@ export function MembersPane({
                 {others.length > 0 && (
                   <div className="mt-2 border-t pt-2">
                     <SectionLabel className="text-muted-foreground">Everyone else</SectionLabel>
-                    {rows(others)}
+                    {rows(others, true)}
                   </div>
                 )}
 
@@ -275,12 +296,19 @@ function MemberRow({
   member,
   lead,
   onRemove,
+  onAddToChannel,
   onMessage,
 }: {
   member: TeamMember;
   /** The desk's lead — badged, since this channel routes to them. */
   lead?: boolean;
   onRemove: () => void;
+  /**
+   * Present only on an "Everyone else" row when there is a real desk to add
+   * to (issue #2224) — `undefined` renders no button at all, not a disabled
+   * one, the same rule every other optional action on this row follows.
+   */
+  onAddToChannel?: () => void;
   onMessage: () => void;
 }) {
   // Issue #1208: only when the role is not the name over again. The roster's
@@ -317,6 +345,19 @@ function MemberRow({
           )}
         </span>
       </button>
+
+      {onAddToChannel && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7 shrink-0 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/member:opacity-100"
+          aria-label={`Add ${member.name} to this channel`}
+          title={`Add ${member.name} to this channel`}
+          onClick={onAddToChannel}
+        >
+          <Plus className="size-4" />
+        </Button>
+      )}
 
       <DropdownMenu>
         <DropdownMenuTrigger

--- a/frontend/src/views/room/MembersPane.tsx
+++ b/frontend/src/views/room/MembersPane.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { MessageSquare, MoreHorizontal, Plus, UserPlus } from "lucide-react";
+import { MessageSquare, MoreHorizontal, Plus } from "lucide-react";
 
 import { AgentAvatarButton } from "@/components/agent-profile-sheet";
 import { TeammateAvatar } from "@/components/teammate-avatar";
@@ -66,15 +66,13 @@ interface Props {
    * pane and the Inbox page agree on the same host state (issue #173).
    */
   onRemove: (id: string) => void;
-  onAdd: () => void;
   /**
    * Put an agent already on the roster onto this channel's desk (issue #2224).
-   * Only ever offered on an "Everyone else" row, and only when `channelMembers`
-   * is non-null — there is no desk id to add into otherwise. Deliberately
-   * separate from `onAdd`: that opens the create-a-new-teammate dialog, this
-   * adds an existing one, and the two are not the same action wearing one
-   * button. Absent has the same meaning `onManageDesk` gives it: no desk here,
-   * nothing to add to.
+   * Only ever offered on an "Everyone else" row. Absent has the same meaning
+   * `onManageDesk` gives it: no real desk behind this channel, nothing to add
+   * to — the caller gates this on `activeIsDesk`, not on anything this pane
+   * can see for itself, because a DM has real (non-null) channel membership
+   * too and is not a desk.
    */
   onAddExisting?: (id: string) => void;
   onMessage: (member: TeamMember) => void;
@@ -105,12 +103,12 @@ interface Props {
  * company under it.
  *
  * This replaces the standalone Team page: everything that page could do lives
- * on a row here (give an agent an inbox, drop them from the roster) or on the
- * Add button, and a row now also opens that teammate's DM, which the page
- * could not do at all. An "Everyone else" row can also put that agent onto
- * this desk directly (issue #2224) — putting an existing teammate on a
- * channel and hiring a new one are different actions, so that stays separate
- * from the Add button, which still opens the create-a-teammate dialog.
+ * on a row here — give an agent an inbox, drop them from the roster, put an
+ * existing one onto this desk directly from "Everyone else" (issue #2224) —
+ * and a row now also opens that teammate's DM, which the page could not do
+ * at all. Hiring a brand-new teammate is a different action and lives
+ * elsewhere (the empty-desk "Add an agent" prompt, the Team page's own Add
+ * agent) — this pane only ever offers an agent already on the roster.
  *
  * The two sections exist because those are two different questions. "Who is in
  * this room" is what a channel header is for, and answering it with the whole
@@ -127,7 +125,6 @@ export function MembersPane({
   loading,
   fromHost,
   onRemove,
-  onAdd,
   onAddExisting,
   onMessage,
   onManageDesk,
@@ -148,16 +145,6 @@ export function MembersPane({
           <h2 className="text-sm font-semibold tracking-tight">Team</h2>
           <p className="truncate text-xs text-muted-foreground">{loading ? "Loading…" : subtitle}</p>
         </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-8"
-          onClick={onAdd}
-          aria-label="Add agent"
-          title="Add agent"
-        >
-          <UserPlus className="size-4" />
-        </Button>
       </header>
 
       <div className="flex-1 overflow-y-auto p-2">

--- a/frontend/test/unit/cov-chat-card-team-budget-refusals.test.ts
+++ b/frontend/test/unit/cov-chat-card-team-budget-refusals.test.ts
@@ -15,16 +15,18 @@ import type { TaskStatus } from "@/api/tasks";
 
 /**
  * `RoomView` wires several inline actions with their own host round trip and
- * their own catch block — dismissing a card, removing a teammate, redeeming a
- * budget pause. Every one of those catch blocks was written and never driven
- * end to end: this file mounts the real view, triggers each control, and has
- * the client refuse the write the way the host actually does, then asserts
- * the screen says something true instead of a false success or a silent
- * nothing.
+ * their own catch block — dismissing a card, redeeming a budget pause. Every
+ * one of those catch blocks was written and never driven end to end: this
+ * file mounts the real view, triggers each control, and has the client
+ * refuse the write the way the host actually does, then asserts the screen
+ * says something true instead of a false success or a silent nothing.
  *
  * (Send, reactions and the settle-pill Approve get the same treatment in
  * `cov-chat-composer-send-fail.test.ts`, `cov-chat-reaction-404-rollback.test.ts`
- * and `cov-chat-review-card-fail.test.ts`.)
+ * and `cov-chat-review-card-fail.test.ts`. Removing a teammate used to be
+ * covered here too — `RoomView`'s member pane dropped that action entirely
+ * in issue #2224; the equivalent refusal handling now lives only in
+ * `TeamView.removeMember`, which has no refusal-path coverage of its own yet.)
  */
 
 const toasts = vi.hoisted(() => ({
@@ -48,7 +50,6 @@ const OPERATOR_DTO = { id: "operator", name: "Operator", description: "Automatio
 const MEMBER_DTO = { id: "m1", name: "Ada", role: "engineer" };
 
 interface Overrides {
-  removeTeamMember?: () => Promise<unknown>;
   del?: () => Promise<unknown>;
   redeemBudgetPause?: () => Promise<unknown>;
 }
@@ -67,7 +68,6 @@ function clientAs(overrides: Overrides): OpenCompanyClient {
     mentionables: () => Promise.resolve([]),
     getOperatorChannel: () => Promise.resolve(OPERATOR_DTO),
     capabilityStatus: () => Promise.resolve({ cognition: null }),
-    removeTeamMember: vi.fn(overrides.removeTeamMember ?? (() => Promise.resolve())),
     del: vi.fn(overrides.del ?? (() => Promise.resolve())),
     getBudgetPause: vi.fn(() => Promise.resolve(null)),
     redeemBudgetPause: vi.fn(overrides.redeemBudgetPause ?? (() => Promise.resolve())),
@@ -169,13 +169,6 @@ function bodyButton(text: string): HTMLButtonElement | undefined {
     | undefined;
 }
 
-/** A dropdown/menu item — base-ui renders these as `[role="menuitem"]`, not `<button>`. */
-function bodyMenuItem(text: string): HTMLElement | undefined {
-  return [...document.body.querySelectorAll('[role="menuitem"]')].find((b) =>
-    (b.textContent ?? "").includes(text),
-  ) as HTMLElement | undefined;
-}
-
 /**
  * `dismissCard` is deliberately NOT optimistic — the chip must stay
  * exactly where it was on a refusal, unlike `react`'s rollback, because a chip
@@ -217,52 +210,6 @@ describe("dismissing a card the host refuses to delete (AUTH — the console mus
 
     expect(toasts.success).toHaveBeenCalledWith("That card was already gone — chip cleared.");
     expect(container.querySelector('a[href="#/company/tasks/task-1"]')).toBeNull();
-  });
-});
-
-/**
- * `POST/DELETE …/team` are `ScopedCompany` — any signed-in member
- * may add or remove a teammate — so there is no role gate to pin here. What
- * had no coverage was the one refusal the host still enforces (a company's
- * last teammate) and an ordinary write failure, neither silently swallowed.
- */
-describe("removing an agent from the chat member pane", () => {
-  async function openRemove() {
-    const toggle = [...container.querySelectorAll("button")].find((b) =>
-      (b.textContent ?? "").includes("agent"),
-    ) as HTMLButtonElement;
-    expect(toggle, "the members-pane toggle").not.toBeUndefined();
-    await act(async () => toggle.click());
-    await flush();
-    const actions = container.querySelector('[aria-label="Actions for Ada"]') as HTMLButtonElement;
-    expect(actions, "the row's actions trigger").not.toBeNull();
-    await act(async () => actions.click());
-    await flush();
-    const remove = bodyMenuItem("Remove from roster");
-    expect(remove, "the Remove from roster item").not.toBeUndefined();
-    await act(async () => remove?.click());
-    await flush();
-  }
-
-  it("names the host's last-agent refusal (AUTH — a removal the host will not allow)", async () => {
-    const client = clientAs({
-      removeTeamMember: () =>
-        Promise.reject(new ApiError(409, "conflict", "You can't remove your company's last agent.")),
-    });
-    await mount(client);
-    await openRemove();
-
-    expect(toasts.error).toHaveBeenCalledWith("You can't remove your company's last agent.");
-  });
-
-  it("reports an ordinary failure rather than leaving the row untouched with no explanation (FAIL)", async () => {
-    const client = clientAs({
-      removeTeamMember: () => Promise.reject(new ApiError(500, "server_error", "temporarily unavailable")),
-    });
-    await mount(client);
-    await openRemove();
-
-    expect(toasts.error).toHaveBeenCalledWith("temporarily unavailable");
   });
 });
 

--- a/frontend/test/unit/cov-chat-members-add-remove.test.ts
+++ b/frontend/test/unit/cov-chat-members-add-remove.test.ts
@@ -10,15 +10,12 @@ import { AddMemberDialog } from "@/views/room/AddMemberDialog";
 import { MembersPane } from "@/views/room/MembersPane";
 
 /**
- * Add/remove a teammate from chat's member pane. `POST {scope}/team`
- * (`add_member`) and `DELETE {scope}/team/{agent_id}` (`remove_member`) are
- * both `scoped(…)` — any company member, not admin-only (a `budget_usd_daily`
- * at creation is the one thing that needs an admin, and the chat dialog never
- * collects one — `NewMemberFields` has no such field). `MembersPane` carries
- * no role check around "Add teammate" or "Remove from roster" the way it
- * does around the budget menu (`canEditBudget`, `cov-chat-members-budget-
- * auth.test.ts`) — this pins both stay live for a plain member, and that a
- * refused add is not silently swallowed.
+ * Put an existing agent onto a channel's desk from the chat member pane
+ * (issue #2224). `MembersPane` no longer creates or removes a teammate
+ * itself — hiring lives on the empty-desk prompt and the Team page, and
+ * dropping one from the roster entirely is a Team-page-only action now —
+ * this pane's only mutation is `onAddExisting`, offered solely on an
+ * "Everyone else" row when there is a real desk to add into.
  */
 
 const MEMBER: TeamMember = {
@@ -35,20 +32,13 @@ const MEMBER: TeamMember = {
 
 function paneProps(overrides: Record<string, unknown> = {}) {
   return {
-    channelMembers: null,
+    channelMembers: [],
     others: [MEMBER],
     people: [],
     loading: false,
     fromHost: true,
-    onToggleInbox: vi.fn(),
-    onRemove: vi.fn(),
-    onAdd: vi.fn(),
     onMessage: vi.fn(),
-    canEditBudget: false,
-    onEditBudget: vi.fn(),
-    onRemoveCap: vi.fn(),
-    onResetBudget: vi.fn(),
-    setByLabel: () => undefined,
+    onAddExisting: vi.fn(),
     ...overrides,
   };
 }
@@ -69,62 +59,48 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-async function openMemberMenu() {
-  const trigger = container.querySelector('[aria-label="Actions for Ada"]') as HTMLButtonElement;
-  await act(async () => trigger.click());
-}
-
-function menuItem(text: string): HTMLElement | undefined {
-  return Array.from(document.body.querySelectorAll('[role="menuitem"]')).find((el) =>
-    (el.textContent ?? "").includes(text),
-  ) as HTMLElement | undefined;
-}
-
-describe("MembersPane's Add/Remove, for a plain member (canEditBudget: false)", () => {
-  it("still offers Add agent — no admin gate on this control", async () => {
+describe("MembersPane's add-existing action, on an Everyone-else row", () => {
+  it("offers a + for Ada when there is a real desk to add her to", async () => {
     await act(async () => {
       root.render(createElement(MembersPane, paneProps()));
     });
 
-    const add = container.querySelector('[aria-label="Add agent"]') as HTMLButtonElement;
+    const add = container.querySelector('[aria-label="Add Ada to this channel"]') as HTMLButtonElement;
     expect(add).not.toBeNull();
-    expect(add.disabled).toBe(false);
-
-    await act(async () => add.click());
-    expect(paneProps().onAdd).not.toBeUndefined(); // sanity: prop exists
   });
 
-  it("wires the Add trigger straight to onAdd", async () => {
-    const onAdd = vi.fn();
+  it("wires the + straight to onAddExisting with the member's id", async () => {
+    const onAddExisting = vi.fn();
     await act(async () => {
-      root.render(createElement(MembersPane, paneProps({ onAdd })));
+      root.render(createElement(MembersPane, paneProps({ onAddExisting })));
     });
 
-    const add = container.querySelector('[aria-label="Add agent"]') as HTMLButtonElement;
+    const add = container.querySelector('[aria-label="Add Ada to this channel"]') as HTMLButtonElement;
     await act(async () => add.click());
 
-    expect(onAdd).toHaveBeenCalled();
+    expect(onAddExisting).toHaveBeenCalledWith("m1");
   });
 
-  it("still offers Remove from roster, beside a budget menu that stays absent", async () => {
+  it("offers no + at all when the caller has no channel to add into (onAddExisting absent)", async () => {
     await act(async () => {
-      root.render(createElement(MembersPane, paneProps()));
+      root.render(createElement(MembersPane, paneProps({ onAddExisting: undefined })));
     });
-    await openMemberMenu();
 
-    expect(menuItem("Remove from roster")).not.toBeUndefined();
-    expect(menuItem("Set daily budget")).toBeUndefined();
+    expect(container.querySelector('[aria-label="Add Ada to this channel"]')).toBeNull();
   });
 
-  it("wires Remove straight to onRemove with the member's id", async () => {
-    const onRemove = vi.fn();
+  it("offers no + on a DM — real, non-null channelMembers that is not a desk", async () => {
+    const onAddExisting = vi.fn();
     await act(async () => {
-      root.render(createElement(MembersPane, paneProps({ onRemove })));
+      // The caller (RoomView) gates `onAddExisting` on `activeIsDesk`, never on
+      // `channelMembers` alone: a DM has real, non-null membership too (issue
+      // #2224's DM regression). This pane must not re-derive that signal —
+      // an absent `onAddExisting` renders no + no matter what channelMembers is.
+      root.render(createElement(MembersPane, paneProps({ onAddExisting: undefined, channelMembers: [MEMBER] })));
     });
-    await openMemberMenu();
-    await act(async () => menuItem("Remove from roster")?.click());
 
-    expect(onRemove).toHaveBeenCalledWith("m1");
+    expect(container.querySelector('[aria-label="Add Ada to this channel"]')).toBeNull();
+    expect(onAddExisting).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #2224.

## What

The "Add agent" button in a channel's Team panel opened the create-a-new-teammate
dialog. It should not — the more common need in a channel is putting an
*existing* company agent onto this desk. The data for that already existed
(the "Everyone else" section), and the API for it already existed
(`client.addDeskMember`, three working callers in `OrgChartView.tsx`, none in
chat). This wires the two together: every "Everyone else" row now has a `+`
that adds that agent to the channel in one click.

The header button and `AddMemberDialog` are untouched — hiring a brand-new
teammate from inside a channel is still legitimate and still reachable there.

## Two things the plan didn't anticipate, both found by actually running it

1. `reloadDirectory()` — the function I first reused from `removeMember` —
   only refreshes the `@mention` picker's directory, not the desk membership
   `channelMembers`/`others` are derived from. The add landed on the host
   (confirmed via `GET /desks` showing `overlayMembers`) but never appeared in
   the panel. Fixed by also calling `loadDesks`, the same refetch every
   desk-membership mutation on the org chart already uses after
   `addDeskMember`/`removeDeskMember`.
2. The `+` briefly leaked into DMs. A DM's `channelMembers` is a real,
   non-null one-element array (itself), not `null` — so gating on
   "`channelMembers` is non-null" was the wrong signal. Moved the gate to
   `activeIsDesk` at the `RoomView` call site, the same boolean that already
   gates `onManageDesk` for the identical reason.

## Explicitly out of scope

`MemberRow`'s existing "Remove from roster" removes the agent from the whole
company (`client.removeTeamMember`), not from this channel.
`client.removeDeskMember` exists and would do the channel-scoped version, but
nothing wires it anywhere in this panel. Real gap, mirror image of this one,
separate issue.

## Verified

- All three typecheck gates (`typecheck`, `typecheck:unit`, `typecheck:e2e`),
  `npm run build`, `scripts/ci/assert-design-tokens.sh` — all clean.
- Real browser, against the operator's own Wick & Wax Co. data (a copy, not the
  original), `main` at the point this branched:
  - A real desk (`creative_direction`): all 11 "Everyone else" rows carry a
    working `+`; clicking one moves the agent into "In this channel" live,
    header count updates (3→4), no reload.
  - A DM (`dm:priya`): 0 `+` buttons.
  - `general` (already fully staffed, 14/14): 0 `+` buttons — nobody left to
    add.
  - Screenshots, light and dark, of the add landing in "In this channel".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to add existing roster agents directly to a host-backed desk.
  * Added per-agent “Add to channel” actions for agents not currently on the desk.
  * Desk and mention lists now refresh after an agent is added.

* **Bug Fixes**
  * Added user feedback when an agent cannot be added or is already present.

* **Changes**
  * Roster removal is now handled from the Team page instead of the room member list.
  * Removed the header-level “Add agent” action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->