### PR TITLE
test(mcp): activate registry grant isolation regressions

### DIFF
--- a/src/harness/built_in/build.rs
+++ b/src/harness/built_in/build.rs
@@ -3312,17 +3312,8 @@ mod tests {
         );
     }
 
-    // --- FAIL-axis: the MCP registry belt is wired without a grant check ------
-
-    /// The read half of the MCP registry family must be withheld from an agent
-    /// whose effective grants cover no namespace at all.
-    ///
-    /// `build_agent` pushes it on `#[cfg(feature = "mcp")]` + a configured
-    /// `mcp_home` alone, with no `grants` term in the condition, so an agent
-    /// granted nothing still receives it. Pinned here as the safe behaviour.
     #[cfg(feature = "mcp")]
     #[test]
-    #[ignore = "confirms fail-open: mcp_registry_list_tools is wired with no grant term"]
     fn mcp_registry_list_tools_is_withheld_from_an_agent_granted_nothing() {
         let names = built_tool_names(&[], false);
         assert!(
@@ -3331,12 +3322,8 @@ mod tests {
         );
     }
 
-    /// The mutating half — the one that invokes an arbitrary tool on any server
-    /// the company has installed. Same ungated wiring, higher blast radius: an
-    /// agent granted nothing can drive every connected MCP server.
     #[cfg(feature = "mcp")]
     #[test]
-    #[ignore = "confirms fail-open: mcp_registry_tool_call is wired with no grant term"]
     fn mcp_registry_tool_call_is_withheld_from_an_agent_granted_nothing() {
         let names = built_tool_names(&[], false);
         assert!(
@@ -3345,11 +3332,8 @@ mod tests {
         );
     }
 
-    /// Narrow grants are not a way in either: an agent granted only `docs`
-    /// holds no MCP namespace, so neither registry tool may appear.
     #[cfg(feature = "mcp")]
     #[test]
-    #[ignore = "confirms fail-open: a docs-only agent still receives both registry tools"]
     fn a_docs_only_agent_receives_no_mcp_registry_tool() {
         let names = built_tool_names(&["docs.*"], false);
         for tool in ["mcp_registry_list_tools", "mcp_registry_tool_call"] {
@@ -3360,12 +3344,6 @@ mod tests {
         }
     }
 
-    /// The server-backed MCP family (`mcp_list_tools` / `mcp_call`) is the
-    /// contrast case, and it fails closed: with no server configured on the
-    /// company, `registry_for_agent` yields nothing and not one of those tools
-    /// is built — even for a `*` agent. This is the gate the registry family
-    /// above is missing, pinned so a change that wires the belt unconditionally
-    /// is caught here.
     #[cfg(feature = "mcp")]
     #[test]
     fn no_configured_mcp_server_wires_no_server_backed_mcp_tool() {


### PR DESCRIPTION
## Summary

Enable three existing MCP registry grant-isolation regressions. The production grant check already passes them, but their stale ignore attributes prevented normal test runs from protecting it.

The test bodies and assertions are byte-identical to the base branch. Only the three ignore attributes and stale comments were removed.

## API Or Behavior Changes

None. Registry discovery and invocation still require an explicit MCP registry grant and a configured registry home. Empty grants and docs-only grants remain insufficient. No production code, dependencies, or submodule pins changed.

## Tests

Final gates ran after signed commit `d94325168`, unpiped, with each command's `$?` captured directly. Builds used `CARGO_BUILD_JOBS=1`, `CARGO_PROFILE_DEV_DEBUG=0`, and `CARGO_PROFILE_TEST_DEBUG=0`; assertions remained enabled.

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` — exit 0.
- [x] `cargo test --locked --lib` — exit 0; 5,019 passed, 0 failed, 6 existing ignores; 233.02 seconds.
- [x] `cargo test --locked --features openhuman,mcp,media --lib -- harness::built_in::build::tests app::types --test-threads=2` — exit 0; 70 passed, 0 failed, 0 ignored; 0.38 seconds. This runs both documented MCP lane filters: 42 tool-belt tests and 28 application-type tests. All three newly enabled tests ran normally, without an ignore override.
- [x] N/A: separate `cargo build --all-targets`; Clippy checked the default all-targets configuration, and the affected gated library was built and executed by the feature-lane test command.

Before changing the attributes, `cargo test --locked --features openhuman,mcp,media --lib harness::built_in::build::tests -- --list --ignored` exited 0 and discovered the three real test paths. Running the just-built binary with `harness::built_in::build::tests --ignored --test-threads=2` and the configured 8 MiB thread stack passed all three tests (exit 0, 0.16 seconds). An earlier discovery attempt was deliberately interrupted under shared-host memory pressure (exit 130, no tests ran); it was not counted as a test result.

Observed red proof before committing: copied the fixed file outside the repository, then replaced only `grants_mcp_registry_explicit(grants)` with `true` at the production registry-wiring gate. Running `cargo test --locked --features openhuman,mcp,media --lib harness::built_in::build::tests -- --test-threads=2` exited 101: 37 passed, 5 failed. All three regressions failed for their intended reasons:

- The no-grant reader test reported that an agent holding no grant must not receive the MCP registry reader.
- The no-grant invocation test reported the corresponding registry-invoker refusal.
- The docs-only test reported that `docs.*` must not confer `mcp_registry_list_tools`.

Two existing tool-belt controls also detected the extra tools. The production gate was immediately restored; both the file comparison and full pre-proof/post-proof diff comparison exited 0. Re-running the same command then passed all 42 tests (exit 0, 0 failed, 0 ignored). The temporary break was never committed.

All 36 recursive submodules were populated and matched their pins before testing and at handoff.

## Documentation

Removed comments describing wiring that no longer exists. No external documentation update is needed because the existing grant contract and runtime behavior are unchanged.
