### PR TITLE
fix(metering): refuse a cost sample a daily cap cannot be judged against

### DIFF
--- a/src/metering/daily_budget.rs
+++ b/src/metering/daily_budget.rs
@@ -71,8 +71,29 @@ pub fn usd_spent_by_agent(samples: &[UsageSample], agent: &str) -> f64 {
     samples
         .iter()
         .filter(|sample| sample.agent == agent)
-        .map(|sample| sample.cost_usd)
+        .filter_map(|sample| {
+            let counted = spend_contribution(sample.cost_usd);
+            if counted.is_none() {
+                tracing::warn!(
+                    agent,
+                    cost_usd = sample.cost_usd,
+                    "[usage] a cost sample that is negative or not finite was left out of the \
+                     daily spend sum; a cap cannot be judged against it"
+                );
+            }
+            counted
+        })
         .fold(0.0, |total, cost| total + cost)
+}
+
+/// `cost` when it can be added to a spend total, `None` when it cannot.
+///
+/// A cap is a floor under how much a teammate may spend, so a sample that would
+/// lower the total (negative) or erase it (`NaN` poisons every later `+`, and an
+/// infinity saturates it) is not a cheaper turn — it is a malformed sample, and
+/// folding it in would let one bad row lift a teammate over their cap unnoticed.
+fn spend_contribution(cost: f64) -> Option<f64> {
+    (cost.is_finite() && cost >= 0.0).then_some(cost)
 }
 
 /// The epoch-millis start (`00:00Z`) of the UTC calendar day `now` falls in —
@@ -211,12 +232,10 @@ mod tests {
         assert_eq!(utc_day_start_millis(midnight), midnight);
     }
 
-    /// `usd_spent_by_agent` has no validation seam: a negative `cost_usd` folds
-    /// straight into the total instead of being rejected, so one bad sample
-    /// silently lowers a teammate's measured spend below what it actually
-    /// spent.
+    /// A negative `cost_usd` must not fold into the total: one such sample would
+    /// lower a teammate's measured spend below what they actually spent, and a
+    /// cap judged against it lets them keep spending.
     #[test]
-    #[ignore = "finding MET-001: usd_spent_by_agent has no validation seam; a negative cost_usd sample lowers measured spend instead of being rejected or clamped"]
     fn a_negative_cost_sample_does_not_lower_measured_spend() {
         let samples = vec![
             sample("analyst", 5.0, SampleKind::Inference),
@@ -229,11 +248,10 @@ mod tests {
         );
     }
 
-    /// Same seam, the non-finite case: `NaN` propagates through `+` and poisons
-    /// every later sum it touches (`x + NaN == NaN`), so one malformed sample
-    /// would erase an agent's whole daily total rather than being rejected.
+    /// The non-finite case: `NaN` propagates through `+` (`x + NaN == NaN`), so a
+    /// single malformed sample would erase the whole daily total and leave every
+    /// cap comparison false.
     #[test]
-    #[ignore = "finding MET-001: usd_spent_by_agent has no validation seam; a NaN cost_usd sample poisons the whole running total instead of being rejected or clamped"]
     fn a_non_finite_cost_sample_does_not_poison_the_total() {
         let samples = vec![
             sample("analyst", 5.0, SampleKind::Inference),


### PR DESCRIPTION
## Summary

`usd_spent_by_agent` accepted any `cost_usd` a sample carried. One malformed row could lift a teammate over their `budget_usd_daily` cap without anything reporting it.

## Problem

The sum folded every `cost_usd` straight in:

- a **negative** sample lowered a teammate's measured spend below what they actually spent
- a **`NaN`** poisoned the running total through `+` (`x + NaN == NaN`), erasing the whole day and leaving every cap comparison false

This is the exact function `budget_usd_daily` sums, so in both cases the cap silently stops binding. The samples reach it from whatever the meter recorded, so a bad row from any producer is enough.

Two tests describing this already existed in the file, both `#[ignore]`d with the defect written into the reason string. They were documenting the bug rather than guarding against it.

## Solution

Count only finite, non-negative costs. A rejected sample is warned about — naming the agent and the value — so it is visible rather than silently dropped; a cap that quietly ignores data is the failure this is fixing, and swapping one silence for another would not be a fix.

The predicate is factored out so the rule reads in one place, and both tests are un-ignored.

## Submission Checklist

- [x] `cargo test --lib daily_budget` — 7 passed, **0 ignored** (was 5 passed, 2 ignored)
- [x] Full lib suite — 5076 passed, 0 failed
- [x] Red proof: removing the guard fails both on their own assertions — `a negative cost_usd sample must not silently lower measured spend, got 2` (expected 5) and `a NaN sample must not poison the running total, got NaN` — then restored to green
- [x] `cargo fmt --all -- --check` clean
- [x] Production-deletion scan: only the `.map` replaced by `.filter_map` and the two `#[ignore]` attributes
- [ ] Console E2E — pre-existing failure on main, unrelated

## Impact

A teammate whose samples included a negative or non-finite cost was under-metered and could exceed their daily cap. They are now metered correctly, so a cap that was not binding starts binding — a behaviour change in the safe direction.

## Related

Found by an edge-coverage audit sweep: both tests were already written and ignored.