### PR TITLE
fix(workflow-scheduler): enumerate global workflows (#2260)

### DIFF
--- a/globals/workflows/weekly_review.toml
+++ b/globals/workflows/weekly_review.toml
@@ -14,7 +14,6 @@ id = "week_end"
 kind = "trigger"
 name = "End of the week"
 summary = "Runs every Friday afternoon."
-schedule = "0 16 * * 5"
 
 [[node]]
 id = "gather"

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -211,7 +211,8 @@ pub use workflow_file::{
 // `parse_workflow` above for validation before writing to disk.
 pub(crate) use workflow_file::{
     RawEdge, RawNode, RawWorkflow, channel_destination_missing_target_message,
-    raw_workflow_from_toml, render_workflow, required_config_problems,
+    list_workflows_with_global_baseline, raw_workflow_from_toml, render_workflow,
+    required_config_problems,
 };
 // Issue #661 (M7): the read half of the agent workflow-admin surface — a stored
 // graph projected onto the narrow agent authoring schema, plus the policy

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -1143,6 +1143,15 @@ pub fn list_workflows_with_globals(
     overlays: &[crate::ports::types::OverlayWorkflow],
     disable: &[String],
 ) -> Vec<WorkflowFile> {
+    list_workflows_with_global_baseline(source_dir, overlays, disable, crate::globals::workflows())
+}
+
+pub(crate) fn list_workflows_with_global_baseline(
+    source_dir: Option<&Path>,
+    overlays: &[crate::ports::types::OverlayWorkflow],
+    disable: &[String],
+    globals: &[WorkflowFile],
+) -> Vec<WorkflowFile> {
     let mut files = list_company_workflows_union(source_dir, overlays);
     // Reserved by *claim*, not by successful parse: a malformed seed file or
     // overlay still names an id the company owns, and `load_workflow_with_globals`
@@ -1152,7 +1161,7 @@ pub fn list_workflows_with_globals(
     // loader can never actually return it, exposing an entry this list cannot
     // back.
     let reserved = reserved_company_workflow_ids(source_dir, overlays);
-    for workflow in crate::globals::workflows() {
+    for workflow in globals {
         if reserved.contains(&workflow.id)
             || crate::globals::disabled(disable, "workflow", &workflow.id)
         {

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -270,6 +270,10 @@ impl WorkflowScheduler {
     /// The flag is read from the record this tick already loaded for its overlay
     /// bodies, so the gate costs no extra store round-trip.
     pub async fn tick(&mut self) -> usize {
+        self.tick_with_globals(crate::globals::workflows()).await
+    }
+
+    async fn tick_with_globals(&mut self, _global_workflows: &[WorkflowFile]) -> usize {
         let now = self.clock.now_millis();
         let minute = now / MINUTE_MS;
         let civil = CivilTime::from_unix_millis(now);
@@ -1176,6 +1180,7 @@ mod test {
     struct Recorded {
         company: String,
         workflow: String,
+        global: bool,
         input: Value,
     }
 
@@ -1241,6 +1246,7 @@ mod test {
             self.started.lock().unwrap().push(Recorded {
                 company: company.as_ref().to_string(),
                 workflow: workflow.id.clone(),
+                global: workflow.global,
                 input,
             });
             if let Some(gate) = &self.gate {
@@ -1343,6 +1349,12 @@ to = "done"
             id: id.to_string(),
             toml: body(id, cron),
         }
+    }
+
+    fn global(id: &str, cron: &str) -> WorkflowFile {
+        let mut workflow = crate::company::parse_workflow(&body(id, Some(cron))).unwrap();
+        workflow.global = true;
+        workflow
     }
 
     /// Builds a registered company whose only workflows are record overlays —
@@ -1495,6 +1507,69 @@ to = "done"
         clock.set(millis_at(2026, 7, 20, 9, 0));
         assert_eq!(scheduler.tick().await, 1);
         wait_for(|| started.lock().unwrap().len() == 2).await;
+    }
+
+    #[tokio::test]
+    async fn fires_a_global_only_workflow() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry =
+            company_with_overlays(&home, "acme", Vec::new(), Some(runner), "running").await;
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry, clock);
+        let workflows = [global("global_digest", "* * * * *")];
+
+        assert_eq!(scheduler.tick_with_globals(&workflows).await, 1);
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+        let run = started.lock().unwrap()[0].clone();
+        assert_eq!(run.workflow, "global_digest");
+        assert!(run.global);
+    }
+
+    #[tokio::test]
+    async fn a_disabled_global_workflow_does_not_fire() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry =
+            company_with_overlays(&home, "acme", Vec::new(), Some(runner), "running").await;
+        let company = CompanyId::new("acme");
+        let runtime = registry.get(&company).unwrap();
+        let store = runtime.store().clone();
+        let mut record = store.load(&company).await.unwrap().unwrap();
+        record.manifest.globals.disable = vec!["workflow:global_digest".to_string()];
+        store.save(&record).await.unwrap();
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry, clock);
+        let workflows = [global("global_digest", "* * * * *")];
+
+        assert_eq!(scheduler.tick_with_globals(&workflows).await, 0);
+        assert!(started.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_company_workflow_shadows_a_scheduled_global() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry = company_with_overlays(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("* * * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry, clock);
+        let workflows = [global("digest", "* * * * *")];
+
+        assert_eq!(scheduler.tick_with_globals(&workflows).await, 1);
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+        let run = started.lock().unwrap()[0].clone();
+        assert_eq!(run.workflow, "digest");
+        assert!(!run.global);
     }
 
     /// The seeded input tells the run — and every agent turn inside it — that a

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -17,12 +17,13 @@
 //!   hosted tenant can be provisioned after boot, so the tick re-reads
 //!   [`CompanyRegistry::list`] every minute rather than snapshotting companies
 //!   at boot.
-//! * **Enumeration goes through the seed ∪ overlay union** (issue #168's
-//!   [`list_workflows_union`]), never a raw `source_dir` scan and never the
-//!   manifest's `[workflows].enabled` list — a console-created workflow lives
-//!   only on the record overlay, and it is exactly the kind an operator attaches
-//!   a schedule to. See [`WorkflowScheduler::tick`] for why the enabled list is
-//!   not a filter.
+//! * **Enumeration includes the global baseline after the seed ∪ overlay
+//!   union**, through
+//!   [`list_workflows_with_globals`](crate::company::list_workflows_with_globals),
+//!   never a raw `source_dir` scan and never the manifest's
+//!   `[workflows].enabled` list. Company graphs keep precedence, and
+//!   `[globals].disable` removes opted-out globals. See [`WorkflowScheduler::tick`]
+//!   for why the enabled list is not a filter.
 //! * **Each fire runs on its own tokio task**, so one long agent run cannot
 //!   starve every other company's schedule, with an in-flight guard so a slow
 //!   run is never overlapped by its own next tick.
@@ -81,7 +82,7 @@ use serde_json::json;
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 
-use crate::company::{WorkflowFile, list_workflows_union};
+use crate::company::{WorkflowFile, list_workflows_with_global_baseline};
 use crate::ports::types::CompanyId;
 use crate::ports::{DeliveryReport, DeliveryStatus, WorkflowRunContext, is_undelivered};
 use crate::runtime::CompanyRegistry;
@@ -273,7 +274,7 @@ impl WorkflowScheduler {
         self.tick_with_globals(crate::globals::workflows()).await
     }
 
-    async fn tick_with_globals(&mut self, _global_workflows: &[WorkflowFile]) -> usize {
+    async fn tick_with_globals(&mut self, global_workflows: &[WorkflowFile]) -> usize {
         let now = self.clock.now_millis();
         let minute = now / MINUTE_MS;
         let civil = CivilTime::from_unix_millis(now);
@@ -315,19 +316,23 @@ impl WorkflowScheduler {
                     tracing::warn!(%company, %err, "workflow scheduler: pruning old fire claims failed");
                 }
             }
-            // The record's runtime-authored graph bodies, and the ids the
-            // operator has switched off (issue #276) — both off the SAME load, so
-            // the gate costs no second round-trip and cannot read a record that
-            // moved between the two reads. A company with no persisted record
-            // contributes neither; a store failure is logged and skipped rather
-            // than aborting every other company's schedules.
+            // The record's runtime-authored graph bodies, the ids the operator
+            // has switched off, and global opt-outs come from the same load, so
+            // the gates cannot observe different record versions. A company
+            // with no persisted record contributes none; a store failure is
+            // logged and skipped rather than aborting every other company's
+            // schedules.
             //
             // A load failure skipping the company is what makes the gate
             // fail-safe: an unreadable record fires nothing, rather than firing
             // everything because the disable list came back empty.
-            let (overlays, disabled) = match runtime.store().load(&company).await {
-                Ok(Some(record)) => (record.overlay_workflows, record.disabled_workflows),
-                Ok(None) => (Vec::new(), Vec::new()),
+            let (overlays, disabled, global_disable) = match runtime.store().load(&company).await {
+                Ok(Some(record)) => (
+                    record.overlay_workflows,
+                    record.disabled_workflows,
+                    record.manifest.globals.disable,
+                ),
+                Ok(None) => (Vec::new(), Vec::new(), Vec::new()),
                 Err(err) => {
                     tracing::warn!(%company, %err, "workflow scheduler: cannot read company record");
                     continue;
@@ -338,7 +343,12 @@ impl WorkflowScheduler {
             // runner: whether any exist is exactly what decides if an unwired
             // company is misconfigured or simply has nothing to run.
             let mut scheduled: Vec<(WorkflowFile, String, CronExpr)> = Vec::new();
-            for file in list_workflows_union(runtime.source_dir(), &overlays) {
+            for file in list_workflows_with_global_baseline(
+                runtime.source_dir(),
+                &overlays,
+                &global_disable,
+                global_workflows,
+            ) {
                 let Some(cron) = trigger_schedule(&file) else {
                     continue; // no schedule: manual-run only
                 };


### PR DESCRIPTION
## Summary

The workflow scheduler enumerated only a company's seed files and saved overlays. A workflow that existed only in the global baseline was invisible, so a cron on that graph could never fire and produced no diagnostic. The scheduler now enumerates the company union plus the global baseline, passing the company's `[globals].disable` list from the record load it already performs.

Company definitions retain precedence, global opt-outs remain excluded, and the existing per-workflow schedule switch remains a separate filter. Enumeration still happens before the runner check, so an unwired company with only a scheduled global is correctly reported as having work it cannot run.

The dormant `weekly_review` schedule was removed deliberately. The graph is otherwise unchanged and remains manually runnable; activating its two billed agent turns and owner delivery is a separate decision that requires a validated staging run and its own review.

The scheduler module documentation now states that enumeration includes globals. A caller sweep found two production resume reloads still using the globals-blind loader on this branch's base; PR #2236 already fixes both. The remaining production listing call computes uniqueness among company-authored workflows and is deliberately company-only.

Closes #2260

## API Or Behavior Changes

- No public signature changes.
- Future scheduled globals are discoverable unless the company opts out with `[globals].disable` or shadows the id with its own graph.
- `weekly_review` ships without a cron, so this defect fix does not activate recurring inference or owner delivery fleet-wide.

## Tests

The regression uses a synthetic scheduled global rather than `weekly_review`, so disarming the shipped graph cannot make it pass for the wrong reason.

Red proof before the enumeration fix:

```
running 1 test
test runtime::workflow_scheduler::test::fires_a_global_only_workflow ... FAILED

failures:

---- runtime::workflow_scheduler::test::fires_a_global_only_workflow stdout ----

thread 'runtime::workflow_scheduler::test::fires_a_global_only_workflow' (102030102) panicked at src/runtime/workflow_scheduler.rs:1523:9:
assertion `left == right` failed
  left: 0
 right: 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    runtime::workflow_scheduler::test::fires_a_global_only_workflow

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 7655 filtered out; finished in 0.20s

error: test failed, to rerun pass `--lib`
```

Green proof after the fix:

```
running 1 test
test runtime::workflow_scheduler::test::fires_a_global_only_workflow ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 7655 filtered out; finished in 0.16s
```

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --features openhuman,tinymemory --lib --all-targets --no-deps -- -D warnings`
- [ ] `cargo build --all-targets` — not run; the scoped feature build was exercised by tests and clippy.
- [ ] `cargo test` — unscoped suite not run; it exhausts memory on this machine.
- [x] `cargo test --features openhuman,tinymemory --lib runtime::workflow_scheduler` — 50 passed, 0 failed.
- [x] `cargo test --features openhuman,tinymemory --lib company::workflow_file` — 107 passed, 0 failed.
- [x] `cargo test --features openhuman,tinymemory --lib globals` — 29 passed, 0 failed.
- [ ] Live or staging scheduler run — not performed. No shipped global remains scheduled in this change.

## Documentation

No user-facing documentation was needed. The scheduler module documentation now describes the globals-aware enumeration and opt-out precedence.
