### PR TITLE
feat(team): message an agent from the Agent board

### DIFF
--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -29,6 +29,7 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { withHostParam } from "@/hooks/use-host-route";
 import { fetchBoardColumns } from "@/lib/board-columns";
 import { shouldPromptSetup } from "@/lib/company-setup";
 import {
@@ -607,9 +608,24 @@ const IDLE: Workload = { open: 0, status: "idle" };
  *
  * The same call, for the same reason, backs the console search results
  * (`search/sources.ts`).
+ *
+ * ## Why it carries the host scope
+ *
+ * Through {@link withHostParam} rather than as a bare `#/chat/…` fragment,
+ * because this addresses an *anchor* — and an anchor is copied, middle-clicked
+ * and Cmd-clicked as well as clicked, which is half of why it is an anchor at
+ * all. A same-tab click survives a dropped scope, since `useHostAddress`
+ * re-asserts it on the `hashchange` that follows. A new document has no
+ * selection to repair from: `useHostRoute` falls back to the bootstrap or
+ * embedded host and resolves this agent's id against whichever console that is
+ * — an unknown DM, or a different company's agent wearing the same id.
+ * `TaskCard`'s `detailsHref` carries the scope for exactly this reason.
+ *
+ * A console holding one host writes no scope at all, so this is the same
+ * string it has always been there.
  */
 export function agentDmHref(member: TeamMember): string {
-  return `#/chat/${encodeURIComponent(dmChannelId(member))}`;
+  return withHostParam(`chat/${encodeURIComponent(dmChannelId(member))}`);
 }
 
 function MemberCard({

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -124,6 +124,21 @@ export function TeamView({
    */
   const [hostEmpty, setHostEmpty] = useState(false);
   const [members, setMembers] = useState<TeamMember[]>([]);
+  /**
+   * Ids of rows this console appended itself, because the host has no team
+   * write plane (`addMember`'s 404 branch below).
+   *
+   * `fromHost` cannot answer this. It is one flag for the whole roster, set by
+   * the *read*, and a host that serves `GET …/team` and 404s the `POST` leaves
+   * it true while a console-only row sits on the grid — so both of the card's
+   * host-addressed controls would offer to open something no host holds. See
+   * {@link hostBackedCard}.
+   *
+   * Emptied by every re-read: `boot` replaces the roster wholesale, so a marker
+   * that outlived its row would suppress the controls on a real teammate who
+   * happens to be minted at the same id.
+   */
+  const [consoleOnly, setConsoleOnly] = useState<ReadonlySet<string>>(NO_CONSOLE_ONLY);
   const [nameQuery, setNameQuery] = useState("");
   const [workingOnly, setWorkingOnly] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
@@ -188,6 +203,10 @@ export function TeamView({
       setHostEmpty(false);
       return false;
     } finally {
+      // Every branch above replaced the roster from the host — with its rows,
+      // with nobody, or with nobody because the read failed. None of them can
+      // still hold a row this console appended, so the markers go with them.
+      setConsoleOnly(NO_CONSOLE_ONLY);
       setLoad("ready");
     }
   }, [client, company]);
@@ -317,7 +336,13 @@ export function TeamView({
     } catch (error) {
       if (error instanceof ApiError && error.status === 404) {
         // No team write plane on this host — keep the edit local-only.
-        setMembers((m) => [...m, newMember(fields)]);
+        const local = newMember(fields);
+        setMembers((m) => [...m, local]);
+        // And say so per row, because the roster-wide `fromHost` still reads
+        // true here: the read landed, only the write had nowhere to go. Without
+        // this the card would offer to open a detail page and a DM against an
+        // id the host has never heard of.
+        setConsoleOnly((ids) => new Set(ids).add(local.id));
         reportAddMember({ kind: "console-only", name: fields.name });
         setAddOpen(false);
         return true;
@@ -538,15 +563,16 @@ export function TeamView({
                   key={m.id}
                   member={m}
                   onRemove={() => void removeMember(m)}
-                  // Only a host-backed teammate can be opened: a starter-team
-                  // card is a local placeholder with no record behind it, so its
-                  // id would 404 and the detail view would report a teammate that
-                  // was never removed.
-                  onOpen={fromHost ? () => onOpenAgent(m.id) : undefined}
-                  // Same host-backed gate as `onOpen`, for the same reason: a
-                  // starter-team card is a local placeholder, and its DM would
-                  // address a thread the host has no agent behind.
-                  messageHref={fromHost ? agentDmHref(m) : undefined}
+                  // Only a host-backed teammate can be opened: a card with no
+                  // record behind it would 404 on its id, and the detail view
+                  // would report a teammate that was never removed.
+                  onOpen={hostBackedCard(m, fromHost, consoleOnly) ? () => onOpenAgent(m.id) : undefined}
+                  // The same gate, because it is the same question: a row no
+                  // host holds has no DM either, and the room would answer with
+                  // its unknown-channel fallback rather than a conversation.
+                  messageHref={
+                    hostBackedCard(m, fromHost, consoleOnly) ? agentDmHref(m) : undefined
+                  }
                   // Looked up by roster id, so a card the board assigned to a
                   // *desk* is never attributed to the people on it.
                   //
@@ -593,6 +619,36 @@ export function TeamView({
  * object per render would change `MemberCard`'s props on every pass.
  */
 const IDLE: Workload = { open: 0, status: "idle" };
+
+/** No row is console-only — the state every roster read returns to. */
+const NO_CONSOLE_ONLY: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Whether this card's two host-addressed controls have anything to address.
+ *
+ * Both the title's detail link and the Message link resolve an **id against the
+ * host**, so both are wrong in exactly the same states and are gated together
+ * rather than separately — one of them silently surviving a narrowing of the
+ * other is how they come to disagree.
+ *
+ * Two states, and `fromHost` alone only covers the first:
+ *
+ *  - **The roster is not the host's.** The read never landed, or landed with
+ *    nobody, so every card on screen is a local placeholder.
+ *  - **This row is not the host's**, on a roster that is. A host serving
+ *    `GET …/team` and 404ing the `POST` leaves `fromHost` true while
+ *    `addMember` appends a console-only row beside the real ones — the state
+ *    `consoleOnly` exists to name. Reaching the detail page for such a row
+ *    reports a teammate that was never removed; reaching its DM lands on the
+ *    room's unknown-channel fallback.
+ */
+export function hostBackedCard(
+  member: TeamMember,
+  fromHost: boolean,
+  consoleOnly: ReadonlySet<string>,
+): boolean {
+  return fromHost && !consoleOnly.has(member.id);
+}
 
 /**
  * The address of this teammate's direct conversation (issue #2252).

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -1,5 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { MoreHorizontal, Network, Plus, Sparkles, UserPlus, Users } from "lucide-react";
+import {
+  MessageSquare,
+  MoreHorizontal,
+  Network,
+  Plus,
+  Sparkles,
+  UserPlus,
+  Users,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
@@ -14,6 +22,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
@@ -32,6 +41,7 @@ import { fromDto, newMember, roleSubtitle, type TeamMember } from "@/lib/team";
 import { workloadByAssignee, type Workload } from "@/lib/team-workload";
 import { usd } from "@/lib/money";
 import { cn } from "@/lib/utils";
+import { dmChannelId } from "@/views/room/channels";
 import { AgentDetailView } from "@/views/team/AgentDetailView";
 import { AddMemberDialog, type NewMemberFields } from "@/views/room/AddMemberDialog";
 
@@ -532,6 +542,10 @@ export function TeamView({
                   // id would 404 and the detail view would report a teammate that
                   // was never removed.
                   onOpen={fromHost ? () => onOpenAgent(m.id) : undefined}
+                  // Same host-backed gate as `onOpen`, for the same reason: a
+                  // starter-team card is a local placeholder, and its DM would
+                  // address a thread the host has no agent behind.
+                  messageHref={fromHost ? agentDmHref(m) : undefined}
                   // Looked up by roster id, so a card the board assigned to a
                   // *desk* is never attributed to the people on it.
                   //
@@ -579,11 +593,30 @@ export function TeamView({
  */
 const IDLE: Workload = { open: 0, status: "idle" };
 
+/**
+ * The address of this teammate's direct conversation (issue #2252).
+ *
+ * Built on {@link dmChannelId} and **not** `dmThreadId`. The two are only the
+ * same string for most of the roster: `dmChannelId` is always `dm:<id>`, the
+ * console-local channel id the hash router resolves, while `dmThreadId` is the
+ * bare id — the *host* thread a DM is addressed on — for everyone except a
+ * teammate whose id itself spells General, where the host folds the bare key
+ * onto the company-wide line. Routing on the thread id therefore sends an
+ * operator who clicked that teammate to the company's General channel instead
+ * of the DM they asked for (issue #1743).
+ *
+ * The same call, for the same reason, backs the console search results
+ * (`search/sources.ts`).
+ */
+export function agentDmHref(member: TeamMember): string {
+  return `#/chat/${encodeURIComponent(dmChannelId(member))}`;
+}
 
 function MemberCard({
   member,
   onRemove,
   onOpen,
+  messageHref,
   workload,
   onNavigateToDesk,
 }: {
@@ -591,6 +624,12 @@ function MemberCard({
   onRemove: () => void;
   /** Open this agent's detail page. Undefined when the card has no host record. */
   onOpen?: () => void;
+  /**
+   * Address of this agent's direct conversation ({@link agentDmHref}).
+   * Undefined when the card has no host record, which is when a DM would
+   * address a thread with no agent behind it — the menu item is then omitted.
+   */
+  messageHref?: string;
   /**
    * What this teammate is on and carrying, or undefined when the board could
    * not be read — in which case the card says nothing about either.
@@ -691,10 +730,9 @@ function MemberCard({
                   via `DailyBudgetLine` below; only the controls that write
                   moved.
 
-                  That leaves exactly one item. It stays a menu rather than a
-                  bare button: Remove is destructive, and a deliberate extra
-                  click before it is worth keeping beside the title action.
-                  Unlike "View agent" it does
+                  What is left passes that same test. Remove is destructive,
+                  and a deliberate extra click before it is worth keeping
+                  beside the title action. Unlike "View agent" it does
                   not duplicate the card's own action, and unlike Budget it is
                   not per-agent configuration that reads better on a
                   detail page — it is the one roster-level action an operator
@@ -702,7 +740,30 @@ function MemberCard({
                   prune, and moving it off the grid would trade a fast,
                   discoverable one-hop delete for an extra full-page
                   navigation with no offsetting benefit.
+
+                  Message (issue #2252) joins it on the same grounds, and is
+                  the reason this reads "what is left" rather than "exactly one
+                  item" as it did after #1206. It is navigation to a
+                  conversation, not configuration of an agent, so the rule that
+                  sent Budget and Inbox to the detail page does not reach it —
+                  and "ask this one something" is exactly the thought an
+                  operator has *while* scanning the roster. The members pane
+                  already ships this menu verbatim (`room/MembersPane.tsx`:
+                  Message, separator, then the destructive item); the board was
+                  the odd surface out.
+
+                  It is an anchor rather than an onClick so the address is a
+                  real link — copyable, middle-clickable — and so the board
+                  needs no chat-navigation prop threaded down from the shell.
                 */}
+                {messageHref && (
+                  <>
+                    <DropdownMenuItem render={<a href={messageHref} />}>
+                      <MessageSquare className="size-4" aria-hidden /> Message
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </>
+                )}
                 <DropdownMenuItem variant="destructive" onClick={onRemove}>
                   Remove
                 </DropdownMenuItem>

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -628,6 +628,20 @@ export function agentDmHref(member: TeamMember): string {
   return withHostParam(`chat/${encodeURIComponent(dmChannelId(member))}`);
 }
 
+/**
+ * One agent on the Agent board.
+ *
+ * The card is a scanning surface first: the title is a stretched link to the
+ * agent's detail page (issue #1810), and the two controls that sit above that
+ * click target are the ones an operator reaches for *without* leaving the grid
+ * — Message on the face (issue #2252) and the destructive Remove behind an
+ * overflow (issue #1206). Everything a card only *reports* — workload, desk,
+ * daily budget — is read-only here and configured on the detail page.
+ *
+ * `onOpen` and `messageHref` are both undefined for a card with no host record,
+ * for the same reason: a starter-team placeholder has no agent behind it, so
+ * both addresses would resolve to nothing.
+ */
 function MemberCard({
   member,
   onRemove,

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -16,19 +16,19 @@ import { ApiError, type TeamMemberDto } from "@/api/types";
 import { PageHeader } from "@/components/page-header";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { fetchBoardColumns } from "@/lib/board-columns";
 import { shouldPromptSetup } from "@/lib/company-setup";
 import {
@@ -707,8 +707,59 @@ function MemberCard({
               )}
             </div>
           )}
-          {/* Above the title button's stretched click target (issue #1810). */}
-          <div className="relative z-10">
+          {/*
+            Above the title button's stretched click target (issue #1810), and
+            holding two controls rather than one since issue #2252.
+
+            `items-center` aligns the pair to each other inside a header that is
+            `items-start`; `shrink-0` keeps them at full size so the squeeze
+            lands on the title's `min-w-0 flex-1` — which truncates — rather
+            than on the buttons, which cannot.
+          */}
+          <div className="relative z-10 flex shrink-0 items-center gap-0.5">
+            {/*
+              Message sits on the card face, not in the overflow (issue #2252).
+
+              It shipped inside the menu first. That put the thing an operator
+              wants *while scanning the roster* — ask this one something — two
+              clicks deep, behind a control whose only other item is
+              destructive. On the face it is one click and always visible: no
+              hover needed to discover it, which matters on a grid where the
+              pointer is travelling between cards rather than resting on one.
+              The menu is back to holding only Remove; two controls doing the
+              same thing would be worse than either alone.
+
+              Still an anchor, so the status bar previews the destination on
+              hover and Cmd-click opens the DM in a new tab — neither of which
+              a button can offer.
+
+              Icon-only, so the name is mandatory and carries the agent:
+              "Message Brand Designer", not a bare "Message" repeated on every
+              card, which would leave a screen reader with thirteen
+              indistinguishable controls. The label is spent twice — as the
+              tooltip and as `aria-label` — the way `McpIconButton` does it.
+            */}
+            {messageHref && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <a
+                      href={messageHref}
+                      aria-label={`Message ${member.name}`}
+                      data-testid="team-card-message"
+                      className={buttonVariants({
+                        variant: "ghost",
+                        size: "icon",
+                        className: "-mt-1 size-7",
+                      })}
+                    />
+                  }
+                >
+                  <MessageSquare className="size-4" />
+                </TooltipTrigger>
+                <TooltipContent>{`Message ${member.name}`}</TooltipContent>
+              </Tooltip>
+            )}
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={<Button variant="ghost" size="icon" className="-mr-1 -mt-1 size-7" aria-label="Agent actions" />}
@@ -730,9 +781,10 @@ function MemberCard({
                   via `DailyBudgetLine` below; only the controls that write
                   moved.
 
-                  What is left passes that same test. Remove is destructive,
-                  and a deliberate extra click before it is worth keeping
-                  beside the title action. Unlike "View agent" it does
+                  That still leaves exactly one item. It stays a menu rather
+                  than a bare button: Remove is destructive, and a deliberate
+                  extra click before it is worth keeping beside the title
+                  action. Unlike "View agent" it does
                   not duplicate the card's own action, and unlike Budget it is
                   not per-agent configuration that reads better on a
                   detail page — it is the one roster-level action an operator
@@ -741,29 +793,13 @@ function MemberCard({
                   discoverable one-hop delete for an extra full-page
                   navigation with no offsetting benefit.
 
-                  Message (issue #2252) joins it on the same grounds, and is
-                  the reason this reads "what is left" rather than "exactly one
-                  item" as it did after #1206. It is navigation to a
-                  conversation, not configuration of an agent, so the rule that
-                  sent Budget and Inbox to the detail page does not reach it —
-                  and "ask this one something" is exactly the thought an
-                  operator has *while* scanning the roster. The members pane
-                  already ships this menu verbatim (`room/MembersPane.tsx`:
-                  Message, separator, then the destructive item); the board was
-                  the odd surface out.
-
-                  It is an anchor rather than an onClick so the address is a
-                  real link — copyable, middle-clickable — and so the board
-                  needs no chat-navigation prop threaded down from the shell.
+                  Message (issue #2252) briefly sat here too, above a
+                  separator. It moved to the card face — see the anchor beside
+                  this trigger — because burying the roster's most-reached-for
+                  action behind an overflow was the thing the menu is supposed
+                  to protect against, not an instance of it. It is deliberately
+                  not in both places: one affordance per action.
                 */}
-                {messageHref && (
-                  <>
-                    <DropdownMenuItem render={<a href={messageHref} />}>
-                      <MessageSquare className="size-4" aria-hidden /> Message
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                  </>
-                )}
                 <DropdownMenuItem variant="destructive" onClick={onRemove}>
                   Remove
                 </DropdownMenuItem>

--- a/frontend/test/e2e/company-cards.spec.ts
+++ b/frontend/test/e2e/company-cards.spec.ts
@@ -447,6 +447,27 @@ test("#1190 the card carries no switch; the inbox lives on the agent", async ({ 
   await expect(page.getByTestId("agent-inbox-toggle")).toBeVisible({ timeout: 30_000 });
 });
 
+test("#2252 a card opens a direct conversation with that agent", async ({ page }) => {
+  await mockApi(page);
+  await page.goto("/#/company");
+
+  const maya = card(page, "Maya");
+  await expect(maya).toBeVisible({ timeout: 30_000 });
+
+  // The action lives in the overflow the card already had, above Remove.
+  await maya.getByRole("button", { name: "Agent actions" }).click();
+  const message = page.getByRole("menuitem", { name: "Message" });
+  await expect(message).toBeVisible();
+
+  // The address is the DM *channel* id (`dm:maya`), which is what the hash
+  // router resolves — not the bare host thread id. The two are the same string
+  // for an ordinary agent and differ for a teammate whose id spells General, so
+  // `test/unit/team-agent-dm-href.test.ts` pins that half; this pins that the
+  // menu item actually lands in the room.
+  await message.click();
+  await expect.poll(() => page.url()).toContain("#/chat/dm%3Amaya");
+});
+
 test("#1141 bare #/team is the Company page now", async ({ page }) => {
   await mockApi(page);
 

--- a/frontend/test/e2e/company-cards.spec.ts
+++ b/frontend/test/e2e/company-cards.spec.ts
@@ -454,18 +454,38 @@ test("#2252 a card opens a direct conversation with that agent", async ({ page }
   const maya = card(page, "Maya");
   await expect(maya).toBeVisible({ timeout: 30_000 });
 
-  // The action lives in the overflow the card already had, above Remove.
-  await maya.getByRole("button", { name: "Agent actions" }).click();
-  const message = page.getByRole("menuitem", { name: "Message" });
+  // On the card face, visible without hovering or opening anything, and named
+  // for the agent rather than a bare "Message" repeated down the grid.
+  const message = maya.getByRole("link", { name: "Message Maya" });
   await expect(message).toBeVisible();
 
   // The address is the DM *channel* id (`dm:maya`), which is what the hash
   // router resolves — not the bare host thread id. The two are the same string
   // for an ordinary agent and differ for a teammate whose id spells General, so
   // `test/unit/team-agent-dm-href.test.ts` pins that half; this pins that the
-  // menu item actually lands in the room.
+  // control on the card actually lands in the room.
+  await expect(message).toHaveAttribute("href", "#/chat/dm%3Amaya");
   await message.click();
   await expect.poll(() => page.url()).toContain("#/chat/dm%3Amaya");
+});
+
+test("#2252 Message is on the card face only, never also in the overflow", async ({ page }) => {
+  await mockApi(page);
+  await page.goto("/#/company");
+
+  const maya = card(page, "Maya");
+  await expect(maya).toBeVisible({ timeout: 30_000 });
+
+  // One affordance per action. Message moved out of this menu when it landed on
+  // the face; leaving it in both places is the regression this guards, and it
+  // is the kind that reads as harmless until an operator wonders which of the
+  // two does something different.
+  await maya.getByRole("button", { name: "Agent actions" }).click();
+  await expect(page.getByRole("menuitem", { name: "Remove" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Message" })).toHaveCount(0);
+
+  // Opening the overflow must still not trigger the title's stretched target.
+  await expect(page).toHaveURL(/#\/company$/);
 });
 
 test("#1141 bare #/team is the Company page now", async ({ page }) => {

--- a/frontend/test/unit/team-agent-dm-href.test.ts
+++ b/frontend/test/unit/team-agent-dm-href.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+//
+// A document, for one reason only: `agentDmHref` carries the connection scope
+// off the current address (`withHostParam` → `window.location.hash`), so there
+// has to be an address for it to read. Every assertion below is still about a
+// pure string — nothing here renders.
+
+import { beforeEach, describe, expect, it } from "vitest";
 
 import type { TeamMember } from "@/lib/team";
 import { dmChannelId, dmThreadId } from "@/views/room/channels";
@@ -42,6 +49,12 @@ function member(over: Partial<TeamMember> & Pick<TeamMember, "id" | "name">): Te
 }
 
 describe("the Agent board's Message address", () => {
+  // A one-host console, which writes no scope at all. Each case that cares
+  // about the scope sets its own address first.
+  beforeEach(() => {
+    window.location.hash = "#/company";
+  });
+
   it("routes to the teammate's DM channel, not the host thread", () => {
     const ada = member({ id: "agent-ada", name: "Ada" });
 
@@ -68,5 +81,28 @@ describe("the Agent board's Message address", () => {
     const odd = member({ id: "agent/ada?x", name: "Ada" });
 
     expect(agentDmHref(odd)).toBe("#/chat/dm%3Aagent%2Fada%3Fx");
+  });
+
+  // The control is an anchor precisely so it can be copied, middle-clicked and
+  // Cmd-clicked. Each of those opens a *new document*, which has no selected
+  // host to repair from — `useHostAddress` only fixes a dropped scope on the
+  // `hashchange` a same-tab click fires. A bare `#/chat/…` therefore resolves
+  // this agent's id against the bootstrap host instead of the console whose
+  // card was clicked, which on a second host is another company's roster.
+  it("carries the console's host scope, so a copied link stays on that host", () => {
+    window.location.hash = "#/company?host=conn-b";
+    const ada = member({ id: "agent-ada", name: "Ada" });
+
+    expect(agentDmHref(ada)).toBe("#/chat/dm%3Aagent-ada?host=conn-b");
+  });
+
+  // Only the scope rides along. `?new` and friends belong to the screen they
+  // were opened over, not to the DM being opened next — the contract
+  // `withHostParam` documents.
+  it("drops the transient flags standing beside the scope", () => {
+    window.location.hash = "#/company?host=conn-b&new";
+    const ada = member({ id: "agent-ada", name: "Ada" });
+
+    expect(agentDmHref(ada)).toBe("#/chat/dm%3Aagent-ada?host=conn-b");
   });
 });

--- a/frontend/test/unit/team-agent-dm-href.test.ts
+++ b/frontend/test/unit/team-agent-dm-href.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import type { TeamMember } from "@/lib/team";
+import { dmChannelId, dmThreadId } from "@/views/room/channels";
+import { agentDmHref } from "@/views/TeamView";
+
+/**
+ * The Agent board's Message action addresses the right conversation (issue #2252).
+ *
+ * The board grew a "Message" item on each agent card, and the only thing about
+ * it that can be silently wrong is the id it routes on. `channels.ts` exports
+ * two id builders that agree for most of the roster and disagree for exactly
+ * one teammate:
+ *
+ * - `dmChannelId(m)` is always `dm:<id>` — the console-local channel id, and so
+ *   the address the hash router resolves.
+ * - `dmThreadId(m)` is the bare `<id>` — the *host* thread a DM is journaled
+ *   under — except when the teammate's own id spells General, where the host
+ *   folds the bare key onto the company-wide line.
+ *
+ * So a board that routed on `dmThreadId` would work for every agent a test
+ * roster usually contains, and send an operator who clicked the one teammate
+ * called `main` to the company's General channel instead of that teammate's DM
+ * (the class of bug behind issue #1743). Nothing in the types separates the two
+ * — both are strings — and in a browser the failure reads as "the console
+ * opened the wrong chat", not as a wrong function call. Hence this test.
+ */
+
+function member(over: Partial<TeamMember> & Pick<TeamMember, "id" | "name">): TeamMember {
+  return {
+    role: "Engineer",
+    description: "",
+    tone: "sky",
+    avatar: "green",
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+    ...over,
+  };
+}
+
+describe("the Agent board's Message address", () => {
+  it("routes to the teammate's DM channel, not the host thread", () => {
+    const ada = member({ id: "agent-ada", name: "Ada" });
+
+    expect(agentDmHref(ada)).toBe("#/chat/dm%3Aagent-ada");
+  });
+
+  it("is built from the channel id the router resolves", () => {
+    const ada = member({ id: "agent-ada", name: "Ada" });
+
+    expect(agentDmHref(ada)).toBe(`#/chat/${encodeURIComponent(dmChannelId(ada))}`);
+  });
+
+  it("keeps a teammate whose id spells General on their own DM", () => {
+    // The one teammate for whom the two builders disagree. Routing on
+    // `dmThreadId` here would address the company-wide line instead.
+    const main = member({ id: "main", name: "Main" });
+
+    expect(dmThreadId(main)).not.toBe(main.id);
+    expect(agentDmHref(main)).toBe("#/chat/dm%3Amain");
+    expect(agentDmHref(main)).toBe(`#/chat/${encodeURIComponent(dmChannelId(main))}`);
+  });
+
+  it("survives an id that needs escaping in an address", () => {
+    const odd = member({ id: "agent/ada?x", name: "Ada" });
+
+    expect(agentDmHref(odd)).toBe("#/chat/dm%3Aagent%2Fada%3Fx");
+  });
+});

--- a/frontend/test/unit/team-agent-dm-href.test.ts
+++ b/frontend/test/unit/team-agent-dm-href.test.ts
@@ -35,6 +35,14 @@ import { agentDmHref } from "@/views/TeamView";
  * opened the wrong chat", not as a wrong function call. Hence this test.
  */
 
+/**
+ * A roster entry with only the fields a case actually varies spelled out.
+ *
+ * `id` and `name` are required because every assertion here is about one or the
+ * other — the id is what the address is built from, the name is what the
+ * control is labelled with — and a default for either would let a case pass
+ * while testing the default instead of its own subject.
+ */
 function member(over: Partial<TeamMember> & Pick<TeamMember, "id" | "name">): TeamMember {
   return {
     role: "Engineer",

--- a/frontend/test/unit/team-agent-dm-href.test.ts
+++ b/frontend/test/unit/team-agent-dm-href.test.ts
@@ -7,10 +7,12 @@ import { agentDmHref } from "@/views/TeamView";
 /**
  * The Agent board's Message action addresses the right conversation (issue #2252).
  *
- * The board grew a "Message" item on each agent card, and the only thing about
- * it that can be silently wrong is the id it routes on. `channels.ts` exports
- * two id builders that agree for most of the roster and disagree for exactly
- * one teammate:
+ * Each agent card carries a Message control on its face — an anchor beside the
+ * overflow trigger, not an item inside it — and the only thing about it that
+ * can be silently wrong is the id it routes on. Moving the control changed
+ * where an operator clicks and nothing about the address, which is why this
+ * file did not move with it. `channels.ts` exports two id builders that agree
+ * for most of the roster and disagree for exactly one teammate:
  *
  * - `dmChannelId(m)` is always `dm:<id>` — the console-local channel id, and so
  *   the address the hash router resolves.
@@ -18,7 +20,7 @@ import { agentDmHref } from "@/views/TeamView";
  *   under — except when the teammate's own id spells General, where the host
  *   folds the bare key onto the company-wide line.
  *
- * So a board that routed on `dmThreadId` would work for every agent a test
+ * So a card that routed on `dmThreadId` would work for every agent a test
  * roster usually contains, and send an operator who clicked the one teammate
  * called `main` to the company's General channel instead of that teammate's DM
  * (the class of bug behind issue #1743). Nothing in the types separates the two

--- a/frontend/test/unit/team-card-host-backed.test.ts
+++ b/frontend/test/unit/team-card-host-backed.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import type { TeamMember } from "@/lib/team";
+import { localMemberId, newMember } from "@/lib/team";
+import { hostBackedCard } from "@/views/TeamView";
+
+/**
+ * Which agent cards may offer a control that resolves an id on the host.
+ *
+ * The Agent board's card carries two of those — the title's link to the detail
+ * page, and the Message link to the agent's DM (issue #2252) — and they are
+ * wrong in exactly the same states, so they share one gate. What this file
+ * pins is that the gate asks **two** questions rather than one.
+ *
+ * `fromHost` is a single flag for the whole roster, set by the *read*. It is
+ * enough for the obvious case: the read failed, or answered with nobody, so
+ * every card on screen is a local placeholder and neither control is offered.
+ *
+ * It is not enough for the case that reads as fine. A host that serves
+ * `GET …/team` and 404s the `POST` — no team write plane — leaves `fromHost`
+ * true, and `TeamView`'s `addMember` appends a console-only row next to the
+ * real ones so the operator's work is not thrown away. That row's id exists
+ * nowhere but this browser tab. Offering the detail link on it opens a page
+ * reporting a teammate that was never removed; offering the DM lands on the
+ * room's unknown-channel fallback. Both read as "the console is broken", and
+ * neither is visible to a test that only ever varies `fromHost`.
+ *
+ * So: one gate, two inputs, and every combination below.
+ */
+
+function member(id: string): TeamMember {
+  return {
+    id,
+    name: "Ada",
+    role: "Engineer",
+    description: "",
+    tone: "sky",
+    avatar: "green",
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+  };
+}
+
+const NONE: ReadonlySet<string> = new Set<string>();
+
+describe("an agent card's host-backed gate", () => {
+  it("offers the controls on a host row of a host roster", () => {
+    expect(hostBackedCard(member("agent-ada"), true, NONE)).toBe(true);
+  });
+
+  it("withholds them from every row when the roster is not the host's", () => {
+    // The read failed or answered with nobody. Nothing on screen has a record
+    // behind it, whatever the row's id happens to look like.
+    expect(hostBackedCard(member("agent-ada"), false, NONE)).toBe(false);
+  });
+
+  it("withholds them from a console-only row standing on a host roster", () => {
+    // The case `fromHost` alone cannot see: the read landed, so the flag is
+    // true, and only the write had nowhere to go.
+    const local = newMember({ name: "Ada", role: "Engineer", description: "" });
+
+    expect(hostBackedCard(local, true, new Set([local.id]))).toBe(false);
+  });
+
+  it("still offers them on the host rows beside that console-only one", () => {
+    // The marker is per row, not per page — one local add must not disarm the
+    // whole roster, which is the over-correction of the bug it fixes.
+    const local = newMember({ name: "Ada", role: "Engineer", description: "" });
+
+    expect(hostBackedCard(member("maya"), true, new Set([local.id]))).toBe(true);
+  });
+
+  it("keys on the id `newMember` actually mints, not on a guess at its shape", () => {
+    // `addMember` marks the row it appended by that row's own id. Pinning the
+    // builder the marker comes from keeps the two from drifting into a gate
+    // that matches nothing and quietly stops gating.
+    const local = newMember({ name: "Ada", role: "Engineer", description: "" });
+
+    expect(local.id).toBe(localMemberId("Ada"));
+    expect(hostBackedCard(local, true, new Set([localMemberId("Ada")]))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2252.

## Summary

The Agent board (`#/company/agents`) gains a **Message** action on each agent card, opening that agent's direct conversation.

The members pane already offers it (`frontend/src/views/room/MembersPane.tsx:321-343`), and so do the console search results. The board was the one roster surface without it, so reaching an agent's DM from the roster meant leaving for the room and finding them again in the rail.

## The part that could have been silently wrong

`frontend/src/views/room/channels.ts` exports two id builders that agree for every ordinary teammate and diverge for one:

- `dmChannelId(m)` is always `dm:<id>` — the console-local channel id, and so the **URL**.
- `dmThreadId(m)` is the bare `<id>` — the **host thread** a DM is journaled under — except when the teammate's own id spells General, where the host folds the bare key onto the company-wide line.

Routing on `dmThreadId` therefore works for every agent a test roster usually contains and sends an operator who clicked the teammate called `main` to the company's General channel (the class of bug behind #1743). Both are `string`, so nothing in the types separates them. The new `agentDmHref()` makes the same call `search/sources.ts:79-81` does, and a unit test pins the General case specifically.

## Approach notes

- **On the card face, not in the overflow.** It shipped inside the existing dropdown first, which is what issue #2252 asked for. That put the thing an operator wants *while scanning the roster* — ask this one something — two clicks deep, behind a control whose only other item is destructive. On the face it is one click and always visible, with no hover needed to discover it, which matters on a grid where the pointer is travelling between cards rather than resting on one. The menu is back to holding only Remove, and the action is deliberately not in both places: one affordance per action. The card's `relative z-10` layer above the stretched title target (issue #1810) is preserved, and now holds the pair.
- **An anchor, not an `onClick`** — via Base UI's `render` prop, which the menu's trigger already uses. The address is a real link: previewed in the status bar on hover, copyable, middle- and Cmd-clickable. The board needs no chat-navigation prop threaded down from `app-shell.tsx`.
- **Icon-only, labelled per agent.** `aria-label` and tooltip are both "Message <name>", so a screen reader gets thirteen distinguishable controls rather than thirteen identical "Message" buttons. `McpIconButton` spends the label the same way.
- **Carries the host scope** (`withHostParam`), because a copied or Cmd-clicked link opens a new document with no selected host to repair from — see the Codex thread below and `TaskCard`'s `detailsHref`, which does this for the same reason.
- **Gated per row, not per roster** (`hostBackedCard`). `fromHost` is one flag set by the *read*, and a host that serves `GET …/team` and 404s the `POST` leaves it true while `addMember` appends a console-only row beside the real ones. Both of the card's host-addressed controls — the title link and Message — now ask the same two-part question, so they cannot drift apart. Found by Codex on this PR; the title link had the hole first.
- **Gated on `fromHost`**, mirroring the adjacent `onOpen`: a starter-team card is a local placeholder whose DM would address a thread with no agent behind it.
- The menu's long "#1206 left exactly one item" comment is updated rather than left contradicting the code.

## Verification

Run locally on a host built from this branch, isolated data dir, on a claimed port (`wt ports --verify 8591` OK — pid and `/spec` instance id pinned, unchanged across the run).

- `npm run typecheck` — clean
- `npm run typecheck:unit` — clean
- `npm run typecheck:e2e` — clean
- `npm test` — 610 files / 5315 tests pass, including `team-agent-dm-href.test.ts` (6 tests: the channel-vs-thread id, the teammate whose id spells General, an id needing escaping, and the two host-scope cases) and `team-card-host-backed.test.ts` (5 tests: the per-row gate on a console-only add)
- `npx playwright test test/e2e/company-cards.spec.ts` — 17 passed against a locally built console, including both `#2252` walks
- `scripts/ci/assert-design-tokens.sh` — "no arbitrary sizes, no palette colours, no stray hex"
- **Browser, light and dark**, card screenshots taken: the Message icon renders on the card face beside the overflow trigger, and clicking it lands in that agent's conversation at `#/chat/dm%3A<id>`. Keyboard path checked: it is a real focusable `<a href>`.

## Out of scope

No board redesign, no remove/delete changes, and the search feature is untouched — it is the reference for the id call, not a target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Message** action directly to each teammate card.
  * Selecting Message opens the teammate’s direct conversation.
  * Message links now support special and URL-escaped teammate identifiers.

* **Updated Experience**
  * Moved the Message action from the teammate card’s overflow menu to an icon on the card.
  * The overflow menu now retains only the available management actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
