### PR TITLE
fix(workspace): refuse racing note writes atomically

### DIFF
--- a/docs/spec/runtime/ports-console-workspace.md
+++ b/docs/spec/runtime/ports-console-workspace.md
@@ -21,6 +21,9 @@ pub trait WorkspaceStore: Send + Sync {
         -> Result<Option<(WorkspaceNode, String, u64)>>;
     async fn write(&self, company: &CompanyId, id: &str, content: &str,
                    author: WorkspaceOrigin) -> Result<WorkspaceNode>;
+    async fn write_with_revision(&self, company: &CompanyId, id: &str, content: &str,
+                                 author: WorkspaceOrigin, expected_updated_at: Option<u64>)
+        -> Result<WorkspaceNode>;
     async fn create(&self, /* parent, name, kind, content */) -> Result<WorkspaceNode>;
     async fn adopt_or_create_folder(&self, company: &CompanyId, parent: Option<&str>,
                                     name: &str, origin: WorkspaceOrigin)
@@ -42,6 +45,18 @@ pub trait WorkspaceStore: Send + Sync {
 
 Nodes are folders or files (`NodeKind`); `[[wikilink]]` backlinks are derived
 at read time by the GraphQL layer.
+
+**Conditional text writes.** `write_with_revision` checks `Some(revision)` at
+the storage boundary and returns `Conflict` without modifying the note when
+its revision no longer matches. `None` is unconditional; `write` delegates to
+that form. Successful text writes advance `updated_at_millis` strictly, even
+within the same millisecond. Renames, moves, and promotions advance the current
+revision too; concurrent metadata updates preserve the latest text revision and
+authorship. All decorators forward the condition unchanged.
+`FsOps` checks under the workspace-index lock (single process per data dir),
+SQLite uses an `IMMEDIATE` transaction, and MongoDB conditions its document
+update on the metadata it read. `workspace_write` passes the revision supplied
+by the agent, so two edits based on one revision cannot both succeed.
 
 **No torn reads (#887).** A `read` concurrent with a `write` on the same node
 returns one whole revision or the other — never an error, and never a prefix.
@@ -267,4 +282,3 @@ result; a minter returns the collision as an error, since its caller needs the
 id. The agent/desks folders are organizational and attribution units only;
 agents may create and write ordinary shared content anywhere. `secrets/` is
 the operator-only exception on the workspace tool surface.
-

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1138,14 +1138,23 @@ mod test {
         ) -> Result<Option<(WorkspaceNode, String, u64)>> {
             WorkspaceStore::read_capped(&*self.0, company, id, max_bytes).await
         }
-        async fn write(
+        async fn write_with_revision(
             &self,
             company: &CompanyId,
             id: &str,
             content: &str,
             author: WorkspaceOrigin,
+            expected_updated_at: Option<u64>,
         ) -> Result<WorkspaceNode> {
-            WorkspaceStore::write(&*self.0, company, id, content, author).await
+            WorkspaceStore::write_with_revision(
+                &*self.0,
+                company,
+                id,
+                content,
+                author,
+                expected_updated_at,
+            )
+            .await
         }
         async fn create(
             &self,
@@ -1256,14 +1265,23 @@ mod test {
         ) -> Result<Option<(WorkspaceNode, String, u64)>> {
             WorkspaceStore::read_capped(&*self.0, company, id, max_bytes).await
         }
-        async fn write(
+        async fn write_with_revision(
             &self,
             company: &CompanyId,
             id: &str,
             content: &str,
             author: WorkspaceOrigin,
+            expected_updated_at: Option<u64>,
         ) -> Result<WorkspaceNode> {
-            WorkspaceStore::write(&*self.0, company, id, content, author).await
+            WorkspaceStore::write_with_revision(
+                &*self.0,
+                company,
+                id,
+                content,
+                author,
+                expected_updated_at,
+            )
+            .await
         }
         async fn create(
             &self,
@@ -1683,14 +1701,23 @@ mod test {
         ) -> Result<Option<(WorkspaceNode, String, u64)>> {
             WorkspaceStore::read_capped(&*self.0, company, id, max_bytes).await
         }
-        async fn write(
+        async fn write_with_revision(
             &self,
             company: &CompanyId,
             id: &str,
             content: &str,
             author: WorkspaceOrigin,
+            expected_updated_at: Option<u64>,
         ) -> Result<WorkspaceNode> {
-            WorkspaceStore::write(&*self.0, company, id, content, author).await
+            WorkspaceStore::write_with_revision(
+                &*self.0,
+                company,
+                id,
+                content,
+                author,
+                expected_updated_at,
+            )
+            .await
         }
         async fn create(
             &self,
@@ -1981,14 +2008,23 @@ mod test {
         ) -> Result<Option<(WorkspaceNode, String, u64)>> {
             WorkspaceStore::read_capped(&*self.inner, company, id, max_bytes).await
         }
-        async fn write(
+        async fn write_with_revision(
             &self,
             company: &CompanyId,
             id: &str,
             content: &str,
             author: WorkspaceOrigin,
+            expected_updated_at: Option<u64>,
         ) -> Result<WorkspaceNode> {
-            WorkspaceStore::write(&*self.inner, company, id, content, author).await
+            WorkspaceStore::write_with_revision(
+                &*self.inner,
+                company,
+                id,
+                content,
+                author,
+                expected_updated_at,
+            )
+            .await
         }
         async fn create(
             &self,

--- a/src/company/avatar.rs
+++ b/src/company/avatar.rs
@@ -1650,12 +1650,13 @@ mod test {
         ) -> Result<Option<(WorkspaceNode, String, u64)>> {
             crate::ports::workspace::read_capped_by_reading(self, company, id, max_bytes).await
         }
-        async fn write(
+        async fn write_with_revision(
             &self,
             _company: &crate::ports::types::CompanyId,
             _id: &str,
             _content: &str,
             _author: WorkspaceOrigin,
+            _expected_updated_at: Option<u64>,
         ) -> Result<WorkspaceNode> {
             unreachable!("resolve does not write prose")
         }

--- a/src/company/workspace_repair/loose_store.rs
+++ b/src/company/workspace_repair/loose_store.rs
@@ -28,7 +28,6 @@ use async_trait::async_trait;
 
 use crate::Result;
 use crate::error::OpenCompanyError;
-use crate::ports::now_millis;
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{
     BlobStream, FolderClaim, NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore,
@@ -134,12 +133,13 @@ impl WorkspaceStore for LooseWorkspace {
         crate::ports::workspace::read_capped_by_reading(self, company, id, max_bytes).await
     }
 
-    async fn write(
+    async fn write_with_revision(
         &self,
         company: &CompanyId,
         id: &str,
         content: &str,
         author: WorkspaceOrigin,
+        expected_updated_at: Option<u64>,
     ) -> Result<WorkspaceNode> {
         self.with(company, |state, key| {
             let node = state
@@ -152,7 +152,10 @@ impl WorkspaceStore for LooseWorkspace {
                     "only a prose file can be written as text".to_string(),
                 ));
             }
-            node.updated_at_millis = now_millis();
+            node.updated_at_millis = crate::ports::workspace::next_write_revision(
+                node.updated_at_millis,
+                expected_updated_at,
+            )?;
             node.updated_by = author;
             let node = node.clone();
             state.text.insert(id.to_string(), content.to_string());
@@ -311,7 +314,8 @@ impl WorkspaceStore for LooseWorkspace {
             if let Some(parent) = parent {
                 node.parent_id = parent.map(str::to_string);
             }
-            node.updated_at_millis = now_millis();
+            node.updated_at_millis =
+                crate::ports::workspace::next_write_revision(node.updated_at_millis, None)?;
             let node = node.clone();
             if let Some(hook) = state.after_move.take() {
                 hook(state.tree(&key));

--- a/src/company/workspace_scaffold.rs
+++ b/src/company/workspace_scaffold.rs
@@ -1785,14 +1785,17 @@ mod tests {
             self.inner.read_capped(company, id, max_bytes).await
         }
 
-        async fn write(
+        async fn write_with_revision(
             &self,
             company: &CompanyId,
             id: &str,
             content: &str,
             author: WorkspaceOrigin,
+            expected_updated_at: Option<u64>,
         ) -> Result<WorkspaceNode> {
-            self.inner.write(company, id, content, author).await
+            self.inner
+                .write_with_revision(company, id, content, author, expected_updated_at)
+                .await
         }
 
         async fn create(

--- a/src/company/workspace_search/test.rs
+++ b/src/company/workspace_search/test.rs
@@ -573,12 +573,13 @@ impl WorkspaceStore for FixedTree {
     ) -> crate::Result<Option<(WorkspaceNode, String, u64)>> {
         crate::ports::workspace::read_capped_by_reading(self, company, id, max_bytes).await
     }
-    async fn write(
+    async fn write_with_revision(
         &self,
         _company: &CompanyId,
         _id: &str,
         _content: &str,
         _author: WorkspaceOrigin,
+        _expected_updated_at: Option<u64>,
     ) -> crate::Result<WorkspaceNode> {
         unreachable!("search never writes")
     }

--- a/src/harness/built_in/workspace_tools.rs
+++ b/src/harness/built_in/workspace_tools.rs
@@ -1763,14 +1763,6 @@ impl Tool for WorkspaceWriteTool {
             )));
         }
 
-        // Revision guard, best-effort: check-then-act, not an atomic
-        // compare-and-swap. The tree snapshot above is one authority on the
-        // current revision and catches the ordinary case — a note edited in the
-        // console since the agent's read is refused here rather than clobbered.
-        // The residual window (an edit landing between this check and the write
-        // below) is narrowed by re-checking against the live read further down,
-        // and can only be closed for real once the port grows a conditional
-        // write.
         let stale_refusal = |current: u64| {
             ToolResult::error(format!(
                 "Refused: `{path}` changed since you read it — you passed \
@@ -1828,11 +1820,12 @@ impl Tool for WorkspaceWriteTool {
         match self
             .workspace
             .store
-            .write(
+            .write_with_revision(
                 &self.workspace.company,
                 &entry.node.id,
                 content,
                 self.workspace.origin(),
+                Some(expected),
             )
             .await
         {
@@ -6524,16 +6517,7 @@ mod tests {
         }
     }
 
-    /// FAIL-axis (HT-033): the revision guard is check-then-act, as this
-    /// module's own comment admits, and `WorkspaceStore::write` takes no
-    /// expected revision — so the check has nothing to hand its decision to.
-    /// Two writers holding the same `expected_updated_at`, released together
-    /// after both have cleared the live re-check, both write and both are told
-    /// they succeeded; one edit is silently gone.
-    ///
-    /// The safe behaviour asserted here needs a conditional write on the port.
     #[tokio::test]
-    #[ignore = "no conditional write on WorkspaceStore: both racing writers are told they succeeded"]
     async fn two_writers_at_the_same_revision_cannot_both_be_told_they_succeeded() {
         let dir = tempfile::tempdir().unwrap();
         let real: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
@@ -6581,6 +6565,20 @@ mod tests {
             text(&ra),
             text(&rb)
         );
+        let (winner, loser, expected_body) = if ra.is_error {
+            (&rb, &ra, "B's edit")
+        } else {
+            (&ra, &rb, "A's edit")
+        };
+        assert!(!winner.is_error, "{}", text(winner));
+        assert!(
+            text(loser).contains("changed since you read it"),
+            "{}",
+            text(loser)
+        );
+        let (stored, body) = real.read(&company, "n-note").await.unwrap().unwrap();
+        assert_eq!(body, expected_body);
+        assert!(stored.updated_at_millis > rev);
     }
 
     /// FAIL-axis (HT-034): `workspace_create`'s duplicate check reads a tree

--- a/src/harness/built_in/workspace_tools.rs
+++ b/src/harness/built_in/workspace_tools.rs
@@ -2837,12 +2837,13 @@ mod tests {
         ) -> crate::Result<Option<(WorkspaceNode, String, u64)>> {
             unreachable!("the ownership gate only reads the tree")
         }
-        async fn write(
+        async fn write_with_revision(
             &self,
             _company: &CompanyId,
             _id: &str,
             _content: &str,
             _author: WorkspaceOrigin,
+            _expected_updated_at: Option<u64>,
         ) -> crate::Result<WorkspaceNode> {
             unreachable!("the ownership gate only reads the tree")
         }
@@ -4246,12 +4247,13 @@ mod tests {
         ) -> crate::Result<Option<(WorkspaceNode, String, u64)>> {
             crate::ports::workspace::read_capped_by_reading(self, company, id, max_bytes).await
         }
-        async fn write(
+        async fn write_with_revision(
             &self,
             _company: &CompanyId,
             _id: &str,
             _content: &str,
             _author: WorkspaceOrigin,
+            _expected_updated_at: Option<u64>,
         ) -> crate::Result<WorkspaceNode> {
             unreachable!("the listing never writes")
         }
@@ -5071,14 +5073,17 @@ mod tests {
         ) -> crate::Result<Option<(WorkspaceNode, String, u64)>> {
             self.inner.read_capped(company, id, max_bytes).await
         }
-        async fn write(
+        async fn write_with_revision(
             &self,
             company: &CompanyId,
             id: &str,
             content: &str,
             author: WorkspaceOrigin,
+            expected_updated_at: Option<u64>,
         ) -> crate::Result<WorkspaceNode> {
-            self.inner.write(company, id, content, author).await
+            self.inner
+                .write_with_revision(company, id, content, author, expected_updated_at)
+                .await
         }
         async fn create(
             &self,
@@ -6430,17 +6435,20 @@ mod tests {
         ) -> crate::Result<Option<(WorkspaceNode, String, u64)>> {
             self.inner.read_capped(company, id, max_bytes).await
         }
-        async fn write(
+        async fn write_with_revision(
             &self,
             company: &CompanyId,
             id: &str,
             content: &str,
             author: WorkspaceOrigin,
+            expected_updated_at: Option<u64>,
         ) -> crate::Result<WorkspaceNode> {
             if let Some(gate) = &self.write_gate {
                 gate.wait().await;
             }
-            self.inner.write(company, id, content, author).await
+            self.inner
+                .write_with_revision(company, id, content, author, expected_updated_at)
+                .await
         }
         async fn create(
             &self,

--- a/src/harness/built_in/workspace_tools/lifecycle/test.rs
+++ b/src/harness/built_in/workspace_tools/lifecycle/test.rs
@@ -1097,14 +1097,17 @@ impl WorkspaceStore for BrittleStore {
         self.inner.read_capped(company, id, max_bytes).await
     }
 
-    async fn write(
+    async fn write_with_revision(
         &self,
         company: &CompanyId,
         id: &str,
         content: &str,
         author: WorkspaceOrigin,
+        expected_updated_at: Option<u64>,
     ) -> crate::Result<WorkspaceNode> {
-        self.inner.write(company, id, content, author).await
+        self.inner
+            .write_with_revision(company, id, content, author, expected_updated_at)
+            .await
     }
 
     async fn create(

--- a/src/ports/workspace.rs
+++ b/src/ports/workspace.rs
@@ -58,6 +58,20 @@ pub fn binary_write_refusal(name: &str, mime: &str) -> String {
     )
 }
 
+pub(crate) fn next_write_revision(current: u64, expected: Option<u64>) -> Result<u64> {
+    if let Some(expected) = expected
+        && expected != current
+    {
+        return Err(crate::error::OpenCompanyError::Conflict(format!(
+            "workspace note changed since you read it: expected revision {expected}, current revision {current}; re-read and re-apply your change"
+        )));
+    }
+    let next = current.checked_add(1).ok_or_else(|| {
+        crate::error::OpenCompanyError::Conflict("workspace revision exhausted".to_string())
+    })?;
+    Ok(crate::ports::now_millis().max(next))
+}
+
 /// The size and content digest of a blob, computed from the bytes themselves.
 ///
 /// Callers never supply either value. A `sha256` a caller could pass would be a
@@ -570,6 +584,20 @@ pub trait WorkspaceStore: Send + Sync {
         id: &str,
         content: &str,
         author: WorkspaceOrigin,
+    ) -> Result<WorkspaceNode> {
+        self.write_with_revision(company, id, content, author, None)
+            .await
+    }
+    /// Overwrites text atomically with its revision check. A mismatched revision
+    /// returns `Conflict` without changing the body or metadata. `None` requests
+    /// an unconditional write. Every successful write advances the revision.
+    async fn write_with_revision(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        content: &str,
+        author: WorkspaceOrigin,
+        expected_updated_at: Option<u64>,
     ) -> Result<WorkspaceNode>;
     /// Creates a node (folder or file). The node's `id` must be fresh; the
     /// `parent_id`, when set, must name an existing folder. `content` seeds a
@@ -836,6 +864,23 @@ pub trait WorkspaceStore: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn text_revisions_refuse_stale_tokens_and_never_wrap() {
+        let current = i64::MAX as u64 / 2;
+        assert_eq!(
+            next_write_revision(current, Some(current)).unwrap(),
+            current + 1
+        );
+        assert_eq!(next_write_revision(current, None).unwrap(), current + 1);
+        let stale = next_write_revision(current, Some(current - 1)).unwrap_err();
+        assert!(matches!(stale, crate::error::OpenCompanyError::Conflict(_)));
+        let exhausted = next_write_revision(u64::MAX, Some(u64::MAX)).unwrap_err();
+        assert!(matches!(
+            exhausted,
+            crate::error::OpenCompanyError::Conflict(_)
+        ));
+    }
 
     /// Every backend persists a node as opaque JSON, so a node written before
     /// authorship existed has neither field. It must still load — and must load

--- a/src/runtime/derived_guard.rs
+++ b/src/runtime/derived_guard.rs
@@ -156,19 +156,22 @@ impl WorkspaceStore for DerivedGuardWorkspace {
         self.inner.read_capped(company, id, max_bytes).await
     }
 
-    async fn write(
+    async fn write_with_revision(
         &self,
         company: &CompanyId,
         id: &str,
         content: &str,
         author: WorkspaceOrigin,
+        expected_updated_at: Option<u64>,
     ) -> Result<WorkspaceNode> {
         if author != WorkspaceOrigin::Seed
             && let Some(path) = self.guarded_node(company, id).await?
         {
             return Err(self.refuse(company, &path).await);
         }
-        self.inner.write(company, id, content, author).await
+        self.inner
+            .write_with_revision(company, id, content, author, expected_updated_at)
+            .await
     }
 
     async fn create(

--- a/src/runtime/workspace_events.rs
+++ b/src/runtime/workspace_events.rs
@@ -152,22 +152,19 @@ impl WorkspaceStore for WorkspaceAnnouncer {
         self.inner.is_empty(company).await
     }
 
-    /// Writes through, then announces `updated`.
-    ///
-    /// Unconditional, unlike [`BoardAnnouncer`](crate::runtime::BoardAnnouncer)'s
-    /// identical-re-save suppression: a `write` always advances the node's
-    /// `updated_at_millis`, which is the revision token the agent tools' CAS
-    /// compares against, so a write that stores the same bytes has still
-    /// changed the node in the way that matters. Detecting "same body" would
-    /// also cost a full read of every note on every save, to save a refetch.
-    async fn write(
+    /// Announces `updated` only after a successful write.
+    async fn write_with_revision(
         &self,
         company: &CompanyId,
         id: &str,
         content: &str,
         author: crate::ports::workspace::WorkspaceOrigin,
+        expected_updated_at: Option<u64>,
     ) -> Result<WorkspaceNode> {
-        let node = self.inner.write(company, id, content, author).await?;
+        let node = self
+            .inner
+            .write_with_revision(company, id, content, author, expected_updated_at)
+            .await?;
         self.announce(company, id, CHANGE_UPDATED).await;
         Ok(node)
     }
@@ -526,6 +523,32 @@ mod test {
             vec![
                 ("n-1".to_string(), "opened".to_string()),
                 ("n-1".to_string(), "updated".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn conditional_writes_cross_all_decorators_and_only_announce_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = Arc::new(FsOps::new(dir.path()));
+        let guarded = Arc::new(crate::runtime::DerivedGuardWorkspace::new(
+            backend.clone(),
+            backend,
+        ));
+        let metered = Arc::new(crate::runtime::QuotaEnforcedWorkspace::new(
+            guarded,
+            crate::runtime::WorkspaceQuota::default(),
+        ));
+        let log = Arc::new(MemLog::default());
+        let store = Arc::new(WorkspaceAnnouncer::new(metered, log.clone()));
+        crate::store::conformance::assert_workspace_conditional_write(store.clone(), store).await;
+        assert_eq!(
+            changes(&log),
+            vec![
+                ("note".to_string(), CHANGE_OPENED.to_string()),
+                ("note".to_string(), CHANGE_UPDATED.to_string()),
+                ("note".to_string(), CHANGE_UPDATED.to_string()),
+                ("note".to_string(), CHANGE_UPDATED.to_string()),
             ]
         );
     }

--- a/src/runtime/workspace_quota.rs
+++ b/src/runtime/workspace_quota.rs
@@ -309,14 +309,17 @@ impl WorkspaceStore for QuotaEnforcedWorkspace {
 
     /// Unmetered — see the module docs on what is counted. A text write also
     /// cannot land on a binary node at all, so it can never grow a payload.
-    async fn write(
+    async fn write_with_revision(
         &self,
         company: &CompanyId,
         id: &str,
         content: &str,
         author: WorkspaceOrigin,
+        expected_updated_at: Option<u64>,
     ) -> Result<WorkspaceNode> {
-        self.inner.write(company, id, content, author).await
+        self.inner
+            .write_with_revision(company, id, content, author, expected_updated_at)
+            .await
     }
 
     async fn create(

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -10542,14 +10542,17 @@ impl crate::ports::workspace::WorkspaceStore for RecordingReads {
         self.inner.read_capped(company, id, max_bytes).await
     }
 
-    async fn write(
+    async fn write_with_revision(
         &self,
         company: &CompanyId,
         id: &str,
         content: &str,
         author: crate::ports::workspace::WorkspaceOrigin,
+        expected_updated_at: Option<u64>,
     ) -> crate::Result<crate::ports::workspace::WorkspaceNode> {
-        self.inner.write(company, id, content, author).await
+        self.inner
+            .write_with_revision(company, id, content, author, expected_updated_at)
+            .await
     }
 
     async fn create(

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -4390,6 +4390,227 @@ pub async fn assert_workspace_store(ws: Arc<dyn WorkspaceStore>) {
     assert!(!ws.delete(&alpha, "root").await.unwrap());
 }
 
+pub async fn assert_workspace_conditional_write(
+    first: Arc<dyn WorkspaceStore>,
+    second: Arc<dyn WorkspaceStore>,
+) {
+    let company = CompanyId::new("conditional-write");
+    let revision = i64::MAX as u64 / 2;
+    let original = WorkspaceNode {
+        id: "note".to_string(),
+        name: "shared.md".to_string(),
+        kind: NodeKind::File,
+        parent_id: None,
+        updated_at_millis: revision,
+        created_by: WorkspaceOrigin::Seed,
+        updated_by: WorkspaceOrigin::Seed,
+        mime: None,
+        size: None,
+        sha256: None,
+        adopted: false,
+    };
+    first
+        .create(&company, &original, Some("original"))
+        .await
+        .unwrap();
+    let gate = Arc::new(tokio::sync::Barrier::new(2));
+    let mut writers = Vec::new();
+    for (store, body) in [(first.clone(), "first"), (second, "second")] {
+        let gate = gate.clone();
+        let company = company.clone();
+        writers.push(tokio::spawn(async move {
+            gate.wait().await;
+            let result = store
+                .write_with_revision(
+                    &company,
+                    "note",
+                    body,
+                    WorkspaceOrigin::Agent {
+                        id: body.to_string(),
+                    },
+                    Some(revision),
+                )
+                .await;
+            (body, result)
+        }));
+    }
+    let mut winners = Vec::new();
+    let mut refused = 0;
+    for writer in writers {
+        let (body, result) = writer.await.unwrap();
+        match result {
+            Ok(node) => {
+                winners.push((body, node));
+            }
+            Err(crate::error::OpenCompanyError::Conflict(message)) => {
+                assert!(message.contains("changed since you read it"), "{message}");
+                refused += 1;
+            }
+            Err(error) => panic!("unexpected conditional-write failure: {error}"),
+        }
+    }
+    assert_eq!(winners.len(), 1, "both writers at one revision succeeded");
+    assert_eq!(refused, 1, "exactly one racing writer must be refused");
+    let (body, node) = winners.pop().unwrap();
+    assert_eq!(node.updated_at_millis, revision + 1);
+    assert_eq!(node.created_by, WorkspaceOrigin::Seed);
+    assert_eq!(
+        node.updated_by,
+        WorkspaceOrigin::Agent {
+            id: body.to_string()
+        }
+    );
+    let stored = first.read(&company, "note").await.unwrap().unwrap();
+    assert_eq!(stored, (node.clone(), body.to_string()));
+    let err = first
+        .write_with_revision(
+            &company,
+            "note",
+            "stale retry",
+            WorkspaceOrigin::Operator,
+            Some(revision),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::error::OpenCompanyError::Conflict(_)));
+    assert_eq!(first.read(&company, "note").await.unwrap().unwrap(), stored);
+    let unconditional = first
+        .write(&company, "note", "operator edit", WorkspaceOrigin::Operator)
+        .await
+        .unwrap();
+    assert_eq!(unconditional.updated_at_millis, revision + 2);
+    let fresh = first
+        .write_with_revision(
+            &company,
+            "note",
+            "rebased edit",
+            WorkspaceOrigin::Operator,
+            Some(unconditional.updated_at_millis),
+        )
+        .await
+        .unwrap();
+    assert_eq!(fresh.updated_at_millis, revision + 3);
+    assert_eq!(
+        first.read(&company, "note").await.unwrap().unwrap().1,
+        "rebased edit"
+    );
+}
+
+pub async fn assert_workspace_revision_mutations(
+    first: Arc<dyn WorkspaceStore>,
+    second: Arc<dyn WorkspaceStore>,
+) {
+    let company = CompanyId::new("revision-mutations");
+    let original = WorkspaceNode {
+        id: "note".to_string(),
+        name: "staged.md".to_string(),
+        kind: NodeKind::File,
+        parent_id: None,
+        updated_at_millis: i64::MAX as u64 / 2,
+        created_by: WorkspaceOrigin::Seed,
+        updated_by: WorkspaceOrigin::Seed,
+        mime: None,
+        size: None,
+        sha256: None,
+        adopted: false,
+    };
+    first
+        .create(&company, &original, Some("original"))
+        .await
+        .unwrap();
+    let written = first
+        .write(&company, "note", "first edit", WorkspaceOrigin::Operator)
+        .await
+        .unwrap();
+    let renamed = second
+        .rename_move(&company, "note", Some("renamed.md"), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        renamed.updated_at_millis,
+        written.updated_at_millis + 1,
+        "a rename must advance the current revision, not reset it to wall-clock time"
+    );
+    let stale = first
+        .write_with_revision(
+            &company,
+            "note",
+            "stale edit",
+            WorkspaceOrigin::Operator,
+            Some(written.updated_at_millis),
+        )
+        .await;
+    assert!(matches!(
+        stale,
+        Err(crate::error::OpenCompanyError::Conflict(_))
+    ));
+    assert_eq!(
+        first.read(&company, "note").await.unwrap().unwrap().1,
+        "first edit"
+    );
+    let promoted = first
+        .swap_files(&company, None, "note", "published.md")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        promoted.updated_at_millis,
+        renamed.updated_at_millis + 1,
+        "promotion must not resurrect an old revision"
+    );
+    for iteration in 0..32 {
+        let before = first.read(&company, "note").await.unwrap().unwrap().0;
+        let gate = Arc::new(tokio::sync::Barrier::new(2));
+        let writer = first.clone();
+        let writer_company = company.clone();
+        let writer_gate = gate.clone();
+        let body = format!("edit {iteration}");
+        let expected_body = body.clone();
+        let write = tokio::spawn(async move {
+            writer_gate.wait().await;
+            writer
+                .write(
+                    &writer_company,
+                    "note",
+                    &body,
+                    WorkspaceOrigin::Agent {
+                        id: "writer".to_string(),
+                    },
+                )
+                .await
+                .unwrap()
+        });
+        let renamer = second.clone();
+        let renamer_company = company.clone();
+        let name = format!("renamed-{iteration}.md");
+        let expected_name = name.clone();
+        let rename = tokio::spawn(async move {
+            gate.wait().await;
+            renamer
+                .rename_move(&renamer_company, "note", Some(&name), None)
+                .await
+                .unwrap()
+        });
+        let (written, renamed) = tokio::join!(write, rename);
+        let (written, renamed) = (written.unwrap(), renamed.unwrap());
+        assert_ne!(
+            written.updated_at_millis, renamed.updated_at_millis,
+            "concurrent writes and renames must receive distinct revisions"
+        );
+        let (stored, body) = first.read(&company, "note").await.unwrap().unwrap();
+        assert_eq!(stored.updated_at_millis, before.updated_at_millis + 2);
+        assert_eq!(stored.name, expected_name);
+        assert_eq!(body, expected_body);
+        assert_eq!(stored.created_by, WorkspaceOrigin::Seed);
+        assert_eq!(
+            stored.updated_by,
+            WorkspaceOrigin::Agent {
+                id: "writer".to_string()
+            }
+        );
+    }
+}
+
 /// Collects a [`BlobStream`](crate::ports::workspace::BlobStream) into bytes.
 ///
 /// Only the suite buffers: the port streams so a production download never has

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -1663,12 +1663,13 @@ impl WorkspaceStore for FsOps {
         Ok(Some((node, content, len)))
     }
 
-    async fn write(
+    async fn write_with_revision(
         &self,
         company: &CompanyId,
         id: &str,
         content: &str,
         author: WorkspaceOrigin,
+        expected_updated_at: Option<u64>,
     ) -> Result<WorkspaceNode> {
         let path = self.bundle(company).workspace_index_json();
         let lock = path_lock(&path);
@@ -1687,9 +1688,10 @@ impl WorkspaceStore for FsOps {
                 crate::ports::workspace::binary_write_refusal(&node.name, &mime),
             ));
         }
-        node.updated_at_millis = now_millis();
-        // Authorship rides the same stamp as the timestamp: "when the body last
-        // changed" and "who changed it" are one fact and must never drift apart.
+        node.updated_at_millis = crate::ports::workspace::next_write_revision(
+            node.updated_at_millis,
+            expected_updated_at,
+        )?;
         node.updated_by = author;
         let node = node.clone();
         let file = self.physical_path(company, &index, id)?;
@@ -1980,7 +1982,8 @@ impl WorkspaceStore for FsOps {
             if let Some(parent) = parent {
                 node.parent_id = parent.map(str::to_string);
             }
-            node.updated_at_millis = now_millis();
+            node.updated_at_millis =
+                crate::ports::workspace::next_write_revision(node.updated_at_millis, None)?;
         }
         let node = index.get(id).cloned().expect("node present");
         let new_physical = self.physical_path(company, &index, id)?;
@@ -2061,7 +2064,8 @@ impl WorkspaceStore for FsOps {
         let staged_physical = self.physical_path(company, &index, replacement_id)?;
         let mut promoted = replacement;
         promoted.name = name.to_string();
-        promoted.updated_at_millis = now_millis();
+        promoted.updated_at_millis =
+            crate::ports::workspace::next_write_revision(promoted.updated_at_millis, None)?;
 
         // Where the staged payload lands differs by mode. Replacing, it is the
         // superseded node's own path — that rename IS the swap boundary, which
@@ -2891,6 +2895,26 @@ mod test {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();
         conformance::assert_workspace_store(Arc::new(FsOps::new(&root))).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn conformance_workspace_conditional_write() {
+        let root = tmp_root();
+        conformance::assert_workspace_conditional_write(
+            Arc::new(FsOps::new(root.path())),
+            Arc::new(FsOps::new(root.path())),
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn conformance_workspace_revision_mutations() {
+        let root = tmp_root();
+        conformance::assert_workspace_revision_mutations(
+            Arc::new(FsOps::new(root.path())),
+            Arc::new(FsOps::new(root.path())),
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -3827,52 +3827,60 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
         Ok(Some((node, get_str(&doc, "content")?, len.max(0) as u64)))
     }
 
-    async fn write(
+    async fn write_with_revision(
         &self,
         company: &CompanyId,
         id: &str,
         content: &str,
         author: crate::ports::workspace::WorkspaceOrigin,
+        expected_updated_at: Option<u64>,
     ) -> Result<crate::ports::workspace::WorkspaceNode> {
         use crate::ports::workspace::NodeKind;
-        let doc = self
-            .collection("workspace_nodes")
-            .find_one(doc! {"company_id": company.as_ref(), "node_id": id})
-            .await
-            .map_err(mongo_err)?;
-        let Some(doc) = doc else {
-            return Err(OpenCompanyError::CompanyNotFound(format!(
-                "workspace node {id}"
-            )));
-        };
-        let mut node: crate::ports::workspace::WorkspaceNode =
-            serde_json::from_str(&get_str(&doc, "node_json")?)?;
-        if node.kind != NodeKind::File {
-            return Err(OpenCompanyError::InvalidRequest(
-                "cannot write content to a folder".to_string(),
-            ));
+        loop {
+            let doc = self
+                .collection("workspace_nodes")
+                .find_one(doc! {"company_id": company.as_ref(), "node_id": id})
+                .projection(doc! {"node_json": 1})
+                .await
+                .map_err(mongo_err)?;
+            let Some(doc) = doc else {
+                return Err(OpenCompanyError::CompanyNotFound(format!(
+                    "workspace node {id}"
+                )));
+            };
+            let original_json = get_str(&doc, "node_json")?;
+            let mut node: crate::ports::workspace::WorkspaceNode =
+                serde_json::from_str(&original_json)?;
+            if node.kind != NodeKind::File {
+                return Err(OpenCompanyError::InvalidRequest(
+                    "cannot write content to a folder".to_string(),
+                ));
+            }
+            if let Some(mime) = node.mime.clone() {
+                return Err(OpenCompanyError::InvalidRequest(
+                    crate::ports::workspace::binary_write_refusal(&node.name, &mime),
+                ));
+            }
+            node.updated_at_millis = crate::ports::workspace::next_write_revision(
+                node.updated_at_millis,
+                expected_updated_at,
+            )?;
+            node.updated_by = author.clone();
+            let updated = self.collection("workspace_nodes")
+                .update_one(
+                    doc! {"company_id": company.as_ref(), "node_id": id, "node_json": original_json},
+                    doc! {"$set": {
+                        "node_json": serde_json::to_string(&node)?,
+                        "content": content,
+                        "updated_ms": node.updated_at_millis as i64,
+                    }},
+                )
+                .await
+                .map_err(mongo_err)?;
+            if updated.matched_count == 1 {
+                return Ok(node);
+            }
         }
-        if let Some(mime) = node.mime.clone() {
-            return Err(OpenCompanyError::InvalidRequest(
-                crate::ports::workspace::binary_write_refusal(&node.name, &mime),
-            ));
-        }
-        node.updated_at_millis = now_millis();
-        // Authorship rides the same stamp as the timestamp. The node is stored
-        // as opaque JSON in `node_json`, so this needs no schema change.
-        node.updated_by = author;
-        self.collection("workspace_nodes")
-            .update_one(
-                doc! {"company_id": company.as_ref(), "node_id": id},
-                doc! {"$set": {
-                    "node_json": serde_json::to_string(&node)?,
-                    "content": content,
-                    "updated_ms": node.updated_at_millis as i64,
-                }},
-            )
-            .await
-            .map_err(mongo_err)?;
-        Ok(node)
     }
 
     async fn create(
@@ -4245,68 +4253,71 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
         parent: Option<Option<&str>>,
     ) -> Result<crate::ports::workspace::WorkspaceNode> {
         use crate::ports::workspace::NodeKind;
-        let nodes = self.workspace_nodes(company).await?;
-        if !nodes.contains_key(id) {
-            return Err(OpenCompanyError::CompanyNotFound(format!(
-                "workspace node {id}"
-            )));
-        }
-        // A move to root (`Some(None)`) never forms a cycle.
-        if let Some(Some(parent)) = parent {
-            if parent == id || mongo_workspace_descendants(&nodes, id).contains(parent) {
-                return Err(OpenCompanyError::InvalidRequest(
-                    "cannot move a folder into its own subtree".to_string(),
-                ));
+        loop {
+            let original = self
+                .collection("workspace_nodes")
+                .find_one(doc! {"company_id": company.as_ref(), "node_id": id})
+                .projection(doc! {"node_json": 1})
+                .await
+                .map_err(mongo_err)?
+                .ok_or_else(|| OpenCompanyError::CompanyNotFound(format!("workspace node {id}")))?;
+            let original_json = get_str(&original, "node_json")?;
+            let nodes = self.workspace_nodes(company).await?;
+            if !nodes.contains_key(id) {
+                return Err(OpenCompanyError::CompanyNotFound(format!(
+                    "workspace node {id}"
+                )));
             }
-            if nodes.get(parent).map(|p| p.kind) != Some(NodeKind::Folder) {
-                return Err(OpenCompanyError::InvalidRequest(
-                    "target parent is not a folder".to_string(),
-                ));
+            if let Some(Some(parent)) = parent {
+                if parent == id || mongo_workspace_descendants(&nodes, id).contains(parent) {
+                    return Err(OpenCompanyError::InvalidRequest(
+                        "cannot move a folder into its own subtree".to_string(),
+                    ));
+                }
+                if nodes.get(parent).map(|p| p.kind) != Some(NodeKind::Folder) {
+                    return Err(OpenCompanyError::InvalidRequest(
+                        "target parent is not a folder".to_string(),
+                    ));
+                }
             }
-        }
-        let mut node = nodes.get(id).cloned().expect("node present");
-        if let Some(name) = name {
-            node.name = name.to_string();
-        }
-        if let Some(parent) = parent {
-            node.parent_id = parent.map(str::to_string);
-        }
-        node.updated_at_millis = now_millis();
-        // A rename or a reparent moves the file to a different path, so its
-        // claim has to move with it (issue #697) or the index would keep
-        // guarding the path it left and ignore the one it took.
-        let mut set = doc! {
-            "node_json": serde_json::to_string(&node)?,
-            "updated_ms": node.updated_at_millis as i64,
-        };
-        let mut unset = Document::new();
-        match node_path_key(&node) {
-            Some(key) => {
-                set.insert("file_path_key", key);
+            let mut node: crate::ports::workspace::WorkspaceNode =
+                serde_json::from_str(&original_json)?;
+            if let Some(name) = name {
+                node.name = name.to_string();
             }
-            None => {
-                unset.insert("file_path_key", "");
+            if let Some(parent) = parent {
+                node.parent_id = parent.map(str::to_string);
             }
-        }
-        // A moved folder **drops** its claim rather than carrying it (issue
-        // #759). The claim exists to decide a race between two publishers on the
-        // publish walk; an operator who moved the folder by hand has taken it
-        // out of that walk's reach, and a key that travelled with it would keep
-        // guarding the path it left — refusing that path to every later publish
-        // forever, which is the very outage this primitive exists to prevent.
-        // Demoting to unguarded is what every console-made folder already is.
-        if node.kind == NodeKind::Folder {
-            unset.insert("folder_path_key", "");
-        }
-        let mut update = doc! {"$set": set};
-        if !unset.is_empty() {
-            update.insert("$unset", unset);
-        }
-        self.collection("workspace_nodes")
-            .update_one(doc! {"company_id": company.as_ref(), "node_id": id}, update)
+            node.updated_at_millis =
+                crate::ports::workspace::next_write_revision(node.updated_at_millis, None)?;
+            let mut set = doc! {
+                "node_json": serde_json::to_string(&node)?,
+                "updated_ms": node.updated_at_millis as i64,
+            };
+            let mut unset = Document::new();
+            match node_path_key(&node) {
+                Some(key) => {
+                    set.insert("file_path_key", key);
+                }
+                None => {
+                    unset.insert("file_path_key", "");
+                }
+            }
+            if node.kind == NodeKind::Folder {
+                unset.insert("folder_path_key", "");
+            }
+            let mut update = doc! {"$set": set};
+            if !unset.is_empty() {
+                update.insert("$unset", unset);
+            }
+            let result = self.collection("workspace_nodes")
+            .update_one(doc! {"company_id": company.as_ref(), "node_id": id, "node_json": original_json}, update)
             .await
             .map_err(mongo_err)?;
-        Ok(node)
+            if result.matched_count == 1 {
+                return Ok(node);
+            }
+        }
     }
 
     async fn swap_files(
@@ -4339,6 +4350,11 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
                 "only files can be promoted from a staging path".to_string(),
             ));
         }
+
+        let mut promoted = replacement.clone();
+        promoted.name = name.to_string();
+        promoted.updated_at_millis =
+            crate::ports::workspace::next_write_revision(promoted.updated_at_millis, None)?;
 
         let expected_doc = match expected_id {
             Some(id) => nodes
@@ -4392,10 +4408,6 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             self.drop_blobs(company, replacement_id, None).await?;
             return Ok(None);
         }
-
-        let mut promoted = replacement.clone();
-        promoted.name = name.to_string();
-        promoted.updated_at_millis = now_millis();
 
         // Issue #697, the first-publish arm. The staged document has just been
         // detached, so re-inserting it under the final name is the whole
@@ -6250,6 +6262,20 @@ mod test {
     async fn conformance_workspace_store() {
         let Some(s) = store().await else { return };
         conformance::assert_workspace_store(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn conformance_workspace_conditional_write() {
+        let Some(s) = store().await else { return };
+        conformance::assert_workspace_conditional_write(s.clone(), s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn conformance_workspace_revision_mutations() {
+        let Some(s) = store().await else { return };
+        conformance::assert_workspace_revision_mutations(s.clone(), s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3585,16 +3585,20 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         }
     }
 
-    async fn write(
+    async fn write_with_revision(
         &self,
         company: &CompanyId,
         id: &str,
         content: &str,
         author: crate::ports::workspace::WorkspaceOrigin,
+        expected_updated_at: Option<u64>,
     ) -> Result<crate::ports::workspace::WorkspaceNode> {
         use crate::ports::workspace::NodeKind;
-        let conn = self.conn();
-        let node_json: Option<String> = conn
+        let mut conn = self.conn();
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(sql_err)?;
+        let node_json: Option<String> = tx
             .query_row(
                 "SELECT node_json FROM workspace_nodes WHERE company_id = ?1 AND id = ?2",
                 params![company.as_ref(), id],
@@ -3618,11 +3622,12 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
                 crate::ports::workspace::binary_write_refusal(&node.name, mime),
             ));
         }
-        node.updated_at_millis = now_millis();
-        // Authorship rides the same stamp as the timestamp. The node is stored
-        // as opaque JSON, so this needs no column and no migration.
+        node.updated_at_millis = crate::ports::workspace::next_write_revision(
+            node.updated_at_millis,
+            expected_updated_at,
+        )?;
         node.updated_by = author;
-        conn.execute(
+        tx.execute(
             "UPDATE workspace_nodes SET node_json = ?1, content = ?2, updated_ms = ?3 \
              WHERE company_id = ?4 AND id = ?5",
             params![
@@ -3634,6 +3639,7 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
             ],
         )
         .map_err(sql_err)?;
+        tx.commit().map_err(sql_err)?;
         Ok(node)
     }
 
@@ -3940,8 +3946,11 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         parent: Option<Option<&str>>,
     ) -> Result<crate::ports::workspace::WorkspaceNode> {
         use crate::ports::workspace::NodeKind;
-        let conn = self.conn();
-        let nodes = self.workspace_nodes(&conn, company)?;
+        let mut conn = self.conn();
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(sql_err)?;
+        let nodes = self.workspace_nodes(&tx, company)?;
         if !nodes.contains_key(id) {
             return Err(OpenCompanyError::CompanyNotFound(format!(
                 "workspace node {id}"
@@ -3967,8 +3976,9 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         if let Some(parent) = parent {
             node.parent_id = parent.map(str::to_string);
         }
-        node.updated_at_millis = now_millis();
-        conn.execute(
+        node.updated_at_millis =
+            crate::ports::workspace::next_write_revision(node.updated_at_millis, None)?;
+        tx.execute(
             "UPDATE workspace_nodes SET node_json = ?1, updated_ms = ?2 \
              WHERE company_id = ?3 AND id = ?4",
             params![
@@ -3979,6 +3989,7 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
             ],
         )
         .map_err(sql_err)?;
+        tx.commit().map_err(sql_err)?;
         Ok(node)
     }
 
@@ -4040,7 +4051,8 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
 
         let mut promoted = replacement;
         promoted.name = name.to_string();
-        promoted.updated_at_millis = now_millis();
+        promoted.updated_at_millis =
+            crate::ports::workspace::next_write_revision(promoted.updated_at_millis, None)?;
         // Nothing to retire on a first publish: the name was free, which is
         // exactly what the guard above established.
         if let Some(id) = expected_id {
@@ -4802,6 +4814,28 @@ mod test {
     #[tokio::test]
     async fn conformance_workspace_store() {
         conformance::assert_workspace_store(store()).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn conformance_workspace_conditional_write() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("conditional.db");
+        conformance::assert_workspace_conditional_write(
+            Arc::new(SqliteStore::open(&path).unwrap()),
+            Arc::new(SqliteStore::open(&path).unwrap()),
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn conformance_workspace_revision_mutations() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("revisions.db");
+        conformance::assert_workspace_revision_mutations(
+            Arc::new(SqliteStore::open(&path).unwrap()),
+            Arc::new(SqliteStore::open(&path).unwrap()),
+        )
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Prevent two agents editing the same workspace note from both being told their write succeeded while one edit is silently discarded. The expected revision now reaches the backend's atomic write boundary, and the losing writer receives a conflict without changing the winning content.

## API Or Behavior Changes

- `WorkspaceStore` implementers must implement `write_with_revision(..., expected_updated_at: Option<u64>)`. Existing `write(...)` callers remain compatible through its default unconditional wrapper.
- Filesystem writes compare under the shared workspace-index lock; SQLite uses an immediate transaction; MongoDB uses a conditional document update. Every decorator forwards the condition, and refused writes emit no successful-update event.
- Successful writes strictly advance the revision, including multiple writes within one millisecond. Related rename/move/promotion paths preserve that invariant under backend synchronization so metadata changes cannot resurrect stale write tokens or overwrite newer authorship. The filesystem retains its existing single-process-per-data-directory contract.
- The other touched adapters are required migrations to the new store method. No schema, dependency, submodule, HTTP route, or unrelated tool changes.

## Tests

All commands run unpiped with their exit status captured directly. Builds use one job and disabled development/test debug information.

- [x] `cargo fmt --all -- --check`: exit 0.
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`: exit 0.
- [x] `cargo test --locked --lib`: exit 0; 5,023 passed, 0 failed, 6 existing ignored, 201.04s.
- [x] `cargo test --locked --features openhuman --tests`: exit 0; 7,632 passed across all eight targets, 0 failed, 19 existing ignored. Breakdown: library 7,572 passed/14 ignored; binary 25; auth matrix 9 passed/5 ignored; desktop 1; hivemind 9; offline 2; one-card-per-message 12; product identity 2. Every target executed a nonzero test count.

Backend and focused suites on the same source:

- `cargo test --locked --features openhuman --lib workspace -- --test-threads=2`: exit 0; 364 passed, 0 failed, 1 unrelated existing ignored test. Includes the restored original two-writer acceptance test, winning-content assertions, and the full decorator stack.
- `cargo test --locked --features sqlite --lib store::sqlite`: exit 0; 61 passed, 0 ignored. New race and metadata tests use independent connections to an isolated temporary database.
- `cargo test --locked --features mongodb --lib store::mongodb`: exit 0; 64 passed, 0 ignored, 146.48s.
- `cargo test --locked --features mongodb --lib store::select`: exit 0; 32 passed, 0 ignored.
- Mongo commands explicitly set `OPENCOMPANY_TEST_MONGODB_URI=mongodb://127.0.0.1:28471/?serverSelectionTimeoutMS=5000` and `OPENCOMPANY_TEST_MONGODB_REQUIRED=1`, against a newly started isolated local MongoDB 8.2.7 with its own temporary data directory. Real connection/index creation was observed; the new conditional-write and revision-mutation tests both executed and passed. No inherited database or credentials were used.
- Test paths were discovered with `-- --list`; passed counts were checked, not inferred from exit 0.

Observed red proof, before committing:

1. Backed up production files outside the worktree, then removed the expected/current revision refusal from `next_write_revision`. The unchanged original acceptance assertion failed: “one of two writers at the same revision must be refused; both were told they succeeded”; refused count was 0 instead of 1. Exit 101, 0 passed/1 failed.
2. Against that same built test binary, the new filesystem concurrent-write conformance test failed with “both writers at one revision succeeded”, 2 instead of 1. Exit 101, 0 passed/1 failed.
3. Also temporarily reset the filesystem rename stamp to wall-clock time. The metadata regression failed with “a rename must advance the current revision, not reset it to wall-clock time”. Exit 101, 0 passed/1 failed.

Restoration ran immediately from a cleanup trap. Both files compared byte-for-byte with their backups, and the complete worktree diff matched the pre-proof diff (all three comparisons exit 0). The restored-source workspace suite then passed 364 tests. No temporary break was committed, and the original acceptance assertion was not changed.

## Documentation

Updated `docs/spec/runtime/ports-console-workspace.md` with the conditional-write API, conflict behavior, monotonic revision contract, decorator forwarding, and backend synchronization guarantees.
