### PR TITLE
fix(policy): report a daily budget cap the shipped path never enforces

### DIFF
--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -835,6 +835,7 @@ pub struct ApprovalPolicy {
     /// the process and bury everything else. Once per policy is the useful
     /// signal.
     no_meter_warned: AtomicBool,
+    unenforced_cap_warned: AtomicBool,
     /// Where a `RequireApproval` decision is recorded so the runtime can park it
     /// (issue #172). The default is a private queue nobody drains, which keeps
     /// every non-harness construction site (and every test) behaving exactly as
@@ -957,6 +958,7 @@ impl ApprovalPolicy {
             workflow: None,
             spend: None,
             no_meter_warned: AtomicBool::new(false),
+            unenforced_cap_warned: AtomicBool::new(false),
             // The strict path by default — see `for_authored_workflow_nodes`.
             call_path: CallPath::Agent,
             // No read declaration by default, so every MCP bridge call gates
@@ -1120,6 +1122,18 @@ impl ApprovalPolicy {
     /// The per-agent daily budget, if any.
     pub fn budget_usd_daily(&self) -> Option<f64> {
         self.budget_usd_daily
+    }
+
+    /// The declared daily cap this call will not be judged against: a priced
+    /// call, a cap in the manifest, and policy-generated approvals off, which
+    /// leaves `daily_budget_verdict` below the `Allow` that `check` returns
+    /// first. `None` when the cap is absent, inapplicable, or in force.
+    fn unenforced_daily_cap(&self, tool: &str, args: &serde_json::Value) -> Option<f64> {
+        if self.policy_hitl_enabled {
+            return None;
+        }
+        let cap = self.budget_usd_daily?;
+        Self::is_priced_call(tool, args, Self::amount_usd(args)).then_some(cap)
     }
 
     /// Whether `kind` is in the manifest's `always_approve` list.
@@ -1942,6 +1956,16 @@ impl ToolPolicy for ApprovalPolicy {
         // Keep the readonly brake and old-grant redemption above this point,
         // but bypass every arm below that would turn classification into HITL.
         if !self.policy_hitl_enabled {
+            if let Some(cap) = self.unenforced_daily_cap(tool, &request.arguments)
+                && !self.unenforced_cap_warned.swap(true, Ordering::Relaxed)
+            {
+                let agent = self.agent.as_deref().unwrap_or("<unnamed>");
+                log::warn!(
+                    "[approval] agent '{agent}' declares a daily budget of ${cap:.2}, but \
+                     policy-generated approvals are disabled on this host, so the cap does not \
+                     gate priced tool calls such as '{tool}'"
+                );
+            }
             return ToolPolicyDecision::Allow;
         }
 
@@ -5932,6 +5956,54 @@ mod tests {
                 .with_spend(meter, CompanyId::new("acme")),
             grants,
         )
+    }
+
+    /// Production disables policy-generated approvals, which puts the daily cap
+    /// below the `Allow` that `check` returns first — so a manifest cap does not
+    /// judge a priced call on the shipped path. Every other test here leaves
+    /// that switch on, a configuration production never runs.
+    ///
+    /// Pins the reporting, not the bypass: the gap must stay detectable.
+    #[test]
+    fn a_declared_cap_reports_itself_unenforced_once_policy_hitl_is_off() {
+        let p = Policy {
+            mode: "full".to_string(),
+            always_approve: Vec::new(),
+            auto_approve_under_usd: None,
+            approval_ttl_hours: None,
+        };
+        let priced = serde_json::json!({ "amount_usd": 1.0 });
+
+        let shipped = ApprovalPolicy::new(&p, Some(5.0))
+            .with_policy_hitl_disabled()
+            .with_agent("writer".to_string());
+        assert_eq!(
+            shipped.unenforced_daily_cap("pay_invoice", &priced),
+            Some(5.0),
+            "a priced call under a declared cap must be reportable as ungated"
+        );
+
+        let gating = ApprovalPolicy::new(&p, Some(5.0)).with_agent("writer".to_string());
+        assert_eq!(
+            gating.unenforced_daily_cap("pay_invoice", &priced),
+            None,
+            "with policy approvals on, the cap is in force and there is nothing to report"
+        );
+
+        let uncapped = ApprovalPolicy::new(&p, None)
+            .with_policy_hitl_disabled()
+            .with_agent("writer".to_string());
+        assert_eq!(
+            uncapped.unenforced_daily_cap("pay_invoice", &priced),
+            None,
+            "no cap declared is not an unenforced cap"
+        );
+
+        assert_eq!(
+            shipped.unenforced_daily_cap("file_read", &serde_json::json!({})),
+            None,
+            "an unpriced call was never the cap's business"
+        );
     }
 
     /// The core of #304: at cap, a **priced** call parks — and it parks through


### PR DESCRIPTION
## Summary

A `budget_usd_daily` declared in a company manifest does not gate anything on the roster production runs, and nothing anywhere says so. This makes the gap audible.

## Problem

`ApprovalPolicy::check` returns `Allow` at the policy-HITL bypass roughly twenty lines above `daily_budget_verdict`. Production disables policy-generated approvals, so on the shipped path the daily cap is never consulted — while the console keeps rendering the number an operator set, which reads as enforcement.

The suite was green over this the whole time: every existing test in that section constructs the policy with the switch left on, a configuration production never runs. A green run said nothing about the shipped behaviour.

## Solution

Warn once per policy, at the skip site, on the first priced call the cap would have judged — naming the agent, the cap, and the tool.

The condition is factored into a predicate so it can be tested directly. The test pins the *reporting*, not the bypass: four cases covering a priced call under a cap with approvals off (reportable), the same with approvals on (in force, nothing to report), no cap declared, and an unpriced call.

Whether the cap should sit above the bypass rather than below it is a product question and is tracked separately; this change does not move it.

## Submission Checklist

- [x] `cargo test --lib --features openhuman a_declared_cap` passes (1 passed)
- [x] Red proof: dropping the `policy_hitl_enabled` guard fails the test on its own assertion — `assertion left == right failed: with policy approvals on, the cap is in force and there is nothing to report / left: Some(5.0) / right: None` — then restored to green
- [x] No production behaviour changes: the diff adds a warn and a predicate, deletes nothing
- [ ] Console E2E — pre-existing failure on main, unrelated to this change

## Impact

No behaviour change. One warn-level line on the first priced call under an unenforced cap, once per policy.

## Related

Tracks the product question separately in #2233.