### PR TITLE
fix(blockers): refuse excess escalations and end the turn

### DIFF
--- a/src/harness/built_in/blockers.rs
+++ b/src/harness/built_in/blockers.rs
@@ -629,16 +629,24 @@ impl openhuman_core::openhuman::tools::traits::Tool for EscalateToHumanTool {
             // every request this turn queued.
             run_id: None,
         };
-        self.requests
-            .push(crate::harness::built_in::policy::ApprovalRequest {
+        if !self
+            .requests
+            .push_blocker(crate::harness::built_in::policy::ApprovalRequest {
                 tool: ESCALATE_TO_HUMAN_TOOL.to_string(),
                 reason,
                 effect,
-            });
+            })
+        {
+            return Ok(ToolResult::error(format!(
+                "Your question was not raised: this batch already has the maximum of {} approval \
+                 requests. Stop and wait for the queued requests to be resolved, then ask again.",
+                crate::harness::built_in::policy::MAX_APPROVAL_REQUESTS_PER_TURN
+            )));
+        }
 
         Ok(ToolResult::success(format!(
             "Raised your question with the operator: \"{question}\". This card parks until they \
-             answer, so do not ask it again — carry on with anything else you can do without it."
+             answer. Stop and wait for their answer; do not ask it again."
         )))
     }
 }
@@ -884,11 +892,6 @@ mod tool_test {
         );
     }
 
-    /// BOUND-axis (REQ-002): the cap boundary through the real tool, not a
-    /// hand-built `ApprovalRequest`. Exactly `MAX_APPROVAL_REQUESTS_PER_TURN`
-    /// distinct questions in one turn must all land with no overflow; the
-    /// existing pin at `escalate_to_human_does_not_set_the_turn_boundary_and_can_overflow_the_cap`
-    /// (`policy.rs`) only exercises one-past the cap.
     #[tokio::test]
     async fn escalate_to_human_exactly_at_the_cap_produces_no_overflow() {
         use crate::harness::built_in::policy::MAX_APPROVAL_REQUESTS_PER_TURN;

--- a/src/harness/built_in/blockers.rs
+++ b/src/harness/built_in/blockers.rs
@@ -486,37 +486,12 @@ mod test {
 /// The `escalate_to_human` tool name.
 pub const ESCALATE_TO_HUMAN_TOOL: &str = "escalate_to_human";
 
-/// Lets an agent stop and **ask**, instead of guessing or going quiet.
+/// Queues an [`Information`](BlockerKind::Information) blocker for the operator.
+/// The turn's drain parks accepted questions through the approval lifecycle.
 ///
-/// Before this, a teammate that hit real ambiguity — "staging or prod?", "which
-/// of these two contradictory briefs is current?" — had two options and both
-/// were bad: pick one and be silently wrong, or produce prose explaining that
-/// it could not proceed, which reads as a completed turn. The orchestrator
-/// brief even pointed at `spawn_task` for "work waiting on a person", which
-/// opens a card that notifies nobody and resumes nothing.
-///
-/// This is the third option. The question parks as a durable
-/// [`Information`](BlockerKind::Information) blocker on the operator's queue,
-/// through the same path a gated tool call parks on, so it survives a restart
-/// and expires through the approval TTL rather than waiting forever.
-///
-/// # Why it stages rather than parks directly
-///
-/// The tool has no host handle — tools receive arguments and nothing else — so
-/// it pushes onto the shared [`ApprovalRequestQueue`] exactly as the approval
-/// policy does for a gated call, and the turn's drain parks it. Both drains
-/// exist: a chat or task turn drains through `park_approval_requests`, a
-/// workflow agent node through `park_gated_calls`. There is no path on which an
-/// agent can raise a question that nothing will deliver.
-///
-/// # What it deliberately does not do
-///
-/// It does not end the turn. The agent asks and keeps working with what it has;
-/// the *run* is what parks, because a turn that queued a blocker settles
-/// [`Blocked`](crate::ports::runs::RunStatus::Blocked) rather than reporting a
-/// result nobody has confirmed. Ending the turn from inside a tool would
-/// discard whatever the agent had already produced, which is the opposite of
-/// what a question is for.
+/// Escalation establishes the turn boundary: subsequent tool calls are refused
+/// until a new turn. An accepted question is queued for the operator; a full
+/// batch returns an explicit refusal.
 pub struct EscalateToHumanTool {
     requests: crate::harness::built_in::policy::ApprovalRequestQueue,
     agent: String,

--- a/src/harness/built_in/blockers.rs
+++ b/src/harness/built_in/blockers.rs
@@ -921,4 +921,130 @@ mod tool_test {
             "no notice is owed when nothing was dropped"
         );
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_questions_compete_for_the_final_slot_without_silent_loss() {
+        use crate::harness::built_in::policy::MAX_APPROVAL_REQUESTS_PER_TURN;
+        use std::sync::{Arc, Barrier};
+
+        for round in 0..20 {
+            let queue = ApprovalRequestQueue::default();
+            for i in 0..MAX_APPROVAL_REQUESTS_PER_TURN - 1 {
+                let asked = tool(&queue)
+                    .execute(serde_json::json!({ "question": format!("existing question {i}") }))
+                    .await
+                    .expect("the tool runs");
+                assert!(!asked.is_error, "{}", asked.text());
+            }
+
+            let barrier = Arc::new(Barrier::new(2));
+            let ask = |agent: &str, question: &'static str| {
+                let tool = EscalateToHumanTool::new(queue.clone(), agent.to_string());
+                let barrier = barrier.clone();
+                tokio::task::spawn_blocking(move || {
+                    barrier.wait();
+                    tokio::runtime::Handle::current()
+                        .block_on(tool.execute(serde_json::json!({ "question": question })))
+                })
+            };
+            let finance = ask("finance", "approve the final budget?");
+            let legal = ask("legal", "approve the final contract?");
+            let results = [
+                (
+                    "approve the final budget?",
+                    finance.await.expect("joins").expect("the tool runs"),
+                ),
+                (
+                    "approve the final contract?",
+                    legal.await.expect("joins").expect("the tool runs"),
+                ),
+            ];
+            assert_eq!(
+                results
+                    .iter()
+                    .filter(|(_, result)| !result.is_error)
+                    .count(),
+                1,
+                "round {round}: one remaining blocker slot must have exactly one successful caller"
+            );
+
+            let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+            assert_eq!(drained.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
+            assert_eq!(
+                drained.discarded, 0,
+                "no accepted question may be discarded"
+            );
+            for i in 0..MAX_APPROVAL_REQUESTS_PER_TURN - 1 {
+                assert!(
+                    drained
+                        .requests
+                        .iter()
+                        .any(|r| r.reason == format!("existing question {i}"))
+                );
+            }
+            for (question, result) in results {
+                let retained = drained.requests.iter().any(|r| r.reason == question);
+                assert_eq!(retained, !result.is_error, "round {round}: {question}");
+                if result.is_error {
+                    assert!(result.text().contains("not raised"), "{}", result.text());
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn a_full_run_accepts_its_duplicate_without_consuming_another_runs_capacity() {
+        use crate::harness::built_in::policy::{ApprovalScope, MAX_APPROVAL_REQUESTS_PER_TURN};
+
+        let queue = ApprovalRequestQueue::default();
+        let full = queue.claim(ApprovalScope::Run("full".to_string()));
+        let other = queue.claim(ApprovalScope::Run("other".to_string()));
+        let tool = tool(&queue);
+        full.scoped(async {
+            for i in 0..MAX_APPROVAL_REQUESTS_PER_TURN {
+                let asked = tool
+                    .execute(serde_json::json!({ "question": format!("question {i}") }))
+                    .await
+                    .expect("the tool runs");
+                assert!(!asked.is_error, "{}", asked.text());
+            }
+            let duplicate = tool
+                .execute(serde_json::json!({ "question": "question 0" }))
+                .await
+                .expect("the tool runs");
+            assert!(
+                !duplicate.is_error,
+                "the existing question is already queued"
+            );
+            let refused = tool
+                .execute(serde_json::json!({ "question": "new question" }))
+                .await
+                .expect("the tool runs");
+            assert!(
+                refused.is_error,
+                "a new question must be refused at the cap"
+            );
+        })
+        .await;
+
+        let independent = other
+            .scoped(tool.execute(serde_json::json!({ "question": "question 0" })))
+            .await
+            .expect("the tool runs");
+        assert!(
+            !independent.is_error,
+            "a different run has its own capacity"
+        );
+        let full_drain = full
+            .scoped(async { queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN) })
+            .await;
+        assert_eq!(full_drain.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(full_drain.discarded, 0);
+        let other_drain = other
+            .scoped(async { queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN) })
+            .await;
+        assert_eq!(other_drain.requests.len(), 1);
+        assert_eq!(other_drain.requests[0].reason, "question 0");
+        assert_eq!(other_drain.discarded, 0);
+    }
 }

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -296,7 +296,7 @@ pub enum ApprovalScope {
 /// which is the property the issue asks for.
 #[derive(Clone)]
 pub struct ApprovalRequestQueue {
-    inner: Arc<Mutex<BTreeMap<ApprovalScope, Vec<ApprovalRequest>>>>,
+    inner: Arc<Mutex<ApprovalQueueState>>,
     /// The live single-use grants (issue #243), riding along so the whole
     /// approval round-trip travels on one handle.
     ///
@@ -321,6 +321,17 @@ pub struct ApprovalRequestQueue {
     /// same way folding it into `inner` would have. `grants_outlive_a_scope`
     /// pins the #439 half of that alongside `grants_survive_a_queue_clear`.
     grants: GrantSet,
+}
+
+#[derive(Default)]
+struct ApprovalQueueState {
+    buckets: BTreeMap<ApprovalScope, Vec<QueuedApproval>>,
+    next_sequence: u64,
+}
+
+struct QueuedApproval {
+    request: ApprovalRequest,
+    sequence: u64,
 }
 
 /// What one cycle-end drain took, and what it threw away (issue #561).
@@ -526,26 +537,14 @@ impl Drop for ApprovalClaim {
 }
 
 impl ApprovalRequestQueue {
-    /// Records a gated call, ignoring one already queued for the same tool and
-    /// arguments.
-    ///
-    /// openhuman blocks the call but lets the turn continue, so a model that
-    /// re-tries the same tool would otherwise park the identical request several
-    /// times over and show the operator a queue of duplicates.
-    /// Records a gated call **in the surrounding claim's scope** (issue #439),
-    /// ignoring one already queued in that same scope for the same tool and
-    /// arguments.
-    ///
-    /// openhuman blocks the call but lets the turn continue, so a model that
-    /// re-tries the same tool would otherwise park the identical request several
-    /// times over and show the operator a queue of duplicates. De-duplication is
-    /// per scope, which is the only reading that makes sense once buckets are
-    /// separate: two different turns asking for the same tool are two requests,
-    /// and collapsing them would hide one turn's ask behind another's.
+    /// Enqueues a gated call in the current scope, deduplicated by effect.
+    /// Overflow is counted and reported by the drain.
     pub fn push(&self, request: ApprovalRequest) {
         self.push_with_cap(request, usize::MAX);
     }
 
+    /// Accepts a blocker only within the first eight entries of its drain order.
+    /// Cycle and Unscoped share that order; Run scopes are independent.
     pub(super) fn push_blocker(&self, request: ApprovalRequest) -> bool {
         self.push_with_cap(request, MAX_APPROVAL_REQUESTS_PER_TURN)
     }
@@ -558,23 +557,37 @@ impl ApprovalRequestQueue {
         }
         let scope = Self::current_scope();
         let mut guard = self.inner.lock().expect("approval request queue");
-        let shared_count = match &scope {
-            ApprovalScope::Cycle => guard.get(&ApprovalScope::Unscoped).map_or(0, Vec::len),
-            ApprovalScope::Unscoped => guard.get(&ApprovalScope::Cycle).map_or(0, Vec::len),
-            ApprovalScope::Run(_) => 0,
+        let shared = match &scope {
+            ApprovalScope::Cycle => guard.buckets.get(&ApprovalScope::Unscoped),
+            ApprovalScope::Unscoped => guard.buckets.get(&ApprovalScope::Cycle),
+            ApprovalScope::Run(_) => None,
         };
-        let bucket = guard.entry(scope).or_default();
-        if bucket.iter().any(|q| {
-            q.effect.kind == request.effect.kind
-                && q.effect.payload == request.effect.payload
-                && q.effect.agent == request.effect.agent
+        let bucket = guard.buckets.get(&scope).map_or(&[][..], Vec::as_slice);
+        if let Some((position, existing)) = bucket.iter().enumerate().find(|(_, q)| {
+            q.request.effect.kind == request.effect.kind
+                && q.request.effect.payload == request.effect.payload
+                && q.request.effect.agent == request.effect.agent
         }) {
-            return true;
+            let earlier_shared = shared.map_or(0, |entries| {
+                entries
+                    .iter()
+                    .take_while(|entry| entry.sequence < existing.sequence)
+                    .count()
+            });
+            return position.saturating_add(earlier_shared) < cap;
         }
-        if bucket.len().saturating_add(shared_count) >= cap {
+        if bucket.len().saturating_add(shared.map_or(0, Vec::len)) >= cap {
             return false;
         }
-        bucket.push(request);
+        let sequence = guard.next_sequence;
+        guard.next_sequence = sequence
+            .checked_add(1)
+            .expect("approval queue sequence exhausted");
+        guard
+            .buckets
+            .entry(scope)
+            .or_default()
+            .push(QueuedApproval { request, sequence });
         true
     }
 
@@ -624,6 +637,7 @@ impl ApprovalRequestQueue {
         self.inner
             .lock()
             .expect("approval request queue")
+            .buckets
             .remove(scope);
     }
 
@@ -638,6 +652,7 @@ impl ApprovalRequestQueue {
         self.inner
             .lock()
             .expect("approval request queue")
+            .buckets
             .get(scope)
             .map_or(0, Vec::len)
     }
@@ -651,45 +666,30 @@ impl ApprovalRequestQueue {
         self.discard(&Self::current_scope());
     }
 
-    /// Drains up to `cap` requests (FIFO) from the **current scope**, discarding
-    /// that scope's remainder, so one turn can never flood the operator's queue.
-    ///
-    /// # Why this returns a struct rather than a `Vec` (issue #561)
-    ///
-    /// The discard is the whole point of the cap and it used to be invisible:
-    /// this method dropped the overflow on the floor and handed back a `Vec`
-    /// that looked exactly like a complete one, so the operator was shown eight
-    /// cards and no indication that five more calls had been gated. `cap`
-    /// travels into the result so the count and the number that produced it
-    /// stay one value — see [`DrainedRequests`].
-    ///
-    /// # What #439 changed, and what it did not
-    ///
-    /// The shape is #561's; only *which* requests it can see is #439's. It used
-    /// to drain one company-wide vector, which is why a concurrent turn's
-    /// entries could be taken by whoever drained first. It now sees the calling
-    /// turn's bucket and nothing else — **which also makes `discarded` mean
-    /// something it could not mean before**. A count taken off a shared vector
-    /// mixed in whatever a concurrent run had appended, so "this turn
-    /// overflowed" was never reliably this turn's fact. Scoped, it is.
-    ///
-    /// From the chat cycle this also drains [`ApprovalScope::Unscoped`], so a
-    /// push from any turn entry point not yet under a claim still reaches the
-    /// operator exactly as it did before — the fallback that makes #439
-    /// non-lossy. A workflow run drains only its own bucket and can no longer
-    /// swallow anyone else's.
+    /// Drains the current scope in enqueue order, counting discarded overflow.
+    /// Cycle also drains Unscoped in their combined enqueue order.
+    /// A cap below [`MAX_APPROVAL_REQUESTS_PER_TURN`] imposes a smaller limit
+    /// than blocker admission; production drains use that constant.
     pub fn drain(&self, cap: usize) -> DrainedRequests {
         let scope = Self::current_scope();
         let mut guard = self.inner.lock().expect("approval request queue");
-        let mut queued: Vec<ApprovalRequest> = guard.remove(&scope).unwrap_or_default();
-        // The cycle owns anything nobody claimed. A workflow run must not take
-        // it: that would be the shared-queue theft this issue removes.
+        let mut queued = guard.buckets.remove(&scope).unwrap_or_default();
         if scope == ApprovalScope::Cycle {
-            queued.extend(guard.remove(&ApprovalScope::Unscoped).unwrap_or_default());
+            queued.extend(
+                guard
+                    .buckets
+                    .remove(&ApprovalScope::Unscoped)
+                    .unwrap_or_default(),
+            );
+            queued.sort_unstable_by_key(|entry| entry.sequence);
         }
         let discarded = queued.len().saturating_sub(cap);
         queued.truncate(cap);
-        DrainedRequests::new(queued, discarded, cap)
+        DrainedRequests::new(
+            queued.into_iter().map(|entry| entry.request).collect(),
+            discarded,
+            cap,
+        )
     }
 
     /// Builds a queue whose grant set is one the caller already holds.
@@ -733,6 +733,7 @@ impl ApprovalRequestQueue {
         self.inner
             .lock()
             .expect("approval request queue")
+            .buckets
             .get(&Self::current_scope())
             .map_or(0, Vec::len)
     }
@@ -758,14 +759,14 @@ impl ApprovalRequestQueue {
     pub fn blockers_since(&self, from: usize) -> usize {
         let scope = Self::current_scope();
         let guard = self.inner.lock().expect("approval request queue");
-        let Some(bucket) = guard.get(&scope) else {
+        let Some(bucket) = guard.buckets.get(&scope) else {
             return 0;
         };
         let prefix = format!("{}.", crate::ports::blockers::BLOCKER_EFFECT_PREFIX);
         bucket
             .iter()
             .skip(from)
-            .filter(|request| request.effect.kind.starts_with(&prefix))
+            .filter(|entry| entry.request.effect.kind.starts_with(&prefix))
             .count()
     }
 
@@ -786,12 +787,12 @@ impl ApprovalRequestQueue {
     pub fn stamp_run(&self, from: usize, run_id: &str) -> usize {
         let scope = Self::current_scope();
         let mut guard = self.inner.lock().expect("approval request queue");
-        let Some(bucket) = guard.get_mut(&scope) else {
+        let Some(bucket) = guard.buckets.get_mut(&scope) else {
             return 0;
         };
         let mut stamped = 0;
-        for request in bucket.iter_mut().skip(from) {
-            request.effect.run_id = Some(run_id.to_string());
+        for entry in bucket.iter_mut().skip(from) {
+            entry.request.effect.run_id = Some(run_id.to_string());
             stamped += 1;
         }
         stamped
@@ -4649,6 +4650,193 @@ mod tests {
                     .any(|r| r.reason == "last available slot")
             );
             assert!(drained.requests.iter().all(|r| r.reason != "overflow"));
+        }
+    }
+
+    #[tokio::test]
+    async fn accepted_blockers_survive_later_ordinary_approvals_across_scopes() {
+        use openhuman_core::openhuman::tools::traits::Tool as _;
+
+        for blocker_in_cycle in [false, true] {
+            for preceding in [0, MAX_APPROVAL_REQUESTS_PER_TURN - 1] {
+                let (policy, queue) = queued_policy("supervised", &[]);
+                let cycle = queue.claim(ApprovalScope::Cycle);
+                let tool = super::super::blockers::EscalateToHumanTool::new(
+                    queue.clone(),
+                    "engineer".to_string(),
+                );
+                for i in 0..preceding {
+                    let call = request("composio_execute", composio_unclassified_args_numbered(i));
+                    let decision = if blocker_in_cycle {
+                        policy.check(&call).await
+                    } else {
+                        cycle.scoped(policy.check(&call)).await
+                    };
+                    assert!(matches!(
+                        decision,
+                        ToolPolicyDecision::RequireApproval { .. }
+                    ));
+                }
+                let args = serde_json::json!({ "question": "must survive later approvals" });
+                let asked = if blocker_in_cycle {
+                    cycle.scoped(tool.execute(args.clone())).await
+                } else {
+                    tool.execute(args.clone()).await
+                }
+                .expect("the tool runs");
+                assert!(!asked.is_error, "{}", asked.text());
+
+                for i in preceding..preceding + MAX_APPROVAL_REQUESTS_PER_TURN {
+                    let call = request("composio_execute", composio_unclassified_args_numbered(i));
+                    let decision = if blocker_in_cycle {
+                        policy.check(&call).await
+                    } else {
+                        cycle.scoped(policy.check(&call)).await
+                    };
+                    assert!(matches!(
+                        decision,
+                        ToolPolicyDecision::RequireApproval { .. }
+                    ));
+                }
+                let duplicate = if blocker_in_cycle {
+                    cycle.scoped(tool.execute(args)).await
+                } else {
+                    tool.execute(args).await
+                }
+                .expect("the tool runs");
+                assert!(
+                    !duplicate.is_error,
+                    "the accepted duplicate retains its slot"
+                );
+
+                let drained = cycle
+                    .scoped(async { queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN) })
+                    .await;
+                assert_eq!(
+                    drained
+                        .requests
+                        .iter()
+                        .filter(|r| r.reason == "must survive later approvals")
+                        .count(),
+                    1,
+                    "an accepted blocker must survive later ordinary approvals; blocker_in_cycle={blocker_in_cycle}, preceding={preceding}"
+                );
+                assert_eq!(drained.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
+                assert_eq!(drained.discarded, preceding + 1);
+                assert!(drained.overflow_notice().is_some());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn a_blocker_duplicate_outside_the_drain_budget_is_refused() {
+        use openhuman_core::openhuman::tools::traits::Tool as _;
+
+        let fixture = ApprovalRequestQueue::default();
+        let args = serde_json::json!({ "question": "outside the budget" });
+        super::super::blockers::EscalateToHumanTool::new(fixture.clone(), "engineer".to_string())
+            .execute(args.clone())
+            .await
+            .expect("the fixture tool runs");
+        let existing = fixture
+            .drain(MAX_APPROVAL_REQUESTS_PER_TURN)
+            .requests
+            .remove(0);
+
+        for (existing_in_cycle, ordinary_in_cycle) in
+            [(false, false), (false, true), (true, false), (true, true)]
+        {
+            let queue = ApprovalRequestQueue::default();
+            let cycle = queue.claim(ApprovalScope::Cycle);
+            for i in 0..MAX_APPROVAL_REQUESTS_PER_TURN {
+                let request = gated(&format!("ordinary.{i}"));
+                if ordinary_in_cycle {
+                    cycle.scoped(async { queue.push(request) }).await;
+                } else {
+                    queue.push(request);
+                }
+            }
+            let tool = super::super::blockers::EscalateToHumanTool::new(
+                queue.clone(),
+                "engineer".to_string(),
+            );
+            let asked = if existing_in_cycle {
+                cycle
+                    .scoped(async {
+                        queue.push(existing.clone());
+                        tool.execute(args.clone()).await
+                    })
+                    .await
+            } else {
+                queue.push(existing.clone());
+                tool.execute(args.clone()).await
+            }
+            .expect("the tool runs");
+            assert!(
+                asked.is_error,
+                "an overflow duplicate must not be reported as raised"
+            );
+            assert!(asked.text().contains("not raised"));
+            let drained = cycle
+                .scoped(async { queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN) })
+                .await;
+            assert_eq!(drained.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
+            assert_eq!(drained.discarded, 1);
+            assert!(
+                drained
+                    .requests
+                    .iter()
+                    .all(|r| r.reason != "outside the budget")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn mixed_scope_drain_preserves_enqueue_order_and_scoped_stamping() {
+        for cap in [0, 3, MAX_APPROVAL_REQUESTS_PER_TURN] {
+            let queue = ApprovalRequestQueue::default();
+            let cycle = queue.claim(ApprovalScope::Cycle);
+            let run = queue.claim(ApprovalScope::Run("independent".to_string()));
+            for i in 0..10 {
+                let request = gated(&format!("ordinary.{i}"));
+                if i % 2 == 0 {
+                    let boundary = queue.queued();
+                    assert_eq!(boundary, i / 2);
+                    queue.push(request);
+                    assert_eq!(queue.stamp_run(boundary, &format!("fallback.{i}")), 1);
+                } else {
+                    cycle
+                        .scoped(async {
+                            let boundary = queue.queued();
+                            assert_eq!(boundary, i / 2);
+                            queue.push(request);
+                            assert_eq!(queue.stamp_run(boundary, &format!("cycle.{i}")), 1);
+                        })
+                        .await;
+                }
+                run.scoped(async { queue.push(gated(&format!("run.{i}"))) })
+                    .await;
+            }
+            let drained = cycle.scoped(async { queue.drain(cap) }).await;
+            assert_eq!(drained.cap(), cap);
+            assert_eq!(drained.discarded, 10 - cap);
+            assert_eq!(drained.requests.len(), cap);
+            for (i, request) in drained.requests.iter().enumerate() {
+                assert_eq!(
+                    request.tool,
+                    format!("ordinary.{i}"),
+                    "merged drains must preserve enqueue order"
+                );
+                let scope = if i % 2 == 0 { "fallback" } else { "cycle" };
+                assert_eq!(request.effect.run_id, Some(format!("{scope}.{i}")));
+            }
+            let independent = run.scoped(async { queue.drain(cap) }).await;
+            assert_eq!(independent.discarded, 10 - cap);
+            assert_eq!(independent.requests.len(), cap);
+            for (i, request) in independent.requests.iter().enumerate() {
+                assert_eq!(request.tool, format!("run.{i}"));
+                assert!(request.effect.run_id.is_none());
+            }
         }
     }
 

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -473,9 +473,7 @@ tokio::task_local! {
     /// not a new dependency — `with_stop_hooks` is itself a task-local scope on
     /// this exact path.
     static CURRENT_SCOPE: ApprovalScope;
-    /// Whether this one actual agent turn has already executed
-    /// `request_approval`. Unlike `CURRENT_SCOPE`, this resets for every model
-    /// turn inside a shared cycle/workflow bucket.
+    /// Whether this agent turn has asked the operator for approval or an answer.
     static EXPLICIT_REQUEST_PENDING: Cell<bool>;
 }
 
@@ -545,23 +543,39 @@ impl ApprovalRequestQueue {
     /// separate: two different turns asking for the same tool are two requests,
     /// and collapsing them would hide one turn's ask behind another's.
     pub fn push(&self, request: ApprovalRequest) {
-        let explicit = request.tool == crate::harness::approval_tool::REQUEST_APPROVAL_TOOL;
+        self.push_with_cap(request, usize::MAX);
+    }
+
+    pub(super) fn push_blocker(&self, request: ApprovalRequest) -> bool {
+        self.push_with_cap(request, MAX_APPROVAL_REQUESTS_PER_TURN)
+    }
+
+    fn push_with_cap(&self, request: ApprovalRequest, cap: usize) -> bool {
+        let explicit = request.tool == crate::harness::approval_tool::REQUEST_APPROVAL_TOOL
+            || request.tool == super::blockers::ESCALATE_TO_HUMAN_TOOL;
         if explicit {
-            // The turn boundary is established by making the request, even if
-            // its card is a duplicate of one already queued in this scope.
             let _ = EXPLICIT_REQUEST_PENDING.try_with(|pending| pending.set(true));
         }
         let scope = Self::current_scope();
         let mut guard = self.inner.lock().expect("approval request queue");
+        let shared_count = match &scope {
+            ApprovalScope::Cycle => guard.get(&ApprovalScope::Unscoped).map_or(0, Vec::len),
+            ApprovalScope::Unscoped => guard.get(&ApprovalScope::Cycle).map_or(0, Vec::len),
+            ApprovalScope::Run(_) => 0,
+        };
         let bucket = guard.entry(scope).or_default();
         if bucket.iter().any(|q| {
             q.effect.kind == request.effect.kind
                 && q.effect.payload == request.effect.payload
                 && q.effect.agent == request.effect.agent
         }) {
-            return;
+            return true;
+        }
+        if bucket.len().saturating_add(shared_count) >= cap {
+            return false;
         }
         bucket.push(request);
+        true
     }
 
     /// The scope pushes are currently filing into.
@@ -576,10 +590,7 @@ impl ApprovalRequestQueue {
             .unwrap_or_default()
     }
 
-    /// Whether the current turn has already made an explicit approval request.
-    /// Tool execution is serial whenever OpenHuman's tool middleware is wired;
-    /// this lets the policy refuse every later sibling call in a provider
-    /// response after `request_approval` has established the turn boundary.
+    /// Whether the current turn has asked the operator for approval or an answer.
     fn explicit_request_pending(&self) -> bool {
         EXPLICIT_REQUEST_PENDING
             .try_with(Cell::get)
@@ -1705,14 +1716,9 @@ impl ToolPolicy for ApprovalPolicy {
     async fn check(&self, request: &ToolPolicyRequest) -> ToolPolicyDecision {
         let tool = request.tool_name.as_str();
 
-        // `request_approval` is a real turn boundary, not advice in a tool
-        // result. The hosted profile requests one call per assistant message;
-        // this is the fail-closed second layer for a provider that nevertheless
-        // returns several calls. Once the explicit request tool has queued its
-        // card, every later call in the serial tool fold is refused.
         if self.requests.explicit_request_pending() {
             return ToolPolicyDecision::deny(format!(
-                "'{tool}' was not run because this turn already asked the operator for approval; \
+                "'{tool}' was not run because this turn already asked the operator for approval or an answer; \
                  stop and wait for the decision"
             ));
         }
@@ -4535,70 +4541,125 @@ mod tests {
         );
     }
 
-    /// `escalate_to_human` (issue #1860's agent-question blocker), unlike
-    /// `request_approval`, never sets `EXPLICIT_REQUEST_PENDING` — so nothing
-    /// stops a model from calling it again inside the same turn. A ninth
-    /// distinct question in one turn overflows `MAX_APPROVAL_REQUESTS_PER_TURN`
-    /// and is dropped by the drain cap with no card ever raised for it, even
-    /// though the run may still park believing it asked something.
     #[tokio::test]
-    async fn escalate_to_human_does_not_set_the_turn_boundary_and_can_overflow_the_cap() {
+    async fn escalate_to_human_sets_the_turn_boundary_and_explicitly_refuses_overflow() {
+        use openhuman_core::openhuman::tools::traits::Tool as _;
+
         let queue = ApprovalRequestQueue::default();
-        let blocker_request = |i: usize| ApprovalRequest {
-            tool: crate::harness::built_in::blockers::ESCALATE_TO_HUMAN_TOOL.to_string(),
-            reason: format!("question {i}"),
-            effect: Effect {
-                kind: "blocker.information".to_string(),
-                group: EffectGroup::Other,
-                amount_usd: None,
-                established_thread: false,
-                first_time_counterparty: false,
-                payload: serde_json::json!({ "reason": format!("question {i}") }),
-                agent: None,
-                run_id: None,
-            },
-        };
+        let tool = crate::harness::built_in::blockers::EscalateToHumanTool::new(
+            queue.clone(),
+            "engineer".to_string(),
+        );
 
         queue
             .turn_scoped(async {
-                for i in 0..(MAX_APPROVAL_REQUESTS_PER_TURN + 1) {
-                    queue.push(blocker_request(i));
+                for i in 0..MAX_APPROVAL_REQUESTS_PER_TURN {
+                    let asked = tool
+                        .execute(serde_json::json!({ "question": format!("question {i}") }))
+                        .await
+                        .expect("the tool runs");
+                    assert!(!asked.is_error, "{}", asked.text());
                 }
+                let refused = tool
+                    .execute(serde_json::json!({ "question": "ninth question" }))
+                    .await
+                    .expect("the tool returns its refusal");
                 assert!(
-                    !queue.explicit_request_pending(),
-                    "unlike request_approval, escalate_to_human never establishes the turn \
-                     boundary — nothing in the queue itself stops a model from calling it \
-                     again in the same turn"
+                    refused.is_error,
+                    "the ninth question must be explicitly refused, not reported as raised: {}",
+                    refused.text()
+                );
+                assert!(refused.text().contains("not raised"));
+                assert!(
+                    refused
+                        .text()
+                        .contains(&MAX_APPROVAL_REQUESTS_PER_TURN.to_string())
+                );
+                assert!(
+                    queue.explicit_request_pending(),
+                    "escalation must end the turn"
                 );
             })
             .await;
 
         let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
         assert_eq!(
-            drained.discarded, 1,
-            "a ninth question in one turn overflows the cap and is silently dropped — no card \
-             is ever raised for it, though the run may still park expecting an answer"
+            drained.discarded, 0,
+            "a question reported as raised must not be lost at drain"
+        );
+        assert_eq!(drained.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert!(
+            drained
+                .requests
+                .iter()
+                .all(|request| request.reason != "ninth question")
         );
     }
 
-    /// `check`'s fail-closed boundary (the block right above `Deny`ing every
-    /// call once `request_approval` has fired) reads the same task-local as
-    /// `explicit_request_pending`. Since `escalate_to_human` never sets it, a
-    /// sibling gated call queued in the same turn right after a question is
-    /// evaluated on its own terms rather than refused outright the way a
-    /// second `request_approval` would be.
     #[tokio::test]
-    async fn escalate_to_human_does_not_refuse_a_sibling_gated_call_in_the_same_turn() {
+    async fn escalate_to_human_respects_combined_cycle_and_unscoped_capacity() {
+        use openhuman_core::openhuman::tools::traits::Tool as _;
+
+        for initially_scoped in [false, true] {
+            let queue = ApprovalRequestQueue::default();
+            let claim = queue.claim(ApprovalScope::Cycle);
+            let tool = crate::harness::built_in::blockers::EscalateToHumanTool::new(
+                queue.clone(),
+                "engineer".to_string(),
+            );
+            for i in 0..MAX_APPROVAL_REQUESTS_PER_TURN - 1 {
+                let args = serde_json::json!({ "question": format!("question {i}") });
+                let asked = if initially_scoped {
+                    claim.scoped(tool.execute(args)).await
+                } else {
+                    tool.execute(args).await
+                }
+                .expect("the tool runs");
+                assert!(!asked.is_error, "{}", asked.text());
+            }
+
+            for (question, refused) in [("last available slot", false), ("overflow", true)] {
+                let args = serde_json::json!({ "question": question });
+                let asked = if initially_scoped {
+                    tool.execute(args).await
+                } else {
+                    claim.scoped(tool.execute(args)).await
+                }
+                .expect("the tool runs");
+                assert_eq!(
+                    asked.is_error,
+                    refused,
+                    "Cycle and Unscoped share one drain cap; initially_scoped={initially_scoped}: {}",
+                    asked.text()
+                );
+            }
+
+            let drained = claim
+                .scoped(async { queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN) })
+                .await;
+            assert_eq!(
+                drained.discarded, 0,
+                "no accepted question may be discarded"
+            );
+            assert_eq!(drained.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
+            assert!(
+                drained
+                    .requests
+                    .iter()
+                    .any(|r| r.reason == "last available slot")
+            );
+            assert!(drained.requests.iter().all(|r| r.reason != "overflow"));
+        }
+    }
+
+    #[tokio::test]
+    async fn escalate_to_human_refuses_a_sibling_gated_call_in_the_same_turn() {
         use openhuman_core::openhuman::tools::traits::Tool as _;
 
         let queue = ApprovalRequestQueue::default();
         let policy = policy("supervised", &[], None).with_requests(queue.clone());
         let claim = queue.claim(ApprovalScope::Cycle);
 
-        // Through the tool, not a hand-built `ApprovalRequest`: the boundary is
-        // established by what `execute` does, so a fixture that pushes the
-        // request itself would keep passing if the tool later began setting the
-        // task-local — the one regression this case exists to catch.
         let tool = crate::harness::built_in::blockers::EscalateToHumanTool::new(
             queue.clone(),
             "engineer".to_string(),
@@ -4617,10 +4678,18 @@ mod tests {
             .await;
 
         assert!(
-            matches!(later_call, ToolPolicyDecision::RequireApproval { .. }),
-            "escalate_to_human must not trip the request_approval turn boundary — the sibling \
-             call should still be gated on its own terms, not refused outright: {later_call:?}"
+            matches!(later_call, ToolPolicyDecision::Deny { .. }),
+            "escalation must refuse later calls in the same turn: {later_call:?}"
         );
+        let next_turn = claim
+            .scoped(
+                queue.turn_scoped(policy.check(&request("composio_execute", composio_send_args()))),
+            )
+            .await;
+        assert!(matches!(
+            next_turn,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
     }
 
     /// A repeated identical question in one turn — a model retrying a call it


### PR DESCRIPTION
## Summary

An escalation could tell an agent its question had been raised even though the approval drain would discard it past the eight-request cap. Escalating also left later calls in the same turn running instead of waiting for the operator.

- Admit blocker requests atomically under the queue mutex and explicitly refuse excess questions.
- Establish the existing turn boundary when an agent escalates.
- Cover real tool calls, combined cycle/fallback capacity, concurrent admission, duplicate questions, and independent workflow runs.

## API Or Behavior Changes

- `escalate_to_human` returns an error tool result when the approval batch is full, stating that the question was not raised and must be asked again later.
- Successful escalation tells the agent to stop and wait. Policy refuses subsequent sibling calls in that turn; a later turn starts with a fresh boundary.
- Cycle and unscoped fallback requests share the budget used by their combined drain. Workflow-run budgets remain independent, and an already-queued duplicate does not consume another slot.
- Every queue producer receives an enqueue sequence under the same mutex. Cycle/Unscoped drains merge chronologically instead of giving all Cycle entries priority, so later ordinary requests cannot displace an accepted blocker. Live scope-local buckets remain append-only, preserving run-stamping boundaries.
- Duplicate blocker admission checks the existing entry's combined drain rank. A duplicate beyond the budget returns an explicit refusal; an already-admitted duplicate keeps its position even after later overflow.
- Ordinary overflow is still counted and reported. `drain(cap)` continues to honor its explicit cap, including zero or smaller limits; both production drains use `MAX_APPROVAL_REQUESTS_PER_TURN` (eight), matching blocker admission. No hidden cap widening or public signature change.

## Tests

Builds use `CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0` to limit shared build pressure. Debug symbols are disabled; assertions and test selection are unchanged.

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` — exit 0.
- [x] `cargo clippy --locked --no-deps --features openhuman --all-targets -- -D warnings` — exit 0.
- [x] `cargo test --locked --lib` — exit 0; 5,019 passed, 0 failed, 6 ignored, 0 filtered out (247.12 seconds).
- [x] `cargo test --locked --features openhuman --tests` — exit 0; 7,633 passed, 0 failed, 20 ignored, 0 filtered out across eight targets. Library: 7,573 passed / 15 ignored; binary: 25 passed; auth matrix: 9 passed / 5 ignored; desktop: 1; hivemind: 9; offline: 2; one-card-per-message: 12; product identity: 2. All pre-existing ignored tests remain unchanged.

Each gate ran without a pipeline, with its exit code read directly from `$?`. Full test output was captured to logs before reading the result summaries. The four existing unused-patch warnings (`tinychannels`, `tinycortex`, `tinycortex-api`, `whisper-rs-sys`) remain unchanged.

Setup on the earlier base stopped at test discovery because its vendor pin disagreed with its lockfile (exit 101); the branch was updated to the repaired main before validation. One redundant filtered build was interrupted (exit 130) while scheduling shared memory. Neither is counted as a red proof or a completed gate. All final gates above ran after the two signed follow-up commits.

Observed red proofs, with test assertions unchanged during every temporary mutation:

1. Disabled only the blocker admission cap by passing `usize::MAX`. The exact overflow regression failed with `the ninth question must be explicitly refused, not reported as raised`, showing a success result for the ninth question. Exit 101, 0 passed / 1 failed. Restored the cap and reran all three focused regressions: exit 0, 3 passed.
2. Removed escalation from turn-boundary recognition. The exact sibling-call regression failed with `escalation must refuse later calls in the same turn: RequireApproval`. Exit 101, 0 passed / 1 failed.
3. Removed the combined Cycle/Unscoped count. The exact mixed-scope regression failed with `Cycle and Unscoped share one drain cap`, because the overflow question was reported as raised (`false != true`). Exit 101, 0 passed / 1 failed.

Proofs 2 and 3 used one temporary build and separate exact test invocations. The sibling-call test has only one request and does not depend on capacity; the mixed-scope test does not inspect the turn flag. Both guards were immediately restored, both source files matched their external backups, and the full diff matched the pre-proof diff. All three focused regressions then passed again through Cargo: exit 0, 3 passed.

4. Disabled only the blocker admission cap again and discovered the newly added tests with `cargo test --locked --features openhuman --lib harness::built_in::blockers::tool_test:: -- --list` (exit 0, 10 tests). The exact concurrent test failed in round 0: `one remaining blocker slot must have exactly one successful caller`, with 2 successes instead of 1. Exit 101, 0 passed / 1 failed.
5. Against that same temporary build, the exact full-run retry test failed with `a new question must be refused at the cap`. Exit 101, 0 passed / 1 failed. Restored immediately, verified both backups and the pre-proof diff, then `cargo test --locked --features openhuman --lib harness::built_in::blockers::` passed: exit 0, 26 passed / 0 failed / 0 ignored. The concurrent test exercises 20 barrier-released races.

Exact tests were discovered rather than inferred from module names. Where multiple independent assertions shared a temporary build, they were invoked separately from Cargo's just-built test binary with `RUST_MIN_STACK=8388608` and `--exact`. Those runs each selected one test; no zero-test result is counted as proof.

Follow-up regressions for mixed producers:

- `cargo test --locked --features openhuman --lib harness::built_in::policy::tests -- --list` exited 0 and listed 160 real tests.
- `cargo test --locked --features openhuman --lib -- harness::built_in::policy::tests harness::built_in::blockers:: --test-threads=2` exited 0 after restoration: 186 passed, 0 failed, 0 ignored (0.20 seconds).
- New coverage exercises the real escalation tool and ordinary approval policy in both Cycle/Unscoped directions, with zero or seven preceding approvals and later ordinary overflow; accepted duplicate retries; over-budget duplicates in the same or opposite bucket; chronological merging; scope-local stamping; independent Run queues; and explicit caps of zero, three, and eight.

All three new tests first failed on the previous PR implementation, each with exit 101, 0 passed / 1 failed. After implementing the fix, the mandatory removal proof repeated those failures:

1. Removed the chronological sort from the merged drain. `accepted_blockers_survive_later_ordinary_approvals_across_scopes` failed: an accepted blocker must survive later ordinary approvals; retained count was 0 instead of 1.
2. Also changed duplicate admission from checking its rank against the requested cap to accepting any representable rank. `a_blocker_duplicate_outside_the_drain_budget_is_refused` failed: an overflow duplicate must not be reported as raised.
3. `mixed_scope_drain_preserves_enqueue_order_and_scoped_stamping` failed: merged drains must preserve enqueue order; `ordinary.1` appeared before `ordinary.0`.

The temporary build was discovered through Cargo; each exact regression was invoked separately from its just-built binary with `RUST_MIN_STACK=8388608`. Every invocation selected one test and exited 101. The ordering tests do not depend on over-budget duplicate acceptance, and the duplicate-refusal assertion runs before draining.

Both source files were backed up outside the repository first. An exit/signal cleanup trap immediately restored the production checks; both file comparisons and the complete before/after diff comparison exited 0. The restored 186-test suite passed before committing. No temporary break was committed.

## Documentation

Updated the escalation's runtime response and queue API contracts. Removed the contradictory Rustdoc claiming escalation lets the agent keep calling tools; it now documents the enforced turn boundary, queued acceptance, and explicit overflow refusal. No endpoint, configuration, or console-layout changes require separate documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Approval requests exceeding the per-turn limit are now explicitly rejected instead of silently dropped.
  - When human input or approval is requested, the agent is instructed to stop and wait for a response.
  - Concurrent requests reliably compete for available approval capacity, preventing accepted questions from being lost.
  - Duplicate approval requests no longer consume additional capacity.
  - Approval capacity remains independent across separate runs and resets appropriately for new turns.
  - Requests are processed in the order they were accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
