### PR TITLE
fix(desktop): open outward links in the operator's browser

### DIFF
--- a/frontend/src/lib/external-links.ts
+++ b/frontend/src/lib/external-links.ts
@@ -1,0 +1,73 @@
+import { tauriCore } from "@/api/transport/bridge";
+
+/**
+ * Hand an outward link to the operator's browser when the console is running
+ * inside the desktop shell.
+ *
+ * # Why this exists
+ *
+ * Every outward link in the console is an ordinary anchor —
+ * `<a href={url} target="_blank" rel="noreferrer">`. In a browser that opens a
+ * tab. A Tauri webview has no tab to open and no browser to open it in, so the
+ * click does nothing at all: no window, no error, no console message. The
+ * operator sees a link that is not a link.
+ *
+ * That was every one of them, on every screen, including the first-run wizard's
+ * only route to an API key — so an operator who did not already hold one had no
+ * way forward on the first screen of a build they had just installed.
+ *
+ * # Why a delegated listener rather than a component
+ *
+ * A helper each anchor calls fixes the anchors that remember to call it. The
+ * next one written is dead again, silently, and the failure only shows up in a
+ * packaged build. One capture-phase listener covers the anchors that exist and
+ * the ones nobody has written yet.
+ *
+ * # Why it is inert on the web
+ *
+ * `tauriCore()` is `null` in a browser, so nothing is intercepted and the
+ * anchor's own behaviour stands. The console keeps working in a normal tab
+ * exactly as before, which is also what keeps the E2E suite meaningful.
+ */
+export function installExternalLinkOpener(doc: Document = document): () => void {
+  const onClick = (event: MouseEvent) => {
+    if (event.defaultPrevented || event.button !== 0) return;
+    // A modified click asks for the platform's own behaviour. Nothing to
+    // improve on, and hijacking it would be worse than the bug.
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+    const anchor = (event.target as Element | null)?.closest?.("a");
+    const href = anchor?.getAttribute("href");
+    if (!anchor || !href) return;
+    if (!isOutwardHref(href)) return;
+
+    // Probed at click time, not at install time: a listener installed before
+    // the bridge is injected would otherwise decide "web" once and stay wrong
+    // for the life of the window.
+    const core = tauriCore();
+    if (!core) return;
+
+    event.preventDefault();
+    // The command is fire-and-forget on purpose. A rejection here means the
+    // shell refused the open, and there is nothing this layer can do about it
+    // that is better than leaving the operator where they were — but it must
+    // not surface as an unhandled rejection.
+    void core.invoke("plugin:shell|open", { path: href }).catch(() => {});
+  };
+
+  doc.addEventListener("click", onClick, true);
+  return () => doc.removeEventListener("click", onClick, true);
+}
+
+/**
+ * Whether this `href` leaves the console.
+ *
+ * `http`/`https` and `mailto:` go out. An in-app hash route, a relative path
+ * and a `blob:`/`data:` URL do not, and handing any of them to the operating
+ * system would replace a working link with a failed one.
+ */
+export function isOutwardHref(href: string): boolean {
+  const value = href.trim();
+  if (!value || value.startsWith("#") || value.startsWith("/")) return false;
+  return /^(https?:|mailto:)/i.test(value);
+}

--- a/frontend/src/lib/external-links.ts
+++ b/frontend/src/lib/external-links.ts
@@ -23,36 +23,41 @@ import { tauriCore } from "@/api/transport/bridge";
  * packaged build. One capture-phase listener covers the anchors that exist and
  * the ones nobody has written yet.
  *
+ * It does **not** cover a URL opened from code — `window.open` never reaches a
+ * click handler — so those call sites use [`openOutward`] directly.
+ *
  * # Why it is inert on the web
  *
  * `tauriCore()` is `null` in a browser, so nothing is intercepted and the
  * anchor's own behaviour stands. The console keeps working in a normal tab
  * exactly as before, which is also what keeps the E2E suite meaningful.
  */
-export function installExternalLinkOpener(doc: Document = document): () => void {
+export function installExternalLinkOpener(
+  doc: Document = document,
+): () => void {
   const onClick = (event: MouseEvent) => {
     if (event.defaultPrevented || event.button !== 0) return;
-    // A modified click asks for the platform's own behaviour. Nothing to
-    // improve on, and hijacking it would be worse than the bug.
-    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
 
     const anchor = (event.target as Element | null)?.closest?.("a");
     const href = anchor?.getAttribute("href");
     if (!anchor || !href) return;
     if (!isOutwardHref(href)) return;
 
+    // The bridge is probed BEFORE the modifier keys are considered, and the
+    // order is the point. A Cmd- or Ctrl-click asks for "open in a new tab",
+    // and honouring that in the desktop shell means falling back to the very
+    // `_blank` path that does nothing here — so the gesture most likely to be
+    // used on a link would be the one most likely to look broken. In a browser
+    // the bridge is absent, this returns, and the platform's own behaviour
+    // stands untouched.
+    //
     // Probed at click time, not at install time: a listener installed before
     // the bridge is injected would otherwise decide "web" once and stay wrong
     // for the life of the window.
-    const core = tauriCore();
-    if (!core) return;
+    if (!tauriCore()) return;
 
     event.preventDefault();
-    // The command is fire-and-forget on purpose. A rejection here means the
-    // shell refused the open, and there is nothing this layer can do about it
-    // that is better than leaving the operator where they were — but it must
-    // not surface as an unhandled rejection.
-    void core.invoke("plugin:shell|open", { path: href }).catch(() => {});
+    openOutward(href);
   };
 
   doc.addEventListener("click", onClick, true);
@@ -60,14 +65,63 @@ export function installExternalLinkOpener(doc: Document = document): () => void 
 }
 
 /**
+ * Open `url` outside the console, wherever the console happens to be running.
+ *
+ * Returns whether the desktop shell took it. `false` means this is a browser,
+ * and the caller's own `window.open` is what opens it — the web path is
+ * deliberately left alone rather than routed through here.
+ *
+ * Exported for the call sites a click listener cannot see. An OAuth flow that
+ * calls `window.open` from code hands the webview a popup it cannot create, so
+ * the authorization page never appears while the console starts polling and
+ * says "complete sign-in" — a worse failure than a dead link, because it looks
+ * like progress.
+ */
+export function openOutward(url: string): boolean {
+  const core = tauriCore();
+  if (!core) return false;
+  // Fire-and-forget. A rejection means the shell refused the open, and there is
+  // nothing this layer can do that is better than leaving the operator where
+  // they were — but it must not surface as an unhandled rejection.
+  void core
+    .invoke("plugin:shell|open", { path: absoluteOutwardUrl(url) })
+    .catch(() => {});
+  return true;
+}
+
+/**
  * Whether this `href` leaves the console.
  *
- * `http`/`https` and `mailto:` go out. An in-app hash route, a relative path
- * and a `blob:`/`data:` URL do not, and handing any of them to the operating
- * system would replace a working link with a failed one.
+ * Kept in step with `isExternalHref` in `components/markdown.tsx`, which is what
+ * decides whether user-authored Markdown gets `target="_blank"` at all: a link
+ * that renderer sends outward and this one calls internal is a link the desktop
+ * leaves inert, which is the bug this module exists to remove. That includes
+ * **protocol-relative** `//host/…`, which reads like a path and is not one.
+ *
+ * `mailto:` is outward here though that renderer leaves it in place — the two
+ * answer different questions. It asks whether to open a tab; this asks whether
+ * the operating system should take the URL, and a mail client is exactly the
+ * thing that should.
+ *
+ * An in-app hash route, a rooted path and a `blob:`/`data:` URL are not
+ * outward, and handing any of them to the operating system would replace a
+ * working in-app link with a failed one.
  */
 export function isOutwardHref(href: string): boolean {
   const value = href.trim();
-  if (!value || value.startsWith("#") || value.startsWith("/")) return false;
-  return /^(https?:|mailto:)/i.test(value);
+  if (!value) return false;
+  return /^((https?:)?\/\/|mailto:)/i.test(value);
+}
+
+/**
+ * A URL the operating system can act on.
+ *
+ * A protocol-relative `//host/…` inherits the page's scheme in a browser. In
+ * the desktop shell that scheme is Tauri's own custom protocol, so inheriting
+ * it would produce an address no browser can open; `https` is both the safe
+ * reading and the one every such link in the console means.
+ */
+function absoluteOutwardUrl(url: string): string {
+  const value = url.trim();
+  return value.startsWith("//") ? `https:${value}` : value;
 }

--- a/frontend/src/lib/external-links.ts
+++ b/frontend/src/lib/external-links.ts
@@ -35,13 +35,30 @@ import { tauriCore } from "@/api/transport/bridge";
 export function installExternalLinkOpener(
   doc: Document = document,
 ): () => void {
-  const onClick = (event: MouseEvent) => {
-    if (event.defaultPrevented || event.button !== 0) return;
+  /**
+   * `click` carries the primary button, `auxclick` the middle one. Both ask for
+   * a new tab on an anchor the webview cannot give one, so both are handled —
+   * dropping every non-primary event left middle-click inert (Codex review on
+   * #2283).
+   */
+  const onActivate = (event: MouseEvent) => {
+    if (event.defaultPrevented) return;
+    const wanted = event.type === "auxclick" ? 1 : 0;
+    if (event.button !== wanted) return;
 
     const anchor = (event.target as Element | null)?.closest?.("a");
-    const href = anchor?.getAttribute("href");
+    const href = anchor?.getAttribute("href")?.trim();
     if (!anchor || !href) return;
     if (!isOutwardHref(href)) return;
+
+    // ONLY a link that asked for a separate tab. An absolute `href` with no
+    // target is a top-level navigation the console means to perform in place,
+    // and the hub sign-in buttons are exactly that: `Login.tsx` sends the
+    // browser to the provider's OAuth start and reads the token back off this
+    // same window when it returns. Handing those to the system browser would
+    // land the callback there and leave the desktop webview permanently signed
+    // out — a worse bug than the one this module fixes (Codex review on #2283).
+    if (anchor.getAttribute("target")?.toLowerCase() !== "_blank") return;
 
     // The bridge is probed BEFORE the modifier keys are considered, and the
     // order is the point. A Cmd- or Ctrl-click asks for "open in a new tab",
@@ -60,8 +77,12 @@ export function installExternalLinkOpener(
     openOutward(href);
   };
 
-  doc.addEventListener("click", onClick, true);
-  return () => doc.removeEventListener("click", onClick, true);
+  doc.addEventListener("click", onActivate, true);
+  doc.addEventListener("auxclick", onActivate, true);
+  return () => {
+    doc.removeEventListener("click", onActivate, true);
+    doc.removeEventListener("auxclick", onActivate, true);
+  };
 }
 
 /**

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import { CrashFallback } from "@/components/crash-fallback";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { purgeStoredSmtpPasswords } from "@/lib/domain";
+import { installExternalLinkOpener } from "@/lib/external-links";
 import { startScrollActivity } from "@/lib/scroll-activity";
 import { initSentry, isReporting } from "@/lib/sentry";
 import "./index.css";
@@ -74,6 +75,14 @@ initSentry();
 // mark the themed scrollbars in `index.css` lift on. Outside React on purpose,
 // so StrictMode's double-invoked effects cannot arm it twice.
 startScrollActivity();
+
+// Outward links reach the operator's browser in the desktop shell (issue
+// #2282). Armed the same way and for the same reason as the scroll listener
+// above: one capturing listener for the life of the document, outside React so
+// StrictMode cannot arm it twice, and covering anchors mounted long after boot
+// — including ones nobody has written yet. Inert in a browser, where an anchor
+// already does the right thing.
+installExternalLinkOpener();
 
 // Deletes SMTP passwords the pre-#1460 console wrote to localStorage, before
 // the first render and therefore before anything can read one back. At boot

--- a/frontend/src/views/OAuthView.tsx
+++ b/frontend/src/views/OAuthView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { openOutward } from "@/lib/external-links";
 import { Info, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 
@@ -21,7 +22,10 @@ import {
   disconnectRouteFor,
   type GridProvider,
 } from "@/lib/provider-grid";
-import { ProviderDetail, type ConnectionSubject } from "@/views/connections/ProviderDetail";
+import {
+  ProviderDetail,
+  type ConnectionSubject,
+} from "@/views/connections/ProviderDetail";
 import { grantNamespace } from "@/components/grant-namespace";
 import { AccountChoiceSection } from "@/views/connections/AccountChoiceSection";
 import { ProvidersSection } from "@/views/connections/ProvidersSection";
@@ -94,7 +98,9 @@ export function OAuthView({ client, company }: Props) {
   // toolkit slug (issue #404). `states` still decides *whether* a provider is
   // connected — this decides *what* is connected, which is what a revoke has to
   // be addressed to and what the detail view opens.
-  const [accounts, setAccounts] = useState<Record<string, ComposioConnectedAccount[]>>({});
+  const [accounts, setAccounts] = useState<
+    Record<string, ComposioConnectedAccount[]>
+  >({});
   // The slug of the provider whose detail view is open, or `null`. A slug rather
   // than the row itself, so the open panel re-derives from `providers` after a
   // refresh instead of showing a snapshot of the state before the revoke.
@@ -136,7 +142,9 @@ export function OAuthView({ client, company }: Props) {
     ]);
     setAccounts(
       Object.fromEntries(
-        rows.filter((r) => r.accounts?.length).map((r) => [toolkitSlug(r.toolkit), r.accounts!]),
+        rows
+          .filter((r) => r.accounts?.length)
+          .map((r) => [toolkitSlug(r.toolkit), r.accounts!]),
       ),
     );
     // Bumped here rather than on the success path: the account-choice section
@@ -186,7 +194,10 @@ export function OAuthView({ client, company }: Props) {
    * happened. Comparing ids answers both cases with one rule, since the first
    * connect starts from an empty set.
    */
-  async function connectComposio(p: { providerId: string; label: string }, toolkit: string) {
+  async function connectComposio(
+    p: { providerId: string; label: string },
+    toolkit: string,
+  ) {
     // A sign-in for this toolkit is already polling (it can have been started
     // from a different tile sharing the slug). Clear the flag we just set rather
     // than leaving this tile spinning on someone else's flow.
@@ -194,7 +205,11 @@ export function OAuthView({ client, company }: Props) {
       setBusy((b) => (b === p.providerId ? null : b));
       return;
     }
-    const { connectUrl } = await startComposioAuthorize(client, company, toolkit);
+    const { connectUrl } = await startComposioAuthorize(
+      client,
+      company,
+      toolkit,
+    );
     // `noopener` keeps the Composio tab from reaching back through
     // `window.opener` — it is a third-party page carrying an OAuth flow, so it
     // stays. The cost is that the handle is ALWAYS null: with `noopener` (or
@@ -208,30 +223,51 @@ export function OAuthView({ client, company }: Props) {
     // and trading a real security property for a nicer error, which is the
     // wrong trade on a tab we hand an OAuth URL to. `ComposioSection.signIn`
     // opens the same URL the same way and likewise does not check.
-    window.open(connectUrl, "_blank", "noopener,noreferrer");
+    // The desktop shell first: a webview cannot create the tab this asks for,
+    // so `window.open` there opens nothing while the toast below and the poll
+    // both proceed — the operator is told to finish a sign-in on a page that
+    // never appeared. `openOutward` returns false in a browser, where the
+    // original call is still the right one.
+    if (!openOutward(connectUrl)) {
+      window.open(connectUrl, "_blank", "noopener,noreferrer");
+    }
     toast.message(`Complete ${p.label} sign-in in the new tab.`);
     // What was already there before the tab opened. Read from the page's own
     // state rather than re-fetched: it is the same list the operator is looking
     // at, and a fresh read here could race the sign-in they have already
     // completed in another tab.
-    const before = new Set((accounts[toolkitSlug(toolkit)] ?? []).map((a) => a.id));
-    const wasConnected = providers.some((row) => row.slug === toolkitSlug(toolkit) && row.connected);
+    const before = new Set(
+      (accounts[toolkitSlug(toolkit)] ?? []).map((a) => a.id),
+    );
+    const wasConnected = providers.some(
+      (row) => row.slug === toolkitSlug(toolkit) && row.connected,
+    );
     const deadline = Date.now() + 120_000;
     const poll = async () => {
       delete pollTimers.current[toolkit];
       if (Date.now() > deadline) {
         setBusy((b) => (b === p.providerId ? null : b));
-        toast.message(`${p.label} sign-in timed out. Try again if it didn't complete.`);
+        toast.message(
+          `${p.label} sign-in timed out. Try again if it didn't complete.`,
+        );
         return;
       }
       try {
         const rows = await listComposioConnections(client, company);
-        const row = rows.find((r) => r.toolkit.toLowerCase() === toolkit.toLowerCase());
+        const row = rows.find(
+          (r) => r.toolkit.toLowerCase() === toolkit.toLowerCase(),
+        );
         // An id we had not seen settles it. Falling back to `connected` covers a
         // host predating the `accounts` field, where the first connect is the
         // only one this poll can observe at all.
-        const arrived = row?.accounts?.some((a) => a.connected && !before.has(a.id)) === true;
-        if (arrived || (row?.accounts === undefined && row?.connected === true && !wasConnected)) {
+        const arrived =
+          row?.accounts?.some((a) => a.connected && !before.has(a.id)) === true;
+        if (
+          arrived ||
+          (row?.accounts === undefined &&
+            row?.connected === true &&
+            !wasConnected)
+        ) {
           setBusy((b) => (b === p.providerId ? null : b));
           toast.success(`Connected ${p.label}.`);
           // Re-read the host's reconciled view so the tile flips to connected.
@@ -297,11 +333,18 @@ export function OAuthView({ client, company }: Props) {
    * it answered 200, the toast said "Disconnected Gmail", and Gmail was still
    * connected on the next refresh.
    */
-  async function disconnectAccount(p: GridProvider, account: ComposioConnectedAccount) {
+  async function disconnectAccount(
+    p: GridProvider,
+    account: ComposioConnectedAccount,
+  ) {
     if (busy) return;
     setBusy(p.providerId);
     try {
-      const { note } = await disconnectComposioConnection(client, company, account.id);
+      const { note } = await disconnectComposioConnection(
+        client,
+        company,
+        account.id,
+      );
       // The host's own words rather than ours: it is the side that knows what a
       // revoke reached, and restating it here is a second place to drift from
       // what actually happened.
@@ -368,7 +411,8 @@ export function OAuthView({ client, company }: Props) {
   // up offering a Connect that could only 400.
   const platformManaged =
     load === "ready" &&
-    (Object.values(states).some((s) => s.credentialSource === "attested") || attested);
+    (Object.values(states).some((s) => s.credentialSource === "attested") ||
+      attested);
 
   // The routing facts, narrowed out of the status the page already holds.
   const reach: ComposioReach | null = useMemo(
@@ -398,7 +442,14 @@ export function OAuthView({ client, company }: Props) {
         platformManaged,
         accounts,
       ),
-    [status?.effectiveCatalog, extraToolkits, states, reach, platformManaged, accounts],
+    [
+      status?.effectiveCatalog,
+      extraToolkits,
+      states,
+      reach,
+      platformManaged,
+      accounts,
+    ],
   );
 
   // Re-derived from the grid every render, so the open panel reflects the last
@@ -428,7 +479,8 @@ export function OAuthView({ client, company }: Props) {
           provider: openedProvider,
           noCredential: status?.credentialSource === "none",
           onConnectAnother: (p) => void connect(p),
-          onDisconnectAccount: (p, account) => void disconnectAccount(p, account),
+          onDisconnectAccount: (p, account) =>
+            void disconnectAccount(p, account),
         };
 
   // Counted off the rendered grid, not off the raw host rows. The badge used to
@@ -446,8 +498,8 @@ export function OAuthView({ client, company }: Props) {
         width="full"
         description={
           <>
-            The third-party accounts your company signs in to and acts through. It only uses
-            what you connect.
+            The third-party accounts your company signs in to and acts through.
+            It only uses what you connect.
           </>
         }
         trailing={
@@ -460,10 +512,13 @@ export function OAuthView({ client, company }: Props) {
         {load === "unavailable" && (
           <Alert>
             <Info className="size-4" />
-            <AlertTitle>OAuth connections aren&apos;t wired on this host yet</AlertTitle>
+            <AlertTitle>
+              OAuth connections aren&apos;t wired on this host yet
+            </AlertTitle>
             <AlertDescription>
-              The catalog below shows what your company can connect once the host exposes its OAuth
-              endpoints. Connecting is disabled until then.
+              The catalog below shows what your company can connect once the
+              host exposes its OAuth endpoints. Connecting is disabled until
+              then.
             </AlertDescription>
           </Alert>
         )}
@@ -473,9 +528,10 @@ export function OAuthView({ client, company }: Props) {
             <ShieldCheck className="size-4" />
             <AlertTitle>Connections are managed by the platform</AlertTitle>
             <AlertDescription>
-              This instance signs in with its own platform identity, so there is no provider key to
-              register here and nothing stored on this instance. Connect a provider from the
-              platform and it shows up here.
+              This instance signs in with its own platform identity, so there is
+              no provider key to register here and nothing stored on this
+              instance. Connect a provider from the platform and it shows up
+              here.
             </AlertDescription>
           </Alert>
         )}
@@ -483,11 +539,14 @@ export function OAuthView({ client, company }: Props) {
         {!canManage && (
           <Alert data-testid="connections-read-only">
             <Info className="size-4" />
-            <AlertTitle>Only an admin can change what this company connects through</AlertTitle>
+            <AlertTitle>
+              Only an admin can change what this company connects through
+            </AlertTitle>
             <AlertDescription>
-              A connection belongs to the company — it is the account your agents act
-              through — so an admin manages it. You can see everything that is wired here; ask an
-              admin to add, change or remove one.
+              A connection belongs to the company — it is the account your
+              agents act through — so an admin manages it. You can see
+              everything that is wired here; ask an admin to add, change or
+              remove one.
             </AlertDescription>
           </Alert>
         )}

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   Check,
+  ExternalLink,
   KeyRound,
   Loader2,
   Plug,
@@ -26,12 +27,22 @@ import { classifyLoadFailure } from "@/lib/section-load";
 import { SectionUnreachable } from "@/views/connections/SectionUnreachable";
 import { GrantNamespace } from "@/components/grant-namespace";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+
+/**
+ * Where a BYOK key comes from.
+ *
+ * The bare host the field's own copy names, not a deep link into the settings
+ * page that mints the key: that path is the vendor's to move, and a stale one
+ * strands the operator on a 404 *after* a sign-in that worked — which is worse
+ * than the landing page they can navigate from themselves.
+ */
+const COMPOSIO_DASHBOARD_URL = "https://app.composio.dev";
 import { COMPOSIO_MANAGED_HIDDEN } from "@/product-scope";
 
 /**
@@ -42,7 +53,10 @@ import { COMPOSIO_MANAGED_HIDDEN } from "@/product-scope";
  * here even when it is not offered: this is what labels the route a company is
  * already on.
  */
-const MODES: Record<ComposioMode, { label: string; blurb: string; billed: string }> = {
+const MODES: Record<
+  ComposioMode,
+  { label: string; blurb: string; billed: string }
+> = {
   managed: {
     label: "OpenHuman-managed",
     blurb:
@@ -197,7 +211,12 @@ interface Props {
  * takes effect on the agents' next turn, no restart. Hidden entirely when the
  * feature is not in the build.
  */
-export function ComposioSection({ client, company, canManage, onChanged }: Props) {
+export function ComposioSection({
+  client,
+  company,
+  canManage,
+  onChanged,
+}: Props) {
   const [load, setLoad] = useState<
     "loading" | "ready" | "unavailable" | "unconfigured" | "error"
   >("loading");
@@ -285,7 +304,9 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
       toast.success(res.note);
       onChanged();
     } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Could not save the token.");
+      toast.error(
+        err instanceof ApiError ? err.message : "Could not save the token.",
+      );
     } finally {
       setBusy(null);
     }
@@ -302,7 +323,9 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
       toast.success(res.note);
       onChanged();
     } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Could not clear the token.");
+      toast.error(
+        err instanceof ApiError ? err.message : "Could not clear the token.",
+      );
     } finally {
       setBusy(null);
     }
@@ -328,7 +351,11 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
       toast.success(res.note);
       onChanged();
     } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Could not save the Composio API key.");
+      toast.error(
+        err instanceof ApiError
+          ? err.message
+          : "Could not save the Composio API key.",
+      );
     } finally {
       setBusy(null);
     }
@@ -347,7 +374,11 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
       toast.success(res.note);
       onChanged();
     } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Could not clear the Composio API key.");
+      toast.error(
+        err instanceof ApiError
+          ? err.message
+          : "Could not clear the Composio API key.",
+      );
     } finally {
       setBusy(null);
     }
@@ -364,7 +395,9 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
   function requestApiKeySave() {
     if (persistedMode === "managed") {
       confirmOpenerRef.current =
-        document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
       setConfirmSwitch(true);
       return;
     }
@@ -384,9 +417,15 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
    */
   function handleModeKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
     if (busy !== null) return;
-    if (!["ArrowDown", "ArrowRight", "ArrowUp", "ArrowLeft"].includes(event.key)) return;
-    const step = event.key === "ArrowDown" || event.key === "ArrowRight" ? 1 : -1;
-    const focused = modeButtons.current.indexOf(event.target as HTMLButtonElement);
+    if (
+      !["ArrowDown", "ArrowRight", "ArrowUp", "ArrowLeft"].includes(event.key)
+    )
+      return;
+    const step =
+      event.key === "ArrowDown" || event.key === "ArrowRight" ? 1 : -1;
+    const focused = modeButtons.current.indexOf(
+      event.target as HTMLButtonElement,
+    );
     if (focused === -1) return;
     event.preventDefault();
     const next = (focused + step + MODE_ORDER.length) % MODE_ORDER.length;
@@ -488,27 +527,33 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                 // filed about, one route over.
                 status.credentialSource === "none" ? (
                   <span className="inline-flex items-center gap-1 text-xs text-status-blocked-text">
-                    <AlertTriangle className="size-3" /> No API key — agents get no Composio tools
+                    <AlertTriangle className="size-3" /> No API key — agents get
+                    no Composio tools
                   </span>
                 ) : (
                   <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
-                    <KeyRound className="size-3" /> Using this company&apos;s own Composio account
+                    <KeyRound className="size-3" /> Using this company&apos;s
+                    own Composio account
                   </span>
                 )
               ) : attested ? (
                 <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
-                  <ShieldCheck className="size-3" /> Linked via cluster identity — nothing stored
+                  <ShieldCheck className="size-3" /> Linked via cluster identity
+                  — nothing stored
                 </span>
               ) : companyKey ? (
                 <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
-                  <ShieldCheck className="size-3" /> Linked via this company&apos;s own credential
+                  <ShieldCheck className="size-3" /> Linked via this
+                  company&apos;s own credential
                 </span>
               ) : byoToken ? (
                 <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
                   <Check className="size-3" /> token set
                 </span>
               ) : (
-                <span className="text-xs text-muted-foreground">not connected</span>
+                <span className="text-xs text-muted-foreground">
+                  not connected
+                </span>
               )}
             </div>
           )}
@@ -542,13 +587,16 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                     `policy-settings` uses for approval tiers, roving tabindex
                     included. */}
                 {MODE_ORDER.length > 1 && (
-                <div
-                  role="radiogroup"
-                  aria-label="Which Composio account this company uses"
-                  className={cn("grid gap-2", MODE_ORDER.length > 1 && "sm:grid-cols-2")}
-                  onKeyDown={handleModeKeyDown}
-                >
-                  {/* A stored route the list does not offer still gets a tile.
+                  <div
+                    role="radiogroup"
+                    aria-label="Which Composio account this company uses"
+                    className={cn(
+                      "grid gap-2",
+                      MODE_ORDER.length > 1 && "sm:grid-cols-2",
+                    )}
+                    onKeyDown={handleModeKeyDown}
+                  >
+                    {/* A stored route the list does not offer still gets a tile.
                       Without one no radio in the group is checked — every tile
                       reports `aria-checked="false"` and the control claims the
                       company has chosen nothing, which is a different (and
@@ -556,64 +604,72 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
 
                       Disabled: it is the state the company is in, not a route to
                       go back to. */}
-                  {!isOffered(mode) && (
-                    <button
-                      type="button"
-                      role="radio"
-                      aria-checked
-                      tabIndex={0}
-                      disabled
-                      data-testid="composio-mode-unconfigured"
-                      className="rounded-md border border-primary bg-primary/5 p-3 text-left disabled:cursor-not-allowed"
-                    >
-                      <span className="text-sm font-medium">{NOT_CONFIGURED}</span>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        No Composio account is configured for this company. Add an API key below to
-                        connect one.
-                      </p>
-                    </button>
-                  )}
-                  {MODE_ORDER.map((m, index) => {
-                    const active = mode === m;
-                    return (
+                    {!isOffered(mode) && (
                       <button
-                        key={m}
-                        ref={(el) => {
-                          modeButtons.current[index] = el;
-                        }}
                         type="button"
                         role="radio"
-                        aria-checked={active}
-                        tabIndex={active ? 0 : -1}
-                        disabled={busy !== null}
-                        data-testid={`composio-mode-${m}`}
-                        onClick={() => {
-                          setMode(m);
-                          setConfirmSwitch(false);
-                        }}
-                        className={cn(
-                          "rounded-md border p-3 text-left transition-colors",
-                          "disabled:cursor-not-allowed disabled:opacity-60",
-                          active ? "border-primary bg-primary/5" : "hover:bg-muted/50",
-                        )}
+                        aria-checked
+                        tabIndex={0}
+                        disabled
+                        data-testid="composio-mode-unconfigured"
+                        className="rounded-md border border-primary bg-primary/5 p-3 text-left disabled:cursor-not-allowed"
                       >
-                        <div className="flex items-start gap-2">
-                          <span className="flex-1 text-sm font-medium">{MODES[m].label}</span>
-                          {persistedMode === m && (
-                            <Badge variant="secondary" className="text-xs">
-                              Current
-                            </Badge>
-                          )}
-                        </div>
-                        <p className="mt-1 text-xs text-muted-foreground">{MODES[m].blurb}</p>
-                        <p className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground">
-                          <Wallet className="size-3 shrink-0" />
-                          {MODES[m].billed}
+                        <span className="text-sm font-medium">
+                          {NOT_CONFIGURED}
+                        </span>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          No Composio account is configured for this company.
+                          Add an API key below to connect one.
                         </p>
                       </button>
-                    );
-                  })}
-                </div>
+                    )}
+                    {MODE_ORDER.map((m, index) => {
+                      const active = mode === m;
+                      return (
+                        <button
+                          key={m}
+                          ref={(el) => {
+                            modeButtons.current[index] = el;
+                          }}
+                          type="button"
+                          role="radio"
+                          aria-checked={active}
+                          tabIndex={active ? 0 : -1}
+                          disabled={busy !== null}
+                          data-testid={`composio-mode-${m}`}
+                          onClick={() => {
+                            setMode(m);
+                            setConfirmSwitch(false);
+                          }}
+                          className={cn(
+                            "rounded-md border p-3 text-left transition-colors",
+                            "disabled:cursor-not-allowed disabled:opacity-60",
+                            active
+                              ? "border-primary bg-primary/5"
+                              : "hover:bg-muted/50",
+                          )}
+                        >
+                          <div className="flex items-start gap-2">
+                            <span className="flex-1 text-sm font-medium">
+                              {MODES[m].label}
+                            </span>
+                            {persistedMode === m && (
+                              <Badge variant="secondary" className="text-xs">
+                                Current
+                              </Badge>
+                            )}
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {MODES[m].blurb}
+                          </p>
+                          <p className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground">
+                            <Wallet className="size-3 shrink-0" />
+                            {MODES[m].billed}
+                          </p>
+                        </button>
+                      );
+                    })}
+                  </div>
                 )}
 
                 {/* The endpoint, so the routing claim above is checkable rather
@@ -635,14 +691,34 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                       id="composio-api-key"
                       type="password"
                       autoComplete="off"
-                      placeholder={onByok ? "stored — paste a new key to rotate" : "ak_…"}
+                      placeholder={
+                        onByok ? "stored — paste a new key to rotate" : "ak_…"
+                      }
                       value={apiKey}
                       onChange={(e) => setApiKey(e.target.value)}
                     />
                     <p className="text-xs text-muted-foreground">
-                      From your Composio dashboard at app.composio.dev. Stored on this host, never
-                      shown again.
+                      From your Composio dashboard at app.composio.dev. Stored
+                      on this host, never shown again.
                     </p>
+                    {/* The dashboard the line above names, as somewhere to go
+                        rather than an address to retype. Deliberately the bare
+                        host from that copy and not a guessed deep link: a
+                        settings path that moves leaves the operator on a 404
+                        after a sign-in that worked. */}
+                    <a
+                      href={COMPOSIO_DASHBOARD_URL}
+                      target="_blank"
+                      rel="noreferrer"
+                      data-testid="composio-open-dashboard"
+                      className={cn(
+                        buttonVariants({ variant: "outline", size: "sm" }),
+                        "mt-1",
+                      )}
+                    >
+                      Open Composio dashboard
+                      <ExternalLink className="size-3.5" />
+                    </a>
                   </div>
                 )}
 
@@ -662,9 +738,10 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                       Providers connected before this stay where they are
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      They live in the Composio account this company reached before, not in this
-                      one, so the grid below will look empty until you connect them again here.
-                      Clearing the key puts this company back where it is now.
+                      They live in the Composio account this company reached
+                      before, not in this one, so the grid below will look empty
+                      until you connect them again here. Clearing the key puts
+                      this company back where it is now.
                     </p>
                     <div className="flex flex-wrap gap-2">
                       <Button
@@ -731,7 +808,10 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                       </>
                     ) : (
                       onByok && (
-                        <Button disabled={busy !== null} onClick={() => void clearApiKey()}>
+                        <Button
+                          disabled={busy !== null}
+                          onClick={() => void clearApiKey()}
+                        >
                           {busy === "route" ? (
                             <Loader2 className="size-4 animate-spin" />
                           ) : (
@@ -755,7 +835,11 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
               alone left a company-key admin with the paste card hidden and no
               control to reveal it — the override became unreachable. */}
           {canManage && !onByok && credentialed && !showTokenCard && (
-            <Button variant="outline" size="sm" onClick={() => setShowOverride(true)}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowOverride(true)}
+            >
               <KeyRound className="size-4" />
               Use your own Composio account instead
             </Button>
@@ -771,21 +855,24 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                     would describe a fallback it does not have. */}
                 {companyKey ? (
                   <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                    Optional. This company&apos;s own TinyHumans credential already authorizes
-                    Composio. A token set here replaces it for Composio only — use it when the
-                    company has a separate Composio account. Clear it to go back to the company
+                    Optional. This company&apos;s own TinyHumans credential
+                    already authorizes Composio. A token set here replaces it
+                    for Composio only — use it when the company has a separate
+                    Composio account. Clear it to go back to the company
                     credential.
                   </p>
                 ) : attested ? (
                   <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                    Optional. A token set here overrides the instance identity for this company only
-                    — use it when the company has its own Composio account. Clear it to go back to
-                    the cluster identity.
+                    Optional. A token set here overrides the instance identity
+                    for this company only — use it when the company has its own
+                    Composio account. Clear it to go back to the cluster
+                    identity.
                   </p>
                 ) : null}
                 <div className="space-y-1">
                   <Label htmlFor="composio-token" className="text-xs">
-                    Composio token {byoToken ? "— set (paste a new value to rotate)" : ""}
+                    Composio token{" "}
+                    {byoToken ? "— set (paste a new value to rotate)" : ""}
                   </Label>
                   <Input
                     id="composio-token"
@@ -796,12 +883,17 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                     onChange={(e) => setToken(e.target.value)}
                   />
                   {status && isOffered(persistedMode) && (
-                    <p className="truncate text-xs text-muted-foreground">{status.backendUrl}</p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {status.backendUrl}
+                    </p>
                   )}
                 </div>
 
                 <div className="flex items-center gap-2">
-                  <Button disabled={busy !== null || !token.trim()} onClick={() => void save()}>
+                  <Button
+                    disabled={busy !== null || !token.trim()}
+                    onClick={() => void save()}
+                  >
                     {busy === "save" ? (
                       <Loader2 className="size-4 animate-spin" />
                     ) : (
@@ -810,7 +902,11 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
                     Save token
                   </Button>
                   {byoToken && (
-                    <Button variant="outline" disabled={busy !== null} onClick={() => void clear()}>
+                    <Button
+                      variant="outline"
+                      disabled={busy !== null}
+                      onClick={() => void clear()}
+                    >
                       {busy === "clear" ? (
                         <Loader2 className="size-4 animate-spin" />
                       ) : (

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { openOutward } from "@/lib/external-links";
 import {
   AlertTriangle,
   Check,
@@ -181,7 +182,12 @@ interface Props {
  * keys, `/connect` and `/disconnect` routes), which crashed on open — a second
  * surface is how the two came to disagree, so there is one (issue #414).
  */
-export function McpServersSection({ client, company, canManage, chrome = "inline" }: Props) {
+export function McpServersSection({
+  client,
+  company,
+  canManage,
+  chrome = "inline",
+}: Props) {
   const [load, setLoad] = useState<McpLoad>("loading");
   // Whether the agent-side MCP bridge is compiled into this host (issue #567).
   // Starts `unknown` so nothing is claimed before the capability read lands.
@@ -274,7 +280,9 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
       // failure. Anything else (offline, 5xx, a body that wasn't the list the
       // route promises) means we do not know what this company has, and saying
       // "no MCP here" would be a claim we cannot make (issue #414).
-      setLoad(err instanceof ApiError && err.status === 404 ? "unavailable" : "error");
+      setLoad(
+        err instanceof ApiError && err.status === 404 ? "unavailable" : "error",
+      );
     }
   }, [client, company]);
 
@@ -339,8 +347,12 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
         endpoint: endpoint.trim(),
         token: token.trim() || undefined,
         authKind,
-        headerName: authKind === "header" ? authFieldName.trim() || undefined : undefined,
-        paramName: authKind === "query_param" ? authFieldName.trim() || undefined : undefined,
+        headerName:
+          authKind === "header" ? authFieldName.trim() || undefined : undefined,
+        paramName:
+          authKind === "query_param"
+            ? authFieldName.trim() || undefined
+            : undefined,
       });
       // A probe that lands "needs config" or "error" is NOT a rollback — the
       // server is added — but surface it inline so the operator acts on it.
@@ -369,7 +381,9 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
       await refresh();
     } catch (err) {
       // Persistent, not a toast: the operator must see why the add failed.
-      setAddError(err instanceof ApiError ? err.message : "Couldn't add the server.");
+      setAddError(
+        err instanceof ApiError ? err.message : "Couldn't add the server.",
+      );
     } finally {
       setBusy(null);
     }
@@ -383,9 +397,13 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
       setTested((t) => ({ ...t, [server.name]: health }));
     } catch (err) {
       if (err instanceof ApiError && err.code === "not_wired") {
-        toast.message("Live testing isn't enabled in this build (the agent harness is off).");
+        toast.message(
+          "Live testing isn't enabled in this build (the agent harness is off).",
+        );
       } else {
-        toast.error(err instanceof ApiError ? err.message : "Couldn't test the server.");
+        toast.error(
+          err instanceof ApiError ? err.message : "Couldn't test the server.",
+        );
       }
     } finally {
       setBusy(null);
@@ -423,7 +441,9 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
       await refresh();
       await test(server);
     } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Couldn't save the token.");
+      toast.error(
+        err instanceof ApiError ? err.message : "Couldn't save the token.",
+      );
     } finally {
       setBusy(null);
     }
@@ -436,8 +456,17 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
     if (busy || pollTimers.current[server.name] !== undefined) return;
     setBusy(server.name);
     try {
-      const { authorizeUrl } = await startMcpOAuth(client, company, server.name);
-      window.open(authorizeUrl, "_blank", "noopener,noreferrer");
+      const { authorizeUrl } = await startMcpOAuth(
+        client,
+        company,
+        server.name,
+      );
+      // See `OAuthView`: in the desktop shell a webview cannot create this tab,
+      // so the authorization page never opens while the toast and the poll
+      // below both carry on as though it had.
+      if (!openOutward(authorizeUrl)) {
+        window.open(authorizeUrl, "_blank", "noopener,noreferrer");
+      }
       toast.message(`Complete sign-in for ${server.name} in the new tab.`);
       // Poll for completion for up to ~2 minutes; stop as soon as it's healthy.
       const deadline = Date.now() + 120_000;
@@ -469,14 +498,24 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
           // Ignore transient probe errors while the operator finishes sign-in.
         }
         if (unmounted.current) return;
-        pollTimers.current[server.name] = window.setTimeout(() => void poll(), 2_000);
+        pollTimers.current[server.name] = window.setTimeout(
+          () => void poll(),
+          2_000,
+        );
       };
-      pollTimers.current[server.name] = window.setTimeout(() => void poll(), 2_000);
+      pollTimers.current[server.name] = window.setTimeout(
+        () => void poll(),
+        2_000,
+      );
     } catch (err) {
       if (err instanceof ApiError && err.code === "not_wired") {
-        toast.message("OAuth sign-in isn't enabled in this build (the agent harness is off).");
+        toast.message(
+          "OAuth sign-in isn't enabled in this build (the agent harness is off).",
+        );
       } else {
-        toast.error(err instanceof ApiError ? err.message : "Couldn't start sign-in.");
+        toast.error(
+          err instanceof ApiError ? err.message : "Couldn't start sign-in.",
+        );
       }
     } finally {
       setBusy(null);
@@ -490,7 +529,9 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
       await updateMcpServer(client, company, server.name, { enabled });
       await refresh();
     } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Couldn't update the server.");
+      toast.error(
+        err instanceof ApiError ? err.message : "Couldn't update the server.",
+      );
     } finally {
       setBusy(null);
     }
@@ -513,7 +554,10 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
    */
   async function remove(server: McpServer) {
     if (busy) return;
-    const removal = mcpRowControls(server, tested[server.name] ?? server.health).removal;
+    const removal = mcpRowControls(
+      server,
+      tested[server.name] ?? server.health,
+    ).removal;
     if (removal.kind === "none") return;
     setBusy(server.name);
     try {
@@ -528,7 +572,9 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
       if (err instanceof ApiError && err.code === "not_wired") {
         toast.message(REGISTRY_UNWIRED_NOTICE);
       } else {
-        toast.error(err instanceof ApiError ? err.message : "Couldn't remove the server.");
+        toast.error(
+          err instanceof ApiError ? err.message : "Couldn't remove the server.",
+        );
       }
     } finally {
       setBusy(null);
@@ -548,7 +594,10 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
    * a server that answers "needs a credential" has told the operator exactly
    * what to do next.
    */
-  async function lifecycle(server: McpServer, direction: "connect" | "disconnect") {
+  async function lifecycle(
+    server: McpServer,
+    direction: "connect" | "disconnect",
+  ) {
     if (busy || !server.serverId) return;
     setBusy(server.name);
     try {
@@ -591,13 +640,18 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
     if (!server.qualifiedName) {
       setEnvFields({
         kind: "failed",
-        message: "This install doesn't name a directory entry, so its credential fields are unknown.",
+        message:
+          "This install doesn't name a directory entry, so its credential fields are unknown.",
       });
       return;
     }
     setEnvFields({ kind: "loading" });
     try {
-      const detail = await getMcpRegistryEntry(client, company, server.qualifiedName);
+      const detail = await getMcpRegistryEntry(
+        client,
+        company,
+        server.qualifiedName,
+      );
       setEnvFields({ kind: "ready", keys: detail.requiredEnvKeys });
     } catch (err) {
       const outage = registryOutage(err);
@@ -630,14 +684,23 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
     setBusy(server.name);
     setEnvError(null);
     try {
-      const res = await updateMcpRegistryEnv(client, company, server.serverId, envDraft);
+      const res = await updateMcpRegistryEnv(
+        client,
+        company,
+        server.serverId,
+        envDraft,
+      );
       const after = res.test;
       if (after) setTested((t) => ({ ...t, [server.name]: after }));
       setEnvFor(null);
       setEnvDraft({});
       await refresh();
     } catch (err) {
-      setEnvError(err instanceof ApiError ? err.message : "Couldn't save those credentials.");
+      setEnvError(
+        err instanceof ApiError
+          ? err.message
+          : "Couldn't save those credentials.",
+      );
     } finally {
       setBusy(null);
     }
@@ -652,7 +715,10 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
     setTools((t) => ({ ...t, [server.name]: { kind: "loading" } }));
     try {
       const list = await discoverMcpTools(client, company, server.name);
-      setTools((t) => ({ ...t, [server.name]: { kind: "ready", tools: list } }));
+      setTools((t) => ({
+        ...t,
+        [server.name]: { kind: "ready", tools: list },
+      }));
     } catch (err) {
       if (err instanceof ApiError && err.code === "not_wired") {
         setTools((t) => ({ ...t, [server.name]: { kind: "unwired" } }));
@@ -661,7 +727,8 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
           ...t,
           [server.name]: {
             kind: "error",
-            message: err instanceof ApiError ? err.message : "Discovery failed.",
+            message:
+              err instanceof ApiError ? err.message : "Discovery failed.",
           },
         }));
       }
@@ -683,7 +750,8 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
         <Info className="size-4" />
         <AlertTitle>MCP servers aren&apos;t wired on this host</AlertTitle>
         <AlertDescription>
-          This host serves no MCP routes, so there is nothing to manage here yet.
+          This host serves no MCP routes, so there is nothing to manage here
+          yet.
         </AlertDescription>
       </Alert>
     );
@@ -702,14 +770,17 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
           promoting this one alone would read as though every section after it
           were a subsection of MCP Servers. */}
       <div className="flex items-center gap-2">
-        {chrome === "inline" && <Server className="size-4 text-muted-foreground" />}
+        {chrome === "inline" && (
+          <Server className="size-4 text-muted-foreground" />
+        )}
         <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
           {chrome === "inline" ? "MCP Servers" : "Installed servers"}
         </h2>
       </div>
       <p className="text-sm text-muted-foreground">
-        Remote MCP tool servers your agents can call. Add an HTTP endpoint and (optionally) a
-        token — the token is stored securely and never shown again.
+        Remote MCP tool servers your agents can call. Add an HTTP endpoint and
+        (optionally) a token — the token is stored securely and never shown
+        again.
       </p>
 
       {/* Issue #567: this screen's routes ship in every build, the agent-side
@@ -719,12 +790,15 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
       {bridge === "absent" && (
         <Alert data-testid="mcp-bridge-absent">
           <AlertTriangle className="size-4" />
-          <AlertTitle>No agent can use tool servers in this deployment</AlertTitle>
+          <AlertTitle>
+            No agent can use tool servers in this deployment
+          </AlertTitle>
           <AlertDescription>
-            The MCP bridge isn&apos;t compiled into this build, so servers added here are stored and
-            can be probed, but no agent ever receives their tools. The configuration survives —
-            rebuild this deployment with the <code className="font-mono">mcp</code> feature and the
-            servers below start reaching agents on the next turn.
+            The MCP bridge isn&apos;t compiled into this build, so servers added
+            here are stored and can be probed, but no agent ever receives their
+            tools. The configuration survives — rebuild this deployment with the{" "}
+            <code className="font-mono">mcp</code> feature and the servers below
+            start reaching agents on the next turn.
           </AlertDescription>
         </Alert>
       )}
@@ -734,10 +808,12 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
         // and this host did not tell us that (issue #414).
         <Alert variant="destructive" data-testid="mcp-load-error">
           <AlertTriangle className="size-4" />
-          <AlertTitle>Couldn&apos;t load this company&apos;s MCP servers</AlertTitle>
+          <AlertTitle>
+            Couldn&apos;t load this company&apos;s MCP servers
+          </AlertTitle>
           <AlertDescription>
-            The host didn&apos;t answer with its server list, so what is installed is unknown.
-            Reload to try again.
+            The host didn&apos;t answer with its server list, so what is
+            installed is unknown. Reload to try again.
           </AlertDescription>
         </Alert>
       ) : load === "loading" ? (
@@ -746,7 +822,9 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
         <Card>
           <CardContent className="space-y-3">
             {servers.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No MCP servers yet.</p>
+              <p className="text-sm text-muted-foreground">
+                No MCP servers yet.
+              </p>
             ) : (
               <ul className="divide-y divide-border">
                 {servers.map((server) => {
@@ -761,7 +839,8 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                   // Hoisted out of the JSX so the direction stays narrowed:
                   // there is one place that decides connect-or-disconnect, and
                   // the button below reads it rather than re-testing it.
-                  const dial = controls.lifecycle === "none" ? null : controls.lifecycle;
+                  const dial =
+                    controls.lifecycle === "none" ? null : controls.lifecycle;
                   const badge = mcpSourceBadge(server.source);
                   const credential = credentialAffordance(health?.authHint, {
                     source: server.source,
@@ -788,7 +867,11 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                             // one; a decorative image, so it is named by the
                             // row beside it rather than by alt text repeating
                             // the server name a screen reader just read.
-                            <img src={server.iconUrl} alt="" className="size-full object-cover" />
+                            <img
+                              src={server.iconUrl}
+                              alt=""
+                              className="size-full object-cover"
+                            />
                           ) : (
                             <Server className="size-4 text-muted-foreground" />
                           )}
@@ -817,7 +900,10 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                               {server.name}
                               <ChevronRight className="size-3.5 text-muted-foreground" />
                             </button>
-                            <Badge variant={badge.variant} data-testid="mcp-source-badge">
+                            <Badge
+                              variant={badge.variant}
+                              data-testid="mcp-source-badge"
+                            >
                               {badge.label}
                             </Badge>
                             <McpHealthBadge
@@ -831,12 +917,17 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                                 reverse. A disabled server therefore says so in
                                 words, where the other statuses are. */}
                             {controls.toggle && !server.enabled && (
-                              <Badge variant="outline" data-testid="mcp-disabled-badge">
+                              <Badge
+                                variant="outline"
+                                data-testid="mcp-disabled-badge"
+                              >
                                 disabled
                               </Badge>
                             )}
                           </div>
-                          <p className="truncate text-xs text-muted-foreground">{server.endpoint}</p>
+                          <p className="truncate text-xs text-muted-foreground">
+                            {server.endpoint}
+                          </p>
                         </div>
                         <span className="flex shrink-0 items-center gap-0.5">
                           {/* Issue #1260: `oauth_required` means the server asked for
@@ -948,7 +1039,9 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                               testId="mcp-toggle"
                               busy={busy === server.name}
                               disabled={busy !== null}
-                              onClick={() => void toggle(server, !server.enabled)}
+                              onClick={() =>
+                                void toggle(server, !server.enabled)
+                              }
                             />
                           )}
                           {controls.removal.kind !== "none" && canManage && (
@@ -987,34 +1080,53 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                           >
                             <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
                             <span>
-                              No agent can reach this server — no tool grant covers{" "}
-                              <code className="font-mono">mcp:{server.name}</code>. Widen a company or
-                              per-agent tool grant, or this server is unused.
+                              No agent can reach this server — no tool grant
+                              covers{" "}
+                              <code className="font-mono">
+                                mcp:{server.name}
+                              </code>
+                              . Widen a company or per-agent tool grant, or this
+                              server is unused.
                             </span>
                           </p>
                         ) : (
-                          <p data-testid="mcp-reachability" className="text-xs text-muted-foreground">
+                          <p
+                            data-testid="mcp-reachability"
+                            className="text-xs text-muted-foreground"
+                          >
                             Reachable by:{" "}
                             <span className="font-medium text-foreground">
                               {/* Names, not ids (issue #931): an operator-added agent's
                                   id is a minted internal string and tells the reader
                                   nothing about who can reach the server. */}
-                              {server.reachableBy.map((agent) => agent.name).join(", ")}
+                              {server.reachableBy
+                                .map((agent) => agent.name)
+                                .join(", ")}
                             </span>
                           </p>
                         ))}
                       {health && health.status !== "ok" && health.message && (
-                        <p className="text-xs text-muted-foreground">{health.message}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {health.message}
+                        </p>
                       )}
                       {credentialFor === server.name && canManage && (
-                        <div className="flex items-end gap-2" data-testid="mcp-token-inline">
+                        <div
+                          className="flex items-end gap-2"
+                          data-testid="mcp-token-inline"
+                        >
                           <div className="flex-1 space-y-1">
-                            <Label htmlFor={`mcp-token-${server.name}`} className="text-xs">
+                            <Label
+                              htmlFor={`mcp-token-${server.name}`}
+                              className="text-xs"
+                            >
                               API token for {server.name}
                               {/* The value is write-only and unrecoverable, so
                                   say when saving it overwrites an existing one
                                   (issue #1464). */}
-                              {server.authConfigured ? " — replaces the stored credential" : ""}
+                              {server.authConfigured
+                                ? " — replaces the stored credential"
+                                : ""}
                             </Label>
                             <Input
                               id={`mcp-token-${server.name}`}
@@ -1022,9 +1134,12 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                               autoComplete="new-password"
                               placeholder="write-only"
                               value={credentialDraft}
-                              onChange={(e) => setCredentialDraft(e.target.value)}
+                              onChange={(e) =>
+                                setCredentialDraft(e.target.value)
+                              }
                               onKeyDown={(e) => {
-                                if (e.key === "Enter") void saveCredential(server);
+                                if (e.key === "Enter")
+                                  void saveCredential(server);
                                 if (e.key === "Escape") setCredentialFor(null);
                               }}
                             />
@@ -1052,17 +1167,24 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                         </div>
                       )}
                       {envFor === server.name && canManage && (
-                        <div className="space-y-2 rounded-md bg-muted/40 p-2" data-testid="mcp-env-inline">
+                        <div
+                          className="space-y-2 rounded-md bg-muted/40 p-2"
+                          data-testid="mcp-env-inline"
+                        >
                           <p className="text-xs text-muted-foreground">
-                            Saving merges these values with the stored credentials and reconnects this server.
+                            Saving merges these values with the stored
+                            credentials and reconnects this server.
                           </p>
                           {envFields.kind === "loading" ? (
                             <p className="flex items-center gap-1 text-xs text-muted-foreground">
-                              <Loader2 className="size-3 animate-spin" /> Reading this
-                              server&apos;s credential fields…
+                              <Loader2 className="size-3 animate-spin" />{" "}
+                              Reading this server&apos;s credential fields…
                             </p>
                           ) : envFields.kind === "failed" ? (
-                            <p className="text-xs text-destructive" data-testid="mcp-env-unavailable">
+                            <p
+                              className="text-xs text-destructive"
+                              data-testid="mcp-env-unavailable"
+                            >
                               {envFields.message}
                             </p>
                           ) : envFields.keys.length === 0 ? (
@@ -1085,42 +1207,55 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                                   placeholder="write-only"
                                   value={envDraft[key] ?? ""}
                                   onChange={(e) =>
-                                    setEnvDraft({ ...envDraft, [key]: e.target.value })
+                                    setEnvDraft({
+                                      ...envDraft,
+                                      [key]: e.target.value,
+                                    })
                                   }
                                 />
                               </div>
                             ))
                           )}
-                          {envError && <p className="text-xs text-destructive">{envError}</p>}
+                          {envError && (
+                            <p className="text-xs text-destructive">
+                              {envError}
+                            </p>
+                          )}
                           <div className="flex items-center gap-2">
-                            {envFields.kind === "ready" && envFields.keys.length > 0 && (
-                              <Button
-                                size="sm"
-                                data-testid="mcp-env-save"
-                                disabled={busy !== null}
-                                onClick={() => void saveEnvRotation(server, envFields.keys)}
-                              >
-                                {busy === server.name ? (
-                                  <Loader2 className="size-4 animate-spin" />
-                                ) : (
-                                  "Save"
-                                )}
-                              </Button>
-                            )}
+                            {envFields.kind === "ready" &&
+                              envFields.keys.length > 0 && (
+                                <Button
+                                  size="sm"
+                                  data-testid="mcp-env-save"
+                                  disabled={busy !== null}
+                                  onClick={() =>
+                                    void saveEnvRotation(server, envFields.keys)
+                                  }
+                                >
+                                  {busy === server.name ? (
+                                    <Loader2 className="size-4 animate-spin" />
+                                  ) : (
+                                    "Save"
+                                  )}
+                                </Button>
+                              )}
                             <Button
                               size="sm"
                               variant="ghost"
                               disabled={busy !== null}
                               onClick={() => setEnvFor(null)}
                             >
-                              {envFields.kind === "ready" && envFields.keys.length > 0
+                              {envFields.kind === "ready" &&
+                              envFields.keys.length > 0
                                 ? "Cancel"
                                 : "Close"}
                             </Button>
                           </div>
                         </div>
                       )}
-                      <McpToolsList state={tools[server.name] ?? { kind: "idle" }} />
+                      <McpToolsList
+                        state={tools[server.name] ?? { kind: "idle" }}
+                      />
                     </li>
                   );
                 })}
@@ -1177,7 +1312,9 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                     <select
                       id="mcp-auth-kind"
                       value={authKind}
-                      onChange={(e) => setAuthKind(e.target.value as McpAuthKind)}
+                      onChange={(e) =>
+                        setAuthKind(e.target.value as McpAuthKind)
+                      }
                       className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-xs"
                     >
                       <option value="bearer">Bearer token</option>
@@ -1188,12 +1325,16 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                   {authKind !== "bearer" && (
                     <div className="space-y-1">
                       <Label htmlFor="mcp-auth-field" className="text-xs">
-                        {authKind === "header" ? "Header name" : "Parameter name"}
+                        {authKind === "header"
+                          ? "Header name"
+                          : "Parameter name"}
                       </Label>
                       <Input
                         id="mcp-auth-field"
                         value={authFieldName}
-                        placeholder={authKind === "header" ? "X-Api-Key" : "apiKey"}
+                        placeholder={
+                          authKind === "header" ? "X-Api-Key" : "apiKey"
+                        }
                         autoComplete="off"
                         onChange={(e) => setAuthFieldName(e.target.value)}
                       />
@@ -1201,7 +1342,9 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                   )}
                   <div className="space-y-1">
                     <Label htmlFor="mcp-token" className="text-xs">
-                      {authKind === "bearer" ? "Token (optional)" : "Credential value"}
+                      {authKind === "bearer"
+                        ? "Token (optional)"
+                        : "Credential value"}
                     </Label>
                     <Input
                       id="mcp-token"
@@ -1227,7 +1370,8 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                   </Button>
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  Adding saves the server now. {bridge === "absent"
+                  Adding saves the server now.{" "}
+                  {bridge === "absent"
                     ? "It stays unavailable to agents until this deployment is rebuilt with MCP support."
                     : "Agents pick up its tools on their next turn."}
                 </p>
@@ -1327,7 +1471,9 @@ function McpHealthBadge({
           ? { className: "text-status-blocked-text", Icon: AlertTriangle }
           : { className: "text-destructive", Icon: AlertTriangle };
   return (
-    <span className={`inline-flex items-center gap-1 text-xs ${tone.className}`}>
+    <span
+      className={`inline-flex items-center gap-1 text-xs ${tone.className}`}
+    >
       <tone.Icon className="size-3" /> {badge.label}
     </span>
   );
@@ -1346,7 +1492,8 @@ function McpToolsList({ state }: { state: ToolsState }) {
   if (state.kind === "unwired") {
     return (
       <p className="text-xs text-muted-foreground">
-        Live tool discovery isn&apos;t enabled in this build (the agent harness is off).
+        Live tool discovery isn&apos;t enabled in this build (the agent harness
+        is off).
       </p>
     );
   }
@@ -1354,7 +1501,11 @@ function McpToolsList({ state }: { state: ToolsState }) {
     return <p className="text-xs text-destructive">{state.message}</p>;
   }
   if (state.tools.length === 0) {
-    return <p className="text-xs text-muted-foreground">This server exposed no tools.</p>;
+    return (
+      <p className="text-xs text-muted-foreground">
+        This server exposed no tools.
+      </p>
+    );
   }
   return (
     <ul className="space-y-1 rounded-md bg-muted/40 p-2">

--- a/frontend/test/unit/external-links.test.ts
+++ b/frontend/test/unit/external-links.test.ts
@@ -2,7 +2,11 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { installExternalLinkOpener, isOutwardHref } from "@/lib/external-links";
+import {
+  installExternalLinkOpener,
+  isOutwardHref,
+  openOutward,
+} from "@/lib/external-links";
 
 /**
  * The desktop shell's bridge, as `tauriCore()` probes for it: `window.__TAURI__`
@@ -10,7 +14,9 @@ import { installExternalLinkOpener, isOutwardHref } from "@/lib/external-links";
  * web case.
  */
 function asDesktop(invoke = vi.fn().mockResolvedValue(undefined)) {
-  (window as unknown as { __TAURI__?: unknown }).__TAURI__ = { core: { invoke } };
+  (window as unknown as { __TAURI__?: unknown }).__TAURI__ = {
+    core: { invoke },
+  };
   return invoke;
 }
 
@@ -23,7 +29,12 @@ function clickAnchor(href: string, init: MouseEventInit = {}) {
   anchor.setAttribute("href", href);
   anchor.setAttribute("target", "_blank");
   document.body.append(anchor);
-  const event = new MouseEvent("click", { bubbles: true, cancelable: true, button: 0, ...init });
+  const event = new MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    ...init,
+  });
   anchor.dispatchEvent(event);
   return event;
 }
@@ -100,15 +111,49 @@ describe("installExternalLinkOpener", () => {
     dispose();
   });
 
-  /** A modified click is the operator asking for the platform's own behaviour. */
-  it("leaves a modified click alone", () => {
+  /**
+   * A Cmd/Ctrl-click asks for a new tab. In the desktop shell that is the very
+   * `_blank` path that opens nothing, so the most natural gesture on a link
+   * would be the one that still looked broken (Codex review on #2283).
+   */
+  it("hands a modified click to the shell in the desktop build", () => {
     const invoke = asDesktop();
     const dispose = installExternalLinkOpener();
 
     const event = clickAnchor("https://openrouter.ai/keys", { metaKey: true });
 
-    expect(invoke).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith("plugin:shell|open", {
+      path: "https://openrouter.ai/keys",
+    });
+    expect(event.defaultPrevented).toBe(true);
+    dispose();
+  });
+
+  /** In a browser the platform's own new-tab behaviour is already right. */
+  it("leaves a modified click to the browser", () => {
+    asBrowser();
+    const dispose = installExternalLinkOpener();
+
+    const event = clickAnchor("https://openrouter.ai/keys", { metaKey: true });
+
     expect(event.defaultPrevented).toBe(false);
+    dispose();
+  });
+
+  /**
+   * `markdown.tsx`'s `isExternalHref` sends `//host/…` outward and gives it
+   * `target="_blank"`. A renderer that calls it external and this module that
+   * called it internal left exactly that class of link inert (Codex review).
+   */
+  it("opens a protocol-relative link, with a scheme the OS can act on", () => {
+    const invoke = asDesktop();
+    const dispose = installExternalLinkOpener();
+
+    clickAnchor("//example.com/docs");
+
+    expect(invoke).toHaveBeenCalledWith("plugin:shell|open", {
+      path: "https://example.com/docs",
+    });
     dispose();
   });
 
@@ -137,5 +182,29 @@ describe("installExternalLinkOpener", () => {
 
     expect(invoke).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe("openOutward", () => {
+  /**
+   * The call sites a click listener cannot see. An OAuth flow calling
+   * `window.open` hands the webview a popup it cannot create, so the
+   * authorization page never appears while the console polls and says
+   * "complete sign-in" — progress that is not happening (Codex review on #2283).
+   */
+  it("takes the url in the desktop build and reports that it did", () => {
+    const invoke = asDesktop();
+
+    expect(openOutward("https://app.composio.dev")).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("plugin:shell|open", {
+      path: "https://app.composio.dev",
+    });
+  });
+
+  /** `false` is what tells the caller its own `window.open` is still correct. */
+  it("declines in a browser so the caller opens its own tab", () => {
+    asBrowser();
+
+    expect(openOutward("https://app.composio.dev")).toBe(false);
   });
 });

--- a/frontend/test/unit/external-links.test.ts
+++ b/frontend/test/unit/external-links.test.ts
@@ -24,12 +24,17 @@ function asBrowser() {
   delete (window as unknown as { __TAURI__?: unknown }).__TAURI__;
 }
 
-function clickAnchor(href: string, init: MouseEventInit = {}) {
+function clickAnchor(
+  href: string,
+  init: MouseEventInit = {},
+  opts: { target?: string | null; type?: "click" | "auxclick" } = {},
+) {
   const anchor = document.createElement("a");
   anchor.setAttribute("href", href);
-  anchor.setAttribute("target", "_blank");
+  const target = opts.target === undefined ? "_blank" : opts.target;
+  if (target !== null) anchor.setAttribute("target", target);
   document.body.append(anchor);
-  const event = new MouseEvent("click", {
+  const event = new MouseEvent(opts.type ?? "click", {
     bubbles: true,
     cancelable: true,
     button: 0,
@@ -206,5 +211,70 @@ describe("openOutward", () => {
     asBrowser();
 
     expect(openOutward("https://app.composio.dev")).toBe(false);
+  });
+});
+
+describe("what must not be intercepted", () => {
+  /**
+   * The hub sign-in buttons in `Login.tsx` are absolute anchors with **no**
+   * target: the OAuth start is a top-level navigation and the token is read
+   * back off this same window when the provider returns. Sending one to the
+   * system browser lands the callback there and leaves the desktop webview
+   * signed out for good (Codex review on #2283).
+   */
+  it("leaves an absolute anchor with no target to navigate in place", () => {
+    const invoke = asDesktop();
+    const dispose = installExternalLinkOpener();
+
+    const event = clickAnchor(
+      "https://hub.example/oauth/start",
+      {},
+      { target: null },
+    );
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    dispose();
+  });
+
+  it("leaves an anchor targeting the same window alone", () => {
+    const invoke = asDesktop();
+    const dispose = installExternalLinkOpener();
+
+    clickAnchor("https://example.com/x", {}, { target: "_self" });
+
+    expect(invoke).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  /** Middle-click asks for the same tab the webview cannot create. */
+  it("hands a middle-click to the shell in the desktop build", () => {
+    const invoke = asDesktop();
+    const dispose = installExternalLinkOpener();
+
+    const event = clickAnchor(
+      "https://example.com/x",
+      { button: 1 },
+      { type: "auxclick" },
+    );
+
+    expect(invoke).toHaveBeenCalledWith("plugin:shell|open", {
+      path: "https://example.com/x",
+    });
+    expect(event.defaultPrevented).toBe(true);
+    dispose();
+  });
+
+  /** Leading whitespace must not reach the shell's URL matcher (CodeRabbit). */
+  it("passes a trimmed url to the shell", () => {
+    const invoke = asDesktop();
+    const dispose = installExternalLinkOpener();
+
+    clickAnchor("  https://example.com/x  ");
+
+    expect(invoke).toHaveBeenCalledWith("plugin:shell|open", {
+      path: "https://example.com/x",
+    });
+    dispose();
   });
 });

--- a/frontend/test/unit/external-links.test.ts
+++ b/frontend/test/unit/external-links.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { installExternalLinkOpener, isOutwardHref } from "@/lib/external-links";
+
+/**
+ * The desktop shell's bridge, as `tauriCore()` probes for it: `window.__TAURI__`
+ * carrying a callable `core.invoke`. Anything less is not a bridge, which is the
+ * web case.
+ */
+function asDesktop(invoke = vi.fn().mockResolvedValue(undefined)) {
+  (window as unknown as { __TAURI__?: unknown }).__TAURI__ = { core: { invoke } };
+  return invoke;
+}
+
+function asBrowser() {
+  delete (window as unknown as { __TAURI__?: unknown }).__TAURI__;
+}
+
+function clickAnchor(href: string, init: MouseEventInit = {}) {
+  const anchor = document.createElement("a");
+  anchor.setAttribute("href", href);
+  anchor.setAttribute("target", "_blank");
+  document.body.append(anchor);
+  const event = new MouseEvent("click", { bubbles: true, cancelable: true, button: 0, ...init });
+  anchor.dispatchEvent(event);
+  return event;
+}
+
+afterEach(() => {
+  asBrowser();
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("isOutwardHref", () => {
+  it("takes the schemes that leave the console", () => {
+    expect(isOutwardHref("https://openrouter.ai/keys")).toBe(true);
+    expect(isOutwardHref("http://localhost:8080/x")).toBe(true);
+    expect(isOutwardHref("mailto:someone@example.com")).toBe(true);
+  });
+
+  /**
+   * The console addresses itself with hash routes, and `WorkspaceView` and the
+   * chat surface both build relative hrefs. Handing either to the operating
+   * system would replace a working in-app link with a failed one — a worse bug
+   * than the one this fixes.
+   */
+  it("leaves in-app and embedded addresses alone", () => {
+    expect(isOutwardHref("#/company/workspace/n-1")).toBe(false);
+    expect(isOutwardHref("/api/v1/company")).toBe(false);
+    expect(isOutwardHref("blob:abc")).toBe(false);
+    expect(isOutwardHref("data:text/plain,x")).toBe(false);
+    expect(isOutwardHref("")).toBe(false);
+  });
+});
+
+describe("installExternalLinkOpener", () => {
+  /**
+   * The defect itself: in the desktop shell an outward anchor did nothing at
+   * all. The click must now reach the shell instead of being swallowed.
+   */
+  it("hands an outward link to the shell in the desktop build", () => {
+    const invoke = asDesktop();
+    const dispose = installExternalLinkOpener();
+
+    const event = clickAnchor("https://openrouter.ai/keys");
+
+    expect(invoke).toHaveBeenCalledWith("plugin:shell|open", {
+      path: "https://openrouter.ai/keys",
+    });
+    expect(event.defaultPrevented).toBe(true);
+    dispose();
+  });
+
+  /**
+   * A browser already opens a tab. Intercepting there would be a regression
+   * dressed as a fix, and it is also what keeps the console E2E suite — which
+   * runs in a browser — a meaningful check of these links.
+   */
+  it("does nothing in a browser", () => {
+    asBrowser();
+    const dispose = installExternalLinkOpener();
+
+    const event = clickAnchor("https://openrouter.ai/keys");
+
+    expect(event.defaultPrevented).toBe(false);
+    dispose();
+  });
+
+  it("leaves an in-app hash route to the router", () => {
+    const invoke = asDesktop();
+    const dispose = installExternalLinkOpener();
+
+    const event = clickAnchor("#/company/workspace/n-1");
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    dispose();
+  });
+
+  /** A modified click is the operator asking for the platform's own behaviour. */
+  it("leaves a modified click alone", () => {
+    const invoke = asDesktop();
+    const dispose = installExternalLinkOpener();
+
+    const event = clickAnchor("https://openrouter.ai/keys", { metaKey: true });
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    dispose();
+  });
+
+  /**
+   * A refusal from the shell must not surface as an unhandled rejection — the
+   * operator is left where they were, and nothing else breaks.
+   */
+  it("swallows a shell refusal", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("denied"));
+    asDesktop(invoke);
+    const dispose = installExternalLinkOpener();
+
+    clickAnchor("https://openrouter.ai/keys");
+    await Promise.resolve();
+
+    expect(invoke).toHaveBeenCalled();
+    dispose();
+  });
+
+  it("stops intercepting once disposed", () => {
+    const invoke = asDesktop();
+    const dispose = installExternalLinkOpener();
+    dispose();
+
+    const event = clickAnchor("https://openrouter.ai/keys");
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "What the console webview may ask the shell to do. Until this file existed the generated capability set was empty, so every plugin command was denied — which is why `shell:allow-open` is the whole of it: the console's only need from a plugin is handing a URL to the operator's browser.",
+  "windows": ["*"],
+  "permissions": ["shell:allow-open"]
+}


### PR DESCRIPTION
## Summary

Every outward link in the console did nothing in the packaged desktop app — no window, no error, no console message. All 16 of them, across 10 files.

Each is an ordinary anchor:

```tsx
<a href={account.manageKeysUrl} target="_blank" rel="noreferrer">
```

A browser opens a tab for that. A Tauri webview has no tab to open, and all three things that would have rescued it were absent:

1. **The webview held no permissions at all.** There was no `src-tauri/capabilities/` directory, so the generated capability set was literally `{}` and every plugin command was denied.
2. **Nothing asked the shell to open anything.** `tauri_plugin_shell::init()` is registered (`src-tauri/src/lib.rs:111`), so the plugin was compiled in and reachable from Rust — and unreachable from the console.
3. **No navigation handler**, so nothing converted a `_blank` request into an OS-level open.

The plugin was present, permitted to nobody, and called by nothing.

The worst instance is the first-run wizard's API-key step: an operator without a key was offered exactly one route to get one, and in the desktop build that button was inert — on the first screen of a build they had just installed. Anyone who already held a key could paste it and never notice, which is how this shipped.

Also adds the button the Composio BYOK field was missing: its copy read "From your Composio dashboard at app.composio.dev", an address to retype rather than somewhere to go.

Closes #2282

## API Or Behavior Changes

A left-click on an `http`/`https`/`mailto:` anchor in the **desktop shell** now opens it in the operator's browser. In a browser nothing changes: `tauriCore()` is `null` there, so the anchor's own behaviour stands.

The capability grants `shell:allow-open` and nothing else. Capabilities are additive, so adding the first one takes nothing away.

The plugin's own `open` scope needed no configuration: `plugins.shell.open` unset means `Unset`, which the plugin treats as enabled with the default regex `^((mailto:\w+)|(tel:\w+)|(https?://\w+)).+`.

### Why a delegated listener rather than a helper each anchor calls

A helper fixes the anchors whose author remembers to call it. The next one written would be dead again — silently, and only in a packaged build, which is exactly how 16 accumulated. One capture-phase listener covers the anchors that exist and the ones nobody has written yet.

It is installed in `main.tsx` beside `startScrollActivity()`, for the reasons already written there: one capturing listener for the life of the document, outside React so StrictMode cannot arm it twice.

- **`tauriCore()` is probed at click time, not install time.** A listener that decided "web" once, before the bridge was injected, would stay wrong for the life of the window.
- **It reuses the existing bridge** (`api/transport/bridge.ts`) rather than taking `@tauri-apps/plugin-shell`, so no new dependency.

Hash routes, relative paths, `blob:` and `data:` are left alone — handing any of them to the OS would replace a working in-app link with a failed one. Modified clicks pass through. A refusal from the shell is swallowed rather than surfacing as an unhandled rejection.

The Composio button points at the bare `https://app.composio.dev` the field's own copy names, not a deep link to the settings page that mints the key. That path is the vendor's to move, and a stale one strands the operator on a 404 *after* a sign-in that worked.

## Tests

`frontend/test/unit/external-links.test.ts` — 8 cases over both runtimes: opens in desktop, **inert in a browser**, hash route untouched, modified click untouched, refusal swallowed, dispose stops intercepting, and the scheme predicate.

The browser case matters beyond symmetry: the console E2E suite runs in a browser, where all 16 links already worked. That is why nothing caught this, and why the fix must not disturb that path.

```
npm run typecheck        pass
npm run typecheck:unit   pass
npm test                 5361 passed | 3 skipped (613 files)
prettier --check         clean
```

**Verified by hand in a packaged build**, which is the only thing that can prove this: a local release `.app` was built from this branch, installed, and an outward link opened the operator's browser.

One finding worth carrying, because it cost a round trip here: **replacing `/Applications/<app>.app` does not replace a running instance.** macOS keeps executing the already-loaded binary, so the first verification attempt was clicking in the old app and reported the bug as unfixed. Kill the running process before testing a rebuilt bundle.

## Documentation

None needed — no documented behaviour changes.
