### PR TITLE
fix(blockers): settle skipped task cards

### DIFF
--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -910,14 +910,8 @@ export function blockerVerdictLabel(verdict: BlockerVerdict): string {
  * rest on its label alone. Every arm says its consequence, so the two that
  * matter are not the only two that look explained.
  *
- * **Worded by step kind, not by one shared assumption.** A paused board card
- * and a stopped workflow-run node do different things on `skip` and `cancel`:
- * a card redispatches on skip (there is no card-level skip yet) and returns
- * to To-do on cancel, while a node produces nothing on skip and stops the run
- * on cancel. Describing the node's behaviour on a card's controls tells an
- * operator their click will do one thing when it does another. `stepKind`
- * absent — no step behind the blocker, or a host that predates the field —
- * falls back to wording that makes no claim either path would contradict.
+ * Task and node blockers have different skip and cancel outcomes. When the
+ * step kind is absent, use wording that is valid for either path.
  */
 export function blockerVerdictConsequence(
   verdict: BlockerVerdict,
@@ -930,7 +924,7 @@ export function blockerVerdictConsequence(
       case "amend":
         return "Puts the card back in progress and runs it again with what you write.";
       case "skip":
-        return "Puts the card back in progress and runs it again — there is no separate skip for a card yet.";
+        return "Moves the card to In review without running it again. No output is produced.";
       case "cancel":
         return "Moves the card back to To-do without running it. It can be picked up again later.";
     }

--- a/frontend/test/e2e/approval-blocker-verdicts.spec.ts
+++ b/frontend/test/e2e/approval-blocker-verdicts.spec.ts
@@ -74,15 +74,7 @@ function parkedBlocker() {
   };
 }
 
-/**
- * A parked blocker whose stopped step is a paused board card (#2028).
- *
- * `skip` and `cancel` do not do the same thing here that they do to a
- * workflow node: skip puts the card back in progress (there is no
- * card-level skip yet — see `resume_task_card` in `src/company/runtime.rs`)
- * and cancel returns it to To-do, neither of which is "produces nothing" or
- * "stops the run". The consequence text must say so, not the node's wording.
- */
+/** A parked blocker whose stopped step is a paused board card. */
 function parkedTaskBlocker() {
   return {
     ...parkedBlocker(),
@@ -275,14 +267,6 @@ test("a blocker card offers four verdicts where an ordinary card offers two", as
   await expect(page.getByText("Stops it here.", { exact: false })).toBeVisible();
 });
 
-/**
- * **The headline of #2028's follow-up.** A card's `skip` and `cancel` do not
- * do what a workflow node's do — a card redispatches on skip (there is no
- * card-level skip yet) and returns to To-do on cancel — so the consequence
- * line must say a different thing for each, and neither may be the node's
- * wording. Real DOM text, on the same three fixtures the resolve-body tests
- * below click through.
- */
 test("a blocker's consequence text is worded by which step it stopped, not one shared line", async ({
   page,
 }) => {
@@ -296,13 +280,10 @@ test("a blocker's consequence text is worded by which step it stopped, not one s
   await expect(node.getByText("Moves past this step. It produces nothing", { exact: false })).toBeVisible();
   await expect(node.getByText("Stops the run here. Nothing after this step will run.", { exact: false })).toBeVisible();
 
-  // The task card must NOT claim the node's behaviour — "produces nothing" /
-  // "stops the run" would tell the operator work is skipped or a run is
-  // halted when the card in fact redispatches on skip and only returns to
-  // To-do on cancel.
-  await expect(task.getByText("Moves past this step. It produces nothing", { exact: false })).toHaveCount(0);
+  await expect(task.getByText("Moves past this step", { exact: false })).toHaveCount(0);
   await expect(task.getByText("Stops the run here.", { exact: false })).toHaveCount(0);
-  await expect(task.getByText("Puts the card back in progress", { exact: false }).first()).toBeVisible();
+  await expect(task.getByText("Moves the card to In review without running it again", { exact: false })).toBeVisible();
+  await expect(task.getByText("No output is produced", { exact: false })).toBeVisible();
   await expect(task.getByText("Moves the card back to To-do without running it.", { exact: false })).toBeVisible();
 
   // A blocker with no step behind it (or an old host) must not borrow either

--- a/frontend/test/unit/approval-blocker-verdicts.test.ts
+++ b/frontend/test/unit/approval-blocker-verdicts.test.ts
@@ -218,15 +218,6 @@ describe("a blocker card offers four verdicts, not two", () => {
   });
 });
 
-/**
- * **The headline finding from the second review round on #2028.** The four
- * consequence lines were worded for a workflow node and rendered on every
- * `blocker.*` card, including a paused board card — whose `skip` in fact
- * redispatches the card (there is no card-level skip yet) and whose `cancel`
- * returns it to To-do rather than stopping a run. An operator reading the
- * node's wording on a card would click Skip expecting the work omitted and
- * get it re-run instead.
- */
 describe("a blocker's consequence is worded by which step it stopped", () => {
   it("gives retry, skip and cancel a different sentence for a card than for a node", () => {
     for (const verdict of ["retry", "skip", "cancel"] as BlockerVerdict[]) {
@@ -239,14 +230,12 @@ describe("a blocker's consequence is worded by which step it stopped", () => {
     }
   });
 
-  it("does not put the node's skip/cancel claims on a task-backed card", () => {
+  it("describes the task skip landing without another run", () => {
     const skip = blockerVerdictConsequence("skip", "task");
     const cancel = blockerVerdictConsequence("cancel", "task");
-    // The node's skip claims the work produces nothing; a card's skip in fact
-    // redispatches it (`resume_task_card` treats skip and retry alike).
-    expect(skip).not.toMatch(/produces nothing/i);
-    // The node's cancel claims it stops a run; a card has no run to stop — it
-    // returns to To-do.
+    expect(skip).toMatch(/in review/i);
+    expect(skip).toMatch(/without running it again/i);
+    expect(skip).toMatch(/no output is produced/i);
     expect(cancel).not.toMatch(/stops the run/i);
     expect(cancel).toMatch(/to-do/i);
   });

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1825,33 +1825,32 @@ impl CompanyRuntime {
         }
     }
 
-    /// Files the durable "a blocker was answered, picking it back up"
-    /// notification (issue #2008), the settle-side counterpart to
-    /// [`notify_blocker_parked`](Self::notify_blocker_parked).
-    ///
-    /// The park badged the operator that a person was blocked; nothing badged
-    /// them when the answer landed and the work resumed. Filed on the same DM
-    /// thread with the same thin `Approval` subject, so a console that folds
-    /// blocker badges by conversation clears the parked one and shows that the
-    /// stopped step is moving again. Best-effort — the resume already stands —
-    /// and a no-op for a blocker raised in no conversation, which has no thread
-    /// to badge.
+    /// Files the durable blocker-answer notification on the original DM thread.
+    /// Best-effort: the resolution already stands if this write fails.
     #[cfg(feature = "openhuman")]
     async fn notify_blocker_resumed(
         &self,
         id: &ApprovalId,
         thread: Option<&str>,
         resolution: &crate::ports::blockers::BlockerResolution,
+        step: Option<&crate::ports::blockers::BlockerStep>,
     ) {
-        use crate::ports::blockers::BlockerStep;
+        use crate::ports::blockers::{BlockerStep, BlockerVerdict};
         let Some(thread) = thread else {
             return;
         };
         let sender = thread.strip_prefix("dm:").unwrap_or(thread);
-        let step = match &resolution.step {
+        let step_id = match step {
             Some(BlockerStep::Task { task_id }) => task_id.clone(),
             Some(BlockerStep::Node { node_id, .. }) => node_id.clone(),
             None => "a question".to_string(),
+        };
+        let title = if resolution.verdict == BlockerVerdict::Skip
+            && matches!(step, Some(BlockerStep::Task { .. }))
+        {
+            format!("{sender}'s blocker on {step_id} was waived")
+        } else {
+            format!("{sender}'s blocker on {step_id} was answered — picking it back up")
         };
         let note = crate::ports::notifications::Notification {
             id: crate::ports::generate_id(),
@@ -1861,7 +1860,7 @@ impl CompanyRuntime {
                 id: id.as_ref().to_string(),
             },
             created_at: now_millis(),
-            title: format!("{sender}'s blocker on {step} was answered — picking it back up"),
+            title,
             audience: None,
             context: Some(thread.to_string()),
         };
@@ -2861,20 +2860,9 @@ impl CompanyRuntime {
         })
     }
 
-    /// Re-enters the step a resolved blocker stopped, carrying the operator's
-    /// answer (issue #1863) — the resume half `park_blocker` deliberately left
-    /// inert.
-    ///
-    /// The fork the whole tier turns on, reached from
-    /// [`spawn_follow_up`](Self::spawn_follow_up) once the verdict is durable.
-    /// A resuming verdict re-dispatches the stopped work carrying the answer; a
-    /// [`Cancel`](crate::ports::blockers::BlockerVerdict::Cancel) settles it and
-    /// starts nothing — the short-circuit that runs *before* any cycle. Which
-    /// step is re-entered is read off the blocker's own
-    /// [`BlockerStep`](crate::ports::blockers::BlockerStep): a board card is
-    /// moved back into In Progress so its dispatch edge fires; a workflow node
-    /// is handed the answer for its run; a bare agent question just carries the
-    /// answer back into the DM it was asked in.
+    /// Applies a durable blocker verdict to its task, workflow node, or DM.
+    /// Retry and amend re-dispatch task work; task skip and cancel settle it
+    /// without another run. Node verdicts retain their workflow semantics.
     ///
     /// The step rides on the resolution itself — the journal scrubs a parked
     /// effect's payload, so it is captured at resolve time — while the DM thread
@@ -2919,7 +2907,7 @@ impl CompanyRuntime {
         }
         outcome?;
         if resolution.resumes() {
-            self.notify_blocker_resumed(approval_id, thread.as_deref(), &resolution)
+            self.notify_blocker_resumed(approval_id, thread.as_deref(), &resolution, step.as_ref())
                 .await;
         }
         Ok(CycleRunner::new(self).already_resolved_report())
@@ -2987,24 +2975,29 @@ impl CompanyRuntime {
         thread: Option<&str>,
         origin_parent: Option<EventSeq>,
     ) -> Result<()> {
-        use crate::ports::blockers::BlockerStep;
+        use crate::ports::blockers::{BlockerStep, BlockerVerdict};
 
-        match step {
-            Some(BlockerStep::Task { task_id }) => {
-                if resolution.resumes() {
-                    self.resume_task_card(task_id, resolution, thread, origin_parent)
-                        .await
-                } else {
-                    self.cancel_task_card(task_id, thread, origin_parent).await
-                }
+        match (step, resolution.verdict) {
+            (Some(BlockerStep::Task { task_id }), BlockerVerdict::Skip) => {
+                self.skip_task_card(task_id, thread, origin_parent).await
             }
-            Some(BlockerStep::Node { run_id, node_id }) => {
+            (Some(BlockerStep::Task { task_id }), BlockerVerdict::Cancel) => {
+                self.cancel_task_card(task_id, thread, origin_parent).await
+            }
+            (
+                Some(BlockerStep::Task { task_id }),
+                BlockerVerdict::Retry | BlockerVerdict::Amend,
+            ) => {
+                self.resume_task_card(task_id, resolution, thread, origin_parent)
+                    .await
+            }
+            (Some(BlockerStep::Node { run_id, node_id }), _) => {
                 self.resume_node_blocker(run_id, node_id, resolution, thread, origin_parent)
                     .await
             }
             // A question with no card or node behind it — carrying the answer
             // back into its DM is the whole of the resume.
-            None => {
+            (None, _) => {
                 self.post_blocker_resume_note(
                     thread,
                     origin_parent,
@@ -3094,6 +3087,50 @@ impl CompanyRuntime {
         drop(_serialized);
         self.post_blocker_resume_note(thread, origin_parent, &blocker_resume_note(resolution))
             .await
+    }
+
+    #[cfg(feature = "openhuman")]
+    async fn skip_task_card(
+        self: &Arc<Self>,
+        task_id: &str,
+        thread: Option<&str>,
+        origin_parent: Option<EventSeq>,
+    ) -> Result<()> {
+        let _serialized = self.task_writes.lock().await;
+        let Some(mut card) = self
+            .ops
+            .tasks
+            .list(&self.id)
+            .await?
+            .into_iter()
+            .find(|task| task.id == task_id)
+        else {
+            return Ok(());
+        };
+        if card.column != crate::ports::tasks::COLUMN_PAUSED {
+            return Ok(());
+        }
+        card.note = Some(crate::runtime::advance::append_result(
+            card.note.as_deref(),
+            "operator",
+            BLOCKER_WAIVED,
+        ));
+        if let Some(thread) = thread {
+            card.origin =
+                crate::ports::tasks::TaskOrigin::new(Some(thread.to_string()), origin_parent);
+        }
+        card.column = crate::ports::tasks::COLUMN_IN_REVIEW.to_string();
+        card.output = None;
+        card.bounced = None;
+        card.updated_at_millis = now_millis();
+        self.ops.tasks.upsert(&self.id, &card).await?;
+        drop(_serialized);
+        self.post_blocker_resume_note(
+            thread,
+            origin_parent,
+            "Okay — I've waived that blocker. The card is in review; nothing ran again.",
+        )
+        .await
     }
 
     /// Settles a blocked card the operator cancelled, moving it back to To-do
@@ -7876,6 +7913,9 @@ pub(crate) enum BlockerReplyPlan {
 #[cfg(feature = "openhuman")]
 const BLOCKER_CANCELLED: &str =
     "cancelled from the blocker chat — the work was stopped, not failed";
+
+#[cfg(feature = "openhuman")]
+const BLOCKER_WAIVED: &str = "blocker question waived by the operator — no work was run";
 
 /// The one line posted back into a blocker's DM when its answer re-enters the
 /// stopped step (issue #1863), phrased per verdict so the operator sees what
@@ -13982,7 +14022,8 @@ mod tests {
         use crate::company::task_intent::BlockerReplyIntent;
         use crate::ports::blockers::{BlockerKind, BlockerPayload, BlockerSource, BlockerStep};
         use crate::ports::tasks::{
-            COLUMN_IN_PROGRESS, COLUMN_PAUSED, COLUMN_TODO, TaskDeliverable, TaskRecord, TaskTitle,
+            COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED, COLUMN_TODO, TaskDeliverable,
+            TaskRecord, TaskTitle,
         };
         use crate::ports::types::CompanyId;
         use std::path::Path;
@@ -14011,6 +14052,14 @@ mod tests {
                 .tempdir()
                 .expect("tempdir");
             let runtime = build(home.path()).await;
+            (runtime, home)
+        }
+
+        async fn runtime_with_harness() -> (Arc<CompanyRuntime>, TempDir) {
+            let (mut runtime, home) = runtime().await;
+            Arc::get_mut(&mut runtime)
+                .expect("runtime is not shared yet")
+                .set_harness(Arc::new(crate::harness::HarnessPool::new()));
             (runtime, home)
         }
 
@@ -14147,12 +14196,15 @@ mod tests {
             );
         }
 
-        /// A skip proceeds past the blocker — the card re-dispatches without a
-        /// correction.
         #[tokio::test]
-        async fn skip_redispatches_the_paused_card() {
-            let (runtime, _home) = runtime().await;
-            seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
+        async fn skip_settles_the_paused_card_without_another_run() {
+            use crate::ports::runs::RunFilter;
+
+            let (runtime, _home) = runtime_with_harness().await;
+            let mut paused = card("t-1", COLUMN_PAUSED);
+            paused.origin = crate::ports::TaskOrigin::new(Some("general".to_string()), None);
+            paused.bounced = Some("an older attempt failed".to_string());
+            seed(&runtime, &paused).await;
             runtime
                 .park_blocker(&blocker("t-1"), "t-1", assignee("eng"))
                 .await
@@ -14168,7 +14220,46 @@ mod tests {
                 .await
                 .expect("resumes");
 
-            assert_eq!(stored(&runtime, "t-1").await.column, COLUMN_IN_PROGRESS);
+            let runs = runtime
+                .runs()
+                .list_runs(runtime.id(), &RunFilter::for_task("t-1"))
+                .await
+                .expect("list runs");
+            assert_eq!(runs.len(), 0, "a skip must not open another attempt");
+
+            let after = stored(&runtime, "t-1").await;
+            assert_eq!(after.column, COLUMN_IN_REVIEW);
+            assert!(after.output.is_none());
+            assert!(after.bounced.is_none());
+            assert_eq!(after.origin_chat_id(), Some("dm:eng"));
+            assert!(
+                after
+                    .note
+                    .as_deref()
+                    .is_some_and(|note| note.contains("blocker question waived by the operator"))
+            );
+
+            let replies = dm_notes(&runtime).await;
+            assert!(replies.iter().any(|reply| {
+                reply
+                    == "Okay — I've waived that blocker. The card is in review; nothing ran again."
+            }));
+
+            let notification = runtime
+                .notifications()
+                .list(runtime.id(), "eng")
+                .await
+                .expect("notifications")
+                .into_iter()
+                .find(|notification| notification.notification.kind == "blocker_resumed")
+                .expect("settle notification");
+            assert!(notification.notification.title.contains("was waived"));
+            assert!(
+                !notification
+                    .notification
+                    .title
+                    .contains("picking it back up")
+            );
         }
 
         /// A cancel settles the card and starts nothing: it lands back in To-do
@@ -14466,9 +14557,8 @@ mod tests {
         /// Every resume acknowledgement lands in the thread the question was
         /// asked in, not at the channel root.
         ///
-        /// The anchor is the one the approval recorded when it parked, and it
-        /// reaches all three resumes — a card re-entered, a card cancelled, and
-        /// a workflow node. Driven directly because `park_blocker` records no
+        /// The anchor is the one the approval recorded when it parked. Driven
+        /// directly because `park_blocker` records no
         /// parent of its own: only an `escalate_to_human` park carries one, and
         /// what is under test is that each resume passes on the anchor it is
         /// handed rather than dropping it.
@@ -14483,6 +14573,10 @@ mod tests {
                     "Okay — I've cancelled that. It's back in To-do if you want to pick it up \
                      later.",
                 ),
+                (
+                    BlockerVerdict::Skip,
+                    "Okay — I've waived that blocker. The card is in review; nothing ran again.",
+                ),
             ] {
                 let (runtime, _home) = runtime().await;
                 seed(&runtime, &card("t-1", COLUMN_PAUSED)).await;
@@ -14493,16 +14587,20 @@ mod tests {
                     step: None,
                 };
 
-                if verdict == BlockerVerdict::Cancel {
-                    runtime
+                match verdict {
+                    BlockerVerdict::Cancel => runtime
                         .cancel_task_card("t-1", Some("dm:eng"), Some(root))
                         .await
-                        .expect("cancels");
-                } else {
-                    runtime
+                        .expect("cancels"),
+                    BlockerVerdict::Skip => runtime
+                        .skip_task_card("t-1", Some("dm:eng"), Some(root))
+                        .await
+                        .expect("skips"),
+                    BlockerVerdict::Retry => runtime
                         .resume_task_card("t-1", &resolution, Some("dm:eng"), Some(root))
                         .await
-                        .expect("resumes");
+                        .expect("resumes"),
+                    BlockerVerdict::Amend => unreachable!(),
                 }
 
                 let threaded: Vec<Option<crate::ports::types::EventSeq>> = dm_replies(&runtime)
@@ -14588,7 +14686,7 @@ mod tests {
         /// A card an operator has since dragged out of `paused` is theirs — a
         /// resume must not yank it back, exactly as the expiry mover leaves it.
         #[tokio::test]
-        async fn a_card_moved_out_of_paused_is_not_yanked_back() {
+        async fn a_skip_leaves_a_card_moved_out_of_paused_alone() {
             let (runtime, _home) = runtime().await;
             seed(&runtime, &card("t-1", COLUMN_TODO)).await;
             runtime
@@ -14602,7 +14700,7 @@ mod tests {
                 .collect();
 
             runtime
-                .apply_blocker_reply(&ids, BlockerReplyIntent::Retry, "retry", None)
+                .apply_blocker_reply(&ids, BlockerReplyIntent::Skip, "skip", None)
                 .await
                 .expect("resumes");
 

--- a/src/ports/blockers.rs
+++ b/src/ports/blockers.rs
@@ -354,12 +354,11 @@ impl BlockerVerdict {
         })
     }
 
-    /// Whether this verdict **re-enters** the stopped step.
+    /// Whether this verdict permits a follow-up after the stopped step.
     ///
-    /// Every verdict but [`Cancel`](Self::Cancel) resumes: a retry runs the step
-    /// again, an amend runs it with the answer, a skip proceeds past it. Cancel
-    /// abandons the work and starts nothing — the one place the resume fork
-    /// short-circuits before any cycle.
+    /// This does not decide whether a task card dispatches: a task skip settles
+    /// without another run, while a node skip re-enters its workflow past the
+    /// node. Cancel abandons either kind and starts nothing.
     pub fn resumes(self) -> bool {
         !matches!(self, Self::Cancel)
     }
@@ -452,8 +451,8 @@ impl BlockerResolution {
         self
     }
 
-    /// Whether resolving with this re-enters the stopped step — a shorthand for
-    /// [`BlockerVerdict::resumes`].
+    /// Whether resolving permits a follow-up — a shorthand for
+    /// [`BlockerVerdict::resumes`]. Task routing may settle without dispatch.
     pub fn resumes(&self) -> bool {
         self.verdict.resumes()
     }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -11855,18 +11855,10 @@ mode = "full"
         assert!(banked_resolutions(&home, &company).await.is_empty());
     }
 
-    /// A blocker raised by `escalate_to_human` carries no
-    /// [`BlockerStep`](crate::ports::blockers::BlockerStep) — the tool holds
-    /// neither a card nor a node — so the resume falls back to the card the
-    /// approval is linked to, and answering re-dispatches it.
-    ///
-    /// The banked resolution is still stepless, and that assertion is
-    /// load-bearing rather than incidental: the fallback is read at resume
-    /// time, so the durable record keeps saying what the blocker actually
-    /// carried instead of being rewritten to claim a step it never had.
+    /// A stepless blocker uses its task link to settle the card it paused.
     #[cfg(feature = "openhuman")]
     #[tokio::test]
-    async fn an_agent_question_re_dispatches_the_card_its_approval_is_linked_to() {
+    async fn skipping_an_agent_question_settles_the_card_its_approval_is_linked_to() {
         use crate::ports::blockers::{BlockerKind, BlockerPayload, BlockerSource};
         use crate::runtime::journal::{ApprovalConversation, TaskLink};
 
@@ -11892,14 +11884,22 @@ mode = "full"
                     origin: None,
                     origin_message_seq: None,
                     parent_task_id: None,
-                    output: None,
+                    output: Some(crate::ports::tasks::TaskOutput {
+                        source: crate::ports::tasks::TaskOutputSource::Run {
+                            run_id: "old-run".to_string(),
+                            attempt: Some(1),
+                        },
+                        at_millis: 1,
+                        artifacts: Vec::new(),
+                        workflows: Vec::new(),
+                    }),
                     plan: None,
                     planning_attempts: Vec::new(),
                     deliverable: crate::ports::tasks::TaskDeliverable::Once,
                     workflow_proposal: None,
                     origin_run_id: None,
                     origin_workflow_id: None,
-                    bounced: None,
+                    bounced: Some("stale failure".to_string()),
                 },
             )
             .await
@@ -11978,8 +11978,28 @@ mode = "full"
             .expect("the card still exists");
         assert_eq!(
             card.column,
-            crate::ports::tasks::COLUMN_IN_PROGRESS,
-            "the answer re-dispatches the linked card"
+            crate::ports::tasks::COLUMN_IN_REVIEW,
+            "the skipped card is ready for human review"
+        );
+        assert!(card.output.is_none(), "a skip produces no output");
+        assert!(card.bounced.is_none(), "a skip clears the old bounce chip");
+        assert_eq!(card.origin_chat_id(), Some("dm:eng"));
+        assert!(
+            card.note
+                .as_deref()
+                .is_some_and(|note| { note.contains("blocker question waived by the operator") })
+        );
+        assert!(
+            runtime
+                .runs()
+                .list_runs(
+                    runtime.id(),
+                    &crate::ports::runs::RunFilter::for_task("t-9"),
+                )
+                .await
+                .unwrap()
+                .is_empty(),
+            "a skip must not open another attempt"
         );
     }
 


### PR DESCRIPTION
## Summary

- Give task-backed blockers a real Skip path that settles the paused card without dispatching another attempt.
- Keep node Skip, task Retry/Amend, and Cancel behavior unchanged.
- Make the task Skip acknowledgement, notification, and console consequence text describe the waived work accurately.

Closes #2185

## API Or Behavior Changes

- Task-backed Skip now writes through the plain task store, lands the card in `in_review`, clears stale output and bounce state, appends the waiver to the note, and stamps the blocker conversation as its review origin.
- Task-backed Skip does not open a run. Its DM acknowledgement says nothing ran again, and its notification says the blocker was waived rather than picked back up.
- The console now says: `Moves the card to In review without running it again. No output is produced.`
- No public API or wire-format changes.

## Tests

Red proof, before the production change:

```text
running 1 test
test company::runtime::tests::blocker_resume::skip_settles_the_paused_card_without_another_run ... FAILED

failures:

---- company::runtime::tests::blocker_resume::skip_settles_the_paused_card_without_another_run stdout ----

thread 'company::runtime::tests::blocker_resume::skip_settles_the_paused_card_without_another_run' (102199443) panicked at src/company/runtime.rs:14188:13:
assertion `left == right` failed: a skip must not open another attempt
  left: 1
 right: 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    company::runtime::tests::blocker_resume::skip_settles_the_paused_card_without_another_run

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 7652 filtered out; finished in 0.23s

error: test failed, to rerun pass `--lib`
```

Green proof, after the production change:

```text
running 1 test
test company::runtime::tests::blocker_resume::skip_settles_the_paused_card_without_another_run ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 7652 filtered out; finished in 0.18s
```

Additional verification:

- `cargo test --features openhuman,tinymemory --lib company::runtime::tests::blocker_resume` — 20 passed.
- `cargo test --features openhuman,tinymemory --lib company::runtime::tests::blocker_dms` — 16 passed.
- `cargo test --features openhuman,tinymemory --lib server::operator::test -- --skip a_real_socket_close_does_not_cancel_the_follow_up_cycle` — 211 passed; the excluded socket case was then run exactly with loopback permission and passed.
- `cargo clippy --features openhuman,tinymemory --lib --all-targets --no-deps -- -D warnings` — passed.
- `cargo build --locked --features openhuman,tinymemory --bin opencompany` — passed.
- `npm run typecheck:unit` — passed.
- `npm run typecheck:e2e` — passed.
- `npx vitest run test/unit/approval-blocker-verdicts.test.ts` — 15 passed.
- `npx playwright test test/e2e/approval-blocker-verdicts.spec.ts --reporter=line` against the freshly built host and console bundle — 10 passed.
- `npx playwright test test/e2e/board-drag.spec.ts --grep 'drop that misses every column' --reporter=line` against the same host — 1 passed, including an `in_review` card rendered under Working.
- `git diff --check upstream/main...HEAD` — passed.

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo build --all-targets`
- [ ] `cargo test`

The three unchecked commands were not run unscoped; the feature-gated/scoped commands above are the repository-prescribed gates for this change.

## Documentation

Updated the blocker verdict API documentation to distinguish follow-up eligibility from task dispatch. No external documentation changes were needed.
