### PR TITLE
fix(publish): refuse oversized files before buffering them whole

### DIFF
--- a/src/harness/built_in/publish.rs
+++ b/src/harness/built_in/publish.rs
@@ -112,6 +112,15 @@ pub const PUBLISH_ARTIFACT_TOOL: &str = "publish_artifact";
 /// unreachable.
 pub const MAX_ARTIFACT_BODY_BYTES: usize = 256 * 1024;
 
+/// The largest file `capture_body` will read into memory at all, in bytes.
+///
+/// Distinct from [`MAX_ARTIFACT_BODY_BYTES`]: that cap decides text-versus-
+/// bytes classification for a file that *is* read; this one decides whether
+/// the read happens in the first place. A file over this line is refused
+/// before `std::fs::read` ever runs, so a sandbox file far past any sane size
+/// for one in-memory `Vec<u8>` cannot be buffered whole just to be classified.
+pub const MAX_CAPTURED_FILE_BYTES: usize = 20 * 1024 * 1024;
+
 /// Directory names the workspace scan never descends into.
 ///
 /// Two families, and the second one is not optional.
@@ -815,13 +824,22 @@ pub fn capture_body(
     source: &str,
     _inferred: ArtifactKind,
 ) -> std::io::Result<PublishPayload> {
-    // Route by size before reading, so the read is bounded by the prose cap: a
-    // file already past it goes straight to bytes, and a file within the cap is
-    // read whole and probed in place.
-    let over_cap = file
-        .metadata()
-        .map(|meta| meta.len() > MAX_ARTIFACT_BODY_BYTES as u64)
-        .unwrap_or(false);
+    // Stat before reading. `size` decides two separate questions from the one
+    // syscall: whether the read happens at all (the hard ceiling below) and,
+    // for a read that does happen, whether the result is prose or bytes (the
+    // prose cap). Checking `bytes.len()` after `std::fs::read` would still
+    // buffer the whole file first, which is the bug this guards against.
+    let size = file.metadata()?.len();
+    if size > MAX_CAPTURED_FILE_BYTES as u64 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "{source} is {size} bytes, over the {MAX_CAPTURED_FILE_BYTES}-byte limit for a \
+                 single publish read"
+            ),
+        ));
+    }
+    let over_cap = size > MAX_ARTIFACT_BODY_BYTES as u64;
     let bytes = std::fs::read(file)?;
     if !over_cap && std::str::from_utf8(&bytes).is_ok() {
         // The borrowed probe validates in place; the move below reuses the same

--- a/src/harness/built_in/publish/test.rs
+++ b/src/harness/built_in/publish/test.rs
@@ -227,19 +227,11 @@ fn one_byte_over_the_cap_is_stored_as_bytes() {
     );
 }
 
-/// `capture_body` has exactly one size constant, `MAX_ARTIFACT_BODY_BYTES`
-/// (256 KiB), and it decides Text-vs-Bytes classification only — the
-/// unconditional `std::fs::read(file)?` a few lines above runs regardless of
-/// how far over that cap the file is. `one_byte_over_the_cap_is_stored_as_bytes`
-/// already pins that the whole file is read for a file just over the cap; this
-/// is the same read, at a size nothing in this module would call reasonable
-/// for a single in-memory `Vec<u8>` allocation on a chat artifact. There is no
-/// second, hard ceiling anywhere in this file — grep confirms `MAX_ARTIFACT`
-/// has exactly one match.
+/// `capture_body` stats before it reads: a file over `MAX_CAPTURED_FILE_BYTES`
+/// is refused before `std::fs::read` ever runs, so nothing this far past any
+/// sane size for a single in-memory `Vec<u8>` allocation is ever buffered
+/// whole just to be classified.
 #[test]
-#[ignore = "no hard byte ceiling exists on capture_body's Bytes path — it reads \
-            an arbitrarily large sandbox file whole via std::fs::read with no \
-            size check before the read, unlike file_read's 10MB pre-read cap"]
 fn capture_body_refuses_a_file_far_past_any_sane_single_read() {
     const UNREASONABLE_FOR_ONE_READ: usize = 64 * 1024 * 1024; // 64 MiB
     let body = vec![b'x'; UNREASONABLE_FOR_ONE_READ];


### PR DESCRIPTION
## Summary

`capture_body` stat'd a file only to decide text-versus-bytes classification, but the `std::fs::read(file)?` a few lines below ran unconditionally regardless of what that stat found. A file far past any sane size for a single in-memory `Vec<u8>` — the ignored test used 64 MiB — was fully buffered before anything checked its length. There was no hard ceiling anywhere in the module; the existing 256 KiB constant only decided how a file that *was* read got stored, never whether it should be read at all.

Fixed by reusing the same stat for a second, earlier decision: a file over a new `MAX_CAPTURED_FILE_BYTES` (20 MiB) is refused before `std::fs::read` runs, so it is never buffered whole. The existing 256 KiB prose-vs-bytes cap is unchanged and still only classifies files within the new ceiling.

`capture_body_refuses_a_file_far_past_any_sane_single_read` (`src/harness/built_in/publish/test.rs`) is un-ignored — it now passes for real.

## API Or Behavior Changes

`capture_body` (`src/harness/built_in/publish.rs`) now returns an `io::Error` (surfaced to the caller as `Could not read '<source>': <message>`) for any file larger than 20 MiB, before reading it. Files at or under that ceiling are unaffected — classification against the existing 256 KiB prose cap is unchanged.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --features openhuman -- -D warnings`
- [x] `cargo build --all-targets` (covered by `cargo check --features openhuman`, ran clean)
- [x] `cargo test --lib --features openhuman harness::built_in::publish::test::` — 55 passed, 0 failed, 0 ignored

Red proof: reverted the fix locally (dropped the pre-read ceiling, restoring the original unconditional `std::fs::read`) and reran the previously-ignored test in isolation — it failed on its own assertion, not a compile error:

```
thread '...capture_body_refuses_a_file_far_past_any_sane_single_read' panicked at src/harness/built_in/publish/test.rs:240:5:
a file this large must be refused before being read whole into memory
test result: FAILED. 0 passed; 1 failed; 0 ignored
```

Restored the fix and reran — green again (55 passed).

## Documentation

Doc comments on `capture_body` and the new `MAX_CAPTURED_FILE_BYTES` constant explain the two-cap split (hard read ceiling vs. prose classification cap). No other docs reference this behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large captured files are now rejected before being read into memory, preventing excessive memory usage.
  * File metadata errors are now reported instead of allowing processing to continue.
  * Files exceeding the 20 MiB capture limit return a clear error.

* **Tests**
  * Added active coverage verifying that oversized files are refused safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->