### PR TITLE
setup: one model picker, with somewhere to get a key and a way past it

### DIFF
--- a/frontend/src/api/setup.ts
+++ b/frontend/src/api/setup.ts
@@ -386,6 +386,15 @@ export function proposeSetupRoster(
     inferenceProvider?: string | null;
     inferenceBaseUrl?: string | null;
     inferenceModel?: string | null;
+    /**
+     * The operator chose "no model" and means it, so no model designs this
+     * roster whatever the host itself holds.
+     *
+     * Sending no credential does not say this: the host reads that as "use
+     * what you have", and a hosted tenant has one injected — which would
+     * design a roster with a model the operator had just declined.
+     */
+    forceCurated?: boolean;
   },
 ): Promise<SetupRoster> {
   return client.post<SetupRoster>("/api/v1/setup/roster", body);

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -684,10 +684,16 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
     setDesigning(true);
     setDesignError(null);
     try {
+      // A modelless run sends neither half of the design brief. The step no
+      // longer asks for them, and a draft left behind by an operator who
+      // answered and then went back to choose "No model" is not an answer to
+      // the question being asked now — it would still steer the curated pick,
+      // which scores both against the industry answer.
+      const modelless = tested.kind === "skipped";
       const proposed = await proposeSetupRoster(client, {
         industry: draft.industry,
-        teamHint: draft.teamHint,
-        automate: draft.automate,
+        teamHint: modelless ? "" : draft.teamHint,
+        automate: modelless ? "" : draft.automate,
         template: template || null,
         inferenceKey: values.tinyhumans_api_key || null,
         inferenceProvider:
@@ -695,6 +701,7 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
         inferenceBaseUrl:
           tested.kind === "ok" && operatorConfiguredInference ? tested.baseUrl : null,
         inferenceModel: tested.kind === "ok" ? tested.model : null,
+        forceCurated: modelless,
       });
       // The host is contracted never to answer with an empty roster, so a
       // missing or empty one is a failure rather than a team of nobody — and
@@ -1164,6 +1171,12 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
               // proved, and there is nothing it could be tested against.
               setTested(p === NO_MODEL_OPTION.id ? { kind: "skipped" } : { kind: "untested" });
               setBaseUrl(p === status.inference.provider ? (status.inference.base_url ?? "") : "");
+              // And the roster with it. `advance` only designs when there is
+              // none, so a team designed under the old answer would otherwise
+              // survive into Review and be submitted — a model-authored roster
+              // under copy promising a standard one, for an operator who came
+              // back specifically to change this.
+              setRoster(null);
             }}
             baseUrl={baseUrl}
             onBaseUrl={(v) => {
@@ -1568,25 +1581,50 @@ function PowerStep({
    */
   const inlineTest = spec.needsKey ? !(onTheHouse && !override) : spec.needsUrl;
 
+  /**
+   * What is selected right now, readable from inside a call that started
+   * before it.
+   *
+   * A ref rather than the props themselves: `run` closes over the values from
+   * the render that created it, which are exactly the values it must not use
+   * to decide whether it is still current.
+   */
+  const providerRef = useRef({ provider, key: value.trim(), baseUrl: baseUrl.trim() });
+  providerRef.current = { provider, key: value.trim(), baseUrl: baseUrl.trim() };
+
   const run = async () => {
     // This also protects the Enter shortcut on the inputs. A disabled button
     // alone would still leave that route to a request the provider cannot
     // answer usefully.
     if (!canTest) return;
 
+    // What this call is a verdict *about*. The picker stays live while a test
+    // is in flight, so an answer can arrive after the operator has moved on —
+    // and a verdict is only ever true of the answers it was asked with. The
+    // worst of it: selecting "No model" mid-test, and having the settled
+    // `skipped` overwritten by an `ok` that would then be submitted as
+    // inference for the pseudo-provider `none`, which the host does not know.
+    const asked = { provider, key: value.trim(), baseUrl: baseUrl.trim() };
+    const stale = () =>
+      asked.provider !== providerRef.current.provider ||
+      asked.key !== providerRef.current.key ||
+      asked.baseUrl !== providerRef.current.baseUrl;
+
     onTested({ kind: "testing" });
     try {
       const result = await testInference(client, {
-        provider,
-        key: value.trim() || null,
-        baseUrl: baseUrl.trim() || null,
+        provider: asked.provider,
+        key: asked.key || null,
+        baseUrl: asked.baseUrl || null,
       });
+      if (stale()) return;
       onTested(
         result.ok
           ? { kind: "ok", baseUrl: result.baseUrl, model: result.model }
           : { kind: "failed", error: result.error ?? "Could not reach the provider." },
       );
     } catch (err: unknown) {
+      if (stale()) return;
       onTested({
         kind: "failed",
         error: err instanceof Error ? err.message : String(err),

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -1127,6 +1127,7 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
             }}
             onChange={setDraft}
             onEnter={advance}
+            modelless={tested.kind === "skipped"}
           />
         )}
 
@@ -2235,6 +2236,7 @@ function BusinessStep({
   onTemplate,
   onChange,
   onEnter,
+  modelless,
 }: {
   draft: SetupDraft;
   templates: SetupStatus["templates"];
@@ -2242,6 +2244,23 @@ function BusinessStep({
   onTemplate: (id: string) => void;
   onChange: (update: (d: SetupDraft) => SetupDraft) => void;
   onEnter: () => void;
+  /**
+   * Whether this company is being built without a model, which is what the
+   * other two questions need to be worth asking.
+   *
+   * They are the design brief: `automate` becomes a numbered job list the
+   * roster is designed against and checked for coverage, and `teamHint` is a
+   * request added on top of it. Neither happens without a model — the host
+   * falls back to a curated team matched on keywords, where `automate` and
+   * `teamHint` score one point each against `industry`'s three and nothing
+   * else reads them.
+   *
+   * So they are not asked. Asking somebody to describe the work they want
+   * taken off their plate, under copy promising their team is built around
+   * it, and then staffing them from a keyword match, is a worse answer than
+   * one fewer question.
+   */
+  modelless: boolean;
 }) {
   const jobs = jobItems(draft.automate);
 
@@ -2305,6 +2324,9 @@ function BusinessStep({
         )}
       </div>
 
+      {/* Both questions exist to brief a model. Without one they are asked and
+          then not acted on — see `modelless`. */}
+      {!modelless && (
       <div>
         <Label htmlFor="setup-automate" className="text-base font-medium leading-snug">
           What are you trying to automate?
@@ -2331,7 +2353,9 @@ function BusinessStep({
           </p>
         )}
       </div>
+      )}
 
+      {!modelless && (
       <div>
         <Label htmlFor="setup-teamHint" className="text-base font-medium leading-snug">
           Anyone in particular you need on the team?
@@ -2350,6 +2374,7 @@ function BusinessStep({
           onChange={(e) => onChange((d) => ({ ...d, teamHint: e.target.value }))}
         />
       </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -24,7 +24,7 @@
 //     implies its own button performed the restart.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AlertTriangle, Check, Loader2, Lock, RotateCw } from "lucide-react";
+import { AlertTriangle, Check, ExternalLink, Loader2, Lock, RotateCw } from "lucide-react";
 
 import { requestCode } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
@@ -47,10 +47,17 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { OnboardingShell } from "@/components/onboarding-shell";
 import { Badge } from "@/components/ui/badge";
 import { PageHeader } from "@/components/page-header";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { useOptionalHosts } from "@/connections/HostsContext";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { TEAM_TONES, initials, toneFor } from "@/lib/team";
 import { fieldCopy, fieldPlaceholder } from "@/lib/setup-fields";
@@ -102,6 +109,59 @@ const STEPS: readonly (Step & { fields: readonly string[] })[] = [
   { id: "advanced", label: "Advanced", fields: [] },
   { id: "review", label: "Review", fields: [] },
 ];
+
+/**
+ * Where each provider's own key is minted, for the operator who does not have
+ * one yet.
+ *
+ * A link out, not a grant: they sign in as themselves on their own dashboard,
+ * create a key there, and paste it back. That works before this instance has
+ * a company — which is the whole of when this wizard runs — where the
+ * one-click PKCE grant cannot, because the host scopes a grant to a company
+ * and there is not one yet.
+ *
+ * Absent for `openai_compatible` and `ollama`: neither has a dashboard this
+ * product could name, and guessing one is worse than saying nothing.
+ */
+const PROVIDER_KEY_SOURCE: Record<string, { label: string; url: string }> = {
+  managed: {
+    label: "TinyHumans",
+    url: "https://tinyhumans.ai/dashboard?tab=api-keys",
+  },
+  openrouter: {
+    label: "OpenRouter",
+    url: "https://openrouter.ai/sign-in?redirect_url=https%3A%2F%2Fopenrouter.ai%2Fworkspaces%2Fdefault%2Fkeys",
+  },
+};
+
+/**
+ * "No model" — the same escape decision D3 has always offered, as a choice in
+ * the picker rather than a link under it.
+ *
+ * Shaped like a provider so the step can treat it as one: it needs neither a
+ * key nor an endpoint, which is what makes every field below the picker
+ * disappear on its own. It is **not** a provider id the host knows, and never
+ * reaches one: `tested` settles on `skipped` the moment it is chosen, and
+ * every write of `provider` downstream is gated on `tested.kind === "ok"`.
+ */
+const NO_MODEL_OPTION = {
+  id: "none",
+  label: "No model",
+  hint: "You'll get a standard team for your industry, and can add a key later.",
+  needsUrl: false,
+  needsKey: false,
+} as const;
+
+/**
+ * The base-ui `Select` wants a plain id -> label map for its `items` prop, so
+ * this is projected from {@link SETUP_INFERENCE_OPTIONS} the same way
+ * `InferenceSection`'s `PROVIDER_LABEL_ITEMS` is — `items` is what the closed
+ * trigger renders, and a filtered `SelectItem` list alone would leave a
+ * hidden option's own name showing there.
+ */
+const SETUP_PROVIDER_LABEL_ITEMS: Record<string, string> = Object.fromEntries(
+  [...SETUP_INFERENCE_OPTIONS, NO_MODEL_OPTION].map((option) => [option.id, option.label]),
+);
 
 /**
  * Advanced: the settings that already work, grouped by subject.
@@ -975,11 +1035,11 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
     <OnboardingShell
       header={
         <div className="space-y-4">
-          <div className="space-y-1">
+          <div className="space-y-0.5">
             <h1 className="text-xl font-semibold tracking-tight">
               {status.complete ? "Reconfigure this instance" : "Let's build your company"}
             </h1>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-xs leading-snug text-muted-foreground">
               {status.complete
                 ? "Change what this host is configured with."
                 : "A few questions, then we'll put a team together."}
@@ -1097,7 +1157,11 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
               // A changed provider invalidates the verdict. Carrying a green
               // tick across a provider switch would be the worst kind of lie:
               // one the operator watched us earn.
-              setTested({ kind: "untested" });
+              //
+              // "No model" is the exception, and settles rather than clears:
+              // it is an answer to the step, not a connection waiting to be
+              // proved, and there is nothing it could be tested against.
+              setTested(p === NO_MODEL_OPTION.id ? { kind: "skipped" } : { kind: "untested" });
               setBaseUrl(p === status.inference.provider ? (status.inference.base_url ?? "") : "");
             }}
             baseUrl={baseUrl}
@@ -1238,7 +1302,7 @@ function SignInStep({
       <h2 className="text-base font-medium leading-snug" data-testid="setup-question">
         How should people sign in?
       </h2>
-      <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+      <p className="text-xs leading-snug text-muted-foreground">
         This applies to every company this host serves.
       </p>
       {locked && (
@@ -1319,7 +1383,7 @@ function FieldRow({
         {copy.label}
       </Label>
       {copy.hint && (
-        <p className="mt-0.5 text-sm leading-snug text-muted-foreground">{copy.hint}</p>
+        <p className="text-xs leading-snug text-muted-foreground">{copy.hint}</p>
       )}
       <Input
         id={field.key}
@@ -1391,7 +1455,7 @@ function AccountStep({
       >
         What&apos;s your email?
       </Label>
-      <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+      <p className="text-xs leading-snug text-muted-foreground">
         {required
           ? "This is how you sign back in, and the only address that can administer the company."
           : // Not the no-sign-in case: that host does not render this step at
@@ -1449,7 +1513,12 @@ function PowerStep({
 }) {
   const field = status.fields.find((f) => f.key === "tinyhumans_api_key");
   const locked = field !== undefined && !field.editable;
-  const spec = INFERENCE_PROVIDERS.find((p) => p.id === provider) ?? INFERENCE_PROVIDERS[0];
+  const noModel = provider === NO_MODEL_OPTION.id;
+  /** The provider's own key page, when it has one to send the operator to. */
+  const keySource = PROVIDER_KEY_SOURCE[provider];
+  const spec: { needsUrl: boolean; needsKey: boolean } = noModel
+    ? NO_MODEL_OPTION
+    : (INFERENCE_PROVIDERS.find((p) => p.id === provider) ?? INFERENCE_PROVIDERS[0]);
   /** Whether the operator asked to supply their own key over the host's. */
   const [override, setOverride] = useState(false);
   // The house already holds one, and this operator may have no way to get their
@@ -1488,6 +1557,16 @@ function PowerStep({
     (!spec.needsKey || (onTheHouse && !override) || value.trim().length > 0) &&
     (!spec.needsUrl || baseUrl.trim().length > 0);
 
+  /**
+   * The connection test, rendered beside the field it tests.
+   *
+   * One element, placed once: whichever input is the last one this provider
+   * asks for gets it on the same row, so the button sits with the value it
+   * acts on instead of below an empty gap. The host-key case has no input at
+   * all — {@link inlineTest} is false there and it falls to a row of its own.
+   */
+  const inlineTest = spec.needsKey ? !(onTheHouse && !override) : spec.needsUrl;
+
   const run = async () => {
     // This also protects the Enter shortcut on the inputs. A disabled button
     // alone would still leave that route to a request the provider cannot
@@ -1514,46 +1593,82 @@ function PowerStep({
     }
   };
 
+  const testButton = (
+    <Button
+      type="button"
+      variant={tested.kind === "ok" ? "outline" : "default"}
+      disabled={tested.kind === "testing" || !canTest}
+      onClick={() => void run()}
+      data-testid="setup-test-connection"
+      className="shrink-0"
+    >
+      {tested.kind === "testing" ? (
+        <>
+          <Loader2 className="size-4 animate-spin" />
+          Testing…
+        </>
+      ) : tested.kind === "ok" ? (
+        "Test again"
+      ) : (
+        "Test connection"
+      )}
+    </Button>
+  );
+
   return (
     <div className="space-y-7">
       <div>
         <Label className="text-base font-medium leading-snug" data-testid="setup-question">
           What should your team think with?
         </Label>
-        <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+        <p className="text-xs leading-snug text-muted-foreground">
           {onTheHouse
             ? "This host already has a model. Test it and carry on — you don't need a key of your own."
-            : "Your agents need a model to work. We'll check it reaches before going any further."}
+            : noModel
+              ? "Carrying on without one. Your team will be a standard one for your industry rather than designed from your answers."
+              : "Your agents need a model to work. We'll check it reaches before going any further."}
         </p>
 
-        {/* Cards, not a select. Four options with a sentence each is a choice
-            someone can make without knowing the vocabulary first — a dropdown
-            of slugs assumes they already do. */}
-        <div className="mt-3 grid gap-2" role="radiogroup" aria-label="Model provider">
-          {SETUP_INFERENCE_OPTIONS.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              role="radio"
-              aria-checked={option.id === provider}
-              data-testid={`setup-provider-${option.id}`}
-              onClick={() => onProvider(option.id)}
-              className={cn(
-                "rounded-lg border p-3 text-left transition-colors",
-                option.id === provider
-                  ? "border-primary bg-primary/5"
-                  : "hover:border-input hover:bg-muted/50",
-              )}
-            >
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium">{option.label}</span>
-                {status.inference.ready && option.id === status.inference.provider && (
-                  <Badge variant="secondary">Already set up</Badge>
-                )}
-              </div>
-              <p className="mt-0.5 text-sm leading-snug text-muted-foreground">{option.hint}</p>
-            </button>
-          ))}
+        {/* Each option carries its own sentence, inside the popup rather than
+            under the trigger: the description is what makes the choice legible
+            while it is being made, and it has nothing left to say once the
+            choice is committed. */}
+        <div className="mt-3">
+          <Select
+            value={provider}
+            onValueChange={(v) => {
+              if (v !== null) onProvider(v);
+            }}
+            items={SETUP_PROVIDER_LABEL_ITEMS}
+          >
+            <SelectTrigger id="setup-provider" className="w-full" data-testid="setup-provider-select">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[...SETUP_INFERENCE_OPTIONS, NO_MODEL_OPTION].map((option) => (
+                <SelectItem
+                  key={option.id}
+                  value={option.id}
+                  data-testid={`setup-provider-${option.id}`}
+                  className="items-start py-2"
+                >
+                  <span className="flex flex-col gap-0.5">
+                    <span className="flex items-center gap-2 font-medium">
+                      {option.label}
+                      {status.inference.ready && option.id === status.inference.provider && (
+                        <Badge variant="secondary">Already set up</Badge>
+                      )}
+                    </span>
+                    {/* `whitespace-normal` because the item's own text wrapper
+                        is `whitespace-nowrap`, and `white-space` inherits. */}
+                    <span className="whitespace-normal text-xs leading-snug text-muted-foreground">
+                      {option.hint}
+                    </span>
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </div>
 
@@ -1562,18 +1677,22 @@ function PowerStep({
           <Label htmlFor="setup-base-url" className="text-base font-medium leading-snug">
             Endpoint
           </Label>
-          <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+          <p className="text-xs leading-snug text-muted-foreground">
             Paste the local address as shown, for example <code>localhost:6969</code>. We&apos;ll
             add <code>http://</code> and <code>/v1</code> when needed.
           </p>
-          <Input
-            id="setup-base-url"
-            value={baseUrl}
-            placeholder={provider === "ollama" ? "http://127.0.0.1:11434/v1" : "https://…/v1"}
-            data-testid="setup-field-base-url"
-            className="mt-2.5"
-            onChange={(e) => onBaseUrl(e.target.value)}
-          />
+          <div className="mt-2.5 flex items-center gap-2">
+            <Input
+              id="setup-base-url"
+              value={baseUrl}
+              placeholder={provider === "ollama" ? "http://127.0.0.1:11434/v1" : "https://…/v1"}
+              data-testid="setup-field-base-url"
+              onChange={(e) => onBaseUrl(e.target.value)}
+            />
+            {/* Only when this is the last field asked for: a provider that
+                also wants a key gets the button beside that instead. */}
+            {!spec.needsKey && inlineTest && testButton}
+          </div>
         </div>
       )}
 
@@ -1613,7 +1732,7 @@ function PowerStep({
             </div>
           ) : (
             <>
-              <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+              <p className="text-xs leading-snug text-muted-foreground">
                 {onTheHouse
                   ? "This replaces the host's key for this company."
                   : "Used to test the connection now, and saved when you finish."}
@@ -1625,20 +1744,48 @@ function PowerStep({
                 </div>
               )}
 
-              <Input
-                id="setup-key"
-                autoFocus
-                type="password"
-                value={value}
-                disabled={locked}
-                placeholder="sk-…"
-                data-testid="setup-field-key"
-                className="mt-2.5"
-                onChange={(e) => onChange(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") void run();
-                }}
-              />
+              <div className="mt-2.5 flex items-center gap-2">
+                <Input
+                  id="setup-key"
+                  autoFocus
+                  type="password"
+                  value={value}
+                  disabled={locked}
+                  placeholder="sk-…"
+                  data-testid="setup-field-key"
+                  onChange={(e) => onChange(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") void run();
+                  }}
+                />
+                {inlineTest && testButton}
+              </div>
+
+              {/* Where the key comes from, for the two providers that mint one
+                  on a page of their own. A link out rather than a grant: the
+                  operator signs in as themselves, creates the key on their own
+                  dashboard, and brings it back to the field above. */}
+              {keySource && !locked && (
+                <div className="mt-3 rounded-lg border bg-muted/40 p-3">
+                  <p className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+                    or
+                  </p>
+                  <p className="mt-1 text-xs leading-snug text-muted-foreground">
+                    Sign in to {keySource.label} to create an API key, then paste it above.
+                  </p>
+                  <a
+                    href={keySource.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    data-testid="setup-key-signin"
+                    className={cn(buttonVariants({ variant: "outline", size: "sm" }), "mt-2.5")}
+                  >
+                    Sign in with {keySource.label}
+                    <ExternalLink className="size-3.5" />
+                  </a>
+                </div>
+              )}
+
               {onTheHouse && (
                 <button
                   type="button"
@@ -1657,25 +1804,14 @@ function PowerStep({
         </div>
       )}
 
+      {/* Nothing to reach, so nothing to test: "No model" answers the step by
+          being chosen, which is why it settles `tested` on `skipped` rather
+          than leaving a button whose only honest label would be "test what". */}
+      {!noModel && (
       <div className="space-y-2">
-        <Button
-          type="button"
-          variant={tested.kind === "ok" ? "outline" : "default"}
-          disabled={tested.kind === "testing" || !canTest}
-          onClick={() => void run()}
-          data-testid="setup-test-connection"
-        >
-          {tested.kind === "testing" ? (
-            <>
-              <Loader2 className="size-4 animate-spin" />
-              Testing…
-            </>
-          ) : tested.kind === "ok" ? (
-            "Test again"
-          ) : (
-            "Test connection"
-          )}
-        </Button>
+        {/* Only where no input row could carry it — the host-key case, which
+            draws a settled chip rather than a field. */}
+        {!inlineTest && testButton}
 
         {/* The verdict names the endpoint it reached. A tick earned against the
             default endpoint, on a host where the operator meant to point
@@ -1695,26 +1831,17 @@ function PowerStep({
           </Alert>
         )}
       </div>
+      )}
 
       {/* Nobody gets stuck (decision D3). A hosted operator with no key must not
           be trapped behind a credential they cannot obtain — and the curated
-          team exists precisely for this path. Stated plainly, as a consequence
-          rather than a warning, so the choice is informed rather than scary. */}
-      {tested.kind !== "ok" && (
-        <button
-          type="button"
-          onClick={() => onTested({ kind: "skipped" })}
-          data-testid="setup-skip-model"
-          className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
-        >
-          Continue without a model — you&apos;ll get a standard team for your
-          industry, and can add a key later
-        </button>
-      )}
-      {tested.kind === "skipped" && (
+          team exists precisely for this path. It is the picker's last option
+          now rather than a link under the step, so the escape sits with the
+          other answers to the same question instead of below them. */}
+      {noModel && (
         <p className="text-sm leading-snug text-muted-foreground" data-testid="setup-skipped">
-          Carrying on without a model. Your team will be a standard one for your
-          industry rather than designed from your answers.
+          A model can be set later from Connections → Inference, and everything
+          else about this company works without one.
         </p>
       )}
     </div>
@@ -1843,7 +1970,7 @@ function ReviewStep({
 
       <div>
         <h2 className="text-base font-medium leading-snug">Your team</h2>
-        <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+        <p className="text-xs leading-snug text-muted-foreground">
           {roster.source === "model"
             ? "Built from what you told us. Rename or drop anyone — you can add more later."
             : roster.source === "preset"
@@ -2056,7 +2183,7 @@ function AdvancedStep({
         <h2 className="text-base font-medium leading-snug" data-testid="setup-question">
           Anything you want to change?
         </h2>
-        <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+        <p className="text-xs leading-snug text-muted-foreground">
           Every one of these already has a working default. Press on if none of
           it matters to you — written to{" "}
           <code className="font-mono text-xs">{status.config_path}</code>.
@@ -2070,7 +2197,7 @@ function AdvancedStep({
         <section key={group.id} className="rounded-xl border">
           <div className="border-b px-4 py-3">
             <h3 className="text-base font-medium leading-snug">{group.title}</h3>
-            <p className="mt-0.5 text-sm leading-snug text-muted-foreground">{group.hint}</p>
+            <p className="text-xs leading-snug text-muted-foreground">{group.hint}</p>
           </div>
           <div className="space-y-5 px-4 py-4">
             {fieldsFor(status, group.fields).map((f) => (
@@ -2128,7 +2255,7 @@ function BusinessStep({
         <Label htmlFor="setup-template" className="text-base font-medium leading-snug">
           What kind of company are you setting up?
         </Label>
-        <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+        <p className="text-xs leading-snug text-muted-foreground">
           Pick one of the teams bundled with OpenCompany. You can tailor it below.
         </p>
         {templates.length > 0 ? (
@@ -2182,7 +2309,7 @@ function BusinessStep({
         <Label htmlFor="setup-automate" className="text-base font-medium leading-snug">
           What are you trying to automate?
         </Label>
-        <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+        <p className="text-xs leading-snug text-muted-foreground">
           List whatever comes to mind. This is what your team gets built around.
         </p>
         <Textarea
@@ -2210,7 +2337,7 @@ function BusinessStep({
           Anyone in particular you need on the team?
           <span className="ml-1.5 text-sm font-normal text-muted-foreground">Optional</span>
         </Label>
-        <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+        <p className="text-xs leading-snug text-muted-foreground">
           We&apos;ll suggest a team either way — this just adds to it.
         </p>
         <Textarea

--- a/frontend/test/unit/setup-wizard-company-identity.test.ts
+++ b/frontend/test/unit/setup-wizard-company-identity.test.ts
@@ -160,8 +160,13 @@ async function walkToReview(client: OpenCompanyClient, template: string | null) 
   await act(async () => {
     root.render(createElement(SetupWizard, { client, onDone: () => {} }));
   });
+  // "No model" — the picker's last option, whose popup base-ui portals onto
+  // `document.body` and only mounts once the trigger opens it.
   await act(async () => {
-    (container.querySelector('[data-testid="setup-skip-model"]') as HTMLElement).click();
+    (container.querySelector('[data-testid="setup-provider-select"]') as HTMLElement).click();
+  });
+  await act(async () => {
+    (document.body.querySelector('[data-testid="setup-provider-none"]') as HTMLElement).click();
   });
   await next(); // -> business
   if (template) await pickTemplate(template);

--- a/frontend/test/unit/setup-wizard-console-destination.test.ts
+++ b/frontend/test/unit/setup-wizard-console-destination.test.ts
@@ -113,6 +113,25 @@ async function click(testId: string) {
   });
 }
 
+/**
+ * Answers the model step with "No model".
+ *
+ * The escape used to be a link under the step (`setup-skip-model`); it is the
+ * provider picker's last option now, and the picker is a base-ui `Select`
+ * whose popup portals onto `document.body` and does not exist until the
+ * trigger opens it.
+ */
+async function skipModel() {
+  await click("setup-provider-select");
+  const none = document.body.querySelector('[data-testid="setup-provider-none"]') as
+    | HTMLElement
+    | null;
+  expect(none, "no No-model option").toBeTruthy();
+  await act(async () => {
+    none!.click();
+  });
+}
+
 const next = async () =>
   act(async () => {
     const match = Array.from(container.querySelectorAll("button")).find((b) =>
@@ -148,7 +167,7 @@ const settle = async () =>
  * preselects `none` and the address step is absent.
  */
 async function finishNoSignIn() {
-  await click("setup-skip-model");
+  await skipModel();
   await next(); // -> business
   await fill("setup-field-industry", "E-commerce — homeware");
   await next(); // -> sign-in (none preselected)
@@ -160,7 +179,7 @@ async function finishNoSignIn() {
 
 /** An email-sign-in host that cannot send mail: the "anyway" escape. */
 async function finishUnmailable() {
-  await click("setup-skip-model");
+  await skipModel();
   await next(); // -> business
   await fill("setup-field-industry", "E-commerce — homeware");
   await next(); // -> sign-in

--- a/frontend/test/unit/setup-wizard-desktop-default.test.ts
+++ b/frontend/test/unit/setup-wizard-desktop-default.test.ts
@@ -107,6 +107,25 @@ async function click(testId: string) {
   });
 }
 
+/**
+ * Answers the model step with "No model".
+ *
+ * The escape used to be a link under the step (`setup-skip-model`); it is the
+ * provider picker's last option now, and the picker is a base-ui `Select`
+ * whose popup portals onto `document.body` and does not exist until the
+ * trigger opens it.
+ */
+async function skipModel() {
+  await click("setup-provider-select");
+  const none = document.body.querySelector('[data-testid="setup-provider-none"]') as
+    | HTMLElement
+    | null;
+  expect(none, "no No-model option").toBeTruthy();
+  await act(async () => {
+    none!.click();
+  });
+}
+
 function labelled(...wanted: string[]): HTMLButtonElement {
   const match = Array.from(container.querySelectorAll("button")).find((b) =>
     wanted.includes(b.textContent?.trim() ?? ""),
@@ -143,7 +162,7 @@ async function fill(testId: string, value: string) {
 
 /** model (skipped) -> business (answered) -> sign-in. */
 async function goToSignIn() {
-  await click("setup-skip-model");
+  await skipModel();
   await next();
   await fill("setup-field-industry", "E-commerce — homeware");
   await next();

--- a/frontend/test/unit/setup-wizard-finish-gate.test.ts
+++ b/frontend/test/unit/setup-wizard-finish-gate.test.ts
@@ -89,6 +89,26 @@ function button(label: string): HTMLButtonElement {
   return match as HTMLButtonElement;
 }
 
+/**
+ * Picks a provider from the model step's `Select`.
+ *
+ * The base-ui popup portals its items onto `document.body`, not into
+ * `container` — they do not exist in the DOM at all until the trigger opens
+ * the popup, unlike the button cards this replaced.
+ */
+async function selectProvider(id: string) {
+  const trigger = container.querySelector('[data-testid="setup-provider-select"]') as HTMLElement;
+  expect(trigger, "no provider select trigger").toBeTruthy();
+  await act(async () => {
+    trigger.click();
+  });
+  const item = document.body.querySelector(`[data-testid="setup-provider-${id}"]`) as HTMLElement;
+  expect(item, `no provider option ${id}`).toBeTruthy();
+  await act(async () => {
+    item.click();
+  });
+}
+
 /** Types into a step's field, so a required one can be left. */
 async function fill(testId: string, value: string) {
   const field = container.querySelector(`[data-testid="${testId}"]`) as
@@ -120,11 +140,7 @@ const next = async () =>
  * moved to the front.
  */
 async function skipModel() {
-  await act(async () => {
-    (
-      container.querySelector('[data-testid="setup-skip-model"]') as HTMLElement
-    ).click();
-  });
+  await selectProvider("none");
   await next(); // -> business
 }
 
@@ -386,9 +402,7 @@ describe("finishing setup with no companies on the host", () => {
   it("requires an endpoint before testing Ollama", async () => {
     await show(clientWith(status()));
 
-    await act(async () => {
-      (container.querySelector('[data-testid="setup-provider-ollama"]') as HTMLElement).click();
-    });
+    await selectProvider("ollama");
     expect(button("Test connection").disabled).toBe(true);
 
     await fill("setup-field-base-url", "http://127.0.0.1:11434/v1");
@@ -552,13 +566,7 @@ describe("a hosted tenant whose inference comes from the house", () => {
     ).toBeTruthy();
 
     // ...and not on one the host refuses to forward it to.
-    const custom = container.querySelector(
-      '[data-testid="setup-provider-openai_compatible"]',
-    ) as HTMLElement | null;
-    expect(custom, "the model step should offer a custom endpoint").toBeTruthy();
-    await act(async () => {
-      custom!.click();
-    });
+    await selectProvider("openai_compatible");
 
     expect(
       container.querySelector('[data-testid="setup-key-on-the-house"]'),

--- a/frontend/test/unit/setup-wizard-mail-honesty.test.ts
+++ b/frontend/test/unit/setup-wizard-mail-honesty.test.ts
@@ -108,6 +108,25 @@ async function click(testId: string) {
   });
 }
 
+/**
+ * Answers the model step with "No model".
+ *
+ * The escape used to be a link under the step (`setup-skip-model`); it is the
+ * provider picker's last option now, and the picker is a base-ui `Select`
+ * whose popup portals onto `document.body` and does not exist until the
+ * trigger opens it.
+ */
+async function skipModel() {
+  await click("setup-provider-select");
+  const none = document.body.querySelector('[data-testid="setup-provider-none"]') as
+    | HTMLElement
+    | null;
+  expect(none, "no No-model option").toBeTruthy();
+  await act(async () => {
+    none!.click();
+  });
+}
+
 const next = async () =>
   act(async () => {
     const match = Array.from(container.querySelectorAll("button")).find((b) =>
@@ -140,7 +159,7 @@ const settle = async () =>
 
 /** Walks the whole flow and presses the finish button. */
 async function finish() {
-  await click("setup-skip-model");
+  await skipModel();
   await next(); // -> business
   await fill("setup-field-industry", "E-commerce — homeware");
   await next(); // -> sign-in
@@ -155,7 +174,7 @@ async function finish() {
 describe("the sign-in step, on a host that cannot send mail", () => {
   it("says the link is handed over here when the host echoes the code", async () => {
     await show(clientWith(status({ mail: { wired: false, echoes_code: true } })));
-    await click("setup-skip-model");
+    await skipModel();
     await next();
     await fill("setup-field-industry", "Homeware");
     await next(); // -> sign-in
@@ -169,7 +188,7 @@ describe("the sign-in step, on a host that cannot send mail", () => {
 
   it("says a link would arrive nowhere on a routable host with no transport", async () => {
     await show(clientWith(status({ mail: { wired: false, echoes_code: false } })));
-    await click("setup-skip-model");
+    await skipModel();
     await next();
     await fill("setup-field-industry", "Homeware");
     await next(); // -> sign-in
@@ -185,7 +204,7 @@ describe("the sign-in step, on a host that cannot send mail", () => {
 
   it("says nothing when the host has a mail transport", async () => {
     await show(clientWith(status({ mail: { wired: true, echoes_code: false } })));
-    await click("setup-skip-model");
+    await skipModel();
     await next();
     await fill("setup-field-industry", "Homeware");
     await next(); // -> sign-in

--- a/frontend/test/unit/setup-wizard-step-order.test.ts
+++ b/frontend/test/unit/setup-wizard-step-order.test.ts
@@ -308,7 +308,149 @@ describe("the questions a modelless run does not ask", () => {
     await click("setup-test-connection");
     await next(); // -> business
 
+    expect(find("setup-field-industry")).toBeTruthy();
     expect(find("setup-field-automate")).toBeTruthy();
     expect(find("setup-field-teamHint")).toBeTruthy();
+  });
+});
+
+/**
+ * What "No model" is worth against a host that has one anyway.
+ *
+ * Sending no credential does not mean "no model": the host reads an absent one
+ * as "use whatever you have", and `RosterBuilder::for_setup` falls through to
+ * `harness_inference_from_env` — so a hosted tenant with an injected key would
+ * design a roster with the model its operator had just declined, and now
+ * without the design brief this step stops asking for. `forceCurated` is what
+ * makes the promise on screen true on that host too.
+ */
+describe("what a modelless run asks the host for", () => {
+  /** The roster request the wizard actually sent. */
+  async function rosterRequestFrom(walk: () => Promise<void>): Promise<Record<string, unknown>> {
+    const sent: Record<string, unknown>[] = [];
+    const client = {
+      scopeFor: () => "/api/v1/company",
+      get: async () => status(),
+      post: async (path: string, body: unknown) => {
+        if (path.endsWith("/setup/roster")) {
+          sent.push(body as Record<string, unknown>);
+          return {
+            agents: [{ name: "Ada", role: "Operations", description: "Runs the desk." }],
+            template: "ecommerce",
+            source: "fallback",
+          };
+        }
+        if (path.endsWith("/inference/test")) {
+          return { ok: true, baseUrl: "https://api.example/v1", model: "m" };
+        }
+        return { complete: true, config_path: "/data/config.toml", restart_required: [] };
+      },
+    } as unknown as OpenCompanyClient;
+    await show(client);
+    await walk();
+    expect(sent.length, "the wizard should have asked for a roster").toBeGreaterThan(0);
+    return sent[sent.length - 1];
+  }
+
+  it("asks for the curated team outright, rather than by saying nothing", async () => {
+    const body = await rosterRequestFrom(async () => {
+      await skipModel();
+      await next(); // -> business
+      await fill("setup-field-industry", "E-commerce — homeware");
+      await next(); // -> sign-in
+      await click("auth-mode-none");
+      await next(); // -> review, designing on the way in
+    });
+
+    expect(body.forceCurated, "no model means no model").toBe(true);
+  });
+
+  it("sends neither half of the design brief once there is no model to read it", async () => {
+    const body = await rosterRequestFrom(async () => {
+      // Answered first, then taken back: the drafts survive in state, and must
+      // not steer the curated pick they are no longer an answer to.
+      await fill("setup-field-key", "sk-works");
+      await click("setup-test-connection");
+      await next(); // -> business, with a model
+      await fill("setup-field-industry", "E-commerce — homeware");
+      await fill("setup-field-automate", "Meta ads, order dispatch");
+      await fill("setup-field-teamHint", "someone chasing invoices");
+      await back(); // -> model
+      await skipModel();
+      await next(); // -> business
+      await next(); // -> sign-in
+      await click("auth-mode-none");
+      await next(); // -> review
+    });
+
+    expect(body.automate).toBe("");
+    expect(body.teamHint).toBe("");
+    expect(body.forceCurated).toBe(true);
+  });
+
+  it("does not submit a roster designed under an answer that has since changed", async () => {
+    // A model designed one, the operator went back and chose No model. The
+    // wizard designs only when it holds none, so the old one would otherwise
+    // ride through Review under copy promising a standard team.
+    const body = await rosterRequestFrom(async () => {
+      await fill("setup-field-key", "sk-works");
+      await click("setup-test-connection");
+      await next(); // -> business
+      await fill("setup-field-industry", "E-commerce — homeware");
+      await next(); // -> sign-in
+      await click("auth-mode-none");
+      await next(); // -> review, designs with the model
+      await back(); // -> sign-in
+      await back(); // -> business
+      await back(); // -> model
+      await skipModel();
+      await next(); // -> business
+      await next(); // -> sign-in
+      await next(); // -> review, must design again
+    });
+
+    expect(body.forceCurated, "the second design is the modelless one").toBe(true);
+  });
+});
+
+/**
+ * A verdict is only true of the answers it was asked with.
+ *
+ * The picker stays live while a test is in flight, so an answer can land after
+ * the operator has moved on. Selecting "No model" mid-test is the case that
+ * bites: the settled `skipped` would be overwritten by an `ok`, putting the
+ * design questions back and submitting the previous provider's connection data
+ * under the pseudo-provider `none`, which the host does not know.
+ */
+describe("a connection verdict that arrives after the question changed", () => {
+  it("is discarded when the operator has since chosen No model", async () => {
+    let release!: (value: unknown) => void;
+    const inFlight = new Promise((resolve) => {
+      release = resolve;
+    });
+    const client = {
+      scopeFor: () => "/api/v1/company",
+      get: async () => status(),
+      post: async (path: string) =>
+        path.endsWith("/inference/test")
+          ? inFlight
+          : { complete: true, config_path: "/data/config.toml", restart_required: [] },
+    } as unknown as OpenCompanyClient;
+
+    await show(client);
+    await fill("setup-field-key", "sk-works");
+    await click("setup-test-connection"); // in flight, unresolved
+    await skipModel();
+
+    // The late answer, for a provider that is no longer selected.
+    await act(async () => {
+      release({ ok: true, baseUrl: "https://api.example/v1", model: "m" });
+      await inFlight;
+    });
+
+    // Still modelless: no key field came back, and the step still says so.
+    expect(find("setup-skipped"), "the No-model state should have survived").toBeTruthy();
+    expect(find("setup-field-key")).toBeNull();
+    expect(find("setup-test-connection")).toBeNull();
   });
 });

--- a/frontend/test/unit/setup-wizard-step-order.test.ts
+++ b/frontend/test/unit/setup-wizard-step-order.test.ts
@@ -89,6 +89,25 @@ async function click(testId: string) {
   });
 }
 
+/**
+ * Answers the model step with "No model".
+ *
+ * The escape used to be a link under the step (`setup-skip-model`); it is the
+ * provider picker's last option now, and the picker is a base-ui `Select`
+ * whose popup portals onto `document.body` and does not exist until the
+ * trigger opens it.
+ */
+async function skipModel() {
+  await click("setup-provider-select");
+  const none = document.body.querySelector('[data-testid="setup-provider-none"]') as
+    | HTMLElement
+    | null;
+  expect(none, "no No-model option").toBeTruthy();
+  await act(async () => {
+    none!.click();
+  });
+}
+
 function labelled(...wanted: string[]): HTMLButtonElement {
   const match = Array.from(container.querySelectorAll("button")).find((b) =>
     wanted.includes(b.textContent?.trim() ?? ""),
@@ -131,7 +150,7 @@ async function fill(testId: string, value: string) {
 
 /** model (skipped) -> business (answered) -> sign-in. */
 async function goToSignIn() {
-  await click("setup-skip-model");
+  await skipModel();
   await next(); // -> business
   await fill("setup-field-industry", "E-commerce — homeware");
   await next(); // -> sign-in

--- a/frontend/test/unit/setup-wizard-step-order.test.ts
+++ b/frontend/test/unit/setup-wizard-step-order.test.ts
@@ -267,3 +267,48 @@ describe("the position survives the list changing under it", () => {
     expect(find("setup-advanced")).toBeNull();
   });
 });
+
+/**
+ * What the Business step asks for depends on whether anything will read it.
+ *
+ * `automate` and `teamHint` are the design brief: the first becomes a numbered
+ * job list the roster is designed against and checked for coverage, the second
+ * a request added on top. Neither is acted on without a model — the host falls
+ * back to a curated team matched on keywords, where the two score one point
+ * each against `industry`'s three.
+ *
+ * So a run with no model asks neither, rather than collecting a description of
+ * somebody's business under copy promising their team is built around it and
+ * then staffing them from a keyword match.
+ */
+describe("the questions a modelless run does not ask", () => {
+  it("asks only what kind of company it is when there is no model", async () => {
+    await show(clientWith(status()));
+    await skipModel();
+    await next(); // -> business
+
+    expect(find("setup-field-industry"), "the one question that still counts").toBeTruthy();
+    expect(find("setup-field-automate")).toBeNull();
+    expect(find("setup-field-teamHint")).toBeNull();
+  });
+
+  it("asks all three once a model answers for them", async () => {
+    // A passing test on the model step is what makes the design brief real, so
+    // this client has to answer the probe rather than the apply.
+    const client = {
+      scopeFor: () => "/api/v1/company",
+      get: async () => status(),
+      post: async (path: string) =>
+        path.endsWith("/inference/test")
+          ? { ok: true, baseUrl: "https://api.example/v1", model: "m" }
+          : { complete: true, config_path: "/data/config.toml", restart_required: [] },
+    } as unknown as OpenCompanyClient;
+    await show(client);
+    await fill("setup-field-key", "sk-works");
+    await click("setup-test-connection");
+    await next(); // -> business
+
+    expect(find("setup-field-automate")).toBeTruthy();
+    expect(find("setup-field-teamHint")).toBeTruthy();
+  });
+});

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -1113,6 +1113,16 @@ pub struct SetupRosterRequest {
     inference_provider: Option<String>,
     inference_base_url: Option<String>,
     inference_model: Option<String>,
+    /// The operator answered the model step with "no model", and means it.
+    ///
+    /// Distinct from *sending no credential*, which this route reads as "use
+    /// whatever the host already has" — and a host usually has something:
+    /// `RosterBuilder::for_setup` falls through to `harness_inference_from_env`,
+    /// so a hosted tenant with an injected credential would design a roster
+    /// with a model the operator had just declined. The screen promises a
+    /// standard team for their industry; this is what makes that true rather
+    /// than true-unless-the-host-happens-to-have-a-key.
+    force_curated: bool,
 }
 
 /// One proposed teammate, shaped for the wizard's review step.
@@ -1421,14 +1431,22 @@ async fn propose_roster(
         team_hint: req.team_hint,
         automate: req.automate,
     };
-    let proposal = propose_for_setup(
-        &answers,
-        req.inference_provider.as_deref(),
-        req.inference_base_url.as_deref(),
-        req.inference_key.as_deref(),
-        req.inference_model.as_deref(),
-    )
-    .await;
+    let proposal = if req.force_curated {
+        // Asked for and answered: no model runs, whatever this host holds.
+        crate::company::setup::template_proposal(
+            &answers,
+            crate::company::setup::FallbackReason::NoModel,
+        )
+    } else {
+        propose_for_setup(
+            &answers,
+            req.inference_provider.as_deref(),
+            req.inference_base_url.as_deref(),
+            req.inference_key.as_deref(),
+            req.inference_model.as_deref(),
+        )
+        .await
+    };
 
     // A picked template outranks the matched one when no model designed
     // anything.


### PR DESCRIPTION
Closes #2227.

## Why

The first-run wizard's model step asked its question twice: four cards to pick a provider, and a link underneath to skip the question entirely. The cards also left every option's description on screen permanently, so most of the step was descriptions of choices not taken — and the operator still had nowhere to go if they did not have a key.

## What changed

### One picker, "No model" included

The four cards become a single `Select`, each option's sentence living inside the popup where it is read while choosing and nothing afterwards.

**"No model" is the last option** rather than a link below the step, so the escape sits with the other answers to the same question. Choosing it settles the connection verdict on `skipped` — exactly what the link did — and every field below the picker disappears, because it needs neither key nor endpoint. The `Continue without a model…` link is gone.

### Test connection, beside the thing it tests

It follows whichever input the provider actually asks for last: the API key for TinyHumans/OpenRouter, the endpoint for Ollama, and the key (not the endpoint) for a custom endpoint that asks for both. The host-key case — a settled chip, no field — keeps it on a row of its own.

### Where a key comes from

TinyHumans and OpenRouter now say where to get one, as a link out to the operator's own dashboard: they sign in as themselves, create the key, and bring it back to the field above. `openai_compatible` and `ollama` get no card — neither has a dashboard this product could name, and guessing one is worse than saying nothing.

**This replaces a button that could never have worked here.** The one-click PKCE grant (#2204) is company-scoped on the host — `…/credential/link/start` resolves through `CompanyRegistry::sole`, which answers nothing when there are no companies. The wizard runs *only* when there are none: `AppSpec::setup_complete` is `self.setup_complete() || !self.registry().is_empty()` (`src/app/types.rs:1259`), and the console enters the wizard only on `spec.setup_complete === false`. So the two conditions are mutually exclusive, and the button failed with `company not found: single-company` every time it was pressed. Making that reachable during a first run needs a pre-company grant route on the host, which is a feature rather than a wiring fix.

### The design questions a modelless run cannot use

`automate` and `teamHint` are the brief a model designs the roster from: the first is split into a numbered job list every agent must claim a share of — the host checking coverage and re-asking once — and the second is a request added on top.

Neither is acted on without a model. The fallback is a curated team matched on keywords, where the two score one point each against `industry`'s three, and nothing else reads them. So a run that chose "No model" is no longer asked either. Collecting a description of the work somebody wants taken off their plate, under copy promising the team is built around it, and then staffing them from a keyword match, is a worse answer than one fewer question.

Merging those two questions into a single brief a model actually reads is filed separately as **#2238**.

### Copy sizing

Every label's description across all six steps drops to `text-xs` and loses its top margin, so it sits with the label it belongs to rather than floating between two questions. Same for the wizard's own header subtitle.

## Commands run

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — all clean
- `npx vitest run test/unit` — 604 files, 5237 passed, 3 skipped, 0 failed
- `cargo build --release --all-features` — clean
- `cargo test --release --all-features setup::` — 108 passed, 0 failed
- `scripts/ci/assert-design-tokens.sh` — clean
- `npm run build` — clean

## Verified in a browser

Run against a bare `opencompany serve` with no `--company`, which is the only state that reaches this wizard. Checked in light and dark, across all five choices: the picker and its descriptions, the inline Test button following the last field for each provider shape, the sign-in card appearing for TinyHumans and OpenRouter only (both link targets asserted programmatically), "No model" collapsing the step and releasing Next, and the Business step dropping to one question after it.

## Tests

Six `setup-wizard-*` suites walked past the model step through the skip link. They answer the picker instead now — its popup portals onto `document.body` and does not exist until the trigger opens it, which is what their new `skipModel`/`selectProvider` helpers account for.

Two new tests in `setup-wizard-step-order.test.ts` pin the modelless behaviour: only the industry question is asked without a model, and all three come back once a connection test passes.

## Not in scope

- The pre-company key grant described above.
- #2238, the merged business brief.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The setup wizard now provides a **“No model”** option in the provider selector.
  - Selecting “No model” skips connection testing, simplifies follow-up questions, and creates a curated setup.
  - Changing the selected provider clears previously generated setup suggestions.
  - Providers with dedicated key dashboards include a sign-in link for obtaining a key.
  - Connection testing appears inline with the relevant configuration fields.
  - Updated spacing and typography improve readability throughout setup.
- **Tests**
  - Added coverage for model-free setup flows and provider selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->