### PR TITLE
fix(setup): rate-limit propose_roster per company

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -203,6 +203,19 @@ pub enum OpenCompanyError {
         limit: usize,
     },
 
+    /// A `POST {scope}/setup/roster` call was refused because this company
+    /// already reached its burst cap of roster-proposal calls for the
+    /// current window. Raised before any model pass runs.
+    #[error(
+        "this company already requested {limit} roster proposals in the last {window_secs}s; each call runs a paid model pass — wait before trying again"
+    )]
+    RosterProposalRateLimit {
+        /// The burst ceiling that was hit.
+        limit: usize,
+        /// The rolling window, in seconds, the ceiling applies over.
+        window_secs: u64,
+    },
+
     /// A workflow run failed after some of its nodes had already done durable
     /// work (issue #1008).
     ///
@@ -477,6 +490,7 @@ impl OpenCompanyError {
             Self::BudgetExceeded(_) => "budget_exceeded".to_string(),
             Self::WorkspaceQuota(_) => "workspace_quota_exceeded".to_string(),
             Self::WorkflowRunLimit { .. } => "workflow_run_limit".to_string(),
+            Self::RosterProposalRateLimit { .. } => "roster_proposal_rate_limited".to_string(),
             // Issue #1008: delegated, not its own code. The wrapper adds a
             // payload for the journal, never a new failure a client should
             // branch on differently.

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -114,6 +114,9 @@ impl ApiError {
             // `provision.rs` already answers when a tenant asks for too much at
             // once — rather than a 4xx that reads as a bad request.
             OpenCompanyError::WorkflowRunLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
+            // The company is at its roster-proposal burst cap: each call runs
+            // a real, metered model pass, so this is a rate-limit refusal too.
+            OpenCompanyError::RosterProposalRateLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
             // tiny.place transport: an unreachable backend degrades to 503 so
             // callers retry; any other protocol failure is an upstream 502.
             OpenCompanyError::Tinyplace { code, .. } if code == "unreachable" => {
@@ -209,6 +212,13 @@ mod test {
         let run_cap = ApiError(OpenCompanyError::WorkflowRunLimit { limit: 8 });
         assert_eq!(run_cap.status(), StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(run_cap.0.code(), "workflow_run_limit");
+
+        let roster_cap = ApiError(OpenCompanyError::RosterProposalRateLimit {
+            limit: 5,
+            window_secs: 60,
+        });
+        assert_eq!(roster_cap.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(roster_cap.0.code(), "roster_proposal_rate_limited");
 
         let other = ApiError(OpenCompanyError::Store("disk full".into()));
         assert_eq!(other.status(), StatusCode::INTERNAL_SERVER_ERROR);

--- a/src/server/ops/setup.rs
+++ b/src/server/ops/setup.rs
@@ -363,8 +363,10 @@ mod roster_burst_tests {
             registry.insert(CompanyId::new(format!("active-{index}")), burst);
         }
 
-        assert!(
-            roster_burst_for_in(&mut registry, &CompanyId::new("overflow"), now).is_err(),
+        let refused = roster_burst_for_in(&mut registry, &CompanyId::new("overflow"), now).is_err();
+        assert_eq!(
+            usize::from(refused),
+            1,
             "a full registry of active bursts must refuse a new key"
         );
         assert_eq!(

--- a/src/server/ops/setup.rs
+++ b/src/server/ops/setup.rs
@@ -37,6 +37,10 @@
 //! which performs it, so a stricter guard here would be a boundary that the very
 //! next call does not enforce.
 
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
 use axum::extract::State;
 use axum::response::IntoResponse;
 use axum::routing::post;
@@ -49,7 +53,7 @@ use crate::company::setup::{
 };
 use crate::error::OpenCompanyError;
 use crate::ports::store::company_write_lock;
-use crate::ports::types::CompanyRecord;
+use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::server::error::ApiError;
 use crate::server::ops::scope::{ScopedCompany, scoped};
 
@@ -145,12 +149,71 @@ impl From<RosterProposal> for RosterProposalDto {
     }
 }
 
+/// Most roster-proposal calls one company may make inside
+/// [`ROSTER_PROPOSAL_WINDOW`] before `propose_roster` refuses the rest with a
+/// `429`. `pub(crate)` so the test module can assert the exact cap without
+/// duplicating the number.
+pub(crate) const ROSTER_PROPOSAL_BURST_LIMIT: usize = 8;
+
+/// The rolling window [`ROSTER_PROPOSAL_BURST_LIMIT`] applies over.
+const ROSTER_PROPOSAL_WINDOW: Duration = Duration::from_secs(60);
+
+/// One company's recent `propose_roster` call timestamps.
+#[derive(Default)]
+struct RosterBurst {
+    calls: Mutex<VecDeque<Instant>>,
+}
+
+/// Process-wide registry of [`RosterBurst`]s, one per company — mirrors
+/// `runtime::grants::budget_pauses_for`: created lazily on first use and kept
+/// for the process lifetime.
+static ROSTER_BURSTS: LazyLock<Mutex<HashMap<CompanyId, Arc<RosterBurst>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn roster_burst_for(company: &CompanyId) -> Arc<RosterBurst> {
+    ROSTER_BURSTS
+        .lock()
+        .expect("roster burst registry poisoned")
+        .entry(company.clone())
+        .or_insert_with(|| Arc::new(RosterBurst::default()))
+        .clone()
+}
+
+/// Admits one `propose_roster` call for `company` at `now`, or refuses once
+/// [`ROSTER_PROPOSAL_BURST_LIMIT`] calls have already landed inside the
+/// trailing [`ROSTER_PROPOSAL_WINDOW`].
+fn admit_roster_proposal(
+    company: &CompanyId,
+    now: Instant,
+) -> Result<(), crate::server::Rejection> {
+    let burst = roster_burst_for(company);
+    let mut calls = burst.calls.lock().expect("roster burst poisoned");
+    while calls
+        .front()
+        .is_some_and(|&at| now.saturating_duration_since(at) >= ROSTER_PROPOSAL_WINDOW)
+    {
+        calls.pop_front();
+    }
+    if calls.len() >= ROSTER_PROPOSAL_BURST_LIMIT {
+        return Err(ApiError(OpenCompanyError::RosterProposalRateLimit {
+            limit: ROSTER_PROPOSAL_BURST_LIMIT,
+            window_secs: ROSTER_PROPOSAL_WINDOW.as_secs(),
+        })
+        .into_response()
+        .into());
+    }
+    calls.push_back(now);
+    Ok(())
+}
+
 /// `POST {scope}/setup/roster` — propose a starting roster.
 async fn propose_roster(
     company: ScopedCompany,
     State(_state): State<AppState>,
     Json(body): Json<SetupRequest>,
 ) -> Result<Json<RosterProposalDto>, crate::server::Rejection> {
+    admit_roster_proposal(company.id(), Instant::now())?;
+
     let answers: SetupAnswers = body.into();
 
     // Remember the answers first. The proposal below may take seconds and the

--- a/src/server/ops/setup.rs
+++ b/src/server/ops/setup.rs
@@ -158,25 +158,60 @@ pub(crate) const ROSTER_PROPOSAL_BURST_LIMIT: usize = 8;
 /// The rolling window [`ROSTER_PROPOSAL_BURST_LIMIT`] applies over.
 const ROSTER_PROPOSAL_WINDOW: Duration = Duration::from_secs(60);
 
+const MAX_ROSTER_BURST_ENTRIES: usize = 1_024;
+
 /// One company's recent `propose_roster` call timestamps.
 #[derive(Default)]
 struct RosterBurst {
     calls: Mutex<VecDeque<Instant>>,
 }
 
-/// Process-wide registry of [`RosterBurst`]s, one per company — mirrors
-/// `runtime::grants::budget_pauses_for`: created lazily on first use and kept
-/// for the process lifetime.
+/// Process-wide registry of [`RosterBurst`]s, one per recently active company.
 static ROSTER_BURSTS: LazyLock<Mutex<HashMap<CompanyId, Arc<RosterBurst>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-fn roster_burst_for(company: &CompanyId) -> Arc<RosterBurst> {
-    ROSTER_BURSTS
+fn roster_burst_for(
+    company: &CompanyId,
+    now: Instant,
+) -> Result<Arc<RosterBurst>, crate::server::Rejection> {
+    let mut registry = ROSTER_BURSTS
         .lock()
-        .expect("roster burst registry poisoned")
-        .entry(company.clone())
-        .or_insert_with(|| Arc::new(RosterBurst::default()))
-        .clone()
+        .expect("roster burst registry poisoned");
+    roster_burst_for_in(&mut registry, company, now)
+}
+
+fn roster_burst_for_in(
+    registry: &mut HashMap<CompanyId, Arc<RosterBurst>>,
+    company: &CompanyId,
+    now: Instant,
+) -> Result<Arc<RosterBurst>, crate::server::Rejection> {
+    if let Some(burst) = registry.get(company) {
+        return Ok(Arc::clone(burst));
+    }
+    registry.retain(|_, burst| {
+        if Arc::strong_count(burst) > 1 {
+            return true;
+        }
+        let mut calls = burst.calls.lock().expect("roster burst poisoned");
+        while calls
+            .front()
+            .is_some_and(|&at| now.saturating_duration_since(at) >= ROSTER_PROPOSAL_WINDOW)
+        {
+            calls.pop_front();
+        }
+        !calls.is_empty()
+    });
+    if registry.len() >= MAX_ROSTER_BURST_ENTRIES {
+        return Err(ApiError(OpenCompanyError::RosterProposalRateLimit {
+            limit: ROSTER_PROPOSAL_BURST_LIMIT,
+            window_secs: ROSTER_PROPOSAL_WINDOW.as_secs(),
+        })
+        .into_response()
+        .into());
+    }
+    let burst = Arc::new(RosterBurst::default());
+    registry.insert(company.clone(), Arc::clone(&burst));
+    Ok(burst)
 }
 
 /// Admits one `propose_roster` call for `company` at `now`, or refuses once
@@ -186,7 +221,7 @@ fn admit_roster_proposal(
     company: &CompanyId,
     now: Instant,
 ) -> Result<(), crate::server::Rejection> {
-    let burst = roster_burst_for(company);
+    let burst = roster_burst_for(company, now)?;
     let mut calls = burst.calls.lock().expect("roster burst poisoned");
     while calls
         .front()
@@ -312,4 +347,40 @@ async fn load_record(company: &ScopedCompany) -> Result<CompanyRecord, crate::se
                 .into_response()
                 .into()
         })
+}
+
+#[cfg(test)]
+mod roster_burst_tests {
+    use super::*;
+
+    #[test]
+    fn roster_burst_registry_is_bounded_and_evicts_only_idle_entries() {
+        let now = Instant::now();
+        let mut registry = HashMap::new();
+        for index in 0..MAX_ROSTER_BURST_ENTRIES {
+            let burst = Arc::new(RosterBurst::default());
+            burst.calls.lock().unwrap().push_back(now);
+            registry.insert(CompanyId::new(format!("active-{index}")), burst);
+        }
+
+        assert!(
+            roster_burst_for_in(&mut registry, &CompanyId::new("overflow"), now).is_err(),
+            "a full registry of active bursts must refuse a new key"
+        );
+        assert_eq!(
+            registry.len(),
+            MAX_ROSTER_BURST_ENTRIES,
+            "company churn must not grow the registry past its cap"
+        );
+
+        let held = Arc::clone(registry.values().next().unwrap());
+        for burst in registry.values() {
+            burst.calls.lock().unwrap().clear();
+        }
+        let inserted = roster_burst_for_in(&mut registry, &CompanyId::new("replacement"), now)
+            .expect("idle entries make room for a new company");
+        assert!(registry.values().any(|burst| Arc::ptr_eq(burst, &held)));
+        assert!(registry.values().any(|burst| Arc::ptr_eq(burst, &inserted)));
+        assert_eq!(registry.len(), 2);
+    }
 }

--- a/src/server/ops/setup_test.rs
+++ b/src/server/ops/setup_test.rs
@@ -23,9 +23,9 @@ fn manifest() -> CompanyManifest {
     toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap()
 }
 
-async fn state_with(home: &std::path::Path) -> AppState {
+async fn state_with(home: &std::path::Path, company: &str) -> AppState {
     let store = FsCompanyStore::new(home.to_path_buf());
-    let id = CompanyId::new("acme");
+    let id = CompanyId::new(company);
     store
         .save(&CompanyRecord {
             overlay_retired_agents: Vec::new(),
@@ -60,15 +60,15 @@ async fn state_with(home: &std::path::Path) -> AppState {
         .unwrap();
     let state = AppState::new(AppConfig::default()).with_home(home.to_path_buf());
     state.registry().insert(id, std::sync::Arc::new(runtime));
-    crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+    crate::server::test_support::seed_fixed_admin(&state, company).await;
     state
 }
 
-fn roster_request() -> Request<Body> {
+fn roster_request(company: &str) -> Request<Body> {
     Request::builder()
         .method("POST")
         .uri("/api/v1/company/setup/roster")
-        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+        .header("cookie", crate::server::test_support::fixed_cookie(company))
         .header("content-type", "application/json")
         .body(Body::from(
             r#"{"industry":"bakery","team_hint":"","automate":"orders"}"#,
@@ -76,24 +76,19 @@ fn roster_request() -> Request<Body> {
         .unwrap()
 }
 
-/// The route has no rate limit and no in-flight/re-entry guard (HT-124):
-/// every one of N back-to-back calls reaches `build_proposal` (a real charged
-/// model pass in production) and returns 200. A route that pays for inference
-/// per call must refuse past some per-company burst rate, not accept an
-/// unbounded rerun.
+/// A route that pays for inference per call must refuse past some
+/// per-company burst rate, not accept an unbounded rerun.
 #[tokio::test]
-#[ignore = "confirms fail-open: propose_roster has no rate limit — an \
-            authenticated operator can re-trigger the paid model pass \
-            unboundedly (HT-124), no cap enforced anywhere on this route"]
 async fn repeated_roster_proposals_are_rate_limited() {
     let home_dir = home();
-    let state = state_with(home_dir.path()).await;
+    let company = "ht124-burst";
+    let state = state_with(home_dir.path(), company).await;
     let app = router(state);
 
     const BURST: usize = 20;
     let mut statuses = Vec::with_capacity(BURST);
     for _ in 0..BURST {
-        let response = app.clone().oneshot(roster_request()).await.unwrap();
+        let response = app.clone().oneshot(roster_request(company)).await.unwrap();
         statuses.push(response.status());
     }
 
@@ -104,20 +99,31 @@ async fn repeated_roster_proposals_are_rate_limited() {
     );
 }
 
-/// Pinned as today's actual behaviour so the finding above isn't mistaken for
-/// a broken test: every call really does complete and return a real proposal.
+/// Calls inside the burst cap succeed with a real proposal; the call that
+/// would exceed it is refused with a `429` naming the cap, not silently
+/// dropped and not let through.
 #[tokio::test]
-async fn today_every_rapid_call_succeeds_uncapped() {
+async fn roster_proposals_within_the_burst_cap_succeed_then_429() {
     let home_dir = home();
-    let state = state_with(home_dir.path()).await;
+    let company = "ht124-capped";
+    let state = state_with(home_dir.path(), company).await;
     let app = router(state);
 
-    const BURST: usize = 5;
-    for _ in 0..BURST {
-        let response = app.clone().oneshot(roster_request()).await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+    for i in 0..crate::server::ops::setup::ROSTER_PROPOSAL_BURST_LIMIT {
+        let response = app.clone().oneshot(roster_request(company)).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "call {i} inside the burst cap should succeed"
+        );
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert!(value["agents"].is_array());
     }
+
+    let response = app.clone().oneshot(roster_request(company)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(value["code"], "roster_proposal_rate_limited");
 }


### PR DESCRIPTION
## Summary

`POST {scope}/setup/roster` (`propose_roster`) had no rate limit at all: an authenticated operator could re-trigger the paid model pass behind it unboundedly, and every call is real, metered inference spend. Adds a per-company burst cap and un-ignores the test that documented the gap.

## API Or Behavior Changes

`propose_roster` now refuses with `429 roster_proposal_rate_limited` once a company has made 8 roster-proposal calls inside a trailing 60-second window. The limiter is a process-wide, per-company in-memory registry (`ROSTER_BURSTS`) checked before any work — including the answer-persisting write — so a refused call has no side effects, mirroring how `WorkflowRunLimit` already refuses workflow runs at their concurrency ceiling with the same status and no partial write.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (via `cargo check --all-targets`)
- [x] `cargo test` (targeted: `server::ops::setup_test`, `server::ops::` (893 tests), `server::error::` — full `cargo test` not re-run for time, but every module touched by this change was run directly)

Red proof: removed the `admit_roster_proposal(...)?;` call, re-ran `repeated_roster_proposals_are_rate_limited` and `roster_proposals_within_the_burst_cap_succeed_then_429` — both failed on their own assertions (`expected at least one 429 across 20 rapid calls... got: [200, 200, ...]` and `assertion left == right failed / left: 200 / right: 429`), then restored the fix and confirmed both green again.

## Documentation

No docs needed — the cap is an internal safety limit, not a new operator-facing contract; the 429 envelope follows the existing `{ "error", "code" }` shape every other refusal on this route already uses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting for roster-proposal requests: up to 8 requests per company within 60 seconds.
  * Requests exceeding the limit now receive a clear 429 rate-limit response with a stable error code.

* **Bug Fixes**
  * Improved handling and reporting of roster-proposal rate-limit errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->