### PR TITLE
fix(mcp): refuse a connected server no teammate can reach

### DIFF
--- a/companies/hive_math_lab/agents/archivist.toml
+++ b/companies/hive_math_lab/agents/archivist.toml
@@ -6,7 +6,7 @@ context = ["GOAL.md", "brief.md", "METHOD.md", "attempts.md", "answers.md"]
 # The one solvers-desk seat with a write grant, mirroring the scribe's on the
 # records desk — and for the same reason: a member that can also compute is a
 # member that will eventually remember a number nobody else on the desk saw.
-tools = ["files", "workspace", "workspace.read", "workspace.write"]
+tools = ["files", "workspace", "workspace.read", "workspace.write", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/hive_math_lab/agents/brute_forcer.toml
+++ b/companies/hive_math_lab/agents/brute_forcer.toml
@@ -4,7 +4,7 @@ description = "The naive method at a bound it can actually finish, with the comm
 # needs a fast model, not a clever one.
 context = ["GOAL.md", "brief.md", "METHOD.md", "attempts.md"]
 
-tools = ["files", "shell", "code", "workspace.read"]
+tools = ["files", "shell", "code", "workspace.read", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/hive_math_lab/agents/programmer.toml
+++ b/companies/hive_math_lab/agents/programmer.toml
@@ -3,7 +3,7 @@ description = "Write the program the approach calls for, run it, and report what
 tier = "reasoning"
 context = ["GOAL.md", "brief.md", "METHOD.md", "attempts.md"]
 
-tools = ["files", "docs", "shell", "code", "workspace.read"]
+tools = ["files", "docs", "shell", "code", "workspace.read", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/hive_math_lab/agents/scribe.toml
+++ b/companies/hive_math_lab/agents/scribe.toml
@@ -5,7 +5,7 @@ context = ["GOAL.md", "brief.md", "METHOD.md", "attempts.md", "answers.md"]
 # The one role that may write the shared note tree, and the one with no shell:
 # a recorder that can re-run the program is a recorder that will eventually
 # record a number nobody else saw.
-tools = ["files", "docs", "workspace", "workspace.write"]
+tools = ["files", "docs", "workspace", "workspace.write", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/hive_math_lab/agents/skeptic.toml
+++ b/companies/hive_math_lab/agents/skeptic.toml
@@ -8,7 +8,7 @@ context = ["GOAL.md", "brief.md"]
 # small case by hand (see prompts/skeptic.md, "Work one small case by hand")
 # — it never runs a program, unlike brute_forcer/programmer/theorist, so it
 # does not need execution access.
-tools = ["files", "workspace.read"]
+tools = ["files", "workspace.read", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/hive_math_lab/agents/theorist.toml
+++ b/companies/hive_math_lab/agents/theorist.toml
@@ -7,7 +7,7 @@ context = ["GOAL.md", "brief.md", "METHOD.md", "attempts.md"]
 # terms of it rather than by staring. What the theorist may NOT do is answer the
 # stated problem — see `prompts/theorist.md`. The boundary is in the brief and
 # in the ledger: this role opens attempts, it never closes an answer.
-tools = ["files", "shell", "workspace.read"]
+tools = ["files", "shell", "workspace.read", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/hive_math_lab/agents/verifier.toml
+++ b/companies/hive_math_lab/agents/verifier.toml
@@ -14,7 +14,7 @@ tier = "frontend"
 # it stays on disk where the verifier can choose not to look at it.
 context = ["GOAL.md", "brief.md", "METHOD.md"]
 
-tools = ["files", "shell", "code", "workspace.read"]
+tools = ["files", "shell", "code", "workspace.read", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/hive_math_lab/company.toml
+++ b/companies/hive_math_lab/company.toml
@@ -35,7 +35,7 @@ admins = ["harness-e2e@tinyhumans.ai"]
 [tools]
 # No `web`, no `search`: the answer has to be computed, not looked up. See the
 # parent bundle for the full argument.
-allow = ["files", "docs", "shell", "code", "workspace", "workspace.*"]
+allow = ["files", "docs", "shell", "code", "workspace", "workspace.*", "mcp:*"]
 
 # A live run routes inference through the local llm-ladder-router, so it costs
 # marketplace rates rather than a hosted subscription: point the managed

--- a/companies/marketing_agency/company.toml
+++ b/companies/marketing_agency/company.toml
@@ -93,7 +93,14 @@ members = ["creative_director", "copywriter", "landing_page_builder"]
 # unrestricted desk would hand the company grant, billing included, straight
 # back. The ceiling still narrows the belt further, keeping `search`, `media`
 # and `composio` off the desk.
-tools = ["*", "workspace.write"]
+#
+# `mcp:*` is listed for the same reason `workspace.write` is: it is an opt-in
+# namespace `*` does not confer, so a ceiling that omits it removes the
+# company's installed servers from this desk. Spend is what the three names
+# above are excluded for, and a server the operator installed and connected is
+# not a spend decision — leaving it out made the desk's teammates report no MCP
+# tools at all while the console showed the server connected and healthy.
+tools = ["*", "workspace.write", "mcp:*"]
 
 [[group_chat]]
 id = "growth"

--- a/companies/math_lab/agents/programmer.toml
+++ b/companies/math_lab/agents/programmer.toml
@@ -3,7 +3,7 @@ description = "Write the program the approach calls for, run it, and report what
 tier = "reasoning"
 context = ["GOAL.md", "brief.md", "METHOD.md", "attempts.md"]
 
-tools = ["files", "docs", "shell", "code", "workspace.read"]
+tools = ["files", "docs", "shell", "code", "workspace.read", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/math_lab/agents/scribe.toml
+++ b/companies/math_lab/agents/scribe.toml
@@ -5,7 +5,7 @@ context = ["GOAL.md", "brief.md", "METHOD.md", "attempts.md", "answers.md"]
 # The one role that may write the shared note tree, and the one with no shell:
 # a recorder that can re-run the program is a recorder that will eventually
 # record a number nobody else saw.
-tools = ["files", "docs", "workspace", "workspace.write"]
+tools = ["files", "docs", "workspace", "workspace.write", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/math_lab/agents/theorist.toml
+++ b/companies/math_lab/agents/theorist.toml
@@ -7,7 +7,7 @@ context = ["GOAL.md", "brief.md", "METHOD.md", "attempts.md"]
 # terms of it rather than by staring. What the theorist may NOT do is answer the
 # stated problem — see `prompts/theorist.md`. The boundary is in the brief and
 # in the ledger: this role opens attempts, it never closes an answer.
-tools = ["files", "shell", "workspace.read"]
+tools = ["files", "shell", "workspace.read", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/math_lab/agents/verifier.toml
+++ b/companies/math_lab/agents/verifier.toml
@@ -7,7 +7,7 @@ tier = "reasoning"
 # it stays on disk where the verifier can choose not to look at it.
 context = ["GOAL.md", "brief.md", "METHOD.md"]
 
-tools = ["files", "shell", "code", "workspace.read"]
+tools = ["files", "shell", "code", "workspace.read", "mcp:*"]
 
 ledgers = [
     { name = "tasks", access = "record" },

--- a/companies/math_lab/company.toml
+++ b/companies/math_lab/company.toml
@@ -69,7 +69,7 @@ admins = ["harness-e2e@tinyhumans.ai"]
 #
 # `search` is absent for the same reason `web` is, and additionally because it
 # is metered: a company that never asked for it never spends on it.
-allow = ["files", "docs", "shell", "code", "workspace", "workspace.*"]
+allow = ["files", "docs", "shell", "code", "workspace", "workspace.*", "mcp:*"]
 
 # ---------------------------------------------------------------------------
 # Desks.

--- a/companies/product_team/company.toml
+++ b/companies/product_team/company.toml
@@ -41,7 +41,7 @@ human_role = "Prioritization calls and roadmap sign-off"
 # teammate here should be able to act on a third-party account under the
 # company's OAuth grant. Both are real-money / real-consequence namespaces that
 # `*` does not confer, so omitting them is the whole decision.
-allow = ["*", "workspace", "search"]
+allow = ["*", "workspace", "search", "mcp:*"]
 
 # Group chats — the desks the human talks to. Each pulls in a few agents from
 # the roster; the first member is the desk's lead (the routing target).

--- a/companies/research_lab/company.toml
+++ b/companies/research_lab/company.toml
@@ -33,7 +33,7 @@ human_role = "Set the question and accept the findings"
 #
 # Search spend is bounded by `search_daily_calls`; set it to `0` to pause
 # search without editing this list.
-allow = ["*", "search"]
+allow = ["*", "search", "mcp:*"]
 search_daily_calls = 200
 
 # ---------------------------------------------------------------------------

--- a/companies/signals_opportunity_studio/agents/opportunity_analyst.toml
+++ b/companies/signals_opportunity_studio/agents/opportunity_analyst.toml
@@ -1,7 +1,7 @@
 role = "Opportunity Analyst"
 description = "Cluster signals into pains and rank the resulting opportunities by evidence and size."
 tier = "reasoning"
-tools = ["web.*", "docs.*", "search"]
+tools = ["web.*", "docs.*", "search", "mcp:*"]
 budget_usd_daily = 8.0
 
 # The role's working rules, checked in beside this file and read at manifest

--- a/companies/signals_opportunity_studio/agents/research_agent.toml
+++ b/companies/signals_opportunity_studio/agents/research_agent.toml
@@ -1,7 +1,7 @@
 role = "Research Agent"
 description = "Deep-dive the top opportunities and compile the operator's weekly brief."
 tier = "reasoning"
-tools = ["web.*", "docs.*", "search"]
+tools = ["web.*", "docs.*", "search", "mcp:*"]
 budget_usd_daily = 8.0
 
 # The role's working rules, checked in beside this file and read at manifest

--- a/companies/signals_opportunity_studio/agents/signal_scout.toml
+++ b/companies/signals_opportunity_studio/agents/signal_scout.toml
@@ -16,7 +16,7 @@ tier = "orchestrator"
 # one. It must appear here AND in `[tools].allow` in `company.toml` — the
 # per-agent list narrows the company-wide one, so either edit alone is a silent
 # no-op (#312).
-tools = ["web.*", "search"]
+tools = ["web.*", "search", "mcp:*"]
 budget_usd_daily = 5.0
 
 # The role's working rules, checked in beside this file and read at manifest

--- a/companies/signals_opportunity_studio/company.toml
+++ b/companies/signals_opportunity_studio/company.toml
@@ -32,7 +32,7 @@ max_passes = 12
 #
 # This list gates the company; each agent's own `tools` narrows it further, so
 # `search` also has to appear on the scout / analyst / research agents above.
-allow = ["web.*", "docs.*", "search"]
+allow = ["web.*", "docs.*", "search", "mcp:*"]
 
 [channels.operator]
 enabled = true

--- a/globals/agents/operations.toml
+++ b/globals/agents/operations.toml
@@ -21,7 +21,10 @@ tier = "reasoning"
 # status page, a policy, a filing deadline), and a teammate that cannot look it
 # up reports "blocked" without saying on what. Admitted only by an explicit
 # company grant, so it costs nothing where nobody opted in.
-tools = ["workspace.*", "workspace.write", "docs.*", "files.*", "search"]
+# `mcp:*` on the same terms: it confers nothing in a company that installed no
+# server, and lets this teammate reach the ones a company did install rather
+# than being the baseline hole a correct roster still falls through.
+tools = ["workspace.*", "workspace.write", "docs.*", "files.*", "search", "mcp:*"]
 
 prompt = """
 You are the company's operations teammate. You keep the record straight: what

--- a/globals/agents/page_builder.toml
+++ b/globals/agents/page_builder.toml
@@ -11,7 +11,10 @@ tier = "frontend"
 # teammate that company never wrote. A request is intersected with
 # `[tools].allow`, so this can only ever be narrower than what the company
 # permits, never wider.
-tools = ["pages.*", "workspace.*"]
+# `mcp:*` on the same terms: it confers nothing in a company that installed no
+# server, and lets this teammate reach the ones a company did install rather
+# than being the baseline hole a correct roster still falls through.
+tools = ["pages.*", "workspace.*", "mcp:*"]
 
 prompt = """
 You are the company's page builder. You design and maintain the small,

--- a/globals/agents/researcher.toml
+++ b/globals/agents/researcher.toml
@@ -19,7 +19,10 @@ tier = "reasoning"
 # `search` bills per call and is admitted only by an explicit company grant, so
 # naming it here costs nothing in a company that never opted into web search and
 # lets the researcher actually search in one that did.
-tools = ["workspace.read", "docs.*", "files.*", "web.*", "search"]
+# `mcp:*` on the same terms: it confers nothing in a company that installed no
+# server, and lets this teammate reach the ones a company did install rather
+# than being the baseline hole a correct roster still falls through.
+tools = ["workspace.read", "docs.*", "files.*", "web.*", "search", "mcp:*"]
 
 prompt = """
 You are the company's researcher. You answer questions the company cannot

--- a/globals/agents/writer.toml
+++ b/globals/agents/writer.toml
@@ -18,7 +18,10 @@ tier = "frontend"
 # one). Both cost nothing in a company that never opted into web search: the
 # request is intersected with `[tools].allow`, and `search` is admitted only by
 # an explicit company grant.
-tools = ["workspace.*", "docs.*", "files.*", "web.*", "search"]
+# `mcp:*` on the same terms: it confers nothing in a company that installed no
+# server, and lets this teammate reach the ones a company did install rather
+# than being the baseline hole a correct roster still falls through.
+tools = ["workspace.*", "docs.*", "files.*", "web.*", "search", "mcp:*"]
 
 prompt = """
 You are the company's writer. Work arrives as notes, findings, transcripts, or

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -1579,3 +1579,173 @@ fn every_shipped_setup_card_is_pickable() {
         }
     }
 }
+
+/// One teammate's effective grants under the full three-level narrowing a
+/// running company applies: `[tools].allow ∩ group_chat.tools ∩ [[agent]].tools`.
+///
+/// Runs the real `agent_scoped_grants` over the desks this teammate actually
+/// sits on, so a bundle cannot pass here and fail in the harness. The
+/// two-level `grants_for_one_agent` above skips the desk ceiling, which is the
+/// level a reachability question turns on.
+fn desk_scoped_grants(manifest: &CompanyManifest, agent: &super::Agent) -> Vec<String> {
+    let desk_tools: Vec<Vec<String>> = manifest
+        .group_chats
+        .iter()
+        .filter(|chat| chat.members.iter().any(|member| member == &agent.id))
+        .map(|chat| chat.tools.clone())
+        .collect();
+    let desk_refs: Vec<&[String]> = desk_tools.iter().map(Vec::as_slice).collect();
+    agent_scoped_grants(&manifest.tools.allow, &desk_refs, agent.tools.as_deref())
+}
+
+/// Every bundle, with its global baseline left on — the roster a running
+/// company actually has.
+fn load_company_with_globals(dir: &Path) -> CompanyManifest {
+    CompanyManifest::from_path(dir).unwrap_or_else(|err| panic!("{}: {err}", dir.display()))
+}
+
+/// A declared MCP server must be callable by somebody.
+///
+/// Declaring a server and granting the namespace are separate edits in
+/// separate files, and nothing until this test compared them. A bundle could
+/// ship a server, document it in its README, pass every parse and safety check
+/// above, and still hand it to a roster where no teammate holds `mcp:*` — an
+/// install that connects, reports healthy, and answers no call anyone can make.
+///
+/// Asserted for declared servers whether or not they ship enabled: enabling is
+/// an operator's one click, and the grant has to already be right when they
+/// make it.
+#[test]
+fn every_declared_mcp_server_is_reachable_by_some_teammate() {
+    let mut checked = 0usize;
+    let mut unreachable = Vec::new();
+    for company in subdirs(&repo_root().join("companies")) {
+        let name = company.file_name().unwrap().to_str().unwrap().to_string();
+        let manifest = load_company_with_globals(&company);
+        for server in &manifest.mcp_servers {
+            checked += 1;
+            let reached = manifest.agents.iter().any(|agent| {
+                crate::runtime::tools::grants_cover_server(
+                    &desk_scoped_grants(&manifest, agent),
+                    &server.name,
+                )
+            });
+            if !reached {
+                unreachable.push(format!(
+                    "  {name}: `{}` — company grants {:?}",
+                    server.name, manifest.tools.allow
+                ));
+            }
+        }
+    }
+    assert!(
+        unreachable.is_empty(),
+        "{} declared MCP server(s) no teammate can reach. Connecting one reports healthy \
+         and answers no call anybody can make:\n{}",
+        unreachable.len(),
+        unreachable.join("\n")
+    );
+    assert!(
+        checked > 0,
+        "no shipped bundle declared an MCP server, so this check looked at nothing — \
+         the walk found no manifests rather than finding them clean"
+    );
+}
+
+/// A desk that can reach none of the company's MCP servers is a dead end.
+///
+/// A desk is a conversation an operator opens, so "somebody in the company can
+/// call it" is not the promise the screen makes — the promise is that the
+/// teammates in front of them can.
+///
+/// Deliberately "at least one server", not "every server". Scoping a single
+/// server to the desk that owns it is the point of the middle level:
+/// `retail_co` gives each teammate exactly one `mcp:<server>` and its desks
+/// reach only their own, which is correct and must keep passing. What a desk
+/// may not be is cut off entirely from a company that installed servers.
+///
+/// This is the level that `every_declared_mcp_server_is_reachable_by_some_teammate`
+/// cannot see: a bundle whose other desks hold the grant passes it while the
+/// desk an operator is typing into holds nothing.
+#[test]
+fn every_desk_can_reach_at_least_one_declared_mcp_server() {
+    let mut dead_ends = Vec::new();
+    for company in subdirs(&repo_root().join("companies")) {
+        let name = company.file_name().unwrap().to_str().unwrap().to_string();
+        let manifest = load_company_with_globals(&company);
+        if manifest.mcp_servers.is_empty() {
+            continue;
+        }
+        for chat in &manifest.group_chats {
+            if chat.members.is_empty() {
+                continue;
+            }
+            let reached = chat.members.iter().any(|member| {
+                manifest
+                    .agents
+                    .iter()
+                    .find(|agent| &agent.id == member)
+                    .is_some_and(|agent| {
+                        let grants = desk_scoped_grants(&manifest, agent);
+                        manifest.mcp_servers.iter().any(|server| {
+                            crate::runtime::tools::grants_cover_server(&grants, &server.name)
+                        })
+                    })
+            });
+            if !reached {
+                dead_ends.push(format!(
+                    "  {name}: desk `{}` reaches none of {} installed server(s) — desk ceiling {:?}",
+                    chat.id,
+                    manifest.mcp_servers.len(),
+                    chat.tools
+                ));
+            }
+        }
+    }
+    assert!(
+        dead_ends.is_empty(),
+        "{} desk(s) narrow the company grant past a server the company installed. An \
+         operator talking to one gets a teammate that cannot call a server the console \
+         reports as connected:\n{}",
+        dead_ends.len(),
+        dead_ends.join("\n")
+    );
+}
+
+/// The global baseline reaches MCP.
+///
+/// Every company inherits these teammates whichever vertical it started from,
+/// including one minted by the setup wizard, and they answer in the main
+/// channel. A baseline teammate without the namespace makes MCP unreachable in
+/// a company whose own roster and grants are entirely correct — the one gap
+/// neither check above can see, because it is not any bundle's fault.
+///
+/// `BASE_BELT` already grants it to every teammate the wizard mints; this holds
+/// the hand-authored baseline to the same rule.
+#[test]
+fn every_global_teammate_can_reach_an_installed_mcp_server() {
+    let globals = crate::globals::agents();
+    assert!(
+        !globals.is_empty(),
+        "the global baseline is empty, so this check looked at nothing"
+    );
+    let allow = vec!["mcp:*".to_string()];
+    let unreachable: Vec<String> = globals
+        .iter()
+        .filter(|agent| {
+            !crate::runtime::tools::grants_cover_server(
+                &agent_scoped_grants(&allow, &[], agent.tools.as_deref()),
+                "any-installed-server",
+            )
+        })
+        .map(|agent| format!("  `{}` — belt {:?}", agent.id, agent.tools))
+        .collect();
+    assert!(
+        unreachable.is_empty(),
+        "{} global teammate(s) cannot reach an installed MCP server. Every company \
+         inherits these, so the gap follows the baseline into companies whose own grants \
+         are correct:\n{}",
+        unreachable.len(),
+        unreachable.join("\n")
+    );
+}

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3775,12 +3775,20 @@ async fn mcp_reachability_lists_reaching_agents_including_overlay() {
     // Issue #931: every row carries the display label the rest of the console
     // uses — a manifest agent's role, an overlay teammate's name — so the minted
     // overlay id is never what a reader sees.
+    // The four baseline teammates every company inherits ask for `mcp:*`, so a
+    // company granting it reaches them too. Listed rather than filtered out:
+    // this asserts the whole reachable set, and hiding the half that is not
+    // this manifest's own would leave the baseline free to drift unseen.
     assert_eq!(
         reach("notion"),
         vec![
             pair("019fa75dbc9b-000000000001", "Helper"),
             pair("ceo", "Chief"),
             pair("eng", "Engineer"),
+            pair("operations", "Operations"),
+            pair("page_builder", "Page Builder"),
+            pair("researcher", "Researcher"),
+            pair("writer", "Writer"),
         ]
     );
     // linear: only the wildcard holders — ceo scoped itself out of it.
@@ -3789,6 +3797,10 @@ async fn mcp_reachability_lists_reaching_agents_including_overlay() {
         vec![
             pair("019fa75dbc9b-000000000001", "Helper"),
             pair("eng", "Engineer"),
+            pair("operations", "Operations"),
+            pair("page_builder", "Page Builder"),
+            pair("researcher", "Researcher"),
+            pair("writer", "Writer"),
         ],
         "ceo narrowed to mcp:notion, so it cannot reach linear"
     );
@@ -3864,10 +3876,21 @@ async fn mcp_reachability_is_empty_for_a_disabled_server() {
             .collect()
     };
 
-    // Enabled: the one agent's grant covers it.
+    // Enabled: the one agent's grant covers it, and so does the baseline's —
+    // this company grants `mcp:*`, which the inherited teammates ask for. The
+    // disabled assertion below is the one this test is about.
     let (status, list) = send(&state, "GET", "/api/v1/company/mcp/servers", None).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(reach(&list[0]), vec!["ceo".to_string()]);
+    assert_eq!(
+        reach(&list[0]),
+        vec![
+            "ceo".to_string(),
+            "operations".to_string(),
+            "page_builder".to_string(),
+            "researcher".to_string(),
+            "writer".to_string(),
+        ]
+    );
 
     // Disabling it empties reachability in the mutating response itself.
     let (status, updated) = send(


### PR DESCRIPTION
## Summary

A connected MCP server could be unreachable by every teammate an operator talks to, while the console reported it healthy and connected.

Reachability is an emergent property of three independently-authored layers — `[tools].allow ∩ group_chat.tools ∩ [[agent]].tools` — plus the global baseline appended to every roster. Each layer is individually reviewable and individually correct-looking, and nothing asserted the result they compose to. `content_test` already proved every shipped `mcp.json` parses, uses https, carries a description and is documented; it never asked whether a single teammate could call any of it. Declaration was tested, reachability was not, and six bundles shipped green with servers nobody could reach.

This adds the missing assertion and fixes everything it names.

**The invariant is not "MCP is always on."** `mcp:*` stays an explicit opt-in that a bare `*` deliberately does not confer, and per-server scoping stays supported — `retail_co` gives each teammate exactly one `mcp:<server>` and its desks reach only their own, which passes unchanged. What is now refused is a *silently* unreachable server.

Three checks, run against the real `agent_scoped_grants` over actual desk membership so a bundle cannot pass here and fail in the harness:

- **`every_declared_mcp_server_is_reachable_by_some_teammate`** — a bundle may not ship a server no teammate can call. Carries a vacuity guard: if the walk finds no manifests it fails rather than passing on an empty set.
- **`every_desk_can_reach_at_least_one_declared_mcp_server`** — a desk is a conversation an operator opens, so "somebody in the company can call it" is not the promise that screen makes. Deliberately *at least one*, not *every*: scoping a server to the desk that owns it is what the middle level is for.
- **`every_global_teammate_can_reach_an_installed_mcp_server`** — the baseline is inherited by every company including one minted by the setup wizard, so a gap there follows into companies whose own grants are entirely correct. `BASE_BELT` already grants `mcp:*` to every teammate the wizard mints; this holds the hand-authored baseline to the same rule.

Each reports every violation rather than the first, so the worklist arrives in one run.

Fixes the checks then named:

- **Global baseline** (`operations`, `page_builder`, `researcher`, `writer`) requested no MCP namespace. These four answer in the main channel, so a company could install a server and have the teammate replying to it hold no MCP tool at all. They now ask for `mcp:*` on the same terms the files already state for `search`: the request is intersected with `[tools].allow`, so it confers nothing where nobody opted in.
- **`hive_math_lab`, `math_lab`, `product_team`, `research_lab`, `signals_opportunity_studio`** declared servers their `[tools].allow` never granted. Granted, plus the agent requests in the rosters that state one.
- **`marketing_agency`** — the `creative` desk ceiling was written to keep `media`/`composio`/`search` off the desk, and removed `mcp:*` with them because a ceiling is a whitelist. Spend is what those three are excluded for; a server the operator installed is not a spend decision.

## API Or Behavior Changes

No API change.

Behaviour: teammates that previously held no MCP grant now hold one where their company grants the namespace and installed a server. Strictly additive and bounded by the company ceiling — `agent_scoped_grants` has no path that returns a grant `[tools].allow` does not already cover, so no company that opted out of MCP is affected.

Two existing `reachableBy` fixtures move as a direct result: their companies grant `mcp:*`, so the four baseline teammates now appear in the reachable set. Expectations updated to list them explicitly rather than filtering the baseline out, so a future drift surfaces there instead of hiding. The disabled-server assertion those tests exist for is untouched.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 5077 lib + 25 bin, 0 failed
- [x] `cargo test --features openhuman --tests` — 7644 lib + 25 bin, 0 failed
- [x] `scripts/ci/assert-integration-targets-run.sh openhuman` — every target non-zero

The default-feature run reports `0 passed` for five of the six integration targets, which is the zero-count trap issue #475 describes; the gated lane above is what actually executes them.

Not run: the `mongodb`, `sqlite` and `mail` lanes, none of which this change reaches.

## Documentation

No doc change. The rule this enforces is already stated where it is authored — `BASE_BELT` documents why the wizard's teammates get `mcp:*`, `globals.toml`'s `default_allow` documents why withholding by default fails on a company minted from a wizard, and `agent_scoped_grants` documents that the company allow is a ceiling. The gap was that nothing checked the composition, which is what this adds.
