### PR TITLE
console: wire the title-row search — @ agents, # channels, / files, and messages in a conversation

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -3671,7 +3671,7 @@ export function AppShell({
             />
           </>
         }
-        search={<TitleBarSearch />}
+        search={<TitleBarSearch client={client} company={company} />}
         utilities={
           // The three that were the sidebar's footer, beside Overview in the
           // same group: all four are about the console rather than the page.

--- a/frontend/src/components/title-bar-search.tsx
+++ b/frontend/src/components/title-bar-search.tsx
@@ -1,82 +1,76 @@
-// The search box in the middle of the window's title row.
+// The search control in the middle of the window's title row.
 //
-// **A placeholder, and it says so.** Nothing is wired behind it yet: there is
-// no search index in the console, and the host exposes no cross-surface search
-// route to call. What this lands is the *place* — one field, in the one band of
-// chrome that is on screen from every page, sized and centred so that the row's
-// final layout is settled before the behaviour arrives.
+// A *trigger*, not a field: clicking it (or pressing ⌘K) opens
+// `SearchDialog`, which owns the actual input. One search box, in a modal, is
+// what makes the results list possible at all — a dropdown hanging off a
+// title-row input has nowhere to put four groups of results.
 //
-// It is `disabled` rather than a live input that silently swallows what you
-// type. A field that accepts text and answers nothing is worse than an absent
-// one: it reads as a working control that has failed, and an operator who types
-// into it has been told nothing. Disabled, its `title` says when it will work,
-// and a screen reader is told the same thing rather than being offered a text
-// box with no results to move to.
-//
-// It is not a `data-tauri-drag-region`. The attribute is opt-in per element and
-// this is a control, so the drag stays on the two spacers either side of it —
-// which is what keeps the band grabbable while the field keeps its clicks.
+// **The button is capped, the wrapper is not.** The wrapper stays the row's one
+// elastic member because it is also the only thing left to grab the window by
+// across the middle: it carries `data-tauri-drag-region`, the button
+// deliberately does not, so the band stays draggable while the control keeps
+// its clicks. Capping the button rather than the wrapper is what lets the
+// control be a sensible width without giving that up.
 
+import { useEffect, useState } from "react";
 import { Search } from "lucide-react";
 
-/** What the field is for, and why it does not answer yet. */
-const SEARCH_PLACEHOLDER = "Search";
-const SEARCH_TITLE = "Search is not available yet";
+import type { OpenCompanyClient } from "@/api/client";
+import { SearchDialog } from "@/search/SearchDialog";
+import { isAppleKeyboard } from "@/connections/HostsContext";
 
-export function TitleBarSearch() {
+/** What the field is for. */
+const SEARCH_PLACEHOLDER = "Search";
+
+export function TitleBarSearch({
+  client,
+  company,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+
+  // ⌘K / Ctrl+K, the shortcut a palette is reached by in every tool this
+  // console sits beside. `⌘1`–`⌘9` belong to the host switcher
+  // (`HostsContext`), and this takes none of them.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "k" && event.key !== "K") return;
+      if (!event.metaKey && !event.ctrlKey) return;
+      event.preventDefault();
+      setOpen((was) => !was);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   return (
-    // Takes the middle, whatever the middle is. It was capped at `max-w-md`
-    // (28rem), which on a 1440px window left the field a third the width of the
-    // gap it sat in and reading as a chip that had drifted to the centre rather
-    // than as the row's search. No cap: the two groups beside it are `flex-none`
-    // and this is not, so it takes exactly what they leave and gives it back
-    // first when the row is crowded. `min-w-0` is what lets it actually shrink
-    // rather than flooring the row at its own content width.
-    // `self-stretch` + `data-tauri-drag-region`: this wrapper is the row's only
-    // elastic member now, so it is also the only thing left to grab the window
-    // by across the middle. Stretched to the full 52px it leaves an 8px band
-    // above and below the 36px field, plus its own side padding — the input
-    // below does NOT carry the attribute (it is opt-in per element), so the
-    // field keeps its own clicks.
     <div
       data-tauri-drag-region
       className="flex min-w-0 flex-1 items-center justify-center self-stretch px-3"
     >
-      <div className="relative w-full">
-        <Search
-          aria-hidden="true"
-          className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
-        />
-        <input
-          type="search"
-          disabled
-          data-testid="title-bar-search"
-          placeholder={SEARCH_PLACEHOLDER}
-          aria-label={SEARCH_PLACEHOLDER}
-          title={SEARCH_TITLE}
-          className={
-            // Taller than the 30px pill beside it and a rung up in type. A
-            // field is a thing you aim a cursor at and read your own words
-            // back from, which is not what a status pill has to do — matching
-            // the pill's height made the one editable control in the row the
-            // least substantial-looking thing in it.
-            // `border-chrome-border` and `bg-background`, not the default
-            // border over `bg-card`. This field stands on the window chrome,
-            // and `--card` is close enough to `--chrome` that the box read as a
-            // faint rectangle you had to look for — at a glance the row had a
-            // magnifier floating in the middle of nothing. Those are the two
-            // tokens the content card itself uses to separate from the same
-            // ground, so the field reads as a well cut into the chrome for the
-            // same reason and by the same rule.
-            "h-9 w-full rounded-lg border border-chrome-border bg-background pr-3 pl-9 text-sm " +
-            "text-foreground placeholder:text-muted-foreground " +
-            "focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none " +
-            // Not greyed to the point of looking broken: it is a real control
-            // that is not ready, so it reads as quiet rather than as failed.
-            "disabled:cursor-default disabled:opacity-70"
-          }
-        />
-      </div>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        data-testid="title-bar-search"
+        aria-label={SEARCH_PLACEHOLDER}
+        aria-keyshortcuts="Meta+K Control+K"
+        className={
+          // Capped, not elastic: a search control that grows to fill a 1440px
+          // window reads as a text field somebody stretched by accident.
+          "flex h-9 w-full max-w-sm items-center gap-2 rounded-lg border border-chrome-border " +
+          "bg-background pr-2 pl-3 text-sm text-muted-foreground " +
+          "hover:bg-accent/40 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+        }
+      >
+        <Search aria-hidden="true" className="size-4 shrink-0" />
+        <span className="flex-1 text-left">{SEARCH_PLACEHOLDER}</span>
+        <kbd className="hidden shrink-0 rounded border border-chrome-border px-1.5 py-0.5 font-sans text-2xs sm:inline">
+          {isAppleKeyboard() ? "⌘K" : "Ctrl K"}
+        </kbd>
+      </button>
+      <SearchDialog client={client} company={company} open={open} onOpenChange={setOpen} />
     </div>
   );
 }

--- a/frontend/src/search/HighlightedText.tsx
+++ b/frontend/src/search/HighlightedText.tsx
@@ -1,0 +1,40 @@
+// A matched string, with the matches marked.
+//
+// Its own component for one reason: the alternative everybody reaches for is
+// building an HTML string with the term wrapped in `<mark>` and setting
+// `dangerouslySetInnerHTML`, which puts whatever was typed — and whatever a
+// teammate wrote in a message — into the DOM as markup. This takes offsets and
+// slices the original string, so nothing is ever parsed as HTML.
+
+import { Fragment } from "react";
+
+import type { MatchRange } from "./types";
+
+export function HighlightedText({
+  text,
+  ranges,
+}: {
+  text: string;
+  /** Half-open `[start, end)` slices, in order and non-overlapping. */
+  ranges?: readonly MatchRange[];
+}) {
+  if (!ranges || ranges.length === 0) return <>{text}</>;
+
+  const parts: React.ReactNode[] = [];
+  let at = 0;
+  ranges.forEach(([from, to], index) => {
+    // Defensive against an out-of-order or overlapping range: rendering the
+    // string twice is a worse failure than dropping one highlight.
+    if (from < at || to > text.length) return;
+    if (from > at) parts.push(<Fragment key={`t${index}`}>{text.slice(at, from)}</Fragment>);
+    parts.push(
+      <mark key={`m${index}`} className="rounded-sm bg-transparent font-medium text-foreground">
+        {text.slice(from, to)}
+      </mark>,
+    );
+    at = to;
+  });
+  if (at < text.length) parts.push(<Fragment key="tail">{text.slice(at)}</Fragment>);
+
+  return <>{parts}</>;
+}

--- a/frontend/src/search/SearchDialog.tsx
+++ b/frontend/src/search/SearchDialog.tsx
@@ -1,0 +1,205 @@
+// The search modal: a field, a title, and the results under it.
+//
+// Everything it decides is about *presentation and keyboard*. What counts as a
+// hit is `sources.ts`, how hits are ordered is `rank.ts`, what was typed is
+// `query.ts`, and what has to be fetched is `useSearch.ts` — all of which are
+// testable without rendering this.
+//
+// ## Two behaviours worth naming
+//
+// **Escape unwinds rather than slams.** With a scope open, the first Escape
+// drops the scope and leaves the modal up; only a second closes it. Losing a
+// whole query because you wanted to widen it is the thing that makes people
+// stop using a palette.
+//
+// **Enter says what it will do before it does it.** `#general` navigates and
+// `#general box` searches inside it, and the active row spells out which —
+// see `SearchResult.action`.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Loader2, Search } from "lucide-react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { parseSearchQuery, SCOPE_PREFIX, withScopeName } from "./query";
+import { SearchResultRow } from "./SearchResultRow";
+import type { SearchResult } from "./types";
+import { useSearch } from "./useSearch";
+
+export function SearchDialog({
+  client,
+  company,
+  open,
+  onOpenChange,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [raw, setRaw] = useState("");
+  const [cursor, setCursor] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const query = useMemo(() => parseSearchQuery(raw), [raw]);
+  const { groups, loading } = useSearch(client, company, query, open);
+
+  /** Every result in draw order, which is what the cursor walks. */
+  const flat = useMemo(() => groups.flatMap((group) => group.results), [groups]);
+
+  // A cursor past the end of a shorter list would point at nothing and make
+  // Enter do nothing, silently.
+  useEffect(() => {
+    setCursor((at) => (at < flat.length ? at : 0));
+  }, [flat.length]);
+
+  // Reopening starts clean. Keeping the last query would answer the previous
+  // question to somebody who has just asked a new one.
+  useEffect(() => {
+    if (!open) {
+      setRaw("");
+      setCursor(0);
+    }
+  }, [open]);
+
+  const activate = (result: SearchResult | undefined) => {
+    if (!result) return;
+    // A picked agent or channel with no term yet is a *choice*, not a
+    // destination: it fills the scope in and waits for what to search for.
+    if (query.scope && !query.term && (result.kind === "agent" || result.kind === "channel")) {
+      const name = result.kind === "agent" ? result.title : result.title.replace(/^#/, "");
+      setRaw(withScopeName(query, name));
+      inputRef.current?.focus();
+      return;
+    }
+    onOpenChange(false);
+    window.location.hash = result.href.replace(/^#/, "");
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setCursor((at) => (flat.length === 0 ? 0 : (at + 1) % flat.length));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setCursor((at) => (flat.length === 0 ? 0 : (at - 1 + flat.length) % flat.length));
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      activate(flat[cursor]);
+      return;
+    }
+    if (event.key === "Escape" && query.scope) {
+      // Unwind one level rather than closing: the scope goes, the modal stays.
+      event.preventDefault();
+      event.stopPropagation();
+      setRaw(query.term);
+      return;
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        // `sm:max-w-2xl`, never a bare `max-w-2xl`: `DialogContent`'s own base
+        // carries `sm:max-w-sm`, which is a different *variant* and so survives
+        // the merge and wins on every screen ≥640px. The bare class is present
+        // in the DOM and simply loses, at 384px, silently
+        // (`dialog-width-override.test.ts`).
+        className="top-24 translate-y-0 gap-0 overflow-hidden p-0 sm:max-w-2xl"
+        data-testid="search-dialog"
+      >
+        <div className="flex items-center gap-2.5 border-b px-3.5 py-3">
+          <Search aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
+          <DialogTitle className="sr-only">Search this company</DialogTitle>
+          <input
+            ref={inputRef}
+            autoFocus
+            value={raw}
+            onChange={(event) => setRaw(event.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Search channels, agents, messages and files"
+            aria-label="Search this company"
+            data-testid="search-input"
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+          {loading && <Loader2 aria-hidden="true" className="size-4 shrink-0 animate-spin text-muted-foreground" />}
+        </div>
+
+        <div
+          role="listbox"
+          aria-label="Search results"
+          className="max-h-[min(60vh,26rem)] overflow-y-auto p-1.5"
+        >
+          {groups.length === 0 ? (
+            <Resting query={query.raw} isEmpty={query.isEmpty} loading={loading} />
+          ) : (
+            groups.map((group) => (
+              <div key={group.kind} className="pb-1">
+                <p className="px-2.5 pt-2 pb-1 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {group.label}
+                </p>
+                {group.results.map((result) => (
+                  <SearchResultRow
+                    key={result.id}
+                    result={result}
+                    active={flat[cursor]?.id === result.id}
+                    onActivate={() => activate(result)}
+                    onHover={() => setCursor(flat.findIndex((r) => r.id === result.id))}
+                  />
+                ))}
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 border-t px-3.5 py-2 text-2xs text-muted-foreground">
+          <span>
+            <kbd className="font-sans font-medium">{SCOPE_PREFIX.person}</kbd> agents
+          </span>
+          <span>
+            <kbd className="font-sans font-medium">{SCOPE_PREFIX.channel}</kbd> channels
+          </span>
+          <span>
+            <kbd className="font-sans font-medium">{SCOPE_PREFIX.file}</kbd> files
+          </span>
+          <span className="ml-auto">↑↓ to move · ↵ to open · esc to close</span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * What the list says when it has nothing to list.
+ *
+ * Three different silences, and they are not interchangeable: nothing typed,
+ * still looking, and genuinely nothing there. A single "No results" for all
+ * three tells an operator their search failed when it has not run yet.
+ */
+function Resting({ query, isEmpty, loading }: { query: string; isEmpty: boolean; loading: boolean }) {
+  if (isEmpty) {
+    return (
+      <p className="px-2.5 py-6 text-center text-sm text-muted-foreground" data-testid="search-resting">
+        Search this company — or start with{" "}
+        <kbd className="font-sans font-medium text-foreground">@</kbd> for an agent and{" "}
+        <kbd className="font-sans font-medium text-foreground">#</kbd> for a channel.
+      </p>
+    );
+  }
+  if (loading) {
+    return (
+      <p className="px-2.5 py-6 text-center text-sm text-muted-foreground" data-testid="search-looking">
+        Looking…
+      </p>
+    );
+  }
+  return (
+    <p className="px-2.5 py-6 text-center text-sm text-muted-foreground" data-testid="search-empty">
+      Nothing matched “{query.trim()}”.
+    </p>
+  );
+}

--- a/frontend/src/search/SearchDialog.tsx
+++ b/frontend/src/search/SearchDialog.tsx
@@ -67,7 +67,11 @@ export function SearchDialog({
     // A picked agent or channel with no term yet is a *choice*, not a
     // destination: it fills the scope in and waits for what to search for.
     if (query.scope && !query.term && (result.kind === "agent" || result.kind === "channel")) {
-      const name = result.kind === "agent" ? result.title : result.title.replace(/^#/, "");
+      // `scopeName`, not the row's label: a display name with a space in it —
+      // "User Researcher" — written back as `@User Researcher ` re-parses as
+      // the scope `user` and the term `researcher`, and searches somebody
+      // else's DM for a word nobody typed.
+      const name = result.scopeName ?? result.title.replace(/^#/, "");
       setRaw(withScopeName(query, name));
       inputRef.current?.focus();
       return;

--- a/frontend/src/search/SearchResultRow.tsx
+++ b/frontend/src/search/SearchResultRow.tsx
@@ -1,0 +1,73 @@
+// One row in the results list.
+//
+// Separated from the dialog so the row's anatomy — what a channel says versus
+// what a message says — can be read, changed and tested without mounting a
+// modal, a client or a keyboard.
+
+import { FileText, Hash, MessageSquare, User } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { HighlightedText } from "./HighlightedText";
+import type { ResultKind, SearchResult } from "./types";
+
+/** The mark each kind wears, so a mixed list is scannable by shape. */
+const ICON: Record<ResultKind, typeof Hash> = {
+  channel: Hash,
+  agent: User,
+  message: MessageSquare,
+  file: FileText,
+};
+
+export function SearchResultRow({
+  result,
+  active,
+  onActivate,
+  onHover,
+}: {
+  result: SearchResult;
+  /** Whether the keyboard cursor is on this row. */
+  active: boolean;
+  onActivate: () => void;
+  onHover: () => void;
+}) {
+  const Icon = ICON[result.kind];
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      data-testid={`search-result-${result.id}`}
+      data-active={active || undefined}
+      onClick={onActivate}
+      // Pointer moves the cursor rather than fighting it: with both a mouse and
+      // arrow keys live, whichever moved last is the one the operator meant.
+      onMouseMove={onHover}
+      className={cn(
+        "flex w-full items-start gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors",
+        active ? "bg-accent" : "hover:bg-accent/50",
+      )}
+    >
+      <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-baseline gap-2">
+          <span className="truncate text-sm font-medium">
+            <HighlightedText text={result.title} ranges={result.titleMatches} />
+          </span>
+          {result.subtitle && (
+            <span className="truncate text-xs text-muted-foreground">{result.subtitle}</span>
+          )}
+        </span>
+        {result.excerpt && (
+          <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+            <HighlightedText text={result.excerpt} ranges={result.excerptMatches} />
+          </span>
+        )}
+      </span>
+      {/* What Enter does, spelled out on the row the cursor is on — the one
+          place a fused palette is genuinely ambiguous. */}
+      {active && (
+        <span className="shrink-0 self-center text-2xs text-muted-foreground">{result.action}</span>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/search/query.ts
+++ b/frontend/src/search/query.ts
@@ -1,0 +1,180 @@
+// What the operator typed, as something the sources can act on.
+//
+// The whole of this file is pure: a string in, a `SearchQuery` out, no React,
+// no client, no DOM. That is deliberate and it is the point — the grammar is
+// the part of search that is easy to get subtly wrong and expensive to debug
+// through a modal, so it is testable on its own terms (`search-query.test.ts`)
+// rather than only through the component that renders it.
+//
+// ## The grammar
+//
+// Three shapes, and the third is the one that makes search feel like Slack:
+//
+// - `priya`      — a bare term. Everything is searched: channels, agents, files.
+// - `@priya`     — a person. Narrows the picker to agents while it is being
+//                  typed, so the operator can pick one.
+// - `@priya box` — a person **and** a term. Now the term is searched *inside*
+//                  that agent's DM, which is the whole reason a scope exists.
+//
+// `#` does the same for a channel. The prefix is not stripped and forgotten:
+// it becomes {@link SearchScope}, which the caller turns into the one
+// conversation to read.
+//
+// ## What is deliberately not here
+//
+// No `in:`/`from:`/`before:` filter vocabulary yet. Slack's is large and every
+// one of those needs a host route to answer against; shipping the two prefixes
+// that the console can genuinely resolve beats shipping eight that mostly
+// return "not supported".
+
+/** Which kind of thing a scope prefix names. */
+export type ScopeKind = "person" | "channel" | "file";
+
+/** The prefix character that opens each scope. */
+export const SCOPE_PREFIX: Record<ScopeKind, string> = {
+  person: "@",
+  channel: "#",
+  file: "/",
+};
+
+/**
+ * Whether what follows the prefix can be narrowed further by a term.
+ *
+ * `@priya box` and `#autumn box` mean "that conversation, this word" — the
+ * scope names a place with things inside it. `/` names the things themselves,
+ * so everything after it is one file query: `/autumn brief` is looking for a
+ * file called something like "autumn brief", not for "brief" inside a file
+ * called "autumn".
+ */
+const SCOPE_TAKES_TERM: Record<ScopeKind, boolean> = {
+  person: true,
+  channel: true,
+  file: false,
+};
+
+/** A scope the operator has begun, whether or not they have finished naming it. */
+export interface SearchScope {
+  kind: ScopeKind;
+  /**
+   * What was typed after the prefix, lowercased and trimmed.
+   *
+   * This is a *name being typed*, not a resolved id: `@pri` is a legitimate
+   * intermediate state and the picker's job is to offer Priya for it. The
+   * caller resolves it against the roster; this module never guesses.
+   */
+  name: string;
+}
+
+/** A parsed query, ready for the sources to answer. */
+export interface SearchQuery {
+  /** Exactly what was typed, untouched. Kept so the input can be restored. */
+  raw: string;
+  /**
+   * The scope, when one was opened with `@` or `#`.
+   *
+   * Present as soon as the prefix is typed — `@` alone parses to a person
+   * scope with an empty name, which is what makes the picker open the moment
+   * the key is pressed rather than after the first letter.
+   */
+  scope: SearchScope | null;
+  /**
+   * What to actually match on, lowercased and trimmed.
+   *
+   * With a scope, this is only the part *after* the scope's name: in
+   * `@priya box`, the term is `box`. Empty means "nothing to match yet",
+   * which is a different state from a term that matched nothing.
+   */
+  term: string;
+  /** Whether anything at all was typed. */
+  isEmpty: boolean;
+}
+
+/**
+ * The scope prefixes, longest first, so a future two-character prefix cannot be
+ * shadowed by a one-character one that happens to share its head.
+ */
+const PREFIXES: readonly (readonly [string, ScopeKind])[] = [
+  ["@", "person"],
+  ["#", "channel"],
+  ["/", "file"],
+];
+
+/**
+ * Parses what the operator typed.
+ *
+ * Never throws and never returns null: every string is a valid query, because
+ * a search box that rejects input has nothing useful to say instead. A string
+ * of only whitespace is `isEmpty`, which is the caller's cue to show the
+ * resting state rather than "no results".
+ */
+export function parseSearchQuery(raw: string): SearchQuery {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return { raw, scope: null, term: "", isEmpty: true };
+  }
+
+  const found = PREFIXES.find(([prefix]) => trimmed.startsWith(prefix));
+  if (!found) {
+    return { raw, scope: null, term: trimmed.toLowerCase(), isEmpty: false };
+  }
+
+  const [prefix, kind] = found;
+  const rest = trimmed.slice(prefix.length);
+
+  // A scope that takes no term swallows the rest whole — see `SCOPE_TAKES_TERM`.
+  if (!SCOPE_TAKES_TERM[kind]) {
+    return {
+      raw,
+      scope: { kind, name: rest.trim().toLowerCase() },
+      term: "",
+      isEmpty: false,
+    };
+  }
+
+  // The scope's name runs to the first space; everything after it is the term
+  // to search *within* that scope. `@priya autumn box` scopes to Priya and
+  // searches "autumn box", so a multi-word term survives the split.
+  const gap = rest.indexOf(" ");
+  const name = gap === -1 ? rest : rest.slice(0, gap);
+  const term = gap === -1 ? "" : rest.slice(gap + 1).trim();
+
+  return {
+    raw,
+    scope: { kind, name: name.trim().toLowerCase() },
+    term: term.toLowerCase(),
+    isEmpty: false,
+  };
+}
+
+/**
+ * Whether the scope names something specific enough to resolve.
+ *
+ * `@` on its own opens the picker but resolves to nobody, and a caller that
+ * fetched a conversation for it would be fetching an arbitrary one.
+ */
+export function scopeIsNamed(query: SearchQuery): boolean {
+  return query.scope !== null && query.scope.name.length > 0;
+}
+
+/**
+ * Whether this query asks for messages inside one conversation.
+ *
+ * Both halves are required: a named scope says *where*, and a term says *what*.
+ * `@priya` alone is the operator choosing a person, not yet a search — offering
+ * them every message Priya ever sent is not what they asked for.
+ */
+export function isScopedMessageSearch(query: SearchQuery): boolean {
+  return scopeIsNamed(query) && query.term.length > 0;
+}
+
+/**
+ * Rewrites a query with its scope resolved to a chosen name.
+ *
+ * What pressing Enter on a picked agent does: `@pri` becomes `@priya `, with
+ * the trailing space that starts the term. Returned as a string rather than a
+ * `SearchQuery` because it goes back into the input the operator is typing in.
+ */
+export function withScopeName(query: SearchQuery, name: string): string {
+  const kind = query.scope?.kind ?? "person";
+  return `${SCOPE_PREFIX[kind]}${name} `;
+}

--- a/frontend/src/search/rank.ts
+++ b/frontend/src/search/rank.ts
@@ -21,8 +21,8 @@ import type { MatchRange } from "./types";
  */
 export function matchRanges(text: string, term: string): MatchRange[] {
   if (!term || !text) return [];
-  const haystack = text.toLowerCase();
-  const needle = term.toLowerCase();
+  const haystack = fold(text);
+  const needle = fold(term);
   const ranges: MatchRange[] = [];
   let from = 0;
   for (;;) {
@@ -39,6 +39,26 @@ export function matchRanges(text: string, term: string): MatchRange[] {
 
 /** Enough to highlight a line; past this the extra marks say nothing. */
 const MAX_RANGES = 20;
+
+/**
+ * Case folded **without changing length**, so an offset into the result is an
+ * offset into the original.
+ *
+ * `String.prototype.toLowerCase` is not length-preserving: `"İ".toLowerCase()`
+ * is two code units, so every index after one drifts by one and a highlight
+ * lands a character late — `İstanbul box` highlighting `ox`. Folding a unit at
+ * a time and keeping any that does not fold to exactly one unit costs those
+ * few characters their case-insensitivity, which is a far smaller wrong than
+ * marking the wrong letters.
+ */
+function fold(value: string): string {
+  let folded = "";
+  for (const unit of value) {
+    const lower = unit.toLowerCase();
+    folded += lower.length === unit.length ? lower : unit;
+  }
+  return folded;
+}
 
 /** Whether `text` contains `term` at all, case-insensitively. */
 export function matches(text: string, term: string): boolean {
@@ -65,8 +85,8 @@ export function matches(text: string, term: string): boolean {
  */
 export function score(text: string, term: string): number {
   if (!term) return 1;
-  const haystack = text.toLowerCase();
-  const needle = term.toLowerCase();
+  const haystack = fold(text);
+  const needle = fold(term);
   const at = haystack.indexOf(needle);
   if (at === -1) return 0;
 
@@ -111,6 +131,10 @@ export function excerptAround(
   width = 160,
 ): { excerpt: string; ranges: MatchRange[] } {
   const collapsed = text.replace(/\s+/g, " ").trim();
+  // The term is collapsed too, or a query carrying a double space matches in
+  // `score` (which sees the raw text) and then cannot be found here, leaving an
+  // unrelated leading excerpt with nothing marked in it.
+  term = term.replace(/\s+/g, " ").trim();
   if (!term) {
     return {
       excerpt: collapsed.length > width ? `${collapsed.slice(0, width)}…` : collapsed,
@@ -118,7 +142,7 @@ export function excerptAround(
     };
   }
 
-  const at = collapsed.toLowerCase().indexOf(term.toLowerCase());
+  const at = fold(collapsed).indexOf(fold(term));
   if (at === -1) {
     return {
       excerpt: collapsed.length > width ? `${collapsed.slice(0, width)}…` : collapsed,

--- a/frontend/src/search/rank.ts
+++ b/frontend/src/search/rank.ts
@@ -1,0 +1,143 @@
+// Matching and ordering, with no idea what it is matching.
+//
+// Pure and total: strings in, ranges and scores out. The two jobs here are the
+// ones a search gets judged on and the ones easiest to get quietly wrong —
+// where a term matched (so it can be highlighted without building HTML) and
+// which hit deserves to be first.
+
+import type { MatchRange } from "./types";
+
+/**
+ * Every place `term` occurs in `text`, case-insensitively.
+ *
+ * Offsets into the ORIGINAL string, so the caller slices the text the operator
+ * will actually read rather than a lowercased copy of it. That is what keeps
+ * highlighting honest: the component renders `text.slice(...)` inside a
+ * `<mark>`, and never re-inserts the term as markup — a search box that builds
+ * HTML out of user input is one paste away from being an injection.
+ *
+ * Empty for an empty term: "everything matched" and "nothing was asked" are
+ * different answers, and highlighting the whole string is neither.
+ */
+export function matchRanges(text: string, term: string): MatchRange[] {
+  if (!term || !text) return [];
+  const haystack = text.toLowerCase();
+  const needle = term.toLowerCase();
+  const ranges: MatchRange[] = [];
+  let from = 0;
+  for (;;) {
+    const at = haystack.indexOf(needle, from);
+    if (at === -1) break;
+    ranges.push([at, at + needle.length]);
+    from = at + needle.length;
+    // A pathological term (one character, long text) would otherwise build a
+    // range per character. Nothing on screen shows more than a few.
+    if (ranges.length >= MAX_RANGES) break;
+  }
+  return ranges;
+}
+
+/** Enough to highlight a line; past this the extra marks say nothing. */
+const MAX_RANGES = 20;
+
+/** Whether `text` contains `term` at all, case-insensitively. */
+export function matches(text: string, term: string): boolean {
+  if (!term) return true;
+  return text.toLowerCase().includes(term.toLowerCase());
+}
+
+/**
+ * How well `text` answers `term`, higher being better.
+ *
+ * Three tiers, because they are three genuinely different qualities of hit and
+ * an operator can feel the difference:
+ *
+ * - **Exact** — they typed the whole name. Nothing should outrank it.
+ * - **Prefix** — they are typing the name. `gen` should put `general` above
+ *   `autumn-general-notes`, which is what makes type-ahead feel like it is
+ *   reading along rather than guessing.
+ * - **Substring** — it is in there somewhere, and the earlier the better.
+ *
+ * Shorter text breaks ties within a tier: given two substring hits, the one
+ * where the term is more of the whole is the more likely answer.
+ *
+ * Returns 0 for no match, which callers use as "drop it" — never as a weak hit.
+ */
+export function score(text: string, term: string): number {
+  if (!term) return 1;
+  const haystack = text.toLowerCase();
+  const needle = term.toLowerCase();
+  const at = haystack.indexOf(needle);
+  if (at === -1) return 0;
+
+  if (haystack === needle) return 1000;
+  if (at === 0) return 800 - Math.min(haystack.length, 200);
+  // Earlier is better, and each character of distance costs one point — so
+  // position never outweighs the tier above it.
+  return 600 - Math.min(at, 200) - Math.min(haystack.length, 100) / 100;
+}
+
+/**
+ * The best score across several fields, so a hit on any of them counts.
+ *
+ * A channel matches on its name or its description; an agent on their name or
+ * their role. Taking the max rather than the sum keeps one strong hit ahead of
+ * two weak ones.
+ */
+export function bestScore(fields: readonly (string | null | undefined)[], term: string): number {
+  let best = 0;
+  for (const field of fields) {
+    if (!field) continue;
+    const value = score(field, term);
+    if (value > best) best = value;
+  }
+  return best;
+}
+
+/**
+ * A window of `text` around its first match, for a message or a file body.
+ *
+ * The match is the point, so the window is placed around it rather than taken
+ * from the start — a 400-character message whose only mention of the term is at
+ * the end, excerpted from character zero, shows the operator a snippet that
+ * does not contain what they searched for.
+ *
+ * Returns the slice and the ranges *within that slice*, already rebased, so the
+ * caller never has to do offset arithmetic to highlight it.
+ */
+export function excerptAround(
+  text: string,
+  term: string,
+  width = 160,
+): { excerpt: string; ranges: MatchRange[] } {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (!term) {
+    return {
+      excerpt: collapsed.length > width ? `${collapsed.slice(0, width)}…` : collapsed,
+      ranges: [],
+    };
+  }
+
+  const at = collapsed.toLowerCase().indexOf(term.toLowerCase());
+  if (at === -1) {
+    return {
+      excerpt: collapsed.length > width ? `${collapsed.slice(0, width)}…` : collapsed,
+      ranges: [],
+    };
+  }
+
+  // A third of the window before the match, so there is context on both sides
+  // and the match is not flush against the left edge.
+  const lead = Math.floor(width / 3);
+  const start = Math.max(0, at - lead);
+  const end = Math.min(collapsed.length, start + width);
+  const body = collapsed.slice(start, end);
+  const excerpt = `${start > 0 ? "…" : ""}${body}${end < collapsed.length ? "…" : ""}`;
+  // Ranges come back relative to `body`, and the only thing between `body` and
+  // `excerpt` is the leading ellipsis — so that is the whole of the shift.
+  const shift = start > 0 ? 1 : 0;
+  const ranges = matchRanges(body, term).map(
+    ([from, to]) => [from + shift, to + shift] as MatchRange,
+  );
+  return { excerpt, ranges };
+}

--- a/frontend/src/search/rank.ts
+++ b/frontend/src/search/rank.ts
@@ -22,13 +22,14 @@ import type { MatchRange } from "./types";
 export function matchRanges(text: string, term: string): MatchRange[] {
   if (!term || !text) return [];
   const haystack = fold(text);
-  const needle = fold(term);
+  const needle = fold(term).folded;
   const ranges: MatchRange[] = [];
   let from = 0;
   for (;;) {
-    const at = haystack.indexOf(needle, from);
+    const at = haystack.folded.indexOf(needle, from);
     if (at === -1) break;
-    ranges.push([at, at + needle.length]);
+    // Mapped back, so the caller slices the string it will actually render.
+    ranges.push([haystack.at[at], haystack.at[at + needle.length]]);
     from = at + needle.length;
     // A pathological term (one character, long text) would otherwise build a
     // range per character. Nothing on screen shows more than a few.
@@ -41,29 +42,57 @@ export function matchRanges(text: string, term: string): MatchRange[] {
 const MAX_RANGES = 20;
 
 /**
- * Case folded **without changing length**, so an offset into the result is an
- * offset into the original.
+ * Case folded, with the way back to the original's offsets.
  *
- * `String.prototype.toLowerCase` is not length-preserving: `"İ".toLowerCase()`
- * is two code units, so every index after one drifts by one and a highlight
- * lands a character late — `İstanbul box` highlighting `ox`. Folding a unit at
- * a time and keeping any that does not fold to exactly one unit costs those
- * few characters their case-insensitivity, which is a far smaller wrong than
- * marking the wrong letters.
+ * `String.prototype.toLowerCase` is not length-preserving — `"İ".toLowerCase()`
+ * is two code units — so an index into the folded string is not an index into
+ * the text the operator reads. Left alone that drifts a highlight one character
+ * late (`İstanbul box` marking `ox`); *refusing* to fold those characters, as
+ * this first did, instead makes them case-sensitive, so `İstanbul` stops
+ * matching `istanbul` altogether.
+ *
+ * So neither: fold everything, and carry `at[i]` — the original offset that
+ * folded character `i` came from. One trailing entry for the end, so a range's
+ * exclusive end maps too.
  */
-function fold(value: string): string {
+function fold(value: string): { folded: string; at: number[] } {
   let folded = "";
-  for (const unit of value) {
-    const lower = unit.toLowerCase();
-    folded += lower.length === unit.length ? lower : unit;
+  const at: number[] = [];
+  let index = 0;
+  // By code point, not by unit: a surrogate pair is one character and must not
+  // be folded or measured in halves.
+  for (const character of value) {
+    // Lowercased, then decomposed, then stripped of the combining marks that
+    // decomposition exposes. All three are needed for one word to match
+    // itself: `"İ".toLowerCase()` is `i` plus a combining dot, so `İstanbul`
+    // never matched `istanbul` — not here, and not under the plain
+    // `toLowerCase` this replaced. Accents fall out of the same pass, so
+    // `cafe` now finds `café`, which is the behaviour a search box is expected
+    // to have anyway.
+    const normalized = character
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(COMBINING_MARKS, "");
+    for (let i = 0; i < normalized.length; i += 1) at.push(index);
+    folded += normalized;
+    index += character.length;
   }
-  return folded;
+  at.push(value.length);
+  return { folded, at };
 }
+
+/**
+ * The marks NFD splits off a composed character.
+ *
+ * Dropped rather than kept so that a character and its decomposition compare
+ * equal — which is the whole point of normalising before a substring search.
+ */
+const COMBINING_MARKS = /\p{M}/gu;
 
 /** Whether `text` contains `term` at all, case-insensitively. */
 export function matches(text: string, term: string): boolean {
   if (!term) return true;
-  return text.toLowerCase().includes(term.toLowerCase());
+  return fold(text).folded.includes(fold(term).folded);
 }
 
 /**
@@ -85,8 +114,8 @@ export function matches(text: string, term: string): boolean {
  */
 export function score(text: string, term: string): number {
   if (!term) return 1;
-  const haystack = fold(text);
-  const needle = fold(term);
+  const haystack = fold(text).folded;
+  const needle = fold(term).folded;
   const at = haystack.indexOf(needle);
   if (at === -1) return 0;
 
@@ -142,7 +171,11 @@ export function excerptAround(
     };
   }
 
-  const at = fold(collapsed).indexOf(fold(term));
+  // Found in the folded string, then mapped back: every slice below indexes
+  // `collapsed`, and the two only share offsets while nothing expanded.
+  const haystack = fold(collapsed);
+  const foundAt = haystack.folded.indexOf(fold(term).folded);
+  const at = foundAt === -1 ? -1 : haystack.at[foundAt];
   if (at === -1) {
     return {
       excerpt: collapsed.length > width ? `${collapsed.slice(0, width)}…` : collapsed,

--- a/frontend/src/search/sources.ts
+++ b/frontend/src/search/sources.ts
@@ -44,6 +44,7 @@ export function channelResults(desks: readonly Desk[], query: SearchQuery): Sear
           ([from, to]) => [from + 1, to + 1] as const,
         ),
         subtitle: desk.blurb || undefined,
+        scopeName: desk.channel,
         href: `#/chat/${encodeURIComponent(desk.id)}`,
         action: `Go to #${desk.channel}`,
         score: value,
@@ -72,6 +73,8 @@ export function agentResults(members: readonly TeamMember[], query: SearchQuery)
         title: member.name,
         titleMatches: matchRanges(member.name, term),
         subtitle: member.role || undefined,
+        // The id, never the display name — see `SearchResult.scopeName`.
+        scopeName: member.id,
         // The console-local channel id, which is what the hash router routes.
         // NOT `dmThreadId` — that is the host thread this DM is addressed on,
         // and the two differ for a teammate whose id spells General.
@@ -112,6 +115,11 @@ export function messageResults(
   const term = query.term;
   if (!term) return [];
 
+  // When each hit was sent, kept beside the results rather than on them: it is
+  // a sort key, not something a row says, and `SearchResult` is what the modal
+  // renders.
+  const recency = new Map(messages.map((message) => [`message:${message.id}`, message.atMillis]));
+
   return messages
     .map((message): SearchResult | null => {
       const value = score(message.text, term);
@@ -130,16 +138,38 @@ export function messageResults(
         // journaled line under an `h`-prefixed console id, and that is what
         // `data-message-id` carries. Linking the bare one lands on the channel
         // and then finds nothing to scroll to.
-        href: `#/chat/${encodeURIComponent(context.channelId)}?m=${encodeURIComponent(hostMessageId(message.id))}`,
+        //
+        // A reply is folded into its thread and is not in the main timeline at
+        // all, so its link names the parent too — `RoomView` opens the panel
+        // and then finds the line inside it. Without that the link lands in the
+        // conversation and quietly gives up.
+        href: messageHref(context.channelId, message),
         action: `Open in ${context.label}`,
         score: value,
       };
     })
     .filter((hit): hit is SearchResult => hit !== null)
-    // Most recent first among equally good matches: in a conversation, later is
-    // usually the one being looked for.
-    .sort((a, b) => b.score - a.score)
+    // Most recent first among equally good matches: in a conversation later is
+    // usually the one being looked for, and the history route answers
+    // oldest-first — so without the second key a search for a word as common as
+    // "yes" fills the limit with the oldest six and hides today's.
+    .sort((a, b) => b.score - a.score || (recency.get(b.id) ?? 0) - (recency.get(a.id) ?? 0))
     .slice(0, PER_GROUP_LIMIT);
+}
+
+/**
+ * Where a message result opens.
+ *
+ * A reply lives in its thread rather than in the timeline, so its address
+ * names the thread as well — `RoomView` consumes `?thread=` first and the
+ * line is then on screen to be found.
+ */
+function messageHref(channelId: string, message: ChatHistoryMessageDto): string {
+  const anchor = `m=${encodeURIComponent(hostMessageId(message.id))}`;
+  const parent = message.parentId
+    ? `thread=${encodeURIComponent(hostMessageId(message.parentId))}&`
+    : "";
+  return `#/chat/${encodeURIComponent(channelId)}?${parent}${anchor}`;
 }
 
 /**
@@ -152,7 +182,10 @@ export function fileResults(hits: readonly SearchHit[], query: SearchQuery): Sea
   if (query.scope && query.scope.kind !== "file") return [];
   const term = query.scope?.kind === "file" ? query.scope.name : query.term;
 
-  return hits.slice(0, PER_GROUP_LIMIT).map((hit): SearchResult => {
+  // Ranked THEN limited. Slicing first drops a name match sitting behind six
+  // body matches — the one hit most likely to be the answer.
+  return hits
+    .map((hit): SearchResult => {
     const excerpt = hit.excerpt ? excerptAround(hit.excerpt, term) : null;
     return {
       kind: "file" as const,
@@ -166,7 +199,9 @@ export function fileResults(hits: readonly SearchHit[], query: SearchQuery): Sea
       action: `Open ${hit.name}`,
       score: hit.matched === "name" ? 800 : 500,
     };
-  });
+    })
+    .sort(byScore)
+    .slice(0, PER_GROUP_LIMIT);
 }
 
 /** Highest first; ties keep the order the source gave them. */
@@ -183,9 +218,16 @@ function byScore(a: SearchResult, b: SearchResult): number {
  */
 export function formatWhen(atMillis: number, now = Date.now()): string {
   const when = new Date(atMillis);
+  const today = new Date(now);
   const elapsed = now - atMillis;
   const DAY = 24 * 60 * 60 * 1000;
-  if (elapsed < DAY) {
+  // The local calendar day, not the last 24 hours: 23:00 yesterday read at
+  // 10:00 today is not "today", and rendering it as a bare time says it is.
+  const sameDay =
+    when.getFullYear() === today.getFullYear() &&
+    when.getMonth() === today.getMonth() &&
+    when.getDate() === today.getDate();
+  if (sameDay) {
     return when.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
   }
   if (elapsed < 7 * DAY) {

--- a/frontend/src/search/sources.ts
+++ b/frontend/src/search/sources.ts
@@ -1,0 +1,195 @@
+// Turning what this console already holds into results.
+//
+// Pure, like its neighbours: collections and a parsed query in, `SearchResult`s
+// out. No fetching happens here — {@link useSearch} owns that — so every rule
+// about *what counts as a hit* and *what a row says* is testable without a
+// host, a client, or a rendered modal.
+
+import type { Desk } from "@/lib/desks";
+import type { TeamMember } from "@/lib/team";
+import type { ChatHistoryMessageDto } from "@/api/types";
+import type { SearchHit } from "@/api/workspace";
+import { hostMessageId } from "@/lib/chat";
+import { dmChannelId } from "@/views/room/channels";
+import { bestScore, excerptAround, matchRanges, score } from "./rank";
+import type { SearchQuery } from "./query";
+import type { SearchResult } from "./types";
+
+/** How many of any one kind are worth showing before the list stops helping. */
+export const PER_GROUP_LIMIT = 6;
+
+/**
+ * Channels, matched on the name you would type and the purpose you might
+ * remember instead.
+ *
+ * The action says which of the two things Enter will do, because in a fused
+ * palette both are reachable from the same row: `#general` goes there, and
+ * `#general box` searches inside it. Inferring that from the shape of what you
+ * typed is not something an operator should have to do.
+ */
+export function channelResults(desks: readonly Desk[], query: SearchQuery): SearchResult[] {
+  if (query.scope && query.scope.kind !== "channel") return [];
+  const term = query.scope?.kind === "channel" ? query.scope.name : query.term;
+
+  return desks
+    .map((desk): SearchResult | null => {
+      const value = bestScore([desk.channel, desk.name, desk.blurb], term);
+      if (value === 0) return null;
+      return {
+        kind: "channel" as const,
+        id: `channel:${desk.id}`,
+        title: `#${desk.channel}`,
+        // +1 for the `#` this title adds in front of the matched name.
+        titleMatches: matchRanges(desk.channel, term).map(
+          ([from, to]) => [from + 1, to + 1] as const,
+        ),
+        subtitle: desk.blurb || undefined,
+        href: `#/chat/${encodeURIComponent(desk.id)}`,
+        action: `Go to #${desk.channel}`,
+        score: value,
+      };
+    })
+    .filter((hit): hit is SearchResult => hit !== null)
+    .sort(byScore)
+    .slice(0, PER_GROUP_LIMIT);
+}
+
+/**
+ * Agents, matched on name and on the role you would describe them by when the
+ * name is the half you have forgotten.
+ */
+export function agentResults(members: readonly TeamMember[], query: SearchQuery): SearchResult[] {
+  if (query.scope && query.scope.kind !== "person") return [];
+  const term = query.scope?.kind === "person" ? query.scope.name : query.term;
+
+  return members
+    .map((member): SearchResult | null => {
+      const value = bestScore([member.name, member.id, member.role], term);
+      if (value === 0) return null;
+      return {
+        kind: "agent" as const,
+        id: `agent:${member.id}`,
+        title: member.name,
+        titleMatches: matchRanges(member.name, term),
+        subtitle: member.role || undefined,
+        // The console-local channel id, which is what the hash router routes.
+        // NOT `dmThreadId` — that is the host thread this DM is addressed on,
+        // and the two differ for a teammate whose id spells General.
+        href: `#/chat/${encodeURIComponent(dmChannelId(member))}`,
+        action: `Message ${member.name}`,
+        score: value,
+      };
+    })
+    .filter((hit): hit is SearchResult => hit !== null)
+    .sort(byScore)
+    .slice(0, PER_GROUP_LIMIT);
+}
+
+/** Where a set of messages came from, so a row can say it. */
+export interface MessageContext {
+  /** The channel id these messages belong to, for the row's link. */
+  channelId: string;
+  /** What to call it on the row — `#autumn-launch`, or an agent's name. */
+  label: string;
+  /** Resolves an author id to something worth reading. */
+  nameFor: (author: string) => string;
+}
+
+/**
+ * Messages inside one conversation.
+ *
+ * Scoped by construction: the caller has already fetched exactly one
+ * conversation's history, because that is the search this console can answer
+ * honestly. There is no host route for message search across a company, and
+ * searching only the channels that happen to be loaded would answer "no
+ * matches" for a message that plainly exists.
+ */
+export function messageResults(
+  messages: readonly ChatHistoryMessageDto[],
+  query: SearchQuery,
+  context: MessageContext,
+): SearchResult[] {
+  const term = query.term;
+  if (!term) return [];
+
+  return messages
+    .map((message): SearchResult | null => {
+      const value = score(message.text, term);
+      if (value === 0) return null;
+      const { excerpt, ranges } = excerptAround(message.text, term);
+      const who = context.nameFor(message.author);
+      return {
+        kind: "message" as const,
+        id: `message:${message.id}`,
+        title: who,
+        titleMatches: [],
+        subtitle: `${context.label} · ${formatWhen(message.atMillis)}`,
+        excerpt,
+        excerptMatches: ranges,
+        // `hostMessageId`, not the bare host id: `fromHistory` renders every
+        // journaled line under an `h`-prefixed console id, and that is what
+        // `data-message-id` carries. Linking the bare one lands on the channel
+        // and then finds nothing to scroll to.
+        href: `#/chat/${encodeURIComponent(context.channelId)}?m=${encodeURIComponent(hostMessageId(message.id))}`,
+        action: `Open in ${context.label}`,
+        score: value,
+      };
+    })
+    .filter((hit): hit is SearchResult => hit !== null)
+    // Most recent first among equally good matches: in a conversation, later is
+    // usually the one being looked for.
+    .sort((a, b) => b.score - a.score)
+    .slice(0, PER_GROUP_LIMIT);
+}
+
+/**
+ * Workspace files, from the host's own search.
+ *
+ * The one source that arrives already matched: `GET …/workspace/search` did the
+ * work and says whether it was the name or the body, so this only shapes it.
+ */
+export function fileResults(hits: readonly SearchHit[], query: SearchQuery): SearchResult[] {
+  if (query.scope && query.scope.kind !== "file") return [];
+  const term = query.scope?.kind === "file" ? query.scope.name : query.term;
+
+  return hits.slice(0, PER_GROUP_LIMIT).map((hit): SearchResult => {
+    const excerpt = hit.excerpt ? excerptAround(hit.excerpt, term) : null;
+    return {
+      kind: "file" as const,
+      id: `file:${hit.id}`,
+      title: hit.name,
+      titleMatches: matchRanges(hit.name, term),
+      subtitle: hit.path,
+      excerpt: excerpt?.excerpt,
+      excerptMatches: excerpt?.ranges,
+      href: `#/workspace/${encodeURIComponent(hit.id)}`,
+      action: `Open ${hit.name}`,
+      score: hit.matched === "name" ? 800 : 500,
+    };
+  });
+}
+
+/** Highest first; ties keep the order the source gave them. */
+function byScore(a: SearchResult, b: SearchResult): number {
+  return b.score - a.score;
+}
+
+/**
+ * A date a person can place at a glance.
+ *
+ * Time for today, weekday within the last week, and a date beyond that — the
+ * three answers to "when was this" that are actually useful at different
+ * distances.
+ */
+export function formatWhen(atMillis: number, now = Date.now()): string {
+  const when = new Date(atMillis);
+  const elapsed = now - atMillis;
+  const DAY = 24 * 60 * 60 * 1000;
+  if (elapsed < DAY) {
+    return when.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  }
+  if (elapsed < 7 * DAY) {
+    return when.toLocaleDateString(undefined, { weekday: "long" });
+  }
+  return when.toLocaleDateString(undefined, { day: "numeric", month: "short" });
+}

--- a/frontend/src/search/types.ts
+++ b/frontend/src/search/types.ts
@@ -55,6 +55,16 @@ export interface SearchResult {
    * of what they typed.
    */
   action: string;
+  /**
+   * The token to write into the box when this result is *picked* as a scope,
+   * where that differs from what the row reads.
+   *
+   * An agent's display name is not a token: "User Researcher" written back as
+   * `@User Researcher ` parses as the scope `user` plus the term `researcher`,
+   * which searches a different agent's DM for a word nobody typed. The id is
+   * one word by construction, so it survives the round trip.
+   */
+  scopeName?: string;
   /** Higher sorts first within its group. Never compared across groups. */
   score: number;
 }

--- a/frontend/src/search/types.ts
+++ b/frontend/src/search/types.ts
@@ -1,0 +1,67 @@
+// What a search answers with, independent of where it came from.
+//
+// One shape for every source, so the modal renders a list rather than four
+// special cases, and so a new source (tasks, workflows) is a function that
+// returns these rather than another branch in the component.
+
+/** Which kind of thing a result is. Also the order its group is shown in. */
+export type ResultKind = "channel" | "agent" | "message" | "file";
+
+/**
+ * The groups, in the order they appear.
+ *
+ * Sections rather than tabs, deliberately: a tab makes the operator choose
+ * where the answer lives before they know, and the common case — "I half
+ * remember a name" — is exactly the one where they cannot.
+ */
+export const RESULT_ORDER: readonly ResultKind[] = ["channel", "agent", "message", "file"];
+
+/** What each group is called on screen. */
+export const RESULT_LABEL: Record<ResultKind, string> = {
+  channel: "Channels",
+  agent: "Agents",
+  message: "Messages",
+  file: "Files",
+};
+
+/** A half-open `[start, end)` slice of a string that matched the term. */
+export type MatchRange = readonly [number, number];
+
+/** One thing the operator can act on. */
+export interface SearchResult {
+  kind: ResultKind;
+  /** Unique within a result set; the list's React key and the highlight cursor. */
+  id: string;
+  /** The primary line — a channel name, an agent's name, a file's name. */
+  title: string;
+  /** Where the title matched, for highlighting without building HTML. */
+  titleMatches: readonly MatchRange[];
+  /** One line of context: a role, a description, a path, a channel and a date. */
+  subtitle?: string;
+  /** The matched text itself, for a message or a file's body. */
+  excerpt?: string;
+  /** Where the excerpt matched. */
+  excerptMatches?: readonly MatchRange[];
+  /**
+   * Where activating this goes — a hash address this console already routes,
+   * so a result is the same navigation as clicking the thing in the sidebar.
+   */
+  href: string;
+  /**
+   * What activating it will do, said plainly on the row.
+   *
+   * Load-bearing in a fused palette: `#general` navigates and `#general box`
+   * searches, and the operator should not have to infer which from the shape
+   * of what they typed.
+   */
+  action: string;
+  /** Higher sorts first within its group. Never compared across groups. */
+  score: number;
+}
+
+/** A group of results, as the modal draws it. */
+export interface ResultGroup {
+  kind: ResultKind;
+  label: string;
+  results: SearchResult[];
+}

--- a/frontend/src/search/useSearch.ts
+++ b/frontend/src/search/useSearch.ts
@@ -87,6 +87,17 @@ export function useSearch(
     const scope = loadedFor.current;
     if (scope && scope.client === client && scope.company === company) return;
 
+    // Emptied before the new company's read, never left standing during it:
+    // `groups` is computed from whatever is held, so the previous company's
+    // channels and agents would otherwise be listed — and activatable — under
+    // the new one's query.
+    if (scope) {
+      setDesks([]);
+      setMembers([]);
+      setFiles([]);
+      setMessages(null);
+    }
+
     let cancelled = false;
     void Promise.allSettled([client.listDesks(company), client.listTeam(company)]).then(
       ([deskResult, teamResult]) => {
@@ -119,6 +130,12 @@ export function useSearch(
       setLoading(false);
       return;
     }
+
+    // Cleared as the query changes rather than when its replacement lands: a
+    // result list that keeps answering the previous question through the
+    // debounce is one an operator can click, and it opens the wrong thing.
+    setFiles([]);
+    setMessages(null);
 
     const timer = setTimeout(() => {
       if (!current()) return;

--- a/frontend/src/search/useSearch.ts
+++ b/frontend/src/search/useSearch.ts
@@ -1,0 +1,254 @@
+// The asynchronous half: what has to be fetched before the pure half can rank it.
+//
+// Everything about *what counts as a hit* lives in `sources.ts` and `rank.ts`,
+// which are pure. What lives here is the part that cannot be: reading the
+// roster and the desks once the modal opens, asking the host to search the
+// workspace, and reading one conversation when the query names one.
+//
+// ## Two rules this file exists to keep
+//
+// **A late answer never wins.** Every fetch is tagged with the generation that
+// asked for it and drops itself if the query has moved on. Typing is a stream
+// of queries and the network reorders them freely, so without this an operator
+// who types `box` sees results for `bo` land on top of them a moment later.
+//
+// **Nothing is fetched for a query that cannot use it.** Workspace search is a
+// host round trip, so it waits for a term and never runs for a scoped query,
+// where the question is about a conversation rather than about files.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { ChatHistoryMessageDto } from "@/api/types";
+import { searchWorkspace, type SearchHit } from "@/api/workspace";
+import type { Desk } from "@/lib/desks";
+import { fromDto, type TeamMember } from "@/lib/team";
+import { deskFromDto, dmChannelId, dmThreadId } from "@/views/room/channels";
+import { isScopedMessageSearch, type SearchQuery } from "./query";
+import { score } from "./rank";
+import {
+  agentResults,
+  channelResults,
+  fileResults,
+  messageResults,
+  type MessageContext,
+} from "./sources";
+import { RESULT_LABEL, RESULT_ORDER, type ResultGroup, type SearchResult } from "./types";
+
+/**
+ * How long to wait after a keystroke before asking the host anything.
+ *
+ * Local matching is synchronous and unaffected — channels and agents update on
+ * every keystroke, which is what makes the modal feel immediate. This bounds
+ * only the round trips.
+ */
+const DEBOUNCE_MS = 160;
+
+/** How much of a conversation to read when searching inside it. */
+const HISTORY_LIMIT = 500;
+
+/** What the modal needs to draw itself. */
+export interface SearchState {
+  groups: ResultGroup[];
+  /** Whether a host round trip is outstanding. Local results are already shown. */
+  loading: boolean;
+  /** The roster, for the resting state's shortcuts. */
+  members: TeamMember[];
+  /** The channels, likewise. */
+  desks: Desk[];
+}
+
+/**
+ * Everything the search modal shows, for one query.
+ *
+ * `enabled` is the modal's open state: nothing is fetched while it is shut, and
+ * what was loaded is kept, so reopening is instant rather than a second load of
+ * the same roster.
+ */
+export function useSearch(
+  client: OpenCompanyClient,
+  company: string | null,
+  query: SearchQuery,
+  enabled: boolean,
+): SearchState {
+  const [desks, setDesks] = useState<Desk[]>([]);
+  const [members, setMembers] = useState<TeamMember[]>([]);
+  const [files, setFiles] = useState<SearchHit[]>([]);
+  const [messages, setMessages] = useState<{ context: MessageContext; rows: ChatHistoryMessageDto[] } | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // The scope the collections were loaded for. A company switch while the modal
+  // is shut must not leave the previous company's channels in it.
+  const loadedFor = useRef<{ client: unknown; company: string | null } | null>(null);
+  const generation = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const scope = loadedFor.current;
+    if (scope && scope.client === client && scope.company === company) return;
+
+    let cancelled = false;
+    void Promise.allSettled([client.listDesks(company), client.listTeam(company)]).then(
+      ([deskResult, teamResult]) => {
+        if (cancelled) return;
+        loadedFor.current = { client, company };
+        // Settled rather than awaited together: a host with no `.../desks` route
+        // still has a roster, and one failure should not empty both lists.
+        if (deskResult.status === "fulfilled") setDesks(deskResult.value.map(deskFromDto));
+        if (teamResult.status === "fulfilled") setMembers(teamResult.value.map(fromDto));
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [client, company, enabled]);
+
+  /** The teammate or desk a scope names, or null while it names nobody. */
+  const scoped = useMemo(() => resolveScope(query, desks, members), [query, desks, members]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const mine = ++generation.current;
+    const current = () => generation.current === mine;
+
+    // Nothing to ask about: clear what the last query fetched rather than
+    // leaving it under a query it does not answer.
+    if (query.isEmpty) {
+      setFiles([]);
+      setMessages(null);
+      setLoading(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (!current()) return;
+
+      if (isScopedMessageSearch(query) && scoped) {
+        setLoading(true);
+        void client
+          .getChatHistory(scoped.threadId, company, { limit: HISTORY_LIMIT })
+          .then((rows) => {
+            if (!current()) return;
+            setMessages({ context: scoped.context, rows });
+            setFiles([]);
+          })
+          .catch(() => {
+            if (!current()) return;
+            setMessages(null);
+          })
+          .finally(() => {
+            if (current()) setLoading(false);
+          });
+        return;
+      }
+
+      setMessages(null);
+      // `/` is a file query in its own right; `@` and `#` half-typed are
+      // pickers, and a picker is not a question for the host.
+      const fileTerm = query.scope?.kind === "file" ? query.scope.name : query.scope ? "" : query.term;
+      if (!fileTerm) {
+        setFiles([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      void searchWorkspace(client, company, fileTerm, { limit: 12 })
+        .then((results) => {
+          if (!current()) return;
+          setFiles(results.hits);
+        })
+        .catch(() => {
+          // A host without the workspace route answers 404. That is a missing
+          // source, not a failed search — the other groups still stand.
+          if (current()) setFiles([]);
+        })
+        .finally(() => {
+          if (current()) setLoading(false);
+        });
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [client, company, enabled, query, scoped]);
+
+  const groups = useMemo(() => {
+    const byKind: Record<string, SearchResult[]> = {
+      channel: channelResults(desks, query),
+      agent: agentResults(members, query),
+      message: messages ? messageResults(messages.rows, query, messages.context) : [],
+      file: fileResults(files, query),
+    };
+    return RESULT_ORDER.map((kind) => ({
+      kind,
+      label: RESULT_LABEL[kind],
+      results: byKind[kind] ?? [],
+    })).filter((group) => group.results.length > 0);
+  }, [desks, members, messages, files, query]);
+
+  return { groups, loading, members, desks };
+}
+
+/** A resolved scope: which conversation to read, and what to call it. */
+interface ResolvedScope {
+  /** The **host thread** to read history from. */
+  threadId: string;
+  context: MessageContext;
+}
+
+/**
+ * The one conversation a scope names, or null when it names none yet.
+ *
+ * The thread and the link are deliberately different strings for a person:
+ * `dmThreadId` is what the host answers history on, `dmChannelId` is what this
+ * console routes — and they diverge for a teammate whose id spells General
+ * (`views/room/channels.ts`). Reading the wrong one gives an empty history for
+ * a DM that plainly has messages.
+ */
+function resolveScope(
+  query: SearchQuery,
+  desks: readonly Desk[],
+  members: readonly TeamMember[],
+): ResolvedScope | null {
+  const scope = query.scope;
+  if (!scope || !scope.name) return null;
+
+  if (scope.kind === "person") {
+    const member = best(members, (m) => Math.max(score(m.name, scope.name), score(m.id, scope.name)));
+    if (!member) return null;
+    const nameById = new Map(members.map((m) => [m.id, m.name]));
+    return {
+      threadId: dmThreadId(member),
+      context: {
+        channelId: dmChannelId(member),
+        label: member.name,
+        nameFor: (author) => nameById.get(author) ?? (author === "operator" ? "You" : author),
+      },
+    };
+  }
+
+  const desk = best(desks, (d) => Math.max(score(d.channel, scope.name), score(d.name, scope.name)));
+  if (!desk) return null;
+  const nameById = new Map(members.map((m) => [m.id, m.name]));
+  return {
+    threadId: desk.id,
+    context: {
+      channelId: desk.id,
+      label: `#${desk.channel}`,
+      nameFor: (author) => nameById.get(author) ?? (author === "operator" ? "You" : author),
+    },
+  };
+}
+
+/** The highest-scoring item, or null when nothing scored at all. */
+function best<T>(items: readonly T[], scoreOf: (item: T) => number): T | null {
+  let winner: T | null = null;
+  let top = 0;
+  for (const item of items) {
+    const value = scoreOf(item);
+    if (value > top) {
+      top = value;
+      winner = item;
+    }
+  }
+  return winner;
+}

--- a/frontend/src/search/useSearch.ts
+++ b/frontend/src/search/useSearch.ts
@@ -44,8 +44,21 @@ import { RESULT_LABEL, RESULT_ORDER, type ResultGroup, type SearchResult } from 
  */
 const DEBOUNCE_MS = 160;
 
-/** How much of a conversation to read when searching inside it. */
-const HISTORY_LIMIT = 500;
+/**
+ * How much of a conversation to read when searching inside it.
+ *
+ * Fetched a page at a time, because the host clamps every request to
+ * `CHAT_HISTORY_PAGE_LIMIT` (200, `src/server/chat_history.rs`) — so asking for
+ * 500 silently returned the newest 200 and reported "Nothing matched" for
+ * anything older, which is the one answer a search must never give wrongly.
+ *
+ * Bounded rather than exhaustive: a search is not an export, and a person
+ * waiting on a modal will not wait out a year of a busy channel. When the cap
+ * is reached the older messages are genuinely unsearched — the honest fix for
+ * that is a host-side message search, not more pages here.
+ */
+const HISTORY_PAGE = 200;
+const HISTORY_PAGES = 5;
 
 /** What the modal needs to draw itself. */
 export interface SearchState {
@@ -102,11 +115,18 @@ export function useSearch(
     void Promise.allSettled([client.listDesks(company), client.listTeam(company)]).then(
       ([deskResult, teamResult]) => {
         if (cancelled) return;
-        loadedFor.current = { client, company };
         // Settled rather than awaited together: a host with no `.../desks` route
         // still has a roster, and one failure should not empty both lists.
         if (deskResult.status === "fulfilled") setDesks(deskResult.value.map(deskFromDto));
         if (teamResult.status === "fulfilled") setMembers(teamResult.value.map(fromDto));
+        // Marked loaded only when both answered. Recording the scope on a
+        // partial read would make one transient failure permanent for the rest
+        // of the session: every later opening returns at the guard above, so a
+        // failed roster read leaves no agents — and with them no `@` scope that
+        // can resolve — until the console is reloaded.
+        if (deskResult.status === "fulfilled" && teamResult.status === "fulfilled") {
+          loadedFor.current = { client, company };
+        }
       },
     );
     return () => {
@@ -142,8 +162,7 @@ export function useSearch(
 
       if (isScopedMessageSearch(query) && scoped) {
         setLoading(true);
-        void client
-          .getChatHistory(scoped.threadId, company, { limit: HISTORY_LIMIT })
+        void readConversation(client, company, scoped.threadId)
           .then((rows) => {
             if (!current()) return;
             setMessages({ context: scoped.context, rows });
@@ -203,6 +222,36 @@ export function useSearch(
   }, [desks, members, messages, files, query]);
 
   return { groups, loading, members, desks };
+}
+
+/**
+ * As much of one conversation as a search is willing to wait for.
+ *
+ * Walks the `before` cursor, which the host keys on a message's sequence — the
+ * bare id it answers with. Stops early on a short page, because that is the
+ * start of the conversation and there is nothing behind it.
+ */
+async function readConversation(
+  client: OpenCompanyClient,
+  company: string | null,
+  threadId: string,
+): Promise<ChatHistoryMessageDto[]> {
+  const all: ChatHistoryMessageDto[] = [];
+  let before: string | undefined;
+  for (let page = 0; page < HISTORY_PAGES; page += 1) {
+    const rows = await client.getChatHistory(threadId, company, {
+      before,
+      limit: HISTORY_PAGE,
+    });
+    if (rows.length === 0) break;
+    // Pages arrive oldest-first within themselves and each page is older than
+    // the last, so earlier pages go in front.
+    all.unshift(...rows);
+    if (rows.length < HISTORY_PAGE) break;
+    before = rows[0]?.id;
+    if (!before) break;
+  }
+  return all;
 }
 
 /** A resolved scope: which conversation to read, and what to call it. */

--- a/frontend/src/views/RoomView.tsx
+++ b/frontend/src/views/RoomView.tsx
@@ -1644,6 +1644,69 @@ export function RoomView({
     if (arrived) setOpenThreadId(null);
   }, [routeOpen, channel?.id, threadQuery]);
 
+  /**
+   * `?m=<messageId>` — the line a search result names, brought into view.
+   *
+   * Carried with a nonce for the same reason `?thread=` is: consuming strips it
+   * from the address, so opening the same message twice is a real hash change
+   * whose parsed value is the one already held, and React would bail out of the
+   * re-render.
+   *
+   * The id is the **console** id (`hostMessageId`, `h`-prefixed), which is what
+   * `MessageRow` puts in `data-message-id`. The bare host id the history route
+   * answers with matches no row.
+   */
+  const [messageQuery, setMessageQuery] = useState<{ value: string | null; nonce: number }>({
+    value: null,
+    nonce: 0,
+  });
+  useEffect(() => {
+    const read = () => {
+      const [, query = ""] = window.location.hash.split("?");
+      return new URLSearchParams(query).get("m");
+    };
+    const apply = () => setMessageQuery((prev) => ({ value: read(), nonce: prev.nonce + 1 }));
+    apply();
+    window.addEventListener("hashchange", apply);
+    return () => window.removeEventListener("hashchange", apply);
+  }, []);
+
+  const consumedMessageNonce = useRef(0);
+  useEffect(() => {
+    const wanted = messageQuery.value;
+    if (!wanted || consumedMessageNonce.current === messageQuery.nonce) return;
+
+    // The transcript for a channel just arrived at is still loading, and the row
+    // cannot be scrolled to before it exists. Poll briefly rather than waiting
+    // on a load signal this effect has no access to, and give up rather than
+    // spin: a message that never appears is one the history did not carry.
+    let attempts = 0;
+    const find = () =>
+      document.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(wanted)}"]`);
+    const timer = window.setInterval(() => {
+      attempts += 1;
+      const row = find();
+      if (!row && attempts < 40) return;
+      window.clearInterval(timer);
+      if (!row) return;
+
+      consumedMessageNonce.current = messageQuery.nonce;
+      row.scrollIntoView({ block: "center", behavior: "smooth" });
+      // Marked on the element rather than in React state: the transcript owns
+      // that state and re-renders on every arriving message, and a highlight
+      // that survives one is a highlight that has to be cleared by something.
+      row.setAttribute("data-found", "true");
+      window.setTimeout(() => row.removeAttribute("data-found"), 2600);
+
+      const [path, query = ""] = window.location.hash.replace(/^#/, "").split("?");
+      const params = new URLSearchParams(query);
+      params.delete("m");
+      const qs = params.toString();
+      window.history.replaceState(null, "", `#${path}${qs ? `?${qs}` : ""}`);
+    }, 100);
+    return () => window.clearInterval(timer);
+  }, [messageQuery, channel?.id]);
+
   // Whoever owns the unread counts needs to know what is actually being looked
   // at. Re-runs as the open channel's transcript grows, not only on a switch:
   // a reply that lands while you are reading the channel is read, and should

--- a/frontend/src/views/room/MessageRow.tsx
+++ b/frontend/src/views/room/MessageRow.tsx
@@ -298,6 +298,10 @@ export function MessageRow({
 
   if (sender.kind === "system") {
     return (
+      // Wrapped only to carry the anchor: the pill renders instead of the
+      // `<article>` below, so a system line had no `data-message-id` and a
+      // search result naming one scrolled to nothing.
+      <div data-message-id={message.id} className="data-[found]:bg-primary/10">
       <SystemPill
         message={message}
         reviewInFlight={message.taskId !== undefined && (reviewingCardIds?.has(message.taskId) ?? false)}
@@ -308,6 +312,7 @@ export function MessageRow({
         redeemingBudgetPauseAgent={redeemingBudgetPauseAgent}
         latestBudgetPauseMessageIdByAgent={latestBudgetPauseMessageIdByAgent}
       />
+      </div>
     );
   }
 

--- a/frontend/src/views/room/MessageRow.tsx
+++ b/frontend/src/views/room/MessageRow.tsx
@@ -318,6 +318,11 @@ export function MessageRow({
         "group/message relative flex gap-2.5 px-4 transition-colors hover:bg-muted/40",
         continuation ? "py-0.5" : "pb-0.5 pt-2",
         threadOpen && "bg-muted/60",
+        // Set by `RoomView` for a moment when a search result scrolls this line
+        // into view, then removed. An attribute rather than a prop: the
+        // transcript re-renders on every arriving message, and this is about
+        // *the arrival* rather than about the message.
+        "data-[found]:bg-primary/10",
       )}
     >
       <div className="w-9 shrink-0">

--- a/frontend/src/views/room/ThreadPanel.tsx
+++ b/frontend/src/views/room/ThreadPanel.tsx
@@ -456,7 +456,10 @@ function Line({
   }
 
   return (
-    <div className="flex gap-2.5 px-4 py-2">
+    // Anchored like a timeline row: a reply lives here and nowhere else, so a
+    // deep link naming one has nothing to find without this
+    // (`search/sources.ts` emits `?thread=…&m=…` for exactly this case).
+    <div data-message-id={message.id} className="flex gap-2.5 px-4 py-2 data-[found]:bg-primary/10">
       <TeammateAvatar
         name={sender.name}
         tone={sender.tone}

--- a/frontend/src/views/room/ThreadPanel.tsx
+++ b/frontend/src/views/room/ThreadPanel.tsx
@@ -449,9 +449,14 @@ function Line({
       latestBudgetPauseMessageIdByAgent,
     });
     return (
-      budgetPauseCard ?? (
-        <p className="px-4 py-1 text-center text-xs text-muted-foreground">{message.text}</p>
-      )
+      // Anchored like every other row here: this branch returns before the one
+      // below, so a system line in a thread — a settle notice, a budget pause —
+      // had nothing for a deep link to find.
+      <div data-message-id={message.id} className="data-[found]:bg-primary/10">
+        {budgetPauseCard ?? (
+          <p className="px-4 py-1 text-center text-xs text-muted-foreground">{message.text}</p>
+        )}
+      </div>
     );
   }
 

--- a/frontend/test/unit/search-query.test.ts
+++ b/frontend/test/unit/search-query.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isScopedMessageSearch,
+  parseSearchQuery,
+  scopeIsNamed,
+  withScopeName,
+} from "@/search/query";
+
+/**
+ * The search grammar, away from the modal that renders it.
+ *
+ * Every rule here is one an operator meets within seconds of pressing the key,
+ * and each fails silently if it is wrong: a scope that does not open leaves the
+ * picker shut for no visible reason, and a term that swallows the scope name
+ * searches the whole company for the word "priya".
+ */
+describe("parsing what was typed", () => {
+  it("treats a bare term as a search of everything", () => {
+    const q = parseSearchQuery("autumn box");
+    expect(q.scope).toBeNull();
+    expect(q.term).toBe("autumn box");
+    expect(q.isEmpty).toBe(false);
+  });
+
+  it("opens a scope on the prefix alone, before a name is typed", () => {
+    // The picker has to appear on the keypress. Waiting for a first letter is
+    // what makes an `@` feel broken for the moment before it works.
+    const q = parseSearchQuery("@");
+    expect(q.scope).toEqual({ kind: "person", name: "" });
+    expect(scopeIsNamed(q)).toBe(false);
+  });
+
+  it("reads @ as a person, # as a channel and / as a file", () => {
+    expect(parseSearchQuery("@priya").scope).toEqual({ kind: "person", name: "priya" });
+    expect(parseSearchQuery("#general").scope).toEqual({ kind: "channel", name: "general" });
+    expect(parseSearchQuery("/brief").scope).toEqual({ kind: "file", name: "brief" });
+  });
+
+  it("gives the whole remainder to a file scope rather than splitting it", () => {
+    // `/autumn brief` is looking for a file called something like "autumn
+    // brief" — not for "brief" inside a file called "autumn". A file scope
+    // names the things themselves, so there is nothing to narrow within.
+    const q = parseSearchQuery("/autumn brief");
+    expect(q.scope).toEqual({ kind: "file", name: "autumn brief" });
+    expect(q.term).toBe("");
+    expect(isScopedMessageSearch(q)).toBe(false);
+  });
+
+  it("splits the scope's name from the term at the first space", () => {
+    const q = parseSearchQuery("@priya autumn box");
+    expect(q.scope).toEqual({ kind: "person", name: "priya" });
+    // Multi-word terms survive: only the FIRST space divides name from term.
+    expect(q.term).toBe("autumn box");
+  });
+
+  it("has a named scope but no term while the name is still being typed", () => {
+    const q = parseSearchQuery("@priya");
+    expect(scopeIsNamed(q)).toBe(true);
+    expect(q.term).toBe("");
+    // Choosing a person is not yet a search — every message they ever sent is
+    // not what was asked for.
+    expect(isScopedMessageSearch(q)).toBe(false);
+  });
+
+  it("asks for messages only once a scope and a term are both present", () => {
+    expect(isScopedMessageSearch(parseSearchQuery("@priya box"))).toBe(true);
+    expect(isScopedMessageSearch(parseSearchQuery("#autumn-launch box"))).toBe(true);
+    expect(isScopedMessageSearch(parseSearchQuery("@ box"))).toBe(false);
+  });
+
+  it("lowercases what it matches on, and keeps the raw string intact", () => {
+    const q = parseSearchQuery("  @Priya Autumn BOX  ");
+    expect(q.scope?.name).toBe("priya");
+    expect(q.term).toBe("autumn box");
+    // The input restores exactly what was typed, spaces and all.
+    expect(q.raw).toBe("  @Priya Autumn BOX  ");
+  });
+
+  it("reads whitespace as nothing typed rather than as a term", () => {
+    for (const raw of ["", "   ", "\t"]) {
+      const q = parseSearchQuery(raw);
+      expect(q.isEmpty, `${JSON.stringify(raw)} should be empty`).toBe(true);
+      expect(q.scope).toBeNull();
+      expect(q.term).toBe("");
+    }
+  });
+
+  it("leaves a prefix in the middle of a term alone", () => {
+    // Only a LEADING prefix opens a scope. An email address or a "#1" is a
+    // term, and scoping on it would search a channel nobody named.
+    const q = parseSearchQuery("ada@example.com");
+    expect(q.scope).toBeNull();
+    expect(q.term).toBe("ada@example.com");
+  });
+});
+
+describe("choosing from the picker", () => {
+  it("rewrites the input to the chosen name, ready for a term", () => {
+    // The trailing space is load-bearing: it is what moves the caret out of the
+    // name and into the term, so the next keystroke searches rather than
+    // renaming.
+    expect(withScopeName(parseSearchQuery("@pri"), "priya")).toBe("@priya ");
+    expect(withScopeName(parseSearchQuery("#aut"), "autumn-launch")).toBe("#autumn-launch ");
+  });
+
+  it("keeps the scope kind that was open", () => {
+    expect(withScopeName(parseSearchQuery("#gen"), "general").startsWith("#")).toBe(true);
+    expect(withScopeName(parseSearchQuery("@gen"), "general").startsWith("@")).toBe(true);
+  });
+});

--- a/frontend/test/unit/search-rank.test.ts
+++ b/frontend/test/unit/search-rank.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { bestScore, excerptAround, matchRanges, matches, score } from "@/search/rank";
+
+/**
+ * Matching and ordering, away from anything that renders them.
+ *
+ * Highlighting is offsets rather than markup on purpose — a search box that
+ * rebuilds user input as HTML is one paste away from being an injection — so
+ * the offsets have to be right against the ORIGINAL string, not a lowercased
+ * copy of it.
+ */
+describe("where a term matched", () => {
+  it("gives offsets into the original text, not a lowercased copy", () => {
+    const text = "Autumn Box";
+    const [range] = matchRanges(text, "box");
+    expect(text.slice(range[0], range[1])).toBe("Box");
+  });
+
+  it("finds every occurrence", () => {
+    expect(matchRanges("box in a box", "box")).toEqual([
+      [0, 3],
+      [9, 12],
+    ]);
+  });
+
+  it("treats an empty term as nothing asked rather than everything matched", () => {
+    expect(matchRanges("anything", "")).toEqual([]);
+    expect(matchRanges("", "box")).toEqual([]);
+  });
+
+  it("answers whether there is a match at all", () => {
+    expect(matches("Autumn Box", "box")).toBe(true);
+    expect(matches("Autumn Box", "candle")).toBe(false);
+    // No term is not a filter.
+    expect(matches("anything", "")).toBe(true);
+  });
+});
+
+describe("which hit deserves to be first", () => {
+  it("puts an exact name above everything", () => {
+    expect(score("general", "general")).toBeGreaterThan(score("general-notes", "general"));
+  });
+
+  it("puts a prefix above a match buried in the middle", () => {
+    // Typing "gen" should read along with `general`, not surface a channel
+    // that merely contains the letters.
+    expect(score("general", "gen")).toBeGreaterThan(score("autumn-general-notes", "gen"));
+  });
+
+  it("prefers an earlier match among substrings", () => {
+    expect(score("a box here", "box")).toBeGreaterThan(score("a much longer line box", "box"));
+  });
+
+  it("scores no match as zero, so callers can drop it", () => {
+    expect(score("autumn", "candle")).toBe(0);
+  });
+
+  it("takes the best of several fields rather than the sum", () => {
+    // One strong hit beats two weak ones: a channel whose NAME is `general`
+    // outranks one that merely mentions it twice in its description.
+    const exact = bestScore(["general", "nothing relevant"], "general");
+    const buried = bestScore(["autumn", "general chat about general things"], "general");
+    expect(exact).toBeGreaterThan(buried);
+  });
+
+  it("ignores empty fields", () => {
+    expect(bestScore([null, undefined, "", "general"], "general")).toBeGreaterThan(0);
+  });
+});
+
+describe("the snippet shown for a body match", () => {
+  const long = `${"lorem ipsum ".repeat(40)}the autumn box ships friday${" and more text".repeat(20)}`;
+
+  it("windows around the match rather than from the start", () => {
+    const { excerpt } = excerptAround(long, "autumn box");
+    // The whole reason this exists: a snippet that does not contain what was
+    // searched for tells the operator nothing.
+    expect(excerpt.toLowerCase()).toContain("autumn box");
+  });
+
+  it("marks where it cut", () => {
+    const { excerpt } = excerptAround(long, "autumn box");
+    expect(excerpt.startsWith("…")).toBe(true);
+    expect(excerpt.endsWith("…")).toBe(true);
+  });
+
+  it("returns ranges that index into the excerpt it returned", () => {
+    const { excerpt, ranges } = excerptAround(long, "autumn box");
+    expect(ranges.length).toBeGreaterThan(0);
+    const [range] = ranges;
+    // The offsets must survive the leading ellipsis, or the highlight lands one
+    // character off — which is exactly the bug this test exists to catch.
+    expect(excerpt.slice(range[0], range[1]).toLowerCase()).toBe("autumn box");
+  });
+
+  it("collapses whitespace so a snippet is one readable line", () => {
+    const { excerpt } = excerptAround("a\n\n  line   with\tgaps", "line");
+    expect(excerpt).toBe("a line with gaps");
+  });
+
+  it("returns a short text whole, with no ellipsis and no ranges for no term", () => {
+    expect(excerptAround("short enough", "")).toEqual({ excerpt: "short enough", ranges: [] });
+  });
+});

--- a/frontend/test/unit/search-rank.test.ts
+++ b/frontend/test/unit/search-rank.test.ts
@@ -135,3 +135,49 @@ describe("a query whose spacing does not match the text's", () => {
     expect(excerpt.slice(range[0], range[1])).toBe("foo bar");
   });
 });
+
+/**
+ * Folding has to do both jobs at once: match regardless of case, and hand back
+ * offsets into the string that will be rendered. The first attempt at the
+ * Unicode fix did the second by giving up the first (CodeRabbit on #2245).
+ */
+describe("a term whose own case folding expands", () => {
+  it("still matches when the match itself contains the character", () => {
+    // `"İ".toLowerCase()` is two code units. Refusing to fold it keeps offsets
+    // honest and makes the word case-SENSITIVE, so this stopped matching.
+    expect(score("İstanbul", "istanbul")).toBeGreaterThan(0);
+    expect(matches("İstanbul", "istanbul")).toBe(true);
+  });
+
+  it("marks the match in the original string, not one character off", () => {
+    const text = "İstanbul";
+    const [range] = matchRanges(text, "istanbul");
+    expect(text.slice(range[0], range[1])).toBe("İstanbul");
+  });
+
+  it("keeps offsets right for a match after an expanding character", () => {
+    const text = "İstanbul box";
+    const [range] = matchRanges(text, "BOX");
+    expect(text.slice(range[0], range[1])).toBe("box");
+  });
+
+  it("does not measure a surrogate pair in halves", () => {
+    const text = "🕯 candle";
+    const [range] = matchRanges(text, "candle");
+    expect(text.slice(range[0], range[1])).toBe("candle");
+  });
+});
+
+describe("accents, which normalising makes free", () => {
+  it("finds an accented word from an unaccented query, and marks it whole", () => {
+    expect(score("café", "cafe")).toBeGreaterThan(0);
+    const text = "the café is open";
+    const [range] = matchRanges(text, "cafe");
+    // The offsets still index the original, accent and all.
+    expect(text.slice(range[0], range[1])).toBe("café");
+  });
+
+  it("works in the other direction too", () => {
+    expect(matches("cafe society", "café")).toBe(true);
+  });
+});

--- a/frontend/test/unit/search-rank.test.ts
+++ b/frontend/test/unit/search-rank.test.ts
@@ -52,6 +52,16 @@ describe("which hit deserves to be first", () => {
     expect(score("a box here", "box")).toBeGreaterThan(score("a much longer line box", "box"));
   });
 
+  it("prefers the shorter text when the match sits in the same place", () => {
+    // Pinned because a reviewer read this tier's arithmetic backwards
+    // (tinysweeper on #2245): the length term is subtracted, so a shorter text
+    // subtracts less and ends up ahead. Position is held equal here so the only
+    // thing under test is the length tie-break.
+    const short = `${"x".repeat(10)}box`;
+    const long = `${"x".repeat(10)}box${"y".repeat(300)}`;
+    expect(score(short, "box")).toBeGreaterThan(score(long, "box"));
+  });
+
   it("scores no match as zero, so callers can drop it", () => {
     expect(score("autumn", "candle")).toBe(0);
   });

--- a/frontend/test/unit/search-rank.test.ts
+++ b/frontend/test/unit/search-rank.test.ts
@@ -103,3 +103,35 @@ describe("the snippet shown for a body match", () => {
     expect(excerptAround("short enough", "")).toEqual({ excerpt: "short enough", ranges: [] });
   });
 });
+
+/**
+ * Case folding that changes length is how a highlight lands on the wrong
+ * letters (Codex P2 on #2245).
+ */
+describe("matching text that does not fold to the same length", () => {
+  it("keeps offsets pointing at the match in the original string", () => {
+    // `"İ".toLowerCase()` is two code units. Lowercasing the haystack shifts
+    // every index after it by one, and the highlight slides off the match.
+    const text = "İstanbul box";
+    const [range] = matchRanges(text, "box");
+    expect(text.slice(range[0], range[1])).toBe("box");
+  });
+
+  it("windows the excerpt on the match, not one character past it", () => {
+    const { excerpt, ranges } = excerptAround("İstanbul box of candles", "box");
+    const [range] = ranges;
+    expect(excerpt.slice(range[0], range[1])).toBe("box");
+  });
+});
+
+describe("a query whose spacing does not match the text's", () => {
+  it("still finds and marks the term the score said was there", () => {
+    // `score` sees the raw text and matches; the excerpt collapses whitespace,
+    // so without collapsing the term too the snippet came back unmarked and
+    // windowed from the start.
+    const { excerpt, ranges } = excerptAround("keep the  foo  bar together", "foo  bar");
+    expect(ranges.length).toBeGreaterThan(0);
+    const [range] = ranges;
+    expect(excerpt.slice(range[0], range[1])).toBe("foo bar");
+  });
+});

--- a/frontend/test/unit/search-sources.test.ts
+++ b/frontend/test/unit/search-sources.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSearchQuery } from "@/search/query";
+import {
+  agentResults,
+  channelResults,
+  fileResults,
+  formatWhen,
+  messageResults,
+} from "@/search/sources";
+import type { Desk } from "@/lib/desks";
+import type { TeamMember } from "@/lib/team";
+import { OPERATOR_ORIGIN, type SearchHit } from "@/api/workspace";
+
+/**
+ * A whole `SearchHit`, rather than a cast of the three fields under test.
+ *
+ * `typecheck:unit` compiles this file against a different tsconfig from
+ * `typecheck`, and a partial cast passes one and fails the other — which is
+ * how a test file ends up green locally and red in CI.
+ */
+function hit(over: Pick<SearchHit, "id" | "name" | "path" | "matched"> & Partial<SearchHit>): SearchHit {
+  return {
+    kind: "file",
+    parentId: null,
+    updatedAt: 0,
+    createdBy: OPERATOR_ORIGIN,
+    updatedBy: OPERATOR_ORIGIN,
+    ...over,
+  };
+}
+
+const desks = [
+  { id: "general", channel: "general", name: "General", blurb: "Everything else." },
+  {
+    id: "autumn_launch",
+    channel: "autumn-launch",
+    name: "Autumn launch",
+    blurb: "Shipping the autumn range.",
+  },
+] as Desk[];
+
+function member(over: Partial<TeamMember> & { id: string; name: string }): TeamMember {
+  return {
+    role: "",
+    description: "",
+    tone: "blue",
+    avatar: over.id,
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+    ...over,
+  } as TeamMember;
+}
+
+const members = [
+  member({ id: "priya", name: "Priya", role: "Ecommerce Merchandiser" }),
+  member({ id: "nadia", name: "Nadia", role: "Packaging Buyer" }),
+];
+
+describe("channels as results", () => {
+  it("matches the name you would type and the purpose you might remember", () => {
+    expect(channelResults(desks, parseSearchQuery("autumn")).map((r) => r.title)).toEqual([
+      "#autumn-launch",
+    ]);
+    // Nobody remembers the slug; they remember what the channel was for.
+    expect(channelResults(desks, parseSearchQuery("shipping")).map((r) => r.title)).toEqual([
+      "#autumn-launch",
+    ]);
+  });
+
+  it("says which of the two things Enter does", () => {
+    // In a fused palette both are reachable from one row, so the row says it.
+    const [go] = channelResults(desks, parseSearchQuery("#general"));
+    expect(go.action).toBe("Go to #general");
+  });
+
+  it("links to the address the hash router already routes", () => {
+    const [hit] = channelResults(desks, parseSearchQuery("autumn"));
+    expect(hit.href).toBe("#/chat/autumn_launch");
+  });
+
+  it("offsets the highlight past the # the title adds", () => {
+    const [hit] = channelResults(desks, parseSearchQuery("general"));
+    const [range] = hit.titleMatches;
+    expect(hit.title.slice(range[0], range[1])).toBe("general");
+  });
+
+  it("stays out of the way when the scope names people", () => {
+    expect(channelResults(desks, parseSearchQuery("@priya"))).toEqual([]);
+  });
+});
+
+describe("agents as results", () => {
+  it("matches a name or the role you would describe them by", () => {
+    expect(agentResults(members, parseSearchQuery("priya")).map((r) => r.title)).toEqual(["Priya"]);
+    expect(agentResults(members, parseSearchQuery("packaging")).map((r) => r.title)).toEqual([
+      "Nadia",
+    ]);
+  });
+
+  it("answers a half-typed @ scope, which is what opens the picker", () => {
+    expect(agentResults(members, parseSearchQuery("@pri")).map((r) => r.title)).toEqual(["Priya"]);
+  });
+
+  it("links to the console-local DM id the router routes", () => {
+    // Deliberately `dmChannelId`, not `dmThreadId` — the latter is the host
+    // thread a DM is addressed on, and the two differ for a teammate whose id
+    // spells General.
+    const [hit] = agentResults(members, parseSearchQuery("priya"));
+    expect(hit.href).toBe("#/chat/dm%3Apriya");
+  });
+
+  it("stays out of the way when the scope names channels", () => {
+    expect(agentResults(members, parseSearchQuery("#general"))).toEqual([]);
+  });
+});
+
+describe("messages inside one conversation", () => {
+  const context = {
+    channelId: "dm:priya",
+    label: "Priya",
+    nameFor: (author: string) => (author === "priya" ? "Priya" : "You"),
+  };
+  const messages = [
+    { id: "m1", channel: "dm:priya", author: "priya", text: "The autumn box ships friday", atMillis: 1, mine: false },
+    { id: "m2", channel: "dm:priya", author: "operator", text: "nothing relevant here", atMillis: 2, mine: true },
+  ];
+
+  it("returns only the messages that match, with the author on the row", () => {
+    const hits = messageResults(messages, parseSearchQuery("@priya box"), context);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].title).toBe("Priya");
+    expect(hits[0].excerpt).toContain("autumn box");
+  });
+
+  it("answers nothing until there is a term, so picking a person is not a search", () => {
+    // `@priya` alone is choosing somebody. Every message they ever sent is not
+    // what was asked for.
+    expect(messageResults(messages, parseSearchQuery("@priya"), context)).toEqual([]);
+  });
+
+  it("says where the message lives and where opening it goes", () => {
+    const [hit] = messageResults(messages, parseSearchQuery("@priya box"), context);
+    expect(hit.subtitle).toContain("Priya");
+    expect(hit.action).toBe("Open in Priya");
+    // Deep link to the line itself, in the `h`-prefixed CONSOLE id form that
+    // `MessageRow` renders into `data-message-id`. The bare host id the history
+    // route answers with matches no row, so the link would land on the channel
+    // and then find nothing to scroll to.
+    expect(hit.href).toBe("#/chat/dm%3Apriya?m=hm1");
+  });
+});
+
+describe("workspace files as results", () => {
+  const hits = [
+    hit({ id: "n1", name: "Autumn brief.md", path: "briefs/Autumn brief.md", matched: "name" }),
+    hit({ id: "n2", name: "Notes.md", path: "Notes.md", matched: "content", excerpt: "the autumn box" }),
+  ];
+
+  it("puts a name match above a body match", () => {
+    const results = fileResults(hits, parseSearchQuery("autumn"));
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+
+  it("shows the path, and the body excerpt where there is one", () => {
+    const [named, bodied] = fileResults(hits, parseSearchQuery("autumn"));
+    expect(named.subtitle).toBe("briefs/Autumn brief.md");
+    expect(bodied.excerpt).toContain("autumn box");
+  });
+
+  it("stays out of the way of a scoped search", () => {
+    // `@priya box` is a question about a conversation, not about files.
+    expect(fileResults(hits, parseSearchQuery("@priya box"))).toEqual([]);
+  });
+});
+
+describe("when a message was sent", () => {
+  const noon = new Date("2026-09-10T12:00:00Z").getTime();
+
+  it("gives a time today, a weekday this week, and a date beyond that", () => {
+    expect(formatWhen(noon, noon + 60_000)).toMatch(/\d/);
+    expect(formatWhen(noon, noon + 3 * 24 * 3600_000)).toMatch(/day$/);
+    expect(formatWhen(noon, noon + 30 * 24 * 3600_000)).toMatch(/\w/);
+  });
+});
+
+describe("the file scope", () => {
+  const hits = [
+    hit({ id: "n1", name: "Autumn brief.md", path: "briefs/Autumn brief.md", matched: "name" }),
+  ];
+
+  it("answers a / scope, where a bare term and an @ scope would not", () => {
+    expect(fileResults(hits, parseSearchQuery("/autumn"))).toHaveLength(1);
+    expect(fileResults(hits, parseSearchQuery("@priya box"))).toEqual([]);
+  });
+
+  it("keeps channels and agents out of a file search", () => {
+    expect(channelResults(desks, parseSearchQuery("/general"))).toEqual([]);
+    expect(agentResults(members, parseSearchQuery("/priya"))).toEqual([]);
+  });
+});

--- a/frontend/test/unit/search-sources.test.ts
+++ b/frontend/test/unit/search-sources.test.ts
@@ -200,3 +200,98 @@ describe("the file scope", () => {
     expect(agentResults(members, parseSearchQuery("/priya"))).toEqual([]);
   });
 });
+
+/**
+ * The things review found could be offered but not reached, or ranked but not
+ * ordered (#2245).
+ */
+describe("results that have to survive the round trip", () => {
+  const multiWord = [member({ id: "user_researcher", name: "User Researcher", role: "Research" })];
+
+  it("hands back a one-word token for an agent whose name has a space", () => {
+    // `@User Researcher ` would re-parse as the scope `user` and the term
+    // `researcher`, searching a different agent's DM for a word nobody typed.
+    const [hit] = agentResults(multiWord, parseSearchQuery("@user"));
+    expect(hit.scopeName).toBe("user_researcher");
+    expect(parseSearchQuery(`@${hit.scopeName} box`).scope).toEqual({
+      kind: "person",
+      name: "user_researcher",
+    });
+  });
+
+  it("hands back the channel's own slug, not the # the row draws", () => {
+    const [hit] = channelResults(desks, parseSearchQuery("#autumn"));
+    expect(hit.scopeName).toBe("autumn-launch");
+  });
+});
+
+describe("ordering that the limit would otherwise decide", () => {
+  const context = {
+    channelId: "dm:priya",
+    label: "Priya",
+    nameFor: () => "Priya",
+  };
+
+  it("breaks an equal-score tie by recency, so the limit keeps the newest", () => {
+    // History answers oldest-first, and a common word scores identically on
+    // every hit — so without the second key the six oldest fill the list.
+    const messages = Array.from({ length: 8 }, (_, index) => ({
+      id: `m${index}`,
+      channel: "dm:priya",
+      author: "priya",
+      text: "yes",
+      atMillis: index + 1,
+      mine: false,
+    }));
+    const hits = messageResults(messages, parseSearchQuery("@priya yes"), context);
+    expect(hits).toHaveLength(6);
+    expect(hits[0].id).toBe("message:m7");
+  });
+
+  it("ranks files before applying the limit, so a name match is not dropped", () => {
+    const many = [
+      ...Array.from({ length: 6 }, (_, index) =>
+        hit({ id: `body${index}`, name: `Note ${index}.md`, path: `Note ${index}.md`, matched: "content" }),
+      ),
+      hit({ id: "named", name: "Autumn.md", path: "Autumn.md", matched: "name" }),
+    ];
+    const results = fileResults(many, parseSearchQuery("autumn"));
+    expect(results[0].id, "the name match should lead, not be sliced away").toBe("file:named");
+  });
+});
+
+describe("links that have somewhere to land", () => {
+  const context = { channelId: "dm:priya", label: "Priya", nameFor: () => "Priya" };
+
+  it("names the parent thread for a folded reply", () => {
+    // A reply renders in `ThreadPanel` and not in the timeline at all, so the
+    // address has to open the panel before there is a line to scroll to.
+    const reply = {
+      id: "r1",
+      parentId: "p1",
+      channel: "dm:priya",
+      author: "priya",
+      text: "the candle ships friday",
+      atMillis: 1,
+      mine: false,
+    };
+    const [result] = messageResults([reply], parseSearchQuery("@priya candle"), context);
+    expect(result.href).toContain("thread=hp1");
+    expect(result.href).toContain("m=hr1");
+  });
+});
+
+describe("when a message was sent, by the calendar", () => {
+  it("does not call yesterday evening today because it is inside 24 hours", () => {
+    const yesterdayEvening = new Date(2026, 8, 9, 23, 0).getTime();
+    const thisMorning = new Date(2026, 8, 10, 10, 0).getTime();
+    // 11 hours ago, and still not today.
+    expect(formatWhen(yesterdayEvening, thisMorning)).not.toMatch(/^\d{1,2}[:.]/);
+  });
+
+  it("gives a bare time for a message from earlier the same day", () => {
+    const earlier = new Date(2026, 8, 10, 9, 0).getTime();
+    const later = new Date(2026, 8, 10, 17, 0).getTime();
+    expect(formatWhen(earlier, later)).toMatch(/\d/);
+  });
+});


### PR DESCRIPTION
## Why

The search field in the title row was a placed control with nothing behind it — `disabled`, and honest about it, with a `title` that said "Search is not available yet". This wires it.

## What it does

**A trigger, not a field.** Clicking it or pressing ⌘K opens a modal that owns the input. One box in a dialog is what makes results possible at all: a dropdown hanging off a title-row input has nowhere to put four groups of results. The button is now capped rather than elastic — a search control that grows to fill a 1440px window reads as a text field somebody stretched by accident — while the *wrapper* stays elastic, because it is still the only thing left to grab the window by across the middle (it carries `data-tauri-drag-region`; the control deliberately does not).

**Three prefixes.**

| Typed | Searches |
|---|---|
| `candle` | channels, agents, and workspace files |
| `@priya` | agents — picking one fills the scope in rather than navigating |
| `@priya candle` | **inside Priya's DM** |
| `#autumn-launch` | channels |
| `#autumn-launch fireside` | **inside that channel** |
| `/autumn` | files |

`/` deliberately does not split at the space the way `@` and `#` do. `/autumn brief` looks for a file *called* something like "autumn brief", not for "brief" inside a file called "autumn" — a file scope names the things themselves, so there is nothing to narrow within.

**Results are grouped, not tabbed** — Channels, Agents, Messages, Files. A tab makes the operator choose where the answer lives before they know, and "I half remember a name" is exactly the case where they cannot.

**A message result opens on the message.** `?m=<messageId>` scrolls the line into the centre and tints it briefly, then strips itself from the address. Previously a result named the conversation and left the operator to find the line themselves, in a DM scrolled to the bottom — the one place the answer is not.

## What it deliberately does not do

**Message search is scoped by construction.** There is no host route for message search across a company, and searching whichever channels happen to be loaded would answer "nothing matched" for a message that plainly exists. So the modal reads exactly one conversation — the search it can answer honestly. A global one needs a route on the host.

Also not here, as v1 scope: recent searches in the resting state, `from:`/`in:`/`before:` filter vocabulary, and result sorting controls.

## Shape

The grammar, the ranking and the shaping are four modules with **no React in them** — `search/query.ts`, `search/rank.ts`, `search/sources.ts`, `search/types.ts`. That is the half which is easy to get quietly wrong and expensive to debug through a modal, and 48 unit tests cover it without rendering anything. React is confined to `SearchDialog`, `SearchResultRow`, `HighlightedText` and `useSearch`.

Three details worth naming, each of which is a test:

- **Highlighting is offsets and slices, never markup.** A search box that rebuilds user input as HTML is one paste away from being an injection. `matchRanges` returns offsets into the *original* string, and `HighlightedText` slices it.
- **The excerpt window is placed around the match**, not taken from the start — a 400-character message excerpted from character zero shows a snippet that does not contain what was searched for.
- **A late answer never wins.** Every fetch is tagged with the generation that asked for it and drops itself if the query moved on, so typing `box` cannot have results for `bo` land on top of them.

## Two traps this hit, for the reviewer's benefit

- **Message ids.** Rendered rows carry the `h`-prefixed *console* id (`hostMessageId`), while `GET …/chat/history` answers with the bare host id. A deep link built from the bare one opens the channel and then finds nothing to scroll to — a link that half works, silently.
- **Dialog width.** A bare `max-w-2xl` on `DialogContent` loses to its own `sm:max-w-sm` base at every width ≥640px, so the modal would have rendered 384px wide. `dialog-width-override.test.ts` caught it; the class is `sm:max-w-2xl`.

## Commands run

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — all three clean (`typecheck:unit` caught a partial cast in a new test that `typecheck` passed)
- `npx vitest run test/unit` — 607 files, 5286 passed, 3 skipped, 0 failed
- `scripts/ci/assert-design-tokens.sh` — clean
- `npm run build` — clean

## Verified in a browser

Against the operator's real company data, in dark and light: the capped trigger and ⌘K, `@pri` picking Priya, Enter filling the scope rather than navigating, `@Priya candle` returning six messages from that DM with excerpts and highlights, `#autumn` returning two channels, `#autumn-launch fireside` returning six messages in that channel, plain `fireside` returning six workspace files, and clicking a message result landing on that line with the highlight applied and the `?m=` param consumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a global search dialog accessible from the title bar or with ⌘K/Ctrl+K.
  - Search channels, people, messages, and files with grouped results, ranking, excerpts, and highlighted matches.
  - Supports scoped searches using `@` for people, `#` for channels, and `/` for files.
  - Navigate results with keyboard controls and open selected items directly.
  - Linked messages and thread replies scroll into view and are temporarily highlighted.
  - Search handles accented text and flexible whitespace, with loading and empty-result states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->