### PR TITLE
chore(release): reconcile every version declaration at 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opencompany-core"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3929,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "opencompany-tui"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = ["crates/opencompany-core", "crates/opencompany-tui"]
 exclude = ["vendor", "worktrees", "crates/opencompany-app"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.4"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/tinyhumansai/opencompany"

--- a/crates/opencompany-app/Cargo.lock
+++ b/crates/opencompany-app/Cargo.lock
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "opencompany-app"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "opencompany-core"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "argon2",

--- a/crates/opencompany-app/Cargo.toml
+++ b/crates/opencompany-app/Cargo.toml
@@ -20,7 +20,7 @@
 
 [package]
 name = "opencompany-app"
-version = "0.1.2"
+version = "0.1.4"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "OpenCompany desktop shell: many hosts at once, and local ACP harnesses."

--- a/crates/opencompany-app/tauri.conf.json
+++ b/crates/opencompany-app/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenCompany",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "ai.tinyhumans.opencompany",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencompany-console",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencompany-console",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@fontsource-variable/geist": "^5.2.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencompany-console",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A company-agnostic operator console for any OpenCompany host, built with Vite + React.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Ahead of cutting `v0.1.4`, brings every version declaration back into agreement. The workspace restructure left them disagreeing, and two of them had gone **backwards past the already-published `v0.1.3`**:

| | before | after |
|---|---|---|
| `Cargo.toml` `[workspace.package]` | `0.1.2` | `0.1.4` |
| `crates/opencompany-app/Cargo.toml` | `0.1.2` | `0.1.4` |
| `crates/opencompany-app/tauri.conf.json` | `0.1.3` | `0.1.4` |
| `frontend/package.json` | `0.1.3` | `0.1.4` |
| `Cargo.lock` — `opencompany-core`, `opencompany-tui` | `0.1.2` | `0.1.4` |
| `crates/opencompany-app/Cargo.lock` — `opencompany-app`, `opencompany-core` | `0.1.2` | `0.1.4` |
| `frontend/package-lock.json` | `0.1.3` | `0.1.4` |

A build before this produced a `0.1.2` binary inside a bundle labelled `0.1.3`.

`opencompany-core` and `opencompany-tui` take `version.workspace = true`, so the workspace value carries them. `opencompany-app` is **excluded** from the workspace and states its own, which is why it needs its own edit and has its own lockfile.

## API Or Behavior Changes

None. Version strings only — no code, no dependency movement.

## Tests

Both lockfiles were validated under the flag the release build uses, with submodules initialised so the resolve is real:

```
cargo metadata --locked                                                → exit 0
cargo metadata --manifest-path crates/opencompany-app/Cargo.toml --locked → exit 0
```

That second one is not ceremony: the `v0.1.3` release failed both matrix legs ~7 minutes into a macOS runner on exactly this, because a bump moved the root lock and left the app crate's own lock stale. `tauri build` passes `--locked` and refuses to reconcile.

- [x] `cargo metadata --locked` (both workspaces)
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test`

Unchecked deliberately: nothing here compiles differently.

## Worth fixing separately

Nothing asserts these eight declarations agree. The count is not obvious — two cargo workspaces, one of them excluded, two lockfiles, two npm files — and a bump that gets seven right fails minutes into a signed macOS build rather than at dispatch. A pre-flight check that reads all of them and refuses a mismatch would turn that into a one-line refusal before any runner time is spent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application and package version to **0.1.4**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->