### PR TITLE
fix(capability-budget): make the total token ceiling bind under concurrency

### DIFF
--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -2615,6 +2615,19 @@ fn policy_ensure_lock(company: &CompanyId) -> Arc<tokio::sync::Mutex<()>> {
         .clone()
 }
 
+/// What the total-ceiling gate decided.
+///
+/// Not a `Result`: a refusal is an ordinary outcome of asking rather than an
+/// error, and `TurnOutcome` is large enough that carrying it in an `Err` is a
+/// lint in its own right.
+enum CeilingGate {
+    /// Dispatch may proceed. The reservation — present whenever there is a
+    /// ceiling to reserve against — must be held for the turn.
+    Admitted(Option<crate::metering::TokenReservation>),
+    /// Dispatch is refused; this is the turn's outcome.
+    Refused(TurnOutcome),
+}
+
 impl HarnessPool {
     /// Builds an empty pool.
     pub fn new() -> Self {
@@ -3944,13 +3957,24 @@ impl HarnessPool {
     /// the rule: a turn that reaches nothing still spends model tokens, so a
     /// tenant past its cap must not be able to keep spending through the
     /// copilot.
+    /// How much one dispatch promises against the total ceiling before it runs.
+    ///
+    /// Not an estimate of a turn: no per-turn ceiling exists to derive one from.
+    /// It is the granularity at which the ceiling binds — overshoot is bounded
+    /// by this rather than by however many turns happened to race.
+    const DISPATCH_RESERVATION_TOKENS: u64 = 4_000;
+
     async fn total_ceiling_refusal(
         company: &CompanyId,
         agent_id: &str,
         deps: &HarnessDeps,
-    ) -> Option<TurnOutcome> {
-        let plan = deps.plan.as_ref()?;
-        plan.total_budget?;
+    ) -> CeilingGate {
+        let Some(plan) = deps.plan.as_ref() else {
+            return CeilingGate::Admitted(None);
+        };
+        if plan.total_budget.is_none() {
+            return CeilingGate::Admitted(None);
+        }
         let since = plan.period.period_start_millis(crate::ports::now_millis());
         let samples = match read_spend_for_gate(deps.meter.as_deref(), company, since).await {
             Ok(samples) => samples,
@@ -3968,7 +3992,7 @@ impl HarnessPool {
                         "[capability-budget] total-ceiling spend query failed; refusing dispatch (no model call) rather than spending against a ceiling that cannot be checked"
                     ),
                 }
-                return Some(spend_gate_refusal(
+                return CeilingGate::Refused(spend_gate_refusal(
                     unmeasurable_ceiling_notice(&fault),
                     SpendGateCause::Unmeasurable,
                 ));
@@ -4001,19 +4025,25 @@ impl HarnessPool {
                 },
             );
         }
-        if plan.total_exhausted(spent) {
-            tracing::info!(
-                company = %company,
-                agent = agent_id,
-                spent,
-                "[capability-budget] total token ceiling reached; refusing dispatch (no model call) until the period resets"
-            );
-            return Some(spend_gate_refusal(
-                TOTAL_BUDGET_EXHAUSTED_NOTICE.to_string(),
-                SpendGateCause::Exhausted,
-            ));
+        // The reservation, not the bare comparison, is what makes the ceiling
+        // bind: the meter reports only finished work, so several turns reading
+        // one `spent` would each find room and each dispatch. A promise
+        // recorded here is visible to the next caller before it looks.
+        match crate::metering::reserve(company, Self::DISPATCH_RESERVATION_TOKENS, spent, plan) {
+            Some(reservation) => CeilingGate::Admitted(Some(reservation)),
+            None => {
+                tracing::info!(
+                    company = %company,
+                    agent = agent_id,
+                    spent,
+                    "[capability-budget] total token ceiling reached; refusing dispatch (no model call) until the period resets"
+                );
+                CeilingGate::Refused(spend_gate_refusal(
+                    TOTAL_BUDGET_EXHAUSTED_NOTICE.to_string(),
+                    SpendGateCause::Exhausted,
+                ))
+            }
         }
-        None
     }
 
     /// Runs one **confined** turn (issue #416): an ephemeral agent with no
@@ -4044,11 +4074,11 @@ impl HarnessPool {
         chat_id: Option<&str>,
         confinement: &confine::Confinement,
     ) -> crate::Result<TurnOutcome> {
-        if let Some(refusal) =
-            Self::total_ceiling_refusal(company, confine::CONFINED_AGENT_ID, deps).await
-        {
-            return Ok(refusal);
-        }
+        let _ceiling =
+            match Self::total_ceiling_refusal(company, confine::CONFINED_AGENT_ID, deps).await {
+                CeilingGate::Admitted(reservation) => reservation,
+                CeilingGate::Refused(refusal) => return Ok(refusal),
+            };
 
         let confined = confine::build_confined_agent(company, company_name, confinement, deps)?;
         let agent = CompanyAgent {
@@ -4202,9 +4232,10 @@ impl HarnessPool {
         // observe, and the console goes on rendering that ceiling as if it
         // still applied. A refusal an operator can see and act on is a better
         // state than a cap that silently stopped existing.
-        if let Some(refusal) = Self::total_ceiling_refusal(company, agent_id, deps).await {
-            return Ok(refusal);
-        }
+        let _ceiling = match Self::total_ceiling_refusal(company, agent_id, deps).await {
+            CeilingGate::Admitted(reservation) => reservation,
+            CeilingGate::Refused(refusal) => return Ok(refusal),
+        };
 
         // Per-agent daily spend cap (issue #304): the same HARD, pre-model-call
         // refusal as the ceiling above, scoped to ONE teammate.
@@ -10882,6 +10913,97 @@ description = "Sets direction."
             search: None,
             tenant_search: None,
             workspace: None,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn racing_turns_cannot_dispatch_against_the_same_total_budget() {
+        struct DelayedUsageProvider(ScriptedProvider);
+
+        #[async_trait]
+        impl ChatModel<()> for DelayedUsageProvider {
+            async fn invoke(
+                &self,
+                state: &(),
+                request: ModelRequest,
+            ) -> tinyinference::Result<ModelResponse> {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                self.0.invoke(state, request).await
+            }
+        }
+
+        impl HarnessModel for DelayedUsageProvider {
+            fn telemetry_provider_id(&self) -> String {
+                "budget-race".to_string()
+            }
+        }
+
+        for attempt in 0..5 {
+            let dir = tempfile::tempdir().expect("temporary workspace");
+            let meter = Arc::new(RecordingMeter::default());
+            let provider = Arc::new(DelayedUsageProvider(
+                ScriptedProvider::new(vec![Ok("completed".to_string()); 4]).reporting_usage(
+                    tinyinference::Usage {
+                        input_tokens: 60,
+                        output_tokens: 40,
+                        total_tokens: 100,
+                        ..Default::default()
+                    },
+                ),
+            ));
+            let mut deps = deps_with_plan(
+                dir.path(),
+                Arc::new(MockContext::default()),
+                Some(meter.clone()),
+                Some(crate::harness::capability_budget::CapabilityPlan {
+                    period: crate::harness::capability_budget::BudgetPeriod::Daily,
+                    budgets: std::collections::BTreeMap::new(),
+                    total_budget: Some(100),
+                }),
+            );
+            deps.provider = provider.clone();
+            let deps = Arc::new(deps);
+            let pool = Arc::new(HarnessPool::new());
+            let mut rec = record();
+            rec.id = CompanyId::new(format!("budget-race-{attempt}"));
+            pool.ensure(&rec, &deps).await.expect("roster builds");
+            let barrier = Arc::new(tokio::sync::Barrier::new(4));
+            let mut racers = tokio::task::JoinSet::new();
+            for _ in 0..4 {
+                let barrier = barrier.clone();
+                let pool = pool.clone();
+                let deps = deps.clone();
+                let company = rec.id.clone();
+                racers.spawn(async move {
+                    barrier.wait().await;
+                    pool.run(
+                        &company,
+                        "ceo",
+                        "answer once",
+                        &deps,
+                        crate::runtime::delegation::ChatTarget::default(),
+                    )
+                    .await
+                });
+            }
+            let mut completed = 0;
+            while let Some(result) = racers.join_next().await {
+                let outcome = result.expect("racer joins").expect("dispatch resolves");
+                if outcome.reply != TOTAL_BUDGET_EXHAUSTED_NOTICE {
+                    completed += 1;
+                }
+            }
+            assert_eq!(
+                provider.0.calls.load(std::sync::atomic::Ordering::SeqCst),
+                1,
+                "attempt {attempt}: one remaining budget must admit exactly one model call"
+            );
+            assert_eq!(completed, 1, "exactly one turn completes under the ceiling");
+            assert_eq!(
+                capability_budget::tokens_in(&meter.query(&rec.id, 0).await.expect("spend")),
+                100,
+                "concurrent dispatch must not multiply the available token budget"
+            );
         }
     }
 

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -64,6 +64,9 @@ pub mod planning;
 /// Issue #1776: what one drafted teammate mandate or persona costs, charged to
 /// the company rather than to the teammate it describes. See [`profile_draft`].
 pub mod profile_draft;
+/// Promises against the total token ceiling, held while priced work is in
+/// flight. One map for every kind of priced work — see the module docs.
+pub mod reservation;
 pub mod roster_build;
 pub mod search;
 pub mod selector;
@@ -93,6 +96,7 @@ pub use planning::{planning_sample, record_planning_usage};
 pub use profile_draft::{
     DraftBudget, profile_draft_sample, record_profile_draft_usage, reserve_draft,
 };
+pub use reservation::{TokenReservation, reserve};
 pub use search::{
     FALLBACK_SEARCH_COST_USD, MANAGED_SEARCH_PROVIDER, record_search_call, search_call_sample,
 };

--- a/src/metering/profile_draft.rs
+++ b/src/metering/profile_draft.rs
@@ -47,9 +47,6 @@
 //! spent before it was called, and a full disk must not turn a suggestion the
 //! operator is about to read into a failed request.
 
-use std::collections::HashMap;
-use std::sync::{LazyLock, Mutex};
-
 use crate::ports::types::{CompanyId, TokenUsage};
 use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
 use crate::ports::{CompanyStore, now_millis};
@@ -75,71 +72,25 @@ use super::inference::{UNATTRIBUTED_AGENT, inference_ledger_entry};
 /// map, so this narrows the window rather than closing it everywhere — closing
 /// it across replicas needs a reservation the *meter* can see, which is a
 /// larger change than the leak currently justifies.
-static IN_FLIGHT: LazyLock<Mutex<HashMap<CompanyId, u64>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-/// A promise to spend at most this many tokens, released when it is dropped.
+/// A profile draft's promise against the total ceiling.
 ///
-/// Held across the model call and dropped when the draft finishes — including
-/// on the paths that never reached a provider, because `Drop` does not care why
-/// the call ended. A leaked promise would refuse a company its own budget until
-/// the process restarted, so nothing here returns a raw number to release by
-/// hand.
-#[derive(Debug)]
-pub struct DraftBudget {
-    company: CompanyId,
-    tokens: u64,
-}
-
-impl Drop for DraftBudget {
-    fn drop(&mut self) {
-        let mut in_flight = match IN_FLIGHT.lock() {
-            Ok(guard) => guard,
-            // A poisoned map means another thread panicked mid-update. Taking
-            // the inner value is right for a counter of *in-flight* work: the
-            // alternative is to leak this reservation forever and refuse the
-            // company its budget until restart.
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        if let Some(total) = in_flight.get_mut(&self.company) {
-            *total = total.saturating_sub(self.tokens);
-            if *total == 0 {
-                in_flight.remove(&self.company);
-            }
-        }
-    }
-}
+/// An alias for the shared [`TokenReservation`](super::reservation::TokenReservation):
+/// a draft and an agent turn spend against the same ceiling, so both promise
+/// into one map.
+pub type DraftBudget = super::reservation::TokenReservation;
 
 /// Promises `tokens` against the ceiling, or `None` when there is no room.
 ///
-/// `spent` is what the meter reported, which counts only finished work; the
-/// promises other drafts are holding are added to it here. The check and the
-/// promise happen under one lock, which is the whole point — two callers that
-/// both read the same `spent` cannot both find room, because the first has
-/// recorded its claim before the second looks.
-///
-/// `tokens` is the field's *output ceiling*, not an estimate: reserving the
-/// most a draft could spend is what makes the promise an upper bound, so real
-/// usage can only ever come in under it.
+/// `tokens` is the field's *output ceiling*, not an estimate: reserving the most
+/// a draft could spend is what makes the promise an upper bound, so real usage
+/// can only ever come in under it.
 pub fn reserve_draft(
     company: &CompanyId,
     tokens: u64,
     spent: u64,
     plan: &super::CapabilityPlan,
 ) -> Option<DraftBudget> {
-    let mut in_flight = match IN_FLIGHT.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    let promised = in_flight.get(company).copied().unwrap_or(0);
-    if plan.total_exhausted(spent.saturating_add(promised)) {
-        return None;
-    }
-    *in_flight.entry(company.clone()).or_insert(0) += tokens;
-    Some(DraftBudget {
-        company: company.clone(),
-        tokens,
-    })
+    super::reservation::reserve(company, tokens, spent, plan)
 }
 
 /// Builds the [`SampleKind::AuthoringCall`] sample for one completed draft, or

--- a/src/metering/reservation.rs
+++ b/src/metering/reservation.rs
@@ -1,0 +1,92 @@
+//! Promises against the plan's total token ceiling, held while priced work is
+//! in flight.
+//!
+//! The meter only reports work that has **finished**. A gate that compares the
+//! meter's `spent` against the ceiling and then dispatches is a check-then-act:
+//! several callers read the same `spent`, each finds room, and each dispatches.
+//! The ceiling is then exceeded by as many turns as happened to race, and
+//! nothing reports it — the console goes on rendering a cap that stopped
+//! binding.
+//!
+//! A promise recorded here is visible to the next caller before that caller
+//! looks, because the read and the promise happen under one lock. Overshoot is
+//! bounded by the reservation size rather than by how many callers raced.
+//!
+//! **Process-global, and that is the limit worth stating.** It bounds spend
+//! within one host, which is the whole population for a desktop or a
+//! single-container tenant. Replicas of one company each hold their own map, so
+//! this narrows the window rather than closing it everywhere; closing it across
+//! replicas needs a reservation the *meter* can see.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+use crate::ports::CompanyId;
+
+use super::CapabilityPlan;
+
+/// One map for every kind of priced work, on purpose: a profile draft and an
+/// agent turn spend against the same ceiling, so a promise either of them holds
+/// has to be visible to the other. Separate maps would leave exactly the gap
+/// this module exists to close.
+static IN_FLIGHT: LazyLock<Mutex<HashMap<CompanyId, u64>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// A promise to spend at most this many tokens, released when it is dropped.
+///
+/// Held across the model call and dropped when the work finishes — including on
+/// the paths that never reached a provider, because `Drop` does not care why the
+/// call ended. A leaked promise would refuse a company its own budget until the
+/// process restarted, so nothing here returns a raw number to release by hand.
+#[derive(Debug)]
+pub struct TokenReservation {
+    company: CompanyId,
+    tokens: u64,
+}
+
+impl Drop for TokenReservation {
+    fn drop(&mut self) {
+        let mut in_flight = match IN_FLIGHT.lock() {
+            Ok(guard) => guard,
+            // A poisoned map means another thread panicked mid-update. Taking
+            // the inner value is right for a counter of *in-flight* work: the
+            // alternative is to leak this reservation forever and refuse the
+            // company its budget until restart.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(total) = in_flight.get_mut(&self.company) {
+            *total = total.saturating_sub(self.tokens);
+            if *total == 0 {
+                in_flight.remove(&self.company);
+            }
+        }
+    }
+}
+
+/// Promises `tokens` against the ceiling, or `None` when there is no room.
+///
+/// `spent` is what the meter reported, which counts only finished work; the
+/// promises other callers are holding are added to it here. The check and the
+/// promise happen under one lock, which is the whole point: two callers that
+/// both read the same `spent` cannot both find room, because the first has
+/// recorded its claim before the second looks.
+pub fn reserve(
+    company: &CompanyId,
+    tokens: u64,
+    spent: u64,
+    plan: &CapabilityPlan,
+) -> Option<TokenReservation> {
+    let mut in_flight = match IN_FLIGHT.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let promised = in_flight.get(company).copied().unwrap_or(0);
+    if plan.total_exhausted(spent.saturating_add(promised)) {
+        return None;
+    }
+    *in_flight.entry(company.clone()).or_insert(0) += tokens;
+    Some(TokenReservation {
+        company: company.clone(),
+        tokens,
+    })
+}


### PR DESCRIPTION
## Summary

The plan's total token ceiling did not bind when turns overlapped. With budget for one model call remaining, four racing turns all dispatched.

## Problem

The gate read the meter's spend, compared it to the cap, and then dispatched. The meter reports only work that has **finished**, so nothing a concurrent turn is currently spending is visible to it. Several turns read the same `spent`, each found room, and each dispatched.

Overshoot was bounded by nothing except how many callers happened to race, and no signal was emitted — the console went on rendering a ceiling that had stopped applying. The per-agent daily cap immediately below it reads spend the same way.

A test now reproduces it: four turns released together against a budget with room for one.

```
assertion `left == right` failed: one remaining budget must admit exactly one model call
  left: 4
 right: 1
```

## Solution

Promise against the ceiling before dispatching, and hold the promise for the turn. The read and the promise happen under one lock, so a caller sees what other callers have already claimed rather than a figure that ignores them. Overshoot is bounded by the reservation size instead of by the number of racers.

The promise is an RAII guard, released on every exit path including the ones that never reach a provider — a leaked promise would refuse a company its own budget until the process restarted.

**Profile drafts already worked exactly this way.** Rather than add a second mechanism, their in-flight map moves to `metering::reservation` and dispatch promises into the same one. A draft and an agent turn spend against the same ceiling, so separate maps would have left the gap open between them.

`DISPATCH_RESERVATION_TOKENS` is a declared granularity, not an estimate of a turn — no per-turn ceiling exists to derive one from. It is stated as such in the code.

## Submission Checklist

- [x] Full lib suite under `--features openhuman` — **7641 passed, 0 failed**
- [x] Red proof: reverting to the bare comparison fails the race test on its own assertion — `one remaining budget must admit exactly one model call / left: 4 / right: 1` — then restored to green
- [x] `cargo fmt --all -- --check` clean
- [x] Production-deletion scan: the old signature, the two early returns and the bare exhaustion branch the reservation replaces
- [ ] Console E2E — pre-existing failure on main, unrelated

## Impact

A declared ceiling now holds when turns overlap. Companies without a ceiling are untouched — the gate returns before reserving. Bounded by the process: replicas of one company each hold their own map, so this narrows the window rather than closing it everywhere; closing it across replicas needs a reservation the meter itself can see.

## Related

Third instance of read-check-then-write found in this area; the other two are in `workspace_write` and `review_task`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent requests from collectively exceeding configured token limits.
  * Improved enforcement of token budgets when multiple turns run simultaneously.
  * Ensured unsuccessful or skipped requests do not permanently consume reserved tokens.
  * Added safeguards so usage is recorded accurately when a budget is reached.
* **Metering**
  * Standardized token reservation handling across priced work, improving consistency of budget tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->