### PR TITLE
fix(runtime): replay standing grants at boot, and validate their lifetimes

### DIFF
--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2521,6 +2521,9 @@ impl RuntimeBuilder {
                 grants.rehydrate(journal.replayed_grants());
                 grants.rehydrate_continuations(journal.replayed_approval_continuations());
                 grants.rehydrate_blocker_resolutions(journal.replayed_blocker_resolutions());
+                grants.rehydrate_standing(
+                    journal.replayed_standing_grants(crate::ports::now_millis()),
+                );
                 grants
             }
         };

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -11208,6 +11208,58 @@ members = ["writer"]
         );
     }
 
+    /// A standing *denial* is the half of this that fails open when it is lost:
+    /// an operator who refused a tool for good gets that refusal silently
+    /// forgotten, and the next boot admits the call again. It must survive the
+    /// same plain `RuntimeBuilder::build` reboot an approval does.
+    #[tokio::test]
+    async fn a_standing_denial_survives_a_restart() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (rt, id) = park_one_blocked_tool_call(
+            home.clone(),
+            grantable_effect(
+                "ops",
+                crate::policy::consequence::WEB_FETCH,
+                serde_json::json!({ "url": "https://docs.rs/x" }),
+            ),
+        )
+        .await;
+
+        let (_, follow_up) = rt
+            .resolve_approval_spawned(&id, Verdict::Deny, operator(), tool_scope())
+            .await
+            .unwrap();
+        let _ = crate::company::runtime::join_follow_up(follow_up).await;
+        let refused = rt.standing_grants()[0].clone();
+        assert_eq!(refused.verdict, Verdict::Deny);
+
+        let rebooted = Arc::new(
+            RuntimeBuilder::new(home, manifest("supervised"))
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        let replayed = rebooted.standing_grants();
+        assert_eq!(
+            replayed.len(),
+            1,
+            "a restart must not forget a refusal the operator made stand"
+        );
+        assert_eq!(replayed[0].id, refused.id);
+        assert_eq!(
+            replayed[0].verdict,
+            Verdict::Deny,
+            "it must come back as a refusal, not as a permission"
+        );
+        assert_eq!(
+            replayed[0].scope.as_deref(),
+            refused.scope.as_deref(),
+            "and refusing exactly what it refused before"
+        );
+    }
+
     /// Issue #1458: when two identical cards park and the operator resolves the
     /// first as a standing **denial** and the second as a standing **approval**,
     /// the newer decision wins. `ApprovalPolicy` checks a deny above a standing
@@ -12129,6 +12181,10 @@ members = ["writer"]
     }
 
     /// Standing grants survive a restart, and revoking one is durable too.
+    ///
+    /// The reboots here take the path `serve` takes — `RuntimeBuilder::build`
+    /// and nothing else. `recover()` is not called, because no production
+    /// caller calls it.
     #[tokio::test]
     async fn a_standing_grant_replays_on_boot_and_a_revoked_one_does_not() {
         let home_dir = tmp_home();
@@ -12153,7 +12209,6 @@ members = ["writer"]
                 .await
                 .unwrap(),
         );
-        rt2.recover().await.unwrap();
         assert_eq!(rt2.grants.standing_count(), 1);
         assert_eq!(rt2.standing_grants()[0].id, grant_id);
 
@@ -12177,7 +12232,6 @@ members = ["writer"]
                 .await
                 .unwrap(),
         );
-        rt3.recover().await.unwrap();
         assert_eq!(
             rt3.grants.standing_count(),
             0,

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -1108,6 +1108,13 @@ impl GrantSet {
     pub fn rehydrate_standing(&self, grants: impl IntoIterator<Item = StandingGrant>) {
         let mut state = self.inner.lock().expect("grant set poisoned");
         for grant in grants {
+            if grant
+                .expires_at_millis
+                .checked_sub(grant.at_millis)
+                .is_none_or(|duration| duration == 0 || duration > MAX_STANDING_GRANT_MILLIS)
+            {
+                continue;
+            }
             state.standing.insert(grant.id.clone(), grant);
         }
     }
@@ -3258,13 +3265,7 @@ mod test {
         assert_eq!(set.live_count(), 0);
     }
 
-    /// The 7-day ceiling (`MAX_STANDING_GRANT_MILLIS`) is enforced at the
-    /// resolve route when a grant is minted, not on `StandingGrant` itself —
-    /// so `rehydrate_standing`, which is what a journal replay calls, accepts
-    /// a line whose `expires_at_millis` is far past that ceiling with no
-    /// re-check.
     #[test]
-    #[ignore = "rehydrate_standing accepts a journal line whose expiry exceeds the 7-day ceiling verbatim, with no re-check against MAX_STANDING_GRANT_MILLIS"]
     fn rehydrate_standing_refuses_a_line_past_the_seven_day_ceiling() {
         let set = GrantSet::default();
         let far_future_expiry = 1_000 + MAX_STANDING_GRANT_MILLIS * 10;
@@ -3276,6 +3277,39 @@ mod test {
             "a rehydrated standing grant must not outlive the 7-day ceiling every other \
              mint path enforces, even when the journal line itself claims a longer expiry"
         );
+    }
+
+    #[test]
+    fn rehydrate_standing_checks_each_duration_without_rebasing_its_expiry() {
+        for (at_millis, expires_at_millis, accepted) in [
+            (1_000, 1_001, true),
+            (1_000, 1_000 + MAX_STANDING_GRANT_MILLIS, true),
+            (1_000, 1_001 + MAX_STANDING_GRANT_MILLIS, false),
+            (1_000, 1_000, false),
+            (1_000, 999, false),
+            (0, u64::MAX, false),
+            (u64::MAX - MAX_STANDING_GRANT_MILLIS, u64::MAX, true),
+        ] {
+            for verdict in [Verdict::Approve, Verdict::Deny] {
+                let set = GrantSet::default();
+                let mut grant = standing("candidate", "maya", "web_fetch", expires_at_millis);
+                grant.at_millis = at_millis;
+                grant.verdict = verdict;
+                let valid = standing("valid", "maya", "web_fetch", 2_000);
+                set.rehydrate_standing([grant.clone(), valid.clone()]);
+
+                assert_eq!(
+                    set.peek_standing_by_approval(&grant.approval_id),
+                    accepted.then_some(grant),
+                    "duration bounds: {at_millis}..{expires_at_millis}, {verdict:?}"
+                );
+                assert_eq!(
+                    set.peek_standing_by_approval(&valid.approval_id),
+                    Some(valid),
+                    "an invalid line must not discard a valid sibling"
+                );
+            }
+        }
     }
 
     /// `subject()` reads an empty `agent` with no `workflow` as an agent

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -1113,6 +1113,14 @@ impl GrantSet {
                 .checked_sub(grant.at_millis)
                 .is_none_or(|duration| duration == 0 || duration > MAX_STANDING_GRANT_MILLIS)
             {
+                tracing::warn!(
+                    "[grants] standing grant '{}' was not restored: its lifetime \
+                     ({} -> {}) is zero, inverted, or past the {}ms ceiling",
+                    grant.id,
+                    grant.at_millis,
+                    grant.expires_at_millis,
+                    MAX_STANDING_GRANT_MILLIS
+                );
                 continue;
             }
             state.standing.insert(grant.id.clone(), grant);


### PR DESCRIPTION
## Summary

Standing approvals and standing denials were silently dropped on every restart, and the replay that was supposed to restore them also accepted lifetimes it should have refused.

## Problem

Two defects on the same path.

**1. The replay never ran in production.** `rehydrate_standing` was reachable only from `CycleRunner::recover()`, and every caller of `recover()` is behind `cfg(test)`. `RuntimeBuilder::build()` — the path `serve` actually takes — rehydrated single-use grants, approval continuations and blocker resolutions, but never standing ones. Every ordinary restart (redeploy, container replace, OOM kill) therefore threw away every standing decision the operator had made.

A lost standing *approval* is lost convenience: the operator gets asked again. A lost standing *denial* fails open — a tool the operator refused for good is admitted again after the next boot, with nothing anywhere reporting it.

The existing test named `a_standing_grant_replays_on_boot_and_a_revoked_one_does_not` called `recover()` itself, so it was green over the whole gap.

**2. The replay trusted the journal line.** A stored lifetime that was zero, inverted, or past the seven-day ceiling was re-armed verbatim, so a restart could resurrect a permission no live mint would ever have produced.

## Solution

Wire `rehydrate_standing` into `RuntimeBuilder::build()`'s cold-boot arm, alongside the three replays already there, filtered through `replayed_standing_grants(now)` so anything already lapsed stays lapsed.

Validate the lifetime during replay, and say so when a grant is dropped — naming the grant and its rejected lifetime, so an operator whose approval stopped applying can find out why instead of guessing.

The boot test now reboots the way production does, with no `recover()` call, and a standing denial gets its own case.

## Submission Checklist

- [x] Full lib suite: 5022 passed, 0 failed
- [x] Red proof (boot replay): removing the `rehydrate_standing` call fails `a_standing_denial_survives_a_restart` on its own assertion — `a restart must not forget a refusal the operator made stand / left: 0 / right: 1` — restored to green
- [x] Red proof (lifetime validation): covered by the existing grants suite, 122 passed
- [x] Production-deletion scan clean apart from the two `recover()` calls this change deliberately removes from the boot test
- [ ] Console E2E — pre-existing failure on main, unrelated

## Impact

Standing approvals and denials now survive a restart. A denial that was being forgotten is now enforced after boot, which is a behaviour change in the safe direction: calls that started being admitted again after a redeploy will be refused, as the operator originally decided.

## Related

Closes the standing half of the durability claim in `a_backend_journal_survives_the_loss_of_the_whole_data_directory`, whose doc comment asserted standing grants survive while its assertions never checked them.