### PR TITLE
test(e2e): anchor the Composio authority pair on the key the console offers (#2270)

### DIFF
--- a/frontend/test/e2e/connections-authority.spec.ts
+++ b/frontend/test/e2e/connections-authority.spec.ts
@@ -140,18 +140,20 @@ test("a member sees what is connected but is offered nothing that changes it", a
     //
     // Its own page since issue #2259. The credential-field assertion below is
     // the one that matters most in this spec — a member must never be handed
-    // somewhere to paste a token — and it lived in the Apps block above until
-    // the page split. Leaving it there would have left it passing for a reason
-    // that has nothing to do with authority: `#composio-token` is not on the
-    // Apps page for an ADMIN either now, so the assertion would have read as
-    // coverage while testing nothing. The admin half below asserts the field IS
-    // here, which is what keeps this one honest.
+    // somewhere to paste a key — and it only means that while the same field
+    // is present for an admin, which the admin half below asserts.
+    //
+    // It names the BYOK key rather than the managed token: `src/product-scope.ts`
+    // leaves BYOK the only route this console offers, and with one route on
+    // offer the form settles there for every company, so the managed token card
+    // never renders for either role. Asserting its absence read as coverage
+    // while testing nothing.
     await openConnectionsPage(memberPage, "composio");
     await expect(memberPage.getByTestId("connections-read-only")).toBeVisible({
       timeout: 30_000,
     });
-    await expect(memberPage.locator("#composio-token")).toHaveCount(0);
-    await expect(button("Save token")).toHaveCount(0);
+    await expect(memberPage.locator("#composio-api-key")).toHaveCount(0);
+    await expect(button("Save key")).toHaveCount(0);
 
     // ---- MCP: the tool servers, rows and the file both ---------------------
     await openSettingsPage(memberPage, "mcp");
@@ -197,9 +199,13 @@ test("an admin is still offered every control across the four pages", async ({ p
   // The credential the member above is refused, on the page it lives on. This
   // is what stops that assertion going vacuous: if the field ever stops
   // rendering here, this fails rather than the member case quietly passing.
+  //
+  // The BYOK key, for the reason given there: it is the write surface this
+  // console offers on every build, where the managed token card is offered on
+  // none.
   await openConnectionsPage(page, "composio");
   await expect(page.getByTestId("connections-read-only")).toHaveCount(0);
-  await expect(page.locator("#composio-token")).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator("#composio-api-key")).toBeVisible({ timeout: 30_000 });
 
   await openSettingsPage(page, "mcp");
   await expect(page.getByTestId("mcp-read-only")).toHaveCount(0);


### PR DESCRIPTION
## Summary

The console e2e lanes are red on `main`. The admin half of the Composio authority spec waits for `#composio-token` and times out.

That field lives inside the managed token card, which requires `mode === "managed"`. `src/product-scope.ts` sets `COMPOSIO_MANAGED_HIDDEN = true`, filtering `managed` out of `MODE_ORDER`; `formModeFor` then returns `MODE_ORDER[0]` whenever one route is on offer, so the form settles on BYOK for every company and that card's condition can never hold. The field is unreachable for either role on any build.

The red lane is the smaller half of the problem. The member case asserts the same field has count 0, and its own comment says the admin assertion is what stops it going vacuous — so with the field unrenderable, the authority check that spec exists to make was passing against something neither role can reach.

Both halves now anchor on `#composio-api-key`: admin-gated behind `canManage`, and rendered on every build because BYOK is the only route offered. The refusal means what it says again.

The same drift already took `#company-credential` out of this spec; this is the second field the scope change left behind.

Part of #2270

## API Or Behavior Changes

None. Test-only — no console or host code is touched.

## Tests

- [x] `npm run typecheck` (exit 0)
- [x] `npm run typecheck:e2e` (exit 0)
- [ ] The spec itself — not run locally. It needs `target/debug/opencompany`, a cold build in this worktree; the CI lanes exercise it in both the mocked and live-brain configurations.

The failure is deterministic — it fails in the mocked lane too, not only under a live brain — so the `Console E2E` lane here is the verification.

## Documentation

None. The spec comments carry the reason, replacing ones that named the field that moved.

## Not fixed here

`composio-account-choice.spec.ts:310` also fails on `main`: the Send button never becomes enabled, so no chat POST is made and the following `waitForResponse` times out. The composer's button is `disabled={disabled || !draft.trim()}`, so either the fill did not reach that composer or it was disabled at click time — not distinguishable by reading, and it reproduces only in the live-brain lane. Left for someone who can run that lane rather than guessed at. Tracked in #2270.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated end-to-end coverage to verify that credential settings display the BYOK API key field correctly for administrators.
  - Confirmed that members do not see the credential field, while administrators can access and save an API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->