### PR TITLE
chore(release): bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3525,7 +3525,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opencompany"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 # Tauri package under src-tauri is therefore its own workspace.
 [package]
 name = "opencompany"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/tinyhumansai/opencompany"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencompany-console",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencompany-console",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@fontsource-variable/geist": "^5.2.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencompany-console",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A company-agnostic operator console for any OpenCompany host, built with Vite + React.",
   "type": "module",
   "engines": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenCompany",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "ai.tinyhumans.opencompany",
   "build": {
     "frontendDist": "../frontend/dist",


### PR DESCRIPTION
## Summary

Bumps the version from `0.1.2` to `0.1.3` ahead of cutting the `v0.1.3` release from current `main`.

`v0.1.2` is already a published release, and this repository has immutable releases — a second build under that tag cannot be attached. Tauri also names the DMG from the version, so a release tagged `v0.1.3` built at `0.1.2` would ship `OpenCompany_0.1.2_*.dmg` under a `v0.1.3` tag. That collision already caused one misidentification today: an unsigned CI artifact of current `main` and the signed 4 Sep release asset carry the identical filename.

All five places the version is declared move together:

| File | |
|---|---|
| `Cargo.toml` | crate version |
| `Cargo.lock` | the `opencompany` package entry |
| `src-tauri/tauri.conf.json` | what names the bundle and the updater manifest |
| `frontend/package.json` | console package |
| `frontend/package-lock.json` | its two matching entries |

## API Or Behavior Changes

None. Version strings only — no code, no configuration, no dependency movement.

## Tests

No test touches the version string. The change is mechanical and verified by inspection of all five files.

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo build --all-targets`
- [ ] `cargo test`

Left unchecked deliberately: nothing here compiles differently, and CI on this branch is the honest check.

## Documentation

None needed — no documented behaviour changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application and package version to 0.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->