### PR TITLE
fix(inference): a credential must not survive in an endpoint, a name, or a log

### DIFF
--- a/docs/modules/inference/credentials.md
+++ b/docs/modules/inference/credentials.md
@@ -22,6 +22,43 @@ The manifest can only ever *name* a slot (`[inference].api_key_secret`), never
 hold a value, and validation rejects a value there that looks like a pasted
 credential.
 
+### The fifth place a credential can hide: the endpoint
+
+A URL can carry userinfo — `http://alice:hunter2@127.0.0.1:8597/v1` — and a
+`base_url` is none of the things that make the four slots above safe. It is
+stored as written, it is returned by `GET {scope}/inference`, which is
+`ScopedCompany` rather than admin, so every console reader receives it on every
+page load, and it is interpolated into operator-facing failure text. A password
+in an endpoint is therefore a password in all three at once.
+
+Two independent mechanisms, because they cover different populations:
+
+- **Refused wherever an endpoint is accepted.**
+  `catalogue::endpoint_has_credentials` gates `normalize_local_endpoint`, which
+  every stored endpoint passes through, and `validate_parts`, which is the
+  manifest and console-`PUT` half of the same rule. It is the same class of
+  rule as the `api_key_secret` check beside it: a credential belongs in the
+  write-only slot, not in a field that is read back. The draft probe refuses
+  one too, rather than putting a basic-auth credential on the wire.
+- **Redacted wherever an endpoint is said.** `catalogue::redact_endpoint`
+  replaces the userinfo with `***`. Refusal cannot reach a value stored before
+  the rule existed, or one arriving from a `company.toml` or
+  `OPENCOMPANY_INFERENCE_URL` this host does not own — so every DTO field,
+  operator-facing message and log line that names an endpoint goes through it.
+  The endpoint used to *make* the request does not, which is the whole
+  distinction between the two call sites.
+
+The subtle half is the failure text. `reqwest` already masks userinfo in its own
+`Display`, so an error that quotes the upstream string looks safe — and then a
+`format!` that adds our copy of the URL beside it puts the credential straight
+back. Three separate messages did exactly that.
+
+Strict manifest `validate()` runs only on a first boot with no persisted record
+(`src/runtime/builder.rs`), so the refusal cannot brick a company that is
+already running on such an endpoint. That company is covered by redaction
+instead, and its next edit of the endpoint is refused with a sentence saying
+where to put the credential.
+
 ## How resolution worked before this rework
 
 **Superseded — kept because the defect it describes is why the chain exists.**

--- a/frontend/src/inference/ProviderConnectDialog.tsx
+++ b/frontend/src/inference/ProviderConnectDialog.tsx
@@ -13,9 +13,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   MANAGED_OPTION_SLUG,
+  MAX_PROVIDER_NAME_CHARS,
+  checkProviderName,
   checkSlug,
   credentialAsk,
   customProviderReady,
+  endpointHasCredentials,
   normalizeEndpoint,
   slugErrorCopy,
   slugify,
@@ -104,7 +107,9 @@ export function ProviderConnectDialog({
   }, [optionSlug, open]);
 
   const slug = slugify(label);
-  const slugError = custom ? checkSlug(providers, slug) : null;
+  // The name's own bound is reported before the slug's, because a name past the
+  // limit is what the operator can actually see and fix — the slug is derived.
+  const slugError = custom ? (checkProviderName(label) ?? checkSlug(providers, slug)) : null;
   const endpointOk = !ask.needsEndpoint || normalizeEndpoint(baseUrl) !== null;
   const ready = custom
     ? customProviderReady(providers, { label, baseUrl })
@@ -143,6 +148,9 @@ export function ProviderConnectDialog({
                 value={label}
                 placeholder="My Provider"
                 autoComplete="off"
+                // The host holds this rule; the attribute only stops a paste
+                // becoming a 400 the operator has to read to understand.
+                maxLength={MAX_PROVIDER_NAME_CHARS}
                 onChange={(e) => setLabel(e.target.value)}
               />
               {/* The slug is what a routing entry will say, so the operator
@@ -179,7 +187,9 @@ export function ProviderConnectDialog({
               />
               {baseUrl.trim() && !endpointOk && (
                 <p className="text-xs text-status-blocked-text">
-                  That must be an http or https address.
+                  {endpointHasCredentials(baseUrl)
+                    ? "Remove the username and password from the URL and put the credential in the API key field — an endpoint is stored as written and is readable by everyone who can see this company's settings."
+                    : "That must be an http or https address."}
                 </p>
               )}
             </div>

--- a/frontend/src/inference/connect.ts
+++ b/frontend/src/inference/connect.ts
@@ -294,15 +294,27 @@ export function slugify(label: string): string {
   return out.replace(/-+$/, "");
 }
 
+/**
+ * The longest a provider name may be, in characters.
+ *
+ * Mirrors `store::MAX_PROVIDER_NAME_CHARS` on the host, which is where the rule
+ * actually lives — the name becomes the address of a secret
+ * (`provider/<slug>/key`), and an unbounded name produced an unbounded path
+ * that 500ed a credential read and truncated a stored key on the way to failing
+ * the delete. This copy only spares the operator a round trip to find that out.
+ */
+export const MAX_PROVIDER_NAME_CHARS = 80;
+
 /** Why a slug cannot be used. */
-export type SlugError = "empty" | "taken" | "reserved";
+export type SlugError = "empty" | "taken" | "reserved" | "too-long";
 
 /**
  * Whether a derived slug may be used for a **custom** provider.
  *
- * Three named failures rather than a boolean, because they need three different
- * sentences: one is "pick another name", one is "you already have this", and one
- * is "that name belongs to something we ship".
+ * Four named failures rather than a boolean, because they need four different
+ * sentences: one is "pick another name", one is "you already have this", one
+ * is "that name belongs to something we ship", and one is "that name is too
+ * long".
  *
  * The catalogue check applies to custom providers only. Adding the catalogue's
  * own `groq` entry *should* take the slug `groq` — that is the same provider,
@@ -311,6 +323,7 @@ export type SlugError = "empty" | "taken" | "reserved";
 export function checkSlug(providers: readonly Provider[], slug: string): SlugError | null {
   const trimmed = slug.trim();
   if (!trimmed) return "empty";
+  if ([...trimmed].length > MAX_PROVIDER_NAME_CHARS) return "too-long";
   if (providers.some((p) => p.slug === trimmed)) return "taken";
   if (isReservedSlug(trimmed)) return "reserved";
   return null;
@@ -325,6 +338,8 @@ export function slugErrorCopy(error: SlugError): string {
       return "This company already has a provider with that name.";
     case "reserved":
       return "That name belongs to a built-in provider.";
+    case "too-long":
+      return `A provider name can be at most ${MAX_PROVIDER_NAME_CHARS} characters.`;
   }
 }
 
@@ -339,6 +354,7 @@ export function slugErrorCopy(error: SlugError): string {
  */
 export function normalizeEndpoint(raw: string): string | null {
   const trimmed = raw.trim().replace(/\/+$/, "");
+  if (endpointHasCredentials(trimmed)) return null;
   const split = trimmed.indexOf("://");
   if (split === -1) return null;
   const scheme = trimmed.slice(0, split).toLowerCase();
@@ -347,6 +363,28 @@ export function normalizeEndpoint(raw: string): string | null {
   if (!rest.trim()) return null;
   if (!rest.includes("/")) return `${trimmed}/v1`;
   return trimmed;
+}
+
+/**
+ * Whether an endpoint URL carries a credential in its authority
+ * (`http://user:password@host/v1`).
+ *
+ * Mirrors `catalogue::endpoint_has_credentials`. The host refuses such an
+ * endpoint at every point one can be set, and redacts it anywhere one is said;
+ * this copy exists so the operator is told *why* beside the field rather than
+ * after a round trip.
+ *
+ * The `@` has to be inside the authority — a path may legitimately contain one
+ * (`https://host/v1/@me`), and that is not a credential.
+ */
+export function endpointHasCredentials(raw: string): boolean {
+  const trimmed = raw.trim();
+  const split = trimmed.indexOf("://");
+  const start = split === -1 ? 0 : split + 3;
+  const rest = trimmed.slice(start);
+  const end = rest.search(/[/?#]/);
+  const authority = end === -1 ? rest : rest.slice(0, end);
+  return authority.includes("@");
 }
 
 /**
@@ -360,7 +398,22 @@ export function customProviderReady(
   draft: { label: string; baseUrl: string },
 ): boolean {
   return (
+    checkProviderName(draft.label) === null &&
     checkSlug(providers, slugify(draft.label)) === null &&
     normalizeEndpoint(draft.baseUrl) !== null
   );
+}
+
+/**
+ * Whether a typed provider **name** may be used, before any slug is derived.
+ *
+ * Mirrors `store::check_provider_name`. Separate from {@link checkSlug} for the
+ * same reason it is separate on the host: a name can be long while its slug is
+ * short, because `slugify` drops everything that is not alphanumeric.
+ */
+export function checkProviderName(label: string): SlugError | null {
+  const trimmed = label.trim();
+  if (!trimmed) return "empty";
+  if ([...trimmed].length > MAX_PROVIDER_NAME_CHARS) return "too-long";
+  return null;
 }

--- a/frontend/src/inference/types.ts
+++ b/frontend/src/inference/types.ts
@@ -9,6 +9,14 @@
 // carries `keyConfigured: boolean` and nothing else. Four independent mechanisms
 // keep credentials off the wire in this subsystem, and the easiest way to break
 // all four at once is to put one on a record for convenience.
+//
+// `baseUrl` is the field that made that sentence briefly untrue. A URL can carry
+// userinfo (`http://user:password@host/v1`), and this shape comes back from a
+// `ScopedCompany` route every console reader can call. The host now refuses such
+// an endpoint everywhere one can be set and redacts it everywhere one is said
+// (`catalogue::endpoint_has_credentials` / `redact_endpoint`), so what arrives
+// here is `http://***@host/v1` at worst — but a `baseUrl` is still a place a
+// credential can hide, which is why it is called out rather than trusted.
 
 /** How a provider expects its credential presented. */
 export type AuthStyle = "bearer" | "anthropic" | "none";

--- a/frontend/test/unit/inference-connect.test.ts
+++ b/frontend/test/unit/inference-connect.test.ts
@@ -9,8 +9,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MAX_PROVIDER_NAME_CHARS,
   addOptions,
+  checkProviderName,
   checkSlug,
+  endpointHasCredentials,
   credentialAsk,
   customProviderReady,
   isConnected,
@@ -115,6 +118,30 @@ describe("the slug, which is derived and never typed", () => {
     expect(slugErrorCopy("empty")).toBe("Enter a provider name to generate a slug.");
     expect(slugErrorCopy("taken")).toContain("already has a provider");
     expect(slugErrorCopy("reserved")).toContain("built-in");
+    expect(slugErrorCopy("too-long")).toContain(String(MAX_PROVIDER_NAME_CHARS));
+  });
+
+  it("bounds the name, because the name becomes the address of a secret", () => {
+    // Mirrors `store::MAX_PROVIDER_NAME_CHARS`. The host holds the rule; this
+    // only spares the operator a round trip. An unbounded name produced an
+    // unbounded secret key, which 500ed a credential read and truncated a
+    // stored key on the way to failing the delete that truncated it.
+    const atLimit = "a".repeat(MAX_PROVIDER_NAME_CHARS);
+    const pastLimit = "a".repeat(MAX_PROVIDER_NAME_CHARS + 1);
+
+    expect(checkProviderName(atLimit)).toBeNull();
+    expect(checkProviderName(pastLimit)).toBe("too-long");
+    expect(checkProviderName("   ")).toBe("empty");
+
+    expect(checkSlug([], atLimit)).toBeNull();
+    expect(checkSlug([], pastLimit)).toBe("too-long");
+
+    expect(customProviderReady([], { label: atLimit, baseUrl: "https://a.example/v1" })).toBe(
+      true,
+    );
+    expect(customProviderReady([], { label: pastLimit, baseUrl: "https://a.example/v1" })).toBe(
+      false,
+    );
   });
 });
 
@@ -133,6 +160,31 @@ describe("the endpoint an operator types", () => {
   it("refuses anything that is not http or https", () => {
     for (const bad of ["file:///etc/passwd", "ftp://acme.example/v1", "localhost:11434", "", "http://"]) {
       expect(normalizeEndpoint(bad)).toBeNull();
+    }
+  });
+
+  it("refuses one that carries a credential, because an endpoint is stored as written", () => {
+    // Mirrors `catalogue::endpoint_has_credentials`. A `baseUrl` is returned
+    // by a `ScopedCompany` route every console reader calls, so a password in
+    // one is a password on the wire for everybody.
+    for (const bad of [
+      "http://alice:hunter2@127.0.0.1:8597/v1",
+      "https://alice@api.acme.example/v1",
+      "http://alice:hun@ter2@127.0.0.1:8597/v1",
+    ]) {
+      expect(endpointHasCredentials(bad)).toBe(true);
+      expect(normalizeEndpoint(bad)).toBeNull();
+    }
+  });
+
+  it("does not mistake an @ in the path for a credential", () => {
+    for (const good of [
+      "https://api.acme.example/v1/@me",
+      "https://api.acme.example/v1?to=a@b",
+      "https://api.acme.example/v1#a@b",
+    ]) {
+      expect(endpointHasCredentials(good)).toBe(false);
+      expect(normalizeEndpoint(good)).toBe(good);
     }
   });
 });

--- a/src/company/inference.rs
+++ b/src/company/inference.rs
@@ -1489,13 +1489,18 @@ fn validate_parts(
     }
 
     let base_url = base_url.map(str::trim).filter(|s| !s.is_empty());
+    // Every echo of the typed URL below is redacted. A `base_url` is quoted back
+    // in a rejection the console renders, and a rejection is the one moment a
+    // malformed URL — the kind most likely to have been typed by hand with a
+    // password in it — is guaranteed to be shown to somebody.
     match provider {
         "ollama" | "openai_compatible" => match base_url {
             None => problems.push(format!(
                 "`[inference].base_url` is required for provider `{provider}` — give the OpenAI-compatible endpoint URL."
             )),
             Some(url) if !is_http_url(url) => problems.push(format!(
-                "`[inference].base_url` must be an `http://` or `https://` URL — you wrote `{url}`."
+                "`[inference].base_url` must be an `http://` or `https://` URL — you wrote `{}`.",
+                catalogue::redact_endpoint(url)
             )),
             _ => {}
         },
@@ -1504,10 +1509,28 @@ fn validate_parts(
                 && !is_http_url(url)
             {
                 problems.push(format!(
-                    "`[inference].base_url` must be an `http://` or `https://` URL — you wrote `{url}`."
+                    "`[inference].base_url` must be an `http://` or `https://` URL — you wrote `{}`.",
+                    catalogue::redact_endpoint(url)
                 ));
             }
         }
+    }
+
+    // A credential in the endpoint, refused for the same reason
+    // `api_key_secret` refuses a pasted token just below: a `base_url` is stored
+    // as written, returned to every console reader on the company status read,
+    // and interpolated into operator-facing failure text. The console's own
+    // endpoint fields refuse this before anything is written
+    // (`catalogue::normalize_local_endpoint`); this is the manifest and
+    // console-`PUT` half of the same rule, so the two ways to set an endpoint
+    // cannot disagree about it.
+    if let Some(url) = base_url
+        && catalogue::endpoint_has_credentials(url)
+    {
+        problems.push(format!(
+            "`[inference].base_url` carries a username or password in the URL — you wrote `{}`. Remove them and store the credential in the key slot instead; an endpoint is readable by everyone who can see this company's settings.",
+            catalogue::redact_endpoint(url)
+        ));
     }
 
     // The credential must be a *key name*, not the token itself. Reject values
@@ -2049,6 +2072,41 @@ mod tests {
         m.base_url = Some("ftp://x/v1".into());
         let problems = validate_inference(&m);
         assert!(problems.iter().any(|p| p.contains("http")), "{problems:?}");
+    }
+
+    #[test]
+    fn a_base_url_carrying_a_credential_is_rejected_and_never_echoed() {
+        // Same rule as `api_key_secret` below, one field over: a credential
+        // belongs in the write-only key slot, and a `base_url` is stored as
+        // written and read back by every console reader.
+        let mut m = inference("openai_compatible");
+        m.base_url = Some("http://alice:hunter2@127.0.0.1:8597/v1".into());
+        let problems = validate_inference(&m);
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("username or password")),
+            "{problems:?}"
+        );
+        // The refusal is the one moment this value is guaranteed to be shown to
+        // somebody, so it must not quote the credential back.
+        for problem in &problems {
+            assert!(
+                !problem.contains("hunter2") && !problem.contains("alice"),
+                "a rejection echoed the credential it was rejecting: {problem}"
+            );
+        }
+
+        // A malformed URL is quoted back redacted too — and the malformed ones
+        // are the likeliest to have been typed by hand with a password in them.
+        let mut bad = inference("openai_compatible");
+        bad.base_url = Some("ftp://alice:hunter2@127.0.0.1/v1".into());
+        for problem in validate_inference(&bad) {
+            assert!(
+                !problem.contains("hunter2"),
+                "a rejection echoed the credential it was rejecting: {problem}"
+            );
+        }
     }
 
     #[test]

--- a/src/company/inference.rs
+++ b/src/company/inference.rs
@@ -2083,9 +2083,7 @@ mod tests {
         m.base_url = Some("http://alice:hunter2@127.0.0.1:8597/v1".into());
         let problems = validate_inference(&m);
         assert!(
-            problems
-                .iter()
-                .any(|p| p.contains("username or password")),
+            problems.iter().any(|p| p.contains("username or password")),
             "{problems:?}"
         );
         // The refusal is the one moment this value is guaranteed to be shown to

--- a/src/company/inference/catalogue.rs
+++ b/src/company/inference/catalogue.rs
@@ -490,6 +490,72 @@ pub fn endpoint_host(endpoint: &str) -> Option<String> {
     (!host.is_empty()).then_some(host)
 }
 
+/// What [`redact_endpoint`] leaves where the userinfo was.
+///
+/// The `@` is kept so the shape still reads as a URL and the operator can see
+/// *that* something was embedded — which is the sentence they need in order to
+/// go and move it into the key field.
+pub const REDACTED_USERINFO: &str = "***";
+
+/// The byte range of an endpoint's userinfo — everything between `://` (or the
+/// start, for a scheme-less value) and the `@` that ends the credential.
+///
+/// `None` when there is none. The `@` must be inside the **authority**: a path
+/// may legitimately contain one (`https://host/v1/@me`), and that is not a
+/// credential.
+fn endpoint_userinfo_range(endpoint: &str) -> Option<std::ops::Range<usize>> {
+    let start = endpoint.find("://").map_or(0, |i| i + "://".len());
+    let rest = endpoint.get(start..)?;
+    let authority_len = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    // `rfind`, not `find`: a password may itself contain an `@`, and the last
+    // one in the authority is the delimiter per RFC 3986.
+    let at = rest.get(..authority_len)?.rfind('@')?;
+    Some(start..start + at)
+}
+
+/// Whether an endpoint URL carries a credential in its authority
+/// (`http://user:password@host/v1`).
+///
+/// The check every place that **accepts** an endpoint makes, so that a
+/// credential in a URL never reaches storage. It is the same class of rule as
+/// the `[inference].api_key_secret` check in
+/// [`validate_parts`](super::validate_inference): a secret belongs in the
+/// credential slot, which is write-only to the console, and nowhere else. An
+/// endpoint is read back by every console reader on every page load, echoed
+/// into operator-facing failure text, and written to a plaintext store — so a
+/// password in one is a password in all three.
+pub fn endpoint_has_credentials(endpoint: &str) -> bool {
+    endpoint_userinfo_range(endpoint.trim()).is_some()
+}
+
+/// The same endpoint with any embedded credential replaced by
+/// [`REDACTED_USERINFO`].
+///
+/// The second, independent mechanism behind the same invariant as
+/// [`endpoint_has_credentials`]. Rejection keeps userinfo out of anything
+/// written from now on; this keeps it out of anything **said**, including about
+/// values stored before the rejection existed and values that arrived from a
+/// `company.toml` or an `OPENCOMPANY_INFERENCE_URL` this host does not own.
+///
+/// Every endpoint that reaches a response body, an operator-facing message or a
+/// log goes through here. The endpoint used to actually *make* a request does
+/// not — redacting there would break the request, which is the difference
+/// between the two call sites and the reason this is a separate function rather
+/// than something done at the point of storage.
+pub fn redact_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim();
+    match endpoint_userinfo_range(trimmed) {
+        None => trimmed.to_string(),
+        Some(range) => {
+            let mut out = String::with_capacity(trimmed.len());
+            out.push_str(&trimmed[..range.start]);
+            out.push_str(REDACTED_USERINFO);
+            out.push_str(&trimmed[range.end..]);
+            out
+        }
+    }
+}
+
 /// The catalogue row for `slug`, if it is a built-in cloud provider.
 pub fn cloud_provider(slug: &str) -> Option<&'static CloudProvider> {
     CLOUD_PROVIDERS.iter().find(|p| p.slug == slug)
@@ -543,8 +609,19 @@ pub fn auth_style_for(kind: &str) -> AuthStyle {
 /// OpenAI-compatible surface lives and `http://localhost:11434` is what the
 /// runtime's own documentation prints. Appending is not guessing: a path the
 /// operator supplied is left exactly as typed.
+///
+/// An endpoint carrying userinfo (`http://user:password@host/v1`) is **not**
+/// normalised — see [`endpoint_has_credentials`]. This is the point every
+/// stored endpoint passes through, so refusing here is what makes "no
+/// credential is ever stored in a `base_url`" a property of the store rather
+/// than of whichever handler remembered to check. Callers that have a sentence
+/// to give the operator ask [`endpoint_has_credentials`] first; this refusal is
+/// the backstop for the ones that do not.
 pub fn normalize_local_endpoint(raw: &str) -> Option<String> {
     let trimmed = raw.trim().trim_end_matches('/');
+    if endpoint_has_credentials(trimmed) {
+        return None;
+    }
     let (scheme, rest) = trimmed.split_once("://")?;
     if !matches!(scheme.to_ascii_lowercase().as_str(), "http" | "https") {
         return None;
@@ -1313,6 +1390,72 @@ mod tests {
         assert_eq!(
             normalize_local_endpoint("http://127.0.0.1:1234/v1/").as_deref(),
             Some("http://127.0.0.1:1234/v1")
+        );
+    }
+
+    #[test]
+    fn an_endpoint_carrying_a_credential_is_not_an_endpoint() {
+        // The security half of the same refusal. `normalize_local_endpoint` is
+        // the funnel every stored endpoint passes through, so refusing here is
+        // what makes "no credential is ever stored in a `base_url`" a property
+        // of the store rather than of whichever handler remembered to check.
+        for bad in [
+            "http://alice:hunter2@127.0.0.1:8597/v1",
+            "https://alice@api.acme.example/v1",
+            "http://alice:hunter2@127.0.0.1:8597",
+            // A password may itself contain an `@`; the authority still has one.
+            "http://alice:hun@ter2@127.0.0.1:8597/v1",
+        ] {
+            assert!(endpoint_has_credentials(bad), "`{bad}` carries userinfo");
+            assert!(
+                normalize_local_endpoint(bad).is_none(),
+                "`{bad}` must not normalise into something storable"
+            );
+        }
+    }
+
+    #[test]
+    fn an_at_sign_in_the_path_is_not_a_credential() {
+        // The `@` has to be inside the authority. A path may legitimately carry
+        // one, and refusing those would reject perfectly good endpoints.
+        for good in [
+            "https://api.acme.example/v1/@me",
+            "https://api.acme.example/v1?to=a@b",
+            "https://api.acme.example/v1#a@b",
+        ] {
+            assert!(!endpoint_has_credentials(good), "`{good}` has no userinfo");
+            assert_eq!(redact_endpoint(good), good);
+        }
+    }
+
+    #[test]
+    fn redacting_an_endpoint_removes_the_credential_and_nothing_else() {
+        // Observed in the incident: reqwest masks userinfo in its own error
+        // Display (`for url (http://127.0.0.1:8597/v1/models)`), and then the
+        // handler's own `format!` put it back from the endpoint we hold.
+        assert_eq!(
+            redact_endpoint("http://alice:hunter2@127.0.0.1:8597/v1"),
+            "http://***@127.0.0.1:8597/v1"
+        );
+        assert_eq!(
+            redact_endpoint("https://alice@api.acme.example/v1"),
+            "https://***@api.acme.example/v1"
+        );
+        // The last `@` in the authority is the delimiter, so a password
+        // containing one is removed whole rather than half-left behind.
+        assert_eq!(
+            redact_endpoint("http://alice:hun@ter2@127.0.0.1:8597/v1"),
+            "http://***@127.0.0.1:8597/v1"
+        );
+        // Scheme-less, as `normalize_setup_base_url` accepts.
+        assert_eq!(
+            redact_endpoint("alice:hunter2@localhost:1234/v1"),
+            "***@localhost:1234/v1"
+        );
+        // Nothing to redact: byte-for-byte the same endpoint, trimmed.
+        assert_eq!(
+            redact_endpoint("  https://api.openai.com/v1  "),
+            "https://api.openai.com/v1"
         );
     }
 

--- a/src/company/inference/catalogue.rs
+++ b/src/company/inference/catalogue.rs
@@ -492,9 +492,10 @@ pub fn endpoint_host(endpoint: &str) -> Option<String> {
 
 /// What [`redact_endpoint`] leaves where the userinfo was.
 ///
-/// The `@` is kept so the shape still reads as a URL and the operator can see
-/// *that* something was embedded — which is the sentence they need in order to
-/// go and move it into the key field.
+/// It replaces the userinfo only; the delimiting `@` survives, so the result
+/// still reads as a URL and the operator can see *that* something was embedded
+/// — which is the sentence they need in order to go and move it into the key
+/// field.
 pub const REDACTED_USERINFO: &str = "***";
 
 /// The byte range of an endpoint's userinfo — everything between `://` (or the

--- a/src/company/inference/probe.rs
+++ b/src/company/inference/probe.rs
@@ -596,6 +596,11 @@ pub async fn probe_models(
 ) -> Result<Vec<String>, ProbeFailure> {
     check_endpoint(base_url, policy).map_err(ProbeFailure::refused)?;
     let url = format!("{}/models", base_url.trim().trim_end_matches('/'));
+    // What the failure text is allowed to say. `raw` reaches a host log, and a
+    // log is disk — so an endpoint carrying userinfo must not be written into
+    // one verbatim. The request itself still goes to `url`; only the sentence
+    // about it is redacted.
+    let named = catalogue::redact_endpoint(&url);
 
     // The redirect policy is where the guard earns its keep. `reqwest` resolves
     // and connects on our behalf, so the only place a redirect target can be
@@ -627,7 +632,7 @@ pub async fn probe_models(
     let response = request.send().await.map_err(|e| {
         // Classified on the condition alone; the full error, URL and all, is
         // kept for the log. See `ProbeFailure::classified_as`.
-        ProbeFailure::classified_as(transport_condition(&e), format!("{url}: {e}"))
+        ProbeFailure::classified_as(transport_condition(&e), format!("{named}: {e}"))
     })?;
     let status = response.status();
     let body = read_capped(response).await;
@@ -644,7 +649,7 @@ pub async fn probe_models(
         );
         return Err(ProbeFailure::classified_as(
             &reason,
-            format!("{url}: {reason}"),
+            format!("{named}: {reason}"),
         ));
     }
     Ok(parse_model_ids(&body))

--- a/src/company/inference/store.rs
+++ b/src/company/inference/store.rs
@@ -257,11 +257,35 @@ pub struct ProviderDraft {
     pub enabled: bool,
 }
 
+/// The longest a provider name — and therefore the slug derived from it — may
+/// be, in characters.
+///
+/// **Bounded at all** because the name is not only a label: [`slugify`] turns it
+/// into the address of a secret (`provider/<slug>/key`), and a secret key is a
+/// path component in the filesystem store. An unbounded name produced an
+/// unbounded path, which is how a 245-character name came to 500 a credential
+/// read and a 300-character one came to truncate a stored key and then fail the
+/// delete that truncated it. The store no longer breaks on a long key — see
+/// `legacy_secret_absent` in `src/store/fs.rs` — but a rule the store has to
+/// absorb is a rule that was never stated, and the name still has to be legible
+/// in a routing row an operator hand-edits.
+///
+/// **Eighty** because that is the bound this codebase already uses for the other
+/// name a person types and then reads back in a list
+/// (`MAX_DISPLAY_NAME_CHARS`, `src/server/users/mod.rs`), and because it keeps
+/// the derived secret key well inside the canonical filename budget: at 80
+/// characters `provider/<slug>/key` percent-encodes to 97 bytes against a
+/// 200-byte budget, so a provider's credential file is never the
+/// truncated-and-digested form and stays readable on disk by the person
+/// debugging it.
+pub const MAX_PROVIDER_NAME_CHARS: usize = 80;
+
 /// Why a slug cannot be used.
 ///
-/// Three named failures rather than a boolean, because they need three different
-/// sentences: one is "pick another name", one is "you already have this", and one
-/// is "that name belongs to something we ship".
+/// Four named failures rather than a boolean, because they need four different
+/// sentences: one is "pick another name", one is "you already have this", one
+/// is "that name belongs to something we ship", and one is "that name is too
+/// long".
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SlugError {
     /// Nothing was typed, or it normalised to nothing.
@@ -270,6 +294,8 @@ pub enum SlugError {
     Taken,
     /// The catalogue ships that name.
     Reserved,
+    /// Past [`MAX_PROVIDER_NAME_CHARS`].
+    TooLong,
 }
 
 impl std::fmt::Display for SlugError {
@@ -278,6 +304,10 @@ impl std::fmt::Display for SlugError {
             Self::Empty => write!(f, "a provider needs a name"),
             Self::Taken => write!(f, "this company already has a provider with that name"),
             Self::Reserved => write!(f, "that name belongs to a built-in provider"),
+            Self::TooLong => write!(
+                f,
+                "a provider name may be at most {MAX_PROVIDER_NAME_CHARS} characters"
+            ),
         }
     }
 }
@@ -305,6 +335,26 @@ pub fn slugify(label: &str) -> String {
     out
 }
 
+/// Whether a typed provider **name** may be used at all, before any slug is
+/// derived from it.
+///
+/// Separate from [`check_slug`] because the two bound different things. The slug
+/// is an address; the label is text that lands in the index blob, in the
+/// provider list, and in every advisory that names a provider. A name can be
+/// long while its slug is short (`slugify` drops everything that is not
+/// alphanumeric), so bounding only the slug leaves a page of prose in the store
+/// under a three-character address.
+pub fn check_provider_name(label: &str) -> std::result::Result<(), SlugError> {
+    let label = label.trim();
+    if label.is_empty() {
+        return Err(SlugError::Empty);
+    }
+    if label.chars().count() > MAX_PROVIDER_NAME_CHARS {
+        return Err(SlugError::TooLong);
+    }
+    Ok(())
+}
+
 /// Whether `slug` may be used for a **custom** provider in a company that
 /// already holds `existing`.
 ///
@@ -312,10 +362,18 @@ pub fn slugify(label: &str) -> String {
 /// own `groq` entry *should* take the slug `groq` — that is the same provider,
 /// not a collision. It is a typed name shadowing a built-in that has to be
 /// refused, because a routing entry saying `groq` would then mean two things.
+///
+/// The length bound is checked **here** rather than only on the label, because
+/// this is the function that stands between a typed name and the address of a
+/// secret ([`provider_key_key`]). A console mirrors it; a console is not a
+/// security boundary.
 pub fn check_slug(existing: &[Provider], slug: &str) -> std::result::Result<(), SlugError> {
     let slug = slug.trim();
     if slug.is_empty() {
         return Err(SlugError::Empty);
+    }
+    if slug.chars().count() > MAX_PROVIDER_NAME_CHARS {
+        return Err(SlugError::TooLong);
     }
     if existing.iter().any(|p| p.slug == slug) {
         return Err(SlugError::Taken);
@@ -1311,6 +1369,44 @@ mod tests {
         assert_eq!(check_slug(&existing, "acme"), Err(SlugError::Taken));
         assert_eq!(check_slug(&existing, "groq"), Err(SlugError::Reserved));
         assert_eq!(check_slug(&existing, "acme-two"), Ok(()));
+    }
+
+    #[test]
+    fn a_provider_name_is_bounded_at_the_limit_and_refused_past_it() {
+        // The bound exists because the name becomes the address of a secret.
+        // At the limit is a legal name; one character past it is not, and the
+        // refusal happens here rather than at the store, where it used to
+        // arrive as `ENAMETOOLONG` after a write had already landed.
+        let at_limit = "a".repeat(MAX_PROVIDER_NAME_CHARS);
+        let past_limit = "a".repeat(MAX_PROVIDER_NAME_CHARS + 1);
+
+        assert_eq!(check_provider_name(&at_limit), Ok(()));
+        assert_eq!(check_provider_name(&past_limit), Err(SlugError::TooLong));
+        assert_eq!(check_provider_name("  "), Err(SlugError::Empty));
+
+        assert_eq!(check_slug(&[], &at_limit), Ok(()));
+        assert_eq!(check_slug(&[], &past_limit), Err(SlugError::TooLong));
+
+        // Characters, not bytes: a name of multi-byte characters is judged by
+        // what the operator typed rather than by how UTF-8 happens to store it.
+        let multibyte = "é".repeat(MAX_PROVIDER_NAME_CHARS);
+        assert_eq!(check_provider_name(&multibyte), Ok(()));
+    }
+
+    #[test]
+    fn a_bounded_name_keeps_its_credential_key_inside_the_filename_budget() {
+        // Why 80 and not some larger round number: the derived secret key has
+        // to stay short enough that the canonical filename is the readable
+        // `%k-` form rather than the truncated-and-digested `%l-` one. The
+        // slug alphabet is `[a-z0-9-]`, one byte per character once
+        // percent-encoded, and `provider/` + `/key` add 17.
+        let key = provider_key_key(&"a".repeat(MAX_PROVIDER_NAME_CHARS));
+        assert_eq!(key.len(), MAX_PROVIDER_NAME_CHARS + 17);
+        assert!(
+            key.len() < 200,
+            "a bounded name must not need a truncated secret filename: {} bytes",
+            key.len()
+        );
     }
 
     #[tokio::test]

--- a/src/company/inference/store.rs
+++ b/src/company/inference/store.rs
@@ -1401,11 +1401,15 @@ mod tests {
         // slug alphabet is `[a-z0-9-]`, one byte per character once
         // percent-encoded, and `provider/` + `/key` add 17.
         let key = provider_key_key(&"a".repeat(MAX_PROVIDER_NAME_CHARS));
-        assert_eq!(key.len(), MAX_PROVIDER_NAME_CHARS + 17);
+        // `provider/` + `/key` is 13 characters around the slug.
+        assert_eq!(key.len(), MAX_PROVIDER_NAME_CHARS + 13);
+        // Percent-encoding is what the budget is measured in. The slug alphabet
+        // (`[a-z0-9-]`) survives as one byte per character; the two `/`
+        // separators become `%2F`, three bytes each.
+        let encoded_len = key.len() + 2 * 2;
         assert!(
-            key.len() < 200,
-            "a bounded name must not need a truncated secret filename: {} bytes",
-            key.len()
+            encoded_len < 200,
+            "a bounded name must not need a truncated secret filename: {encoded_len} bytes"
         );
     }
 

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -1765,6 +1765,11 @@ fn model_unavailable_advice(
         ),
         (_, None) => "update the company's `[inference].models` mapping".to_string(),
     };
+    // Redacted here rather than at the two call sites, so a third one cannot
+    // reintroduce the leak. An endpoint may carry userinfo, and this sentence is
+    // operator-facing: it reaches the console and gets screenshotted into
+    // tickets.
+    let models_url = crate::company::inference::catalogue::redact_endpoint(models_url);
     Some(format!(
         "the configured inference model is not available from the provider — {where_to_fix}, to \
          one the provider offers (list them with `GET {models_url}`). {error}"

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -269,13 +269,19 @@ async fn fetch_catalog(
     // Verified against `platform.claude.com/docs/en/api/models/list`, whose own
     // curl example is `-H 'anthropic-version: 2023-06-01' -H "X-Api-Key: …"`.
     let request = crate::company::inference::probe::apply_auth(client.get(url), auth, bearer);
+    // Every message below names the endpoint **redacted**. A URL may carry
+    // userinfo, and `reqwest` already masks it in its own `Display` — so a
+    // `format!` that interpolates our copy of the URL beside that error is
+    // precisely how a credential that reqwest had already hidden gets put back
+    // into a string the console renders.
+    let named = crate::company::inference::catalogue::redact_endpoint(url);
     let response = request
         .send()
         .await
-        .map_err(|error| DiscoveryError::endpoint(format!("request to {url} failed: {error}")))?;
+        .map_err(|error| DiscoveryError::endpoint(format!("request to {named} failed: {error}")))?;
     let status = response.status();
     let response = response.error_for_status().map_err(|error| {
-        let message = format!("request to {url} failed: {error}");
+        let message = format!("request to {named} failed: {error}");
         match status {
             reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
                 DiscoveryError::credential(message)
@@ -285,7 +291,7 @@ async fn fetch_catalog(
         }
     })?;
     let payload = response.json::<RegistryResponse>().await.map_err(|error| {
-        DiscoveryError::endpoint(format!("model catalog from {url} was invalid: {error}"))
+        DiscoveryError::endpoint(format!("model catalog from {named} was invalid: {error}"))
     })?;
     Ok(parse_models(payload))
 }

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -202,7 +202,7 @@ async fn list_models(company: ScopedCompany) -> Result<Json<ModelCatalogDto>, Ap
                 models.iter().map(|model| model.id.as_str()),
             );
             Ok(Json(ModelCatalogDto {
-                base_url,
+                base_url: catalogue::redact_endpoint(&base_url),
                 models,
                 tier_vocabulary: Some(vocabulary.as_str()),
                 tier_defaults: vocabulary.tier_defaults(),
@@ -210,10 +210,15 @@ async fn list_models(company: ScopedCompany) -> Result<Json<ModelCatalogDto>, Ap
             }))
         }
         Err(error) => Ok(Json(ModelCatalogDto {
+            // Redacted, not raw. `reqwest` masks userinfo in its own `Display`,
+            // but this `format!` re-adds it from the endpoint we hold — which
+            // is how a stored `http://user:password@host/v1` came to be printed
+            // in full in a banner an operator screenshots into a ticket.
             error: Some(format!(
-                "Could not list models from {base_url}: {error}. Enter model ids directly."
+                "Could not list models from {endpoint}: {error}. Enter model ids directly.",
+                endpoint = catalogue::redact_endpoint(&base_url)
             )),
-            base_url,
+            base_url: catalogue::redact_endpoint(&base_url),
             models: Vec::new(),
             tier_vocabulary: None,
             tier_defaults: BTreeMap::new(),
@@ -490,7 +495,7 @@ async fn provider_list(runtime: &CompanyRuntime) -> Result<Vec<ProviderDto>, Api
             slug: provider.slug,
             label: provider.label,
             kind: provider.kind,
-            base_url: provider.base_url,
+            base_url: catalogue::redact_endpoint(&provider.base_url),
             models: provider.models,
             enabled: provider.enabled,
             key_configured,
@@ -827,6 +832,13 @@ async fn effective_status_with(
             |d| d.base_url.clone(),
         ),
     };
+    // This route is `ScopedCompany`, not admin — every console reader gets this
+    // field on every page load. A credential embedded in the endpoint is
+    // refused at every point one can be set, but an endpoint stored before that
+    // rule existed, or one arriving from a `company.toml` or
+    // `OPENCOMPANY_INFERENCE_URL` this host does not own, still has to be safe
+    // to *say*.
+    let base_url = catalogue::redact_endpoint(&base_url);
     // What the company actually booted onto, not what the config implies.
     let cognition = runtime.cognition();
     let restart_required = restart_pending(runtime, decl.is_some());
@@ -923,9 +935,11 @@ async fn managed_state(
     Ok(ManagedDto {
         source: source.as_str().to_string(),
         configured: source.resolves(),
-        base_url: platform
-            .map(|p| p.base_url.clone())
-            .unwrap_or_else(|| inference::PLATFORM_BASE_URL.to_string()),
+        base_url: catalogue::redact_endpoint(
+            &platform
+                .map(|p| p.base_url.clone())
+                .unwrap_or_else(|| inference::PLATFORM_BASE_URL.to_string()),
+        ),
         enabled: store::managed_enabled(runtime.id(), secrets)
             .await
             .map_err(ApiError)?,
@@ -1165,7 +1179,7 @@ async fn unauthenticated_reason(
          fall back on — a request to {base} would carry no Authorization header and be rejected, \
          so none was sent. Save a key that {base} accepts above, or point this company at an \
          endpoint that needs none.",
-        base = decl.base_url
+        base = catalogue::redact_endpoint(&decl.base_url)
     )))
 }
 
@@ -1189,7 +1203,8 @@ fn probe_failure(decl: &inference::InferenceDecl, raw: &str) -> (String, &'stati
                  stored against the provider selected when it was saved, so a key for another \
                  vendor fails here even while this card reports one is set. Re-save the key under \
                  {}, or Remove key to fall back. The provider said: {raw}",
-                decl.base_url, decl.provider
+                catalogue::redact_endpoint(&decl.base_url),
+                decl.provider
             ),
             "credential_rejected",
         );

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -1458,6 +1458,32 @@ base_url = "https://byo.example/v1"
         state
     }
 
+    /// [`state_with_company`] over a caller-supplied manifest.
+    ///
+    /// The strict `validate()` only runs on a first boot with no persisted
+    /// record (`src/runtime/builder.rs`), and `save_record` writes one first —
+    /// so this can plant a manifest a fresh company would now be refused. That
+    /// is the point: an endpoint stored before the refusal existed is exactly
+    /// the case the redaction half of the rule is for.
+    async fn state_with_manifest(
+        home: &std::path::Path,
+        name: &str,
+        manifest_toml: &str,
+    ) -> AppState {
+        let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+        let id = CompanyId::new(name);
+        save_record(home, &id, &manifest).await;
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, name).await;
+        state
+    }
+
     /// [`state_with_company`] over a harness-only-inference manifest. The
     /// routes read `manifest_inference` from the saved record, so the company
     /// boots on the echo brain here (no pool attached) while the record it
@@ -2099,6 +2125,250 @@ base_url = "https://byo.example/v1"
                 .as_object()
                 .is_some_and(serde_json::Map::is_empty),
             "no catalog means no defaults we can honestly prefill: {raw}"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // A credential embedded in an endpoint: refused on the way in, redacted on
+    // the way out. Three paths, because the leak had three.
+    // ---------------------------------------------------------------------
+
+    /// The credential a test endpoint carries. Obviously fake, and asserted on
+    /// by substring everywhere below — a leak anywhere is a leak.
+    const EMBEDDED_PASSWORD: &str = "hunter2";
+    /// Loopback discard: refuses immediately, offline and deterministically.
+    const CREDENTIALED_ENDPOINT: &str = "http://alice:hunter2@127.0.0.1:9/unreachable/v1";
+    const CREDENTIALED_MANIFEST: &str =
+        "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+         [inference]\nprovider = \"openai_compatible\"\n\
+         base_url = \"http://alice:hunter2@127.0.0.1:9/unreachable/v1\"\n";
+
+    /// Path 1 — it is never stored.
+    #[tokio::test]
+    async fn an_endpoint_carrying_a_credential_is_refused_before_anything_is_written() {
+        let home_dir = home();
+        let state = state_with_company_named(home_dir.path(), "credurl-add").await;
+
+        for body in [
+            json!({
+                "kind": "custom",
+                "label": "Acme gateway",
+                "baseUrl": CREDENTIALED_ENDPOINT,
+            }),
+            // The local-runtime category types its own endpoint too.
+            json!({ "kind": "ollama", "baseUrl": CREDENTIALED_ENDPOINT }),
+        ] {
+            let (status, _, raw) = send_as(
+                &state,
+                "credurl-add",
+                "POST",
+                "/api/v1/company/inference/providers",
+                Some(body.clone()),
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{body}: {raw}");
+            assert!(
+                !raw.contains(EMBEDDED_PASSWORD),
+                "the refusal echoed the credential it was refusing: {raw}"
+            );
+        }
+
+        // The draft probe refuses it too, rather than putting a basic-auth
+        // credential on the wire to an address the operator named.
+        let (status, _, raw) = send_as(
+            &state,
+            "credurl-add",
+            "POST",
+            "/api/v1/company/inference/probe",
+            Some(json!({ "baseUrl": CREDENTIALED_ENDPOINT })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{raw}");
+        assert!(!raw.contains(EMBEDDED_PASSWORD), "{raw}");
+
+        // And nothing landed: no stored endpoint anywhere in the status read.
+        let (_, _, raw) = send_as(
+            &state,
+            "credurl-add",
+            "GET",
+            "/api/v1/company/inference",
+            None,
+        )
+        .await;
+        assert!(
+            !raw.contains(EMBEDDED_PASSWORD),
+            "a refused endpoint reached the store: {raw}"
+        );
+    }
+
+    /// Path 2 — the catalog-read failure note does not re-add it.
+    ///
+    /// `reqwest` redacts userinfo in its own error `Display`; the handler's own
+    /// `format!` used to put it back from the endpoint we hold.
+    #[tokio::test]
+    async fn a_catalog_read_failure_names_the_endpoint_without_its_credential() {
+        let home_dir = home();
+        let state =
+            state_with_manifest(home_dir.path(), "credurl-models", CREDENTIALED_MANIFEST).await;
+
+        let (status, body, raw) = send_as(
+            &state,
+            "credurl-models",
+            "GET",
+            "/api/v1/company/inference/models",
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert!(
+            !raw.contains(EMBEDDED_PASSWORD),
+            "the catalog route leaked an embedded credential: {raw}"
+        );
+        let error = body["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("Could not list models from"),
+            "the failure still names the endpoint it could not reach: {raw}"
+        );
+        assert!(
+            error.contains("http://***@127.0.0.1:9/unreachable/v1"),
+            "the endpoint is redacted, not dropped — the operator still needs to \
+             recognise which one it was: {raw}"
+        );
+    }
+
+    /// Path 3 — the read DTO, on the non-admin route every console reader calls.
+    #[tokio::test]
+    async fn the_company_status_read_redacts_an_endpoint_credential() {
+        let home_dir = home();
+        let state =
+            state_with_manifest(home_dir.path(), "credurl-status", CREDENTIALED_MANIFEST).await;
+
+        let (status, body, raw) = send_as(
+            &state,
+            "credurl-status",
+            "GET",
+            "/api/v1/company/inference",
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert!(
+            !raw.contains(EMBEDDED_PASSWORD),
+            "`GET …/inference` is `ScopedCompany`, so this is the password on the \
+             wire for every console reader: {raw}"
+        );
+        assert_eq!(
+            body["baseUrl"].as_str(),
+            Some("http://***@127.0.0.1:9/unreachable/v1"),
+            "{raw}"
+        );
+    }
+
+    /// The same rule over a provider **row**, which is a different DTO built
+    /// from a different store.
+    #[tokio::test]
+    async fn a_provider_row_redacts_an_endpoint_credential() {
+        use crate::company::inference::store;
+
+        let home_dir = home();
+        let runtime = runtime_with(home_dir.path(), NO_INFERENCE).await;
+        // Written straight to the store, as a record predating the refusal
+        // would be — the handler now refuses this endpoint.
+        store::put_provider(
+            runtime.id(),
+            runtime.secrets().as_ref(),
+            store::ProviderDraft {
+                slug: "acme-gateway".into(),
+                label: "Acme gateway".into(),
+                kind: "custom".into(),
+                base_url: CREDENTIALED_ENDPOINT.into(),
+                models: BTreeMap::new(),
+                enabled: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let dto = effective_status_with(&runtime, None, false).await.unwrap();
+        let row = dto
+            .providers
+            .iter()
+            .find(|p| p.slug == "acme-gateway")
+            .expect("the planted provider is listed");
+        assert_eq!(row.base_url, "http://***@127.0.0.1:9/unreachable/v1");
+        assert!(
+            !serde_json::to_string(&dto)
+                .unwrap()
+                .contains(EMBEDDED_PASSWORD),
+            "the whole status DTO must be free of it, not just the field we looked at"
+        );
+    }
+
+    /// Defect B, end to end: a name past the bound is a 400 before any write,
+    /// not a 500 with a truncated credential behind it.
+    #[tokio::test]
+    async fn a_provider_name_past_the_bound_is_refused_rather_than_breaking_the_store() {
+        use crate::company::inference::store::MAX_PROVIDER_NAME_CHARS;
+
+        let home_dir = home();
+        let state = state_with_company_named(home_dir.path(), "longname").await;
+
+        // At the bound: accepted, and its credential round-trips through the
+        // store — including the clear the delete issues.
+        let at_limit = "a".repeat(MAX_PROVIDER_NAME_CHARS);
+        let (status, _, raw) = send_as(
+            &state,
+            "longname",
+            "POST",
+            "/api/v1/company/inference/providers",
+            Some(json!({
+                "kind": "custom",
+                "label": at_limit,
+                "baseUrl": UNREACHABLE,
+                "key": "sk-not-a-real-key",
+                "addAnyway": true,
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "a name at the bound is legal: {raw}");
+        let (status, _, raw) = send_as(
+            &state,
+            "longname",
+            "DELETE",
+            &format!("/api/v1/company/inference/providers/{at_limit}"),
+            None,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "removing it clears the credential, which is the write that used to \
+             fail after truncating it: {raw}"
+        );
+
+        // Past the bound: refused, and refused *before* the key is written.
+        let past_limit = "a".repeat(MAX_PROVIDER_NAME_CHARS + 1);
+        let (status, _, raw) = send_as(
+            &state,
+            "longname",
+            "POST",
+            "/api/v1/company/inference/providers",
+            Some(json!({
+                "kind": "custom",
+                "label": past_limit,
+                "baseUrl": UNREACHABLE,
+                "key": "sk-not-a-real-key",
+            })),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "a 500 here is the incident: {raw}"
+        );
+        assert!(
+            raw.contains(&MAX_PROVIDER_NAME_CHARS.to_string()),
+            "the refusal says what the limit is: {raw}"
         );
     }
 

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -2138,8 +2138,7 @@ base_url = "https://byo.example/v1"
     const EMBEDDED_PASSWORD: &str = "hunter2";
     /// Loopback discard: refuses immediately, offline and deterministically.
     const CREDENTIALED_ENDPOINT: &str = "http://alice:hunter2@127.0.0.1:9/unreachable/v1";
-    const CREDENTIALED_MANIFEST: &str =
-        "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+    const CREDENTIALED_MANIFEST: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
          [inference]\nprovider = \"openai_compatible\"\n\
          base_url = \"http://alice:hunter2@127.0.0.1:9/unreachable/v1\"\n";
 
@@ -2330,7 +2329,11 @@ base_url = "https://byo.example/v1"
             })),
         )
         .await;
-        assert_eq!(status, StatusCode::OK, "a name at the bound is legal: {raw}");
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a name at the bound is legal: {raw}"
+        );
         let (status, _, raw) = send_as(
             &state,
             "longname",

--- a/src/server/ops/inference/providers.rs
+++ b/src/server/ops/inference/providers.rs
@@ -459,9 +459,8 @@ fn plan_add(
                     local.label
                 ))
             })?;
-        let base_url = catalogue::normalize_local_endpoint(&typed).ok_or_else(|| {
-            invalid(endpoint_refusal(&typed))
-        })?;
+        let base_url = catalogue::normalize_local_endpoint(&typed)
+            .ok_or_else(|| invalid(endpoint_refusal(&typed)))?;
         // **The catalogue says whether this runtime wants a credential, and the
         // host has to hold that rule too.** OMLX declares `needs_key: true`; the
         // console's dialog showed and required the field, and the handler
@@ -645,7 +644,12 @@ async fn edit_provider(
     // A rename goes through the same bound an add does. The slug is fixed here,
     // so this bounds only the label — but an edit that could set a name an add
     // would refuse is a rule the host does not actually hold.
-    let label = match body.label.as_deref().map(str::trim).filter(|l| !l.is_empty()) {
+    let label = match body
+        .label
+        .as_deref()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+    {
         Some(typed) => {
             store::check_provider_name(typed)
                 .map_err(|e| ApiError(OpenCompanyError::InvalidRequest(e.to_string())))?;

--- a/src/server/ops/inference/providers.rs
+++ b/src/server/ops/inference/providers.rs
@@ -460,7 +460,7 @@ fn plan_add(
                 ))
             })?;
         let base_url = catalogue::normalize_local_endpoint(&typed).ok_or_else(|| {
-            invalid("A local runtime endpoint must be an http or https address.".to_string())
+            invalid(endpoint_refusal(&typed))
         })?;
         // **The catalogue says whether this runtime wants a credential, and the
         // host has to hold that rule too.** OMLX declares `needs_key: true`; the
@@ -503,6 +503,9 @@ fn plan_add(
     // invites them to disagree, and the one that appears in a routing entry
     // would then be the one they never chose.
     let label = label.map(str::trim).unwrap_or("").to_string();
+    // Bounded before the slug is derived, so the sentence names what the
+    // operator typed rather than the address that fell out of it.
+    store::check_provider_name(&label).map_err(|e| invalid(e.to_string()))?;
     let slug = store::slugify(&label);
     if slug.is_empty() {
         return Err(invalid(store::SlugError::Empty.to_string()));
@@ -512,7 +515,7 @@ fn plan_add(
         .filter(|u| !u.is_empty())
         .ok_or_else(|| invalid("A custom provider needs an OpenAI-compatible URL.".to_string()))?;
     let base_url = catalogue::normalize_local_endpoint(typed)
-        .ok_or_else(|| invalid("That endpoint must be an http or https address.".to_string()))?;
+        .ok_or_else(|| invalid(endpoint_refusal(typed)))?;
     Ok(AddPlan {
         slug,
         label,
@@ -530,6 +533,24 @@ fn plan_add(
 /// answered at Acme gateway" is not.
 fn advisory_subject(provider: &store::Provider) -> String {
     catalogue::endpoint_host(&provider.base_url).unwrap_or_else(|| provider.label.clone())
+}
+
+/// What to say about an endpoint that cannot be used.
+///
+/// Two reasons, and they need two sentences. "Not an http address" is a typo.
+/// A credential embedded in the authority is a security answer: the endpoint is
+/// stored in the provider record, returned to **every** console reader on the
+/// company status read, and interpolated into operator-facing failure text — so
+/// a password in a URL is a password in all three, and the fix is to move it to
+/// the field that is write-only.
+fn endpoint_refusal(typed: &str) -> String {
+    if catalogue::endpoint_has_credentials(typed) {
+        return "That endpoint carries a username or password in the URL. Remove them and put \
+                the credential in the API key field — an endpoint is stored as written and is \
+                readable by everyone who can see this company's settings."
+            .to_string();
+    }
+    "That endpoint must be an http or https address.".to_string()
 }
 
 /// Undoes an add whose probe rejected the credential.
@@ -615,12 +636,22 @@ async fn edit_provider(
                 existing.base_url.clone()
             } else {
                 catalogue::normalize_local_endpoint(typed).ok_or_else(|| {
-                    ApiError(OpenCompanyError::InvalidRequest(
-                        "That endpoint must be an http or https address.".to_string(),
-                    ))
+                    ApiError(OpenCompanyError::InvalidRequest(endpoint_refusal(typed)))
                 })?
             }
         }
+    };
+
+    // A rename goes through the same bound an add does. The slug is fixed here,
+    // so this bounds only the label — but an edit that could set a name an add
+    // would refuse is a rule the host does not actually hold.
+    let label = match body.label.as_deref().map(str::trim).filter(|l| !l.is_empty()) {
+        Some(typed) => {
+            store::check_provider_name(typed)
+                .map_err(|e| ApiError(OpenCompanyError::InvalidRequest(e.to_string())))?;
+            typed.to_string()
+        }
+        None => existing.label.clone(),
     };
 
     let provider = store::put_provider(
@@ -628,13 +659,7 @@ async fn edit_provider(
         secrets,
         store::ProviderDraft {
             slug: existing.slug.clone(),
-            label: body
-                .label
-                .as_deref()
-                .map(str::trim)
-                .filter(|l| !l.is_empty())
-                .map(str::to_string)
-                .unwrap_or(existing.label.clone()),
+            label,
             kind: existing.kind.clone(),
             base_url,
             models: body.models.unwrap_or(existing.models.clone()),
@@ -1108,8 +1133,12 @@ async fn list_provider_models(
     )
     .await
     {
+        // Redacted on both arms. This route is `ScopedCompany`, and `{error}`
+        // alone is not enough: `reqwest` masks userinfo in its own `Display`,
+        // and then a `format!` like this one re-adds it from the endpoint we
+        // hold.
         Ok(models) => Ok(Json(ProviderCatalogDto {
-            base_url: provider.base_url,
+            base_url: catalogue::redact_endpoint(&provider.base_url),
             models: models.into_iter().map(|m| m.id).collect(),
             free_text_only,
             error: None,
@@ -1117,9 +1146,9 @@ async fn list_provider_models(
         Err(error) => Ok(Json(ProviderCatalogDto {
             error: Some(format!(
                 "Could not list models from {}: {error}. Enter a model id directly.",
-                provider.base_url
+                catalogue::redact_endpoint(&provider.base_url)
             )),
-            base_url: provider.base_url,
+            base_url: catalogue::redact_endpoint(&provider.base_url),
             models: Vec::new(),
             free_text_only,
         })),
@@ -1309,6 +1338,17 @@ async fn test_provider(
 async fn probe_draft(company: AdminScopedCompany, Json(body): Json<ProbeDraft>) -> Response {
     let _ = &company;
     let kind = body.kind.as_deref().unwrap_or("custom");
+    // Refused before the request is made, not after. A draft is never stored, so
+    // this is not about the store — it is that "probe this URL" would otherwise
+    // be a way to make this host put a basic-auth credential on the wire to an
+    // address the operator names, on an endpoint shape the add flow will refuse
+    // to save anyway.
+    if catalogue::endpoint_has_credentials(&body.base_url) {
+        return ApiError(OpenCompanyError::InvalidRequest(endpoint_refusal(
+            body.base_url.trim(),
+        )))
+        .into_response();
+    }
     let auth = catalogue::auth_style_for(kind);
     let subject = catalogue::endpoint_host(&body.base_url).unwrap_or_else(|| "that host".into());
     match probe::probe_models(

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -222,9 +222,11 @@ pub struct InferenceReadyDto {
     /// The provider slug behind it, for the picker's initial value. Always
     /// `managed` today: the injected path is the platform's own endpoint.
     pub provider: Option<&'static str>,
-    /// The endpoint it resolves to. Shown, not secret — it is a URL, and seeing
-    /// which one a test is about to hit is the difference between a green tick
-    /// and a green tick you can trust.
+    /// The endpoint it resolves to, with any embedded credential redacted.
+    /// Seeing which endpoint a test is about to hit is the difference between a
+    /// green tick and a green tick you can trust — but a URL is not
+    /// automatically safe to show, because it can carry userinfo. See
+    /// [`redact_endpoint`](crate::company::inference::catalogue::redact_endpoint).
     pub base_url: Option<String>,
 }
 
@@ -239,7 +241,12 @@ pub struct InferenceReadyDto {
 /// The credential itself never leaves this function.
 #[cfg(feature = "openhuman")]
 fn house_credential(env: &dyn EnvSource) -> Option<String> {
-    crate::harness::provider::harness_inference_from_env(env).map(|(config, _)| config.base_url)
+    crate::harness::provider::harness_inference_from_env(env)
+        // Redacted, because "it is a URL" is not the same as "it is not a
+        // secret": `OPENCOMPANY_INFERENCE_URL` can carry userinfo, and this
+        // one is the deployer's own endpoint rather than a tenant's, so no
+        // input rule this workload holds can have kept it out.
+        .map(|(config, _)| crate::company::inference::catalogue::redact_endpoint(&config.base_url))
 }
 
 /// Without the harness there is no inference path at all, so the host holds

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -2887,6 +2887,35 @@ impl FsSecretStore {
     }
 }
 
+/// Whether an error from the **legacy** secret path means "there is no legacy
+/// file", as opposed to a real IO failure worth surfacing.
+///
+/// `NotFound` is the obvious case. `InvalidFilename` is the one that cost an
+/// incident: [`Bundle::legacy_secret`] slugs the whole key into one path
+/// component with **no length bound**, unlike the canonical `Bundle::secret`,
+/// which is digest-truncated to a fixed budget. A key long enough to overflow
+/// `NAME_MAX` — a 245-character provider name was enough — makes the kernel
+/// answer `ENAMETOOLONG` (`ErrorKind::InvalidFilename`) rather than `ENOENT`.
+///
+/// Surfacing that as a store error had two consequences. [`SecretStore::get`]
+/// turned a plain credential read into a 500 on every route that reads one.
+/// Worse, [`SecretStore::set`]'s clear path had **already written** the
+/// canonical file before it went looking for a legacy file to revoke, so a
+/// credential delete returned 500 with the key truncated to zero bytes and the
+/// provider row still listed — an inconsistent store repairable only by
+/// hand-editing the index.
+///
+/// A name too long to *be* a path component cannot name a file that exists, so
+/// the honest reading of `ENAMETOOLONG` is "absent", exactly like `ENOENT`.
+/// Every other kind still propagates: a permissions failure or a read-only
+/// mount under `secrets/` has to stay loud.
+fn legacy_secret_absent(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::InvalidFilename
+    )
+}
+
 #[async_trait]
 impl SecretStore for FsSecretStore {
     async fn get(&self, company: &CompanyId, key: &str) -> Result<Option<SecretValue>> {
@@ -2898,7 +2927,7 @@ impl SecretStore for FsSecretStore {
                 let legacy_path = bundle.legacy_secret(key);
                 match tokio::fs::read_to_string(&legacy_path).await {
                     Ok(value) => Ok(Some(SecretValue(value))),
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                    Err(e) if legacy_secret_absent(&e) => Ok(None),
                     Err(e) => Err(io_err(&legacy_path, e)),
                 }
             }
@@ -2924,7 +2953,7 @@ impl SecretStore for FsSecretStore {
             let legacy_path = bundle.legacy_secret(key);
             match tokio::fs::remove_file(&legacy_path).await {
                 Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) if legacy_secret_absent(&e) => {}
                 Err(e) => return Err(io_err(&legacy_path, e)),
             }
         }
@@ -6440,6 +6469,85 @@ mod test {
             secrets.get(&company, "key-foo").await.unwrap(),
             Some(SecretValue("value-for-key-foo".into()))
         );
+    }
+
+    /// A key whose legacy slug is far past `NAME_MAX`. 300 characters is the
+    /// length that reproduced the incident end to end; the canonical filename
+    /// is digest-truncated and unaffected, so this exercises only the legacy
+    /// fallback.
+    fn over_long_key() -> String {
+        format!("provider/{}/key", "a".repeat(300))
+    }
+
+    #[tokio::test]
+    async fn a_key_too_long_for_a_legacy_path_reads_as_absent() {
+        // `get` used to fall through to `legacy_secret`, take `ENAMETOOLONG`
+        // from the kernel, and return `Err` — 500ing every route that merely
+        // reads a credential, including the add flow's own existence check.
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        let secrets = FsSecretStore::new(&root);
+        let company = CompanyId::new("company-a");
+        let key = over_long_key();
+
+        assert_eq!(
+            secrets.get(&company, &key).await.unwrap(),
+            None,
+            "an unset over-long key must read as absent, not as a store error"
+        );
+
+        secrets
+            .set(&company, &key, SecretValue("sk-not-a-real-key".into()))
+            .await
+            .unwrap();
+        assert_eq!(
+            secrets.get(&company, &key).await.unwrap(),
+            Some(SecretValue("sk-not-a-real-key".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn clearing_a_key_too_long_for_a_legacy_path_succeeds() {
+        // The P0: `set` writes the canonical file first, then removes the
+        // legacy one. With an over-long key that removal answered
+        // `ENAMETOOLONG`, so `set` returned `Err` *after* truncating the stored
+        // credential — a 500 on `DELETE` with the key already at zero bytes and
+        // the row still listed.
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        let secrets = FsSecretStore::new(&root);
+        let company = CompanyId::new("company-a");
+        let key = over_long_key();
+
+        secrets
+            .set(&company, &key, SecretValue("sk-not-a-real-key".into()))
+            .await
+            .unwrap();
+        secrets
+            .set(&company, &key, SecretValue(String::new()))
+            .await
+            .expect("clearing an over-long key must not fail after the write lands");
+        // The port has no delete: a clear is a write of the empty string, which
+        // every caller reads as unset. What matters here is that the write and
+        // its result agree — the incident was a 500 over a key that was already
+        // empty on disk.
+        assert_eq!(
+            secrets.get(&company, &key).await.unwrap(),
+            Some(SecretValue(String::new()))
+        );
+    }
+
+    #[test]
+    fn only_absence_like_errors_are_read_as_a_missing_legacy_file() {
+        use std::io::{Error, ErrorKind};
+        assert!(legacy_secret_absent(&Error::from(ErrorKind::NotFound)));
+        assert!(legacy_secret_absent(&Error::from(ErrorKind::InvalidFilename)));
+        // Everything else stays loud: a secrets directory that cannot be read
+        // must not be mistaken for one holding nothing.
+        assert!(!legacy_secret_absent(&Error::from(
+            ErrorKind::PermissionDenied
+        )));
+        assert!(!legacy_secret_absent(&Error::from(ErrorKind::Other)));
     }
 
     #[tokio::test]

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -6541,7 +6541,9 @@ mod test {
     fn only_absence_like_errors_are_read_as_a_missing_legacy_file() {
         use std::io::{Error, ErrorKind};
         assert!(legacy_secret_absent(&Error::from(ErrorKind::NotFound)));
-        assert!(legacy_secret_absent(&Error::from(ErrorKind::InvalidFilename)));
+        assert!(legacy_secret_absent(&Error::from(
+            ErrorKind::InvalidFilename
+        )));
         // Everything else stays loud: a secrets directory that cannot be read
         // must not be mistaken for one holding nothing.
         assert!(!legacy_secret_absent(&Error::from(


### PR DESCRIPTION
Two high-severity defects found by a QA sweep of the inference surface, plus the store bug underneath one of them.

> **Now based on `main`.** #2262 merged on 2026-09-12, and on 2026-09-14 this branch merged `upstream/main` (`4b6a99b35`). The PR diff is now **only** the credential-safety change: the seven commits below, 15 files. The conflicts were in `ProviderConnectDialog.tsx`, `probe.rs` and `providers.rs`, and each was resolved by keeping both sides. The dialog keeps the name bound and main's `rivals` slug check. `probe_models` keeps main's credential-aware endpoint check and catalogue query, and both failure strings still name the redacted endpoint. `edit_provider` keeps the name bound, then main's cross-origin credential refusal and key rollback.

## 1. A credential embedded in an endpoint was stored, echoed, and served

A provider added at `http://user:secret@host/v1` kept the credential in `base_url`. The sweep reported three leak sites; the fix found **seven**, two of them caught by a new end-to-end test rather than by reading:

1. `inference_models::fetch_catalog` — `request to {url} failed: {error}`. reqwest had *already* masked the userinfo in its half of the string; our half put it back. This is what produced the originally-observed message.
2. `probe::probe_models` → `ProbeFailure::raw`, which reaches a host log — and a log is disk.
3. `model_unavailable_advice` — tells the operator to `GET {models_url}`, built from `base_url`.
4. `GET …/inference/providers/{slug}/models` — a second `ScopedCompany` catalog route with the same shape.
5. `validate_parts` echoed ``you wrote `{url}` `` on a malformed URL — the moment a hand-typed URL is *guaranteed* to be shown to someone.
6. The first-run setup status, and 7. the harness advice.

Served breadth mattered: `baseUrl` comes back from `GET …/inference`, which uses `ScopedCompany`, **not** `AdminScopedCompany` — so it reached anyone who could open the page, on every load.

**The fix is two independent mechanisms, not one patch:**

- **Refused where an endpoint is accepted** — `catalogue::endpoint_has_credentials` gates `normalize_local_endpoint`, the funnel every stored endpoint passes through, so the rule holds by construction rather than by whichever handler remembered. Also on `validate_parts` (manifest + console `PUT`), and on the draft probe, so the console cannot be used to put basic-auth on the wire.
- **Redacted where an endpoint is said** — `redact_endpoint` → `http://***@host/v1` at **16 non-test call sites**. Refusal cannot reach values stored before the rule existed, nor ones arriving from a `company.toml` or `OPENCOMPANY_INFERENCE_URL`. The endpoint used to *make* the request is untouched.

**No company already running can be bricked by the new refusal:** strict manifest `validate()` runs only when `existing.is_none()` (`src/runtime/builder.rs:1677`), so an existing instance is covered by redaction and its next edit is refused with a sentence saying where to put the credential instead.

`frontend/src/inference/types.ts` asserted that no shape in it carries a key. `baseUrl` could. That assertion is corrected rather than deleted — it now names the field that made it untrue and says what holds it.

## 2. A long provider name corrupted the secret store

No length bound on the name. `FsSecretStore::set` writes the canonical hashed path, then — on an empty value — `remove_file`s the **legacy** path, which is unbounded. Past the filesystem limit that returns `ENAMETOOLONG`, not `NotFound`, so `set` returned `Err` **after the file was already truncated**. `get` had the same flaw, so merely reading the credential 500'd.

Measured on APFS: 230 chars fine, **245 chars 500s on add**, 300 chars adds then 500s on delete — leaving a zero-byte key file, a row still listed, and no way to remove it but editing the index by hand.

- **Store:** `ErrorKind::InvalidFilename` is the portable std mapping for `ENAMETOOLONG`, verified empirically on APFS (`kind=InvalidFilename raw=Some(63)`) rather than hard-coding an errno. `legacy_secret_absent()` treats `NotFound | InvalidFilename` as "no legacy file"; everything else still propagates, so a permissions failure or a read-only mount stays loud. Applied at both legacy call sites, which are the only two in the tree. The SQLite and MongoDB stores have no legacy path and are unaffected.
- **Limit: 80 characters**, for two stated reasons. It matches `MAX_DISPLAY_NAME_CHARS` — the bound already used for the other name a person types and reads back in a list. And it keeps the derived key inside the canonical filename budget: at 80 chars `provider/<slug>/key` is 93 bytes raw / 97 percent-encoded against a 200-byte budget, so the credential file stays the readable `%k-` form rather than the truncated-and-digested `%l-` one. A test pins that arithmetic.
- Held **host-side** in `check_provider_name` and `check_slug`, enforced in `plan_add` **and** `edit_provider` — a rename that could set a name an add would refuse is a rule the host does not hold. The console mirrors it only to save a round trip.

## The seven commits

| SHA | |
|---|---|
| `32abd5b6e` | a legacy secret path too long to exist reads as absent |
| `69928fc1e` | bound the provider name, refuse an endpoint that carries a credential |
| `dae707869` | redact credentials embedded in provider endpoints |
| `d94a86225` | prove the credential-in-endpoint invariant on every path |
| `91ffd3082` | record the endpoint-credential rule beside the four slots |
| `f11942f07` | redact the endpoint in the model-unavailable advice |
| `bd96c60d1` | redact the house endpoint the first-run status reports |

## Verification

`cargo fmt --check` · `cargo clippy --all-targets -D warnings` exit 0 · `cargo test` **5255 lib + 26 integration passed, 0 failed** · `cargo check --features openhuman,mcp` exit 0 · all **three** frontend typecheck gates · `npm test` 619 files / **5463 passed, 0 failed** · `assert-design-tokens.sh`, `assert-feature-lanes.sh`, `assert-toolchain-pin.sh` all pass. All re-run after the rebase. **After the 2026-09-14 merge of `main`, nothing was re-run locally.** The merged head is verified by CI only.

**Not verified:** no browser pass — no UI surface changed beyond one inline error string and a `maxLength`, and every behaviour is covered host-side.

Every test value is an obvious fake. No real credential was used, written or logged, and nothing was cleared from a live company.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Custom provider names are limited to 80 characters, with clear validation messages and safe handling of pasted text.
  - Provider endpoint URLs containing embedded usernames or passwords are rejected.

- **Bug Fixes**
  - Credentials are redacted from endpoint values shown in errors, logs, responses, status information, and setup results.
  - Credential details are also removed from provider failure responses.
  - Uppercase and variably formatted URL schemes are handled correctly.
  - Overly long legacy credential keys are handled as absent instead of producing storage errors.

- **Documentation**
  - Added guidance on endpoint credential rejection, redaction, and existing persisted endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->