### PR TITLE
fix(workflow-resume): resolve a global graph when a resume reloads it (#2235)

### DIFF
--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -1069,6 +1069,9 @@ pub fn load_workflow_with_globals(
     if let Some(file) = load_company_workflow_union(source_dir, overlays, id)? {
         return Ok(Some(file));
     }
+    if claims_workflow_id(source_dir, id) {
+        return Ok(None);
+    }
     if crate::globals::disabled(disable, "workflow", id) {
         return Ok(None);
     }
@@ -1080,6 +1083,18 @@ pub fn load_workflow_with_globals(
             workflow.global = true;
             workflow
         }))
+}
+
+/// Whether the company's seed directory claims `id`, whatever the file there
+/// turns out to hold.
+///
+/// A graph file the company committed under this id is a claim on it, and a
+/// claim the loader could not honour — a body whose own id disagrees with the
+/// filename is skipped — must not become a global instead. Resolving a
+/// different graph under an id the company named is worse than resolving none:
+/// releasing a parked approval would run nodes nobody asked for.
+fn claims_workflow_id(source_dir: Option<&Path>, id: &str) -> bool {
+    source_dir.is_some_and(|dir| dir.join("workflows").join(format!("{id}.toml")).is_file())
 }
 
 /// The company's own two sources — seed file, then overlay — with no baseline.

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -1022,10 +1022,13 @@ pub fn list_source_workflows(source_dir: Option<&Path>) -> Vec<WorkflowFile> {
 /// sources: the version-controlled seed file (`source_dir/workflows/<id>.toml`)
 /// and the record's runtime-authored [`OverlayWorkflow`] bodies.
 ///
-/// This is the single read path for "give me graph `<id>`" — the REST
-/// `GET …/workflows/{wid}` and run routes, the GraphQL resolver, the
-/// orchestrator's `run_workflow` tool, and the `sub_workflow` resolver all go
-/// through it, so they can never disagree about which graphs exist.
+/// The company's own two sources and nothing else: a **global** graph is in
+/// neither, so this returns `Ok(None)` for one. Readers that resolve an id an
+/// operator could have meant — the REST `GET …/workflows/{wid}` and run routes,
+/// the GraphQL resolver, the orchestrator's `run_workflow` tool, the
+/// `sub_workflow` resolver, and both resume paths — go through
+/// [`load_workflow_with_globals`] instead, so they can never disagree about
+/// which graphs exist.
 ///
 /// **The seed file wins on an id collision.** An overlay body with the same id
 /// as a committed file is shadowed, not destroyed — it stays on the record and

--- a/src/globals/test.rs
+++ b/src/globals/test.rs
@@ -336,6 +336,32 @@ fn global_workflows_list_last_and_a_company_graph_of_the_same_id_wins() {
 }
 
 #[test]
+fn a_company_file_claiming_a_global_id_never_resolves_to_the_global() {
+    let taken = &workflows()[0].id;
+    let dir = tempfile::Builder::new()
+        .prefix("opencompany-globals-")
+        .tempdir()
+        .expect("tempdir");
+    let workflows_dir = dir.path().join("workflows");
+    std::fs::create_dir_all(&workflows_dir).expect("workflows dir");
+    // The file claims the id by its name; its body disagrees, so the seed scan
+    // skips it and the company union yields nothing.
+    std::fs::write(
+        workflows_dir.join(format!("{taken}.toml")),
+        "id = \"renamed\"\nname = \"Ours\"\n\n[[node]]\nid = \"t\"\nkind = \"trigger\"\nname = \"T\"\n",
+    )
+    .expect("seed graph");
+
+    let loaded = crate::company::load_workflow_with_globals(Some(dir.path()), &[], &[], taken)
+        .expect("loads");
+    assert!(
+        loaded.is_none(),
+        "a company file claiming this id must not resolve to the global behind it: got {:?}",
+        loaded.map(|file| (file.id, file.name, file.global))
+    );
+}
+
+#[test]
 fn a_disabled_global_workflow_neither_lists_nor_loads() {
     let dropped = &workflows()[0].id;
     let disable = vec![format!("workflow:{dropped}")];

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -1257,12 +1257,13 @@ async fn spawn_continuation(
                     "workflow {workflow_id} (it was approved, but the graph no longer exists)"
                 ))
             })?;
-    if a_global_this_run_never_parked_against(
+    if a_contested_id_no_longer_holds_the_parked_graph(
         effect
             .payload
             .get(PAYLOAD_WORKFLOW_FINGERPRINT)
             .and_then(Value::as_str),
         &workflow,
+        &disable,
     ) {
         return Err(OpenCompanyError::CompanyNotFound(format!(
             "workflow {workflow_id} (it was approved, but the graph it parked against is gone)"
@@ -1428,7 +1429,11 @@ pub async fn spawn_blocked_node_continuation(
              exists)"
                 ))
             })?;
-    if a_global_this_run_never_parked_against(workflow_fingerprint.as_deref(), &workflow) {
+    if a_contested_id_no_longer_holds_the_parked_graph(
+        workflow_fingerprint.as_deref(),
+        &workflow,
+        &disable,
+    ) {
         return Err(OpenCompanyError::CompanyNotFound(format!(
             "workflow {workflow_id} (a blocked step was approved, but the graph it parked \
              against is gone)"
@@ -1536,19 +1541,30 @@ fn graph_unchanged_since_park(effect: &Effect, workflow: &crate::company::Workfl
     )
 }
 
-/// Whether the graph that resolved is a global this run never parked against.
+/// Whether an id a global could answer to resolved to a graph this run did not
+/// park against.
 ///
-/// A company graph and a global can answer to one id: the company's wins while
-/// it exists, and the global surfaces if it is deleted. A parked fingerprint
-/// that no longer matches normally means the graph was edited, and a trigger
-/// re-run is the honest answer. On a global it means something stronger — the
-/// graph the operator answered for is gone and a different one now holds its
-/// id, so a re-run would execute nodes nobody approved.
-fn a_global_this_run_never_parked_against(
+/// A company graph and a global can hold one id, and either can replace the
+/// other while a run sits parked: deleting the company's copy surfaces the
+/// global, and authoring one buries it. Both directions end with a graph that
+/// is not what the operator answered for, and a trigger re-run there executes
+/// nodes nobody approved.
+///
+/// Keyed on the id being contested rather than on which side won, so the two
+/// directions cannot drift apart. An id no global answers to is untouched: an
+/// edited company graph is the operator's own edit of their own graph, and
+/// still falls back to a trigger re-run. A run parked before fingerprints were
+/// stashed still replays as it did.
+fn a_contested_id_no_longer_holds_the_parked_graph(
     parked: Option<&str>,
     workflow: &crate::company::WorkflowFile,
+    disable: &[String],
 ) -> bool {
-    workflow.global && parked.is_some_and(|parked| parked != workflow.content_fingerprint())
+    let contested = !crate::globals::disabled(disable, "workflow", &workflow.id)
+        && crate::globals::workflows()
+            .iter()
+            .any(|global| global.id == workflow.id);
+    contested && parked.is_some_and(|parked| parked != workflow.content_fingerprint())
 }
 
 /// The shared check behind [`graph_unchanged_since_park`] (the gate path,
@@ -2823,41 +2839,71 @@ from = "start"
 to = "gate"
 "#;
 
-    /// A global is not the graph a run parked against just because it answers
-    /// to the same id.
+    /// A contested id that no longer holds the graph a run parked against is
+    /// refused, whichever side won it.
     ///
-    /// A company graph can shadow a global, and deleting it leaves the global
-    /// holding that id with no claim behind it. The parked fingerprint is the
-    /// only thing that still knows which graph the operator answered for.
+    /// A company graph and a global can hold one id. Deleting the company's
+    /// copy surfaces the global; authoring one buries it. Both directions end
+    /// with a graph the operator never answered for.
     #[test]
-    fn a_global_holding_a_deleted_graphs_id_is_not_what_parked() {
-        let mut global = crate::company::parse_workflow(FINGERPRINT_V1).expect("parses");
-        global.global = true;
-        let parked_against_something_else =
-            crate::company::parse_workflow(FINGERPRINT_V2).expect("parses");
+    fn a_contested_id_is_refused_in_both_directions() {
+        let contested = &crate::globals::workflows()[0].id;
+        let parked = crate::company::parse_workflow(FINGERPRINT_V1).expect("parses");
+        let other = crate::company::parse_workflow(FINGERPRINT_V2).expect("parses");
 
+        let mut surfaced_global = other.clone();
+        surfaced_global.id = contested.clone();
+        surfaced_global.global = true;
         assert!(
-            a_global_this_run_never_parked_against(
-                Some(&parked_against_something_else.content_fingerprint()),
-                &global,
+            a_contested_id_no_longer_holds_the_parked_graph(
+                Some(&parked.content_fingerprint()),
+                &surfaced_global,
+                &[],
             ),
-            "a global whose content is not what parked must not be re-run in its place"
+            "a global surfacing under a deleted company graph's id must not run in its place"
+        );
+
+        let mut authored_company = other.clone();
+        authored_company.id = contested.clone();
+        authored_company.global = false;
+        assert!(
+            a_contested_id_no_longer_holds_the_parked_graph(
+                Some(&parked.content_fingerprint()),
+                &authored_company,
+                &[],
+            ),
+            "a company graph authored over a parked global must not run in its place either"
+        );
+
+        let mut unchanged = surfaced_global.clone();
+        unchanged.global = true;
+        assert!(
+            !a_contested_id_no_longer_holds_the_parked_graph(
+                Some(&unchanged.content_fingerprint()),
+                &unchanged,
+                &[],
+            ),
+            "the graph a run genuinely parked against still resumes"
         );
         assert!(
-            !a_global_this_run_never_parked_against(Some(&global.content_fingerprint()), &global),
-            "the global a run genuinely parked against still resumes"
-        );
-        assert!(
-            !a_global_this_run_never_parked_against(None, &global),
+            !a_contested_id_no_longer_holds_the_parked_graph(None, &surfaced_global, &[]),
             "a run parked before fingerprints were stashed keeps replaying as it did"
         );
-        let company = crate::company::parse_workflow(FINGERPRINT_V1).expect("parses");
         assert!(
-            !a_global_this_run_never_parked_against(
-                Some(&parked_against_something_else.content_fingerprint()),
-                &company,
+            !a_contested_id_no_longer_holds_the_parked_graph(
+                Some(&parked.content_fingerprint()),
+                &other,
+                &[],
             ),
-            "an edited company graph is the operator's own edit — unchanged behaviour"
+            "an id no global answers to is the operator's own edit — unchanged behaviour"
+        );
+        assert!(
+            !a_contested_id_no_longer_holds_the_parked_graph(
+                Some(&parked.content_fingerprint()),
+                &surfaced_global,
+                &[format!("workflow:{contested}")],
+            ),
+            "a global the company disabled cannot contest the id at all"
         );
     }
 

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -1257,6 +1257,17 @@ async fn spawn_continuation(
                     "workflow {workflow_id} (it was approved, but the graph no longer exists)"
                 ))
             })?;
+    if a_global_this_run_never_parked_against(
+        effect
+            .payload
+            .get(PAYLOAD_WORKFLOW_FINGERPRINT)
+            .and_then(Value::as_str),
+        &workflow,
+    ) {
+        return Err(OpenCompanyError::CompanyNotFound(format!(
+            "workflow {workflow_id} (it was approved, but the graph it parked against is gone)"
+        )));
+    }
 
     let input = continuation_input(effect, approved, denied)?;
     // Issue #1862 prerequisite: carry the paused run's attribution into the
@@ -1417,6 +1428,12 @@ pub async fn spawn_blocked_node_continuation(
              exists)"
                 ))
             })?;
+    if a_global_this_run_never_parked_against(workflow_fingerprint.as_deref(), &workflow) {
+        return Err(OpenCompanyError::CompanyNotFound(format!(
+            "workflow {workflow_id} (a blocked step was approved, but the graph it parked \
+             against is gone)"
+        )));
+    }
     // Issue #401: `begin` refuses at the concurrency ceiling; propagate it so
     // the caller surfaces the same refusal rather than losing the run
     // silently. Deliberately split from `spawn_admitted` below (mirroring the
@@ -1509,6 +1526,21 @@ pub async fn spawn_blocked_node_continuation(
 /// before. `false` only when a fingerprint WAS stashed and no longer matches:
 /// the workflow was edited while this approval sat pending, so its checkpoint
 /// no longer describes the graph the continuation would run against.
+/// Whether the graph that resolved is a global this run never parked against.
+///
+/// A company graph and a global can answer to one id: the company's wins while
+/// it exists, and the global surfaces if it is deleted. A parked fingerprint
+/// that no longer matches normally means the graph was edited, and a trigger
+/// re-run is the honest answer. On a global it means something stronger — the
+/// graph the operator answered for is gone and a different one now holds its
+/// id, so a re-run would execute nodes nobody approved.
+fn a_global_this_run_never_parked_against(
+    parked: Option<&str>,
+    workflow: &crate::company::WorkflowFile,
+) -> bool {
+    workflow.global && parked.is_some_and(|parked| parked != workflow.content_fingerprint())
+}
+
 fn graph_unchanged_since_park(effect: &Effect, workflow: &crate::company::WorkflowFile) -> bool {
     fingerprint_unchanged_since_park(
         effect
@@ -2791,6 +2823,44 @@ from = "start"
 to = "gate"
 "#;
 
+    /// A global is not the graph a run parked against just because it answers
+    /// to the same id.
+    ///
+    /// A company graph can shadow a global, and deleting it leaves the global
+    /// holding that id with no claim behind it. The parked fingerprint is the
+    /// only thing that still knows which graph the operator answered for.
+    #[test]
+    fn a_global_holding_a_deleted_graphs_id_is_not_what_parked() {
+        let mut global = crate::company::parse_workflow(FINGERPRINT_V1).expect("parses");
+        global.global = true;
+        let parked_against_something_else =
+            crate::company::parse_workflow(FINGERPRINT_V2).expect("parses");
+
+        assert!(
+            a_global_this_run_never_parked_against(
+                Some(&parked_against_something_else.content_fingerprint()),
+                &global,
+            ),
+            "a global whose content is not what parked must not be re-run in its place"
+        );
+        assert!(
+            !a_global_this_run_never_parked_against(Some(&global.content_fingerprint()), &global),
+            "the global a run genuinely parked against still resumes"
+        );
+        assert!(
+            !a_global_this_run_never_parked_against(None, &global),
+            "a run parked before fingerprints were stashed keeps replaying as it did"
+        );
+        let company = crate::company::parse_workflow(FINGERPRINT_V1).expect("parses");
+        assert!(
+            !a_global_this_run_never_parked_against(
+                Some(&parked_against_something_else.content_fingerprint()),
+                &company,
+            ),
+            "an edited company graph is the operator's own edit — unchanged behaviour"
+        );
+    }
+
     /// A card parked before this check existed carries no
     /// `PAYLOAD_WORKFLOW_FINGERPRINT` at all — must not be treated as a
     /// mismatch, or every pre-existing parked card would spuriously fall back
@@ -3176,6 +3246,70 @@ mode = "full"
             crate::ports::types::StartedBy::Operator,
             "a card with no started_by payload must degrade to the old default, not error: {:?}",
             started[0].started_by
+        );
+    }
+
+    /// The gate path resolves a global too.
+    ///
+    /// The blocked-node twin is the reachable half today — no global declares
+    /// an approval gate — so this pins the other arm against the day one does,
+    /// and against a reader restoring the company-only loader on either.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn an_approved_gate_on_a_global_graph_continues() {
+        let global = crate::globals::workflows()
+            .first()
+            .expect("the baseline ships at least one workflow");
+        let home = seed_home();
+        assert!(
+            !home
+                .path()
+                .join("workflows")
+                .join(format!("{}.toml", global.id))
+                .exists(),
+            "the fixture must not carry a company copy of {}",
+            global.id
+        );
+        let (rt, runner) = runtime(home.path(), true).await;
+
+        let effect = gate_effect(
+            &global.id,
+            "gather",
+            &json!({ "request": "the week" }),
+            "run-that-paused",
+            &[],
+            &[],
+            None,
+        );
+        let id = rt
+            .approvals
+            .park(rt.id(), effect.clone())
+            .await
+            .expect("parks");
+        rt.journal()
+            .record_parked(
+                &id,
+                &effect,
+                crate::ports::now_millis(),
+                TaskLink::Unlinked,
+                ApprovalConversation::default(),
+                None,
+            )
+            .await
+            .expect("journals");
+
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .expect("resolves");
+
+        let started = wait_for_runs(&runner, 1).await;
+        assert_eq!(
+            started
+                .iter()
+                .map(|run| run.workflow_id.as_str())
+                .collect::<Vec<_>>(),
+            vec![global.id.as_str()],
+            "approving a gate on a global must start its continuation"
         );
     }
 

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -114,7 +114,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 
 use crate::Result;
-use crate::company::load_workflow_union;
+use crate::company::load_workflow_with_globals;
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ports::types::Effect;
@@ -1244,21 +1244,19 @@ async fn spawn_continuation(
         )));
     };
 
-    // The same seed ∪ overlay union the run route loads through, so a graph
-    // authored on a hosted tenant (no source directory) resumes exactly like a
-    // committed one.
-    let overlays = runtime
+    let (overlays, disable) = runtime
         .store()
         .load(runtime.id())
         .await?
-        .map(|record| record.overlay_workflows)
+        .map(|record| (record.overlay_workflows, record.manifest.globals.disable))
         .unwrap_or_default();
     let workflow =
-        load_workflow_union(runtime.source_dir(), &overlays, workflow_id)?.ok_or_else(|| {
-            OpenCompanyError::CompanyNotFound(format!(
-                "workflow {workflow_id} (it was approved, but the graph no longer exists)"
-            ))
-        })?;
+        load_workflow_with_globals(runtime.source_dir(), &overlays, &disable, workflow_id)?
+            .ok_or_else(|| {
+                OpenCompanyError::CompanyNotFound(format!(
+                    "workflow {workflow_id} (it was approved, but the graph no longer exists)"
+                ))
+            })?;
 
     let input = continuation_input(effect, approved, denied)?;
     // Issue #1862 prerequisite: carry the paused run's attribution into the
@@ -1405,19 +1403,20 @@ pub async fn spawn_blocked_node_continuation(
              workflow execution wired, so there is nothing to continue"
         )));
     };
-    let overlays = runtime
+    let (overlays, disable) = runtime
         .store()
         .load(runtime.id())
         .await?
-        .map(|record| record.overlay_workflows)
+        .map(|record| (record.overlay_workflows, record.manifest.globals.disable))
         .unwrap_or_default();
     let workflow =
-        load_workflow_union(runtime.source_dir(), &overlays, workflow_id)?.ok_or_else(|| {
-            OpenCompanyError::CompanyNotFound(format!(
-                "workflow {workflow_id} (a blocked step was approved, but the graph no longer \
-                 exists)"
-            ))
-        })?;
+        load_workflow_with_globals(runtime.source_dir(), &overlays, &disable, workflow_id)?
+            .ok_or_else(|| {
+                OpenCompanyError::CompanyNotFound(format!(
+                    "workflow {workflow_id} (a blocked step was approved, but the graph no longer \
+             exists)"
+                ))
+            })?;
     // Issue #401: `begin` refuses at the concurrency ceiling; propagate it so
     // the caller surfaces the same refusal rather than losing the run
     // silently. Deliberately split from `spawn_admitted` below (mirroring the
@@ -3721,6 +3720,63 @@ mode = "full"
             remaining.is_empty(),
             "the refused lineage is unreachable from here on, so it must be pruned rather than \
              leaked: {remaining:?}"
+        );
+    }
+
+    /// A blocked node on a global graph resumes.
+    ///
+    /// A global lives only in the static baseline, so a resume that reloads
+    /// the graph through the company's own two sources cannot find it: the
+    /// answer is banked, the continuation never starts, and the run ends
+    /// stranded carrying a message that says the graph no longer exists.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn a_blocked_node_on_a_global_graph_resumes() {
+        let global = crate::globals::workflows()
+            .first()
+            .expect("the baseline ships at least one workflow");
+
+        let home = seed_home();
+        assert!(
+            !home
+                .path()
+                .join("workflows")
+                .join(format!("{}.toml", global.id))
+                .exists(),
+            "the fixture must not carry a company copy of {}, or the union loader would find \
+             it and the global layer would go untested",
+            global.id
+        );
+
+        let mut rt = RuntimeBuilder::new(home.path().to_path_buf(), manifest())
+            .with_seed_dir(home.path().to_path_buf())
+            .build()
+            .await
+            .expect("runtime builds");
+        let runner = Arc::new(RecordingRunner::default());
+        rt.set_workflow_runner(runner.clone());
+        let rt = Arc::new(rt);
+
+        spawn_blocked_node_continuation(
+            &rt,
+            "blocked-turn",
+            &global.id,
+            json!({ "request": "x" }),
+            crate::ports::types::StartedBy::Operator,
+            None,
+            None,
+        )
+        .await
+        .expect("a blocked node on a global graph continues");
+
+        let started = wait_for_runs(&runner, 1).await;
+        assert_eq!(
+            started
+                .iter()
+                .map(|run| run.workflow_id.as_str())
+                .collect::<Vec<_>>(),
+            vec![global.id.as_str()],
+            "answering the question must start the continuation, not strand the run"
         );
     }
 

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -1526,6 +1526,16 @@ pub async fn spawn_blocked_node_continuation(
 /// before. `false` only when a fingerprint WAS stashed and no longer matches:
 /// the workflow was edited while this approval sat pending, so its checkpoint
 /// no longer describes the graph the continuation would run against.
+fn graph_unchanged_since_park(effect: &Effect, workflow: &crate::company::WorkflowFile) -> bool {
+    fingerprint_unchanged_since_park(
+        effect
+            .payload
+            .get(PAYLOAD_WORKFLOW_FINGERPRINT)
+            .and_then(Value::as_str),
+        workflow,
+    )
+}
+
 /// Whether the graph that resolved is a global this run never parked against.
 ///
 /// A company graph and a global can answer to one id: the company's wins while
@@ -1539,16 +1549,6 @@ fn a_global_this_run_never_parked_against(
     workflow: &crate::company::WorkflowFile,
 ) -> bool {
     workflow.global && parked.is_some_and(|parked| parked != workflow.content_fingerprint())
-}
-
-fn graph_unchanged_since_park(effect: &Effect, workflow: &crate::company::WorkflowFile) -> bool {
-    fingerprint_unchanged_since_park(
-        effect
-            .payload
-            .get(PAYLOAD_WORKFLOW_FINGERPRINT)
-            .and_then(Value::as_str),
-        workflow,
-    )
 }
 
 /// The shared check behind [`graph_unchanged_since_park`] (the gate path,


### PR DESCRIPTION
## Summary

Answering an agent's clarifying question on a run of a **global** workflow stranded the run: the answer was banked, the continuation never started, and the run ended `stranded` carrying `the graph no longer exists` into the channel.

A global lives only in the static baseline, in neither of a company's own two graph sources. Both resume paths reloaded the graph through the seed-∪-overlay form, which cannot see one. They now resolve through the globals-aware form, threading the company's own `[globals].disable` opt-out — both paths already load the record for its overlays, so the list costs no extra read.

Passing the opt-out rather than an empty slice is deliberate: `globals/test.rs` pins that a disabled global must not be runnable by naming it directly, and a resume is a run.

The blocked-node path is the reachable half — a node blocks when its agent asks a question, and both shipped globals have agent nodes. The gate path is inert today (no global declares `requires_approval`), but the two are written as mirrors, so leaving one blind to globals only sets up the next reader to copy the wrong one. The change is provably inert for every currently reachable input on that path.

Also corrects the doc comment that caused this. `load_workflow_union` claimed to be "the single read path" and named callers — REST, GraphQL, the orchestrator tool, the `sub_workflow` resolver — that had all since moved to the globals-aware form. A confidently wrong doc is what makes a new resume path pick the wrong loader by name.

Closes #2235
Part of #1860

## API Or Behavior Changes

- No signature changes. Both resume paths widen a store read they already perform, from `record.overlay_workflows` to `(record.overlay_workflows, record.manifest.globals.disable)`.
- Behaviour: a blocked step on a global workflow now resumes instead of stranding. A global the company disabled stays unrunnable.
- Second-order: with globals resolvable at resume, the parked-fingerprint check can now compare against a baseline graph for the first time. If a release changes a global's nodes/edges while a run sits parked, that run correctly falls back to re-running from the trigger — designed behaviour, newly reachable for globals. Flagged so a re-run is not read as a new defect.

## Tests

New `a_blocked_node_on_a_global_graph_resumes` in `runtime::workflow_resume::decide_tests`. It takes its id from `globals::workflows().first()` and asserts the fixture home carries no company copy of that id, so the graph can only resolve through the baseline. It asserts the continuation actually **started** — not merely that the load succeeded — which is what makes it a regression test for the strand rather than a loader unit test.

Red proof, before the fix:

```
CompanyNotFound("workflow research_request (a blocked step was approved, but the graph no longer exists)")
```

That is the production message verbatim, on the first graph the baseline ships.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --features openhuman,tinymemory --lib --all-targets --no-deps -- -D warnings` (exit 0)
- [x] `cargo test --features openhuman,tinymemory --lib -- runtime::workflow_resume company::workflow_file globals` — 194 passed, 0 failed
- [ ] `cargo test` unscoped — not run; the full suite exhausts memory on this machine
- [ ] End-to-end on a live run — not done. This is an availability failure that only fully shows on a real parked run; the test exercises the same entry point rather than a console-driven agent turn.

## Documentation

No user-facing docs. The corrected loader doc is the documentation change.

## Known and deliberately not in this PR

- **The same root cause exists in the scheduler.** `runtime/workflow_scheduler.rs:337` enumerates schedulable graphs through `list_workflows_union`, the globals-blind listing form, so a global carrying a cron schedule is never enumerated and never fires in any company that has not authored its own copy — `globals/workflows/weekly_review.toml` carries `schedule = "0 16 * * 5"`. Its symptom is silent: no error, no stranded run. Kept out because fixing it starts firing a weekly cron in every non-opted-out company, which deserves its own review, and because whether that cron is meant to be live is unconfirmed.
- **Narrowing the globals-blind loader.** After this change it has no production callers left, which makes `pub(crate)` or deletion attractive — and makes it a cleaner standalone change than a rename touching ~13 sites inside a two-line behaviour fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workflow continuations can resume global-baseline workflows paused at gates or blocked agent nodes.
  - Global workflows disabled through manifest configuration remain respected.
  - Prevented incorrectly resolving a global workflow when a company workflow file claims the same identifier with different content.
  - Prevented resuming a workflow when the parked global or replacement workflow no longer matches the approved content.
  - Existing missing-workflow errors remain unchanged.

- **Documentation**
  - Clarified workflow source resolution and when broader global workflow resolution is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
