### PR TITLE
chore(release): bump the desktop crate and its lockfile to 0.1.3

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "opencompany"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "opencompany-desktop"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "opencompany-desktop"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "OpenCompany desktop shell: many hosts at once, and local ACP harnesses."


### PR DESCRIPTION
## Summary

`src-tauri` is a **second, separate cargo workspace** with its own `Cargo.toml` and its own `Cargo.lock`. #2276 bumped the root crate to `0.1.3` and missed both, so `src-tauri/Cargo.lock` still pinned `opencompany 0.1.2` while the root manifest declared `0.1.3`.

`tauri build` runs cargo with `--locked`, which refuses to reconcile a stale lock rather than silently updating it. Both matrix legs of the v0.1.3 desktop release failed identically:

```
error: cannot update the lock file .../src-tauri/Cargo.lock because --locked was passed to prevent this
failed to build app
```

This bumps the two first-party entries the root bump left behind:

| File | Entry |
|---|---|
| `src-tauri/Cargo.toml` | `opencompany-desktop` package version |
| `src-tauri/Cargo.lock` | the `opencompany` and `opencompany-desktop` entries |

No dependency is touched — only the two first-party version strings, so the rest of the resolved graph is byte-identical.

Worth noting for the next release: the version lives in **seven** places across two workspaces, and nothing asserts they agree. A release that bumps six of them fails ~7 minutes into a macOS build rather than at dispatch. A check that reads all seven and refuses a mismatch would turn this into a one-line failure before any runner time is spent.

## API Or Behavior Changes

None. Version strings only.

## Tests

Validated the exact condition CI enforces, with submodules initialised so the resolve is real:

```
cargo metadata --manifest-path src-tauri/Cargo.toml --locked   → exit 0
cargo metadata --locked                                        → exit 0
```

Before this change the first of those is what the release build failed on.

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo build --all-targets`
- [ ] `cargo test`

Unchecked deliberately: no code changes, and the `--locked` resolve above is the check that actually covers this.

## Documentation

None needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application version to 0.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->