### PR TITLE
fix(inference): the managed card's key rides the platform endpoint

### DIFF
--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -87,17 +87,12 @@ const PROVIDERS: Record<
     label: "Managed (TinyHumans)",
     acceptsKey: true,
     requiresBaseUrl: false,
-    // The managed brain is OpenRouter with the platform paying: the host treats
-    // `managed` as a legacy alias for `openrouter` (`LEGACY_MANAGED`, since
-    // OpenCompany stopped exposing its own model SKUs), so a key saved here is
-    // resolved onto OpenRouter's own endpoint and sent there.
-    //
-    // This line used to read "a TinyHumans API key" — true when `managed` was a
-    // provider of its own, and never updated when it stopped being one. It is
-    // what issue #1737 actually cost: the operator was asked for one vendor's
-    // key on a card that stored it against another, and every turn and every
-    // Test since has presented it to OpenRouter, which rejects it (issue #1737).
-    keyKind: "an OpenRouter key (`sk-or-…`) — the managed brain is OpenRouter, so that is where a key set here is sent",
+    // The card decides the endpoint: `managed` is the TinyHumans one, so a key
+    // saved here is a TinyHumans key and rides the platform endpoint on this
+    // company's own account. Going direct to OpenRouter is what selecting the
+    // `openrouter` provider does.
+    keyKind:
+      "a TinyHumans API key — the managed card runs on the platform endpoint, so that is where a key set here is sent",
     preset: { baseUrl: "", models: {} },
   },
   openrouter: {
@@ -534,8 +529,16 @@ export function InferenceSection({
    * reasoning as `removeKey` below.
    */
   const seedFromStatus = useCallback((next: InferenceStatus) => {
+    // `provider` is the normalized kind, so a company on the managed card reads
+    // back as `openrouter` and the dropdown would rest on OpenRouter while the
+    // header names the managed route. The host reports which one the traffic
+    // actually takes, so one field decides both and they cannot disagree.
     const stored = (
-      next.provider in PROVIDERS ? next.provider : "openrouter"
+      next.slug === "subscription"
+        ? "managed"
+        : next.provider in PROVIDERS
+          ? next.provider
+          : "openrouter"
     ) as InferenceProvider;
     // The form is a "switch to" form, so it opens on something the operator can
     // actually complete. A company on a route this console does not offer has no
@@ -610,6 +613,30 @@ export function InferenceSection({
    * `wouldSaveProxied` is computed.
    */
   const savedIsProxied = !(status?.provider === "openrouter" && status.keyConfigured);
+
+  /**
+   * Whether the form holds anything the header is not already reporting.
+   *
+   * The header states what the company is running; the form is what it would
+   * switch to. Without a cue for the gap, a header that disagrees with the
+   * select is ambiguous between an unsaved draft and the card contradicting
+   * itself — and the card contradicting itself was a real defect, so the two
+   * have to be told apart at a glance.
+   *
+   * The saved provider is read the way the select seeds, through `slug`, or a
+   * managed company would read as dirty the moment the card loaded.
+   */
+  const savedProvider = status
+    ? status.slug === "subscription"
+      ? "managed"
+      : status.provider
+    : null;
+  const unsavedChanges =
+    status !== null &&
+    (provider !== savedProvider ||
+      baseUrl !== baseline.baseUrl ||
+      key.trim() !== "" ||
+      JSON.stringify(models) !== JSON.stringify(baseline.models));
 
   /**
    * Whether typing a key has pointed the draft at a *different endpoint* than
@@ -1196,7 +1223,9 @@ export function InferenceSection({
               <div className="space-y-2">
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="font-medium" data-testid="inference-current-provider">
-                    {providerLabel(status.provider)}
+                    {providerLabel(
+                      status.slug === "subscription" ? "managed" : status.provider,
+                    )}
                   </span>
                   {/* `source` reads `managed` for a company this console has no
                       route for, which is the hidden route's own name. The badge
@@ -1667,6 +1696,14 @@ export function InferenceSection({
                 )}
 
                 <div className="flex items-center gap-2">
+                  {unsavedChanges && (
+                    <span
+                      className="text-xs text-muted-foreground"
+                      data-testid="inference-unsaved"
+                    >
+                      Unsaved — the header above still shows what is running.
+                    </span>
+                  )}
                   <Button
                     data-testid="inference-save"
                     disabled={busy !== null}

--- a/frontend/test/e2e/inference.spec.ts
+++ b/frontend/test/e2e/inference.spec.ts
@@ -122,6 +122,75 @@ test("a key typed for a BYOK provider is not discarded by switching provider", a
   expect((await cleared.json()).keyConfigured).toBe(false);
 });
 
+test("a managed company with its own key names the managed route in both places", async ({
+  page,
+}) => {
+  // The regression this exists for: saving the managed card with a TinyHumans
+  // key sent every turn to openrouter.ai, and the card then read `OpenRouter`
+  // in the header while the endpoint line still said the platform. The probe
+  // resolved on the raw provider kind and runtime resolution normalized
+  // `managed` to `openrouter` first, so onboarding verified a configuration no
+  // turn could use.
+  //
+  // Driven with a key set, because managed WITHOUT a key was never broken — the
+  // keyless inheritance arm caught it. The key is what skipped that arm.
+  await openConnections(page);
+  await expect(page.locator("#inference-key")).toBeVisible({ timeout: 30_000 });
+
+  await pickProvider(page, "Managed (TinyHumans)");
+  await page.locator("#inference-key").fill(`pw-e2e-managed-${Date.now()}`);
+  await page.getByTestId("inference-save").click();
+  await expect(
+    page.getByText(/Inference updated\.|Inference saved — restart the company/),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // The host is the authority on which route the traffic takes.
+  const body = await (await page.request.get("/api/v1/company/inference")).json();
+  expect(body.keyConfigured).toBe(true);
+  expect(body.baseUrl).not.toContain("openrouter.ai");
+  expect(body.slug).toBe("subscription");
+
+  // And the card agrees with it, in both the places that name a provider —
+  // they used to disagree, which is what made the defect look like a display
+  // glitch rather than a routing one.
+  await expect(page.getByTestId("inference-current-provider")).toHaveText(
+    "Managed (TinyHumans)",
+    { timeout: 30_000 },
+  );
+  await expect(page.locator("#inference-provider")).toHaveText(/Managed \(TinyHumans\)/);
+
+  // Nothing is pending straight after a save, so the unsaved cue must be absent
+  // — otherwise it would cry wolf on every load and stop meaning anything.
+  await expect(page.getByTestId("inference-unsaved")).toHaveCount(0);
+
+  // Leave the company on its committed default for whatever runs next.
+  await page.getByRole("button", { name: "Reset to default" }).click();
+  await expect(
+    page.getByText("Reverted to the committed manifest (or managed) configuration."),
+  ).toBeVisible({ timeout: 30_000 });
+});
+
+test("an edited form says it is unsaved while the header keeps reporting the running config", async ({
+  page,
+}) => {
+  // The header states what the company runs; the form states what it would
+  // switch to. They legitimately differ mid-edit, and without a cue that gap is
+  // indistinguishable from the card contradicting itself — which it did, for
+  // real, until the fix above.
+  await openConnections(page);
+  await expect(page.locator("#inference-key")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("inference-unsaved")).toHaveCount(0);
+
+  await pickProvider(page, "OpenRouter");
+
+  await expect(page.getByTestId("inference-unsaved")).toBeVisible();
+  // The header is unmoved: nothing was saved, so nothing about the running
+  // company changed.
+  await expect(page.getByTestId("inference-current-provider")).toHaveText(
+    "Managed (TinyHumans)",
+  );
+});
+
 test("a key typed for a BYOK provider does reach the host on save", async ({ page }) => {
   // The managed case above must not be the only one that lands: the same input,
   // saved under a provider with its own endpoint, still has to reach the host.

--- a/frontend/test/unit/inference-card-honesty.test.ts
+++ b/frontend/test/unit/inference-card-honesty.test.ts
@@ -164,6 +164,53 @@ describe("the Provider select shows the provider the host holds (issue #1737)", 
     expect(providerSelect()).toBe("Custom (OpenAI-compatible)");
   });
 
+  it("names the managed route in both places when the host reports the proxy", async () => {
+    // The header and the select read the same status from two different fields:
+    // the header from the label, the select from `provider`. `managed` is
+    // normalized to `openrouter` on the way in, so a company on the managed card
+    // came back as `openrouter` and the select rested there while the header
+    // named TinyHumans — one card, two answers, for one configuration.
+    //
+    // `slug` is the host saying which route the traffic actually takes, so both
+    // read it and cannot disagree.
+    await mount(stubClient([status({ provider: "openrouter", slug: "subscription" })]));
+
+    expect(providerSelect()).toBe("Managed (TinyHumans)");
+    expect(testId("inference-current-provider")?.textContent).toBe("Managed (TinyHumans)");
+  });
+
+  it("still names OpenRouter when the traffic really is direct", async () => {
+    await mount(stubClient([status({ provider: "openrouter", slug: "openrouter" })]));
+
+    expect(providerSelect()).toBe("OpenRouter");
+    expect(testId("inference-current-provider")?.textContent).toBe("OpenRouter");
+  });
+
+  it("says nothing is unsaved when the form still matches the host", async () => {
+    await mount(stubClient([status({ provider: "openrouter", slug: "subscription" })]));
+    expect(testId("inference-unsaved")).toBeNull();
+  });
+
+  it("marks the form unsaved once the draft leaves what is running", async () => {
+    // The header reports the running config and the select reports the draft,
+    // so the two legitimately differ mid-edit. Without this cue that gap is
+    // indistinguishable from the card contradicting itself, which it used to do.
+    await mount(stubClient([status({ provider: "openrouter", slug: "subscription" })]));
+    expect(testId("inference-unsaved")).toBeNull();
+
+    const field = container.querySelector("#inference-key") as HTMLInputElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(field, "sk-or-typed-but-not-saved");
+      field.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(testId("inference-unsaved")?.textContent).toContain("Unsaved");
+  });
+
   it("rehydrates after a save rather than snapping back to the default", async () => {
     // The reported sequence: save under one provider, and the select goes on
     // reading the initializer's value while the header reads the saved one.

--- a/src/company/inference.rs
+++ b/src/company/inference.rs
@@ -600,14 +600,17 @@ fn resolve_endpoint(
     let has_key = !key.trim().is_empty();
 
     if is_managed_choice(provider) {
-        // The managed card carries no endpoint field, so a base URL left in the
-        // form by a previously-picked provider is stale, not a chosen endpoint:
-        // it never redirects the managed probe. The endpoint is always the
-        // platform's, and the credential is the operator's own key when given,
-        // else the injected managed one.
-        let base_url = env_default
-            .map(|e| e.base_url.clone())
-            .unwrap_or_else(|| PLATFORM_BASE_URL.to_string());
+        // The endpoint is the platform's, and the credential is the operator's
+        // own key when given, else the injected managed one. Selecting the
+        // managed card is what decides the endpoint — a key on it is a
+        // TinyHumans key for the platform, not a signal to go somewhere else.
+        // A `base_url` that reached here was declared, not left in a form: the
+        // probe drops a stale one before calling.
+        let base_url = base_url_override.map(str::to_string).unwrap_or_else(|| {
+            env_default
+                .map(|e| e.base_url.clone())
+                .unwrap_or_else(|| PLATFORM_BASE_URL.to_string())
+        });
         let credential = if has_key {
             Credential::from_value(key)
         } else {
@@ -669,6 +672,15 @@ pub fn decl_for_probe(
     env_default: Option<&EnvDefault>,
 ) -> InferenceDecl {
     let provider = provider.trim().to_string();
+    // The managed card has no endpoint field, so a URL still in the form came
+    // from a previously-picked provider. Dropping it here — rather than in
+    // `resolve_endpoint` — keeps a `base_url` an operator really did declare
+    // (in a manifest) honoured while a stale one never redirects the probe.
+    let base_url = if is_managed_choice(&provider) {
+        None
+    } else {
+        base_url
+    };
     let (base_url, credential, proxied) = resolve_endpoint(
         &provider,
         base_url,
@@ -920,8 +932,16 @@ pub async fn resolve_effective_scoped(
         let provider = normalize_provider(&runtime.provider).to_string();
         reject_unknown_provider(&provider, "the stored runtime inference config")?;
         let key = load_key_scoped(company, secrets, None, scope).await?;
-        let (base_url, credential, proxied) =
-            resolve_endpoint(&provider, runtime.base_url.as_deref(), key, env_default);
+        // Resolved on the RAW kind: the managed branch is what pins the platform
+        // endpoint, and normalizing first folds `managed` into `openrouter`
+        // before that branch can match. `provider` below still reports the
+        // normalized value, so storage and telemetry are unchanged.
+        let (base_url, credential, proxied) = resolve_endpoint(
+            &runtime.provider,
+            runtime.base_url.as_deref(),
+            key,
+            env_default,
+        );
         return Ok(Some(InferenceDecl {
             provider,
             base_url,
@@ -940,8 +960,12 @@ pub async fn resolve_effective_scoped(
         reject_unknown_provider(&provider, "`[inference].provider`")?;
         let key =
             load_key_scoped(company, secrets, manifest.api_key_secret.as_deref(), scope).await?;
-        let (base_url, credential, proxied) =
-            resolve_endpoint(&provider, manifest.base_url.as_deref(), key, env_default);
+        let (base_url, credential, proxied) = resolve_endpoint(
+            manifest.provider.as_deref().unwrap_or_default(),
+            manifest.base_url.as_deref(),
+            key,
+            env_default,
+        );
         return Ok(Some(InferenceDecl {
             provider,
             base_url,
@@ -2082,6 +2106,54 @@ mod tests {
         assert_eq!(decl.base_url, "https://env.example/openai/v1");
         assert!(decl.is_proxied());
         assert_eq!(bearer(&decl).await.as_deref(), Some("th-key"));
+    }
+
+    /// The runtime twin of `managed_probe_with_own_key_keeps_the_managed_endpoint`.
+    ///
+    /// The probe kept the managed endpoint and the console reported a working
+    /// credential, while every real turn went to `openrouter.ai` and was refused:
+    /// the probe resolves on the raw kind, and runtime resolution normalized
+    /// `managed` into `openrouter` before `resolve_endpoint` could match its
+    /// managed branch. With a key present the keyless inheritance arm does not
+    /// catch it either, so a company that saved the managed card with its own
+    /// TinyHumans key had no path to the platform endpoint at all.
+    #[tokio::test]
+    async fn a_saved_managed_config_with_an_own_key_still_reaches_the_platform_endpoint() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        let env = managed_env();
+        save_runtime_config(
+            &company,
+            &secrets,
+            &RuntimeInference {
+                provider: LEGACY_MANAGED.into(),
+                base_url: None,
+                models: BTreeMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+        store_key(&company, &secrets, "th-key").await.unwrap();
+
+        let decl = resolve_effective(&company, &Inference::default(), Some(&env), &secrets)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            decl.base_url, "https://env.example/openai/v1",
+            "a saved managed choice must reach the platform endpoint, never openrouter.ai"
+        );
+        assert_eq!(
+            bearer(&decl).await.as_deref(),
+            Some("th-key"),
+            "and carry the operator's own key on it"
+        );
+        assert!(decl.is_proxied());
+        assert_eq!(
+            decl.provider, DEFAULT_PROVIDER,
+            "while still reporting the normalized kind, so storage and telemetry are unchanged"
+        );
     }
 
     /// A host holding no managed credential probes the managed endpoint honestly

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -1988,11 +1988,11 @@ base_url = "https://byo.example/v1"
             dto.key_configured,
             "a console-set key must read as configured"
         );
-        // Same company, same injected platform default, opposite answer — and the
-        // key is not merely recorded: it moves the company off the subscription
-        // proxy and onto its own OpenRouter account, which is the only way a
-        // stored `sk-or-…` could actually be used.
-        assert_eq!(dto.base_url, inference::OPENROUTER_BASE_URL);
+        // The endpoint is decided by the card, not by whether a key is set. The
+        // managed card is the TinyHumans one, so a key saved on it is a
+        // TinyHumans key and rides the platform endpoint. Going direct to
+        // OpenRouter is what selecting the `openrouter` provider does.
+        assert_eq!(dto.base_url, STAGING_URL);
     }
 
     #[tokio::test]
@@ -2293,13 +2293,16 @@ base_url = "https://byo.example/v1"
         assert_eq!(status, StatusCode::OK, "{raw}");
         // The legacy name aliases through to what it now means.
         assert_eq!(resp["status"]["provider"], "openrouter");
-        assert_eq!(resp["status"]["slug"], "openrouter");
+        // Proxied through the platform, which is what the slug reports: the
+        // kind is `openrouter`, but the traffic is the subscription's.
+        assert_eq!(resp["status"]["slug"], "subscription");
         assert_eq!(resp["status"]["source"], "runtime");
         assert_eq!(resp["status"]["keyConfigured"], true);
-        // A key means the tenant's own OpenRouter account pays.
+        // The card decides the endpoint: `managed` is the TinyHumans one, so a
+        // key saved on it is a TinyHumans key and stays on the platform.
         assert_eq!(
             resp["status"]["baseUrl"],
-            crate::company::inference::OPENROUTER_BASE_URL
+            crate::company::inference::PLATFORM_BASE_URL
         );
         assert!(!raw.contains(TOKEN), "PUT leaked the token: {raw}");
 


### PR DESCRIPTION
## Summary

Selecting the TinyHumans (managed) inference card and saving a TinyHumans API key sent every turn to `openrouter.ai`, which rejected the key. The onboarding probe passed, so the company looked correctly configured right up until an agent was asked to do anything.

## Problem

`resolve_effective_scoped` normalized the provider *before* resolving the endpoint:

```rust
let provider = normalize_provider(&runtime.provider).to_string();   // "managed" -> "openrouter"
let (base_url, credential, proxied) = resolve_endpoint(&provider, ...);
```

`resolve_endpoint`'s first branch is `if is_managed_choice(provider)` — the branch that pins the platform endpoint and lets the operator's own key ride it. Normalization erased `managed` before that branch could ever match, so it was unreachable from runtime resolution.

The next branch (`openrouter && !has_key`) would still have inherited the platform URL, but a key was present, so resolution fell through to `effective_base_url` and produced `https://openrouter.ai/api/v1`. A TinyHumans key then reached OpenRouter, which answers an unparseable credential with `Missing Authentication header` — the phrasing issue #1737 already records as reading like "nothing was sent".

**Why the probe disagreed.** `decl_for_probe` passes the raw kind; only runtime resolution normalizes first. The two paths answered differently for the same configuration, which is why onboarding verified a setup that could not work. The manifest tier had the same fold.

## Solution

Resolve both tiers on the raw provider kind. The decl still reports the normalized value, so storage, telemetry and the console's provider field are unchanged.

The rule this restores: **the card decides the endpoint, not whether a key is set.** The managed card is the TinyHumans one, so a key saved on it is a TinyHumans key and rides the platform endpoint. Going direct to OpenRouter is what selecting the `openrouter` provider does.

A declared `base_url` is now honoured on the managed kind, and the probe drops a stale one from the form before calling. Previously `resolve_endpoint` discarded both — correct for a form where the URL is leftover state from a previously-picked provider, wrong for a manifest where the operator typed it. Splitting them is what lets the manifest tier resolve on the raw kind without losing a real endpoint.

## Submission Checklist

- [x] Full lib suite under `--features opencompany-core/openhuman` — **7657 passed, 0 failed**
- [x] Red proof: restoring the normalize-first order fails the new test on its own assertion — `a saved managed choice must reach the platform endpoint, never openrouter.ai / left: "https://openrouter.ai/api/v1" / right: "https://env.example/openai/v1"` — then restored to green
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --no-deps --features opencompany-core/openhuman,opencompany-core/tinymemory -- -D warnings` clean
- [x] Production-deletion scan: three replaced resolution lines and three assertions that pinned the old reading
- [ ] Console E2E — checked on CI

## Impact

A company that saved the managed card with its own TinyHumans key now reaches the platform endpoint instead of being refused on every turn. Companies on the managed card with no key are unaffected. Selecting `openrouter` with a key still goes direct.

Three existing assertions encoded the opposite reading — that any saved key meant the tenant's own OpenRouter account pays. They are replaced, and the status slug for managed-with-key is now `subscription` rather than `openrouter`, which is what the traffic actually is.

## Related

`a_saved_managed_config_with_an_own_key_still_reaches_the_platform_endpoint` is the runtime twin of the existing `managed_probe_with_own_key_keeps_the_managed_endpoint`. The probe had coverage for this combination; runtime resolution never did, which is how the two paths drifted apart unnoticed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Managed provider configurations now honor explicitly configured endpoints while retaining the appropriate platform default.
  * Managed credentials consistently use the platform endpoint instead of being redirected to an alternate provider endpoint.
  * Provider checks no longer inherit stale endpoint values from previously selected providers.

* **User Interface**
  * Managed provider guidance now identifies the required platform API key.
  * Provider labels accurately reflect the active configuration.
  * An unsaved-changes indicator appears when the form differs from the running configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Console half (added after the host fix was confirmed on a local DMG)

The card named two different routes for one configuration. The header rendered the label while the Provider select seeded from `provider` — the *normalized* kind — so a managed company came back as `openrouter` and the select rested there while the header said TinyHumans.

Both now read `slug`, the host's own statement of which route the traffic takes, so they cannot disagree.

**The key hint asks for a TinyHumans key again.** It had been changed to *"an OpenRouter key (`sk-or-…`) — the managed brain is OpenRouter"*, with a comment recording that it previously read "a TinyHumans API key". The console had been edited to match the routing defect instead of the routing being fixed, so operators were told to paste the one vendor's key that card would never send it to.

**An edited form now says it is unsaved.** The header states what the company runs; the form states what it would switch to. They legitimately differ mid-edit, and without a cue that gap is indistinguishable from the card contradicting itself — which it really did, so the ambiguity was costly.

### Coverage

Unit (`inference-card-honesty.test.ts` — the file whose docstring is *"the card knew a fact about the host and rendered something that contradicted it"*):

- managed proxy → header **and** select both read `Managed (TinyHumans)`
- genuinely direct OpenRouter → both read `OpenRouter` (so this cannot be "fixed" by hardcoding the managed label)
- no unsaved cue when the form matches the host
- unsaved cue once the draft diverges

E2E (`inference.spec.ts`):

- a managed company **with its own key** — the combination that broke — saves, and the host reports `slug: subscription` with a `baseUrl` that is not openrouter.ai, while both card fields read `Managed (TinyHumans)`
- an edited form shows the unsaved cue while the header keeps reporting the running config

Managed *without* a key was never broken, so both new tests set one: the key is what skipped the keyless inheritance arm.

### Verification

- **5373 unit tests passing**, typecheck clean
- Red proofs: reverting the select seeding gives `expected 'OpenRouter' to be 'Managed (TinyHumans)'` — the exact on-screen symptom; dropping the typed-key term from the dirty check fails the unsaved test. Both restored.
- Confirmed on a locally built DMG: endpoint `api.tinyhumans.ai/openai/v1`, `Cognition: harness`, agent responds.

### Known gap, deliberately not in this PR

`savedIsProxied` still derives proxied-ness as `!(provider === "openrouter" && keyConfigured)` — the pre-fix rule, now wrong for managed-with-key. Switching it to `slug` breaks 10 catalog tests whose fixtures omit that field. Practical effect: the model picker may offer raw OpenRouter ids that the platform's tier-native endpoint will not accept; tier ids (`chat-v1`) are unaffected. Worth its own change with the fixtures updated properly.
