### PR TITLE
fix: prevent consumed grant replay after restart

### DIFF
--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -661,17 +661,19 @@ impl<'a> CycleRunner<'a> {
             drop(guard);
             return Err(err);
         }
-        for id in events.iter().filter_map(|(_, event)| match event {
-            CompanyEvent::ApprovalResolved { approval_id, .. }
-                if self.rt.grants.peek(approval_id).is_some() =>
-            {
-                Some(approval_id)
-            }
-            _ => None,
-        }) {
+        let claimed_grants: Vec<GrantedCall> = events
+            .iter()
+            .filter_map(|(_, event)| match event {
+                CompanyEvent::ApprovalResolved { approval_id, .. } => {
+                    self.rt.grants.peek(approval_id)
+                }
+                _ => None,
+            })
+            .collect();
+        for grant in &claimed_grants {
             self.rt
                 .journal
-                .record_grant_dispatched(id, now_millis())
+                .record_grant_dispatched(&grant.approval_id, now_millis())
                 .await?;
         }
         let mut claimed: Vec<ApprovalContinuation> = Vec::new();
@@ -716,6 +718,17 @@ impl<'a> CycleRunner<'a> {
             self.run_locked(events, cycle_id.clone(), run_id, &mut effects),
         )
         .await;
+        for grant in &claimed_grants {
+            if self.rt.grants.peek(&grant.approval_id).is_some()
+                && let Err(err) = self.rt.journal.record_granted(grant).await
+            {
+                tracing::warn!(
+                    approval_id = %grant.approval_id,
+                    error = %err,
+                    "[approval] an unused single-use grant could not be re-armed after its turn"
+                );
+            }
+        }
         if outcome.is_ok() {
             // Harness cognition consumes while redispatching and run_locked
             // journals that buffered fact. Hosted and sidecar cognition instead
@@ -7149,81 +7162,115 @@ members = ["writer"]
         );
     }
 
-    /// Two grants consumed concurrently before their ordinary cycle drain stay
-    /// spent across a restart.
+    /// A restart inside the window between grant redemption and the cycle drain
+    /// must not re-arm the call.
     #[tokio::test]
-    async fn two_undrained_consumptions_stay_spent_after_a_restart() {
+    async fn an_undrained_consumption_stays_spent_during_a_restart() {
+        struct ConsumingBrain {
+            effect: Effect,
+            grants: Arc<std::sync::Mutex<Option<crate::runtime::grants::GrantSet>>>,
+            consumed: Arc<tokio::sync::Barrier>,
+            release: Arc<tokio::sync::Barrier>,
+        }
+
+        #[async_trait]
+        impl Brain for ConsumingBrain {
+            async fn run_cycle(
+                &self,
+                req: CycleRequest,
+                host: &dyn CycleHost,
+            ) -> Result<CycleResult> {
+                for event in &req.events {
+                    match event {
+                        CompanyEvent::OperatorMessage { .. } => {
+                            host.park_effect(self.effect.clone()).await?;
+                        }
+                        CompanyEvent::ApprovalResolved { .. } => {
+                            let grants = self
+                                .grants
+                                .lock()
+                                .expect("grant slot")
+                                .clone()
+                                .expect("runtime grant set installed");
+                            assert!(
+                                grants
+                                    .consume(
+                                        "finance",
+                                        "composio_execute",
+                                        &serde_json::json!({ "to": "a@b.test" }),
+                                    )
+                                    .is_some(),
+                                "the approved call is redeemed inside the follow-up turn"
+                            );
+                            self.consumed.wait().await;
+                            self.release.wait().await;
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(CycleResult {
+                    channel_responses: Vec::new(),
+                    new_traces: Vec::new(),
+                    ledger_deltas: Vec::new(),
+                    token_usage: TokenUsage::default(),
+                })
+            }
+        }
+
         let home_dir = tmp_home();
         let home = home_dir.path().to_path_buf();
-        let (rt, ids) = park_two_blocked_tool_calls(
-            home.clone(),
-            harness_effect(
-                "finance",
-                "composio_execute",
-                serde_json::json!({ "to": "a@b.test" }),
-            ),
-        )
-        .await;
-        rt.resolve_approval(&ids[0], Verdict::Approve, operator())
-            .await
-            .unwrap();
-        rt.resolve_approval(&ids[1], Verdict::Approve, operator())
-            .await
-            .unwrap();
-        assert_eq!(rt.grants.live_count(), 2, "both tool calls were granted");
-
-        // Both tools run at roughly the same moment — a real race between the
-        // two `consume` calls, on real OS threads, neither drained before the
-        // crash this test models.
-        let args = serde_json::json!({ "to": "a@b.test" });
-        let barrier = Arc::new(std::sync::Barrier::new(2));
-        let handles: Vec<_> = (0..2)
-            .map(|_| {
-                let grants = rt.grants.clone();
-                let args = args.clone();
-                let barrier = Arc::clone(&barrier);
-                std::thread::spawn(move || {
-                    barrier.wait();
-                    grants
-                        .consume("finance", "composio_execute", &args)
-                        .is_some()
-                })
-            })
-            .collect();
-        for h in handles {
-            assert!(
-                h.join().expect("thread"),
-                "both concurrent tool calls were admitted"
-            );
-        }
-        assert_eq!(rt.grants.live_count(), 0, "both grants were redeemed");
-        // Neither drain ran — nothing journals the consumption before the
-        // crash this test models.
-        drop(rt);
-
-        let restarted = Arc::new(
-            RuntimeBuilder::fs_defaults(home, manifest("supervised"))
+        let grants = Arc::new(std::sync::Mutex::new(None));
+        let consumed = Arc::new(tokio::sync::Barrier::new(2));
+        let release = Arc::new(tokio::sync::Barrier::new(2));
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("supervised"))
+                .with_brain(Arc::new(ConsumingBrain {
+                    effect: harness_effect(
+                        "finance",
+                        "composio_execute",
+                        serde_json::json!({ "to": "a@b.test" }),
+                    ),
+                    grants: Arc::clone(&grants),
+                    consumed: Arc::clone(&consumed),
+                    release: Arc::clone(&release),
+                }))
+                .build()
                 .await
                 .unwrap(),
         );
+        *grants.lock().expect("grant slot") = Some(rt.grants.clone());
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
+                parent: None,
+                text: "do it".into(),
+                by: None,
+                chat: None,
+                deliverable: None,
+                attachments: Vec::new(),
+            }])
+            .await
+            .unwrap();
+        let id = report.parked[0].clone();
+        let resolving = {
+            let rt = Arc::clone(&rt);
+            tokio::spawn(
+                async move { rt.resolve_approval(&id, Verdict::Approve, operator()).await },
+            )
+        };
+        consumed.wait().await;
+        assert_eq!(rt.grants.live_count(), 0, "the grant was redeemed");
+
+        let restarted = RuntimeBuilder::fs_defaults(home, manifest("supervised"))
+            .await
+            .unwrap();
         assert_eq!(
             restarted.grants.live_count(),
             0,
-            "a dispatch claim must keep both undrained consumptions spent"
+            "a dispatch claim must keep an undrained consumption spent"
         );
-        for id in &ids {
-            assert!(
-                restarted.grants.peek(id).is_none(),
-                "a dispatched single-use grant must not replay: {id}"
-            );
-        }
-        assert!(
-            restarted
-                .grants
-                .consume("finance", "composio_execute", &args)
-                .is_none(),
-            "the identical call must not be admitted again after restart"
-        );
+        release.wait().await;
+        resolving.await.expect("follow-up task").unwrap();
     }
 
     /// Issue #243: a grant the agent never redeemed expires, is journaled, and

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -661,6 +661,19 @@ impl<'a> CycleRunner<'a> {
             drop(guard);
             return Err(err);
         }
+        for id in events.iter().filter_map(|(_, event)| match event {
+            CompanyEvent::ApprovalResolved { approval_id, .. }
+                if self.rt.grants.peek(approval_id).is_some() =>
+            {
+                Some(approval_id)
+            }
+            _ => None,
+        }) {
+            self.rt
+                .journal
+                .record_grant_dispatched(id, now_millis())
+                .await?;
+        }
         let mut claimed: Vec<ApprovalContinuation> = Vec::new();
         for continuation in continuation_claims {
             if let Err(error) = self
@@ -7136,21 +7149,10 @@ members = ["writer"]
         );
     }
 
-    /// The boot-time twin of `grants_replay_on_boot_but_a_spent_one_does_not`:
-    /// this is what happens when the restart lands **before** the cycle's own
-    /// drain journals the consumption, rather than after. Two different
-    /// agents' tool calls are running when the crash hits — a routine shape
-    /// under real traffic, not a corner case — and neither had reached the
-    /// drain yet. Both must re-arm on replay, both must keep their **original**
-    /// mint time rather than being handed a fresh TTL by the restart (so the
-    /// duplication window this leaves stays bounded by the grant's own
-    /// [`GRANT_TTL_MILLIS`], not extended indefinitely by however many times
-    /// the process happens to restart), and both must re-admit their exact
-    /// original call a second time — the concrete, exploitable shape of the
-    /// window TOOL-005 documents, now proven at the boot path GRANT-004 names
-    /// rather than only at the bare journal file.
+    /// Two grants consumed concurrently before their ordinary cycle drain stay
+    /// spent across a restart.
     #[tokio::test]
-    async fn two_undrained_consumptions_both_re_arm_and_re_admit_after_a_restart() {
+    async fn two_undrained_consumptions_stay_spent_after_a_restart() {
         let home_dir = tmp_home();
         let home = home_dir.path().to_path_buf();
         let (rt, ids) = park_two_blocked_tool_calls(
@@ -7169,10 +7171,6 @@ members = ["writer"]
             .await
             .unwrap();
         assert_eq!(rt.grants.live_count(), 2, "both tool calls were granted");
-        let original_at_millis: Vec<u64> = ids
-            .iter()
-            .map(|id| rt.grants.peek(id).unwrap().at_millis)
-            .collect();
 
         // Both tools run at roughly the same moment — a real race between the
         // two `consume` calls, on real OS threads, neither drained before the
@@ -7210,38 +7208,22 @@ members = ["writer"]
         );
         assert_eq!(
             restarted.grants.live_count(),
-            2,
-            "both undrained consumptions must re-arm on the next boot"
+            0,
+            "a dispatch claim must keep both undrained consumptions spent"
         );
-        for (id, expected_at_millis) in ids.iter().zip(original_at_millis) {
-            let replayed = restarted
-                .grants
-                .peek(id)
-                .expect("each grant replays as live");
-            assert_eq!(
-                replayed.at_millis, expected_at_millis,
-                "a restart must not reset a re-armed grant's clock — its TTL exposure stays \
-                 bounded by the ORIGINAL mint time, not extended by the crash"
+        for id in &ids {
+            assert!(
+                restarted.grants.peek(id).is_none(),
+                "a dispatched single-use grant must not replay: {id}"
             );
         }
-
-        // The exploitable shape: the identical call each agent already made
-        // once is admitted again, with no new approval anywhere in between.
         assert!(
             restarted
                 .grants
                 .consume("finance", "composio_execute", &args)
-                .is_some(),
-            "the first re-armed grant re-admits its already-executed call"
+                .is_none(),
+            "the identical call must not be admitted again after restart"
         );
-        assert!(
-            restarted
-                .grants
-                .consume("finance", "composio_execute", &args)
-                .is_some(),
-            "the second re-armed grant re-admits its already-executed call too"
-        );
-        assert_eq!(restarted.grants.live_count(), 0);
     }
 
     /// Issue #243: a grant the agent never redeemed expires, is journaled, and

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -3218,35 +3218,6 @@ mod test {
         );
     }
 
-    /// `GrantConsumed` is only written at the cycle drain, not at `consume`
-    /// itself, so a crash between the two loses the durable record of the
-    /// consumption. A fresh boot's `rehydrate`, seeing only the journal's
-    /// `ApprovalGranted` line and no `GrantConsumed` to fold it back out,
-    /// re-arms a grant that was already spent — the boot-time surfacing of
-    /// the window names for the in-process case.
-    #[test]
-    #[ignore = "a grant consumed but not yet journal-drained before a restart rehydrates as live again, because GrantConsumed is only written at the cycle drain"]
-    fn a_grant_consumed_before_its_journal_drain_does_not_survive_a_restart() {
-        let args = serde_json::json!({ "to": "a@b.test" });
-        let before_crash = GrantSet::default();
-        before_crash.grant(call("a1", "finance", "composio_execute", args.clone()));
-        assert!(
-            before_crash
-                .consume("finance", "composio_execute", &args)
-                .is_some(),
-            "the agent redeemed it just before the crash"
-        );
-        // The crash lands before `drain_consumed` is journaled, so replay at
-        // boot only has the original `ApprovalGranted` line to fold in.
-        let after_restart = GrantSet::default();
-        after_restart.rehydrate([call("a1", "finance", "composio_execute", args.clone())]);
-        assert!(
-            after_restart.peek(&ApprovalId::new("a1")).is_none(),
-            "a grant already redeemed before the crash must not come back live \
-             after a restart that never saw its consumption journaled"
-        );
-    }
-
     /// The approval sweep caps how much housekeeping one tick does
     /// (`MAX_RETIREMENTS_PER_TICK`); `GrantSet::sweep` has no equivalent, so a
     /// company with a large expired-grant backlog processes every one of them

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -256,6 +256,15 @@ enum JournalRecord {
         /// The grant, whole.
         grant: GrantedCall,
     },
+    /// A single-use grant committed to one follow-up turn.
+    /// Written before that turn starts so recovery cannot re-arm authority
+    /// whose tool call may already have run.
+    GrantDispatched {
+        /// The grant committed to the turn.
+        id: ApprovalId,
+        /// Epoch-millis the dispatch was committed.
+        at_millis: u64,
+    },
     /// A follow-up turn owed after an agent explicitly asked the operator a
     /// question. Unlike `ApprovalGranted`, this carries either verdict and
     /// conveys no authority to execute a tool call.
@@ -665,6 +674,7 @@ impl JournalRecord {
             // direction — the cost of the loss is an extra question, never an
             // extra call.
             Self::ApprovalGranted { .. } => Durability::Process,
+            Self::GrantDispatched { .. } => Durability::Host,
             // Conversation continuations carry no execution authority. Losing
             // a queued one means the agent misses a verdict; losing a terminal
             // line can repeat a model follow-up, but cannot repeat an effect.
@@ -1449,6 +1459,9 @@ impl RuntimeJournal {
             }
             JournalRecord::ApprovalGranted { grant } => {
                 state.grants.insert(grant.approval_id.clone(), grant);
+            }
+            JournalRecord::GrantDispatched { id, .. } => {
+                state.grants.remove(&id);
             }
             JournalRecord::ApprovalContinuationQueued { continuation } => {
                 state
@@ -2435,6 +2448,21 @@ impl RuntimeJournal {
             .insert(grant.approval_id.clone(), grant.clone());
         self.append(&JournalRecord::ApprovalGranted {
             grant: grant.clone(),
+        })
+        .await
+    }
+
+    /// Durably commits a single-use grant to one follow-up turn before the
+    /// turn can re-issue its approved tool call.
+    pub async fn record_grant_dispatched(&self, id: &ApprovalId, at_millis: u64) -> Result<()> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .grants
+            .remove(id);
+        self.append(&JournalRecord::GrantDispatched {
+            id: id.clone(),
+            at_millis,
         })
         .await
     }
@@ -3949,15 +3977,10 @@ mod test {
         );
     }
 
-    /// `GrantConsumed` is buffered in memory and journaled only at
-    /// the cycle drain (see `GrantState::consumed`'s doc), so a restart that
-    /// lands between "the tool ran" and "the drain wrote the record" replays
-    /// the grant as still live. This pins that this is what actually happens
-    /// on replay today — the documented duplication window, not a guess about
-    /// it — so a fix that closes the window is a deliberate, visible change to
-    /// this test rather than a silent behavior shift.
+    /// A single-use grant claimed for a follow-up turn must not re-arm when the
+    /// tool consumes it but the cycle has not drained that consumption yet.
     #[tokio::test]
-    async fn a_grant_consumed_but_not_yet_drained_replays_as_live_after_a_restart() {
+    async fn a_grant_consumed_but_not_yet_drained_does_not_replay_after_a_restart() {
         let dir = tmp_dir();
         let path = dir.path().join("journal.jsonl");
         let journal = RuntimeJournal::new(&path);
@@ -3966,20 +3989,36 @@ mod test {
             .record_granted(&grant("appr-crash", 1_000))
             .await
             .unwrap();
-        // The tool ran and `GrantSet::consume` removed it from the in-memory
-        // live set here, in the real path — but that consumption is buffered,
-        // not journaled, until the cycle runner's drain. No `record_grant_consumed`
-        // call happens before the crash this test models.
+        let live = crate::runtime::grants::GrantSet::default();
+        live.rehydrate(journal.replayed_grants());
+        journal
+            .record_grant_dispatched(&ApprovalId::new("appr-crash"), 1_500)
+            .await
+            .unwrap();
+        assert!(
+            live.consume(
+                "finance",
+                "composio_execute",
+                &crate::policy::test_support::composio_send_args(),
+            )
+            .is_some()
+        );
+        assert_eq!(live.live_count(), 0);
 
         let reloaded = RuntimeJournal::new(&path);
         reloaded.load().await.unwrap();
         let replayed = reloaded.replayed_grants();
         assert_eq!(
             replayed.len(),
-            1,
-            "an undrained consumption re-arms the grant on replay: {replayed:?}"
+            0,
+            "a grant already consumed by its claimed turn must not re-arm before the drain: \
+             {replayed:?}"
         );
-        assert_eq!(replayed[0].approval_id, ApprovalId::new("appr-crash"));
+        assert_eq!(
+            live.drain_consumed(),
+            vec![ApprovalId::new("appr-crash")],
+            "the terminal consumption is still waiting for the ordinary cycle drain"
+        );
     }
 
     #[tokio::test]
@@ -4730,6 +4769,10 @@ mod test {
             JournalRecord::ApprovalGranted {
                 grant: grant("a", 4),
             },
+            JournalRecord::GrantDispatched {
+                id: ApprovalId::new("a"),
+                at_millis: 4,
+            },
             JournalRecord::ApprovalContinuationQueued {
                 continuation: ApprovalContinuation {
                     call: grant("continuation", 4),
@@ -4825,12 +4868,12 @@ mod test {
     /// pinned separately below (issue #1145) — deliberately not by loosening
     /// this list, which is the assertion that would have stopped noticing.
     #[test]
-    fn host_durable_kinds_are_exactly_the_nine_that_protect_approval_work() {
+    fn host_durable_kinds_are_exactly_the_ten_that_protect_approval_work() {
         let all = every_record_kind();
         let tags: HashSet<String> = all.iter().map(record_tag).collect();
         assert_eq!(
             tags.len(),
-            21,
+            22,
             "every JournalRecord variant must appear once in every_record_kind"
         );
 
@@ -4851,9 +4894,10 @@ mod test {
                 "BlockedNodeStashed".to_string(),
                 "EffectExecuted".to_string(),
                 "GrantConsumed".to_string(),
+                "GrantDispatched".to_string(),
                 "StandingGrantRevoked".to_string()
             ],
-            "the host-durable set is these nine kinds and nothing else; \
+            "the host-durable set is these ten kinds and nothing else; \
              widening it taxes the hot path, narrowing it lets an effect duplicate, \
              a spent grant re-arm, an explicit follow-up repeat, or a blocked node's \
              stash/approval/dispatch survive a process restart but not the host crash it also \


### PR DESCRIPTION
## Summary

Make single-use grant dispatch durable before an approved follow-up turn can re-issue its tool call, preventing a crash before the ordinary consumption drain from re-arming spent authority.

## Problem

A grant was removed from the live set synchronously when a tool redeemed it, but `GrantConsumed` was appended only after the cycle finished. A restart inside that window replayed the earlier `ApprovalGranted` record and admitted the identical call again.

The pre-fix journal-layer acceptance failed on its own assertion:

```
assertion `left == right` failed: a grant already consumed by its claimed turn must not re-arm before the drain
  left: 1
 right: 0
```

## Solution

Append a host-durable `GrantDispatched` claim after the continuation owns its execution lock and before the brain runs. Replay folds that claim out of `replayed_grants`. If the completed turn did not redeem the grant, append `ApprovalGranted` again so unused authority still survives an ordinary restart; a crash during an uncertain turn stays fail-closed.

The impossible GrantSet-only ignored test was replaced at the journal layer, where the replayed grant and pending `drain_consumed` state can both be observed. The prior passing cycle test that asserted re-arming was replaced with a deterministic two-barrier test that pauses after real redemption and reloads the journal before the cycle drain.

## Submission Checklist

- [x] Journal acceptance filter listed exactly 1 test; green with 1 passed, 0 failed under `openhuman,tinymemory`
- [x] Crash-window integration filter listed exactly 1 test; green with 1 passed, 0 failed under `openhuman,tinymemory`
- [x] Whole `runtime::` filter listed 1101 tests; green with 1100 passed, 0 failed, 1 ignored under `openhuman,tinymemory`
- [x] Existing unused-grant restart and concurrent-mint tests are green, 1 passed each
- [x] Red proof: removing only the pre-turn `record_grant_dispatched` loop made the crash-window test fail with left 1/right 0 and exit 101; restore matched the saved SHA-256 and the test returned 1 passed
- [x] `cargo fmt --check` — exit 0
- [x] `cargo clippy --all-targets --no-deps --features openhuman,tinymemory -- -D warnings` — exit 0
- [x] Production-deletion scan reviewed: only the superseded broad claim loop and bug-asserting tests were removed, with replacements in the same commits

## Impact

A single-use approval cannot be spent again after a restart in the consume-before-drain window. Unused grants remain restart-durable after a completed follow-up, while a crash during an indeterminate turn chooses loss of authority over duplicate execution.

## Related

PR #2226 owns standing-grant behavior. This change is limited to single-use grants and does not alter standing-grant replay or validation.
